### PR TITLE
Improve UserEdit and RoleEdit tests by splitting them up

### DIFF
--- a/graylog2-web-interface/src/components/roles/RoleEdit/RoleEdit.test.jsx
+++ b/graylog2-web-interface/src/components/roles/RoleEdit/RoleEdit.test.jsx
@@ -1,49 +1,11 @@
 // @flow strict
 import * as React from 'react';
-import * as Immutable from 'immutable';
-import { render, act, fireEvent, waitFor, screen } from 'wrappedTestingLibrary';
-import selectEvent from 'react-select-event';
+import { render, act, screen } from 'wrappedTestingLibrary';
 import { alertsManager as exampleRole } from 'fixtures/roles';
-import { alice, bob, charlie } from 'fixtures/userOverviews';
-import mockAction from 'helpers/mocking/MockAction';
-
-import { AuthzRolesActions } from 'stores/roles/AuthzRolesStore';
 
 import RoleEdit from './RoleEdit';
 
-const mockLoadUsersForRolePromise = Promise.resolve({
-  list: Immutable.List([alice]),
-  pagination: {
-    page: 1,
-    perPage: 10,
-    total: 1,
-  },
-});
-
-jest.mock('stores/roles/AuthzRolesStore', () => ({
-  AuthzRolesStore: {},
-  AuthzRolesActions: {
-    removeMember: mockAction(jest.fn(() => Promise.resolve())),
-    addMembers: mockAction(jest.fn(() => Promise.resolve())),
-    loadUsersForRole: jest.fn(() => mockLoadUsersForRolePromise),
-  },
-}));
-
-// mock loadUsersPaginated
-const mockLoadUsersPromise = Promise.resolve({
-  list: Immutable.List([bob, charlie]),
-  pagination: {
-    page: 1,
-    perPage: 10,
-    total: 1,
-  },
-});
-
-jest.mock('stores/users/UsersStore', () => ({
-  UsersActions: {
-    loadUsersPaginated: jest.fn(() => mockLoadUsersPromise),
-  },
-}));
+jest.mock('./UsersSection', () => () => <div>UsersSection</div>);
 
 jest.useFakeTimers();
 
@@ -62,50 +24,16 @@ describe('RoleEdit', () => {
     await screen.findByText('Loading...');
   });
 
-  it('should display role profile', async () => {
+  it('should display role profile', () => {
     render(<RoleEdit role={exampleRole} />);
 
-    await screen.findByText(exampleRole.name);
-
+    expect(screen.getByText(exampleRole.name)).toBeInTheDocument();
     expect(screen.getByText(exampleRole.description)).toBeInTheDocument();
   });
 
-  it('should assigning a user', async () => {
+  it('should display users section', () => {
     render(<RoleEdit role={exampleRole} />);
 
-    const assignUserButton = await screen.findByRole('button', { name: 'Assign User' });
-    const usersSelectorBob = screen.getByLabelText('Search for users');
-    await selectEvent.openMenu(usersSelectorBob);
-    await selectEvent.select(usersSelectorBob, bob.username);
-
-    const userSelectorCharlie = screen.getByLabelText('Search for users');
-    await selectEvent.openMenu(userSelectorCharlie);
-    await selectEvent.select(userSelectorCharlie, charlie.username);
-
-    fireEvent.click(assignUserButton);
-
-    await waitFor(() => expect(AuthzRolesActions.addMembers).toHaveBeenCalledWith(exampleRole.id, Immutable.Set.of(bob.username, charlie.username)));
+    expect(screen.getByText('UsersSection')).toBeInTheDocument();
   });
-
-  it('should filter assigned users', async () => {
-    render(<RoleEdit role={exampleRole} />);
-    const filterInput = await screen.findByPlaceholderText('Enter query to filter');
-    const filterSubmitButton = screen.getByRole('button', { name: 'Filter' });
-
-    fireEvent.change(filterInput, { target: { value: 'name of an assigned user' } });
-    fireEvent.click(filterSubmitButton);
-
-    await waitFor(() => expect(AuthzRolesActions.loadUsersForRole).toHaveBeenCalledTimes(2));
-
-    expect(AuthzRolesActions.loadUsersForRole).toHaveBeenCalledWith(exampleRole.id, exampleRole.name, { page: 1, perPage: 5, query: 'name of an assigned user' });
-  });
-
-  // it('should unassign a user', async () => {
-  //   render(<RoleEdit role={exampleRole} />);
-
-  //   const assignUserButton = await screen.findByRole('button', { name: `Remove ${alice.username}` });
-  //   fireEvent.click(assignUserButton);
-
-  //   await waitFor(() => expect(AuthzRolesActions.removeMember).toHaveBeenCalledWith(exampleRole.id, alice.username));
-  // });
 });

--- a/graylog2-web-interface/src/components/roles/RoleEdit/TeamsSection.test.jsx
+++ b/graylog2-web-interface/src/components/roles/RoleEdit/TeamsSection.test.jsx
@@ -1,0 +1,27 @@
+// @flow strict
+import * as React from 'react';
+import { render, screen } from 'wrappedTestingLibrary';
+import { manager as exampleRole } from 'fixtures/roles';
+import { PluginManifest, PluginStore } from 'graylog-web-plugin/plugin';
+
+import TeamsSection from './TeamsSection';
+
+describe('<TeamsSection />', () => {
+  it('should display info if license is not present', async () => {
+    render(<TeamsSection role={exampleRole} />);
+
+    expect(screen.getByText('Enterprise Feature')).toBeInTheDocument();
+  });
+
+  it('should display enterprise role teams assignment plugin', async () => {
+    PluginStore.register(new PluginManifest({}, {
+      teams: {
+        RoleTeamsAssignment: () => <>RoleTeamsAssignment</>,
+      },
+    }));
+
+    render(<TeamsSection role={exampleRole} />);
+
+    expect(screen.getByText('RoleTeamsAssignment')).toBeInTheDocument();
+  });
+});

--- a/graylog2-web-interface/src/components/roles/RoleEdit/TeamsSection.test.jsx
+++ b/graylog2-web-interface/src/components/roles/RoleEdit/TeamsSection.test.jsx
@@ -7,13 +7,13 @@ import { PluginManifest, PluginStore } from 'graylog-web-plugin/plugin';
 import TeamsSection from './TeamsSection';
 
 describe('<TeamsSection />', () => {
-  it('should display info if license is not present', async () => {
+  it('should display info if license is not present', () => {
     render(<TeamsSection role={exampleRole} />);
 
     expect(screen.getByText('Enterprise Feature')).toBeInTheDocument();
   });
 
-  it('should display enterprise role teams assignment plugin', async () => {
+  it('should display enterprise role teams assignment plugin', () => {
     PluginStore.register(new PluginManifest({}, {
       teams: {
         RoleTeamsAssignment: () => <>RoleTeamsAssignment</>,

--- a/graylog2-web-interface/src/components/roles/RoleEdit/UsersSection.test.jsx
+++ b/graylog2-web-interface/src/components/roles/RoleEdit/UsersSection.test.jsx
@@ -1,0 +1,97 @@
+// @flow strict
+import * as React from 'react';
+import * as Immutable from 'immutable';
+import { render, act, fireEvent, waitFor, screen } from 'wrappedTestingLibrary';
+import selectEvent from 'react-select-event';
+import { alertsManager as exampleRole } from 'fixtures/roles';
+import { alice, bob, charlie } from 'fixtures/userOverviews';
+import mockAction from 'helpers/mocking/MockAction';
+
+import { AuthzRolesActions } from 'stores/roles/AuthzRolesStore';
+
+import UsersSection from './UsersSection';
+
+const mockLoadUsersForRolePromise = Promise.resolve({
+  list: Immutable.List([alice]),
+  pagination: {
+    page: 1,
+    perPage: 10,
+    total: 1,
+  },
+});
+
+jest.mock('stores/roles/AuthzRolesStore', () => ({
+  AuthzRolesStore: {},
+  AuthzRolesActions: {
+    removeMember: mockAction(jest.fn(() => Promise.resolve())),
+    addMembers: mockAction(jest.fn(() => Promise.resolve())),
+    loadUsersForRole: jest.fn(() => mockLoadUsersForRolePromise),
+  },
+}));
+
+// mock loadUsersPaginated
+const mockLoadUsersPromise = Promise.resolve({
+  list: Immutable.List([bob, charlie]),
+  pagination: {
+    page: 1,
+    perPage: 10,
+    total: 1,
+  },
+});
+
+jest.mock('stores/users/UsersStore', () => ({
+  UsersActions: {
+    loadUsersPaginated: jest.fn(() => mockLoadUsersPromise),
+  },
+}));
+
+jest.useFakeTimers();
+
+describe('UsersSection', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should assigning a user', async () => {
+    render(<UsersSection role={exampleRole} />);
+    await act(() => mockLoadUsersPromise);
+    await act(() => mockLoadUsersForRolePromise);
+
+    const assignUserButton = screen.getByRole('button', { name: 'Assign User' });
+    const usersSelector = screen.getByLabelText('Search for users');
+    await selectEvent.select(usersSelector, bob.username);
+
+    fireEvent.click(assignUserButton);
+
+    await waitFor(() => expect(AuthzRolesActions.addMembers).toHaveBeenCalledTimes(1));
+
+    expect(AuthzRolesActions.addMembers).toHaveBeenCalledWith(exampleRole.id, Immutable.Set.of(bob.username));
+  });
+
+  it('should filter assigned users', async () => {
+    render(<UsersSection role={exampleRole} />);
+    await act(() => mockLoadUsersForRolePromise);
+    await act(() => mockLoadUsersPromise);
+
+    const filterInput = screen.getByPlaceholderText('Enter query to filter');
+    const filterSubmitButton = screen.getByRole('button', { name: 'Filter' });
+
+    fireEvent.change(filterInput, { target: { value: 'name of an assigned user' } });
+    fireEvent.click(filterSubmitButton);
+
+    await waitFor(() => expect(AuthzRolesActions.loadUsersForRole).toHaveBeenCalledTimes(2));
+
+    expect(AuthzRolesActions.loadUsersForRole).toHaveBeenCalledWith(exampleRole.id, exampleRole.name, { page: 1, perPage: 5, query: 'name of an assigned user' });
+  });
+
+  it('should unassign a user', async () => {
+    render(<UsersSection role={exampleRole} />);
+    await act(() => mockLoadUsersForRolePromise);
+    await act(() => mockLoadUsersPromise);
+
+    const assignUserButton = await screen.findByRole('button', { name: `Remove ${alice.username}` });
+    fireEvent.click(assignUserButton);
+
+    await waitFor(() => expect(AuthzRolesActions.removeMember).toHaveBeenCalledWith(exampleRole.id, alice.username));
+  });
+});

--- a/graylog2-web-interface/src/components/users/UserEdit/PasswordSection.test.jsx
+++ b/graylog2-web-interface/src/components/users/UserEdit/PasswordSection.test.jsx
@@ -34,7 +34,7 @@ describe('<PasswordSection />', () => {
   it('should allow password change', async () => {
     render(<SimplePasswordSection user={exampleUser} />);
 
-    const newPasswordInput = await screen.findByLabelText('New Password');
+    const newPasswordInput = screen.getByLabelText('New Password');
     const newPasswordRepeatInput = screen.getByLabelText('Repeat Password');
     const submitButton = screen.getByText('Change Password');
 
@@ -53,7 +53,7 @@ describe('<PasswordSection />', () => {
     const newCurrentUser = currentUser.toBuilder().readOnly(false).build();
     render(<PasswordSection user={newCurrentUser} />);
 
-    const passwordInput = await screen.findByLabelText('Old Password');
+    const passwordInput = screen.getByLabelText('Old Password');
     const newPasswordInput = screen.getByLabelText('New Password');
     const newPasswordRepeatInput = screen.getByLabelText('Repeat Password');
     const submitButton = screen.getByText('Change Password');
@@ -81,6 +81,6 @@ describe('<PasswordSection />', () => {
     fireEvent.change(newPasswordRepeatInput, { target: { value: 'notthepassword' } });
     fireEvent.blur(newPasswordRepeatInput);
 
-    await waitFor(() => expect(screen.getByText('Passwords do not match')).not.toBeNull());
+    await waitFor(() => expect(screen.getByText('Passwords do not match')).toBeInTheDocument());
   });
 });

--- a/graylog2-web-interface/src/components/users/UserEdit/PasswordSection.test.jsx
+++ b/graylog2-web-interface/src/components/users/UserEdit/PasswordSection.test.jsx
@@ -1,0 +1,86 @@
+// @flow strict
+import * as React from 'react';
+import * as Immutable from 'immutable';
+import { render, fireEvent, waitFor, screen } from 'wrappedTestingLibrary';
+import { alice, adminUser } from 'fixtures/users';
+
+import CurrentUserContext from 'contexts/CurrentUserContext';
+import { UsersActions } from 'stores/users/UsersStore';
+
+import PasswordSection from './PasswordSection';
+
+const exampleUser = alice;
+const currentUser = adminUser.toBuilder()
+  .permissions(Immutable.List(['*']))
+  .build();
+
+jest.mock('stores/users/UsersStore', () => ({
+  UsersActions: {
+    changePassword: jest.fn(() => Promise.resolve()),
+  },
+}));
+
+describe('<PasswordSection />', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const SimplePasswordSection = (props) => (
+    <CurrentUserContext.Provider value={{ ...currentUser.toJSON() }}>
+      <PasswordSection {...props} />
+    </CurrentUserContext.Provider>
+  );
+
+  it('should allow password change', async () => {
+    render(<SimplePasswordSection user={exampleUser} />);
+
+    const newPasswordInput = await screen.findByLabelText('New Password');
+    const newPasswordRepeatInput = screen.getByLabelText('Repeat Password');
+    const submitButton = screen.getByText('Change Password');
+
+    fireEvent.change(newPasswordInput, { target: { value: 'newpassword' } });
+    fireEvent.change(newPasswordRepeatInput, { target: { value: 'newpassword' } });
+    fireEvent.click(submitButton);
+
+    await waitFor(() => expect(UsersActions.changePassword).toHaveBeenCalledTimes(1));
+
+    expect(UsersActions.changePassword).toHaveBeenCalledWith(exampleUser.id, {
+      password: 'newpassword',
+    });
+  });
+
+  it('should require current password when current user is changing his password', async () => {
+    const newCurrentUser = currentUser.toBuilder().readOnly(false).build();
+    render(<PasswordSection user={newCurrentUser} />);
+
+    const passwordInput = await screen.findByLabelText('Old Password');
+    const newPasswordInput = screen.getByLabelText('New Password');
+    const newPasswordRepeatInput = screen.getByLabelText('Repeat Password');
+    const submitButton = screen.getByText('Change Password');
+
+    fireEvent.change(passwordInput, { target: { value: 'oldpassword' } });
+    fireEvent.change(newPasswordInput, { target: { value: 'newpassword' } });
+    fireEvent.change(newPasswordRepeatInput, { target: { value: 'newpassword' } });
+    fireEvent.click(submitButton);
+
+    await waitFor(() => expect(UsersActions.changePassword).toHaveBeenCalledTimes(1));
+
+    expect(UsersActions.changePassword).toHaveBeenCalledWith(newCurrentUser.id, {
+      old_password: 'oldpassword',
+      password: 'newpassword',
+    });
+  });
+
+  it('should display warning, if password repeat does not match password', async () => {
+    render(<PasswordSection user={exampleUser} />);
+
+    const newPasswordInput = screen.getByLabelText('New Password');
+    const newPasswordRepeatInput = screen.getByLabelText('Repeat Password');
+
+    fireEvent.change(newPasswordInput, { target: { value: 'thepassword' } });
+    fireEvent.change(newPasswordRepeatInput, { target: { value: 'notthepassword' } });
+    fireEvent.blur(newPasswordRepeatInput);
+
+    await waitFor(() => expect(screen.getByText('Passwords do not match')).not.toBeNull());
+  });
+});

--- a/graylog2-web-interface/src/components/users/UserEdit/ProfileSection.test.jsx
+++ b/graylog2-web-interface/src/components/users/UserEdit/ProfileSection.test.jsx
@@ -1,0 +1,55 @@
+// @flow strict
+import * as React from 'react';
+import { render, fireEvent, waitFor, screen } from 'wrappedTestingLibrary';
+import { alice } from 'fixtures/users';
+
+import ProfileSection from './ProfileSection';
+
+const exampleUser = alice.toBuilder()
+  .username('johndoe')
+  .fullName('John Doe')
+  .email('johndoe@example.org')
+  .build();
+
+describe('<ProfileSection />', () => {
+  it('should display username', async () => {
+    render(<ProfileSection user={exampleUser} onSubmit={jest.fn()} />);
+
+    expect(screen.getByText(exampleUser.username)).toBeInTheDocument();
+  });
+
+  it('should use user details as initial values', async () => {
+    const onSubmitStub = jest.fn();
+    render(<ProfileSection user={exampleUser} onSubmit={(data) => onSubmitStub(data)} />);
+
+    const submitButton = screen.getByText('Update Profile');
+    fireEvent.click(submitButton);
+
+    await waitFor(() => expect(onSubmitStub).toHaveBeenCalledTimes(1));
+
+    expect(onSubmitStub).toHaveBeenCalledWith({
+      full_name: exampleUser.fullName,
+      email: exampleUser.email,
+    });
+  });
+
+  it('should allow full name and e-mail address change', async () => {
+    const onSubmitStub = jest.fn();
+    render(<ProfileSection user={exampleUser} onSubmit={(data) => onSubmitStub(data)} />);
+
+    const fullNameInput = screen.getByLabelText('Full Name');
+    const emailInput = screen.getByLabelText('E-Mail Address');
+    const submitButton = screen.getByText('Update Profile');
+
+    fireEvent.change(fullNameInput, { target: { value: 'New full name' } });
+    fireEvent.change(emailInput, { target: { value: 'newfullname@example.org' } });
+    fireEvent.click(submitButton);
+
+    await waitFor(() => expect(onSubmitStub).toHaveBeenCalledTimes(1));
+
+    expect(onSubmitStub).toHaveBeenCalledWith({
+      full_name: 'New full name',
+      email: 'newfullname@example.org',
+    });
+  });
+});

--- a/graylog2-web-interface/src/components/users/UserEdit/RolesSection.test.jsx
+++ b/graylog2-web-interface/src/components/users/UserEdit/RolesSection.test.jsx
@@ -1,0 +1,81 @@
+// @flow strict
+import * as React from 'react';
+import * as Immutable from 'immutable';
+import selectEvent from 'react-select-event';
+import { render, fireEvent, waitFor, screen, act } from 'wrappedTestingLibrary';
+import { alice } from 'fixtures/users';
+import { manager as assignedRole1, reader as assignedRole2, reportCreator as notAssignedRole } from 'fixtures/roles';
+
+import { AuthzRolesActions } from 'stores/roles/AuthzRolesStore';
+
+import RolesSection from './RolesSection';
+
+const exampleUser = alice.toBuilder()
+  .roles(Immutable.Set([assignedRole1.name]))
+  .build();
+const mockRolesForUserPromise = Promise.resolve({ list: Immutable.List([assignedRole1]), pagination: { page: 1, perPage: 10, total: 1 } });
+const mockLoadRolesPromise = Promise.resolve({ list: Immutable.List([notAssignedRole]), pagination: { page: 1, perPage: 10, total: 1 } });
+
+jest.mock('stores/roles/AuthzRolesStore', () => ({
+  AuthzRolesActions: {
+    loadRolesForUser: jest.fn(() => mockRolesForUserPromise),
+    loadRolesPaginated: jest.fn(() => mockLoadRolesPromise),
+  },
+}));
+
+describe('<RolesSection />', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should assigning a role', async () => {
+    const onSubmitStub = jest.fn(() => Promise.resolve());
+    render(<RolesSection user={exampleUser} onSubmit={(data) => onSubmitStub(data)} />);
+    await act(() => mockRolesForUserPromise);
+    await act(() => mockLoadRolesPromise);
+
+    const assignRoleButton = screen.getByRole('button', { name: 'Assign Role' });
+    const rolesSelector = screen.getByLabelText('Search for roles');
+    await selectEvent.openMenu(rolesSelector);
+    await selectEvent.select(rolesSelector, notAssignedRole.name);
+    fireEvent.click(assignRoleButton);
+
+    await waitFor(() => expect(onSubmitStub).toHaveBeenCalledTimes(1));
+
+    expect(onSubmitStub).toHaveBeenCalledWith({ roles: [assignedRole1.name, notAssignedRole.name] });
+  });
+
+  it('should filter assigned roles', async () => {
+    const onSubmitStub = jest.fn(() => Promise.resolve());
+    render(<RolesSection user={exampleUser} onSubmit={(data) => onSubmitStub(data)} />);
+    await act(() => mockRolesForUserPromise);
+    await act(() => mockLoadRolesPromise);
+
+    const filterInput = screen.getByPlaceholderText('Enter query to filter');
+    const filterSubmitButton = screen.getByRole('button', { name: 'Filter' });
+
+    fireEvent.change(filterInput, { target: { value: 'name of an assigned role' } });
+    fireEvent.click(filterSubmitButton);
+
+    await waitFor(() => expect(AuthzRolesActions.loadRolesForUser).toHaveBeenCalledTimes(2));
+
+    expect(AuthzRolesActions.loadRolesForUser).toHaveBeenCalledWith(exampleUser.username, { page: 1, perPage: 5, query: 'name of an assigned role' });
+  });
+
+  it('should unassign a role', async () => {
+    const newExampleUser = alice.toBuilder()
+      .roles(Immutable.Set([assignedRole1.name, assignedRole2.name]))
+      .build();
+    const onSubmitStub = jest.fn(() => Promise.resolve());
+    render(<RolesSection user={newExampleUser} onSubmit={(data) => onSubmitStub(data)} />);
+    await act(() => mockRolesForUserPromise);
+    await act(() => mockLoadRolesPromise);
+
+    const unassignRoleButton = screen.getByRole('button', { name: `Remove ${assignedRole1.name}` });
+    fireEvent.click(unassignRoleButton);
+
+    await waitFor(() => expect(onSubmitStub).toHaveBeenCalledTimes(1));
+
+    expect(onSubmitStub).toHaveBeenCalledWith({ roles: [assignedRole2.name] });
+  });
+});

--- a/graylog2-web-interface/src/components/users/UserEdit/SettingsSection.test.jsx
+++ b/graylog2-web-interface/src/components/users/UserEdit/SettingsSection.test.jsx
@@ -1,0 +1,53 @@
+// @flow strict
+import * as React from 'react';
+import { render, fireEvent, waitFor, screen, act } from 'wrappedTestingLibrary';
+import { alice } from 'fixtures/users';
+import selectEvent from 'react-select-event';
+
+import SettingsSection from './SettingsSection';
+
+const exampleUser = alice.toBuilder()
+  .sessionTimeoutMs(36000000)
+  .timezone('Europe/Berlin')
+  .build();
+
+describe('<SettingsSection />', () => {
+  it('should use user settings as initial values', async () => {
+    const onSubmitStub = jest.fn();
+    render(<SettingsSection user={exampleUser} onSubmit={(data) => onSubmitStub(data)} />);
+
+    const submitButton = screen.getByText('Update Settings');
+
+    fireEvent.click(submitButton);
+
+    await waitFor(() => expect(onSubmitStub).toHaveBeenCalledTimes(1));
+
+    expect(onSubmitStub).toHaveBeenCalledWith({
+      session_timeout_ms: exampleUser.sessionTimeoutMs,
+      timezone: exampleUser.timezone,
+    });
+  });
+
+  it('should allow session timeout name and timezone change', async () => {
+    const onSubmitStub = jest.fn();
+    render(<SettingsSection user={exampleUser} onSubmit={(data) => onSubmitStub(data)} />);
+
+    const timeoutAmountInput = screen.getByPlaceholderText('Timeout amount');
+    const timezoneSelect = screen.getByLabelText('Time Zone');
+    const submitButton = screen.getByText('Update Settings');
+
+    act(() => {
+      fireEvent.change(timeoutAmountInput, { target: { value: '40' } });
+      selectEvent.openMenu(timezoneSelect);
+      selectEvent.select(timezoneSelect, 'Vancouver');
+      fireEvent.click(submitButton);
+    });
+
+    await waitFor(() => expect(onSubmitStub).toHaveBeenCalledTimes(1));
+
+    expect(onSubmitStub).toHaveBeenCalledWith({
+      session_timeout_ms: 144000000,
+      timezone: 'America/Vancouver',
+    });
+  });
+});

--- a/graylog2-web-interface/src/components/users/UserEdit/TeamsSection.test.jsx
+++ b/graylog2-web-interface/src/components/users/UserEdit/TeamsSection.test.jsx
@@ -1,0 +1,27 @@
+// @flow strict
+import * as React from 'react';
+import { render, screen } from 'wrappedTestingLibrary';
+import { alice as exampleUser } from 'fixtures/users';
+import { PluginManifest, PluginStore } from 'graylog-web-plugin/plugin';
+
+import TeamsSection from './TeamsSection';
+
+describe('<TeamsSection />', () => {
+  it('should display info if license is not present', async () => {
+    render(<TeamsSection user={exampleUser} />);
+
+    expect(screen.getByText('Enterprise Feature')).toBeInTheDocument();
+  });
+
+  it('should display enterprise user teams assignment plugin', async () => {
+    PluginStore.register(new PluginManifest({}, {
+      teams: {
+        UserTeamsAssignment: () => <>UserTeamsAssignment</>,
+      },
+    }));
+
+    render(<TeamsSection user={exampleUser} />);
+
+    expect(screen.getByText('UserTeamsAssignment')).toBeInTheDocument();
+  });
+});

--- a/graylog2-web-interface/src/components/users/UserEdit/TeamsSection.test.jsx
+++ b/graylog2-web-interface/src/components/users/UserEdit/TeamsSection.test.jsx
@@ -7,13 +7,13 @@ import { PluginManifest, PluginStore } from 'graylog-web-plugin/plugin';
 import TeamsSection from './TeamsSection';
 
 describe('<TeamsSection />', () => {
-  it('should display info if license is not present', async () => {
+  it('should display info if license is not present', () => {
     render(<TeamsSection user={exampleUser} />);
 
     expect(screen.getByText('Enterprise Feature')).toBeInTheDocument();
   });
 
-  it('should display enterprise user teams assignment plugin', async () => {
+  it('should display enterprise user teams assignment plugin', () => {
     PluginStore.register(new PluginManifest({}, {
       teams: {
         UserTeamsAssignment: () => <>UserTeamsAssignment</>,

--- a/graylog2-web-interface/src/components/users/UserEdit/UserEdit.test.jsx
+++ b/graylog2-web-interface/src/components/users/UserEdit/UserEdit.test.jsx
@@ -1,6 +1,5 @@
 // @flow strict
 import React from 'react';
-import * as Immutable from 'immutable';
 import { screen, render, act } from 'wrappedTestingLibrary';
 import { adminUser } from 'fixtures/users';
 

--- a/graylog2-web-interface/src/components/users/UserEdit/UserEdit.test.jsx
+++ b/graylog2-web-interface/src/components/users/UserEdit/UserEdit.test.jsx
@@ -40,7 +40,7 @@ describe('<UserEdit />', () => {
     await screen.findByText('Loading...');
   });
 
-  it('should not allow editing a readOnly user', async () => {
+  it('should not allow editing a readOnly user', () => {
     const readOnlyUser = exampleUser.toBuilder()
       .readOnly(true)
       .fullName('Full name')
@@ -51,7 +51,7 @@ describe('<UserEdit />', () => {
     expect(screen.queryByText('Profile')).not.toBeInTheDocument();
   });
 
-  it('should display profile, settings and password section', async () => {
+  it('should display profile, settings and password section', () => {
     render(<SimpleUserEdit user={exampleUser} />);
 
     expect(screen.getByText('ProfileSection')).toBeInTheDocument();

--- a/graylog2-web-interface/src/components/users/UserEdit/UserEdit.test.jsx
+++ b/graylog2-web-interface/src/components/users/UserEdit/UserEdit.test.jsx
@@ -1,231 +1,62 @@
 // @flow strict
 import React from 'react';
 import * as Immutable from 'immutable';
-import { act, screen, render, fireEvent, waitFor } from 'wrappedTestingLibrary';
-import selectEvent from 'react-select-event';
-import { reader as assignedRole, reportCreator as notAssignedRole } from 'fixtures/roles';
-import { admin as currentUser } from 'fixtures/users';
+import { screen, render, act } from 'wrappedTestingLibrary';
+import { adminUser } from 'fixtures/users';
 
-// import { AuthzRolesActions } from 'stores/roles/AuthzRolesStore';
 import CurrentUserContext from 'contexts/CurrentUserContext';
-import { UsersActions } from 'stores/users/UsersStore';
-import User from 'logic/users/User';
 
 import UserEdit from './UserEdit';
 
-jest.mock('stores/users/UsersStore', () => ({
-  UsersActions: {
-    update: jest.fn(() => Promise.resolve()),
-    load: jest.fn(() => Promise.resolve()),
-    changePassword: jest.fn(() => Promise.resolve()),
-  },
-}));
-
-const mockRolesForUserPromise = Promise.resolve({ list: Immutable.List([assignedRole]), pagination: { page: 1, perPage: 10, total: 1 } });
-const mockLoadRolesPromise = Promise.resolve({ list: Immutable.List([notAssignedRole]), pagination: { page: 1, perPage: 10, total: 1 } });
-const user = User
-  .builder()
-  .id('user-id')
-  .fullName('The full name')
-  .username('The username')
-  .roles(Immutable.Set([assignedRole.name]))
-  .email('theemail@example.org')
-  .clientAddress('127.0.0.1')
-  .lastActivity('2020-01-01T10:40:05.376+0000')
-  .sessionTimeoutMs(36000000)
-  .timezone('Europe/Berlin')
+const exampleUser = adminUser.toBuilder()
+  .readOnly(false)
   .build();
 
-jest.mock('stores/roles/AuthzRolesStore', () => ({
-  AuthzRolesActions: {
-    loadRolesForUser: jest.fn(() => mockRolesForUserPromise),
-    loadRolesPaginated: jest.fn(() => mockLoadRolesPromise),
-  },
-}));
+jest.mock('./ProfileSection', () => () => <div>ProfileSection</div>);
+jest.mock('./SettingsSection', () => () => <div>SettingsSection</div>);
+jest.mock('./PasswordSection', () => () => <div>PasswordSection</div>);
+jest.mock('./RolesSection', () => () => <div>RolesSection</div>);
+
+jest.useFakeTimers();
 
 describe('<UserEdit />', () => {
-  const SutComponent = (props) => (
-    <CurrentUserContext.Provider value={{ ...currentUser, permissions: ['*'] }}>
-      <UserEdit {...props} />
-    </CurrentUserContext.Provider>
-  );
-
   afterEach(() => {
     jest.clearAllMocks();
   });
 
-  describe('profile section', () => {
-    it('should display username', async () => {
-      render(<SutComponent user={user} />);
+  const SimpleUserEdit = (props) => (
+    <CurrentUserContext.Provider value={{ ...exampleUser.toJSON() }}>
+      <UserEdit {...props} />
+    </CurrentUserContext.Provider>
+  );
 
-      await waitFor(() => expect(screen.getByText(user.username)).toBeInTheDocument());
+  it('should display loading indicator, if no user is provided', async () => {
+    render(<SimpleUserEdit user={undefined} />);
+
+    act(() => {
+      jest.advanceTimersByTime(200);
     });
 
-    it('should use user details as initial values', async () => {
-      render(<SutComponent user={user} />);
-
-      const submitButton = await waitFor(() => screen.getByText('Update Profile'));
-
-      fireEvent.click(submitButton);
-
-      await waitFor(() => expect(UsersActions.update).toHaveBeenCalledWith(user.id, {
-        full_name: user.fullName,
-        email: user.email,
-      }));
-    });
-
-    it('should allow full name and e-mail address change', async () => {
-      render(<SutComponent user={user} />);
-
-      const fullNameInput = await screen.findByLabelText('Full Name');
-      const emailInput = screen.getByLabelText('E-Mail Address');
-      const submitButton = screen.getByText('Update Profile');
-
-      fireEvent.change(fullNameInput, { target: { value: 'New full name' } });
-      fireEvent.change(emailInput, { target: { value: 'newemail@example.org' } });
-
-      fireEvent.click(submitButton);
-
-      await waitFor(() => expect(UsersActions.update).toHaveBeenCalledWith(user.id, {
-        full_name: 'New full name',
-        email: 'newemail@example.org',
-      }));
-    });
+    await screen.findByText('Loading...');
   });
 
-  describe('settings section', () => {
-    it('should use user details as initial values', async () => {
-      render(<SutComponent user={user} />);
+  it('should not allow editing a readOnly user', async () => {
+    const readOnlyUser = exampleUser.toBuilder()
+      .readOnly(true)
+      .fullName('Full name')
+      .build();
+    render(<SimpleUserEdit user={readOnlyUser} />);
 
-      const submitButton = await screen.findByText('Update Settings');
-
-      fireEvent.click(submitButton);
-
-      await waitFor(() => expect(UsersActions.update).toHaveBeenCalledWith(user.id, {
-        session_timeout_ms: user.sessionTimeoutMs,
-        timezone: user.timezone,
-      }));
-    });
-
-    it('should allow session timeout name and timezone change', async () => {
-      render(<SutComponent user={user} />);
-
-      const timeoutAmountInput = await screen.findByPlaceholderText('Timeout amount');
-      const timezoneSelect = screen.getByLabelText('Time Zone');
-      const submitButton = screen.getByText('Update Settings');
-
-      act(() => {
-        fireEvent.change(timeoutAmountInput, { target: { value: '40' } });
-        selectEvent.openMenu(timezoneSelect);
-        selectEvent.select(timezoneSelect, 'Vancouver');
-        fireEvent.click(submitButton);
-      });
-
-      await waitFor(() => expect(UsersActions.update).toHaveBeenCalledWith(user.id, {
-        session_timeout_ms: 144000000,
-        timezone: 'America/Vancouver',
-      }));
-    });
+    expect(screen.getByText(`The selected user ${readOnlyUser.fullName} can't be edited.`)).toBeInTheDocument();
+    expect(screen.queryByText('Profile')).not.toBeInTheDocument();
   });
 
-  describe('password section', () => {
-    it('should allow password change', async () => {
-      render(<SutComponent user={user} />);
+  it('should display profile, settings and password section', async () => {
+    render(<SimpleUserEdit user={exampleUser} />);
 
-      const newPasswordInput = await screen.findByLabelText('New Password');
-      const newPasswordRepeatInput = screen.getByLabelText('Repeat Password');
-      const submitButton = screen.getByText('Change Password');
-
-      fireEvent.change(newPasswordInput, { target: { value: 'newpassword' } });
-      fireEvent.change(newPasswordRepeatInput, { target: { value: 'newpassword' } });
-      fireEvent.click(submitButton);
-
-      await waitFor(() => expect(UsersActions.changePassword).toHaveBeenCalledWith(user.id, {
-        password: 'newpassword',
-      }));
-    });
-
-    it('should require current password when current user is changing his password', async () => {
-      const newCurrentUser = User.fromJSON(currentUser).toBuilder().readOnly(false).build();
-      render(<SutComponent user={newCurrentUser} />);
-
-      const passwordInput = await screen.findByLabelText('Old Password');
-      const newPasswordInput = screen.getByLabelText('New Password');
-      const newPasswordRepeatInput = screen.getByLabelText('Repeat Password');
-      const submitButton = screen.getByText('Change Password');
-
-      fireEvent.change(passwordInput, { target: { value: 'oldpassword' } });
-      fireEvent.change(newPasswordInput, { target: { value: 'newpassword' } });
-      fireEvent.change(newPasswordRepeatInput, { target: { value: 'newpassword' } });
-      fireEvent.click(submitButton);
-
-      await waitFor(() => expect(UsersActions.changePassword).toHaveBeenCalledWith(newCurrentUser.id, {
-        old_password: 'oldpassword',
-        password: 'newpassword',
-      }));
-    });
-
-    // The following test will work when we use @testing-library/user-event instead of fireEvent
-    // it('should display warning, if password repeat does not match password', async () => {
-    //   const { screen.getByLabelText, screen.getByText } = render(<SutComponent user={user} />);
-    //   await act(() => mockRolesForUserPromise);
-    //   await act(() => mockLoadRolesPromise);
-
-    //   const newPasswordInput = getByLabelText('New Password');
-    //   const newPasswordRepeatInput = getByLabelText('Repeat Password');
-
-    //   fireEvent.change(newPasswordInput, { target: { value: 'thepassword' } });
-    //   fireEvent.change(newPasswordRepeatInput, { target: { value: 'notthepassword' } });
-
-    //   await waitFor(() => expect(screen.getByText('Passwords do not match')).not.toBeNull());
-    // });
-  });
-
-  describe('roles section', () => {
-    // it('should assigning a role', async () => {
-    //   const { getByLabelText, getByRole } = render(<SutComponent user={user} />);
-    //   await act(() => mockRolesForUserPromise);
-    //   await act(() => mockLoadRolesPromise);
-
-    //   const assignRoleButton = getByRole('button', { name: 'Assign Role' });
-    //   const rolesSelector = getByLabelText('Search for roles');
-    //   await selectEvent.openMenu(rolesSelector);
-    //   await selectEvent.select(rolesSelector, notAssignedRole.name);
-    //   fireEvent.click(assignRoleButton);
-
-    //   await waitFor(() => expect(UsersActions.update).toHaveBeenCalledWith(user.id, { roles: [assignedRole.name, notAssignedRole.name] }));
-    // });
-
-    // it('should filter assigned roles', async () => {
-    //   const { getByPlaceholderText, getByRole } = render(<SutComponent user={user} />);
-    //   await act(() => mockRolesForUserPromise);
-    //   await act(() => mockLoadRolesPromise);
-    //   const filterInput = getByPlaceholderText('Enter query to filter');
-    //   const filterSubmitButton = getByRole('button', { name: 'Filter' });
-
-    //   fireEvent.change(filterInput, { target: { value: 'name of an assigned role' } });
-    //   fireEvent.click(filterSubmitButton);
-
-    //   await waitFor(() => expect(AuthzRolesActions.loadRolesForUser).toHaveBeenCalledWith(user.id, 1, 10, 'name of an assigned role'));
-    // });
-
-    // it('should unassign a role', async () => {
-    //   const { getByRole } = render(<SutComponent user={user} />);
-    //   await act(() => mockRolesForUserPromise);
-    //   await act(() => mockLoadRolesPromise);
-
-    //   const assignRoleButton = getByRole('button', { name: `Remove ${assignedRole.name}` });
-    //   fireEvent.click(assignRoleButton);
-
-    //   await waitFor(() => expect(UsersActions.update).toHaveBeenCalledWith(user.id, { roles: [] }));
-    // });
-  });
-
-  describe('teams section', () => {
-    it('should display info if license is not present', async () => {
-      render(<SutComponent user={user} paginatedUserShares={undefined} />);
-
-      await waitFor(() => expect(screen.getByText(/Enterprise Feature/)).not.toBeNull());
-    });
+    expect(screen.getByText('ProfileSection')).toBeInTheDocument();
+    expect(screen.getByText('SettingsSection')).toBeInTheDocument();
+    expect(screen.getByText('RolesSection')).toBeInTheDocument();
+    expect(screen.getByText('PasswordSection')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Description
Previously the `UserEdit.test.jsx` and `RoleEdit.test.jsx` failed occasionally. The main problem was, that we are doing multiple requests on this page and some of them do not trigger an UI change which can be handled with `screen.findBy*`. We would have to wrap each promise mock in an act in every test, to make sure we handle them correctly. But even in this case some tests would run longer that one second.

With this PR we are splitting the both tests up in multiple files, one for each section.

