### PR TITLE
Remove unusual domain actions usage in auth backend edit and create component

### DIFF
--- a/graylog2-web-interface/src/components/authentication/BackendsOverview/BackendsOverviewItem.jsx
+++ b/graylog2-web-interface/src/components/authentication/BackendsOverview/BackendsOverviewItem.jsx
@@ -63,7 +63,7 @@ const ActionsCell = ({ isActive, authenticationBackend }: { authenticationBacken
 
   const _deleteBackend = () => {
     if (window.confirm(confirmMessage(title, 'delete'))) {
-      AuthenticationDomain.delete()(id, title);
+      AuthenticationDomain.delete(id, title);
     }
   };
 

--- a/graylog2-web-interface/src/components/authentication/directoryServices/ldap/BackendCreate.jsx
+++ b/graylog2-web-interface/src/components/authentication/directoryServices/ldap/BackendCreate.jsx
@@ -74,20 +74,18 @@ export const handleSubmit = (payload: WizardSubmitPayload, formValues: WizardFor
   const notifyOnSuccess = () => UserNotification.success('Authentication service was created successfully.');
   const notifyOnError = (error) => UserNotification.error(`Creating authentication service failed with status: ${error}`);
 
-  const onError = (error) => {
-    notifyOnError(error);
-    throw error;
-  };
-
   return AuthenticationActions.create(payload).then((result) => {
     if (result.backend && formValues.synchronizeGroups && enterpriseGroupSyncPlugin && shouldUpdateGroupSync) {
-      return enterpriseGroupSyncPlugin.actions.onDirectoryServiceBackendUpdate(false, formValues, result.backend.id, AUTH_BACKEND_META.serviceType).then(notifyOnSuccess).catch(onError);
+      return enterpriseGroupSyncPlugin.actions.onDirectoryServiceBackendUpdate(false, formValues, result.backend.id, AUTH_BACKEND_META.serviceType).then(notifyOnSuccess);
     }
 
     notifyOnSuccess();
 
     return result;
-  }).catch(onError);
+  }).catch((error) => {
+    notifyOnError(error);
+    throw error;
+  });
 };
 
 const BackendCreate = () => {

--- a/graylog2-web-interface/src/components/authentication/directoryServices/ldap/BackendCreate.jsx
+++ b/graylog2-web-interface/src/components/authentication/directoryServices/ldap/BackendCreate.jsx
@@ -71,8 +71,8 @@ const INITIAL_VALUES = {
 
 export const handleSubmit = (payload: WizardSubmitPayload, formValues: WizardFormValues, serviceType: $PropertyType<AuthBackendMeta, 'serviceType'>, shouldUpdateGroupSync?: boolean = true) => {
   const enterpriseGroupSyncPlugin = getEnterpriseGroupSyncPlugin();
-  const notifyOnSuccess = () => UserNotification.success('Authentication service was created successfully.');
-  const notifyOnError = (error) => UserNotification.error(`Creating authentication service failed with status: ${error}`);
+  const notifyOnSuccess = () => UserNotification.success('Authentication service was created successfully.', 'Success');
+  const notifyOnError = (error) => UserNotification.error(`Creating authentication service failed with status: ${error}`, 'Error');
 
   return AuthenticationActions.create(payload).then((result) => {
     if (result.backend && formValues.synchronizeGroups && enterpriseGroupSyncPlugin && shouldUpdateGroupSync) {

--- a/graylog2-web-interface/src/components/authentication/directoryServices/ldap/BackendCreate.jsx
+++ b/graylog2-web-interface/src/components/authentication/directoryServices/ldap/BackendCreate.jsx
@@ -1,8 +1,9 @@
 // @flow strict
 import * as React from 'react';
 
+import UserNotification from 'util/UserNotification';
 import type { WizardSubmitPayload } from 'logic/authentication/directoryServices/types';
-import AuthenticationDomain from 'domainActions/authentication/AuthenticationDomain';
+import { AuthenticationActions } from 'stores/authentication/AuthenticationStore';
 import { DocumentTitle } from 'components/common';
 import { getEnterpriseGroupSyncPlugin } from 'util/AuthenticationService';
 
@@ -70,18 +71,18 @@ const INITIAL_VALUES = {
 
 export const handleSubmit = (payload: WizardSubmitPayload, formValues: WizardFormValues, serviceType: $PropertyType<AuthBackendMeta, 'serviceType'>, shouldUpdateGroupSync?: boolean = true) => {
   const enterpriseGroupSyncPlugin = getEnterpriseGroupSyncPlugin();
-  const shouldCreateGroupSync = formValues.synchronizeGroups && enterpriseGroupSyncPlugin && shouldUpdateGroupSync;
-  const backendCreateNotificationSettings = {
-    notifyOnSuccess: !shouldCreateGroupSync,
-  };
+  const notifyOnSuccess = () => UserNotification.success('Authentication service was created successfully.');
+  const notifyOnError = (error) => UserNotification.error(`Creating authentication service failed with status: ${error}`);
 
-  return AuthenticationDomain.create(backendCreateNotificationSettings)(payload).then((result) => {
+  return AuthenticationActions.create(payload).then((result) => {
     if (result.backend && formValues.synchronizeGroups && enterpriseGroupSyncPlugin && shouldUpdateGroupSync) {
-      return enterpriseGroupSyncPlugin.actions.onDirectoryServiceBackendUpdate(false, formValues, result.backend.id, AUTH_BACKEND_META.serviceType);
+      return enterpriseGroupSyncPlugin.actions.onDirectoryServiceBackendUpdate(false, formValues, result.backend.id, AUTH_BACKEND_META.serviceType).then(notifyOnSuccess).catch(notifyOnError);
     }
 
+    notifyOnSuccess();
+
     return result;
-  });
+  }).catch(notifyOnError);
 };
 
 const BackendCreate = () => {

--- a/graylog2-web-interface/src/components/authentication/directoryServices/ldap/BackendCreate.jsx
+++ b/graylog2-web-interface/src/components/authentication/directoryServices/ldap/BackendCreate.jsx
@@ -74,18 +74,20 @@ export const handleSubmit = (payload: WizardSubmitPayload, formValues: WizardFor
   const notifyOnSuccess = () => UserNotification.success('Authentication service was created successfully.');
   const notifyOnError = (error) => UserNotification.error(`Creating authentication service failed with status: ${error}`);
 
+  const onError = (error) => {
+    notifyOnError(error);
+    throw error;
+  };
+
   return AuthenticationActions.create(payload).then((result) => {
     if (result.backend && formValues.synchronizeGroups && enterpriseGroupSyncPlugin && shouldUpdateGroupSync) {
-      return enterpriseGroupSyncPlugin.actions.onDirectoryServiceBackendUpdate(false, formValues, result.backend.id, AUTH_BACKEND_META.serviceType).then(notifyOnSuccess).catch(notifyOnError);
+      return enterpriseGroupSyncPlugin.actions.onDirectoryServiceBackendUpdate(false, formValues, result.backend.id, AUTH_BACKEND_META.serviceType).then(notifyOnSuccess).catch(onError);
     }
 
     notifyOnSuccess();
 
     return result;
-  }).catch((error) => {
-    notifyOnError(error);
-    throw error;
-  });
+  }).catch(onError);
 };
 
 const BackendCreate = () => {

--- a/graylog2-web-interface/src/components/authentication/directoryServices/ldap/BackendCreate.jsx
+++ b/graylog2-web-interface/src/components/authentication/directoryServices/ldap/BackendCreate.jsx
@@ -82,7 +82,10 @@ export const handleSubmit = (payload: WizardSubmitPayload, formValues: WizardFor
     notifyOnSuccess();
 
     return result;
-  }).catch(notifyOnError);
+  }).catch((error) => {
+    notifyOnError(error);
+    throw error;
+  });
 };
 
 const BackendCreate = () => {

--- a/graylog2-web-interface/src/components/authentication/directoryServices/ldap/BackendEdit.jsx
+++ b/graylog2-web-interface/src/components/authentication/directoryServices/ldap/BackendEdit.jsx
@@ -63,23 +63,21 @@ export const handleSubmit = (payload: WizardSubmitPayload, formValues: WizardFor
   const notifyOnSuccess = () => UserNotification.success('Authentication service was updated successfully.');
   const notifyOnError = (error) => UserNotification.error(`Updating authentication service failed with status: ${error}`);
 
-  const onError = (error) => {
-    notifyOnError(error);
-    throw error;
-  };
-
   return AuthenticationActions.update(backendId, {
     ...payload,
     id: backendId,
   }).then((result) => {
     if (enterpriseGroupSyncPlugin && shouldUpdateGroupSync) {
-      return enterpriseGroupSyncPlugin.actions.onDirectoryServiceBackendUpdate(backendGroupSyncIsActive, formValues, backendId, serviceType).then(notifyOnSuccess).catch(onError);
+      return enterpriseGroupSyncPlugin.actions.onDirectoryServiceBackendUpdate(backendGroupSyncIsActive, formValues, backendId, serviceType).then(notifyOnSuccess);
     }
 
     notifyOnSuccess();
 
     return result;
-  }).catch(onError);
+  }).catch((error) => {
+    notifyOnError(error);
+    throw error;
+  });
 };
 
 const BackendEdit = ({ authenticationBackend, initialStepKey }: Props) => {

--- a/graylog2-web-interface/src/components/authentication/directoryServices/ldap/BackendEdit.jsx
+++ b/graylog2-web-interface/src/components/authentication/directoryServices/ldap/BackendEdit.jsx
@@ -63,21 +63,23 @@ export const handleSubmit = (payload: WizardSubmitPayload, formValues: WizardFor
   const notifyOnSuccess = () => UserNotification.success('Authentication service was updated successfully.');
   const notifyOnError = (error) => UserNotification.error(`Updating authentication service failed with status: ${error}`);
 
+  const onError = (error) => {
+    notifyOnError(error);
+    throw error;
+  };
+
   return AuthenticationActions.update(backendId, {
     ...payload,
     id: backendId,
   }).then((result) => {
     if (enterpriseGroupSyncPlugin && shouldUpdateGroupSync) {
-      return enterpriseGroupSyncPlugin.actions.onDirectoryServiceBackendUpdate(backendGroupSyncIsActive, formValues, backendId, serviceType).then(notifyOnSuccess).catch(notifyOnError);
+      return enterpriseGroupSyncPlugin.actions.onDirectoryServiceBackendUpdate(backendGroupSyncIsActive, formValues, backendId, serviceType).then(notifyOnSuccess).catch(onError);
     }
 
     notifyOnSuccess();
 
     return result;
-  }).catch((error) => {
-    notifyOnError(error);
-    throw error;
-  });
+  }).catch(onError);
 };
 
 const BackendEdit = ({ authenticationBackend, initialStepKey }: Props) => {

--- a/graylog2-web-interface/src/components/authentication/directoryServices/ldap/BackendEdit.jsx
+++ b/graylog2-web-interface/src/components/authentication/directoryServices/ldap/BackendEdit.jsx
@@ -74,7 +74,10 @@ export const handleSubmit = (payload: WizardSubmitPayload, formValues: WizardFor
     notifyOnSuccess();
 
     return result;
-  }).catch(notifyOnError);
+  }).catch((error) => {
+    notifyOnError(error);
+    throw error;
+  });
 };
 
 const BackendEdit = ({ authenticationBackend, initialStepKey }: Props) => {

--- a/graylog2-web-interface/src/components/authentication/directoryServices/ldap/BackendEdit.jsx
+++ b/graylog2-web-interface/src/components/authentication/directoryServices/ldap/BackendEdit.jsx
@@ -60,8 +60,8 @@ const _optionalWizardProps = (initialStepKey: ?string) => {
 
 export const handleSubmit = (payload: WizardSubmitPayload, formValues: WizardFormValues, backendId: string, backendGroupSyncIsActive: boolean, serviceType: string, shouldUpdateGroupSync: ?boolean = true) => {
   const enterpriseGroupSyncPlugin = getEnterpriseGroupSyncPlugin();
-  const notifyOnSuccess = () => UserNotification.success('Authentication service was updated successfully.');
-  const notifyOnError = (error) => UserNotification.error(`Updating authentication service failed with status: ${error}`);
+  const notifyOnSuccess = () => UserNotification.success('Authentication service was updated successfully.', 'Success');
+  const notifyOnError = (error) => UserNotification.error(`Updating authentication service failed with status: ${error}`, 'Error');
 
   return AuthenticationActions.update(backendId, {
     ...payload,

--- a/graylog2-web-interface/src/domainActions/authentication/AuthenticationDomain.js
+++ b/graylog2-web-interface/src/domainActions/authentication/AuthenticationDomain.js
@@ -4,13 +4,11 @@ import { AuthenticationActions } from 'stores/authentication/AuthenticationStore
 
 import notifyingAction from '../notifyingAction';
 
-type OverrideSettings = { notifyOnSuccess: boolean };
-
-const create = ({ notifyOnSuccess }: OverrideSettings = { notifyOnSuccess: true }): $PropertyType<ActionsType, 'create'> => notifyingAction({
+const create: $PropertyType<ActionsType, 'create'> = notifyingAction({
   action: AuthenticationActions.create,
-  success: notifyOnSuccess ? (authBackend) => ({
+  success: (authBackend) => ({
     message: `Authentication service "${authBackend.title} was created successfully`,
-  }) : undefined,
+  }),
   error: (error, authBackend) => ({
     message: `Creating authentication service "${authBackend.title}" failed with status: ${error}`,
   }),
@@ -31,21 +29,21 @@ const loadActive: $PropertyType<ActionsType, 'loadActive'> = notifyingAction({
   }),
 });
 
-const update = ({ notifyOnSuccess }: OverrideSettings = { notifyOnSuccess: true }): $PropertyType<ActionsType, 'update'> => notifyingAction({
+const update: $PropertyType<ActionsType, 'update'> = notifyingAction({
   action: AuthenticationActions.update,
-  success: notifyOnSuccess ? (authBackendId, authBackend) => ({
+  success: (authBackendId, authBackend) => ({
     message: `Authentication service "${authBackend.title} was updated successfully`,
-  }) : undefined,
+  }),
   error: (error, authBackendId, authBackend) => ({
     message: `Updating authentication service "${authBackend.title}" failed with status: ${error}`,
   }),
 });
 
-const deleteBackend = ({ notifyOnSuccess }: OverrideSettings = { notifyOnSuccess: true }): $PropertyType<ActionsType, 'delete'> => notifyingAction({
+const deleteBackend: $PropertyType<ActionsType, 'delete'> = notifyingAction({
   action: AuthenticationActions.delete,
-  success: notifyOnSuccess ? (authBackendId, authBackendTitle) => ({
+  success: (authBackendId, authBackendTitle) => ({
     message: `Authentication service "${authBackendTitle} was deleted successfully`,
-  }) : undefined,
+  }),
   error: (error, authBackendId, authBackendTitle) => ({
     message: `Deleting authentication service "${authBackendTitle}" failed with status: ${error}`,
   }),


### PR DESCRIPTION
## Description
Previously, we've implemented closures for some authentication domain actions, to be able to control the notification, when updating and creating an authentication service. This was necessary because there are cases were we do not want to trigger a notification.
```
AuthenticationDomain.create(backendCreateNotificationSettings)(payload);
```
This is an unusual usage which can be confusing, we now call the authentication actions directly and tigger the user notification inside the create and update component.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
