### PR TITLE
Fix Input error color for Inputs which use the help prop to display errors

### DIFF
--- a/graylog2-web-interface/src/components/common/InputDescription.jsx
+++ b/graylog2-web-interface/src/components/common/InputDescription.jsx
@@ -9,10 +9,6 @@ const ErrorMessage = styled.span(({ theme }) => `
   color: ${theme.colors.variant.danger};
 `);
 
-const HelpMessage = styled.span(({ theme }) => `
-  color: ${theme.colors.gray[50]};
-`);
-
 type Props = {
   help?: React.Node,
   error?: React.Node,
@@ -36,9 +32,9 @@ const InputDescription = ({ help, error }: Props) => {
       )}
       {(!!error && !!help) && <br />}
       {help && (
-        <HelpMessage>
+        <HelpBlock>
           {help}
-        </HelpMessage>
+        </HelpBlock>
       )}
     </HelpBlock>
   );

--- a/graylog2-web-interface/src/components/common/InputDescription.jsx
+++ b/graylog2-web-interface/src/components/common/InputDescription.jsx
@@ -32,9 +32,9 @@ const InputDescription = ({ help, error }: Props) => {
       )}
       {(!!error && !!help) && <br />}
       {help && (
-        <HelpBlock>
+        <span>
           {help}
-        </HelpBlock>
+        </span>
       )}
     </HelpBlock>
   );


### PR DESCRIPTION
## Description
With https://github.com/Graylog2/graylog2-server/pull/9059 we've added the `error` prop for our `Input` component, to be able to display errors next to the help text.

With these changes we've defined a color for help text, to ensure the color does not change when the related `Input` has the prop `bsStyle="error"`.

A side effect is that errors of `Input`'s which still use `help` prop, do not have the correct color:
![image](https://user-images.githubusercontent.com/46300478/98224905-580ea200-1f54-11eb-964c-e33353f92f8f.png)

With this PR we are removing this styling change. 
This also means `Input`'s which already use the new error prop will look like this: 
![image](https://user-images.githubusercontent.com/46300478/98225178-b0de3a80-1f54-11eb-95c7-7a5186b96da3.png)
(The help text has the error color when an error occurs)

But this is still a better solution than the alternative in terms of usability. I had a look at the cases where we use the `help` prop to display an error, but it is not a suitable solution to adjust all these cases right now.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

/jenkins-pr-deps Graylog2/graylog-plugin-enterprise#1914