### PR TITLE
Change RolesSelector button type from submit to button 

### DIFF
--- a/graylog2-web-interface/src/components/permissions/RolesSelector.jsx
+++ b/graylog2-web-interface/src/components/permissions/RolesSelector.jsx
@@ -105,7 +105,7 @@ const RolesSelector = ({ assignedRolesIds, onSubmit, identifier }: Props) => {
                       onClick={_onSubmit}
                       disabled={isSubmitting || !selectedRoleName}
                       title="Assign Role"
-                      type="submit">
+                      type="button">
           Assign Role
         </SubmitButton>
       </FormElements>


### PR DESCRIPTION
## Description
The `RolesSelector` previously contained a form and still has a button with `type="submit"`. Because of this type the user and team create form, which use the `RolesSelector`, currently do not submit on enter.

This PR changes the `RolesSelector` button type to `button`.

Fixes: https://github.com/Graylog2/graylog-plugin-enterprise/issues/1911

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)