### PR TITLE
Revert "Fix read handling of corrupted journal segments"

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/shared/journal/KafkaJournal.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/journal/KafkaJournal.java
@@ -564,55 +564,9 @@ public class KafkaJournal extends AbstractIdleService implements Journal {
 
     @Override
     public List<JournalReadEntry> read(long requestedMaximumCount) {
-        return readNext(nextReadOffset, requestedMaximumCount);
+        return read(nextReadOffset, requestedMaximumCount);
     }
 
-    /**
-     * Read next messages from the journal, starting at the given offset. If the underlying journal implementation
-     * returns an empty list of entries, but we know there are more entries in the journal, we'll try to skip the
-     * problematic offset(s) until we find entries again.
-     *
-     * @param startOffset Offset to start reading at
-     * @param requestedMaximumCount Maximum number of entries to return.
-     * @return A list of entries
-     */
-    public List<JournalReadEntry> readNext(long startOffset, long requestedMaximumCount) {
-        List<JournalReadEntry> messages = read(startOffset, requestedMaximumCount);
-
-        if (messages.isEmpty()) {
-            // If we got an empty result BUT we know that there are more messages in the log, we bump the readOffset
-            // by 1 and try to read again. We continue until we either get an non-empty result or we reached the
-            // end of the log.
-            // This can happen when a log segment is truncated at the end but later segments have valid messages again.
-            long failedReadOffset = startOffset;
-            long retryReadOffset = failedReadOffset + 1;
-
-            while (messages.isEmpty() && failedReadOffset < (getLogEndOffset() - 1)) {
-                LOG.warn(
-                        "Couldn't read any messages from offset <{}> but journal has more messages. Skipping and " +
-                                "trying to read from offset <{}>",
-                        failedReadOffset, retryReadOffset);
-
-                // Retry the read with an increased offset to skip corrupt segments
-                messages = read(retryReadOffset, requestedMaximumCount);
-
-                // Bump offsets in case we still read an empty result
-                failedReadOffset++;
-                retryReadOffset++;
-            }
-        }
-
-        return messages;
-    }
-
-    /**
-     * Read from the journal, starting at the given offset. If the underlying journal implementation returns an empty
-     * list of entries, it will be returned even if we know there are more entries in the journal.
-     *
-     * @param readOffset Offset to start reading at
-     * @param requestedMaximumCount Maximum number of entries to return.
-     * @return A list of entries
-     */
     public List<JournalReadEntry> read(long readOffset, long requestedMaximumCount) {
         // Always read at least one!
         final long maximumCount = Math.max(1, requestedMaximumCount);

--- a/graylog2-server/src/test/java/org/graylog2/shared/journal/KafkaJournalTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/shared/journal/KafkaJournalTest.java
@@ -47,13 +47,9 @@ import org.mockito.junit.MockitoRule;
 
 import java.io.File;
 import java.io.FileFilter;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.nio.channels.FileChannel;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.UUID;
@@ -495,40 +491,5 @@ public class KafkaJournalTest {
         journal.flushDirtyLogs();
         journal.cleanupLogs();
         assertThat(serverStatus.getLifecycle()).isEqualTo(Lifecycle.RUNNING);
-    }
-
-    @Test
-    public void truncatedSegment() throws Exception {
-        final Size segmentSize = Size.kilobytes(1L);
-        final KafkaJournal journal = new KafkaJournal(journalDirectory.toPath(),
-                scheduler,
-                segmentSize,
-                Duration.standardHours(1),
-                Size.kilobytes(10L),
-                Duration.standardDays(1),
-                1_000_000,
-                Duration.standardMinutes(1),
-                100,
-                new MetricRegistry(),
-                serverStatus);
-
-        // this will create two segments, each containing 25 messages
-        createBulkChunks(journal, segmentSize, 2);
-
-        final Path firstSegmentPath =
-                Paths.get(journalDirectory.getAbsolutePath(), "messagejournal-0", "00000000000000000000.log");
-
-        assertThat(firstSegmentPath).isRegularFile();
-
-        // truncate the first segment so that the last message is cut off
-        final File firstSegment = firstSegmentPath.toFile();
-        try (FileChannel channel = new FileOutputStream(firstSegment, true).getChannel()) {
-            channel.truncate(firstSegment.length() - 1);
-        }
-
-        final List<Journal.JournalReadEntry> entriesFromFirstSegment = journal.read(25);
-        assertThat(entriesFromFirstSegment).hasSize(24);
-        final List<Journal.JournalReadEntry> entriesFromSecondSegment = journal.read(25);
-        assertThat(entriesFromSecondSegment).hasSize(25);
     }
 }


### PR DESCRIPTION
We noticed a race condition during testing on a live setup. Reverting until it's been fixed.

Reverts Graylog2/graylog2-server#9306