### PR TITLE
Fix view type detection for user permission migration

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/migrations/V20200803120800_GrantsMigrations/GrantsMetaMigration.java
+++ b/graylog2-server/src/main/java/org/graylog2/migrations/V20200803120800_GrantsMigrations/GrantsMetaMigration.java
@@ -45,7 +45,6 @@ import java.util.Set;
 
 import static org.graylog.grn.GRNTypes.DASHBOARD;
 import static org.graylog.grn.GRNTypes.EVENT_DEFINITION;
-import static org.graylog.grn.GRNTypes.SEARCH;
 import static org.graylog.grn.GRNTypes.STREAM;
 import static org.graylog.plugins.views.search.rest.ViewsRestPermissions.VIEW_EDIT;
 import static org.graylog.plugins.views.search.rest.ViewsRestPermissions.VIEW_READ;
@@ -96,8 +95,8 @@ public class GrantsMetaMigration extends Migration {
             .put(ImmutableSet.of(DASHBOARDS_READ), new GRNTypeCapability(DASHBOARD, Capability.VIEW))
             .put(ImmutableSet.of(STREAMS_READ, STREAMS_EDIT), new GRNTypeCapability(STREAM, Capability.MANAGE))
             .put(ImmutableSet.of(STREAMS_READ), new GRNTypeCapability(STREAM, Capability.VIEW))
-            .put(ImmutableSet.of(VIEW_READ, VIEW_EDIT), new GRNTypeCapability(SEARCH, Capability.MANAGE))
-            .put(ImmutableSet.of(VIEW_READ), new GRNTypeCapability(SEARCH, Capability.VIEW))
+            .put(ImmutableSet.of(VIEW_READ, VIEW_EDIT), new GRNTypeCapability(null, Capability.MANAGE))
+            .put(ImmutableSet.of(VIEW_READ), new GRNTypeCapability(null, Capability.VIEW))
             .put(ImmutableSet.of(EVENT_DEFINITIONS_READ, EVENT_DEFINITIONS_EDIT), new GRNTypeCapability(EVENT_DEFINITION, Capability.MANAGE))
             .put(ImmutableSet.of(EVENT_DEFINITIONS_READ), new GRNTypeCapability(EVENT_DEFINITION, Capability.VIEW))
             .build();
@@ -112,7 +111,7 @@ public class GrantsMetaMigration extends Migration {
         new ViewSharingToGrantsMigration(mongoConnection, dbGrantService, userService, roleService, rootUsername, viewService, grnRegistry).upgrade();
         new RolesToGrantsMigration(roleService, userService, dbGrantService, grnRegistry, rootUsername).upgrade();
         new ViewOwnerShipToGrantsMigration(userService, dbGrantService, rootUsername, viewService, grnRegistry).upgrade();
-        new UserPermissionsToGrantsMigration(userService, dbGrantService, grnRegistry, rootUsername).upgrade();
+        new UserPermissionsToGrantsMigration(userService, dbGrantService, grnRegistry, viewService, rootUsername).upgrade();
 
         this.clusterConfigService.write(MigrationCompleted.create());
     }

--- a/graylog2-server/src/test/java/org/graylog2/migrations/V20200803120800_GrantsMigrations/UserPermissionsToGrantsMigrationTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/migrations/V20200803120800_GrantsMigrations/UserPermissionsToGrantsMigrationTest.java
@@ -18,6 +18,8 @@ package org.graylog2.migrations.V20200803120800_GrantsMigrations;
 
 import com.google.common.collect.ImmutableSet;
 import org.graylog.grn.GRNRegistry;
+import org.graylog.plugins.views.search.views.ViewDTO;
+import org.graylog.plugins.views.search.views.ViewService;
 import org.graylog.security.Capability;
 import org.graylog.security.DBGrantService;
 import org.graylog.security.GrantDTO;
@@ -35,11 +37,15 @@ import org.graylog2.shared.users.UserService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Optional;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MongoDBExtension.class)
 @ExtendWith(MongoJackExtension.class)
@@ -53,30 +59,40 @@ class UserPermissionsToGrantsMigrationTest {
     private GRNRegistry grnRegistry;
     private UserService userService;
     private int userSelfEditPermissionCount;
+    private ViewService viewService;
 
     @BeforeEach
     void setUp(MongoDBTestService mongodb,
                MongoJackObjectMapperProvider mongoJackObjectMapperProvider,
                GRNRegistry grnRegistry,
-               TestUserService userService) {
+               TestUserService userService,
+               @Mock ViewService viewService) {
 
         this.grnRegistry = grnRegistry;
+        this.viewService = viewService;
 
         this.userSelfEditPermissionCount = new Permissions(ImmutableSet.of()).userSelfEditPermissions("dummy").size();
 
         dbGrantService = new DBGrantService(mongodb.mongoConnection(), mongoJackObjectMapperProvider, grnRegistry);
         this.userService = userService;
         DBGrantService dbGrantService = new DBGrantService(mongodb.mongoConnection(), mongoJackObjectMapperProvider, grnRegistry);
-        migration = new UserPermissionsToGrantsMigration(userService, dbGrantService, grnRegistry, "admin");
+        migration = new UserPermissionsToGrantsMigration(userService, dbGrantService, grnRegistry, viewService, "admin");
     }
 
     @Test
     void migrateAllUserPermissions() {
+        final ViewDTO view1 = mock(ViewDTO.class);
+        final ViewDTO view2 = mock(ViewDTO.class);
+
+        when(view1.type()).thenReturn(ViewDTO.Type.DASHBOARD);
+        when(view2.type()).thenReturn(ViewDTO.Type.SEARCH);
+        when(viewService.get("5c40ad603c034441a56943be")).thenReturn(Optional.of(view1));
+        when(viewService.get("5c40ad603c034441a56943c0")).thenReturn(Optional.of(view2));
 
         User testuser1 = userService.load("testuser1");
         assertThat(testuser1).isNotNull();
 
-        assertThat(testuser1.getPermissions().size()).isEqualTo(10 + userSelfEditPermissionCount);
+        assertThat(testuser1.getPermissions().size()).isEqualTo(11 + userSelfEditPermissionCount);
         assertThat(dbGrantService.getForGranteesOrGlobal(ImmutableSet.of(grnRegistry.ofUser(testuser1)))).isEmpty();
 
         migration.upgrade();
@@ -87,10 +103,11 @@ class UserPermissionsToGrantsMigrationTest {
         assertGrantInSet(grants, "grn::::dashboard:5e2afc66cd19517ec2dabadf", Capability.MANAGE);
         assertGrantInSet(grants, "grn::::stream:5c40ad603c034441a56942bd", Capability.VIEW);
         assertGrantInSet(grants, "grn::::stream:5e2f5cfb4868e67ad4da562d", Capability.VIEW);
-        assertGrantInSet(grants, "grn::::search:5c40ad603c034441a56942be", Capability.MANAGE);
+        assertGrantInSet(grants, "grn::::dashboard:5c40ad603c034441a56943be", Capability.MANAGE);
+        assertGrantInSet(grants, "grn::::search:5c40ad603c034441a56943c0", Capability.VIEW);
         assertGrantInSet(grants, "grn::::event_definition:5c40ad603c034441a56942bf", Capability.MANAGE);
         assertGrantInSet(grants, "grn::::event_definition:5c40ad603c034441a56942c0", Capability.VIEW);
-        assertThat(grants.size()).isEqualTo(7);
+        assertThat(grants.size()).isEqualTo(8);
 
         // reload user and check that all migrated permissions have been removed
         testuser1 = userService.load("testuser1");

--- a/graylog2-server/src/test/resources/org/graylog2/migrations/V20200803120800_GrantsMigrations/MigrateUserPermissionsToGrantsTest.json
+++ b/graylog2-server/src/test/resources/org/graylog2/migrations/V20200803120800_GrantsMigrations/MigrateUserPermissionsToGrantsTest.json
@@ -14,8 +14,9 @@
         "dashboards:edit:5e2afc66cd19517ec2dabadf",
         "streams:read:5c40ad603c034441a56942bd",
         "streams:read:5e2f5cfb4868e67ad4da562d",
-        "view:read:5c40ad603c034441a56942be",
-        "view:edit:5c40ad603c034441a56942be",
+        "view:read:5c40ad603c034441a56943be",
+        "view:edit:5c40ad603c034441a56943be",
+        "view:read:5c40ad603c034441a56943c0",
         "eventdefinitions:edit:5c40ad603c034441a56942bf",
         "eventdefinitions:read:5c40ad603c034441a56942bf",
         "eventdefinitions:read:5c40ad603c034441a56942c0"

--- a/graylog2-server/src/test/resources/org/graylog2/migrations/V20200803120800_GrantsMigrations/MigrateUserPermissionsToGrantsTest.json
+++ b/graylog2-server/src/test/resources/org/graylog2/migrations/V20200803120800_GrantsMigrations/MigrateUserPermissionsToGrantsTest.json
@@ -13,7 +13,12 @@
         "dashboards:read:5e2afc66cd19517ec2dabadf",
         "dashboards:edit:5e2afc66cd19517ec2dabadf",
         "streams:read:5c40ad603c034441a56942bd",
-        "streams:read:5e2f5cfb4868e67ad4da562d"
+        "streams:read:5e2f5cfb4868e67ad4da562d",
+        "view:read:5c40ad603c034441a56942be",
+        "view:edit:5c40ad603c034441a56942be",
+        "eventdefinitions:edit:5c40ad603c034441a56942bf",
+        "eventdefinitions:read:5c40ad603c034441a56942bf",
+        "eventdefinitions:read:5c40ad603c034441a56942c0"
       ],
       "timezone" : "UTC",
       "roles" : [


### PR DESCRIPTION
Previously we created "search" grants for view permissions in users.
This was not correct because a view can also be a dashboard.

The migration is now lookin up the view in the database and creates a
grant based on the view type.

Fixes #9376