### PR TITLE
Display explanation for share button why unsaved searches and dashboards can not be shared

### DIFF
--- a/graylog2-web-interface/src/components/common/ShareButton.jsx
+++ b/graylog2-web-interface/src/components/common/ShareButton.jsx
@@ -7,18 +7,22 @@ import HasOwnership from 'components/common/HasOwnership';
 import Icon from 'components/common/Icon';
 
 type Props = {
-  disabled?: boolean,
+  /**
+   * When a custom description is provided
+   * the button will be disabled
+   */
+  disabledInfo?: string,
   entityId: string,
   entityType: string,
   onClick: () => void,
   bsStyle?: string,
 };
 
-const ShareButton = ({ bsStyle, entityId, entityType, onClick, disabled }: Props) => (
+const ShareButton = ({ bsStyle, entityId, entityType, onClick, disabledInfo }: Props) => (
   <HasOwnership id={entityId} type={entityType}>
     {({ disabled: hasMissingPermissions }) => (
-      <Button bsStyle={bsStyle} onClick={onClick} disabled={disabled || hasMissingPermissions} title="Share">
-        <Icon name="user-plus" /> Share {(!disabled && hasMissingPermissions) && <SharingDisabledPopover type={entityType} />}
+      <Button bsStyle={bsStyle} onClick={onClick} disabled={!!disabledInfo || hasMissingPermissions} title="Share">
+        <Icon name="user-plus" /> Share {(!!disabledInfo || hasMissingPermissions) && <SharingDisabledPopover type={entityType} description={disabledInfo} />}
       </Button>
     )}
   </HasOwnership>
@@ -26,7 +30,7 @@ const ShareButton = ({ bsStyle, entityId, entityType, onClick, disabled }: Props
 
 ShareButton.defaultProps = {
   bsStyle: 'info',
-  disabled: false,
+  disabledInfo: undefined,
 };
 
 export default ShareButton;

--- a/graylog2-web-interface/src/components/common/ShareButton.test.jsx
+++ b/graylog2-web-interface/src/components/common/ShareButton.test.jsx
@@ -38,9 +38,9 @@ describe('<ShareButton />', () => {
     expect(onClickStub).not.toHaveBeenCalled();
   });
 
-  it('should not be clickable if button is disabled', async () => {
+  it('should not be clickable if disabledInfo is provided', async () => {
     const onClickStub = jest.fn();
-    render(<SimpleShareButton onClick={onClickStub} grnPermissions={[`entity:own:${entityGRN}`]} disabled />);
+    render(<SimpleShareButton onClick={onClickStub} grnPermissions={[`entity:own:${entityGRN}`]} disabledInfo="Only saved entities can be shared" />);
 
     const button = screen.getByRole('button', { name: /Share/ });
     fireEvent.click(button);

--- a/graylog2-web-interface/src/components/permissions/SharingDisabledPopover.jsx
+++ b/graylog2-web-interface/src/components/permissions/SharingDisabledPopover.jsx
@@ -7,16 +7,21 @@ import HoverForHelp from 'components/common/HoverForHelp';
 
 type Props = {
   type: string,
+  description?: string,
 };
 
 const StyledHoverForHelp: StyledComponent<{}, ThemeInterface, typeof HoverForHelp> = styled(HoverForHelp)`
   margin-left: 8px;
 `;
 
-const SharingDisabledPopover = ({ type }: Props) => (
+const SharingDisabledPopover = ({ type, description }: Props) => (
   <StyledHoverForHelp title="Sharing not possible" pullRight={false}>
-    Only owners of this {type} are allowed to share it.
+    {description || `Only owners of this ${type} are allowed to share it.`}
   </StyledHoverForHelp>
 );
+
+SharingDisabledPopover.defaultProps = {
+  description: undefined,
+};
 
 export default SharingDisabledPopover;

--- a/graylog2-web-interface/src/views/components/ViewActionsMenu.jsx
+++ b/graylog2-web-interface/src/views/components/ViewActionsMenu.jsx
@@ -66,7 +66,7 @@ const ViewActionsMenu = ({ view, isNewView, metadata }) => {
                    entityId={view.id}
                    onClick={() => setShareViewOpen(true)}
                    bsStyle="default"
-                   disabled={isNewView || !allowedToEdit} />
+                   disabledInfo={isNewView && 'Only saved dashboards can be shared.'} />
       <DropdownButton title={<Icon name="ellipsis-h" />} id="query-tab-actions-dropdown" pullRight noCaret>
         <MenuItem onSelect={() => setEditViewOpen(true)} disabled={isNewView || !allowedToEdit}>
           <Icon name="edit" /> Edit metadata

--- a/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchControls.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchControls.jsx
@@ -253,7 +253,7 @@ class SavedSearchControls extends React.Component<Props, State> {
                                  entityId={view.id}
                                  onClick={this.toggleShareSearch}
                                  bsStyle="default"
-                                 disabled={!isAllowedToEdit} />
+                                 disabledInfo={!view.id && 'Only saved searches can be shared.'} />
                     <DropdownButton title={<Icon name="ellipsis-h" />} id="search-actions-dropdown" pullRight noCaret>
                       <MenuItem onSelect={this.toggleMetadataEdit} disabled={!isAllowedToEdit}>
                         <Icon name="edit" /> Edit metadata

--- a/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchControls.test.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchControls.test.jsx
@@ -94,7 +94,13 @@ describe('SavedSearchControls', () => {
       });
 
       it('which should be disabled if current user is neither owner nor permitted to edit search', () => {
-        const wrapper = mount(<SimpleSavedSearchControls viewStoreState={createViewStoreState(false, 'some-id')} />);
+        const notOwningUser = {
+          ...viewsManager,
+          username: 'notOwningUser',
+          permissions: [],
+          grn_permissions: [],
+        };
+        const wrapper = mount(<SimpleSavedSearchControls currentUser={notOwningUser} viewStoreState={createViewStoreState(false, 'some-id')} />);
 
         const shareSearch = wrapper.find('button[title="Share"]');
 

--- a/graylog2-web-interface/src/views/components/searchbar/saved-search/__snapshots__/SavedSearchControls.test.jsx.snap
+++ b/graylog2-web-interface/src/views/components/searchbar/saved-search/__snapshots__/SavedSearchControls.test.jsx.snap
@@ -281,6 +281,10 @@ exports[`SavedSearchControls Button handling has "Share" option which should be 
   color: rgb(88,73,5);
 }
 
+.c1 {
+  margin-left: 8px;
+}
+
 <button
   className="c0 btn btn-default"
   disabled={true}
@@ -306,5 +310,70 @@ exports[`SavedSearchControls Button handling has "Share" option which should be 
     </FontAwesomeIcon>
   </Icon>
    Share 
+  <SharingDisabledPopover
+    description="Only saved searches can be shared."
+    type="search"
+  >
+    <SharingDisabledPopover__StyledHoverForHelp
+      pullRight={false}
+      title="Sharing not possible"
+    >
+      <HoverForHelp
+        className="c1"
+        id="help-popover"
+        pullRight={false}
+        title="Sharing not possible"
+      >
+        <OverlayTrigger
+          defaultOverlayShown={false}
+          overlay={
+            <Popover
+              id="help-popover"
+              title="Sharing not possible"
+            >
+              Only saved searches can be shared.
+            </Popover>
+          }
+          placement="bottom"
+          trigger={
+            Array [
+              "hover",
+              "focus",
+            ]
+          }
+        >
+          <Icon
+            className="c1 "
+            name="question-circle"
+            onBlur={[Function]}
+            onClick={null}
+            onFocus={[Function]}
+            onMouseOut={[Function]}
+            onMouseOver={[Function]}
+            type="solid"
+          >
+            <FontAwesomeIcon
+              className="c1 "
+              icon={
+                Object {
+                  "iconName": "question-circle",
+                  "prefix": "fas",
+                }
+              }
+              onBlur={[Function]}
+              onClick={null}
+              onFocus={[Function]}
+              onMouseOut={[Function]}
+              onMouseOver={[Function]}
+            >
+              <svg
+                className="svg-inline--fa fa-question-circle"
+              />
+            </FontAwesomeIcon>
+          </Icon>
+        </OverlayTrigger>
+      </HoverForHelp>
+    </SharingDisabledPopover__StyledHoverForHelp>
+  </SharingDisabledPopover>
 </button>
 `;


### PR DESCRIPTION
## Description
As described in https://github.com/Graylog2/graylog2-server/issues/9382 an unsaved search cannot be shared and there is no explanation why it cannot be shared. With this PR we are showing an explanation, that a search / dashboards needs to be saved first.