### PR TITLE
We put new selections to the top of selected grantees

### DIFF
--- a/graylog2-web-interface/src/logic/permissions/EntityShareState.fixtures.json
+++ b/graylog2-web-interface/src/logic/permissions/EntityShareState.fixtures.json
@@ -42,6 +42,11 @@
       "grant": "grn::::grant:5ee2393bb3ceb9225f056efe",
       "grantee": "grn::::user:john",
       "capability": "grn::::capability:54e3deadbeefdeadbeef0002"
+    },
+    {
+      "grant": "grn::::grant:5ee2393bb3ceb9225f056fef",
+      "grantee": "grn::::user:jane",
+      "capability": "grn::::capability:54e3deadbeefdeadbeef0002"
     }
   ],
   "selected_grantee_capabilities": {

--- a/graylog2-web-interface/src/logic/permissions/EntityShareState.js
+++ b/graylog2-web-interface/src/logic/permissions/EntityShareState.js
@@ -42,7 +42,8 @@ const _sortAndOrderGrantees = <T: GranteeInterface>(grantees: Immutable.List<T>,
     .sort((granteeA, granteeB) => defaultCompare(granteeA.title, granteeB.title))
     .groupBy((grantee) => grantee.type);
   const newGrantees = grantees
-    .filter((grantee) => activeShares && activeShares.findIndex((activeShare) => activeShare.grantee === grantee.id) === -1);
+    .filter((grantee) => activeShares && activeShares.findIndex((activeShare) => activeShare.grantee === grantee.id) === -1)
+    .reverse();
 
   return Immutable.List().concat(
     newGrantees,

--- a/graylog2-web-interface/src/logic/permissions/EntityShareState.test.js
+++ b/graylog2-web-interface/src/logic/permissions/EntityShareState.test.js
@@ -119,5 +119,52 @@ describe('EntityShareState', () => {
       expect(third.title).toBe('Jane Doe');
       expect(forth.title).toBe('John Wick');
     });
+
+    it('should put new selections to the beginning', () => {
+      const janeIsOwner = ActiveShare
+        .builder()
+        .grant('grant-jane-id')
+        .grantee(jane.id)
+        .capability(owner.id)
+        .build();
+      const aliceIsOwner = ActiveShare
+        .builder()
+        .grant('grant-jane-id')
+        .grantee(alice.id)
+        .capability(owner.id)
+        .build();
+      const bobIsViewer = ActiveShare
+        .builder()
+        .grant('grant-bob-id')
+        .grantee(bob.id)
+        .capability(viewer.id)
+        .build();
+      const newSelection = ActiveShare
+        .builder()
+        .grant('grant-john-id')
+        .grantee(john.id)
+        .capability(manager.id)
+        .build();
+      const activeShares = Immutable.List([janeIsOwner, aliceIsOwner, bobIsViewer]);
+
+      const selection = Immutable.Map({
+        [janeIsOwner.grantee]: janeIsOwner.capability,
+        [aliceIsOwner.grantee]: aliceIsOwner.capability,
+        [bobIsViewer.grantee]: bobIsViewer.capability,
+        [newSelection.grantee]: newSelection.capability,
+      });
+
+      const { selectedGrantees } = entityShareStateFixture.toBuilder()
+        .activeShares(activeShares)
+        .selectedGranteeCapabilities(selection)
+        .build();
+
+      const [first, second, third, forth] = selectedGrantees.toArray();
+
+      expect(first.title).toBe('John Wick');
+      expect(second.title).toBe('Alice Muad\'Dib');
+      expect(third.title).toBe('Bob Bobson');
+      expect(forth.title).toBe('Jane Doe');
+    });
   });
 });

--- a/graylog2-web-interface/src/logic/permissions/__snapshots__/EntityShareState.test.js.snap
+++ b/graylog2-web-interface/src/logic/permissions/__snapshots__/EntityShareState.test.js.snap
@@ -8,6 +8,11 @@ Object {
       "grant": "grn::::grant:5ee2393bb3ceb9225f056efe",
       "grantee": "grn::::user:john",
     },
+    Object {
+      "capability": "grn::::capability:54e3deadbeefdeadbeef0002",
+      "grant": "grn::::grant:5ee2393bb3ceb9225f056fef",
+      "grantee": "grn::::user:jane",
+    },
   ],
   "available_capabilities": Array [
     Object {


### PR DESCRIPTION
## Motivation
Prior to this change, if a share dialog has a lot of selected grantees
the pagination is shown. With the current ordering new entries to the
selection could be displayed somewhere in the pagination and a user
would not see that he had selected a new entry.

## Description
This change will put the new grantees to the beginning of the entity
share modal.

Fixes #8765 
