### PR TITLE
Consistently Load the Proper Theme

### DIFF
--- a/graylog2-web-interface/src/components/graylog/Popover.jsx
+++ b/graylog2-web-interface/src/components/graylog/Popover.jsx
@@ -1,9 +1,9 @@
-import React, { useContext } from 'react';
+import React from 'react';
 // eslint-disable-next-line no-restricted-imports
 import { Popover as BootstrapPopover } from 'react-bootstrap';
-import styled, { css, ThemeContext } from 'styled-components';
+import styled, { css } from 'styled-components';
 
-import GraylogThemeProvider from 'theme/GraylogThemeProvider';
+import ThemeAndUserProvider from 'contexts/ThemeAndUserProvider';
 
 const StyledPopover = styled(BootstrapPopover)(({ theme }) => {
   const borderColor = theme.colors.variant.light.default;
@@ -24,7 +24,7 @@ const StyledPopover = styled(BootstrapPopover)(({ theme }) => {
     &.top {
       > .arrow {
         border-top-color: ${borderColor};
-  
+
         &::after {
           border-top-color: ${backgroundColor};
         }
@@ -34,7 +34,7 @@ const StyledPopover = styled(BootstrapPopover)(({ theme }) => {
     &.right {
       > .arrow {
         border-right-color: ${borderColor};
-  
+
         &::after {
           border-right-color: ${backgroundColor};
           z-index: 1;
@@ -45,7 +45,7 @@ const StyledPopover = styled(BootstrapPopover)(({ theme }) => {
     &.bottom {
       > .arrow {
         border-bottom-color: ${borderColor};
-  
+
         &::after {
           border-bottom-color: ${arrowColor};
         }
@@ -55,7 +55,7 @@ const StyledPopover = styled(BootstrapPopover)(({ theme }) => {
     &.left {
       > .arrow {
         border-left-color: ${borderColor};
-  
+
         &::after {
           border-left-color: ${backgroundColor};
         }
@@ -65,12 +65,10 @@ const StyledPopover = styled(BootstrapPopover)(({ theme }) => {
 });
 
 const Popover = (props) => {
-  const theme = useContext(ThemeContext);
-
   return (
-    <GraylogThemeProvider overrideMode={theme?.mode}>
+    <ThemeAndUserProvider>
       <StyledPopover {...props} />
-    </GraylogThemeProvider>
+    </ThemeAndUserProvider>
   );
 };
 

--- a/graylog2-web-interface/src/components/graylog/Tooltip.jsx
+++ b/graylog2-web-interface/src/components/graylog/Tooltip.jsx
@@ -1,10 +1,10 @@
-import React, { useContext } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 // eslint-disable-next-line no-restricted-imports
 import { Tooltip as BootstrapTooltip } from 'react-bootstrap';
-import styled, { css, ThemeContext } from 'styled-components';
+import styled, { css } from 'styled-components';
 
-import GraylogThemeProvider from 'theme/GraylogThemeProvider';
+import ThemeAndUserProvider from 'contexts/ThemeAndUserProvider';
 
 const arrowSize = 10;
 const StyledTooltip = styled(BootstrapTooltip)(({ theme }) => css`
@@ -66,10 +66,8 @@ const StyledTooltip = styled(BootstrapTooltip)(({ theme }) => css`
 `);
 
 const Tooltip = ({ children, className, id, placement, positionTop, positionLeft, arrowOffsetTop, arrowOffsetLeft }) => {
-  const theme = useContext(ThemeContext);
-
   return (
-    <GraylogThemeProvider overrideMode={theme?.mode}>
+    <ThemeAndUserProvider>
       <StyledTooltip className={className}
                      id={id}
                      placement={placement}
@@ -79,7 +77,7 @@ const Tooltip = ({ children, className, id, placement, positionTop, positionLeft
                      arrowOffsetLeft={arrowOffsetLeft}>
         {children}
       </StyledTooltip>
-    </GraylogThemeProvider>
+    </ThemeAndUserProvider>
   );
 };
 

--- a/graylog2-web-interface/src/contexts/CurrentUserPreferencesProvider.jsx
+++ b/graylog2-web-interface/src/contexts/CurrentUserPreferencesProvider.jsx
@@ -1,25 +1,23 @@
 // @flow strict
 import * as React from 'react';
+import { useContext } from 'react';
 import PropTypes from 'prop-types';
 
 import UserPreferencesContext from './UserPreferencesContext';
 import CurrentUserContext from './CurrentUserContext';
 
-const CurrentUserPreferencesProvider = ({ children }: { children: React.Node }) => (
-  <CurrentUserContext.Consumer>
-    {(currentUser) => {
-      const preferences = currentUser?.preferences;
+const CurrentUserPreferencesProvider = ({ children }: { children: React.Node }) => {
+  const currentUser = useContext(CurrentUserContext);
+  const preferences = currentUser?.preferences;
 
-      return preferences
-        ? (
-          <UserPreferencesContext.Provider value={preferences}>
-            {children}
-          </UserPreferencesContext.Provider>
-        )
-        : children;
-    }}
-  </CurrentUserContext.Consumer>
-);
+  return preferences
+    ? (
+      <UserPreferencesContext.Provider value={preferences}>
+        {children}
+      </UserPreferencesContext.Provider>
+    )
+    : children;
+};
 
 CurrentUserPreferencesProvider.propTypes = {
   children: PropTypes.node.isRequired,

--- a/graylog2-web-interface/src/contexts/ThemeAndUserProvider.jsx
+++ b/graylog2-web-interface/src/contexts/ThemeAndUserProvider.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import GraylogThemeProvider from 'theme/GraylogThemeProvider';
+import GlobalThemeStyles from 'theme/GlobalThemeStyles';
+
+import CurrentUserPreferencesProvider from './CurrentUserPreferencesProvider';
+import CurrentUserProvider from './CurrentUserProvider';
+
+const ThemeAndUserProvider = ({ children }) => {
+  return (
+    <CurrentUserProvider>
+      <CurrentUserPreferencesProvider>
+        <GraylogThemeProvider>
+          <GlobalThemeStyles />
+          {children}
+        </GraylogThemeProvider>
+      </CurrentUserPreferencesProvider>
+    </CurrentUserProvider>
+  );
+};
+
+ThemeAndUserProvider.propTypes = {
+  children: PropTypes.any.isRequired,
+};
+
+export default ThemeAndUserProvider;

--- a/graylog2-web-interface/src/pages/LoggedInPage.jsx
+++ b/graylog2-web-interface/src/pages/LoggedInPage.jsx
@@ -1,20 +1,17 @@
 import React from 'react';
 
-import CurrentUserPreferencesProvider from 'contexts/CurrentUserPreferencesProvider';
 import AppRouter from 'routing/AppRouter';
-import CurrentUserProvider from 'contexts/CurrentUserProvider';
+import ThemeAndUserProvider from 'contexts/ThemeAndUserProvider';
 
 import StreamsProvider from '../contexts/StreamsProvider';
 
 const LoggedInPage = () => {
   return (
-    <CurrentUserProvider>
-      <CurrentUserPreferencesProvider>
-        <StreamsProvider>
-          <AppRouter />
-        </StreamsProvider>
-      </CurrentUserPreferencesProvider>
-    </CurrentUserProvider>
+    <ThemeAndUserProvider>
+      <StreamsProvider>
+        <AppRouter />
+      </StreamsProvider>
+    </ThemeAndUserProvider>
   );
 };
 

--- a/graylog2-web-interface/src/theme/GraylogThemeProvider.jsx
+++ b/graylog2-web-interface/src/theme/GraylogThemeProvider.jsx
@@ -1,6 +1,6 @@
 // @flow strict
 import * as React from 'react';
-import { useMemo } from 'react';
+import { useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { ThemeProvider } from 'styled-components';
 
@@ -13,52 +13,42 @@ import useCurrentThemeMode from './UseCurrentThemeMode';
 
 type Props = {
   children: React.Node,
-  overrideMode: ?string,
 };
 
-const createTheme = (mode, themeColors, changeMode): ThemeInterface => {
-  const formattedUtils = {
-    ...utils,
-    colorLevel: utils.colorLevel(themeColors),
-    readableColor: utils.readableColor(themeColors),
-  };
-
-  return {
-    mode,
-    changeMode,
-    breakpoints,
-    colors: themeColors,
-    fonts,
-    components: {
-      button: buttonStyles({ colors: themeColors, utils: formattedUtils }),
-      aceEditor: aceEditorStyles({ colors: themeColors }),
-    },
-    utils: formattedUtils,
-  };
-};
-
-const GraylogThemeProvider = ({ children, overrideMode }: Props) => {
-  const [mode, setCurrentThemeMode] = useCurrentThemeMode(overrideMode);
-
+const GraylogThemeProvider = ({ children }: Props) => {
+  const [mode, changeMode] = useCurrentThemeMode();
   const themeColors = colors[mode];
 
-  const generatedTheme = themeColors ? createTheme(mode, themeColors, setCurrentThemeMode) : undefined;
-  const theme = useMemo(() => (generatedTheme), [mode, themeColors]);
+  const theme = useCallback((): ThemeInterface => {
+    const formattedUtils = {
+      ...utils,
+      colorLevel: utils.colorLevel(themeColors),
+      readableColor: utils.readableColor(themeColors),
+    };
 
-  return theme ? (
+    return {
+      mode,
+      changeMode,
+      breakpoints,
+      colors: themeColors,
+      fonts,
+      components: {
+        button: buttonStyles({ colors: themeColors, utils: formattedUtils }),
+        aceEditor: aceEditorStyles({ colors: themeColors }),
+      },
+      utils: formattedUtils,
+    };
+  }, [mode, themeColors, changeMode]);
+
+  return (
     <ThemeProvider theme={theme}>
       {children}
     </ThemeProvider>
-  ) : null;
+  );
 };
 
 GraylogThemeProvider.propTypes = {
   children: PropTypes.any.isRequired,
-  overrideMode: PropTypes.string,
-};
-
-GraylogThemeProvider.defaultProps = {
-  overrideMode: undefined,
 };
 
 export default GraylogThemeProvider;

--- a/graylog2-web-interface/src/theme/UseCurrentThemeMode.jsx
+++ b/graylog2-web-interface/src/theme/UseCurrentThemeMode.jsx
@@ -13,23 +13,25 @@ import usePrefersColorScheme from '../hooks/usePrefersColorScheme';
 const { CurrentUserStore } = CombinedProvider.get('CurrentUser');
 const { PreferencesStore } = CombinedProvider.get('Preferences');
 
-const useCurrentThemeMode = (overrideMode: ?string) => {
-  const browserPreference = usePrefersColorScheme();
+const useCurrentThemeMode = () => {
+  const browserThemePreference = usePrefersColorScheme();
+
   const { userIsReadOnly, username } = useStore(CurrentUserStore, (userStore) => ({
     username: userStore?.currentUser?.username,
     // eslint-disable-next-line camelcase
     userIsReadOnly: userStore?.currentUser?.read_only ?? true,
   }));
+
   const userPreferences = useContext(UserPreferencesContext);
-  const initialThemeMode = overrideMode ?? (userIsReadOnly ? Store.get(PREFERENCES_THEME_MODE) : userPreferences[PREFERENCES_THEME_MODE]) ?? browserPreference ?? DEFAULT_THEME_MODE;
+  const userThemePreference = userPreferences[PREFERENCES_THEME_MODE] ?? Store.get(PREFERENCES_THEME_MODE);
+  const initialThemeMode = userThemePreference ?? browserThemePreference ?? DEFAULT_THEME_MODE;
   const [currentThemeMode, setCurrentThemeMode] = useState<string>(initialThemeMode);
 
   const changeCurrentThemeMode = useCallback((newThemeMode: string) => {
     setCurrentThemeMode(newThemeMode);
+    Store.set(PREFERENCES_THEME_MODE, newThemeMode);
 
-    if (userIsReadOnly) {
-      Store.set(PREFERENCES_THEME_MODE, newThemeMode);
-    } else {
+    if (!userIsReadOnly) {
       const nextPreferences = { ...userPreferences, [PREFERENCES_THEME_MODE]: newThemeMode };
 
       PreferencesStore.saveUserPreferences(username, nextPreferences);

--- a/graylog2-web-interface/src/theme/UseCurrentThemeMode.jsx
+++ b/graylog2-web-interface/src/theme/UseCurrentThemeMode.jsx
@@ -32,7 +32,7 @@ const useCurrentThemeMode = (overrideMode: ?string) => {
     } else {
       const nextPreferences = { ...userPreferences, [PREFERENCES_THEME_MODE]: newThemeMode };
 
-      PreferencesStore.saveUserPreferences(username, PreferencesStore.convertPreferenceMapToArray(nextPreferences));
+      PreferencesStore.saveUserPreferences(username, nextPreferences);
     }
   }, [userIsReadOnly, userPreferences, username]);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Initially the Theme was being generated before the user was loaded. 
This has been updated by creating a User and Theme context wrapper that we can then reuse as necessary to verify that we can loading in the proper User preferences before generating the theme

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Theme would not always load the same one in user preferences consistently and some Popovers and Tooltips were not loading in the same theme as other parts of the app.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/122591/98414502-1ad40e00-2041-11eb-87ce-9342a61c956b.png)
![image](https://user-images.githubusercontent.com/122591/98414535-29bac080-2041-11eb-8276-202152199681.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

