### PR TITLE
Make sure to use the OSS ES container for tests

### DIFF
--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/testing/ClientES7.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/testing/ClientES7.java
@@ -68,11 +68,12 @@ public class ClientES7 implements Client {
 
     @Override
     public void deleteIndices(String... indices) {
-        for (String index : indices)
+        for (String index : indices) {
             if (indicesExists(index)) {
                 final DeleteIndexRequest deleteIndexRequest = new DeleteIndexRequest(index);
                 client.execute((c, requestOptions) -> c.indices().delete(deleteIndexRequest, requestOptions));
             }
+        }
     }
 
     @Override
@@ -192,7 +193,7 @@ public class ClientES7 implements Client {
     }
 
     private String[] existingTemplates() {
-        final GetIndexTemplatesRequest getIndexTemplatesRequest = new GetIndexTemplatesRequest("*");
+        final GetIndexTemplatesRequest getIndexTemplatesRequest = new GetIndexTemplatesRequest();
         final GetIndexTemplatesResponse result = client.execute((c, requestOptions) -> c.indices().getIndexTemplate(getIndexTemplatesRequest, requestOptions));
         return result.getIndexTemplates().stream()
                 .map(IndexTemplateMetadata::name)
@@ -206,7 +207,7 @@ public class ClientES7 implements Client {
 
         final JsonNode jsonResponse = client.execute((c, requestOptions) -> {
             request.setOptions(requestOptions);
-             final Response response = c.getLowLevelClient().performRequest(request);
+            final Response response = c.getLowLevelClient().performRequest(request);
             return objectMapper.readTree(response.getEntity().getContent());
         });
 

--- a/graylog2-server/src/test/java/org/graylog/testing/elasticsearch/ElasticsearchInstance.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/elasticsearch/ElasticsearchInstance.java
@@ -46,10 +46,11 @@ public abstract class ElasticsearchInstance extends ExternalResource {
     protected final ElasticsearchContainer container;
 
     protected abstract Client client();
+
     protected abstract FixtureImporter fixtureImporter();
 
     protected static String imageNameFrom(Version version) {
-        final String defaultImage = version.satisfies("^6.0.0")
+        final String defaultImage = version.satisfies(">=6.0.0")
                 // The OSS image only exists for 6.0.0 and later
                 ? DEFAULT_IMAGE_OSS
                 // For older versions do not use the official image because it contains x-pack stuff we don't want
@@ -77,7 +78,7 @@ public abstract class ElasticsearchInstance extends ExternalResource {
                 .withReuse(true)
                 .withEnv("ES_JAVA_OPTS", "-Xms2g -Xmx2g")
                 .withEnv("discovery.type", "single-node")
-                .withEnv("action.auto_create_index", ".watches,.triggered_watches,.watcher-history-*")
+                .withEnv("action.auto_create_index", "false")
                 .withEnv("cluster.info.update.interval", "10s")
                 .withNetwork(network)
                 .withNetworkAliases(NETWORK_ALIAS)
@@ -104,7 +105,8 @@ public abstract class ElasticsearchInstance extends ExternalResource {
     public void importFixtureResource(String resourcePath, Class<?> testClass) {
         boolean isFullResourcePath = Paths.get(resourcePath).getNameCount() > 1;
 
-        @SuppressWarnings("UnstableApiUsage") final URL fixtureResource = isFullResourcePath
+        @SuppressWarnings("UnstableApiUsage")
+        final URL fixtureResource = isFullResourcePath
                 ? Resources.getResource(resourcePath)
                 : Resources.getResource(testClass, resourcePath);
 

--- a/graylog2-server/src/test/java/org/graylog/testing/elasticsearch/ElasticsearchInstance.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/elasticsearch/ElasticsearchInstance.java
@@ -39,7 +39,6 @@ public abstract class ElasticsearchInstance extends ExternalResource {
     private static final Map<Version, ElasticsearchContainer> containersByVersion = new HashMap<>();
 
     private static final String DEFAULT_IMAGE_OSS = "docker.elastic.co/elasticsearch/elasticsearch-oss";
-    private static final String DEFAULT_IMAGE = "elasticsearch";
 
     private static final int ES_PORT = 9200;
     private static final String NETWORK_ALIAS = "elasticsearch";
@@ -52,12 +51,7 @@ public abstract class ElasticsearchInstance extends ExternalResource {
     protected abstract FixtureImporter fixtureImporter();
 
     protected static String imageNameFrom(Version version) {
-        final String defaultImage = version.satisfies(">=6.0.0")
-                // The OSS image only exists for 6.0.0 and later
-                ? DEFAULT_IMAGE_OSS
-                // For older versions do not use the official image because it contains x-pack stuff we don't want
-                : DEFAULT_IMAGE;
-        return defaultImage + ":" + version.toString();
+        return DEFAULT_IMAGE_OSS + ":" + version.toString();
     }
 
     protected ElasticsearchInstance(String image, Version version, Network network) {

--- a/graylog2-server/src/test/java/org/graylog/testing/elasticsearch/ElasticsearchInstance.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/elasticsearch/ElasticsearchInstance.java
@@ -30,6 +30,8 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 
+import static java.util.Objects.isNull;
+
 /**
  * This rule starts an Elasticsearch instance and provides a configured {@link Client}.
  */
@@ -75,7 +77,8 @@ public abstract class ElasticsearchInstance extends ExternalResource {
 
     private ElasticsearchContainer buildContainer(String image, Network network) {
         return new ElasticsearchContainer(DockerImageName.parse(image).asCompatibleSubstituteFor("docker.elastic.co/elasticsearch/elasticsearch"))
-                .withReuse(true)
+                // Avoids reuse warning on Jenkins (we don't want reuse in our CI environment)
+                .withReuse(isNull(System.getenv("BUILD_ID")))
                 .withEnv("ES_JAVA_OPTS", "-Xms2g -Xmx2g")
                 .withEnv("discovery.type", "single-node")
                 .withEnv("action.auto_create_index", "false")


### PR DESCRIPTION
Due to the version constraint of "^6.0.0" we only used the OSS container
for ES 6.x.

Adjust ClientES7#existingTemplates to not use a wildcard ("*") argument
when creating the GetIndexTemplatesRequest object.
Using the wildcard argument with no existing index templates returns a
404 from ES and throws an exception.

This fixes the IndicesGetAllMessageFieldsES7IT test when switching to
the OSS container. The regular ES container is automatically creating
indices for x-pack features so there are always existing indices and
index templates. The OSS container doesn't create any indices and
templates by default and so the #existingTemplates call failed with a
404.