### PR TITLE
Create session when user can be authenticated based on trusted header

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/SessionsResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/SessionsResource.java
@@ -30,6 +30,7 @@ import org.glassfish.grizzly.http.server.Request;
 import org.graylog2.audit.AuditEventTypes;
 import org.graylog2.audit.jersey.AuditEvent;
 import org.graylog2.audit.jersey.NoAuditEvent;
+import org.graylog2.plugin.database.users.User;
 import org.graylog2.rest.RestTools;
 import org.graylog2.rest.models.system.sessions.responses.SessionResponseFactory;
 import org.graylog2.rest.models.system.sessions.responses.SessionValidationResponse;
@@ -161,13 +162,22 @@ public class SessionsResource extends RestResource {
         // session information from the response to perform subsequent requests to the backend using this session.
         if (subject.getSession(false) == null && ShiroSecurityContext.isSessionCreationRequested()) {
             final Session session = subject.getSession();
+
+            final String userId = subject.getPrincipal().toString();
+            final User user = userService.loadById(userId);
+            if (user == null) {
+                throw new InternalServerErrorException("Unable to load user with ID <" + userId + ">.");
+            }
+
+            session.setAttribute("username", user.getName());
+
             LOG.debug("Session created {}", session.getId());
             session.touch();
             // save subject in session, otherwise we can't get the username back in subsequent requests.
             ((DefaultSecurityManager) SecurityUtils.getSecurityManager()).getSubjectDAO().save(subject);
 
             return SessionValidationResponse.validWithNewSession(String.valueOf(session.getId()),
-                                                                 String.valueOf(subject.getPrincipal()));
+                                                                 String.valueOf(user.getName()));
         }
         return SessionValidationResponse.valid();
     }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/SessionsResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/SessionsResource.java
@@ -154,7 +154,11 @@ public class SessionsResource extends RestResource {
             return SessionValidationResponse.invalid();
         }
 
-        // there's no valid session, but the authenticator would like us to create one
+        // There's no valid session, but the authenticator would like us to create one.
+        // This is the "Trusted Header Authentication" scenario, where the browser performs this request to check if a
+        // session exists, with a trusted header identifying the user. The authentication filter will authenticate the
+        // user based on the trusted header and request a session to be created transparently. The UI will take the
+        // session information from the response to perform subsequent requests to the backend using this session.
         if (subject.getSession(false) == null && ShiroSecurityContext.isSessionCreationRequested()) {
             final Session session = subject.getSession();
             LOG.debug("Session created {}", session.getId());

--- a/graylog2-server/src/main/java/org/graylog2/security/realm/HTTPHeaderAuthenticationRealm.java
+++ b/graylog2-server/src/main/java/org/graylog2/security/realm/HTTPHeaderAuthenticationRealm.java
@@ -30,6 +30,7 @@ import org.graylog.security.authservice.AuthServiceResult;
 import org.graylog2.plugin.cluster.ClusterConfigService;
 import org.graylog2.security.headerauth.HTTPHeaderAuthConfig;
 import org.graylog2.shared.security.HttpHeadersToken;
+import org.graylog2.shared.security.ShiroSecurityContext;
 import org.graylog2.utilities.IpSubnet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -117,6 +118,9 @@ public class HTTPHeaderAuthenticationRealm extends AuthenticatingRealm {
             if (result.isSuccess()) {
                 LOG.debug("Successfully authenticated username <{}> for user profile <{}> with backend <{}/{}/{}>",
                         result.username(), result.userProfileId(), result.backendTitle(), result.backendType(), result.backendId());
+                // Setting this, will let the SessionResource know, that when a non-existing session is validated, it
+                // should in fact create a session.
+                ShiroSecurityContext.requestSessionCreation(true);
                 return toAuthenticationInfo(result);
             } else {
                 LOG.warn("Failed to authenticate username <{}> from trusted HTTP header <{}> via proxy <{}>",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
With this change, we will implicitly create a session, when no session exists yet, but the user has been authenticated based on a trusted header.

This PR also fixes a wrong response to the session validation request.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #9403 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested with the instructions in #9403

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

