### PR TITLE
Show users in roles overview

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/users/PaginatedUserService.java
+++ b/graylog2-server/src/main/java/org/graylog2/users/PaginatedUserService.java
@@ -62,9 +62,9 @@ public class PaginatedUserService extends PaginatedDbService<UserOverviewDTO> {
 
     public PaginatedList<UserOverviewDTO> findPaginatedByRole(SearchQuery searchQuery, int page,
                                                               int perPage, String sortField, String order,
-                                                              String roleId) {
+                                                              Set<String> roleIds) {
         final DBQuery.Query dbQuery = searchQuery.toDBQuery()
-                .all(UserImpl.ROLES, roleId);
+                .in(UserImpl.ROLES, roleIds);
         final DBSort.SortBuilder sortBuilder = getSortBuilder(order, sortField);
         return findPaginatedWithQueryAndSort(dbQuery, sortBuilder, page, perPage);
     }

--- a/graylog2-web-interface/src/actions/roles/AuthzRolesActions.js
+++ b/graylog2-web-interface/src/actions/roles/AuthzRolesActions.js
@@ -8,7 +8,18 @@ import { singletonActions } from 'views/logic/singleton';
 import type { RefluxActions } from 'stores/StoreTypes';
 import type { PaginatedList, Pagination } from 'stores/PaginationTypes';
 
-export type PaginatedRoles = PaginatedList<Role>;
+export type UserContext = {
+  id: string,
+  username: string,
+};
+
+export type RoleContext = {
+  users: { [string]: UserContext[] },
+};
+
+export type PaginatedRoles = PaginatedList<Role> & {
+  context: RoleContext,
+};
 export type PaginatedUsers = PaginatedList<UserOverview>;
 
 export type ActionsType = {

--- a/graylog2-web-interface/src/components/roles/RolesOverview/RolesOverview.jsx
+++ b/graylog2-web-interface/src/components/roles/RolesOverview/RolesOverview.jsx
@@ -13,7 +13,7 @@ import { Col, Row } from 'components/graylog';
 import RolesOverviewItem from './RolesOverviewItem';
 import RolesFilter from './RolesFilter';
 
-const TABLE_HEADERS = ['Name', 'Description', 'Actions'];
+const TABLE_HEADERS = ['Name', 'Description', 'Users', 'Actions'];
 const DEFAULT_PAGINATION = {
   page: 1,
   perPage: 10,

--- a/graylog2-web-interface/src/components/roles/RolesOverview/RolesOverview.jsx
+++ b/graylog2-web-interface/src/components/roles/RolesOverview/RolesOverview.jsx
@@ -54,8 +54,8 @@ const _headerCellFormatter = (header) => {
 const _loadRoles = (pagination, setLoading, setPaginatedRoles) => {
   setLoading(true);
 
-  AuthzRolesDomain.loadRolesPaginated(pagination).then((paginatedUsers) => {
-    setPaginatedRoles(paginatedUsers);
+  AuthzRolesDomain.loadRolesPaginated(pagination).then((paginatedRoles) => {
+    setPaginatedRoles(paginatedRoles);
     setLoading(false);
   });
 };
@@ -77,7 +77,7 @@ const RolesOverview = () => {
   }
 
   const searchFilter = <RolesFilter onSearch={(newQuery) => setPagination({ ...pagination, query: newQuery, page: DEFAULT_PAGINATION.page })} />;
-  const _rolesOverviewItem = (role) => <RolesOverviewItem role={role} />;
+  const _rolesOverviewItem = (role) => <RolesOverviewItem role={role} users={paginatedRoles?.context?.users[role.id]} />;
 
   return (
     <Container>

--- a/graylog2-web-interface/src/components/roles/RolesOverview/RolesOverview.test.jsx
+++ b/graylog2-web-interface/src/components/roles/RolesOverview/RolesOverview.test.jsx
@@ -1,5 +1,7 @@
 // @flow strict
 import * as React from 'react';
+import * as Immutable from 'immutable';
+
 import { render, waitFor, fireEvent, screen } from 'wrappedTestingLibrary';
 import mockAction from 'helpers/mocking/MockAction';
 import { rolesList as mockRoles } from 'fixtures/roles';
@@ -16,6 +18,12 @@ const loadRolesPaginatedResponse = {
     query: '',
     count: mockRoles.size,
     total: mockRoles.size,
+  },
+  context: {
+    users: {
+      'manager-id': Immutable.Set.of({ id: 'first-id', username: 'bob' }),
+      'reader-id': Immutable.Set.of({ id: 'first-id', username: 'bob' }),
+    },
   },
 };
 

--- a/graylog2-web-interface/src/components/roles/RolesOverview/RolesOverview.test.jsx
+++ b/graylog2-web-interface/src/components/roles/RolesOverview/RolesOverview.test.jsx
@@ -1,7 +1,6 @@
 // @flow strict
 import * as React from 'react';
 import * as Immutable from 'immutable';
-
 import { render, waitFor, fireEvent, screen } from 'wrappedTestingLibrary';
 import mockAction from 'helpers/mocking/MockAction';
 import { rolesList as mockRoles } from 'fixtures/roles';

--- a/graylog2-web-interface/src/components/roles/RolesOverview/RolesOverviewItem.jsx
+++ b/graylog2-web-interface/src/components/roles/RolesOverview/RolesOverviewItem.jsx
@@ -1,15 +1,18 @@
 // @flow strict
 import * as React from 'react';
+import * as Immutable from 'immutable';
 
 import { Link } from 'components/graylog/router';
 import Routes from 'routing/Routes';
 import Role from 'logic/roles/Role';
+import type { UserContext } from 'actions/roles/AuthzRolesActions';
 
 import ActionsCell from './ActionsCell';
 import UsersCell from './UsersCell';
 
 type Props = {
   role: Role,
+  users: UserContext[],
 };
 
 const RolesOverviewItem = ({
@@ -18,8 +21,8 @@ const RolesOverviewItem = ({
     name,
     description,
     readOnly,
-    users,
   },
+  users,
 }: Props) => {
   return (
     <tr key={id}>
@@ -29,7 +32,7 @@ const RolesOverviewItem = ({
         </Link>
       </td>
       <td>{description}</td>
-      <UsersCell users={users} />
+      <UsersCell users={Immutable.Set(users)} />
       <ActionsCell roleId={id} roleName={name} readOnly={readOnly} />
     </tr>
   );

--- a/graylog2-web-interface/src/components/roles/RolesOverview/RolesOverviewItem.jsx
+++ b/graylog2-web-interface/src/components/roles/RolesOverview/RolesOverviewItem.jsx
@@ -6,6 +6,7 @@ import Routes from 'routing/Routes';
 import Role from 'logic/roles/Role';
 
 import ActionsCell from './ActionsCell';
+import UsersCell from './UsersCell';
 
 type Props = {
   role: Role,
@@ -17,6 +18,7 @@ const RolesOverviewItem = ({
     name,
     description,
     readOnly,
+    users,
   },
 }: Props) => {
   return (
@@ -26,7 +28,8 @@ const RolesOverviewItem = ({
           {name}
         </Link>
       </td>
-      <td className="limited">{description}</td>
+      <td>{description}</td>
+      <UsersCell users={users} />
       <ActionsCell roleId={id} roleName={name} readOnly={readOnly} />
     </tr>
   );

--- a/graylog2-web-interface/src/components/roles/RolesOverview/UsersCell.jsx
+++ b/graylog2-web-interface/src/components/roles/RolesOverview/UsersCell.jsx
@@ -1,14 +1,39 @@
 // @flow strict
 import * as React from 'react';
+import * as Immutable from 'immutable';
 
+import { Link } from 'components/graylog/router';
+import Routes from 'routing/Routes';
+import { IfPermitted, CountBadge } from 'components/common';
 import type { UserContext } from 'logic/roles/Role';
 
-type Props: {
-  users: UserContext[],
+type Props = {
+  users: Immutable.Set<UserContext>,
 };
 
-const UsersCell = ({ users }: Props) => {
+const MAX_USERS = 10;
 
+const UsersCell = ({ users = Immutable.Set() }: Props) => {
+  const usersLength = users.size;
+  const usersComponents = users.take(MAX_USERS).toArray().map(({ id, username }, index) => {
+    return (
+      <IfPermitted permissions={[`users:read:${username}`]} key={id}>
+        <Link to={Routes.SYSTEM.USERS.show(id)}>{username}</Link>{index < (usersLength - 1) && ',  '}
+      </IfPermitted>
+    );
+  });
+
+  if (usersLength > MAX_USERS) {
+    usersComponents.push(<span key="dots">...</span>);
+  }
+
+  return (
+    <td>
+      <CountBadge>{users.size}</CountBadge>
+      {' '}
+      {usersComponents}
+    </td>
+  );
 };
 
-return UserCell;
+export default UsersCell;

--- a/graylog2-web-interface/src/components/roles/RolesOverview/UsersCell.jsx
+++ b/graylog2-web-interface/src/components/roles/RolesOverview/UsersCell.jsx
@@ -1,0 +1,14 @@
+// @flow strict
+import * as React from 'react';
+
+import type { UserContext } from 'logic/roles/Role';
+
+type Props: {
+  users: UserContext[],
+};
+
+const UsersCell = ({ users }: Props) => {
+
+};
+
+return UserCell;

--- a/graylog2-web-interface/src/components/roles/RolesOverview/UsersCell.jsx
+++ b/graylog2-web-interface/src/components/roles/RolesOverview/UsersCell.jsx
@@ -5,7 +5,7 @@ import * as Immutable from 'immutable';
 import { Link } from 'components/graylog/router';
 import Routes from 'routing/Routes';
 import { IfPermitted, CountBadge } from 'components/common';
-import type { UserContext } from 'logic/roles/Role';
+import type { UserContext } from 'actions/roles/AuthzRolesActions';
 
 type Props = {
   users: Immutable.Set<UserContext>,

--- a/graylog2-web-interface/src/components/users/UserEdit/RolesSection.jsx
+++ b/graylog2-web-interface/src/components/users/UserEdit/RolesSection.jsx
@@ -87,10 +87,11 @@ const RolesSection = ({ user, onSubmit }: Props) => {
       </ErrorAlert>
       <h3>Selected Roles</h3>
       <Container>
+        {/* $FlowFixMe Role is a DescriptiveItem! */}
         <PaginatedItemOverview noDataText="No selected roles have been found."
-                               // $FlowFixMe Role is a DescriptiveItem!
+                               /* $FlowFixMe Role is a DescriptiveItem! */
                                onLoad={_onLoad}
-                               // $FlowFixMe Role is a DescriptiveItem!
+                               /* $FlowFixMe Role is a DescriptiveItem! */
                                overrideList={paginatedRoles}
                                onDeleteItem={onDeleteRole}
                                queryHelper={<RolesQueryHelp />} />

--- a/graylog2-web-interface/src/logic/roles/Role.js
+++ b/graylog2-web-interface/src/logic/roles/Role.js
@@ -1,22 +1,12 @@
 // @flow strict
 import * as Immutable from 'immutable';
 
-export type UserContext = {
-  id: string,
-  username: string,
-};
-
 type InternalState = {
   id: string,
   name: string,
   description: string,
   permissions: Immutable.Set<string>,
   readOnly: boolean,
-  users: Immutable.Set<UserContext>,
-};
-
-export type RoleContext = {
-  users: { [string]: UserContext[] },
 };
 
 export type RoleJSON = {
@@ -37,7 +27,6 @@ export default class Role {
     description: $PropertyType<InternalState, 'description'>,
     permissions: $PropertyType<InternalState, 'permissions'>,
     readOnly: $PropertyType<InternalState, 'readOnly'>,
-    users: $PropertyType<InternalState, 'users'>,
   ) {
     this._value = {
       id,
@@ -45,7 +34,6 @@ export default class Role {
       description,
       permissions,
       readOnly,
-      users,
     };
   }
 
@@ -69,10 +57,6 @@ export default class Role {
     return this._value.readOnly;
   }
 
-  get users() {
-    return this._value.users;
-  }
-
   toBuilder() {
     const {
       id,
@@ -80,7 +64,6 @@ export default class Role {
       description,
       permissions,
       readOnly,
-      users,
     } = this._value;
 
     // eslint-disable-next-line no-use-before-define
@@ -90,7 +73,6 @@ export default class Role {
       description,
       permissions,
       readOnly,
-      users,
     }));
   }
 
@@ -101,7 +83,6 @@ export default class Role {
     description: $PropertyType<InternalState, 'description'>,
     permissions: $PropertyType<InternalState, 'permissions'>,
     readOnly: $PropertyType<InternalState, 'readOnly'>,
-    users: $PropertyType<InternalState, 'users'>,
   ) {
     return new Role(
       id,
@@ -109,7 +90,6 @@ export default class Role {
       description,
       permissions,
       readOnly,
-      users,
     );
   }
 
@@ -131,9 +111,7 @@ export default class Role {
     };
   }
 
-  static fromJSON(value: RoleJSON, userContext: Array<UserContext> = []) {
-    const users = Immutable.Set(userContext || []);
-
+  static fromJSON(value: RoleJSON) {
     const {
       id,
       name,
@@ -148,7 +126,6 @@ export default class Role {
       description,
       permissions,
       readOnly,
-      users,
     );
   }
 
@@ -188,10 +165,6 @@ class Builder {
     return new Builder(this.value.set('readOnly', value));
   }
 
-  users(value: $PropertyType<InternalState, 'users'>) {
-    return new Builder(this.value.set('users', value));
-  }
-
   build() {
     const {
       id,
@@ -199,7 +172,6 @@ class Builder {
       description,
       permissions,
       readOnly,
-      users,
     } = this.value.toObject();
 
     return new Role(
@@ -208,7 +180,6 @@ class Builder {
       description,
       permissions,
       readOnly,
-      users,
     );
   }
 }

--- a/graylog2-web-interface/src/logic/roles/Role.js
+++ b/graylog2-web-interface/src/logic/roles/Role.js
@@ -131,7 +131,7 @@ export default class Role {
     };
   }
 
-  static fromJSON(value: RoleJSON, userContext: UserContext[]) {
+  static fromJSON(value: RoleJSON, userContext: Array<UserContext> = []) {
     const users = Immutable.Set(userContext || []);
 
     const {

--- a/graylog2-web-interface/src/logic/roles/Role.js
+++ b/graylog2-web-interface/src/logic/roles/Role.js
@@ -1,12 +1,22 @@
 // @flow strict
 import * as Immutable from 'immutable';
 
+export type UserContext = {
+  id: string,
+  username: string,
+};
+
 type InternalState = {
   id: string,
   name: string,
   description: string,
   permissions: Immutable.Set<string>,
   readOnly: boolean,
+  users: Immutable.Set<UserContext>,
+};
+
+export type RoleContext = {
+  users: { [string]: UserContext[] },
 };
 
 export type RoleJSON = {
@@ -27,6 +37,7 @@ export default class Role {
     description: $PropertyType<InternalState, 'description'>,
     permissions: $PropertyType<InternalState, 'permissions'>,
     readOnly: $PropertyType<InternalState, 'readOnly'>,
+    users: $PropertyType<InternalState, 'users'>,
   ) {
     this._value = {
       id,
@@ -34,6 +45,7 @@ export default class Role {
       description,
       permissions,
       readOnly,
+      users,
     };
   }
 
@@ -57,6 +69,10 @@ export default class Role {
     return this._value.readOnly;
   }
 
+  get users() {
+    return this._value.users;
+  }
+
   toBuilder() {
     const {
       id,
@@ -64,6 +80,7 @@ export default class Role {
       description,
       permissions,
       readOnly,
+      users,
     } = this._value;
 
     // eslint-disable-next-line no-use-before-define
@@ -73,6 +90,7 @@ export default class Role {
       description,
       permissions,
       readOnly,
+      users,
     }));
   }
 
@@ -83,6 +101,7 @@ export default class Role {
     description: $PropertyType<InternalState, 'description'>,
     permissions: $PropertyType<InternalState, 'permissions'>,
     readOnly: $PropertyType<InternalState, 'readOnly'>,
+    users: $PropertyType<InternalState, 'users'>,
   ) {
     return new Role(
       id,
@@ -90,6 +109,7 @@ export default class Role {
       description,
       permissions,
       readOnly,
+      users,
     );
   }
 
@@ -111,7 +131,9 @@ export default class Role {
     };
   }
 
-  static fromJSON(value: RoleJSON) {
+  static fromJSON(value: RoleJSON, userContext: UserContext[]) {
+    const users = Immutable.Set(userContext || []);
+
     const {
       id,
       name,
@@ -126,6 +148,7 @@ export default class Role {
       description,
       permissions,
       readOnly,
+      users,
     );
   }
 
@@ -165,6 +188,10 @@ class Builder {
     return new Builder(this.value.set('readOnly', value));
   }
 
+  users(value: $PropertyType<InternalState, 'users'>) {
+    return new Builder(this.value.set('users', value));
+  }
+
   build() {
     const {
       id,
@@ -172,6 +199,7 @@ class Builder {
       description,
       permissions,
       readOnly,
+      users,
     } = this.value.toObject();
 
     return new Role(
@@ -180,6 +208,7 @@ class Builder {
       description,
       permissions,
       readOnly,
+      users,
     );
   }
 }

--- a/graylog2-web-interface/src/stores/roles/AuthzRolesStore.js
+++ b/graylog2-web-interface/src/stores/roles/AuthzRolesStore.js
@@ -10,7 +10,7 @@ import { qualifyUrl } from 'util/URLUtils';
 import { singletonStore } from 'views/logic/singleton';
 import PaginationURL from 'util/PaginationURL';
 import Role from 'logic/roles/Role';
-import type { RoleJSON, RoleContext } from 'logic/roles/Role';
+import type { RoleJSON } from 'logic/roles/Role';
 import AuthzRolesActions, { type PaginatedRoles, type PaginatedUsers } from 'actions/roles/AuthzRolesActions';
 import UserOverview from 'logic/users/UserOverview';
 import type { PaginatedListJSON, Pagination } from 'stores/PaginationTypes';
@@ -22,7 +22,7 @@ export type PaginatedRolesResponse = PaginatedListJSON & {
 
 // eslint-disable-next-line camelcase
 const _responseToPaginatedList = ({ count, total, page, per_page, query, roles = [], context = {} }: PaginatedRolesResponse) => ({
-  list: Immutable.List(roles.map((r) => Role.fromJSON(r, context?.users && context.users[r.id]))),
+  list: Immutable.List(roles.map((r) => Role.fromJSON(r))),
   pagination: {
     query,
     page,
@@ -30,6 +30,7 @@ const _responseToPaginatedList = ({ count, total, page, per_page, query, roles =
     count,
     total,
   },
+  context,
 });
 
 // eslint-disable-next-line camelcase

--- a/graylog2-web-interface/src/stores/roles/AuthzRolesStore.js
+++ b/graylog2-web-interface/src/stores/roles/AuthzRolesStore.js
@@ -11,7 +11,7 @@ import { singletonStore } from 'views/logic/singleton';
 import PaginationURL from 'util/PaginationURL';
 import Role from 'logic/roles/Role';
 import type { RoleJSON } from 'logic/roles/Role';
-import AuthzRolesActions, { type PaginatedRoles, type PaginatedUsers } from 'actions/roles/AuthzRolesActions';
+import AuthzRolesActions, { type PaginatedRoles, type PaginatedUsers, type RoleContext } from 'actions/roles/AuthzRolesActions';
 import UserOverview from 'logic/users/UserOverview';
 import type { PaginatedListJSON, Pagination } from 'stores/PaginationTypes';
 

--- a/graylog2-web-interface/src/stores/roles/AuthzRolesStore.js
+++ b/graylog2-web-interface/src/stores/roles/AuthzRolesStore.js
@@ -10,18 +10,19 @@ import { qualifyUrl } from 'util/URLUtils';
 import { singletonStore } from 'views/logic/singleton';
 import PaginationURL from 'util/PaginationURL';
 import Role from 'logic/roles/Role';
-import type { RoleJSON } from 'logic/roles/Role';
+import type { RoleJSON, RoleContext } from 'logic/roles/Role';
 import AuthzRolesActions, { type PaginatedRoles, type PaginatedUsers } from 'actions/roles/AuthzRolesActions';
 import UserOverview from 'logic/users/UserOverview';
 import type { PaginatedListJSON, Pagination } from 'stores/PaginationTypes';
 
 export type PaginatedRolesResponse = PaginatedListJSON & {
   roles: Array<RoleJSON>,
+  context?: RoleContext,
 };
 
 // eslint-disable-next-line camelcase
-const _responseToPaginatedList = ({ count, total, page, per_page, query, roles = [] }: PaginatedRolesResponse) => ({
-  list: Immutable.List(roles.map((r) => Role.fromJSON(r))),
+const _responseToPaginatedList = ({ count, total, page, per_page, query, roles = [], context = {} }: PaginatedRolesResponse) => ({
+  list: Immutable.List(roles.map((r) => Role.fromJSON(r, context?.users && context.users[r.id]))),
   pagination: {
     query,
     page,

--- a/graylog2-web-interface/src/stores/users/RolesStore.js
+++ b/graylog2-web-interface/src/stores/users/RolesStore.js
@@ -20,7 +20,7 @@ type RoleMembership = {
 
 const RolesStore = Reflux.createStore({
   loadRoles(): Promise<string[]> {
-    const promise = fetch('GET', qualifyUrl(ApiRoutes.RolesApiController.listRoles().url))
+    return fetch('GET', qualifyUrl(ApiRoutes.RolesApiController.listRoles().url))
       .then(
         (response) => response.roles,
         (error) => {
@@ -30,8 +30,6 @@ const RolesStore = Reflux.createStore({
           }
         },
       );
-
-    return promise;
   },
 
   createRole(role: Role): Promise<Role> {


### PR DESCRIPTION
## Description
This PR will display the users of a role on the roles overview page.

## Motivation and Context
All other overview pages display their relationships. So the user expects to see the users of a role on the roles overviewpage.

![Graylog - Roles Overview](https://user-images.githubusercontent.com/448763/98541817-4e58a780-2290-11eb-843d-cca78ee42400.png)

Fixes #9219 