### PR TITLE
Display backend validation errors next to related input in directory service wizard

### DIFF
--- a/graylog2-web-interface/src/components/authentication/directoryServices/BackendWizard/BackendWizard.jsx
+++ b/graylog2-web-interface/src/components/authentication/directoryServices/BackendWizard/BackendWizard.jsx
@@ -1,15 +1,16 @@
 // @flow strict
+
 import * as React from 'react';
 import { useState, useRef, useEffect } from 'react';
-import { compact } from 'lodash';
+import { compact, camelCase, mapKeys, mapValues } from 'lodash';
 import PropTypes from 'prop-types';
 
+import history from 'util/History';
+import { validateField } from 'util/FormsUtils';
+import { getEnterpriseGroupSyncPlugin } from 'util/AuthenticationService';
 import { Spinner } from 'components/common';
 import AuthzRolesDomain from 'domainActions/roles/AuthzRolesDomain';
 import Routes from 'routing/Routes';
-import { getEnterpriseGroupSyncPlugin } from 'util/AuthenticationService';
-import { validateField } from 'util/FormsUtils';
-import history from 'util/History';
 import type { WizardSubmitPayload } from 'logic/authentication/directoryServices/types';
 import { Row, Col, Alert } from 'components/graylog';
 import Wizard, { type Step } from 'components/common/Wizard';
@@ -18,9 +19,17 @@ import type { LoadResponse as LoadBackendResponse } from 'actions/authentication
 import type { PaginatedRoles } from 'actions/roles/AuthzRolesActions';
 
 import BackendWizardContext, { type WizardStepsState, type WizardFormValues, type AuthBackendMeta } from './BackendWizardContext';
-import { FORM_VALIDATION as SERVER_CONFIG_VALIDATION, STEP_KEY as SERVER_CONFIG_KEY } from './ServerConfigStep';
-import { FORM_VALIDATION as USER_SYNC_VALIDATION, STEP_KEY as USER_SYNC_KEY } from './UserSyncStep';
-import { STEP_KEY as GROUP_SYNC_KEY } from './GroupSyncStep';
+import {
+  FORM_VALIDATION as SERVER_CONFIG_VALIDATION,
+  STEP_KEY as SERVER_CONFIG_KEY,
+} from './ServerConfigStep';
+import {
+  FORM_VALIDATION as USER_SYNC_VALIDATION,
+  STEP_KEY as USER_SYNC_KEY,
+} from './UserSyncStep';
+import {
+  STEP_KEY as GROUP_SYNC_KEY,
+} from './GroupSyncStep';
 import wizardSteps from './wizardSteps';
 import Sidebar from './Sidebar';
 
@@ -40,6 +49,13 @@ const SubmitAllError = ({ error, backendId }: { error: FetchError, backendId: ?s
     </Col>
   </Row>
 );
+
+const _formatBackendValidationErrors = (backendErrors: { [inputNameJSON: string]: ?string }) => {
+  const backendErrorStrings = mapValues(backendErrors, (errorArray) => `Server validation error: ${errorArray.join(', ')}`);
+  const formattedBackendErrors = mapKeys(backendErrorStrings, (value, key) => camelCase(key));
+
+  return formattedBackendErrors;
+};
 
 export const _passwordPayload = (backendId: ?string, systemUserPassword: ?string) => {
   const _formatPayload = (password) => {
@@ -112,7 +128,7 @@ const _prepareSubmitPayload = (stepsState, getUpdatedFormsValues) => (overrideFo
   };
 };
 
-const _getInvalidStepKeys = (formValues, excludedFields) => {
+const _getInvalidStepKeys = (formValues, newBackendValidationErrors, excludedFields) => {
   const validation = { ...FORMS_VALIDATION, [GROUP_SYNC_KEY]: {} };
   const enterpriseGroupSyncPlugin = getEnterpriseGroupSyncPlugin();
   const groupSyncValidation = enterpriseGroupSyncPlugin?.validation.GroupSyncValidation;
@@ -124,7 +140,15 @@ const _getInvalidStepKeys = (formValues, excludedFields) => {
   const invalidStepKeys = Object.entries(validation).map(([stepKey, formValidation]) => {
     // $FlowFixMe formValidation is valid input for Object.entries
     const stepHasError = Object.entries(formValidation).some(([fieldName, fieldValidation]) => {
-      return !excludedFields[fieldName] && !!validateField(fieldValidation)(formValues?.[fieldName]);
+      if (excludedFields[fieldName]) {
+        return false;
+      }
+
+      if (newBackendValidationErrors?.[fieldName]) {
+        return true;
+      }
+
+      return !!validateField(fieldValidation)(formValues?.[fieldName]);
     });
 
     return stepHasError ? stepKey : undefined;
@@ -133,9 +157,17 @@ const _getInvalidStepKeys = (formValues, excludedFields) => {
   return compact(invalidStepKeys);
 };
 
-const _onSubmitAll = (stepsState, setSubmitAllError, onSubmit, getUpdatedFormsValues, getSubmitPayload, validateSteps, shouldUpdateGroupSync) => {
+const _onSubmitAll = (
+  stepsState,
+  setSubmitAllError,
+  onSubmit,
+  getUpdatedFormsValues,
+  getSubmitPayload,
+  validateSteps,
+  shouldUpdateGroupSync,
+) => {
   const formValues = getUpdatedFormsValues();
-  const invalidStepKeys = validateSteps(formValues);
+  const invalidStepKeys = validateSteps(formValues, {});
 
   // Do not submit if there are invalid steps
   if (invalidStepKeys.length >= 1) {
@@ -149,7 +181,12 @@ const _onSubmitAll = (stepsState, setSubmitAllError, onSubmit, getUpdatedFormsVa
   const _submit = () => onSubmit(payload, formValues, stepsState.authBackendMeta.serviceType, shouldUpdateGroupSync).then(() => {
     history.push(Routes.SYSTEM.AUTHENTICATION.BACKENDS.OVERVIEW);
   }).catch((error) => {
-    setSubmitAllError(error);
+    if (typeof error?.additional?.body?.errors === 'object') {
+      const backendValidationErrors = _formatBackendValidationErrors(error.additional.body.errors);
+      validateSteps(formValues, backendValidationErrors);
+    } else {
+      setSubmitAllError(error);
+    }
   });
 
   if (stepsState.authBackendMeta.backendGroupSyncIsActive && !formValues.synchronizeGroups) {
@@ -195,16 +232,16 @@ const BackendWizard = ({ initialValues, initialStepKey, onSubmit, authBackendMet
   const [stepsState, setStepsState] = useState<WizardStepsState>({
     activeStepKey: initialStepKey,
     authBackendMeta,
+    backendValidationErrors: undefined,
     formValues: initialValues,
     invalidStepKeys: [],
-    loadGroupsResult: undefined,
   });
+
   const formRefs = {
     [SERVER_CONFIG_KEY]: useRef(),
     [USER_SYNC_KEY]: useRef(),
     [GROUP_SYNC_KEY]: useRef(),
   };
-
   useEffect(() => _loadRoles(setPaginatedRoles), []);
 
   useEffect(() => {
@@ -223,13 +260,20 @@ const BackendWizard = ({ initialValues, initialStepKey, onSubmit, authBackendMet
     return { ...stepsState.formValues, ...activeForm?.values };
   };
 
-  const _validateSteps = (formValues: WizardFormValues): Array<string> => {
-    const invalidStepKeys = _getInvalidStepKeys(formValues, excludedFields);
+  const _validateSteps = (formValues: WizardFormValues, newBackendValidationErrors): Array<string> => {
+    const invalidStepKeys = _getInvalidStepKeys(
+      formValues,
+      newBackendValidationErrors,
+      excludedFields,
+    );
 
     if (invalidStepKeys.length >= 1) {
+      const nextStepKey = invalidStepKeys.includes(stepsState.activeStepKey) ? stepsState.activeStepKey : invalidStepKeys[0];
+
       setStepsState({
         ...stepsState,
-        activeStepKey: invalidStepKeys[0],
+        backendValidationErrors: newBackendValidationErrors,
+        activeStepKey: nextStepKey,
         formValues,
         invalidStepKeys,
       });
@@ -246,7 +290,7 @@ const BackendWizard = ({ initialValues, initialStepKey, onSubmit, authBackendMet
 
     // Only update invalid steps keys, we create them on submit all only
     if (invalidStepKeys.length >= 1) {
-      invalidStepKeys = _getInvalidStepKeys(formValues, excludedFields);
+      invalidStepKeys = _getInvalidStepKeys(formValues, stepsState.backendValidationErrors, excludedFields);
     }
 
     setStepsState({

--- a/graylog2-web-interface/src/components/authentication/directoryServices/BackendWizard/BackendWizard.jsx
+++ b/graylog2-web-interface/src/components/authentication/directoryServices/BackendWizard/BackendWizard.jsx
@@ -51,7 +51,7 @@ const SubmitAllError = ({ error, backendId }: { error: FetchError, backendId: ?s
 );
 
 const _formatBackendValidationErrors = (backendErrors: { [inputNameJSON: string]: ?string }) => {
-  const backendErrorStrings = mapValues(backendErrors, (errorArray) => `Server validation error: ${errorArray.join(', ')}`);
+  const backendErrorStrings = mapValues(backendErrors, (errorArray) => `Server validation error: ${errorArray.join(' ')}`);
   const formattedBackendErrors = mapKeys(backendErrorStrings, (value, key) => camelCase(key));
 
   return formattedBackendErrors;

--- a/graylog2-web-interface/src/components/authentication/directoryServices/BackendWizard/BackendWizardContext.jsx
+++ b/graylog2-web-interface/src/components/authentication/directoryServices/BackendWizard/BackendWizardContext.jsx
@@ -36,6 +36,7 @@ export type AuthBackendMeta = {
 };
 export type WizardStepsState = {
   activeStepKey: $PropertyType<Step, 'key'>,
+  backendValidationErrors: ?{ [inputName: string]: ?string },
   formValues: WizardFormValues,
   invalidStepKeys: Array<string>,
   authBackendMeta: AuthBackendMeta,
@@ -47,6 +48,7 @@ export type BackendWizardType = WizardStepsState & {
 
 const initialState = {
   activeStepKey: '',
+  backendValidationErrors: undefined,
   authBackendMeta: {},
   formValues: {},
   invalidStepKeys: [],

--- a/graylog2-web-interface/src/components/authentication/directoryServices/BackendWizard/GroupSyncStep.jsx
+++ b/graylog2-web-interface/src/components/authentication/directoryServices/BackendWizard/GroupSyncStep.jsx
@@ -23,7 +23,17 @@ export type Props = {
   validateOnMount: boolean,
 };
 
-const GroupSyncStep = ({ onSubmitAll, prepareSubmitPayload, formRef, submitAllError, validateOnMount, roles, help, excludedFields }: Props) => {
+const GroupSyncStep = ({
+  onSubmitAll,
+  prepareSubmitPayload,
+  formRef,
+  submitAllError,
+  validateOnMount,
+  roles,
+  help,
+  excludedFields,
+  validateSteps,
+}: Props) => {
   const enterpriseGroupSyncPlugin = getEnterpriseGroupSyncPlugin();
   const GroupSyncForm = enterpriseGroupSyncPlugin?.components?.GroupSyncForm;
 
@@ -53,7 +63,8 @@ const GroupSyncStep = ({ onSubmitAll, prepareSubmitPayload, formRef, submitAllEr
                    prepareSubmitPayload={prepareSubmitPayload}
                    roles={roles}
                    submitAllError={submitAllError}
-                   validateOnMount={validateOnMount} />
+                   validateOnMount={validateOnMount}
+                   validateSteps={validateSteps} />
   );
 };
 

--- a/graylog2-web-interface/src/components/authentication/directoryServices/BackendWizard/GroupSyncStep.jsx
+++ b/graylog2-web-interface/src/components/authentication/directoryServices/BackendWizard/GroupSyncStep.jsx
@@ -32,7 +32,6 @@ const GroupSyncStep = ({
   roles,
   help,
   excludedFields,
-  validateSteps,
 }: Props) => {
   const enterpriseGroupSyncPlugin = getEnterpriseGroupSyncPlugin();
   const GroupSyncForm = enterpriseGroupSyncPlugin?.components?.GroupSyncForm;
@@ -63,8 +62,7 @@ const GroupSyncStep = ({
                    prepareSubmitPayload={prepareSubmitPayload}
                    roles={roles}
                    submitAllError={submitAllError}
-                   validateOnMount={validateOnMount}
-                   validateSteps={validateSteps} />
+                   validateOnMount={validateOnMount} />
   );
 };
 

--- a/graylog2-web-interface/src/components/authentication/directoryServices/BackendWizard/ServerConfigStep.jsx
+++ b/graylog2-web-interface/src/components/authentication/directoryServices/BackendWizard/ServerConfigStep.jsx
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 import { useContext } from 'react';
 import { Formik, Form, Field } from 'formik';
 
-import { formHasErrors, validateField } from 'util/FormsUtils';
+import { validateField, formHasErrors } from 'util/FormsUtils';
 import { FormikFormGroup, FormikInput, InputOptionalInfo as Opt } from 'components/common';
 import { Button, ButtonToolbar } from 'components/graylog';
 import { Input } from 'components/bootstrap';
@@ -14,6 +14,8 @@ import BackendWizardContext from './BackendWizardContext';
 
 export type StepKeyType = 'server-configuration';
 export const STEP_KEY: StepKeyType = 'server-configuration';
+// Form validation needs to include all input names
+// to be able to associate backend validation errors with the form
 export const FORM_VALIDATION = {
   serverHost: {
     required: true,
@@ -23,6 +25,10 @@ export const FORM_VALIDATION = {
     min: 1,
     max: 65535,
   },
+  transportSecurity: {},
+  verifyCertificates: {},
+  systemUserDn: {},
+  systemUserPassword: {},
 };
 
 const ServerUrl = styled.div`
@@ -66,15 +72,7 @@ type Props = {
 
 const ServerConfigStep = ({ formRef, help = {}, onSubmit, onSubmitAll, submitAllError, validateOnMount }: Props) => {
   const { setStepsState, ...stepsState } = useContext(BackendWizardContext);
-  const { backendHasPassword } = stepsState.authBackendMeta;
-
-  const _onSubmitAll = (validateForm) => {
-    validateForm().then((errors) => {
-      if (!formHasErrors(errors)) {
-        onSubmitAll();
-      }
-    });
-  };
+  const { backendValidationErrors, authBackendMeta: { backendHasPassword } } = stepsState;
 
   const _onTransportSecurityChange = (event, values, setFieldValue, onChange) => {
     const currentValue = values.transportSecurity;
@@ -93,10 +91,19 @@ const ServerConfigStep = ({ formRef, help = {}, onSubmit, onSubmitAll, submitAll
     onChange(event);
   };
 
+  const _onSubmitAll = (validateForm) => {
+    validateForm().then((errors) => {
+      if (!formHasErrors(errors)) {
+        onSubmitAll();
+      }
+    });
+  };
+
   return (
     // $FlowFixMe innerRef works as expected
     <Formik initialValues={stepsState.formValues}
             innerRef={formRef}
+            initialErrors={backendValidationErrors}
             onSubmit={onSubmit}
             validateOnBlur={false}
             validateOnChange={false}
@@ -111,11 +118,13 @@ const ServerConfigStep = ({ formRef, help = {}, onSubmit, onSubmitAll, submitAll
               <ServerUrl className="input-group">
                 <FormikInput formGroupClassName=""
                              name="serverHost"
+                             error={backendValidationErrors?.serverHost}
                              placeholder="Hostname"
-                             validate={validateField(FORM_VALIDATION.serverPort)} />
+                             validate={validateField(FORM_VALIDATION.serverHost)} />
                 <span className="input-group-addon input-group-separator">:</span>
                 <FormikInput formGroupClassName=""
                              name="serverPort"
+                             error={backendValidationErrors?.serverPort}
                              placeholder="Port"
                              type="number"
                              validate={validateField(FORM_VALIDATION.serverPort)} />
@@ -162,8 +171,10 @@ const ServerConfigStep = ({ formRef, help = {}, onSubmit, onSubmitAll, submitAll
             </>
           </Input>
           <FormikFormGroup help={help.systemUserDn}
+                           error={backendValidationErrors?.systemUserDn}
                            label={<>System User DN <Opt /></>}
                            name="systemUserDn"
+                           validate={validateField(FORM_VALIDATION.systemUserDn)}
                            placeholder="System User DN" />
 
           {(backendHasPassword && values.systemUserPassword === undefined) ? (
@@ -185,7 +196,9 @@ const ServerConfigStep = ({ formRef, help = {}, onSubmit, onSubmitAll, submitAll
                              help={help.systemUserPassword}
                              label={<>System Password <Opt /></>}
                              name="systemUserPassword"
+                             error={backendValidationErrors?.systemUserPassword}
                              placeholder="System Password"
+                             validate={validateField(FORM_VALIDATION.systemUserPassword)}
                              type="password" />
           )}
 

--- a/graylog2-web-interface/src/components/authentication/directoryServices/BackendWizard/UserSyncStep.jsx
+++ b/graylog2-web-interface/src/components/authentication/directoryServices/BackendWizard/UserSyncStep.jsx
@@ -14,12 +14,15 @@ import BackendWizardContext from './BackendWizardContext';
 
 export type StepKeyType = 'user-synchronization';
 export const STEP_KEY: StepKeyType = 'user-synchronization';
+// Form validation needs to include all input names
+// to be able to associate backend validation errors with the form
 export const FORM_VALIDATION = {
   defaultRoles: { required: true },
   userFullNameAttribute: { required: true },
   userNameAttribute: { required: true },
   userSearchBase: { required: true },
   userSearchPattern: { required: true },
+  userUniqueIdAttribute: {},
 };
 
 type Props = {
@@ -35,6 +38,7 @@ type Props = {
 
 const UserSyncStep = ({ help = {}, excludedFields = {}, formRef, onSubmit, onSubmitAll, submitAllError, validateOnMount, roles }: Props) => {
   const { setStepsState, ...stepsState } = useContext(BackendWizardContext);
+  const { backendValidationErrors } = stepsState;
   const rolesOptions = roles.map((role) => ({ label: role.name, value: role.id })).toArray();
 
   const _onSubmitAll = (validateForm) => {
@@ -48,6 +52,7 @@ const UserSyncStep = ({ help = {}, excludedFields = {}, formRef, onSubmit, onSub
   return (
     // $FlowFixMe innerRef works as expected
     <Formik initialValues={stepsState.formValues}
+            initialErrors={backendValidationErrors}
             innerRef={formRef}
             onSubmit={onSubmit}
             validateOnBlur={false}
@@ -57,6 +62,7 @@ const UserSyncStep = ({ help = {}, excludedFields = {}, formRef, onSubmit, onSub
         <Form className="form form-horizontal">
           <FormikFormGroup help={help.userSearchBase}
                            label="Search Base DN"
+                           error={backendValidationErrors?.userSearchBase}
                            name="userSearchBase"
                            placeholder="Search Base DN"
                            validate={validateField(FORM_VALIDATION.userSearchBase)} />
@@ -64,12 +70,14 @@ const UserSyncStep = ({ help = {}, excludedFields = {}, formRef, onSubmit, onSub
           <FormikFormGroup help={help.userSearchPattern}
                            label="Search Pattern"
                            name="userSearchPattern"
+                           error={backendValidationErrors?.userSearchPattern}
                            placeholder="Search Pattern"
                            validate={validateField(FORM_VALIDATION.userSearchPattern)} />
 
           <FormikFormGroup help={help.userNameAttribute}
                            label="Name Attribute"
                            name="userNameAttribute"
+                           error={backendValidationErrors?.userNameAttribute}
                            placeholder="Name Attribute"
                            validate={validateField(FORM_VALIDATION.userNameAttribute)} />
 
@@ -84,7 +92,7 @@ const UserSyncStep = ({ help = {}, excludedFields = {}, formRef, onSubmit, onSub
                              label="ID Attribute"
                              name="userUniqueIdAttribute"
                              placeholder="ID Attribute"
-                             validate={validateField(FORM_VALIDATION.userFullNameAttribute)} />
+                             validate={validateField(FORM_VALIDATION.userUniqueIdAttribute)} />
           )}
 
           <Row>
@@ -100,7 +108,7 @@ const UserSyncStep = ({ help = {}, excludedFields = {}, formRef, onSubmit, onSub
             {({ field: { name, value, onChange, onBlur }, meta: { error } }) => (
               <Input bsStyle={error ? 'error' : undefined}
                      help={help.defaultRoles}
-                     error={error}
+                     error={error ?? backendValidationErrors?.defaultRoles}
                      id="default-roles-select"
                      label="Default Roles"
                      labelClassName="col-sm-3"

--- a/graylog2-web-interface/src/components/authentication/directoryServices/BackendWizard/UserSyncStep.jsx
+++ b/graylog2-web-interface/src/components/authentication/directoryServices/BackendWizard/UserSyncStep.jsx
@@ -85,6 +85,7 @@ const UserSyncStep = ({ help = {}, excludedFields = {}, formRef, onSubmit, onSub
                            label="Full Name Attribute"
                            name="userFullNameAttribute"
                            placeholder="Full Name Attribute"
+                           error={backendValidationErrors?.userFullNameAttribute}
                            validate={validateField(FORM_VALIDATION.userFullNameAttribute)} />
 
           {!excludedFields.userUniqueIdAttribute && (
@@ -92,6 +93,7 @@ const UserSyncStep = ({ help = {}, excludedFields = {}, formRef, onSubmit, onSub
                              label="ID Attribute"
                              name="userUniqueIdAttribute"
                              placeholder="ID Attribute"
+                             error={backendValidationErrors?.userUniqueIdAttribute}
                              validate={validateField(FORM_VALIDATION.userUniqueIdAttribute)} />
           )}
 

--- a/graylog2-web-interface/src/components/common/FormikInput.jsx
+++ b/graylog2-web-interface/src/components/common/FormikInput.jsx
@@ -13,6 +13,7 @@ type Props = {
   onChange?: (SyntheticInputEvent<Input>) => void,
   wrapperClassName?: string,
   validate?: (string) => ?string,
+  error?: string,
 };
 
 const checkboxProps = (value) => {
@@ -24,14 +25,15 @@ const inputProps = (value) => {
 };
 
 /** Wraps the common Input component with a formik Field */
-const FormikInput = ({ name, type, help, validate, onChange: propagateOnChange, ...rest }: Props) => {
+const FormikInput = ({ name, type, help, validate, onChange: propagateOnChange, error: errorProp, ...rest }: Props) => {
   const { validateOnChange } = useFormikContext();
 
   return (
     <Field name={name} validate={validate}>
-      {({ field: { value, onChange, onBlur }, meta: { error, touched } }) => {
+      {({ field: { value, onChange, onBlur }, meta: { error: validationError, touched } }) => {
         const typeSpecificProps = type === 'checkbox' ? checkboxProps(value) : inputProps(value);
-        const displayError = validateOnChange ? !!(error && touched) : !!error;
+        const displayValidationError = validateOnChange ? !!(validationError && touched) : !!validationError;
+        const error = displayValidationError ? validationError : errorProp;
 
         const _handleChange = (e) => {
           if (typeof propagateOnChange === 'function') {
@@ -47,7 +49,7 @@ const FormikInput = ({ name, type, help, validate, onChange: propagateOnChange, 
                  onBlur={onBlur}
                  help={help}
                  id={name}
-                 error={displayError ? error : undefined}
+                 error={error}
                  onChange={_handleChange}
                  type={type} />
         );
@@ -72,6 +74,7 @@ FormikInput.defaultProps = {
   type: 'text',
   validate: () => {},
   wrapperClassName: undefined,
+  error: undefined,
 };
 
 export default FormikInput;

--- a/graylog2-web-interface/src/components/common/InputDescription.jsx
+++ b/graylog2-web-interface/src/components/common/InputDescription.jsx
@@ -9,6 +9,10 @@ const ErrorMessage = styled.span(({ theme }) => `
   color: ${theme.colors.variant.danger};
 `);
 
+const HelpMessage = styled.span(({ theme, hasError }) => `
+  color: ${hasError ? theme.colors.gray[50] : 'inherit'};
+`);
+
 type Props = {
   help?: React.Node,
   error?: React.Node,
@@ -32,9 +36,9 @@ const InputDescription = ({ help, error }: Props) => {
       )}
       {(!!error && !!help) && <br />}
       {help && (
-        <span>
+        <HelpMessage hasError={!!error}>
           {help}
-        </span>
+        </HelpMessage>
       )}
     </HelpBlock>
   );


### PR DESCRIPTION
## Description
Previously backend validation errors in the directory service wizard were just displayed under the current form. With this PR we are displaying a backend validation message as an input validation error. If the error relates to an input which is part of a different wizard step we navigate to the specific step on submit.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

/jenkins-pr-deps Graylog2/graylog-plugin-enterprise#1922