### PR TITLE
Allow configuring title and description of an authentication backend

### DIFF
--- a/graylog2-web-interface/src/components/authentication/BackendsOverview/BackendsOverview.jsx
+++ b/graylog2-web-interface/src/components/authentication/BackendsOverview/BackendsOverview.jsx
@@ -14,7 +14,7 @@ import { Col, Row } from 'components/graylog';
 import BackendsFilter from './BackendsFilter';
 import BackendsOverviewItem from './BackendsOverviewItem';
 
-const TABLE_HEADERS = ['Title', 'Default Roles'];
+const TABLE_HEADERS = ['Title', 'Description', 'Default Roles', 'Actions'];
 
 const DEFAULT_PAGINATION = {
   page: 1,

--- a/graylog2-web-interface/src/components/authentication/BackendsOverview/BackendsOverviewItem.jsx
+++ b/graylog2-web-interface/src/components/authentication/BackendsOverview/BackendsOverviewItem.jsx
@@ -23,6 +23,16 @@ const StyledButtonToolbar = styled(ButtonToolbar)`
   justify-content: flex-end;
 `;
 
+const DescriptionCell = styled.td`
+  max-width: 300px;
+`;
+
+const TextOverflowEllipsis = styled.div`
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
 const RolesList = ({ defaultRolesIds, roles }: {defaultRolesIds: Immutable.List<string>, roles: Immutable.List<Role>}) => {
   const defaultRolesNames = defaultRolesIds.map((roleId) => roles.find((role) => role.id === roleId)?.name ?? 'Role not found');
 
@@ -94,7 +104,7 @@ const ActionsCell = ({ isActive, authenticationBackend }: { authenticationBacken
 };
 
 const BackendsOverviewItem = ({ authenticationBackend, isActive, roles }: Props) => {
-  const { title, defaultRoles, id } = authenticationBackend;
+  const { title, description, defaultRoles, id } = authenticationBackend;
   const detailsLink = isActive ? Routes.SYSTEM.AUTHENTICATION.BACKENDS.ACTIVE : Routes.SYSTEM.AUTHENTICATION.BACKENDS.show(id);
 
   return (
@@ -104,6 +114,11 @@ const BackendsOverviewItem = ({ authenticationBackend, isActive, roles }: Props)
           {title}
         </Link>
       </td>
+      <DescriptionCell>
+        <TextOverflowEllipsis>
+          {description}
+        </TextOverflowEllipsis>
+      </DescriptionCell>
       <td className="limited">
         <RolesList defaultRolesIds={defaultRoles} roles={roles} />
       </td>

--- a/graylog2-web-interface/src/components/authentication/directoryServices/BackendConfigDetails/ServerConfigSection.jsx
+++ b/graylog2-web-interface/src/components/authentication/directoryServices/BackendConfigDetails/ServerConfigSection.jsx
@@ -14,11 +14,13 @@ type Props = {
 };
 
 const ServerConfigSection = ({ authenticationBackend }: Props) => {
-  const { servers = [], systemUserDn, systemUserPassword, transportSecurity, verifyCertificates } = authenticationBackend.config;
+  const { title, description, config: { servers = [], systemUserDn, systemUserPassword, transportSecurity, verifyCertificates } } = authenticationBackend;
   const serverUrls = servers.map((server) => `${server.host}:${server.port}`).join(', ');
 
   return (
     <SectionComponent title="Server Configuration" headerActions={<EditLinkButton authenticationBackendId={authenticationBackend.id} stepKey={SERVER_CONFIG_KEY} />}>
+      <ReadOnlyFormGroup label="Title" value={title} />
+      <ReadOnlyFormGroup label="Description" value={description} />
       <ReadOnlyFormGroup label="Server Address" value={serverUrls} />
       <ReadOnlyFormGroup label="System Username" value={systemUserDn} />
       <ReadOnlyFormGroup label="System Password" value={systemUserPassword?.isSet ? '******' : null} />

--- a/graylog2-web-interface/src/components/authentication/directoryServices/BackendWizard/BackendWizard.jsx
+++ b/graylog2-web-interface/src/components/authentication/directoryServices/BackendWizard/BackendWizard.jsx
@@ -89,10 +89,12 @@ const _prepareSubmitPayload = (stepsState, getUpdatedFormsValues) => (overrideFo
   const formValues = overrideFormValues ?? getUpdatedFormsValues();
   const {
     defaultRoles = '',
+    description,
     serverHost,
     serverPort,
     systemUserDn,
     systemUserPassword,
+    title,
     transportSecurity,
     userUniqueIdAttribute,
     userFullNameAttribute,
@@ -102,16 +104,14 @@ const _prepareSubmitPayload = (stepsState, getUpdatedFormsValues) => (overrideFo
     verifyCertificates,
   } = formValues;
   const {
-    serviceTitle,
     serviceType,
     backendId,
   } = stepsState.authBackendMeta;
-  const serverUrl = `${serverHost}:${serverPort}`;
 
   return {
+    title,
+    description,
     default_roles: defaultRoles.split(','),
-    description: '',
-    title: `${serviceTitle} ${serverUrl}`,
     config: {
       servers: [{ host: serverHost, port: serverPort }],
       system_user_dn: systemUserDn,

--- a/graylog2-web-interface/src/components/authentication/directoryServices/BackendWizard/BackendWizardContext.jsx
+++ b/graylog2-web-interface/src/components/authentication/directoryServices/BackendWizard/BackendWizardContext.jsx
@@ -6,6 +6,8 @@ import type { Step } from 'components/common/Wizard';
 import { singleton } from 'views/logic/singleton';
 
 export type WizardFormValues = {
+  title?: string,
+  description?: string,
   defaultRoles?: string,
   groupSearchBase?: string,
   groupSearchPattern?: string,

--- a/graylog2-web-interface/src/components/authentication/directoryServices/BackendWizard/ServerConfigStep.jsx
+++ b/graylog2-web-interface/src/components/authentication/directoryServices/BackendWizard/ServerConfigStep.jsx
@@ -146,7 +146,7 @@ const ServerConfigStep = ({ formRef, help = {}, onSubmit, onSubmitAll, submitAll
               </ServerUrl>
 
               <ProtocolOptions>
-                <Field name="transportSecurity" validate={validateField(FORM_VALIDATION.transportSecurity)}>
+                <Field name="transportSecurity">
                   {({ field: { name, onChange, onBlur, value } }) => (
                     <>
                       <Input defaultChecked={value === 'none'}

--- a/graylog2-web-interface/src/components/authentication/directoryServices/BackendWizard/ServerConfigStep.jsx
+++ b/graylog2-web-interface/src/components/authentication/directoryServices/BackendWizard/ServerConfigStep.jsx
@@ -28,7 +28,6 @@ export const FORM_VALIDATION = {
     min: 1,
     max: 65535,
   },
-  title: {},
   description: {},
   transportSecurity: {},
   verifyCertificates: {},

--- a/graylog2-web-interface/src/components/authentication/directoryServices/BackendWizard/ServerConfigStep.jsx
+++ b/graylog2-web-interface/src/components/authentication/directoryServices/BackendWizard/ServerConfigStep.jsx
@@ -131,7 +131,7 @@ const ServerConfigStep = ({ formRef, help = {}, onSubmit, onSubmitAll, submitAll
               </ServerUrl>
 
               <ProtocolOptions>
-                <Field name="transportSecurity">
+                <Field name="transportSecurity" validate={validateField(FORM_VALIDATION.transportSecurity)}>
                   {({ field: { name, onChange, onBlur, value } }) => (
                     <>
                       <Input defaultChecked={value === 'none'}

--- a/graylog2-web-interface/src/components/authentication/directoryServices/BackendWizard/ServerConfigStep.jsx
+++ b/graylog2-web-interface/src/components/authentication/directoryServices/BackendWizard/ServerConfigStep.jsx
@@ -17,6 +17,9 @@ export const STEP_KEY: StepKeyType = 'server-configuration';
 // Form validation needs to include all input names
 // to be able to associate backend validation errors with the form
 export const FORM_VALIDATION = {
+  title: {
+    required: true,
+  },
   serverHost: {
     required: true,
   },
@@ -25,6 +28,8 @@ export const FORM_VALIDATION = {
     min: 1,
     max: 65535,
   },
+  title: {},
+  description: {},
   transportSecurity: {},
   verifyCertificates: {},
   systemUserDn: {},
@@ -110,6 +115,17 @@ const ServerConfigStep = ({ formRef, help = {}, onSubmit, onSubmitAll, submitAll
             validateOnMount={validateOnMount}>
       {({ isSubmitting, setFieldValue, values, validateForm }) => (
         <Form className="form form-horizontal">
+          <FormikFormGroup help={help.title}
+                           label="Title"
+                           name="title"
+                           placeholder="Title" />
+
+          <FormikFormGroup help={help.description}
+                           label={<>Description <Opt /></>}
+                           type="textarea"
+                           name="description"
+                           placeholder="Description" />
+
           <Input id="uri-host"
                  label="Server Address"
                  labelClassName="col-sm-3"

--- a/graylog2-web-interface/src/components/authentication/directoryServices/BackendWizard/UserSyncStep.jsx
+++ b/graylog2-web-interface/src/components/authentication/directoryServices/BackendWizard/UserSyncStep.jsx
@@ -5,7 +5,7 @@ import { useContext } from 'react';
 import { Formik, Form, Field } from 'formik';
 
 import Role from 'logic/roles/Role';
-import { validateField } from 'util/FormsUtils';
+import { validateField, formHasErrors } from 'util/FormsUtils';
 import { Alert, Button, ButtonToolbar, Row, Col, Panel } from 'components/graylog';
 import { Icon, FormikFormGroup, Select } from 'components/common';
 import { Input } from 'components/bootstrap';
@@ -41,12 +41,12 @@ const UserSyncStep = ({ help = {}, excludedFields = {}, formRef, onSubmit, onSub
   const { backendValidationErrors } = stepsState;
   const rolesOptions = roles.map((role) => ({ label: role.name, value: role.id })).toArray();
 
-  const _validateField = (fieldName) => {
-    if (backendValidationErrors?.[fieldName]) {
-      return () => backendValidationErrors[fieldName];
-    }
-
-    return validateField(FORM_VALIDATION[fieldName]);
+  const _onSubmitAll = (validateForm) => {
+    validateForm().then((errors) => {
+      if (!formHasErrors(errors)) {
+        onSubmitAll();
+      }
+    });
   };
 
   return (
@@ -58,28 +58,28 @@ const UserSyncStep = ({ help = {}, excludedFields = {}, formRef, onSubmit, onSub
             validateOnBlur={false}
             validateOnChange={false}
             validateOnMount={validateOnMount}>
-      {({ isSubmitting }) => (
+      {({ isSubmitting, validateForm }) => (
         <Form className="form form-horizontal">
           <FormikFormGroup help={help.userSearchBase}
                            label="Search Base DN"
                            error={backendValidationErrors?.userSearchBase}
                            name="userSearchBase"
                            placeholder="Search Base DN"
-                           validate={_validateField('userSearchBase')} />
+                           validate={validateField(FORM_VALIDATION.userSearchBase)} />
 
           <FormikFormGroup help={help.userSearchPattern}
                            label="Search Pattern"
                            name="userSearchPattern"
                            error={backendValidationErrors?.userSearchPattern}
                            placeholder="Search Pattern"
-                           validate={_validateField('userSearchPattern')} />
+                           validate={validateField(FORM_VALIDATION.userSearchPattern)} />
 
           <FormikFormGroup help={help.userNameAttribute}
                            label="Name Attribute"
                            name="userNameAttribute"
                            error={backendValidationErrors?.userNameAttribute}
                            placeholder="Name Attribute"
-                           validate={_validateField('userNameAttribute')} />
+                           validate={validateField(FORM_VALIDATION.userNameAttribute)} />
 
           <FormikFormGroup help={help.userFullNameAttribute}
                            label="Full Name Attribute"
@@ -106,7 +106,7 @@ const UserSyncStep = ({ help = {}, excludedFields = {}, formRef, onSubmit, onSub
             </Col>
           </Row>
 
-          <Field name="defaultRoles" validate={_validateField('defaultRoles')}>
+          <Field name="defaultRoles" validate={validateField(FORM_VALIDATION.defaultRoles)}>
             {({ field: { name, value, onChange, onBlur }, meta: { error } }) => (
               <Input bsStyle={error ? 'error' : undefined}
                      help={help.defaultRoles}
@@ -139,7 +139,7 @@ const UserSyncStep = ({ help = {}, excludedFields = {}, formRef, onSubmit, onSub
 
           <ButtonToolbar className="pull-right">
             <Button disabled={isSubmitting}
-                    onClick={onSubmitAll}
+                    onClick={() => _onSubmitAll(validateForm)}
                     type="button">
               Finish & Save Identity Service
             </Button>

--- a/graylog2-web-interface/src/components/authentication/directoryServices/BackendWizard/UserSyncStep.jsx
+++ b/graylog2-web-interface/src/components/authentication/directoryServices/BackendWizard/UserSyncStep.jsx
@@ -5,7 +5,7 @@ import { useContext } from 'react';
 import { Formik, Form, Field } from 'formik';
 
 import Role from 'logic/roles/Role';
-import { validateField, formHasErrors } from 'util/FormsUtils';
+import { validateField } from 'util/FormsUtils';
 import { Alert, Button, ButtonToolbar, Row, Col, Panel } from 'components/graylog';
 import { Icon, FormikFormGroup, Select } from 'components/common';
 import { Input } from 'components/bootstrap';
@@ -41,12 +41,12 @@ const UserSyncStep = ({ help = {}, excludedFields = {}, formRef, onSubmit, onSub
   const { backendValidationErrors } = stepsState;
   const rolesOptions = roles.map((role) => ({ label: role.name, value: role.id })).toArray();
 
-  const _onSubmitAll = (validateForm) => {
-    validateForm().then((errors) => {
-      if (!formHasErrors(errors)) {
-        onSubmitAll();
-      }
-    });
+  const _validateField = (fieldName) => {
+    if (backendValidationErrors?.[fieldName]) {
+      return () => backendValidationErrors[fieldName];
+    }
+
+    return validateField(FORM_VALIDATION[fieldName]);
   };
 
   return (
@@ -58,28 +58,28 @@ const UserSyncStep = ({ help = {}, excludedFields = {}, formRef, onSubmit, onSub
             validateOnBlur={false}
             validateOnChange={false}
             validateOnMount={validateOnMount}>
-      {({ isSubmitting, validateForm }) => (
+      {({ isSubmitting }) => (
         <Form className="form form-horizontal">
           <FormikFormGroup help={help.userSearchBase}
                            label="Search Base DN"
                            error={backendValidationErrors?.userSearchBase}
                            name="userSearchBase"
                            placeholder="Search Base DN"
-                           validate={validateField(FORM_VALIDATION.userSearchBase)} />
+                           validate={_validateField('userSearchBase')} />
 
           <FormikFormGroup help={help.userSearchPattern}
                            label="Search Pattern"
                            name="userSearchPattern"
                            error={backendValidationErrors?.userSearchPattern}
                            placeholder="Search Pattern"
-                           validate={validateField(FORM_VALIDATION.userSearchPattern)} />
+                           validate={_validateField('userSearchPattern')} />
 
           <FormikFormGroup help={help.userNameAttribute}
                            label="Name Attribute"
                            name="userNameAttribute"
                            error={backendValidationErrors?.userNameAttribute}
                            placeholder="Name Attribute"
-                           validate={validateField(FORM_VALIDATION.userNameAttribute)} />
+                           validate={_validateField('userNameAttribute')} />
 
           <FormikFormGroup help={help.userFullNameAttribute}
                            label="Full Name Attribute"
@@ -106,7 +106,7 @@ const UserSyncStep = ({ help = {}, excludedFields = {}, formRef, onSubmit, onSub
             </Col>
           </Row>
 
-          <Field name="defaultRoles" validate={validateField(FORM_VALIDATION.defaultRoles)}>
+          <Field name="defaultRoles" validate={_validateField('defaultRoles')}>
             {({ field: { name, value, onChange, onBlur }, meta: { error } }) => (
               <Input bsStyle={error ? 'error' : undefined}
                      help={help.defaultRoles}
@@ -139,7 +139,7 @@ const UserSyncStep = ({ help = {}, excludedFields = {}, formRef, onSubmit, onSub
 
           <ButtonToolbar className="pull-right">
             <Button disabled={isSubmitting}
-                    onClick={() => _onSubmitAll(validateForm)}
+                    onClick={onSubmitAll}
                     type="button">
               Finish & Save Identity Service
             </Button>

--- a/graylog2-web-interface/src/components/authentication/directoryServices/PrepareInitialWizardValues.js
+++ b/graylog2-web-interface/src/components/authentication/directoryServices/PrepareInitialWizardValues.js
@@ -6,6 +6,8 @@ import type { DirectoryServiceBackend } from 'logic/authentication/directoryServ
 import type { WizardFormValues } from './BackendWizard/BackendWizardContext';
 
 export default ({
+  title,
+  description,
   defaultRoles = Immutable.List(),
   config: {
     servers = [],
@@ -19,6 +21,8 @@ export default ({
     verifyCertificates,
   },
 }: DirectoryServiceBackend): WizardFormValues => ({
+  title,
+  description,
   defaultRoles: defaultRoles.join(),
   serverHost: servers[0].host,
   serverPort: servers[0].port,

--- a/graylog2-web-interface/src/components/authentication/directoryServices/activeDirectory/BackendCreate.jsx
+++ b/graylog2-web-interface/src/components/authentication/directoryServices/activeDirectory/BackendCreate.jsx
@@ -46,7 +46,13 @@ export const HELP = {
   ),
 };
 
+export const AUTH_BACKEND_META = {
+  serviceTitle: 'Active Directory',
+  serviceType: 'active-directory',
+};
+
 const INITIAL_VALUES = {
+  title: AUTH_BACKEND_META.serviceTitle,
   serverHost: 'localhost',
   serverPort: 636,
   transportSecurity: 'tls',
@@ -54,11 +60,6 @@ const INITIAL_VALUES = {
   userFullNameAttribute: 'displayName',
   userNameAttribute: 'userPrincipalName',
   verifyCertificates: true,
-};
-
-export const AUTH_BACKEND_META = {
-  serviceTitle: 'Active Directory',
-  serviceType: 'active-directory',
 };
 
 const BackendCreate = () => {

--- a/graylog2-web-interface/src/components/authentication/directoryServices/ldap/BackendCreate.jsx
+++ b/graylog2-web-interface/src/components/authentication/directoryServices/ldap/BackendCreate.jsx
@@ -57,6 +57,7 @@ export const HELP = {
 };
 
 const INITIAL_VALUES = {
+  title: AUTH_BACKEND_META.serviceTitle,
   serverHost: 'localhost',
   serverPort: 636,
   transportSecurity: 'tls',

--- a/graylog2-web-interface/src/domainActions/authentication/AuthenticationDomain.js
+++ b/graylog2-web-interface/src/domainActions/authentication/AuthenticationDomain.js
@@ -32,7 +32,7 @@ const loadActive: $PropertyType<ActionsType, 'loadActive'> = notifyingAction({
 const update: $PropertyType<ActionsType, 'update'> = notifyingAction({
   action: AuthenticationActions.update,
   success: (authBackendId, authBackend) => ({
-    message: `Authentication service "${authBackend.title} was updated successfully`,
+    message: `Authentication service "${authBackend.title}" was updated successfully`,
   }),
   error: (error, authBackendId, authBackend) => ({
     message: `Updating authentication service "${authBackend.title}" failed with status: ${error}`,


### PR DESCRIPTION
_This PR is based on https://github.com/Graylog2/graylog2-server/pull/9412 which needs to be merged first_

## Description
The title of an authentication backend is currently based on the service type + the server address and can't be configured. 
With this PR we are adding inputs for both fields to the server configuration step. We also display de description in backends overview and on the details page.
With custom titles it will be easier to differentiate between authentication backends.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Fixes https://github.com/Graylog2/graylog2-server/issues/9359