### PR TITLE
Register ownership for streams

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/security/entities/EntityOwnershipService.java
+++ b/graylog2-server/src/main/java/org/graylog/security/entities/EntityOwnershipService.java
@@ -64,6 +64,11 @@ public class EntityOwnershipService {
         registerNewEntity(grn, user);
     }
 
+    public void registerNewStream(String id, User user) {
+        final GRN grn = grnRegistry.newGRN(GRNTypes.STREAM, id);
+        registerNewEntity(grn, user);
+    }
+
     private void registerNewEntity(GRN entity, User user) {
         // Don't create ownership grants for the admin user.
         // They can access anything anyhow

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/StreamFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/StreamFacade.java
@@ -50,6 +50,7 @@ import org.graylog2.indexer.indexset.IndexSetService;
 import org.graylog2.plugin.alarms.AlertCondition;
 import org.graylog2.plugin.configuration.ConfigurationException;
 import org.graylog2.plugin.database.ValidationException;
+import org.graylog2.plugin.database.users.User;
 import org.graylog2.plugin.streams.Output;
 import org.graylog2.plugin.streams.Stream;
 import org.graylog2.plugin.streams.StreamRule;
@@ -58,6 +59,7 @@ import org.graylog2.rest.models.alarmcallbacks.requests.CreateAlarmCallbackReque
 import org.graylog2.rest.models.streams.alerts.requests.CreateConditionRequest;
 import org.graylog2.rest.resources.streams.requests.CreateStreamRequest;
 import org.graylog2.rest.resources.streams.rules.requests.CreateStreamRuleRequest;
+import org.graylog2.shared.users.UserService;
 import org.graylog2.streams.StreamRuleService;
 import org.graylog2.streams.StreamService;
 import org.slf4j.Logger;
@@ -87,6 +89,7 @@ public class StreamFacade implements EntityFacade<Stream> {
     private final AlarmCallbackConfigurationService alarmCallbackConfigurationService;
     private final V20190722150700_LegacyAlertConditionMigration legacyAlertsMigration;
     private final IndexSetService indexSetService;
+    private final UserService userService;
 
     @Inject
     public StreamFacade(ObjectMapper objectMapper,
@@ -95,7 +98,7 @@ public class StreamFacade implements EntityFacade<Stream> {
                         AlertService streamAlertService,
                         AlarmCallbackConfigurationService alarmCallbackConfigurationService,
                         V20190722150700_LegacyAlertConditionMigration legacyAlertsMigration,
-                        IndexSetService indexSetService) {
+                        IndexSetService indexSetService, UserService userService) {
         this.objectMapper = objectMapper;
         this.streamService = streamService;
         this.streamRuleService = streamRuleService;
@@ -103,6 +106,7 @@ public class StreamFacade implements EntityFacade<Stream> {
         this.alarmCallbackConfigurationService = alarmCallbackConfigurationService;
         this.legacyAlertsMigration = legacyAlertsMigration;
         this.indexSetService = indexSetService;
+        this.userService = userService;
     }
 
     @VisibleForTesting
@@ -149,7 +153,8 @@ public class StreamFacade implements EntityFacade<Stream> {
                                                    Map<EntityDescriptor, Object> nativeEntities,
                                                    String username) {
         if (entity instanceof EntityV1) {
-            return decode((EntityV1) entity, parameters, nativeEntities, username);
+            final User user = Optional.ofNullable(userService.load(username)).orElseThrow(() -> new IllegalStateException("Cannot load user <" + username + "> from db"));
+            return decode((EntityV1) entity, parameters, nativeEntities, user);
         } else {
             throw new IllegalArgumentException("Unsupported entity version: " + entity.getClass());
         }
@@ -158,7 +163,7 @@ public class StreamFacade implements EntityFacade<Stream> {
     private NativeEntity<Stream> decode(EntityV1 entity,
                                         Map<String, ValueReference> parameters,
                                         Map<EntityDescriptor, Object> nativeEntities,
-                                        String username) {
+                                        User user) {
         final StreamEntity streamEntity = objectMapper.convertValue(entity.data(), StreamEntity.class);
         final CreateStreamRequest createStreamRequest = CreateStreamRequest.create(
                 streamEntity.title().asString(parameters),
@@ -168,7 +173,7 @@ public class StreamFacade implements EntityFacade<Stream> {
                 streamEntity.matchingType().asString(parameters),
                 streamEntity.removeMatches().asBoolean(parameters),
                 indexSetService.getDefault().id());
-        final Stream stream = streamService.create(createStreamRequest, username);
+        final Stream stream = streamService.create(createStreamRequest, user.getName());
         final List<StreamRule> streamRules = streamEntity.streamRules().stream()
                 .map(streamRuleEntity -> createStreamRuleRequest(streamRuleEntity, parameters))
                 .map(request -> streamRuleService.create(DUMMY_STREAM_ID, request))
@@ -178,7 +183,7 @@ public class StreamFacade implements EntityFacade<Stream> {
                 .map(alertCondition -> createStreamAlertConditionRequest(alertCondition, parameters))
                 .map(request -> {
                     try {
-                        return streamAlertService.fromRequest(request, stream, username);
+                        return streamAlertService.fromRequest(request, stream, user.getName());
                     } catch (ConfigurationException e) {
                         throw new ContentPackException("Couldn't create entity " + entity.toEntityDescriptor(), e);
                     }
@@ -187,11 +192,11 @@ public class StreamFacade implements EntityFacade<Stream> {
         // TODO: The creation of legacy alarm callback should be avoided and a new event notification should be created instead
         final List<AlarmCallbackConfiguration> alarmCallbacks = streamEntity.alarmCallbacks().stream()
                 .map(alarmCallback -> createStreamAlarmCallbackRequest(alarmCallback, parameters))
-                .map(request -> alarmCallbackConfigurationService.create(stream.getId(), request, username))
+                .map(request -> alarmCallbackConfigurationService.create(stream.getId(), request, user.getName()))
                 .collect(Collectors.toList());
         final String savedStreamId;
         try {
-            savedStreamId = streamService.saveWithRules(stream, streamRules);
+            savedStreamId = streamService.saveWithRulesAndOwnership(stream, streamRules, user);
 
             for (final AlertCondition alertCondition : alertConditions) {
                 streamService.addAlertCondition(stream, alertCondition);

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/StreamResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/StreamResource.java
@@ -18,7 +18,6 @@ package org.graylog2.rest.resources.streams;
 
 import com.codahale.metrics.annotation.Timed;
 import com.google.common.base.Strings;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
@@ -32,6 +31,7 @@ import io.swagger.annotations.ApiResponses;
 import org.apache.shiro.authz.annotation.RequiresAuthentication;
 import org.apache.shiro.authz.annotation.RequiresPermissions;
 import org.bson.types.ObjectId;
+import org.graylog.security.UserContext;
 import org.graylog2.alarmcallbacks.AlarmCallbackConfiguration;
 import org.graylog2.alarmcallbacks.AlarmCallbackConfigurationService;
 import org.graylog2.alerts.AlertService;
@@ -47,7 +47,6 @@ import org.graylog2.plugin.Tools;
 import org.graylog2.plugin.alarms.AlertCondition;
 import org.graylog2.plugin.configuration.ConfigurationException;
 import org.graylog2.plugin.database.ValidationException;
-import org.graylog2.plugin.database.users.User;
 import org.graylog2.plugin.streams.Output;
 import org.graylog2.plugin.streams.Stream;
 import org.graylog2.plugin.streams.StreamRule;
@@ -96,6 +95,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.net.URI;
@@ -160,7 +160,8 @@ public class StreamResource extends RestResource {
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     @AuditEvent(type = AuditEventTypes.STREAM_CREATE)
-    public Response create(@ApiParam(name = "JSON body", required = true) final CreateStreamRequest cr) throws ValidationException {
+    public Response create(@ApiParam(name = "JSON body", required = true) final CreateStreamRequest cr,
+                           @Context UserContext userContext) throws ValidationException {
         // Create stream.
         final Stream stream = streamService.create(cr, getCurrentUser().getName());
         stream.setDisabled(true);
@@ -172,9 +173,7 @@ public class StreamResource extends RestResource {
         final Set<StreamRule> streamRules = cr.rules().stream()
                 .map(streamRule -> streamRuleService.create(null, streamRule))
                 .collect(Collectors.toSet());
-        final String id = streamService.saveWithRules(stream, streamRules);
-
-        ensureUserHasPermissionsForStream(getCurrentUser(), id);
+        final String id = streamService.saveWithRulesAndOwnership(stream, streamRules, userContext.getUser());
 
         final Map<String, String> result = ImmutableMap.of("stream_id", id);
         final URI streamUri = getUriBuilderToSelf().path(StreamResource.class)
@@ -182,31 +181,6 @@ public class StreamResource extends RestResource {
             .build(id);
 
         return Response.created(streamUri).entity(result).build();
-    }
-
-    private boolean ensureUserHasPermissionsForStream(User user, String id) throws ValidationException {
-        boolean permissionsChanged = false;
-        final ImmutableList.Builder<String> permissionsBuilder = ImmutableList.<String>builder()
-                .addAll(user.getPermissions());
-        if (!isPermitted(RestPermissions.STREAMS_READ, id)) {
-            permissionsChanged = true;
-            permissionsBuilder.add(RestPermissions.STREAMS_READ + ":" + id);
-        }
-        if (!isPermitted(RestPermissions.STREAMS_EDIT, id)) {
-            permissionsChanged = true;
-            permissionsBuilder.add(RestPermissions.STREAMS_EDIT + ":" + id);
-        }
-        if (!isPermitted(RestPermissions.STREAMS_CHANGESTATE, id)) {
-            permissionsChanged = true;
-            permissionsBuilder.add(RestPermissions.STREAMS_CHANGESTATE + ":" + id);
-        }
-
-        if (permissionsChanged) {
-            user.setPermissions(permissionsBuilder.build());
-            userService.save(user);
-        }
-
-        return permissionsChanged;
     }
 
     @GET
@@ -463,7 +437,8 @@ public class StreamResource extends RestResource {
     @Produces(MediaType.APPLICATION_JSON)
     @AuditEvent(type = AuditEventTypes.STREAM_CREATE)
     public Response cloneStream(@ApiParam(name = "streamId", required = true) @PathParam("streamId") String streamId,
-                                @ApiParam(name = "JSON body", required = true) @Valid @NotNull CloneStreamRequest cr) throws ValidationException, NotFoundException {
+                                @ApiParam(name = "JSON body", required = true) @Valid @NotNull CloneStreamRequest cr,
+                                @Context UserContext userContext) throws ValidationException, NotFoundException {
         checkPermission(RestPermissions.STREAMS_CREATE);
         checkPermission(RestPermissions.STREAMS_READ, streamId);
         checkNotDefaultStream(streamId, "The default stream cannot be cloned.");
@@ -497,7 +472,7 @@ public class StreamResource extends RestResource {
         streamData.put(StreamImpl.FIELD_INDEX_SET_ID, cr.indexSetId());
 
         final Stream stream = streamService.create(streamData);
-        final String savedStreamId = streamService.saveWithRules(stream, newStreamRules.build());
+        final String savedStreamId = streamService.saveWithRulesAndOwnership(stream, newStreamRules.build(), userContext.getUser());
         final ObjectId savedStreamObjectId = new ObjectId(savedStreamId);
 
         for (AlertCondition alertCondition : streamService.getAlertConditions(sourceStream)) {
@@ -524,8 +499,6 @@ public class StreamResource extends RestResource {
                 .map(ObjectId::new)
                 .collect(Collectors.toSet());
         streamService.addOutputs(savedStreamObjectId, outputIds);
-
-        ensureUserHasPermissionsForStream(getCurrentUser(), savedStreamId);
 
         final Map<String, String> result = ImmutableMap.of("stream_id", savedStreamId);
         final URI streamUri = getUriBuilderToSelf().path(StreamResource.class)

--- a/graylog2-server/src/main/java/org/graylog2/streams/StreamService.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/StreamService.java
@@ -21,6 +21,7 @@ import org.graylog2.database.NotFoundException;
 import org.graylog2.plugin.alarms.AlertCondition;
 import org.graylog2.plugin.database.PersistedService;
 import org.graylog2.plugin.database.ValidationException;
+import org.graylog2.plugin.database.users.User;
 import org.graylog2.plugin.streams.Output;
 import org.graylog2.plugin.streams.Stream;
 import org.graylog2.plugin.streams.StreamRule;
@@ -38,7 +39,7 @@ public interface StreamService extends PersistedService {
 
     String save(Stream stream) throws ValidationException;
 
-    String saveWithRules(Stream stream, Collection<StreamRule> streamRules) throws ValidationException;
+    String saveWithRulesAndOwnership(Stream stream, Collection<StreamRule> streamRules, User user) throws ValidationException;
 
     Stream load(String id) throws NotFoundException;
 

--- a/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/processors/ConfigurationStateUpdaterTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/processors/ConfigurationStateUpdaterTest.java
@@ -56,6 +56,7 @@ import org.graylog2.plugin.Tools;
 import org.graylog2.plugin.alarms.AlertCondition;
 import org.graylog2.plugin.database.Persisted;
 import org.graylog2.plugin.database.ValidationException;
+import org.graylog2.plugin.database.users.User;
 import org.graylog2.plugin.database.validators.ValidationResult;
 import org.graylog2.plugin.database.validators.Validator;
 import org.graylog2.plugin.streams.Output;
@@ -169,7 +170,7 @@ public class ConfigurationStateUpdaterTest {
         }
 
         @Override
-        public String saveWithRules(Stream stream, Collection<StreamRule> streamRules) throws ValidationException {
+        public String saveWithRulesAndOwnership(Stream stream, Collection<StreamRule> streamRules, User user) throws ValidationException {
             return save(stream);
         }
 

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/ContentPackServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/ContentPackServiceTest.java
@@ -47,6 +47,7 @@ import org.graylog2.plugin.PluginMetaData;
 import org.graylog2.plugin.outputs.MessageOutput;
 import org.graylog2.plugin.streams.Output;
 import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
+import org.graylog2.shared.users.UserService;
 import org.graylog2.streams.OutputImpl;
 import org.graylog2.streams.OutputService;
 import org.graylog2.streams.StreamImpl;
@@ -93,6 +94,8 @@ public class ContentPackServiceTest {
     @Mock
     private GrokPatternService patternService;
     @Mock
+    private UserService userService;
+    @Mock
     private ContentPackInstallationPersistenceService contentPackInstallService;
     @Mock
     private V20190722150700_LegacyAlertConditionMigration legacyAlertConditionMigration;
@@ -117,7 +120,7 @@ public class ContentPackServiceTest {
         outputFactories2 = new HashMap<>();
         final Map<ModelType, EntityFacade<?>> entityFacades = ImmutableMap.of(
                 ModelTypes.GROK_PATTERN_V1, new GrokPatternFacade(objectMapper, patternService),
-                ModelTypes.STREAM_V1, new StreamFacade(objectMapper, streamService, streamRuleService, alertService, alarmCallbackConfigurationService, legacyAlertConditionMigration, indexSetService),
+                ModelTypes.STREAM_V1, new StreamFacade(objectMapper, streamService, streamRuleService, alertService, alarmCallbackConfigurationService, legacyAlertConditionMigration, indexSetService, userService),
                 ModelTypes.OUTPUT_V1, new OutputFacade(objectMapper, outputService, pluginMetaData, outputFactories, outputFactories2)
         );
 

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/StreamCatalogTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/StreamCatalogTest.java
@@ -47,6 +47,7 @@ import org.graylog2.plugin.streams.StreamRule;
 import org.graylog2.plugin.streams.StreamRuleType;
 import org.graylog2.shared.SuppressForbidden;
 import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
+import org.graylog2.shared.users.UserService;
 import org.graylog2.streams.OutputImpl;
 import org.graylog2.streams.OutputService;
 import org.graylog2.streams.StreamImpl;
@@ -97,6 +98,8 @@ public class StreamCatalogTest {
     private V20190722150700_LegacyAlertConditionMigration legacyAlertConditionMigration;
     @Mock
     private EntityOwnershipService entityOwnershipService;
+    @Mock
+    private UserService userService;
     private StreamFacade facade;
 
     @Before
@@ -120,7 +123,7 @@ public class StreamCatalogTest {
                 OutputImpl.create("5adf239e4b900a0fdb4e5197", "Title", "Type", "admin", Collections.emptyMap(), new Date(1524654085L), null)
         );
 
-        facade = new StreamFacade(objectMapper, streamService, streamRuleService, alertService, alarmCallbackConfigurationService, legacyAlertConditionMigration, indexSetService);
+        facade = new StreamFacade(objectMapper, streamService, streamRuleService, alertService, alarmCallbackConfigurationService, legacyAlertConditionMigration, indexSetService, userService);
     }
 
     @Test


### PR DESCRIPTION
And remove code that writes user permissions.

While we haven't complete support for grants in the processing layer,
it's cleaner to support ownership with grants now.

