### PR TITLE
Create common TextOverflowEllipsis component and implement it for roles and auth backend overview

### DIFF
--- a/graylog2-web-interface/src/components/authentication/BackendsOverview/BackendsOverviewItem.jsx
+++ b/graylog2-web-interface/src/components/authentication/BackendsOverview/BackendsOverviewItem.jsx
@@ -10,6 +10,7 @@ import Routes from 'routing/Routes';
 import Role from 'logic/roles/Role';
 import AuthenticationDomain from 'domainActions/authentication/AuthenticationDomain';
 import AuthenticationBackend from 'logic/authentication/AuthenticationBackend';
+import { TextOverflowEllipsis } from 'components/common';
 import { Button, ButtonToolbar } from 'components/graylog';
 
 type Props = {
@@ -25,12 +26,6 @@ const StyledButtonToolbar = styled(ButtonToolbar)`
 
 const DescriptionCell = styled.td`
   max-width: 300px;
-`;
-
-const TextOverflowEllipsis = styled.div`
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 `;
 
 const RolesList = ({ defaultRolesIds, roles }: {defaultRolesIds: Immutable.List<string>, roles: Immutable.List<Role>}) => {

--- a/graylog2-web-interface/src/components/common/TextOverflowEllipsis.jsx
+++ b/graylog2-web-interface/src/components/common/TextOverflowEllipsis.jsx
@@ -1,0 +1,27 @@
+// @flow strict
+import * as React from 'react';
+import styled, { type StyledComponent } from 'styled-components';
+
+import type { ThemeInterface } from 'theme';
+
+const Wrapper: StyledComponent<{}, ThemeInterface, HTMLDivElement> = styled.div`
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
+type Props = {
+  children: String,
+};
+
+/**
+ * Component that signals text overflow to users by using an ellipsis.
+ * The parent component needs a concrete width.
+ */
+const TextOverflowEllipsis = ({ children }: Props) => (
+  <Wrapper>
+    {children}
+  </Wrapper>
+);
+
+export default TextOverflowEllipsis;

--- a/graylog2-web-interface/src/components/common/TextOverflowEllipsis.jsx
+++ b/graylog2-web-interface/src/components/common/TextOverflowEllipsis.jsx
@@ -19,7 +19,7 @@ type Props = {
  * The parent component needs a concrete width.
  */
 const TextOverflowEllipsis = ({ children }: Props) => (
-  <Wrapper>
+  <Wrapper title={children}>
     {children}
   </Wrapper>
 );

--- a/graylog2-web-interface/src/components/common/index.jsx
+++ b/graylog2-web-interface/src/components/common/index.jsx
@@ -63,6 +63,7 @@ export { default as SortableListItem } from './SortableListItem';
 export { SourceCodeEditor };
 export { default as Spinner } from './Spinner';
 export { default as TableList } from './TableList';
+export { default as TextOverflowEllipsis } from './TextOverflowEllipsis';
 export { default as Timestamp } from './Timestamp';
 export { default as TimezoneSelect } from './TimezoneSelect';
 export { default as TypeAheadDataFilter } from './TypeAheadDataFilter';

--- a/graylog2-web-interface/src/components/roles/RolesOverview/RolesOverviewItem.jsx
+++ b/graylog2-web-interface/src/components/roles/RolesOverview/RolesOverviewItem.jsx
@@ -1,14 +1,20 @@
 // @flow strict
 import * as React from 'react';
 import * as Immutable from 'immutable';
+import styled from 'styled-components';
 
 import { Link } from 'components/graylog/router';
 import Routes from 'routing/Routes';
 import Role from 'logic/roles/Role';
+import { TextOverflowEllipsis } from 'components/common';
 import type { UserContext } from 'actions/roles/AuthzRolesActions';
 
 import ActionsCell from './ActionsCell';
 import UsersCell from './UsersCell';
+
+const DescriptionCell = styled.td`
+  max-width: 300px;
+`;
 
 type Props = {
   role: Role,
@@ -31,7 +37,11 @@ const RolesOverviewItem = ({
           {name}
         </Link>
       </td>
-      <td>{description}</td>
+      <DescriptionCell>
+        <TextOverflowEllipsis>
+          {description}
+        </TextOverflowEllipsis>
+      </DescriptionCell>
       <UsersCell users={Immutable.Set(users)} />
       <ActionsCell roleId={id} roleName={name} readOnly={readOnly} />
     </tr>


### PR DESCRIPTION
## Description
There are some cases where we want to signal text overflow with an ellipses. This PR creates a shared component and implements it for the description cell in `RolesOverviewItem` and `BackendOverviewItem`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)