### PR TITLE
Fix condition for session extension

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/security/realm/SessionAuthenticator.java
+++ b/graylog2-server/src/main/java/org/graylog2/security/realm/SessionAuthenticator.java
@@ -73,10 +73,10 @@ public class SessionAuthenticator extends AuthenticatingRealm {
         }
 
         final Optional<String> noSessionExtension = ShiroRequestHeadersBinder.getHeaderFromThreadContext(X_GRAYLOG_NO_SESSION_EXTENSION);
-        if (noSessionExtension.isPresent() && !"true".equalsIgnoreCase(noSessionExtension.get())) {
-            session.touch();
-        } else {
+        if (noSessionExtension.isPresent() && "true".equalsIgnoreCase(noSessionExtension.get())) {
             LOG.debug("Not extending session because the request indicated not to.");
+        } else {
+            session.touch();
         }
         ThreadContext.bind(subject);
 


### PR DESCRIPTION
The session wasn't "touched" if the `X-Graylog-No-Session-Extension`
header was missing.
(And that's what the frontend is doing)

Bug introduced with #9287

