### PR TITLE
Display and manage user account status in the frontend

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/users/UsersResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/users/UsersResource.java
@@ -563,6 +563,7 @@ public class UsersResource extends RestResource {
 
         final User.AccountStatus newStatus = User.AccountStatus.valueOf(newStatusString.toUpperCase(Locale.US));
         final User user = loadUserById(userId);
+        checkPermission(RestPermissions.USERS_EDIT, user.getName());
         final User.AccountStatus oldStatus = user.getAccountStatus();
 
         if (oldStatus.equals(newStatus)) {

--- a/graylog2-web-interface/src/actions/authentication/AuthenticationActions.js
+++ b/graylog2-web-interface/src/actions/authentication/AuthenticationActions.js
@@ -80,8 +80,6 @@ export type LoadActiveResponse = LoadActiveResponse & {
 export type ActionsType = {
   create: (AuthenticationBackendCreate) => Promise<LoadResponse>,
   delete: (authBackendId: ?$PropertyType<AuthenticationBackend, 'id'>, authBackendTitle: $PropertyType<AuthenticationBackend, 'title'>) => Promise<void>,
-  disableUser: (userId: string, username: string) => Promise<void>,
-  enableUser: (userId: string, username: string) => Promise<void>,
   load: (id: string) => Promise<LoadResponse>,
   loadActive: () => Promise<LoadActiveResponse>,
   loadBackendsPaginated: (pagination: Pagination) => Promise<PaginatedBackends>,
@@ -97,8 +95,6 @@ const AuthenticationActions: RefluxActions<ActionsType> = singletonActions(
   () => Reflux.createActions({
     create: { asyncResult: true },
     delete: { asyncResult: true },
-    disableUser: { asyncResult: true },
-    enableUser: { asyncResult: true },
     load: { asyncResult: true },
     loadActive: { asyncResult: true },
     loadBackendsPaginated: { asyncResult: true },

--- a/graylog2-web-interface/src/actions/users/UsersActions.js
+++ b/graylog2-web-interface/src/actions/users/UsersActions.js
@@ -6,7 +6,7 @@ import { singletonActions } from 'views/logic/singleton';
 import type { RefluxActions } from 'stores/StoreTypes';
 import type { Pagination, PaginatedList } from 'stores/PaginationTypes';
 import User, { type UserJSON } from 'logic/users/User';
-import UserOverview from 'logic/users/UserOverview';
+import UserOverview, { type AccountStatus } from 'logic/users/UserOverview';
 
 export type UserCreate = {
   email: $PropertyType<UserJSON, 'email'>,
@@ -50,6 +50,7 @@ export type ActionsType = {
   deleteToken: (userId: string, tokenId: string, tokenName: string) => Promise<void>,
   loadUsers: () => Promise<Immutable.List<User>>,
   loadUsersPaginated: (pagination: Pagination) => Promise<PaginatedUsers>,
+  setStatus: (userId: string, newStatus: AccountStatus) => Promise<void>,
 };
 
 const UsersActions: RefluxActions<ActionsType> = singletonActions(
@@ -66,6 +67,7 @@ const UsersActions: RefluxActions<ActionsType> = singletonActions(
     deleteToken: { asyncResult: true },
     loadUsersPaginated: { asyncResult: true },
     loadUsers: { asyncResult: true },
+    setStatus: { asyncResult: true },
   }),
 );
 

--- a/graylog2-web-interface/src/components/authentication/BackendDetails/SyncedUsersSection/SyncedUsersOverviewItem.jsx
+++ b/graylog2-web-interface/src/components/authentication/BackendDetails/SyncedUsersSection/SyncedUsersOverviewItem.jsx
@@ -6,7 +6,6 @@ import styled from 'styled-components';
 import { LinkContainer, Link } from 'components/graylog/router';
 import Role from 'logic/roles/Role';
 import Routes from 'routing/Routes';
-import AuthenticationDomain from 'domainActions/authentication/AuthenticationDomain';
 import UserOverview from 'logic/users/UserOverview';
 import { Button, ButtonToolbar } from 'components/graylog';
 import RolesCell from 'components/permissions/RolesCell';
@@ -23,7 +22,6 @@ const ActionsWrapper = styled(ButtonToolbar)`
 
 const SyncedUsersOverviewItem = ({
   user: {
-    enabled,
     fullName,
     id,
     roles: userRolesIds,
@@ -46,16 +44,6 @@ const SyncedUsersOverviewItem = ({
       <RolesCell roles={userRolesNames} />
       <td className="limited">
         <ActionsWrapper>
-          {enabled
-            ? (
-              <Button type="button" bsStyle="info" bsSize="xs" onClick={() => AuthenticationDomain.disableUser(id, username)}>
-                Disable
-              </Button>
-            ) : (
-              <Button type="button" bsStyle="info" bsSize="xs" onClick={() => AuthenticationDomain.enableUser(id, username)}>
-                Enable
-              </Button>
-            )}
           <LinkContainer to={Routes.SYSTEM.USERS.edit(id)}>
             <Button type="button" bsStyle="info" bsSize="xs">
               Edit

--- a/graylog2-web-interface/src/components/authentication/BackendDetails/SyncedUsersSection/SyncedUsersSection.jsx
+++ b/graylog2-web-interface/src/components/authentication/BackendDetails/SyncedUsersSection/SyncedUsersSection.jsx
@@ -6,7 +6,6 @@ import * as Immutable from 'immutable';
 import Role from 'logic/roles/Role';
 import type { PaginatedUsers } from 'actions/users/UsersActions';
 import AuthenticationDomain from 'domainActions/authentication/AuthenticationDomain';
-import { AuthenticationActions } from 'stores/authentication/AuthenticationStore';
 import { DataTable, PaginatedList, Spinner, EmptyResult } from 'components/common';
 import SectionComponent from 'components/common/Section/SectionComponent';
 import AuthenticationBackend from 'logic/authentication/AuthenticationBackend';
@@ -49,7 +48,7 @@ const SyncedUsersSection = ({ roles, authenticationBackend }: Props) => {
   const [paginatedUsers, setPaginatedUsers] = useState<?PaginatedUsers>();
   const [pagination, setPagination] = useState(DEFAULT_PAGINATION);
   const { list: users } = paginatedUsers || {};
-  const { page, perPage, query } = pagination;
+  const { page } = pagination;
 
   useEffect(() => _loadSyncedTeams(authenticationBackend.id, pagination, setLoading, setPaginatedUsers), [authenticationBackend.id, pagination]);
 

--- a/graylog2-web-interface/src/components/authentication/BackendDetails/SyncedUsersSection/SyncedUsersSection.jsx
+++ b/graylog2-web-interface/src/components/authentication/BackendDetails/SyncedUsersSection/SyncedUsersSection.jsx
@@ -39,9 +39,6 @@ const _loadSyncedTeams = (authBackendId, pagination, setLoading, setPaginatedUse
   });
 };
 
-const _updateListOnUserDisable = (perPage, query, setPagination) => AuthenticationActions.disableUser.completed.listen(() => setPagination({ page: DEFAULT_PAGINATION.page, perPage, query }));
-const _updateListOnUserEnable = (perPage, query, setPagination) => AuthenticationActions.enableUser.completed.listen(() => setPagination({ page: DEFAULT_PAGINATION.page, perPage, query }));
-
 type Props = {
   roles: Immutable.List<Role>,
   authenticationBackend: AuthenticationBackend,
@@ -55,8 +52,6 @@ const SyncedUsersSection = ({ roles, authenticationBackend }: Props) => {
   const { page, perPage, query } = pagination;
 
   useEffect(() => _loadSyncedTeams(authenticationBackend.id, pagination, setLoading, setPaginatedUsers), [authenticationBackend.id, pagination]);
-  useEffect(() => _updateListOnUserDisable(perPage, query, setPagination), [perPage, query]);
-  useEffect(() => _updateListOnUserEnable(perPage, query, setPagination), [perPage, query]);
 
   if (!paginatedUsers) {
     return <Spinner />;

--- a/graylog2-web-interface/src/components/authentication/BackendsOverview/BackendsOverview.jsx
+++ b/graylog2-web-interface/src/components/authentication/BackendsOverview/BackendsOverview.jsx
@@ -56,8 +56,6 @@ const _loadBackends = (pagination, setLoading, setPaginatedBackends) => {
   });
 };
 
-const _updateListOnUserDisable = (refreshOverview) => AuthenticationActions.disableUser.completed.listen(refreshOverview);
-const _updateListOnUserEnable = (refreshOverview) => AuthenticationActions.enableUser.completed.listen(refreshOverview);
 const _updateListOnBackendDelete = (refreshOverview) => AuthenticationActions.delete.completed.listen(refreshOverview);
 const _updateListOnBackendActivation = (refreshOverview) => AuthenticationActions.setActiveBackend.completed.listen(refreshOverview);
 
@@ -73,8 +71,6 @@ const BackendsOverview = () => {
 
   useEffect(() => _loadRoles(setPaginatedRoles), []);
   useEffect(() => _loadBackends(pagination, setLoading, setPaginatedBackends), [pagination]);
-  useEffect(() => _updateListOnUserDisable(_refreshOverview), [_refreshOverview]);
-  useEffect(() => _updateListOnUserEnable(_refreshOverview), [_refreshOverview]);
   useEffect(() => _updateListOnBackendDelete(_refreshOverview), [_refreshOverview]);
   useEffect(() => _updateListOnBackendActivation(_refreshOverview), [_refreshOverview]);
 

--- a/graylog2-web-interface/src/components/users/LoggedInIcon.jsx
+++ b/graylog2-web-interface/src/components/users/LoggedInIcon.jsx
@@ -11,7 +11,7 @@ const Wrapper: StyledComponent<{active?: boolean}, ThemeInterface, HTMLDivElemen
 
 const LoggedInIcon = ({ active, ...rest }: { active: boolean }) => (
   <Wrapper active={active}>
-    <Icon {...rest} name="circle" />
+    <Icon {...rest} name={active ? 'check-circle' : 'times-circle'} />
   </Wrapper>
 );
 

--- a/graylog2-web-interface/src/components/users/UserDetails/ProfileSection.jsx
+++ b/graylog2-web-interface/src/components/users/UserDetails/ProfileSection.jsx
@@ -19,6 +19,7 @@ const ProfileSection = ({
     clientAddress,
     lastActivity,
     sessionActive,
+    accountStatus,
   },
 }: Props) => (
   <SectionComponent title="Profile">
@@ -28,6 +29,7 @@ const ProfileSection = ({
     <ReadOnlyFormGroup label="Client Address" value={clientAddress} />
     <ReadOnlyFormGroup label="Last Activity" value={lastActivity} />
     <ReadOnlyFormGroup label="Logged In" value={<LoggedInIcon active={sessionActive} />} />
+    <ReadOnlyFormGroup label="Enabled" value={accountStatus === 'enabled'} />
   </SectionComponent>
 );
 

--- a/graylog2-web-interface/src/components/users/UsersOverview/UserOverviewItem/ActionsCell.jsx
+++ b/graylog2-web-interface/src/components/users/UsersOverview/UserOverviewItem/ActionsCell.jsx
@@ -49,7 +49,12 @@ const ReadOnlyActions = ({ user }: { user: UserOverview }) => {
   );
 };
 
-const EditActions = ({ user, user: { username, id, fullName } }: { user: UserOverview }) => {
+const EditActions = ({ user, user: { username, id, fullName, accountStatus } }: { user: UserOverview }) => {
+  const _toggleStatus = () => {
+    const newStatus = accountStatus === 'enabled' ? 'disabled' : 'enabled';
+    UsersDomain.setStatus(id, newStatus);
+  };
+
   const _deleteUser = () => {
     // eslint-disable-next-line no-alert
     if (window.confirm(`Do you really want to delete user ${fullName}?`)) {
@@ -70,6 +75,11 @@ const EditActions = ({ user, user: { username, id, fullName } }: { user: UserOve
       <DropdownButton bsSize="xs" title="More actions" pullRight id={`delete-user-${id}`}>
         <EditTokensAction user={user} wrapperComponent={MenuItem} />
         <IfPermitted permissions={[`users:edit:${username}`]}>
+          <MenuItem id={`set-status-user-${id}`}
+                    onClick={_toggleStatus}
+                    title={`Set new account status for ${fullName}`}>
+            {accountStatus === 'enabled' ? 'Disable' : 'Enable'}
+          </MenuItem>
           <MenuItem id={`delete-user-${id}`}
                     bsStyle="primary"
                     bsSize="xs"

--- a/graylog2-web-interface/src/components/users/UsersOverview/UserOverviewItem/ActionsCell.jsx
+++ b/graylog2-web-interface/src/components/users/UsersOverview/UserOverviewItem/ActionsCell.jsx
@@ -49,7 +49,7 @@ const ReadOnlyActions = ({ user }: { user: UserOverview }) => {
   );
 };
 
-const EditActions = ({ user, user: { username, id, fullName, accountStatus } }: { user: UserOverview }) => {
+const EditActions = ({ user, user: { username, id, fullName, accountStatus, external, readOnly } }: { user: UserOverview }) => {
   const _toggleStatus = () => {
     const newStatus = accountStatus === 'enabled' ? 'disabled' : 'enabled';
     UsersDomain.setStatus(id, newStatus);
@@ -75,11 +75,13 @@ const EditActions = ({ user, user: { username, id, fullName, accountStatus } }: 
       <DropdownButton bsSize="xs" title="More actions" pullRight id={`delete-user-${id}`}>
         <EditTokensAction user={user} wrapperComponent={MenuItem} />
         <IfPermitted permissions={[`users:edit:${username}`]}>
-          <MenuItem id={`set-status-user-${id}`}
-                    onClick={_toggleStatus}
-                    title={`Set new account status for ${fullName}`}>
-            {accountStatus === 'enabled' ? 'Disable' : 'Enable'}
-          </MenuItem>
+          { !external && !readOnly && (
+            <MenuItem id={`set-status-user-${id}`}
+                      onClick={_toggleStatus}
+                      title={`Set new account status for ${fullName}`}>
+              {accountStatus === 'enabled' ? 'Disable' : 'Enable'}
+            </MenuItem>
+          ) }
           <MenuItem id={`delete-user-${id}`}
                     bsStyle="primary"
                     bsSize="xs"

--- a/graylog2-web-interface/src/components/users/UsersOverview/UserOverviewItem/StatusCell.jsx
+++ b/graylog2-web-interface/src/components/users/UsersOverview/UserOverviewItem/StatusCell.jsx
@@ -1,0 +1,40 @@
+// @flow strict
+import * as React from 'react';
+import styled, { type StyledComponent } from 'styled-components';
+
+import UserOverview from 'logic/users/UserOverview';
+import { OverlayTrigger, Popover } from 'components/graylog';
+import type { ThemeInterface } from 'theme';
+import { Icon } from 'components/common';
+
+type Props = {
+  accountStatus: $PropertyType<UserOverview, 'accountStatus'>,
+};
+
+const Wrapper: StyledComponent<{enabled?: boolean}, ThemeInterface, HTMLDivElement> = styled.div(({ theme, enabled }) => `
+  color: ${enabled ? theme.colors.variant.success : theme.colors.variant.default};
+`);
+
+const Td: StyledComponent<{}, ThemeInterface, HTMLTableCellElement> = styled.td`
+  width: 35px;
+  text-align: center;
+`;
+
+const StatusCell = ({ accountStatus }: Props) => (
+  <Td>
+    <OverlayTrigger trigger={['hover', 'focus']}
+                    placement="right"
+                    overlay={(
+                      <Popover id="session-badge-details">
+                        {`User is ${accountStatus}`}
+                      </Popover>
+                    )}
+                    rootClose>
+      <Wrapper enabled={accountStatus === 'enabled'}>
+        <Icon name={accountStatus === 'enabled' ? 'check-circle' : 'times-circle'} />
+      </Wrapper>
+    </OverlayTrigger>
+  </Td>
+);
+
+export default StatusCell;

--- a/graylog2-web-interface/src/components/users/UsersOverview/UserOverviewItem/UsersOverviewItem.jsx
+++ b/graylog2-web-interface/src/components/users/UsersOverview/UserOverviewItem/UsersOverviewItem.jsx
@@ -8,6 +8,7 @@ import RolesCell from 'components/permissions/RolesCell';
 
 import ActionsCell from './ActionsCell';
 import LoggedInCell from './LoggedInCell';
+import StatusCell from './StatusCell';
 
 type Props = {
   user: UserOverview,
@@ -25,6 +26,7 @@ const UsersOverviewItem = ({
     sessionActive,
     username,
     roles,
+    accountStatus,
   },
   isActive,
 }: Props) => {
@@ -41,6 +43,7 @@ const UsersOverviewItem = ({
       <td className="limited">{username}</td>
       <td className="limited">{email}</td>
       <td className="limited">{clientAddress}</td>
+      <StatusCell accountStatus={accountStatus} />
       <RolesCell roles={roles} />
       <ActionsCell user={user} />
     </tr>

--- a/graylog2-web-interface/src/components/users/UsersOverview/UsersOverview.jsx
+++ b/graylog2-web-interface/src/components/users/UsersOverview/UsersOverview.jsx
@@ -22,7 +22,7 @@ const DEFAULT_PAGINATION = {
   query: '',
 };
 
-const TABLE_HEADERS = ['', 'Full name', 'Username', 'E-Mail Address', 'Client Address', 'Role', 'Actions'];
+const TABLE_HEADERS = ['', 'Full name', 'Username', 'E-Mail Address', 'Client Address', 'Enabled', 'Role', 'Actions'];
 
 const Container: StyledComponent<{}, ThemeInterface, HTMLDivElement> = styled.div`
   .data-table {

--- a/graylog2-web-interface/src/components/users/UsersOverview/UsersOverview.jsx
+++ b/graylog2-web-interface/src/components/users/UsersOverview/UsersOverview.jsx
@@ -67,6 +67,7 @@ const _loadUsers = (pagination, setLoading, setPaginatedUsers) => {
 };
 
 const _updateListOnUserDelete = (perPage, query, setPagination) => UsersActions.delete.completed.listen(() => setPagination({ page: DEFAULT_PAGINATION.page, perPage, query }));
+const _updateListOnUserSetStatus = (pagination, setLoading, setPaginatedUsers) => UsersActions.setStatus.completed.listen(() => _loadUsers(pagination, setLoading, setPaginatedUsers));
 
 const UsersOverview = () => {
   const currentUser = useContext(CurrentUserContext);
@@ -78,6 +79,7 @@ const UsersOverview = () => {
 
   useEffect(() => _loadUsers(pagination, setLoading, setPaginatedUsers), [pagination]);
   useEffect(() => _updateListOnUserDelete(perPage, query, setPagination), [perPage, query]);
+  useEffect(() => _updateListOnUserSetStatus(pagination, setLoading, setPaginatedUsers), [pagination]);
 
   if (!users) {
     return <Spinner />;

--- a/graylog2-web-interface/src/components/users/UsersOverview/UsersOverview.test.jsx
+++ b/graylog2-web-interface/src/components/users/UsersOverview/UsersOverview.test.jsx
@@ -18,6 +18,7 @@ jest.mock('stores/users/UsersStore', () => ({
   UsersActions: {
     loadUsersPaginated: jest.fn(() => mockLoadUsersPaginatedPromise),
     delete: mockAction(jest.fn(() => Promise.resolve())),
+    setStatus: mockAction(jest.fn(() => Promise.resolve())),
   },
 }));
 

--- a/graylog2-web-interface/src/domainActions/authentication/AuthenticationDomain.js
+++ b/graylog2-web-interface/src/domainActions/authentication/AuthenticationDomain.js
@@ -63,26 +63,6 @@ const testLogin: $PropertyType<ActionsType, 'testLogin'> = notifyingAction({
   }),
 });
 
-const enableUser: $PropertyType<ActionsType, 'enableUser'> = notifyingAction({
-  action: AuthenticationActions.enableUser,
-  success: (userId, username) => ({
-    message: `User "${username} was enabled successfully`,
-  }),
-  error: (error, userId, username) => ({
-    message: `Enabling user "${username}" failed with status: ${error}`,
-  }),
-});
-
-const disableUser: $PropertyType<ActionsType, 'disableUser'> = notifyingAction({
-  action: AuthenticationActions.disableUser,
-  success: (userId, username) => ({
-    message: `User "${username} was disabled successfully`,
-  }),
-  error: (error, userId, username) => ({
-    message: `Disabling user "${username}" failed with status: ${error}`,
-  }),
-});
-
 const setActiveBackend: $PropertyType<ActionsType, 'setActiveBackend'> = notifyingAction({
   action: AuthenticationActions.setActiveBackend,
   success: (authBackendId, authBackendTitle) => ({
@@ -115,8 +95,6 @@ export default {
   delete: deleteBackend,
   testConnection,
   testLogin,
-  enableUser,
-  disableUser,
   setActiveBackend,
   loadBackendsPaginated,
   loadUsersPaginated,

--- a/graylog2-web-interface/src/domainActions/users/UsersDomain.js
+++ b/graylog2-web-interface/src/domainActions/users/UsersDomain.js
@@ -101,6 +101,16 @@ const loadUsersPaginated: $PropertyType<ActionsType, 'loadUsersPaginated'> = not
   }),
 });
 
+const setStatus: $PropertyType<ActionsType, 'setStatus'> = notifyingAction({
+  action: UsersActions.setStatus,
+  success: (userId, accountStatus) => ({
+    message: `User "${userId}" was set to ${accountStatus}`,
+  }),
+  error: (error, userId, accountStatus) => ({
+    message: `Updating user ("${userId}") to ${accountStatus} failed with status: ${error}`,
+  }),
+});
+
 export default {
   create,
   load,
@@ -113,4 +123,5 @@ export default {
   deleteToken,
   loadUsers,
   loadUsersPaginated,
+  setStatus,
 };

--- a/graylog2-web-interface/src/logic/users/User.js
+++ b/graylog2-web-interface/src/logic/users/User.js
@@ -3,6 +3,8 @@ import * as Immutable from 'immutable';
 
 import type { PreferencesMap } from 'stores/users/PreferencesStore';
 
+import type { AccountStatus } from './UserOverview';
+
 type StartPage = {
   id: string,
   type: string,
@@ -25,6 +27,7 @@ export type UserJSON = {
   startpage?: StartPage,
   timezone: ?string,
   username: string,
+  account_status: AccountStatus,
 };
 
 type InternalState = {
@@ -43,6 +46,7 @@ type InternalState = {
   sessionActive: boolean,
   clientAddress: string,
   lastActivity: ?string,
+  accountStatus: AccountStatus,
 };
 
 export default class User {
@@ -64,6 +68,7 @@ export default class User {
     sessionActive: $PropertyType<InternalState, 'sessionActive'>,
     clientAddress: $PropertyType<InternalState, 'clientAddress'>,
     lastActivity: $PropertyType<InternalState, 'lastActivity'>,
+    accountStatus: $PropertyType<InternalState, 'accountStatus'>,
   ) {
     this._value = {
       id,
@@ -81,6 +86,7 @@ export default class User {
       sessionActive,
       clientAddress,
       lastActivity,
+      accountStatus,
     };
   }
 
@@ -122,6 +128,10 @@ export default class User {
 
   get external() {
     return this._value.external;
+  }
+
+  get accountStatus() {
+    return this._value.accountStatus;
   }
 
   get sessionTimeoutMs() {
@@ -201,6 +211,7 @@ export default class User {
       sessionActive,
       clientAddress,
       lastActivity,
+      accountStatus,
     } = this._value;
 
     // eslint-disable-next-line no-use-before-define
@@ -220,6 +231,7 @@ export default class User {
       sessionActive,
       clientAddress,
       lastActivity,
+      accountStatus,
     }));
   }
 
@@ -239,6 +251,7 @@ export default class User {
     sessionActive: $PropertyType<InternalState, 'sessionActive'>,
     clientAddress: $PropertyType<InternalState, 'clientAddress'>,
     lastActivity: $PropertyType<InternalState, 'lastActivity'>,
+    accountStatus: $PropertyType<InternalState, 'accountStatus'>,
   ) {
     return new User(
       id,
@@ -256,11 +269,12 @@ export default class User {
       sessionActive,
       clientAddress,
       lastActivity,
+      accountStatus,
     );
   }
 
   static empty() {
-    return User.create('', '', '', '', Immutable.List(), '', {}, Immutable.Set(), false, false, -1, undefined, false, '', '');
+    return User.create('', '', '', '', Immutable.List(), '', {}, Immutable.Set(), false, false, -1, undefined, false, '', '', 'enabled');
   }
 
   toJSON(): UserJSON {
@@ -280,6 +294,7 @@ export default class User {
       sessionActive,
       clientAddress,
       lastActivity,
+      accountStatus,
     } = this._value;
 
     return {
@@ -298,6 +313,7 @@ export default class User {
       session_active: sessionActive,
       client_address: clientAddress,
       last_activity: lastActivity,
+      account_status: accountStatus,
     };
   }
 
@@ -324,6 +340,8 @@ export default class User {
       client_address,
       // eslint-disable-next-line camelcase
       last_activity,
+      // eslint-disable-next-line camelcase
+      account_status,
     } = value;
 
     return User.create(
@@ -342,6 +360,7 @@ export default class User {
       session_active,
       client_address,
       last_activity,
+      account_status,
     );
   }
 
@@ -421,6 +440,10 @@ class Builder {
     return new Builder(this.value.set('lastActivity', value));
   }
 
+  accountStatus(value: $PropertyType<InternalState, 'accountStatus'>) {
+    return new Builder(this.value.set('accountStatus', value));
+  }
+
   build() {
     const {
       id,
@@ -438,6 +461,7 @@ class Builder {
       sessionActive,
       clientAddress,
       lastActivity,
+      accountStatus,
     } = this.value.toObject();
 
     return new User(
@@ -456,6 +480,7 @@ class Builder {
       sessionActive,
       clientAddress,
       lastActivity,
+      accountStatus,
     );
   }
 }

--- a/graylog2-web-interface/src/logic/users/UserOverview.js
+++ b/graylog2-web-interface/src/logic/users/UserOverview.js
@@ -1,6 +1,8 @@
 // @flow strict
 import * as Immutable from 'immutable';
 
+export type AccountStatus = 'enabled' | 'disabled' | 'deleted';
+
 export type UserOverviewJSON = {
   id: string,
   username: string,
@@ -15,6 +17,7 @@ export type UserOverviewJSON = {
   enabled: boolean,
   auth_service_id: string,
   auth_service_uid: string,
+  account_status: AccountStatus,
 };
 
 type InternalState = {
@@ -31,6 +34,7 @@ type InternalState = {
   enabled: boolean,
   authServiceId: string,
   authServiceUid: string,
+  accountStatus: AccountStatus,
 };
 
 export default class UserOverview {
@@ -50,6 +54,7 @@ export default class UserOverview {
     enabled: $PropertyType<InternalState, 'enabled'>,
     authServiceId: $PropertyType<InternalState, 'authServiceId'>,
     authServiceUid: $PropertyType<InternalState, 'authServiceUid'>,
+    accountStatus: $PropertyType<InternalState, 'accountStatus'>,
   ) {
     this._value = {
       id,
@@ -65,6 +70,7 @@ export default class UserOverview {
       enabled,
       authServiceId,
       authServiceUid,
+      accountStatus,
     };
   }
 
@@ -128,6 +134,10 @@ export default class UserOverview {
     return this._value.authServiceUid;
   }
 
+  get accountStatus() {
+    return this._value.accountStatus;
+  }
+
   toBuilder() {
     const {
       id,
@@ -143,6 +153,7 @@ export default class UserOverview {
       enabled,
       authServiceId,
       authServiceUid,
+      accountStatus,
     } = this._value;
 
     // eslint-disable-next-line no-use-before-define
@@ -160,6 +171,7 @@ export default class UserOverview {
       enabled,
       authServiceId,
       authServiceUid,
+      accountStatus,
     }));
   }
 
@@ -177,6 +189,7 @@ export default class UserOverview {
     enabled: $PropertyType<InternalState, 'enabled'>,
     authServiceId: $PropertyType<InternalState, 'authServiceId'>,
     authServiceUid: $PropertyType<InternalState, 'authServiceUid'>,
+    accountStatus: $PropertyType<InternalState, 'accountStatus'>,
   ) {
     return new UserOverview(
       id,
@@ -192,6 +205,7 @@ export default class UserOverview {
       enabled,
       authServiceId,
       authServiceUid,
+      accountStatus,
     );
   }
 
@@ -210,6 +224,7 @@ export default class UserOverview {
       enabled,
       authServiceId,
       authServiceUid,
+      accountStatus,
     } = this._value;
 
     return {
@@ -226,6 +241,7 @@ export default class UserOverview {
       enabled,
       auth_service_id: authServiceId,
       auth_service_uid: authServiceUid,
+      account_status: accountStatus,
     };
   }
 
@@ -244,6 +260,7 @@ export default class UserOverview {
       enabled,
       auth_service_id: authServiceId,
       auth_service_uid: authServiceUid,
+      account_status: accountStatus,
     } = value;
 
     return UserOverview.create(
@@ -260,6 +277,7 @@ export default class UserOverview {
       enabled,
       authServiceId,
       authServiceUid,
+      accountStatus,
     );
   }
 
@@ -331,6 +349,10 @@ class Builder {
     return new Builder(this.value.set('authServiceUid', value));
   }
 
+  accountStatus(value: $PropertyType<InternalState, 'accountStatus'>) {
+    return new Builder(this.value.set('accountStatus', value));
+  }
+
   build() {
     const {
       id,
@@ -346,6 +368,7 @@ class Builder {
       enabled,
       authServiceId,
       authServiceUid,
+      accountStatus,
     } = this.value.toObject();
 
     return new UserOverview(
@@ -362,6 +385,7 @@ class Builder {
       enabled,
       authServiceId,
       authServiceUid,
+      accountStatus,
     );
   }
 }

--- a/graylog2-web-interface/src/routing/ApiRoutes.js
+++ b/graylog2-web-interface/src/routing/ApiRoutes.js
@@ -340,6 +340,7 @@ const ApiRoutes = {
     create_token: (userId, tokenName) => { return { url: `/users/${userId}/tokens/${tokenName}` }; },
     delete_token: (userId, tokenName) => { return { url: `/users/${userId}/tokens/${tokenName}` }; },
     list_tokens: (userId) => { return { url: `/users/${userId}/tokens` }; },
+    setStatus: (userId, accountStatus) => { return { url: `/users/${userId}/status/${accountStatus}` }; },
   },
   DashboardsController: {
     show: (id) => { return { url: `/dashboards/${id}` }; },

--- a/graylog2-web-interface/src/stores/authentication/AuthenticationStore.js
+++ b/graylog2-web-interface/src/stores/authentication/AuthenticationStore.js
@@ -116,22 +116,6 @@ const AuthenticationStore: Store<{ authenticators: any }> = singletonStore(
       return promise;
     },
 
-    enableUser(userId: string): Promise<void> {
-      const url = qualifyUrl(ApiRoutes.AuthenticationController.enableUser(userId).url);
-      const promise = fetch('POST', url);
-      AuthenticationActions.enableUser.promise(promise);
-
-      return promise;
-    },
-
-    disableUser(userId: string): Promise<void> {
-      const url = qualifyUrl(ApiRoutes.AuthenticationController.disableUser(userId).url);
-      const promise = fetch('POST', url);
-      AuthenticationActions.disableUser.promise(promise);
-
-      return promise;
-    },
-
     setActiveBackend(backendId: ?$PropertyType<AuthenticationBackend, 'id'>): Promise<void> {
       const url = qualifyUrl(ApiRoutes.AuthenticationController.updateConfiguration().url);
       const promise = fetch('POST', url, { active_backend: backendId });

--- a/graylog2-web-interface/src/stores/users/UsersStore.js
+++ b/graylog2-web-interface/src/stores/users/UsersStore.js
@@ -3,7 +3,7 @@ import Reflux from 'reflux';
 import * as Immutable from 'immutable';
 
 import type { Store } from 'stores/StoreTypes';
-import type { UserOverviewJSON } from 'logic/users/UserOverview';
+import type { UserOverviewJSON, AccountStatus } from 'logic/users/UserOverview';
 import fetch from 'logic/rest/FetchProvider';
 import ApiRoutes from 'routing/ApiRoutes';
 import { singletonStore } from 'views/logic/singleton';
@@ -130,6 +130,14 @@ const UsersStore: Store<{}> = singletonStore(
         }));
 
       UsersActions.loadUsersPaginated.promise(promise);
+
+      return promise;
+    },
+
+    setStatus(userId: string, accountStatus: AccountStatus): Promise<void> {
+      const url = qualifyUrl(ApiRoutes.UsersApiController.setStatus(userId, accountStatus).url);
+      const promise = fetch('PUT', url);
+      UsersActions.setStatus.promise(promise);
 
       return promise;
     },

--- a/graylog2-web-interface/test/fixtures/users.js
+++ b/graylog2-web-interface/test/fixtures/users.js
@@ -21,6 +21,7 @@ export const viewsManager: UserJSON = {
   timezone: 'UTC',
   username: 'betty',
   client_address: '127.0.0.1',
+  account_status: 'enabled',
 };
 
 export const admin: UserJSON = {
@@ -38,6 +39,7 @@ export const admin: UserJSON = {
   session_timeout_ms: 28800000,
   timezone: 'UTC',
   username: 'alonzo',
+  account_status: 'enabled',
 };
 
 export const alice = User.builder()
@@ -53,6 +55,7 @@ export const alice = User.builder()
   .sessionActive(true)
   .sessionTimeoutMs(10000000000)
   .clientAddress('127.0.0.1')
+  .accountStatus('enabled')
   .build();
 
 export const bob = User.builder()
@@ -68,6 +71,7 @@ export const bob = User.builder()
   .sessionActive(false)
   .sessionTimeoutMs(10000000000)
   .clientAddress('172.0.0.1')
+  .accountStatus('enabled')
   .build();
 
 export const adminUser = User.builder()
@@ -82,6 +86,7 @@ export const adminUser = User.builder()
   .sessionActive(true)
   .sessionTimeoutMs(10000000000)
   .clientAddress('192.168.0.1')
+  .accountStatus('enabled')
   .build();
 
 export const userList = Immutable.List<User>([adminUser, bob, alice]);


### PR DESCRIPTION
## Motivation
If a user is on vacation a often used routine is to disable a user account. Right now the backend did support disable and enabling a user account but the frontend did not use it.

## Description
- Show user enable and disable status in users details page and useroverivew
- Add a enable / disable menu item to a user in the useroverview page
- Also: Add missing permission check in the backend resource

Fixes #9413