### PR TITLE
Do not create new component for plugin routes with parent on every AppRouter render

### DIFF
--- a/graylog2-web-interface/src/routing/AppRouter.jsx
+++ b/graylog2-web-interface/src/routing/AppRouter.jsx
@@ -107,7 +107,7 @@ const renderPluginRoute = ({ path, component: Component, parentComponent }) => {
     <Route key={`${path}-${Component.displayName}`}
            exact
            path={appPrefixed(path)}
-           component={WrappedComponent} />
+           render={WrappedComponent} />
   );
 };
 


### PR DESCRIPTION
## Description
When a plugin route has a parent component we wrap the component with its parent in AppRouter -> renderPluginRoute.
When creating the route we provided the component for the Route component by using the Route component prop.

Because of this combination plugin routes with a parent got newly created every time the AppRouter rendered.
This is not the case when using the render prop of the Route component. Please have a look at the react-router docs for more information.

You can test this change on a dashboard by changing the sidebar pinning (with a non system admin user). Before this change the whole page rerendered sometimes and the sidebar got closed.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)