### PR TITLE
Prevent search bar elements from overlaying search sidebar

### DIFF
--- a/graylog2-web-interface/src/views/components/searchbar/StreamsFilter.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/StreamsFilter.jsx
@@ -10,7 +10,7 @@ const StreamsFilter = ({ disabled, value, streams, onChange }) => {
   const options = streams.sort(({ key: key1 }, { key: key2 }) => defaultCompare(key1, key2));
 
   return (
-    <div style={{ position: 'relative', zIndex: 10 }} data-testid="streams-filter" title={placeholder}>
+    <div style={{ position: 'relative' }} data-testid="streams-filter" title={placeholder}>
       <Select placeholder={placeholder}
               disabled={disabled}
               displayKey="key"

--- a/graylog2-web-interface/src/views/components/searchbar/queryinput/StyledAceEditor.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/queryinput/StyledAceEditor.jsx
@@ -144,7 +144,7 @@ const StyledAceEditor = styled(AceEditor).attrs(({ aceTheme, theme }) => ({
 
     .ace_placeholder {
       font-family: inherit !important;
-      z-index: auto;
+      z-index: auto !important;
     }
   }
 `);


### PR DESCRIPTION
## Description
This PR is removing the not needed `z-index` from the `StreamsFilter` and `StyledAceEditor`. Previously they overlaid the sidebar:
![image](https://user-images.githubusercontent.com/46300478/98695879-6e14cc00-2373-11eb-99b6-03945aab1199.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
