### PR TITLE
Use description instead of spinner in search sidebar description section

### DIFF
--- a/graylog2-web-interface/src/views/components/sidebar/description/SearchResultOverview.jsx
+++ b/graylog2-web-interface/src/views/components/sidebar/description/SearchResultOverview.jsx
@@ -20,7 +20,7 @@ const SearchResultOverview = ({ results: { timestamp, duration } }: Props) => {
   const timezone = currentUser?.timezone ?? AppConfig.rootTimeZone();
 
   if (!timestamp || !duration) {
-    return <Spinner />;
+    return <i>No query executed yet.</i>;
   }
 
   return (

--- a/graylog2-web-interface/src/views/components/sidebar/description/SearchResultOverview.jsx
+++ b/graylog2-web-interface/src/views/components/sidebar/description/SearchResultOverview.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import numeral from 'numeral';
 
 import AppConfig from 'util/AppConfig';
-import { Timestamp, Spinner } from 'components/common';
+import { Timestamp } from 'components/common';
 import CurrentUserContext from 'contexts/CurrentUserContext';
 import DateTime from 'logic/datetimes/DateTime';
 

--- a/graylog2-web-interface/src/views/components/sidebar/description/ViewDescription.jsx
+++ b/graylog2-web-interface/src/views/components/sidebar/description/ViewDescription.jsx
@@ -56,10 +56,10 @@ const ViewDescription = ({ results, viewMetadata }: Props) => {
         Search
       </SectionSubheadline>
       <p>
-        {viewMetadata.summary || <>This {viewTypeLabel} has no summary.</>}
+        {viewMetadata.summary || <i>This {viewTypeLabel} has no summary.</i>}
       </p>
       <p>
-        {viewMetadata.description || <>This {viewTypeLabel} has no description.</>}
+        {viewMetadata.description || <i>This {viewTypeLabel} has no description.</i>}
       </p>
     </>
   );


### PR DESCRIPTION
## Description
Previously we displayed a spinner in the search sidebar section while executing a search.
![image](https://user-images.githubusercontent.com/46300478/98698034-e4b2c900-2375-11eb-8700-f612d0eecad5.png)

This spinner was also being displayed when a dashboard had no widgets, since there was no query to execute.

Now we just display a description for both cases:
![image](https://user-images.githubusercontent.com/46300478/98698050-e7152300-2375-11eb-84b6-a2abbf0381ca.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
