### PR TITLE
Fix cluster stats endpoints.

### DIFF
--- a/UPGRADING.rst
+++ b/UPGRADING.rst
@@ -4,6 +4,15 @@ Upgrading to Graylog 4.0.x
 
 .. _upgrade-from-33-to-40:
 
+Deprecation of cluster stats endpoints
+======================================
+
+Starting with v4.0, the cluster stats endpoints are deprecated and will be removed in a future version. Those include:
+
+  - '/system/cluster/stats'
+  - '/system/cluster/stats/elasticsearch'
+  - '/system/cluster/stats/mongo'
+
 [BREAKING] Fixing certificate validation for LDAP servers used for authentication
 =================================================================================
 

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/ClusterAdapterES7.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/ClusterAdapterES7.java
@@ -192,7 +192,7 @@ public class ClusterAdapterES7 implements ClusterAdapter {
 
     @Override
     public ClusterStats clusterStats() {
-        final Request request = new Request("GET", "/_cluster/stats/nodes");
+        final Request request = new Request("GET", "/_cluster/stats");
 
         final JsonNode clusterStatsResponseJson = jsonApi.perform(request,
                 "Couldn't read Elasticsearch cluster stats");

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/ClusterAdapterES7.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/ClusterAdapterES7.java
@@ -192,7 +192,7 @@ public class ClusterAdapterES7 implements ClusterAdapter {
 
     @Override
     public ClusterStats clusterStats() {
-        final Request request = new Request("GET", "/_cluster/stats");
+        final Request request = new Request("GET", "/_cluster/stats/nodes/*");
 
         final JsonNode clusterStatsResponseJson = jsonApi.perform(request,
                 "Couldn't read Elasticsearch cluster stats");

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/DashboardService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/DashboardService.java
@@ -30,7 +30,7 @@ public class DashboardService {
     }
 
     public long count() {
-        final PaginatedList<ViewDTO> result = viewService.searchPaginatedByType(ViewDTO.Type.DASHBOARD, new SearchQuery(""), dashboard -> true, "ASC", null, 1, 0);
+        final PaginatedList<ViewDTO> result = viewService.searchPaginatedByType(ViewDTO.Type.DASHBOARD, new SearchQuery(""), dashboard -> true, "ASC", ViewDTO.FIELD_ID, 1, 0);
         return result.grandTotal().orElseThrow(() -> new IllegalStateException("Missing grand total in response when counting dashboards!"));
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/ViewService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/ViewService.java
@@ -39,6 +39,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Strings.isNullOrEmpty;
 
 public class ViewService extends PaginatedDbService<ViewDTO> {
@@ -90,6 +91,7 @@ public class ViewService extends PaginatedDbService<ViewDTO> {
                                                         String sortField,
                                                         int page,
                                                         int perPage) {
+        checkNotNull(sortField);
         return searchPaginated(
                 DBQuery.and(
                         DBQuery.or(DBQuery.is(ViewDTO.FIELD_TYPE, type), DBQuery.notExists(ViewDTO.FIELD_TYPE)),

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/ClusterStatsResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/ClusterStatsResource.java
@@ -32,10 +32,11 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
-@Api(value = "System/ClusterStats", description = "Cluster stats")
+@Api(value = "System/ClusterStats", description = "[DEPRECATED] Cluster stats")
 @RequiresAuthentication
 @Path("/system/cluster/stats")
 @Produces(MediaType.APPLICATION_JSON)
+@Deprecated
 public class ClusterStatsResource extends RestResource {
     private final ClusterStatsService clusterStatsService;
 

--- a/graylog2-server/src/main/java/org/graylog2/system/stats/ClusterStatsService.java
+++ b/graylog2-server/src/main/java/org/graylog2/system/stats/ClusterStatsService.java
@@ -28,7 +28,6 @@ import org.graylog2.streams.StreamService;
 import org.graylog2.system.stats.elasticsearch.ElasticsearchStats;
 import org.graylog2.system.stats.mongo.MongoProbe;
 import org.graylog2.system.stats.mongo.MongoStats;
-import org.graylog2.users.RoleService;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -42,7 +41,6 @@ public class ClusterStatsService {
     private final StreamService streamService;
     private final StreamRuleService streamRuleService;
     private final OutputService outputService;
-    private final RoleService roleService;
     private final AlertService alertService;
     private final AlarmCallbackConfigurationService alarmCallbackConfigurationService;
     private final DashboardService dashboardService;
@@ -55,7 +53,6 @@ public class ClusterStatsService {
                                StreamService streamService,
                                StreamRuleService streamRuleService,
                                OutputService outputService,
-                               RoleService roleService,
                                AlertService alertService,
                                AlarmCallbackConfigurationService alarmCallbackConfigurationService,
                                DashboardService dashboardService,
@@ -66,7 +63,6 @@ public class ClusterStatsService {
         this.streamService = streamService;
         this.streamRuleService = streamRuleService;
         this.outputService = outputService;
-        this.roleService = roleService;
         this.alertService = alertService;
         this.alarmCallbackConfigurationService = alarmCallbackConfigurationService;
         this.dashboardService = dashboardService;


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Prior to this change, the cluster stats endpoints (`/api/system/cluster/stats` and `/api/system/cluster/stats/elasticsearch`) had two separate issues that prevented it from working:

  - (For ES7): The retrieval of stats for ES cluster nodes was missing a mandatory filter argument (now using `*`)
  - Retrieving the current count of dashboards was using a `null` field to sort on, which resulted in an exception being thrown by the MongoDB client library

This PR is fixing both of these.

In addition, this PR is marking those endpoints as deprecated and flag them for removal in a future version.

Fixes #9435.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.