### PR TITLE
Prevent disabling your own user account

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/users/UsersResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/users/UsersResource.java
@@ -103,7 +103,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.maxBy;
 import static org.graylog2.shared.security.RestPermissions.USERS_EDIT;
@@ -561,10 +560,10 @@ public class UsersResource extends RestResource {
             @PathParam("userId") @NotBlank String userId,
             @ApiParam(name = "newStatus", value = "The account status to be set", required = true,
                       defaultValue = "enabled", allowableValues = "enabled,disabled,deleted")
-            @PathParam("newStatus") @NotBlank String newStatusString) throws ValidationException {
+            @PathParam("newStatus") @NotBlank String newStatusString,
+            @Context UserContext userContext) throws ValidationException {
 
-        final User currentUser = requireNonNull(getCurrentUser(), "currentUser cannot be null");
-        if (userId.equalsIgnoreCase(currentUser.getId())) {
+        if (userId.equalsIgnoreCase(userContext.getUserId())) {
             throw new BadRequestException("Users are not allowed to set their own status");
         }
 

--- a/graylog2-web-interface/src/components/users/UsersOverview/UserOverviewItem/ActionsCell.jsx
+++ b/graylog2-web-interface/src/components/users/UsersOverview/UserOverviewItem/ActionsCell.jsx
@@ -55,9 +55,11 @@ const EditActions = ({ user, user: { username, id, fullName, accountStatus, exte
   const currentUser = useContext(CurrentUserContext) || {};
 
   const _toggleStatus = () => {
-    // eslint-disable-next-line no-alert
-    if (accountStatus === 'enabled' && window.confirm(`Do you really want to disable user ${fullName}? All current sessions will be terminated.`)) {
-      UsersDomain.setStatus(id, 'disabled');
+    if (accountStatus === 'enabled') {
+      // eslint-disable-next-line no-alert
+      if (window.confirm(`Do you really want to disable user ${fullName}? All current sessions will be terminated.`)) {
+        UsersDomain.setStatus(id, 'disabled');
+      }
 
       return;
     }


### PR DESCRIPTION
## Motivation
Prior to this change, a logged in user was able to disable himself (if
he had the necessary permissions).

## Description
This change will hide the menu item `Enable`/`Disable` for the user
himself.

## Also
Add a confirmation dialog for disabling user which explains that
disabling a user also stops its current session.