### PR TITLE
Add startpage to the Settings Section of a user

### DIFF
--- a/graylog2-web-interface/src/actions/streams/StreamsActions.jsx
+++ b/graylog2-web-interface/src/actions/streams/StreamsActions.jsx
@@ -16,11 +16,22 @@
  */
 import Reflux from 'reflux';
 
-const StreamsActions = Reflux.createActions({
-  list: { asyncResult: true },
-  create: { asyncResult: true },
+import { singletonActions } from 'views/logic/singleton';
+
+const StreamsActions = singletonActions('Streams', () => Reflux.createActions({
+  searchPaginated: { asyncResult: true },
+  listStreams: { asyncResult: true },
+  load: { asyncResult: true },
+  get: { asyncResult: true },
+  remove: { asyncResult: true },
+  pause: { asyncResult: true },
+  resume: { asyncResult: true },
+  cloneStream: { asyncResult: true },
   update: { asyncResult: true },
-  delete: { asyncResult: true },
-});
+  save: { asyncResult: true },
+  removeOutput: { asyncResult: true },
+  addOutput: { asyncResult: true },
+  testMatch: { asyncResult: true },
+}));
 
 export default StreamsActions;

--- a/graylog2-web-interface/src/components/configurations/DecoratorsConfig.tsx
+++ b/graylog2-web-interface/src/components/configurations/DecoratorsConfig.tsx
@@ -21,7 +21,7 @@ import { IfPermitted } from 'components/common';
 import { Button } from 'components/graylog';
 import Spinner from 'components/common/Spinner';
 import CombinedProvider from 'injection/CombinedProvider';
-import StreamsStore, { Stream } from 'stores/streams/StreamsStore';
+import { StreamsActions, Stream } from 'stores/streams/StreamsStore';
 import UserNotification from 'util/UserNotification';
 import DecoratorList from 'views/components/messagelist/decorators/DecoratorList';
 import { Decorator } from 'views/components/messagelist/decorators/Types';
@@ -42,7 +42,7 @@ const DecoratorsConfig = () => {
   const [types, setTypes] = useState();
   const configModal = useRef<BootstrapModalWrapper>();
 
-  useEffect(() => { StreamsStore.listStreams().then(setStreams); }, [setStreams]);
+  useEffect(() => { StreamsActions.listStreams().then(setStreams); }, [setStreams]);
   useEffect(() => { DecoratorsActions.available().then(setTypes); }, [setTypes]);
   useEffect(() => { DecoratorsActions.list().then(setDecorators); }, [setDecorators]);
 

--- a/graylog2-web-interface/src/components/streams/StreamControls.jsx
+++ b/graylog2-web-interface/src/components/streams/StreamControls.jsx
@@ -76,7 +76,7 @@ const StreamControls = createReactClass({
 
   _setStartpage() {
     const { user, stream } = this.props;
-    StartpageStore.set(user.username, 'stream', stream.id);
+    StartpageStore.set(user.id, 'stream', stream.id);
   },
 
   render() {

--- a/graylog2-web-interface/src/components/users/StartpageFormGroup.tsx
+++ b/graylog2-web-interface/src/components/users/StartpageFormGroup.tsx
@@ -1,4 +1,19 @@
-// @flow strict
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 import * as React from 'react';
 import { Field } from 'formik';
 import { upperFirst } from 'lodash';

--- a/graylog2-web-interface/src/components/users/StartpageFormGroup.tsx
+++ b/graylog2-web-interface/src/components/users/StartpageFormGroup.tsx
@@ -21,7 +21,7 @@ import { Field } from 'formik';
 import styled from 'styled-components';
 
 import { getValuesFromGRN } from 'logic/permissions/GRN';
-import { Button, Col, Row } from 'components/graylog';
+import { Button, Alert } from 'components/graylog';
 import { Input } from 'components/bootstrap';
 import SharedEntity from 'logic/permissions/SharedEntity';
 import EntityShareDomain from 'domainActions/permissions/EntityShareDomain';
@@ -101,6 +101,11 @@ const StartpageFormGroup = ({ userId, permissions }: Props) => {
       {({ field: { name, value, onChange } }) => {
         const type = value?.type ?? 'dashboard';
         const options = type === 'dashboard' ? dashboards : streams;
+
+        const error = value?.id && options.findIndex(({ value: v }) => v === value.id) < 0
+          ? <Alert bsStyle="warning">User is missing permission for the configured page</Alert>
+          : null;
+
         const resetBtn = value?.type
           ? (
             <ResetBtn onClick={() => onChange({ target: { name, value: {} } })}>
@@ -125,6 +130,7 @@ const StartpageFormGroup = ({ userId, permissions }: Props) => {
                              value={value?.id} />
                 {resetBtn}
               </Container>
+              {error}
             </Input>
           </>
         );

--- a/graylog2-web-interface/src/components/users/StartpageFormGroup.tsx
+++ b/graylog2-web-interface/src/components/users/StartpageFormGroup.tsx
@@ -31,7 +31,7 @@ import { DashboardsActions } from 'views/stores/DashboardsStore';
 import { StreamsActions } from 'stores/streams/StreamsStore';
 
 const Container = styled.div`
-  display:flex;
+  display: flex;
   align-items: center;
 `;
 

--- a/graylog2-web-interface/src/components/users/StartpageFormGroup.tsx
+++ b/graylog2-web-interface/src/components/users/StartpageFormGroup.tsx
@@ -117,15 +117,17 @@ const StartpageFormGroup = ({ userId, permissions }: Props) => {
           <>
             <Input id="startpage"
                    label="Start page"
-                   help="Select the page the user sees right after log in"
+                   help="Select the page the user sees right after log in. Only entities are selectable which the user has permissions for."
                    labelClassName="col-sm-3"
                    wrapperClassName="col-sm-9">
               <>
                 <Container>
                   <TypeSelect options={typeOptions}
+                              placeholder="Select type"
                               onChange={(newType) => onChange({ target: { name, value: { type: newType, id: undefined } } })}
                               value={value?.type} />
                   <ValueSelect options={options}
+                               placeholder={`Select ${value?.type}`}
                                onChange={(newId) => onChange({ target: { name, value: { type: type, id: newId } } })}
                                value={value?.id} />
                   {resetBtn}

--- a/graylog2-web-interface/src/components/users/StartpageFormGroup.tsx
+++ b/graylog2-web-interface/src/components/users/StartpageFormGroup.tsx
@@ -127,7 +127,7 @@ const StartpageFormGroup = ({ userId, permissions }: Props) => {
                               onChange={(newType) => onChange({ target: { name, value: { type: newType, id: undefined } } })}
                               value={value?.type} />
                   <ValueSelect options={options}
-                               placeholder={`Select ${value?.type}`}
+                               placeholder={`Select ${value?.type ?? 'entity'}`}
                                onChange={(newId) => onChange({ target: { name, value: { type: type, id: newId } } })}
                                value={value?.id} />
                   {resetBtn}

--- a/graylog2-web-interface/src/components/users/StartpageFormGroup.tsx
+++ b/graylog2-web-interface/src/components/users/StartpageFormGroup.tsx
@@ -87,8 +87,7 @@ const StartpageFormGroup = ({ userId, permissions }: Props) => {
         .then(() => EntityShareDomain.loadUserSharesPaginated(userId, {
           ...UNLIMITED_ENTITY_SHARE_REQ,
           additionalQueries: { entity_type: 'stream' },
-        })
-          .then(({ list }) => setStreams(list.map(_grnOptionFormatter).toArray())));
+        }).then(({ list }) => setStreams(list.map(_grnOptionFormatter).toArray())));
     }
   }, [permissions, userId]);
 
@@ -121,16 +120,18 @@ const StartpageFormGroup = ({ userId, permissions }: Props) => {
                    help="Select the page the user sees right after log in"
                    labelClassName="col-sm-3"
                    wrapperClassName="col-sm-9">
-              <Container>
-                <TypeSelect options={typeOptions}
-                            onChange={(newType) => onChange({ target: { name, value: { type: newType, id: undefined } } })}
-                            value={value?.type} />
-                <ValueSelect options={options}
-                             onChange={(newId) => onChange({ target: { name, value: { type: type, id: newId } } })}
-                             value={value?.id} />
-                {resetBtn}
-              </Container>
-              {error}
+              <>
+                <Container>
+                  <TypeSelect options={typeOptions}
+                              onChange={(newType) => onChange({ target: { name, value: { type: newType, id: undefined } } })}
+                              value={value?.type} />
+                  <ValueSelect options={options}
+                               onChange={(newId) => onChange({ target: { name, value: { type: type, id: newId } } })}
+                               value={value?.id} />
+                  {resetBtn}
+                </Container>
+                {error}
+              </>
             </Input>
           </>
         );

--- a/graylog2-web-interface/src/components/users/UserCreate/StartpageFormGroup.jsx
+++ b/graylog2-web-interface/src/components/users/UserCreate/StartpageFormGroup.jsx
@@ -1,0 +1,49 @@
+// @flow strict
+import * as React from 'react';
+import { Field } from 'formik';
+import { upperFirst } from 'lodash';
+import styled from 'styled-components';
+
+import { Button } from 'components/graylog';
+import { Input } from 'components/bootstrap';
+
+const Container = styled.div`
+  display:flex;
+  align-items: center;
+  padding-top: 6px;
+`;
+
+const ResetBtn = styled(Button)`
+  margin-left: 5px;
+`;
+
+const StartpageFormGroup = () => (
+  <Field name="startpage">
+    {({ field: { name, value, onChange } }) => {
+      const valueTxt = value?.type
+        ? `${upperFirst(value.type)} ${value.id}`
+        : 'No Startpage set';
+      const resetBtn = value?.type
+        ? (
+          <ResetBtn bsSize="xs"
+                    onClick={() => onChange({ target: { name, value: {} } })}>
+            Reset
+          </ResetBtn>
+        )
+        : null;
+
+      return (
+        <>
+          <Input id="startpage"
+                 label="Startpage"
+                 labelClassName="col-sm-3"
+                 wrapperClassName="col-sm-9">
+            <Container>{valueTxt}{resetBtn}</Container>
+          </Input>
+        </>
+      );
+    }}
+  </Field>
+);
+
+export default StartpageFormGroup;

--- a/graylog2-web-interface/src/components/users/UserDetails/SettingsSection.tsx
+++ b/graylog2-web-interface/src/components/users/UserDetails/SettingsSection.tsx
@@ -15,6 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
+import { useState, useEffect } from 'react';
 import { upperFirst } from 'lodash';
 
 import Routes from 'routing/Routes';
@@ -22,6 +23,9 @@ import { Link } from 'components/graylog/router';
 import { ReadOnlyFormGroup } from 'components/common';
 import User from 'logic/users/User';
 import SectionComponent from 'components/common/Section/SectionComponent';
+import { StreamsActions } from 'stores/streams/StreamsStore';
+import { DashboardsActions } from 'views/stores/DashboardsStore';
+import { ViewManagementActions } from 'views/stores/ViewManagementStore';
 
 type Props = {
   user: User,
@@ -36,14 +40,28 @@ const _sessionTimeout = (sessionTimeout) => {
 };
 
 const StartpageValue = ({ type, id }: { type: string | null | undefined, id: string | null | undefined }) => {
+  const [title, setTitle] = useState<string | undefined>();
+
+  useEffect(() => {
+    if (!type || !id) {
+      return;
+    }
+
+    if (type === 'stream') {
+      StreamsActions.get(id).then(({ title: streamTitle }) => setTitle(streamTitle));
+    } else {
+      ViewManagementActions.get(id).then(({ title: viewTitle }) => setTitle(viewTitle));
+    }
+  }, [id, type]);
+
   if (!type || !id) {
-    return <span>No Startpage set</span>;
+    return <span>No start page set</span>;
   }
 
   const route = type === 'stream' ? Routes.stream_search(id) : Routes.dashboard_show(id);
 
   return (
-    <Link to={route}>{upperFirst(type)} {id}</Link>
+    <Link to={route}><b>{upperFirst(type)}</b>:  {title}</Link>
   );
 };
 

--- a/graylog2-web-interface/src/components/users/UserDetails/SettingsSection.tsx
+++ b/graylog2-web-interface/src/components/users/UserDetails/SettingsSection.tsx
@@ -24,7 +24,6 @@ import { ReadOnlyFormGroup } from 'components/common';
 import User from 'logic/users/User';
 import SectionComponent from 'components/common/Section/SectionComponent';
 import { StreamsActions } from 'stores/streams/StreamsStore';
-import { DashboardsActions } from 'views/stores/DashboardsStore';
 import { ViewManagementActions } from 'views/stores/ViewManagementStore';
 
 type Props = {

--- a/graylog2-web-interface/src/components/users/UserDetails/SettingsSection.tsx
+++ b/graylog2-web-interface/src/components/users/UserDetails/SettingsSection.tsx
@@ -35,7 +35,7 @@ const _sessionTimeout = (sessionTimeout) => {
   return 'Sessions do not timeout';
 };
 
-const StartpageValue = ({ type, id }: { type: ?string, id: ?string }) => {
+const StartpageValue = ({ type, id }: { type: string | null | undefined, id: string | null | undefined }) => {
   if (!type || !id) {
     return <span>No Startpage set</span>;
   }

--- a/graylog2-web-interface/src/components/users/UserDetails/SettingsSection.tsx
+++ b/graylog2-web-interface/src/components/users/UserDetails/SettingsSection.tsx
@@ -15,7 +15,10 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
+import { upperFirst } from 'lodash';
 
+import Routes from 'routing/Routes';
+import { Link } from 'components/graylog/router';
 import { ReadOnlyFormGroup } from 'components/common';
 import User from 'logic/users/User';
 import SectionComponent from 'components/common/Section/SectionComponent';
@@ -32,15 +35,29 @@ const _sessionTimeout = (sessionTimeout) => {
   return 'Sessions do not timeout';
 };
 
+const StartpageValue = ({ type, id }: { type: ?string, id: ?string }) => {
+  if (!type || !id) {
+    return <span>No Startpage set</span>;
+  }
+
+  const route = type === 'stream' ? Routes.stream_search(id) : Routes.dashboard_show(id);
+
+  return (
+    <Link to={route}>{upperFirst(type)} {id}</Link>
+  );
+};
+
 const SettingsSection = ({
   user: {
     timezone,
     sessionTimeout,
+    startpage,
   },
 }: Props) => (
   <SectionComponent title="Settings">
     <ReadOnlyFormGroup label="Sessions Timeout" value={_sessionTimeout(sessionTimeout)} />
     <ReadOnlyFormGroup label="Timezone" value={timezone} />
+    <ReadOnlyFormGroup label="Startpage" value={<StartpageValue type={startpage?.type} id={startpage?.id} />} />
   </SectionComponent>
 );
 

--- a/graylog2-web-interface/src/components/users/UserEdit/SettingsSection.test.tsx
+++ b/graylog2-web-interface/src/components/users/UserEdit/SettingsSection.test.tsx
@@ -19,11 +19,8 @@ import { render, fireEvent, waitFor, screen, act } from 'wrappedTestingLibrary';
 import { alice } from 'fixtures/users';
 import selectEvent from 'react-select-event';
 import { List } from 'immutable';
-import mockAction from 'helpers/mocking/MockAction';
 
-import { EntityShareActions } from 'stores/permissions/EntityShareStore';
 import SharedEntity from 'logic/permissions/SharedEntity';
-import { createGRN } from 'logic/permissions/GRN';
 import Grantee from 'logic/permissions/Grantee';
 
 import SettingsSection from './SettingsSection';

--- a/graylog2-web-interface/src/components/users/UserEdit/SettingsSection.test.tsx
+++ b/graylog2-web-interface/src/components/users/UserEdit/SettingsSection.test.tsx
@@ -18,8 +18,32 @@ import * as React from 'react';
 import { render, fireEvent, waitFor, screen, act } from 'wrappedTestingLibrary';
 import { alice } from 'fixtures/users';
 import selectEvent from 'react-select-event';
+import { List } from 'immutable';
+import mockAction from 'helpers/mocking/MockAction';
+
+import { EntityShareActions } from 'stores/permissions/EntityShareStore';
+import SharedEntity from 'logic/permissions/SharedEntity';
+import { createGRN } from 'logic/permissions/GRN';
+import Grantee from 'logic/permissions/Grantee';
 
 import SettingsSection from './SettingsSection';
+
+const sharedEntity = SharedEntity
+  .builder()
+  .id('grn::::dashboard:57bc9188e62a2373778d9e03')
+  .type('dashboard')
+  .title('Security Data')
+  .owners(List([Grantee.builder().id('foo-id').title('alice').type('user')
+    .build()]))
+  .build();
+
+const mockList = Promise.resolve({ list: List.of(sharedEntity) });
+
+jest.mock('stores/permissions/EntityShareStore', () => ({
+  EntityShareActions: {
+    loadUserSharesPaginated: jest.fn(() => mockList),
+  },
+}));
 
 const exampleUser = alice.toBuilder()
   .sessionTimeoutMs(36000000)

--- a/graylog2-web-interface/src/components/users/UserEdit/SettingsSection.test.tsx
+++ b/graylog2-web-interface/src/components/users/UserEdit/SettingsSection.test.tsx
@@ -16,12 +16,13 @@
  */
 import * as React from 'react';
 import { render, fireEvent, waitFor, screen, act } from 'wrappedTestingLibrary';
-import { alice } from 'fixtures/users';
+import { alice, adminUser } from 'fixtures/users';
 import selectEvent from 'react-select-event';
 import { List } from 'immutable';
 
 import SharedEntity from 'logic/permissions/SharedEntity';
 import Grantee from 'logic/permissions/Grantee';
+import CurrentUserContext from 'contexts/CurrentUserContext';
 
 import SettingsSection from './SettingsSection';
 
@@ -66,7 +67,12 @@ describe('<SettingsSection />', () => {
 
   it('should allow session timeout name and timezone change', async () => {
     const onSubmitStub = jest.fn();
-    render(<SettingsSection user={exampleUser} onSubmit={(data) => onSubmitStub(data)} />);
+
+    render(
+      <CurrentUserContext.Provider value={adminUser.toJSON()}>
+        <SettingsSection user={exampleUser} onSubmit={(data) => onSubmitStub(data)} />
+      </CurrentUserContext.Provider>,
+    );
 
     const timeoutAmountInput = screen.getByPlaceholderText('Timeout amount');
     const timezoneSelect = screen.getByLabelText('Time Zone');

--- a/graylog2-web-interface/src/components/users/UserEdit/SettingsSection.tsx
+++ b/graylog2-web-interface/src/components/users/UserEdit/SettingsSection.tsx
@@ -33,9 +33,11 @@ type Props = {
 
 const SettingsSection = ({
   user: {
+    id,
     timezone,
     sessionTimeoutMs,
     startpage,
+    permissions,
   },
   onSubmit,
 }: Props) => (
@@ -46,7 +48,7 @@ const SettingsSection = ({
         <Form className="form form-horizontal">
           <TimeoutFormGroup />
           <TimezoneFormGroup />
-          <StartpageFormGroup />
+          <StartpageFormGroup userId={id} permissions={permissions} />
 
           <Row className="no-bm">
             <Col xs={12}>

--- a/graylog2-web-interface/src/components/users/UserEdit/SettingsSection.tsx
+++ b/graylog2-web-interface/src/components/users/UserEdit/SettingsSection.tsx
@@ -24,7 +24,7 @@ import SectionComponent from 'components/common/Section/SectionComponent';
 
 import TimezoneFormGroup from '../UserCreate/TimezoneFormGroup';
 import TimeoutFormGroup from '../UserCreate/TimeoutFormGroup';
-import StartpageFormGroup from '../UserCreate/StartpageFormGroup';
+import StartpageFormGroup from '../StartpageFormGroup';
 
 type Props = {
   user: User,

--- a/graylog2-web-interface/src/components/users/UserEdit/SettingsSection.tsx
+++ b/graylog2-web-interface/src/components/users/UserEdit/SettingsSection.tsx
@@ -21,6 +21,7 @@ import { $PropertyType } from 'utility-types';
 import { Button, Row, Col } from 'components/graylog';
 import User from 'logic/users/User';
 import SectionComponent from 'components/common/Section/SectionComponent';
+import { IfPermitted } from 'components/common';
 
 import TimezoneFormGroup from '../UserCreate/TimezoneFormGroup';
 import TimeoutFormGroup from '../UserCreate/TimeoutFormGroup';
@@ -46,7 +47,9 @@ const SettingsSection = ({
             initialValues={{ timezone, session_timeout_ms: sessionTimeoutMs, startpage }}>
       {({ isSubmitting, isValid }) => (
         <Form className="form form-horizontal">
-          <TimeoutFormGroup />
+          <IfPermitted permissions="*">
+            <TimeoutFormGroup />
+          </IfPermitted>
           <TimezoneFormGroup />
           <StartpageFormGroup userId={id} permissions={permissions} />
 

--- a/graylog2-web-interface/src/components/users/UserEdit/SettingsSection.tsx
+++ b/graylog2-web-interface/src/components/users/UserEdit/SettingsSection.tsx
@@ -24,6 +24,7 @@ import SectionComponent from 'components/common/Section/SectionComponent';
 
 import TimezoneFormGroup from '../UserCreate/TimezoneFormGroup';
 import TimeoutFormGroup from '../UserCreate/TimeoutFormGroup';
+import StartpageFormGroup from '../UserCreate/StartpageFormGroup';
 
 type Props = {
   user: User,
@@ -34,16 +35,19 @@ const SettingsSection = ({
   user: {
     timezone,
     sessionTimeoutMs,
+    startpage,
   },
   onSubmit,
 }: Props) => (
   <SectionComponent title="Settings">
     <Formik onSubmit={onSubmit}
-            initialValues={{ timezone, session_timeout_ms: sessionTimeoutMs }}>
+            initialValues={{ timezone, session_timeout_ms: sessionTimeoutMs, startpage }}>
       {({ isSubmitting, isValid }) => (
         <Form className="form form-horizontal">
           <TimeoutFormGroup />
           <TimezoneFormGroup />
+          <StartpageFormGroup />
+
           <Row className="no-bm">
             <Col xs={12}>
               <div className="pull-right">

--- a/graylog2-web-interface/src/components/users/UserEdit/UserEdit.tsx
+++ b/graylog2-web-interface/src/components/users/UserEdit/UserEdit.tsx
@@ -43,7 +43,6 @@ type Props = {
 };
 
 const _updateUser = (data, currentUser, userId) => {
-  console.log(data);
   return UsersDomain.update(userId, data).then(() => {
     if (userId === currentUser?.id) {
       CurrentUserStore.reload();

--- a/graylog2-web-interface/src/components/users/UserEdit/UserEdit.tsx
+++ b/graylog2-web-interface/src/components/users/UserEdit/UserEdit.tsx
@@ -43,6 +43,7 @@ type Props = {
 };
 
 const _updateUser = (data, currentUser, userId) => {
+  console.log(data);
   return UsersDomain.update(userId, data).then(() => {
     if (userId === currentUser?.id) {
       CurrentUserStore.reload();

--- a/graylog2-web-interface/src/components/users/UserEdit/UserEdit.tsx
+++ b/graylog2-web-interface/src/components/users/UserEdit/UserEdit.tsx
@@ -77,10 +77,8 @@ const UserEdit = ({ user }: Props) => {
           <ProfileSection user={user}
                           onSubmit={(data) => _updateUser(data, currentUser, user.id)} />
           ) }
-          <IfPermitted permissions="*">
-            <SettingsSection user={user}
-                             onSubmit={(data) => _updateUser(data, currentUser, user.id)} />
-          </IfPermitted>
+          <SettingsSection user={user}
+                           onSubmit={(data) => _updateUser(data, currentUser, user.id)} />
           <IfPermitted permissions={`users:passwordchange:${user.username}`}>
             { !user.external && <PasswordSection user={user} /> }
           </IfPermitted>

--- a/graylog2-web-interface/src/stores/streams/StreamsStore.ts
+++ b/graylog2-web-interface/src/stores/streams/StreamsStore.ts
@@ -38,6 +38,56 @@ export type Stream = {
   creatorUser: string,
   createdAt: number,
 };
+
+type StreamRule = {
+  id: string,
+  type: string,
+  value: string,
+  inverted: boolean,
+  stream_id: string,
+  description: string,
+};
+
+type OutputSummary = {
+  id: string,
+  title: string,
+  type: string,
+  creator_user_id: string,
+  created_at: string,
+  configuration: { [key: string]: string },
+};
+
+type AlertConditionSummary = {
+  id: string,
+  type: string,
+  creator_user_id: string,
+  created_at: string,
+  parameters: { [key: string]: any },
+  in_grace: boolean | null | undefined,
+  title: string | null | undefined,
+};
+
+type AlertReceiver = {
+  emails: string[],
+  users: string[],
+};
+
+export type StreamResponse = {
+  id: string,
+  creator_user_id: string,
+  outputs: OutputSummary[],
+  matching_type: string,
+  description: string,
+  created_at: string,
+  disabled: boolean,
+  rules: StreamRule[],
+  alert_conditions: AlertConditionSummary[],
+  alert_receivers: AlertReceiver
+  title: string,
+  is_default: boolean | null | undefined,
+  remove_matches_from_default_stream: boolean,
+  index_set_id: string,
+}
 /* eslint-enable camelcase */
 
 type TestMatchResponse = {
@@ -119,7 +169,7 @@ const StreamsStore = singletonStore('Streams', () => Reflux.createStore({
         callback(streams);
       });
   },
-  get(streamId: string, callback: ((stream: Stream) => void)) {
+  get(streamId: string, callback: ((stream: Stream) => void)): Promise<StreamResponse> {
     const failCallback = (errorThrown) => {
       UserNotification.error(`Loading Stream failed with status: ${errorThrown}`,
         'Could not retrieve Stream');

--- a/graylog2-web-interface/src/stores/streams/StreamsStore.ts
+++ b/graylog2-web-interface/src/stores/streams/StreamsStore.ts
@@ -23,9 +23,12 @@ import { qualifyUrl } from 'util/URLUtils';
 import UserNotification from 'util/UserNotification';
 import CombinedProvider from 'injection/CombinedProvider';
 import PaginationURL from 'util/PaginationURL';
+import StreamsActions from 'actions/streams/StreamsActions';
+import { singletonStore } from 'views/logic/singleton';
 
 const { CurrentUserStore } = CombinedProvider.get('CurrentUser');
 
+/* eslint-disable camelcase */
 export type Stream = {
   id: string,
   title: string,
@@ -35,6 +38,7 @@ export type Stream = {
   creatorUser: string,
   createdAt: number,
 };
+/* eslint-enable camelcase */
 
 type TestMatchResponse = {
   matches: boolean,
@@ -50,6 +54,7 @@ type StreamSummaryResponse = {
   streams: Array<Stream>,
 };
 
+/* eslint-disable camelcase */
 type PaginatedResponse = {
   pagination: {
     count: number,
@@ -58,16 +63,19 @@ type PaginatedResponse = {
     per_page: number,
     query: string,
   },
-  streams: Array<any>,
+  streams: Array<Stream>,
 };
+/* eslint-enable camelcase */
 
-const StreamsStore = Reflux.createStore({
+const StreamsStore = singletonStore('Streams', () => Reflux.createStore({
+  listenables: [StreamsActions],
+
   callbacks: [],
 
   searchPaginated(page, perPage, query) {
     const url = PaginationURL(ApiRoutes.StreamsApiController.paginated().url, page, perPage, query);
 
-    return fetch('GET', qualifyUrl(url))
+    const promise = fetch('GET', qualifyUrl(url))
       .then((response: PaginatedResponse) => {
         const pagination = {
           count: response.pagination.count,
@@ -86,16 +94,24 @@ const StreamsStore = Reflux.createStore({
         UserNotification.error(`Loading streams failed with status: ${errorThrown}`,
           'Could not load streams');
       });
+
+    StreamsActions.searchPaginated.promise(promise);
+
+    return promise;
   },
   listStreams() {
     const url = '/streams';
 
-    return fetch('GET', qualifyUrl(url))
+    const promise = fetch('GET', qualifyUrl(url))
       .then((result: StreamSummaryResponse) => result.streams)
       .catch((errorThrown) => {
         UserNotification.error(`Loading streams failed with status: ${errorThrown}`,
           'Could not load streams');
       });
+
+    StreamsActions.listStreams.promise(promise);
+
+    return promise;
   },
   load(callback: ((streams: Array<Stream>) => void)) {
     this.listStreams()
@@ -111,8 +127,12 @@ const StreamsStore = Reflux.createStore({
 
     const { url } = ApiRoutes.StreamsApiController.get(streamId);
 
-    fetch('GET', qualifyUrl(url))
+    const promise = fetch('GET', qualifyUrl(url))
       .then(callback, failCallback);
+
+    StreamsActions.get.promise(promise);
+
+    return promise;
   },
   remove(streamId: string, callback: (() => void)) {
     const failCallback = (errorThrown) => {
@@ -122,10 +142,14 @@ const StreamsStore = Reflux.createStore({
 
     const url = qualifyUrl(ApiRoutes.StreamsApiController.delete(streamId).url);
 
-    fetch('DELETE', url)
+    const promise = fetch('DELETE', url)
       .then(callback, failCallback)
       .then(() => CurrentUserStore.reload()
         .then(this._emitChange.bind(this)));
+
+    StreamsActions.remove.promise(promise);
+
+    return promise;
   },
   pause(streamId: string, callback: (() => void)) {
     const failCallback = (errorThrown) => {
@@ -135,13 +159,17 @@ const StreamsStore = Reflux.createStore({
 
     const url = qualifyUrl(ApiRoutes.StreamsApiController.pause(streamId).url);
 
-    return fetch('POST', url)
+    const promise = fetch('POST', url)
       .then(callback, failCallback)
       .then((response) => {
         this._emitChange();
 
         return response;
       });
+
+    StreamsActions.pause.promise(promise);
+
+    return promise;
   },
   resume(streamId: string, callback: (() => void)) {
     const failCallback = (errorThrown) => {
@@ -151,13 +179,17 @@ const StreamsStore = Reflux.createStore({
 
     const url = qualifyUrl(ApiRoutes.StreamsApiController.resume(streamId).url);
 
-    return fetch('POST', url)
+    const promise = fetch('POST', url)
       .then(callback, failCallback)
       .then((response) => {
         this._emitChange();
 
         return response;
       });
+
+    StreamsActions.resume.promise(promise);
+
+    return promise;
   },
   save(stream: any, callback: ((streamId: string) => void)) {
     const failCallback = (errorThrown) => {
@@ -167,10 +199,14 @@ const StreamsStore = Reflux.createStore({
 
     const url = qualifyUrl(ApiRoutes.StreamsApiController.create().url);
 
-    fetch('POST', url, stream)
+    const promise = fetch('POST', url, stream)
       .then(callback, failCallback)
       .then(() => CurrentUserStore.reload()
         .then(this._emitChange.bind(this)));
+
+    StreamsActions.save.promise(promise);
+
+    return promise;
   },
   update(streamId: string, data: any, callback: ((stream: Stream) => void)) {
     const failCallback = (errorThrown) => {
@@ -180,9 +216,13 @@ const StreamsStore = Reflux.createStore({
 
     const url = qualifyUrl(ApiRoutes.StreamsApiController.update(streamId).url);
 
-    fetch('PUT', url, data)
+    const promise = fetch('PUT', url, data)
       .then(callback, failCallback)
       .then(this._emitChange.bind(this));
+
+    StreamsActions.update.promise(promise);
+
+    return promise;
   },
   cloneStream(streamId: string, data: any, callback: ((streamId: string) => void)) {
     const failCallback = (errorThrown) => {
@@ -192,39 +232,55 @@ const StreamsStore = Reflux.createStore({
 
     const url = qualifyUrl(ApiRoutes.StreamsApiController.cloneStream(streamId).url);
 
-    fetch('POST', url, data)
+    const promise = fetch('POST', url, data)
       .then(callback, failCallback)
       .then(() => CurrentUserStore.reload()
         .then(this._emitChange.bind(this)));
+
+    StreamsActions.cloneStream.promise(promise);
+
+    return promise;
   },
   removeOutput(streamId: string, outputId: string, callback: () => void) {
     const url = qualifyUrl(ApiRoutes.StreamOutputsApiController.delete(streamId, outputId).url);
 
-    fetch('DELETE', url)
+    const promise = fetch('DELETE', url)
       .then(callback, (errorThrown) => {
         UserNotification.error(`Removing output from stream failed with status: ${errorThrown}`,
           'Could not remove output from stream');
       })
       .then(this._emitChange.bind(this));
+
+    StreamsActions.removeOutput.promise(promise);
+
+    return promise;
   },
   addOutput(streamId: string, outputId: string, callback: (response: any) => void) {
     const url = qualifyUrl(ApiRoutes.StreamOutputsApiController.add(streamId, outputId).url);
 
-    fetch('POST', url, { outputs: [outputId] })
+    const promise = fetch('POST', url, { outputs: [outputId] })
       .then(callback, (errorThrown) => {
         UserNotification.error(`Adding output to stream failed with status: ${errorThrown}`,
           'Could not add output to stream');
       })
       .then(this._emitChange.bind(this));
+
+    StreamsActions.addOutput.promise(promise);
+
+    return promise;
   },
   testMatch(streamId: string, message: any, callback: (response: TestMatchResponse) => void) {
     const url = qualifyUrl(ApiRoutes.StreamsApiController.testMatch(streamId).url);
 
-    fetch('POST', url, message)
+    const promise = fetch('POST', url, message)
       .then(callback, (error) => {
         UserNotification.error(`Testing stream rules of stream failed with status: ${error.message}`,
           'Could not test stream rules of stream');
       });
+
+    StreamsActions.testMatch.promise(promise);
+
+    return promise;
   },
   onChange(callback: Callback) {
     this.callbacks.push(callback);
@@ -235,6 +291,7 @@ const StreamsStore = Reflux.createStore({
   unregister(callback: Callback) {
     lodash.pull(this.callbacks, callback);
   },
-});
+}));
 
+export { StreamsStore, StreamsActions };
 export default StreamsStore;

--- a/graylog2-web-interface/src/stores/users/StartpageStore.js
+++ b/graylog2-web-interface/src/stores/users/StartpageStore.js
@@ -18,14 +18,14 @@ import Reflux from 'reflux';
 
 import ApiRoutes from 'routing/ApiRoutes';
 import UserNotification from 'util/UserNotification';
-import URLUtils from 'util/URLUtils';
+import { qualifyUrl } from 'util/URLUtils';
 import fetch from 'logic/rest/FetchProvider';
 
 const StartpageStore = Reflux.createStore({
   listenables: [],
 
-  set(username, type, id) {
-    const url = URLUtils.qualifyUrl(ApiRoutes.UsersApiController.update(username).url);
+  set(userId, type, id) {
+    const url = qualifyUrl(ApiRoutes.UsersApiController.update(userId).url);
     const payload = {};
 
     if (type && id) {

--- a/graylog2-web-interface/src/views/stores/DashboardsStore.ts
+++ b/graylog2-web-interface/src/views/stores/DashboardsStore.ts
@@ -86,7 +86,10 @@ const DashboardsStore: Store<DashboardsStoreState> = singletonStore(
             pagination: this.pagination,
           });
 
-          return response;
+          return {
+            list: this.dashboards,
+            pagination: this.pagination,
+          };
         })
         .catch((error) => {
           UserNotification.error(`Fetching dashboards failed with status: ${error}`,

--- a/graylog2-web-interface/src/views/stores/DashboardsStore.ts
+++ b/graylog2-web-interface/src/views/stores/DashboardsStore.ts
@@ -16,7 +16,7 @@
  */
 import Reflux from 'reflux';
 
-import URLUtils from 'util/URLUtils';
+import { qualifyUrl } from 'util/URLUtils';
 import { singletonActions, singletonStore } from 'views/logic/singleton';
 import fetch from 'logic/rest/FetchProvider';
 import UserNotification from 'util/UserNotification';
@@ -37,7 +37,7 @@ const DashboardsActions: DashboardsActionsType = singletonActions(
   }),
 );
 
-const dashboardsUrl = URLUtils.qualifyUrl('/dashboards');
+const dashboardsUrl = qualifyUrl('/dashboards');
 
 export type Pagination = {
   total: number;


### PR DESCRIPTION
## Motivation
Make startpage configureable in settings section of a user

## Description
Add two selects one for the type `dashboard` / `stream` and one for the list of available options.
For normal users we as entity share resource for a list of dashboards or streams and for admin users
we ask dashboards resource and stream resource.

If a user lost a view permission for the selected startpage we show a warning message.


![Graylog - Edit User (5)](https://user-images.githubusercontent.com/448763/100244856-b5848600-2f37-11eb-88c0-e8903201ad77.png)
![Graylog - User Details](https://user-images.githubusercontent.com/448763/100244859-b61d1c80-2f37-11eb-970a-ce8d093a433f.png)
![Graylog - Edit User (6)](https://user-images.githubusercontent.com/448763/100244851-b4ebef80-2f37-11eb-9315-d150107a3080.png)



Refs #9443 