### PR TITLE
Add reset startpage button to profile section of user edit 4.0

### DIFF
--- a/graylog2-web-interface/src/components/streams/StreamControls.jsx
+++ b/graylog2-web-interface/src/components/streams/StreamControls.jsx
@@ -60,7 +60,7 @@ const StreamControls = createReactClass({
 
   _setStartpage() {
     const { user, stream } = this.props;
-    StartpageStore.set(user.username, 'stream', stream.id);
+    StartpageStore.set(user.id, 'stream', stream.id);
   },
 
   render() {

--- a/graylog2-web-interface/src/components/users/UserEdit/PreferencesSection.jsx
+++ b/graylog2-web-interface/src/components/users/UserEdit/PreferencesSection.jsx
@@ -9,18 +9,36 @@ import { FormikFormGroup, ReadOnlyFormGroup } from 'components/common';
 import SectionComponent from 'components/common/Section/SectionComponent';
 import User from 'logic/users/User';
 import CombinedProvider from 'injection/CombinedProvider';
+import StoreProvider from 'injection/StoreProvider';
 
+const StartpageStore = StoreProvider.getStore('Startpage');
 const { PreferencesActions } = CombinedProvider.get('Preferences');
 
 type Props = {
   user: User,
 };
 
+
 const PreferencesSection = ({ user }: Props) => {
   const onSubmit = (data) => PreferencesActions.saveUserPreferences(user.username, data);
+  const _resetStartpage = () => {
+    // eslint-disable-next-line no-alert
+    if (window.confirm(`You are about to reset the startpage from user ${user.fullName}. Please confirm.`)) {
+      StartpageStore.set(user.id);
+    }
+  };
+  const isStartpageSet = !!user.startpage?.type;
+  const resetTitle = isStartpageSet ? 'Reset startpage' : 'No startpage set';
+  const resetButton = (
+    <Button title={resetTitle}
+            disabled={!isStartpageSet}
+            onClick={_resetStartpage}>
+      Reset Startpage
+    </Button>
+  );
 
   return (
-    <SectionComponent title="Preferences">
+    <SectionComponent title="Preferences" headerActions={resetButton}>
       <Formik onSubmit={onSubmit}
               initialValues={user.preferences}>
         {({ isSubmitting, isValid }) => (

--- a/graylog2-web-interface/src/components/users/UserEdit/PreferencesSection.jsx
+++ b/graylog2-web-interface/src/components/users/UserEdit/PreferencesSection.jsx
@@ -18,15 +18,16 @@ type Props = {
   user: User,
 };
 
-
 const PreferencesSection = ({ user }: Props) => {
   const onSubmit = (data) => PreferencesActions.saveUserPreferences(user.username, data);
+
   const _resetStartpage = () => {
     // eslint-disable-next-line no-alert
     if (window.confirm(`You are about to reset the startpage from user ${user.fullName}. Please confirm.`)) {
       StartpageStore.set(user.id);
     }
   };
+
   const isStartpageSet = !!user.startpage?.type;
   const resetTitle = isStartpageSet ? 'Reset startpage' : 'No startpage set';
   const resetButton = (

--- a/graylog2-web-interface/src/components/users/UserEdit/ProfileSection.jsx
+++ b/graylog2-web-interface/src/components/users/UserEdit/ProfileSection.jsx
@@ -2,6 +2,7 @@
 import * as React from 'react';
 import { Formik, Form } from 'formik';
 
+import StoreProvider from 'injection/StoreProvider';
 import { Button, Col, Row } from 'components/graylog';
 import { ReadOnlyFormGroup } from 'components/common';
 import User from 'logic/users/User';
@@ -9,6 +10,8 @@ import SectionComponent from 'components/common/Section/SectionComponent';
 
 import FullNameFormGroup from '../UserCreate/FullNameFormGroup';
 import EmailFormGroup from '../UserCreate/EmailFormGroup';
+
+const StartpageStore = StoreProvider.getStore('Startpage');
 
 type Props = {
   user: User,
@@ -28,8 +31,25 @@ const ProfileSection = ({
     email,
   } = user;
 
+  const _resetStartpage = () => {
+    // eslint-disable-next-line no-alert
+    if (window.confirm(`You are about to reset the startpage from user ${user.fullName}. Please confirm.`)) {
+      StartpageStore.set(user.id);
+    }
+  };
+
+  const isStartpageSet = !!user.startpage?.type;
+  const resetTitle = isStartpageSet ? 'Reset startpage' : 'No startpage set';
+  const resetButton = (
+    <Button title={resetTitle}
+            disabled={!isStartpageSet}
+            onClick={_resetStartpage}>
+      Reset Startpage
+    </Button>
+  );
+
   return (
-    <SectionComponent title="Profile">
+    <SectionComponent title="Profile" headerActions={resetButton}>
       <Formik onSubmit={onSubmit}
               initialValues={{ email, full_name: fullName }}>
         {({ isSubmitting, isValid }) => (

--- a/graylog2-web-interface/src/components/users/UserEdit/ProfileSection.jsx
+++ b/graylog2-web-interface/src/components/users/UserEdit/ProfileSection.jsx
@@ -2,7 +2,6 @@
 import * as React from 'react';
 import { Formik, Form } from 'formik';
 
-import StoreProvider from 'injection/StoreProvider';
 import { Button, Col, Row } from 'components/graylog';
 import { ReadOnlyFormGroup } from 'components/common';
 import User from 'logic/users/User';
@@ -10,8 +9,6 @@ import SectionComponent from 'components/common/Section/SectionComponent';
 
 import FullNameFormGroup from '../UserCreate/FullNameFormGroup';
 import EmailFormGroup from '../UserCreate/EmailFormGroup';
-
-const StartpageStore = StoreProvider.getStore('Startpage');
 
 type Props = {
   user: User,
@@ -31,25 +28,8 @@ const ProfileSection = ({
     email,
   } = user;
 
-  const _resetStartpage = () => {
-    // eslint-disable-next-line no-alert
-    if (window.confirm(`You are about to reset the startpage from user ${user.fullName}. Please confirm.`)) {
-      StartpageStore.set(user.id);
-    }
-  };
-
-  const isStartpageSet = !!user.startpage?.type;
-  const resetTitle = isStartpageSet ? 'Reset startpage' : 'No startpage set';
-  const resetButton = (
-    <Button title={resetTitle}
-            disabled={!isStartpageSet}
-            onClick={_resetStartpage}>
-      Reset Startpage
-    </Button>
-  );
-
   return (
-    <SectionComponent title="Profile" headerActions={resetButton}>
+    <SectionComponent title="Profile">
       <Formik onSubmit={onSubmit}
               initialValues={{ email, full_name: fullName }}>
         {({ isSubmitting, isValid }) => (


### PR DESCRIPTION
## Motivation
Prior to this change, there was no way to reset a startpage for a user.

## Description
This change will add the most minimal solution by adding a Reset
Startpage button to the header of the profile section on the user edit page.

## Also
Fix setting the Set as Startpage menuitem for streams.

![Graylog - Edit User (3)](https://user-images.githubusercontent.com/448763/98822756-80edd600-2431-11eb-92a7-822554850d32.png)

Refs #9443 

