### PR TITLE
Support TypeScript in Jest.

### DIFF
--- a/graylog2-web-interface/package.json
+++ b/graylog2-web-interface/package.json
@@ -60,10 +60,7 @@
     },
     "testPathIgnorePatterns": [
       ".fixtures.js$"
-    ],
-    "transform": {
-      "^.+\\.jsx?$": "<rootDir>/node_modules/babel-jest"
-    }
+    ]
   },
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^1.2.28",

--- a/graylog2-web-interface/package.json
+++ b/graylog2-web-interface/package.json
@@ -48,6 +48,8 @@
       "node_modules"
     ],
     "moduleFileExtensions": [
+      "ts",
+      "tsx",
       "js",
       "jsx"
     ],

--- a/graylog2-web-interface/package.json
+++ b/graylog2-web-interface/package.json
@@ -141,6 +141,7 @@
     "@testing-library/dom": "7.20.2",
     "@testing-library/jest-dom": "5.11.0",
     "@testing-library/react": "11.0.4",
+    "@types/jest": "25.2.3",
     "assets-webpack-plugin": "^5.1.2",
     "babel-core": "^7.0.0-0",
     "babel-jest": "^25.1.0",

--- a/graylog2-web-interface/package.json
+++ b/graylog2-web-interface/package.json
@@ -61,7 +61,7 @@
       "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/test/fileMock.js"
     },
     "testPathIgnorePatterns": [
-      ".fixtures.js$"
+      ".fixtures.[jt]s$"
     ]
   },
   "dependencies": {

--- a/graylog2-web-interface/src/pages/UserHasNoStreamAccess.test.tsx
+++ b/graylog2-web-interface/src/pages/UserHasNoStreamAccess.test.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react';
+import { render, screen } from 'wrappedTestingLibrary';
+import mockComponent from 'helpers/mocking/MockComponent';
+
+import UserHasNoStreamAccess from 'pages/UserHasNoStreamAccess';
+
+jest.mock('components/layout/Footer', () => mockComponent('Footer'));
+
+describe('UserHasNoStreamAccess', () => {
+  it('should render error message', () => {
+    render(<UserHasNoStreamAccess />);
+    screen.findByText(/We cannot start a search right now, because you are not allowed to access any stream./);
+  });
+});

--- a/graylog2-web-interface/test/setup-jest.js
+++ b/graylog2-web-interface/test/setup-jest.js
@@ -16,14 +16,9 @@
  */
 /// <reference types="jest-enzyme" />
 
-import jQuery from 'jquery';
 import sizeMe from 'react-sizeme';
 
 import registerBuiltinStores from 'injection/registerBuiltinStores';
-
-global.$ = jQuery;
-
-global.jQuery = jQuery;
 
 sizeMe.noPlaceholders = true;
 

--- a/graylog2-web-interface/test/setup-jest.js
+++ b/graylog2-web-interface/test/setup-jest.js
@@ -14,6 +14,8 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
+/// <reference types="jest-enzyme" />
+
 import jQuery from 'jquery';
 import sizeMe from 'react-sizeme';
 

--- a/graylog2-web-interface/tsconfig.json
+++ b/graylog2-web-interface/tsconfig.json
@@ -20,7 +20,7 @@
     "jsx": "react",
     "baseUrl": ".",
     "paths": {
-      "*": ["*", "./src/*"]
+      "*": ["*", "./src/*", "./test/*"]
     }
   },
   "include": [


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

**Note:** This PR requires #9411 to be merged before.

This PR contains the required change to parse TypeScript files in jest.  It uses the `babel-parser` with the TypeScript preset just as we do for webpack. It is activated implicitly for `.ts(x)` files by removing the `transform` clause from the jest config in `package.json`. The [Jest docs](https://jestjs.io/docs/en/getting-started) say:

```
Note: babel-jest is automatically installed when installing Jest and will automatically transform files if a babel configuration exists in your project. To avoid this behavior, you can explicitly reset the transform configuration option:
```

Therefore, removing the `transform` section implicitly tells Jest to just use the babel config which uses the TypeScript preset.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.