### PR TITLE
Fix scoping of current page in system messages list.

### DIFF
--- a/graylog2-web-interface/src/components/systemmessages/SystemMessagesComponent.jsx
+++ b/graylog2-web-interface/src/components/systemmessages/SystemMessagesComponent.jsx
@@ -20,7 +20,11 @@ class SystemMessagesComponent extends React.Component {
     const { currentPage } = this.state;
 
     this.loadMessages(currentPage);
-    this.interval = setInterval(() => { this.loadMessages(currentPage); }, 1000);
+
+    this.interval = setInterval(() => {
+      const { currentPage: page } = this.state;
+      this.loadMessages(page);
+    }, 1000);
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

During a refactoring, the scoping of the `currentPage` variable used to specify the page of system messages which is currently fetched was changed, effectively fixing it to its initial value. This leads to page changes not being reflected for the periodical refresh.

This change is now adjusting the scope and using the value of the current page which is up to date.

Fixes #9454.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.