### PR TITLE
Verify session against http auth header

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/security/realm/HTTPHeaderAuthenticationRealm.java
+++ b/graylog2-server/src/main/java/org/graylog2/security/realm/HTTPHeaderAuthenticationRealm.java
@@ -51,6 +51,7 @@ public class HTTPHeaderAuthenticationRealm extends AuthenticatingRealm {
     private static final Joiner JOINER = Joiner.on(", ");
 
     public static final String NAME = "http-header-authentication";
+    public static final String SESSION_AUTH_HEADER = "http-header-auth-user";
 
     private final ClusterConfigService clusterConfigService;
     private final AuthServiceAuthenticator authServiceAuthenticator;


### PR DESCRIPTION
If the username in the HTTPHeaderAuth request changes,
we need to destroy the session.

Fixes https://github.com/Graylog2/graylog-plugin-auth-sso/issues/35

