### PR TITLE
Fix index field types update

### DIFF
--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/RestHighLevelClientProvider.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/RestHighLevelClientProvider.java
@@ -18,7 +18,6 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Provider;
 import javax.inject.Singleton;
-import java.io.IOException;
 import java.net.URI;
 import java.util.List;
 import java.util.Locale;
@@ -61,8 +60,6 @@ public class RestHighLevelClientProvider implements Provider<RestHighLevelClient
         sniffer = discoveryEnabled
                 ? createNodeDiscoverySniffer(client.getLowLevelClient(), discoveryFrequency, defaultSchemeForDiscoveredNodes, discoveryFilter)
                 : null;
-
-        registerShutdownHook(shutdownService);
 
         if (discoveryEnabled) {
             registerSnifferShutdownHook(shutdownService);
@@ -119,16 +116,6 @@ public class RestHighLevelClientProvider implements Provider<RestHighLevelClient
                 );
 
         return new RestHighLevelClient(restClientBuilder);
-    }
-
-    private void registerShutdownHook(GracefulShutdownService shutdownService) {
-        shutdownService.register(() -> {
-            try {
-                client.close();
-            } catch (IOException e) {
-                LOG.warn("Failed to close Elasticsearch RestHighLevelClient", e);
-            }
-        });
     }
 
     private void registerSnifferShutdownHook(GracefulShutdownService shutdownService) {

--- a/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/IndexFieldTypePollerPeriodical.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/IndexFieldTypePollerPeriodical.java
@@ -102,11 +102,6 @@ public class IndexFieldTypePollerPeriodical extends Periodical {
      */
     @Override
     public void doRun() {
-        if (serverIsNotRunning()) {
-            LOG.debug("Server is not running, skipping run.");
-            return;
-        }
-
         if (!cluster.isConnected()) {
             LOG.info("Cluster not connected yet, delaying index field type initialization until it is reachable.");
             while (true) {

--- a/graylog2-server/src/test/java/org/graylog2/indexer/fieldtypes/IndexFieldTypePollerPeriodicalTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/fieldtypes/IndexFieldTypePollerPeriodicalTest.java
@@ -68,14 +68,6 @@ class IndexFieldTypePollerPeriodicalTest {
     }
 
     @Test
-    void executionIsSkippedWhenServerIsNotRunning() {
-        when(serverStatus.getLifecycle()).thenReturn(Lifecycle.HALTING);
-        when(cluster.isConnected()).thenThrow(new RuntimeException("If this exception is thrown, then execution is not skipped!"));
-
-        this.periodical.doRun();
-    }
-
-    @Test
     void scheduledExecutionIsSkippedWhenServerIsNotRunning() throws InterruptedException {
         when(serverStatus.getLifecycle()).thenReturn(Lifecycle.HALTING);
         final IndexSetConfig indexSetConfig = mockIndexSetConfig();


### PR DESCRIPTION
In #9177 we introduced a check to skip the periodical run when the
server is not in RUNNING state. This was added to fix exceptions during
server shutdown by preventing the periodical to run in that state.

Unfortunately this is will delay index field types update by an hour
when the periodical starts for the first time on server startup. The
periodical only runs once an hour by default.

This change is removing the RUNNING state check in the periodical's
run() method. We keep the check in the individual poller jobs. These are
running way more often.

This change also removes the shutdown hook that closes the ES client
during server shutdown. Closing the client connection can cause
exceptions during the server shutdown when the index field type poller
job (and others) run during shutdown and try to use a closed client.

Since all connections will be closed during process shutdown anyway, we
skip the closing for ES 7 to prevent exceptions. (we didn't do that for
the ES 6 client anyway)