### PR TITLE
Update roles section on user edit page correctly when assigning or removing a role (Backport for 4.0)

### DIFF
--- a/graylog2-web-interface/src/components/users/UserEdit/RolesSection.jsx
+++ b/graylog2-web-interface/src/components/users/UserEdit/RolesSection.jsx
@@ -28,7 +28,7 @@ const Container = styled.div`
 `;
 
 const RolesSection = ({ user, onSubmit }: Props) => {
-  const { username } = user;
+  const { username, id } = user;
   const [loading, setLoading] = useState(false);
   const [paginatedRoles, setPaginatedRoles] = useState<?PaginatedRoles>();
   const [errors, setErrors] = useState();
@@ -45,7 +45,7 @@ const RolesSection = ({ user, onSubmit }: Props) => {
 
   const onRolesUpdate = (data: { roles: Array<string> }) => onSubmit(data).then(() => {
     _onLoad().then(setPaginatedRoles);
-    UsersDomain.loadByUsername(username);
+    UsersDomain.load(id);
   });
 
   const _onAssignRole = (newRoles: Immutable.Set<DescriptiveItem>) => {

--- a/graylog2-web-interface/src/pages/UserEditPage.jsx
+++ b/graylog2-web-interface/src/pages/UserEditPage.jsx
@@ -2,6 +2,7 @@
 import * as React from 'react';
 import { useEffect, useState } from 'react';
 
+import { UsersActions } from 'stores/users/UsersStore';
 import withParams from 'routing/withParams';
 import DocsHelper from 'util/DocsHelper';
 import UsersDomain from 'domainActions/users/UsersDomain';
@@ -27,12 +28,18 @@ const PageTitle = ({ fullName }: {fullName: ?string}) => (
   </>
 );
 
+const _updateUserOnLoad = (setLoadedUser) => UsersActions.load.completed.listen(setLoadedUser);
+
 const UserEditPage = ({ params }: Props) => {
   const [loadedUser, setLoadedUser] = useState();
   const userId = params?.userId;
 
+  // We need to trigger a user state update in child components and do so by calling the load action
+  // and by defining a listener for this action which updates the state.
+  useEffect(() => _updateUserOnLoad(setLoadedUser), []);
+
   useEffect(() => {
-    UsersDomain.load(userId).then(setLoadedUser);
+    UsersDomain.load(userId);
   }, [userId]);
 
   return (


### PR DESCRIPTION
**This is a backport of https://github.com/Graylog2/graylog2-server/pull/9471 for 4.0**

## Description
As described in https://github.com/Graylog2/graylog2-server/issues/9469  the roles section on the user edit page is sometimes not getting updated correctly when adding or removing a role. This includes the list of assigned roles and the list of available roles.

This PR fixes the issue by updating the user state correctly.

Refs https://github.com/Graylog2/graylog2-server/issues/9469

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
