### PR TITLE
Fix error in authentication service details group sync section which occurs without an enterprise plugin

### DIFF
--- a/graylog2-web-interface/src/components/authentication/directoryServices/BackendConfigDetails/GroupSyncSection.jsx
+++ b/graylog2-web-interface/src/components/authentication/directoryServices/BackendConfigDetails/GroupSyncSection.jsx
@@ -23,13 +23,15 @@ const GroupSyncSection = ({ authenticationBackend, roles, excludedFields }: Prop
   const GroupSyncSectionPlugin = enterpriseGroupSyncPlugin?.components.GroupSyncSection;
 
   if (!GroupSyncSectionPlugin) {
-    <SectionComponent title="Group Synchronization"
-                      headerActions={(
-                        <EditLinkButton authenticationBackendId={authenticationBackend.id}
-                                        stepKey={GROUP_SYNC_KEY} />
+    return (
+      <SectionComponent title="Group Synchronization"
+                        headerActions={(
+                          <EditLinkButton authenticationBackendId={authenticationBackend.id}
+                                          stepKey={GROUP_SYNC_KEY} />
                       )}>
-      <EnterprisePluginNotFound featureName="group synchronization" />
-    </SectionComponent>;
+        <EnterprisePluginNotFound featureName="group synchronization" />
+      </SectionComponent>
+    );
   }
 
   return (

--- a/graylog2-web-interface/src/components/authentication/directoryServices/BackendConfigDetails/GroupSyncSection.test.jsx
+++ b/graylog2-web-interface/src/components/authentication/directoryServices/BackendConfigDetails/GroupSyncSection.test.jsx
@@ -1,0 +1,33 @@
+// @flow strict
+import * as React from 'react';
+import * as Immutable from 'immutable';
+import { render, screen } from 'wrappedTestingLibrary';
+import { PluginManifest, PluginStore } from 'graylog-web-plugin/plugin';
+import { ldapBackend as exampleAuthBackend } from 'fixtures/authenticationBackends';
+
+import GroupSyncSection from './GroupSyncSection';
+
+describe('<GroupSyncSection />', () => {
+  it('should display info if enterprise plugin does not exist', () => {
+    // $FlowFixMe AuthenticationBackend has the correct format
+    render(<GroupSyncSection authenticationBackend={exampleAuthBackend} roles={Immutable.List()} />);
+
+    expect(screen.getByText('Enterprise Feature')).toBeInTheDocument();
+    expect(screen.getByText('Group Synchronization')).toBeInTheDocument();
+  });
+
+  it('should display enterprise group sync section', () => {
+    PluginStore.register(new PluginManifest({}, {
+      'authentication.enterprise.directoryServices.groupSync': {
+        components: {
+          GroupSyncSection: () => <>GroupSyncSection</>,
+        },
+      },
+    }));
+
+    // $FlowFixMe AuthenticationBackend has the correct format
+    render(<GroupSyncSection authenticationBackend={exampleAuthBackend} roles={Immutable.List()} />);
+
+    expect(screen.getByText('GroupSyncSection')).toBeInTheDocument();
+  });
+});

--- a/graylog2-web-interface/test/fixtures/authenticationBackends.js
+++ b/graylog2-web-interface/test/fixtures/authenticationBackends.js
@@ -1,0 +1,43 @@
+// @flow strict
+import * as Immutable from 'immutable';
+
+import AuthenticationBackend from 'logic/authentication/AuthenticationBackend';
+
+export const ldapBackend = AuthenticationBackend.builder()
+  .id('ldap-auth-backend-id')
+  .title('Ldap authentication backend')
+  .description('Ldap authentication backend')
+  .defaultRoles(Immutable.List(['reader-role-id']))
+  .config({
+    servers: [{ host: 'localhost', port: 389 }],
+    system_user_dn: '',
+    system_user_password: { is_set: false },
+    transport_security: 'none',
+    type: 'ldap',
+    user_full_name_attribute: 'cn',
+    user_name_attribute: 'uid',
+    user_search_base: 'cn=users,dc=example,dc=com',
+    user_search_pattern: '(&(objectClass=person)(sn={0}))',
+    user_unique_id_attribute: 'entryUUID',
+    verify_certificates: true,
+  })
+  .build();
+
+export const activeDirectoryBackend = AuthenticationBackend.builder()
+  .id('ldap-auth-backend-id')
+  .title('Active directory authentication backend')
+  .description('Active directory authentication backend')
+  .defaultRoles(Immutable.List(['reader-role-id']))
+  .config({
+    servers: [{ host: 'localhost', port: 636 }],
+    system_user_dn: '',
+    system_user_password: { is_set: false },
+    transport_security: 'tls',
+    type: 'active-directory',
+    user_full_name_attribute: 'displayName',
+    user_name_attribute: 'userPrincipalName',
+    user_search_base: 'cn=users,dc=example,dc=com',
+    user_search_pattern: '(&(objectClass=user)(|(sAMAccountName={0})(userPrincipalName={0})))',
+    verify_certificates: true,
+  })
+  .build();


### PR DESCRIPTION
**This PR needs a backport for 4.0**

## Description
The following error https://github.com/Graylog2/graylog2-server/issues/9481 occurs when opening the authentication backend details page without an enterprise plugin. This PR is fixing the error and adding a test for this case.

Fixes: https://github.com/Graylog2/graylog2-server/issues/9481

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
