### PR TITLE
Remove logging config for apache ldap client

### DIFF
--- a/graylog2-server/src/main/resources/log4j2.xml
+++ b/graylog2-server/src/main/resources/log4j2.xml
@@ -12,8 +12,6 @@
         <!-- Application Loggers -->
         <Logger name="org.graylog2" level="info"/>
         <Logger name="com.github.joschi.jadconfig" level="warn"/>
-        <!-- this emits a harmless warning for ActiveDirectory every time which we can't work around :( -->
-        <Logger name="org.apache.directory.api.ldap.model.message.BindRequestImpl" level="error"/>
         <!-- Prevent DEBUG message about Lucene Expressions not found. -->
         <Logger name="org.elasticsearch.script" level="warn"/>
         <!-- Disable messages from the version check -->


### PR DESCRIPTION
We don't use the apache library anymore.

Refs #8984
