### PR TITLE
Extend license formatter for TypeScript

### DIFF
--- a/graylog2-web-interface/src/pages/UserHasNoStreamAccess.test.tsx
+++ b/graylog2-web-interface/src/pages/UserHasNoStreamAccess.test.tsx
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 import * as React from 'react';
 import { render, screen } from 'wrappedTestingLibrary';
 import mockComponent from 'helpers/mocking/MockComponent';

--- a/graylog2-web-interface/src/routing/ApiRoutes.d.ts
+++ b/graylog2-web-interface/src/routing/ApiRoutes.d.ts
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 declare module 'routing/ApiRoutes' {
   var noTypeInfoYet: any; // any var name here really
   export = noTypeInfoYet;

--- a/graylog2-web-interface/src/stores/StoreTypes.ts
+++ b/graylog2-web-interface/src/stores/StoreTypes.ts
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 export type PromiseProvider = (...args: any[]) => Promise<any>;
 type ExtractResultType<R extends PromiseProvider> = ExtractTypeFromPromise<ReturnType<R>>;
 type ExtractTypeFromPromise<P> = P extends Promise<infer R> ? R : P;

--- a/graylog2-web-interface/src/types.d.ts
+++ b/graylog2-web-interface/src/types.d.ts
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 declare module '*.css' {
   interface CSSClasses { [key: string]: any }
   const classes: CSSClasses;

--- a/pom.xml
+++ b/pom.xml
@@ -389,6 +389,8 @@
                     <mapping>
                         <java>SLASHSTAR_STYLE</java>
                         <jsx>SLASHSTAR_STYLE</jsx>
+                        <ts>SLASHSTAR_STYLE</ts>
+                        <tsx>SLASHSTAR_STYLE</tsx>
                     </mapping>
                     <licenseSets>
                         <licenseSet>
@@ -408,16 +410,26 @@
                                 <include>*.js</include>
                                 <include>src/web/**/*.js</include>
                                 <include>src/web/**/*.jsx</include>
+                                <include>src/web/**/*.ts</include>
+                                <include>src/web/**/*.tsx</include>
                                 <include>graylog2-web-interface/*.js</include>
+                                <include>graylog2-web-interface/*.ts</include>
                                 <include>graylog2-web-interface/config/**/*.js</include>
+                                <include>graylog2-web-interface/config/**/*.ts</include>
                                 <include>graylog2-web-interface/packages/**/*.js</include>
                                 <include>graylog2-web-interface/packages/**/*.jsx</include>
-                                <include>graylog2-web-interface/src/**/*.js</include>
+                                <include>graylog2-web-interface/packages/**/*.ts</include>
+                                <include>graylog2-web-interface/packages/**/*.tsx</include>
                                 <include>graylog2-web-interface/src/**/*.js</include>
                                 <include>graylog2-web-interface/src/**/*.jsx</include>
+                                <include>graylog2-web-interface/src/**/*.ts</include>
+                                <include>graylog2-web-interface/src/**/*.tsx</include>
                                 <include>graylog2-web-interface/test/**/*.js</include>
                                 <include>graylog2-web-interface/test/**/*.jsx</include>
+                                <include>graylog2-web-interface/test/**/*.ts</include>
+                                <include>graylog2-web-interface/test/**/*.tsx</include>
                                 <include>graylog2-web-interface/webpack/**/*.js</include>
+                                <include>graylog2-web-interface/webpack/**/*.ts</include>
                             </includes>
                             <excludes>
                                 <exclude>**/resources/swagger/**</exclude>


### PR DESCRIPTION
Extend the license formatter configuration to handle TypeScript files.