### PR TITLE
Make sure jest-environment pragma is at the top of the file

### DIFF
--- a/graylog2-web-interface/src/views/spec/CreateNewDashboard.test.jsx
+++ b/graylog2-web-interface/src/views/spec/CreateNewDashboard.test.jsx
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment <rootDir>/test/integration-environment.js
+ */
 /*
  * Copyright (C) 2020 Graylog, Inc.
  *
@@ -13,9 +16,6 @@
  * You should have received a copy of the Server Side Public License
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
- */
-/**
- * @jest-environment <rootDir>/test/integration-environment.js
  */
 // @flow strict
 import * as React from 'react';


### PR DESCRIPTION
The new license header has been added at the top of the file. Jest
requires the pragma to be at the top, though.

(cherry picked from commit 3ce4f4ad8b059432edcb116fed0e9a36b18a92f4)