### PR TITLE
backlog is nullable

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/events/notifications/EventNotificationModelData.java
+++ b/graylog2-server/src/main/java/org/graylog/events/notifications/EventNotificationModelData.java
@@ -24,6 +24,7 @@ import org.graylog.events.processor.EventDefinitionDto;
 import org.graylog.scheduler.JobTriggerDto;
 import org.graylog2.plugin.MessageSummary;
 
+import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Optional;
 
@@ -55,6 +56,7 @@ public abstract class EventNotificationModelData {
     @JsonProperty("event")
     public abstract EventDto event();
 
+    @Nullable
     @JsonProperty("backlog")
     public abstract ImmutableList<MessageSummary> backlog();
 
@@ -80,7 +82,7 @@ public abstract class EventNotificationModelData {
 
         public abstract Builder event(EventDto event);
 
-        public abstract Builder backlog(List<MessageSummary> backlog);
+        public abstract Builder backlog(@Nullable List<MessageSummary> backlog);
 
         public abstract EventNotificationModelData build();
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
To eliminate NullPointerExceptions and permit the field `backlog` to be nullable. 

## Description
https://github.com/google/guice/wiki/UseNullable

## Motivation and Context
To prevent the `NullPointerException` when we call the SlackEventNotification.execute method with a mock object like below,  `when(notificationCallbackService.getBacklogForEvent(eventNotificationContext)).thenReturn(null);`


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

