### PR TITLE
Hide inputs and related on cloud

### DIFF
--- a/graylog2-web-interface/src/components/navigation/SystemMenu.jsx
+++ b/graylog2-web-interface/src/components/navigation/SystemMenu.jsx
@@ -85,9 +85,11 @@ const SystemMenu = ({ location }) => {
         <NavigationLink path={Routes.SYSTEM.CONFIGURATIONS} description="Configurations" />
       </IfPermitted>
       <NavigationLink path={Routes.SYSTEM.NODES.LIST} description="Nodes" />
-      <IfPermitted permissions={['inputs:read']}>
-        <NavigationLink path={Routes.SYSTEM.INPUTS} description="Inputs" />
-      </IfPermitted>
+      <HideOnCloud>
+        <IfPermitted permissions={['inputs:read']}>
+          <NavigationLink path={Routes.SYSTEM.INPUTS} description="Inputs" />
+        </IfPermitted>
+      </HideOnCloud>
       <IfPermitted permissions={['outputs:read']}>
         <NavigationLink path={Routes.SYSTEM.OUTPUTS} description="Outputs" />
       </IfPermitted>

--- a/graylog2-web-interface/src/components/nodes/NodeOverview.jsx
+++ b/graylog2-web-interface/src/components/nodes/NodeOverview.jsx
@@ -1,9 +1,11 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { LinkContainer } from 'react-router-bootstrap';
-import { Row, Col, Button } from 'components/graylog';
 
+import { Row, Col, Button } from 'components/graylog';
 import Routes from 'routing/Routes';
+import HideOnCloud from 'util/conditional/HideOnCloud';
+
 import BufferUsage from './BufferUsage';
 import SystemOverviewDetails from './SystemOverviewDetails';
 import JvmHeapUsage from './JvmHeapUsage';
@@ -12,7 +14,6 @@ import SystemInformation from './SystemInformation';
 import RestApiOverview from './RestApiOverview';
 import PluginsDataTable from './PluginsDataTable';
 import InputTypesDataTable from './InputTypesDataTable';
-
 
 class NodeOverview extends React.Component {
   static propTypes = {
@@ -109,11 +110,13 @@ class NodeOverview extends React.Component {
 
         <Row className="content">
           <Col md={12}>
-            <span className="pull-right">
-              <LinkContainer to={Routes.node_inputs(node.node_id)}>
-                <Button bsStyle="success" bsSize="small">Manage inputs</Button>
-              </LinkContainer>
-            </span>
+            <HideOnCloud>
+              <span className="pull-right">
+                <LinkContainer to={Routes.node_inputs(node.node_id)}>
+                  <Button bsStyle="success" bsSize="small">Manage inputs</Button>
+                </LinkContainer>
+              </span>
+            </HideOnCloud>
             <h2 style={{ marginBottom: 15 }}>Available input types <small>{inputCount}</small></h2>
             <InputTypesDataTable inputDescriptions={this.props.inputDescriptions} />
           </Col>

--- a/graylog2-web-interface/src/components/nodes/NodesActions.jsx
+++ b/graylog2-web-interface/src/components/nodes/NodesActions.jsx
@@ -7,6 +7,7 @@ import { DropdownButton, DropdownSubmenu, MenuItem, Button } from 'components/gr
 import { ExternalLinkButton, IfPermitted } from 'components/common';
 import StoreProvider from 'injection/StoreProvider';
 import Routes from 'routing/Routes';
+import HideOnCloud from 'util/conditional/HideOnCloud';
 
 const SystemProcessingStore = StoreProvider.getStore('SystemProcessing');
 const SystemLoadBalancerStore = StoreProvider.getStore('SystemLoadBalancer');
@@ -82,11 +83,13 @@ class NodesActions extends React.Component {
             </IfPermitted>
           </IfPermitted>
 
-          <IfPermitted permissions="inputs:read">
-            <LinkContainer to={Routes.node_inputs(this.props.node.node_id)}>
-              <MenuItem>Local message inputs</MenuItem>
-            </LinkContainer>
-          </IfPermitted>
+          <HideOnCloud>
+            <IfPermitted permissions="inputs:read">
+              <LinkContainer to={Routes.node_inputs(this.props.node.node_id)}>
+                <MenuItem>Local message inputs</MenuItem>
+              </LinkContainer>
+            </IfPermitted>
+          </HideOnCloud>
           <IfPermitted permissions="threads:dump">
             <LinkContainer to={Routes.SYSTEM.THREADDUMP(this.props.node.node_id)}>
               <MenuItem>Get thread dump</MenuItem>

--- a/graylog2-web-interface/src/logic/notifications/NotificationsFactory.jsx
+++ b/graylog2-web-interface/src/logic/notifications/NotificationsFactory.jsx
@@ -4,6 +4,7 @@ import { Link } from 'react-router';
 import Routes from 'routing/Routes';
 import DocsHelper from 'util/DocsHelper';
 import DocumentationLink from 'components/support/DocumentationLink';
+import HideOnCloud from 'util/conditional/HideOnCloud';
 
 class NotificationsFactory {
   static getForNotification(notification) {
@@ -123,8 +124,10 @@ class NotificationsFactory {
             <span>
               Input {notification.details.input_id} has failed to start on node {notification.node_id} for this reason:
               »{notification.details.reason}«. This means that you are unable to receive any messages from this input.
-              This is mostly an indication for a misconfiguration or an error. You can click {' '}
-              <Link to={Routes.SYSTEM.INPUTS}>here</Link> to solve this.
+              This is mostly an indication for a misconfiguration or an error.
+              <HideOnCloud>
+                You can click <Link to={Routes.SYSTEM.INPUTS}>here</Link> to solve this.
+              </HideOnCloud>
             </span>
           ),
         };

--- a/graylog2-web-interface/src/logic/notifications/NotificationsFactory.jsx
+++ b/graylog2-web-interface/src/logic/notifications/NotificationsFactory.jsx
@@ -172,7 +172,9 @@ class NotificationsFactory {
             <span>
               There is a node without any running inputs. This means that you are not receiving any messages from this
               node at this point in time. This is most probably an indication of an error or misconfiguration.
-              You can click <Link to={Routes.SYSTEM.INPUTS}>here</Link> to solve this.
+              <HideOnCloud>
+                You can click <Link to={Routes.SYSTEM.INPUTS}>here</Link> to solve this.
+              </HideOnCloud>
             </span>
           ),
         };

--- a/graylog2-web-interface/src/routing/AppRouter.jsx
+++ b/graylog2-web-interface/src/routing/AppRouter.jsx
@@ -149,8 +149,12 @@ const AppRouter = () => {
               <Route path={Routes.show_alert_condition(':streamId', ':conditionId')}
                      component={EditAlertConditionPage} />
               <Route path={Routes.show_alert(':alertId')} component={ShowAlertPage} />
-              {!isCloud && <Route path={Routes.SYSTEM.INPUTS} component={InputsPage} />}
-              <Route path={Routes.node_inputs(':nodeId')} component={NodeInputsPage} />
+              {!isCloud && (
+                <>
+                  <Route path={Routes.SYSTEM.INPUTS} component={InputsPage} />
+                  <Route path={Routes.node_inputs(':nodeId')} component={NodeInputsPage} />
+                </>
+              )}
               <Route path={Routes.global_input_extractors(':inputId')} component={ExtractorsPage} />
               <Route path={Routes.local_input_extractors(':nodeId', ':inputId')} component={ExtractorsPage} />
               <Route path={Routes.new_extractor(':nodeId', ':inputId')} component={CreateExtractorsPage} />

--- a/graylog2-web-interface/src/routing/AppRouter.jsx
+++ b/graylog2-web-interface/src/routing/AppRouter.jsx
@@ -153,15 +153,15 @@ const AppRouter = () => {
                 <>
                   <Route path={Routes.SYSTEM.INPUTS} component={InputsPage} />
                   <Route path={Routes.node_inputs(':nodeId')} component={NodeInputsPage} />
+                  <Route path={Routes.global_input_extractors(':inputId')} component={ExtractorsPage} />
+                  <Route path={Routes.local_input_extractors(':nodeId', ':inputId')} component={ExtractorsPage} />
+                  <Route path={Routes.new_extractor(':nodeId', ':inputId')} component={CreateExtractorsPage} />
+                  <Route path={Routes.edit_extractor(':nodeId', ':inputId', ':extractorId')}
+                         component={EditExtractorsPage} />
+                  <Route path={Routes.import_extractors(':nodeId', ':inputId')} component={ImportExtractorsPage} />
+                  <Route path={Routes.export_extractors(':nodeId', ':inputId')} component={ExportExtractorsPage} />
                 </>
               )}
-              <Route path={Routes.global_input_extractors(':inputId')} component={ExtractorsPage} />
-              <Route path={Routes.local_input_extractors(':nodeId', ':inputId')} component={ExtractorsPage} />
-              <Route path={Routes.new_extractor(':nodeId', ':inputId')} component={CreateExtractorsPage} />
-              <Route path={Routes.edit_extractor(':nodeId', ':inputId', ':extractorId')}
-                     component={EditExtractorsPage} />
-              <Route path={Routes.import_extractors(':nodeId', ':inputId')} component={ImportExtractorsPage} />
-              <Route path={Routes.export_extractors(':nodeId', ':inputId')} component={ExportExtractorsPage} />
               <Route path={Routes.SYSTEM.CONFIGURATIONS} component={ConfigurationsPage} />
               <Route path={Routes.SYSTEM.CONTENTPACKS.LIST} component={ContentPacksPage} />
               <Route path={Routes.SYSTEM.CONTENTPACKS.CREATE} component={CreateContentPackPage} />

--- a/graylog2-web-interface/src/routing/AppRouter.jsx
+++ b/graylog2-web-interface/src/routing/AppRouter.jsx
@@ -149,7 +149,7 @@ const AppRouter = () => {
               <Route path={Routes.show_alert_condition(':streamId', ':conditionId')}
                      component={EditAlertConditionPage} />
               <Route path={Routes.show_alert(':alertId')} component={ShowAlertPage} />
-              <Route path={Routes.SYSTEM.INPUTS} component={InputsPage} />
+              {!isCloud && <Route path={Routes.SYSTEM.INPUTS} component={InputsPage} />}
               <Route path={Routes.node_inputs(':nodeId')} component={NodeInputsPage} />
               <Route path={Routes.global_input_extractors(':inputId')} component={ExtractorsPage} />
               <Route path={Routes.local_input_extractors(':nodeId', ':inputId')} component={ExtractorsPage} />

--- a/graylog2-web-interface/src/util/conditional/filterMenuItems.js
+++ b/graylog2-web-interface/src/util/conditional/filterMenuItems.js
@@ -2,20 +2,13 @@
 
 import AppConfig from '../AppConfig';
 
-function isAllowedPath(
-  path: string,
-  toExclude: Array<string>,
-): boolean {
-  return toExclude.indexOf(path) === -1;
-}
-
 type MenuItem = { path: string };
 
 function filterMenuItems(
   menuItems: Array<MenuItem>,
   toExclude: Array<string>,
 ): Array<MenuItem> {
-  return menuItems.filter((item) => isAllowedPath(item.path, toExclude));
+  return menuItems.filter((item) => !toExclude.includes(item.path));
 }
 
 export function filterCloudMenuItems(

--- a/graylog2-web-interface/src/util/conditional/filterValueActions.js
+++ b/graylog2-web-interface/src/util/conditional/filterValueActions.js
@@ -1,0 +1,25 @@
+// @flow strict
+
+import AppConfig from '../AppConfig';
+
+type ValueAction = { type: string };
+
+function filterValueActions(
+  items: Array<ValueAction>,
+  toExclude: Array<string>,
+): Array<ValueAction> {
+  return items.filter((item) => !toExclude.includes(item.type));
+}
+
+export function filterCloudValueActions(
+  valueActions: Array<ValueAction>,
+  toExclude: Array<string>,
+): Array<ValueAction> {
+  if (!AppConfig.isCloud()) {
+    return valueActions;
+  }
+
+  return filterValueActions(valueActions, toExclude);
+}
+
+export default filterValueActions;

--- a/graylog2-web-interface/src/util/conditional/filterValueActions.test.js
+++ b/graylog2-web-interface/src/util/conditional/filterValueActions.test.js
@@ -1,0 +1,45 @@
+// @flow strict
+
+import filterValueActions, { filterCloudValueActions } from './filterValueActions';
+
+describe('filterValueActions', () => {
+  it('should filter items by type', () => {
+    const items = [
+      { type: 'something', name: 'something' },
+      { type: 'delete-me', name: 'delete me' },
+    ];
+
+    expect(filterValueActions(items, ['delete-me'])).toEqual([
+      { type: 'something', name: 'something' },
+    ]);
+  });
+});
+
+describe('filterCloudValueActions', () => {
+  it('should not filter items by type when not on cloud', () => {
+    const items = [
+      { type: 'something', name: 'something' },
+      { type: 'delete-me', name: 'delete me' },
+    ];
+
+    expect(filterCloudValueActions(items, ['delete-me'])).toEqual([
+      { type: 'something', name: 'something' },
+      { type: 'delete-me', name: 'delete me' },
+    ]);
+  });
+
+  it('should filter items by type when on cloud', () => {
+    window.IS_CLOUD = true;
+
+    const items = [
+      { type: 'something', name: 'something' },
+      { type: 'delete-me', name: 'delete me' },
+    ];
+
+    expect(filterCloudValueActions(items, ['delete-me'])).toEqual([
+      { type: 'something', name: 'something' },
+    ]);
+
+    window.IS_CLOUD = undefined;
+  });
+});

--- a/graylog2-web-interface/src/views/bindings.jsx
+++ b/graylog2-web-interface/src/views/bindings.jsx
@@ -76,6 +76,7 @@ import {
 } from 'views/Constants';
 import ShowDashboardInBigDisplayMode from 'views/pages/ShowDashboardInBigDisplayMode';
 import LookupTableParameter from 'views/logic/parameters/LookupTableParameter';
+import { filterCloudValueActions } from 'util/conditional/filterValueActions';
 import type { ActionHandlerArguments, ActionHandlerCondition } from './components/actions/ActionHandler';
 import NumberVisualizationConfig from './logic/aggregationbuilder/visualizations/NumberVisualizationConfig';
 import BarVisualizationConfiguration from './components/aggregationbuilder/BarVisualizationConfiguration';
@@ -235,7 +236,7 @@ export default {
       isEnabled: (({ field, type }) => (!isFunction(field) && !type.isDecorated()): ActionHandlerCondition),
     },
   ],
-  valueActions: [
+  valueActions: filterCloudValueActions([
     {
       type: 'exclude',
       title: 'Exclude from results',
@@ -266,7 +267,7 @@ export default {
       handler: HighlightValueHandler,
       isEnabled: HighlightValueHandler.isEnabled,
     },
-  ],
+  ], ['create-extractor']),
   visualizationTypes: [
     {
       type: AreaVisualization.type,

--- a/graylog2-web-interface/src/views/bindings.routes.test.jsx
+++ b/graylog2-web-interface/src/views/bindings.routes.test.jsx
@@ -5,6 +5,7 @@ import bindings from './bindings';
 jest.mock('util/AppConfig', () => ({
   gl2ServerUrl: () => 'localhost:9000/api/',
   gl2AppPathPrefix: jest.fn(() => '/gl2/'),
+  isCloud: jest.fn(() => false),
 }));
 
 describe('bindings.routes', () => {

--- a/graylog2-web-interface/src/views/bindings.valueActions.test.jsx
+++ b/graylog2-web-interface/src/views/bindings.valueActions.test.jsx
@@ -3,6 +3,12 @@ import FieldType, { FieldTypes, Properties } from 'views/logic/fieldtypes/FieldT
 import bindings from './bindings';
 import type { ActionHandlerCondition } from './components/actions/ActionHandler';
 
+jest.mock('util/AppConfig', () => ({
+  gl2ServerUrl: jest.fn(() => global.api_url),
+  gl2AppPathPrefix: jest.fn(() => ''),
+  isCloud: jest.fn(() => false),
+}));
+
 describe('Views bindings value actions', () => {
   const { valueActions } = bindings;
   type ValueAction = {


### PR DESCRIPTION
Inputs on cloud will be managed through forwarders instead of `system/inputs`

Hide / disable features that allow access to these parts on cloud.

## Motivation and Context

See https://github.com/Graylog2/graylog-plugin-cloud/issues/99

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Tested in the cloud environment

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

## To do:
- [x] Disable inputs page and navigation
- [x] Solve notifications
- [x] Node Inputs
- [x] Input extractors

External:
- [x] Solve cloudwatch (https://github.com/Graylog2/graylog-plugin-integrations/pull/657)
- [x] Solve 0365 (https://github.com/Graylog2/graylog-plugin-enterprise-integrations/pull/425)