### PR TITLE
Change eslint-config-graylog package.json license to SSPL

### DIFF
--- a/graylog2-web-interface/packages/eslint-config-graylog/package.json
+++ b/graylog2-web-interface/packages/eslint-config-graylog/package.json
@@ -11,7 +11,7 @@
     "eslint"
   ],
   "author": "Graylog, Inc. <hello@graylog.com>",
-  "license": "MIT",
+  "license": "SSPL-1.0",
   "dependencies": {
     "@typescript-eslint/parser": "4.6.1",
     "@typescript-eslint/eslint-plugin": "4.6.1",


### PR DESCRIPTION
This PR changes the license info of the `eslint-config-graylog` `package.json` to SSPL.

See the following links for more details:
- https://www.graylog.org/post/graylog-announces-4-0-release-of-its-log-management-platform
- https://www.graylog.org/post/graylog-v4-0-licensing-sspl