### PR TITLE
DateTimePicker: Add updated TimeRangeDisplay to WidgetQueryControls

### DIFF
--- a/graylog2-web-interface/src/views/components/WidgetQueryControls.jsx
+++ b/graylog2-web-interface/src/views/components/WidgetQueryControls.jsx
@@ -20,18 +20,13 @@ import TimeRangeTypeSelector from './searchbar/TimeRangeTypeSelector';
 import StreamsFilter from './searchbar/StreamsFilter';
 import SearchButton from './searchbar/SearchButton';
 import QueryInput from './searchbar/AsyncQueryInput';
+import TimeRangeDisplay from './searchbar/TimeRangeDisplay';
 
 type Props = {
   availableStreams: Array<any>,
   config: any,
   globalOverride: ?GlobalOverride,
 };
-
-const StyledTimeRange = styled.input`
-  width: 100%;
-  padding: 3px 9px;
-  margin: 0 12px;
-`;
 
 const FlexCol = styled(Col)`
   display: flex;
@@ -89,9 +84,8 @@ const WidgetQueryControls = ({ availableStreams, config, globalOverride = {} }: 
             <FlexCol md={4}>
               <TimeRangeTypeSelector disabled={isGloballyOverridden}
                                      config={config} />
-              <StyledTimeRange type="text"
-                               value={JSON.stringify(values?.timerange)}
-                               disabled />
+
+              <TimeRangeDisplay timerange={values?.timerange} />
             </FlexCol>
 
             <Col md={8}>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Updates the `WidgetQueryControls` search bar to use the new `TimeRangeDisplay` component to output the chosen dates

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/122591/99991059-2aaa5c80-2d7a-11eb-9642-30955a4e8877.png)
