### PR TITLE
Hide authentication pages on cloud

### DIFF
--- a/graylog2-web-interface/src/components/navigation/SystemMenu.jsx
+++ b/graylog2-web-interface/src/components/navigation/SystemMenu.jsx
@@ -139,9 +139,11 @@ const SystemMenu = ({ location }) => {
       <IfPermitted permissions={['roles:read']} anyPermissions>
         <NavigationLink path={Routes.SYSTEM.AUTHZROLES.OVERVIEW} description="Roles" />
       </IfPermitted>
-      <IfPermitted permissions={['authentication:edit']} anyPermissions>
-        <NavigationLink path={Routes.SYSTEM.AUTHENTICATION.BACKENDS.ACTIVE} description="Authentication" />
-      </IfPermitted>
+      <HideOnCloud>
+        <IfPermitted permissions={['authentication:edit']} anyPermissions>
+          <NavigationLink path={Routes.SYSTEM.AUTHENTICATION.BACKENDS.ACTIVE} description="Authentication" />
+        </IfPermitted>
+      </HideOnCloud>
       <IfPermitted permissions={['dashboards:create', 'inputs:create', 'streams:create']}>
         <NavigationLink path={Routes.SYSTEM.CONTENTPACKS.LIST} description="Content Packs" />
       </IfPermitted>

--- a/graylog2-web-interface/src/routing/AppRouter.jsx
+++ b/graylog2-web-interface/src/routing/AppRouter.jsx
@@ -274,15 +274,47 @@ const AppRouter = () => {
 
                         {!isCloud && <Route exact path={Routes.SYSTEM.OUTPUTS} component={SystemOutputsPage} />}
 
-                        <Route exact path={Routes.SYSTEM.AUTHENTICATION.BACKENDS.ACTIVE} component={AuthenticationPage} />
-                        <Route exact path={Routes.SYSTEM.AUTHENTICATION.BACKENDS.CREATE} component={AuthenticationCreatePage} />
-                        <Route exact path={Routes.SYSTEM.AUTHENTICATION.BACKENDS.OVERVIEW} component={AuthenticationOverviewPage} />
-                        <Route exact path={Routes.SYSTEM.AUTHENTICATION.BACKENDS.show(':backendId')} component={AuthenticationBackendDetailsPage} />
-                        <Route exact path={Routes.SYSTEM.AUTHENTICATION.BACKENDS.edit(':backendId')} component={AuthenticationBackendEditPage} />
-                        <Route exact path={Routes.SYSTEM.AUTHENTICATION.BACKENDS.createBackend(':name')} component={AuthenticationBackendCreatePage} />
+                        {!isCloud && (
+                          <Route exact
+                                 path={Routes.SYSTEM.AUTHENTICATION.BACKENDS.ACTIVE}
+                                 component={AuthenticationPage} />
+                        )}
+                        {!isCloud && (
+                          <Route exact
+                                 path={Routes.SYSTEM.AUTHENTICATION.BACKENDS.CREATE}
+                                 component={AuthenticationCreatePage} />
+                        )}
+                        {!isCloud && (
+                          <Route exact
+                                 path={Routes.SYSTEM.AUTHENTICATION.BACKENDS.OVERVIEW}
+                                 component={AuthenticationOverviewPage} />
+                        )}
+                        {!isCloud && (
+                          <Route exact
+                                 path={Routes.SYSTEM.AUTHENTICATION.BACKENDS.show(':backendId')}
+                                 component={AuthenticationBackendDetailsPage} />
+                        )}
+                        {!isCloud && (
+                          <Route exact
+                                 path={Routes.SYSTEM.AUTHENTICATION.BACKENDS.edit(':backendId')}
+                                 component={AuthenticationBackendEditPage} />
+                        )}
+                        {!isCloud && (
+                          <Route exact
+                                 path={Routes.SYSTEM.AUTHENTICATION.BACKENDS.createBackend(':name')}
+                                 component={AuthenticationBackendCreatePage} />
+                        )}
 
-                        <Route exact path={Routes.SYSTEM.AUTHENTICATION.AUTHENTICATORS.SHOW} component={AuthenticatorsPage} />
-                        <Route exact path={Routes.SYSTEM.AUTHENTICATION.AUTHENTICATORS.EDIT} component={AuthenticatorsEditPage} />
+                        {!isCloud && (
+                          <Route exact
+                                 path={Routes.SYSTEM.AUTHENTICATION.AUTHENTICATORS.SHOW}
+                                 component={AuthenticatorsPage} />
+                        )}
+                        {!isCloud && (
+                          <Route exact
+                                 path={Routes.SYSTEM.AUTHENTICATION.AUTHENTICATORS.EDIT}
+                                 component={AuthenticatorsEditPage} />
+                        )}
 
                         <Route exact path={Routes.SYSTEM.USERS.OVERVIEW} component={UsersOverviewPage} />
                         <Route exact path={Routes.SYSTEM.USERS.CREATE} component={UserCreatePage} />


### PR DESCRIPTION
## Description
Because having authentication page on cloud at the moment does not make any sense, we need to hide them for now until we'll handle user management.

Needs https://github.com/Graylog2/graylog2-server/pull/9587 (so wait before merging)

See https://github.com/Graylog2/graylog-plugin-cloud/issues/102 and https://github.com/Graylog2/graylog-plugin-cloud/issues/555

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Disable the auth pages for now because they are broken on cloud at the moment.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
By navigating

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

