### PR TITLE
Fix event definitions share button permissions check and add tests

### DIFF
--- a/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitionEntry.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitionEntry.jsx
@@ -96,7 +96,7 @@ const EventDefinitionEntry = ({
           </Button>
         </LinkContainer>
       </IfPermitted>
-      <ShareButton entryId={eventDefinition.id} entityType="event_definition" onClick={() => setShowEntityShareModal(true)} />
+      <ShareButton entityId={eventDefinition.id} entityType="event_definition" onClick={() => setShowEntityShareModal(true)} />
       <IfPermitted permissions={`eventdefinitions:delete:${eventDefinition.id}`}>
         <DropdownButton id="more-dropdown" title="More" pullRight>
           {toggle}

--- a/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitionEntry.test.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitionEntry.test.jsx
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+// @flow strict
+import * as React from 'react';
+import { render, screen, fireEvent, waitFor } from 'wrappedTestingLibrary';
+import { viewsManager as currentUser } from 'fixtures/users';
+
+import CurrentUserContext from 'contexts/CurrentUserContext';
+
+import EventDefinitionEntry from './EventDefinitionEntry';
+
+jest.mock('components/permissions/EntityShareModal', () => () => <div>EntityShareModal content</div>);
+
+const exampleEventDefinition = {
+  alert: false,
+  config: {
+    conditions: { expression: null },
+    execute_every_ms: 60000,
+    group_by: [],
+    query: '',
+    query_parameters: [],
+    search_within_ms: 60000,
+    series: [],
+    streams: ['5fad57fde23593249ad8a6af'],
+    type: 'aggregation-v1',
+  },
+  description: '',
+  field_spec: {},
+  id: 'event-definition-id',
+  key_spec: [],
+  notification_settings: { grace_period_ms: 0, backlog_size: 0 },
+  notifications: [],
+  priority: 2,
+  storage: [{
+    streams: ['000000000000000000000002'],
+    type: 'persist-to-streams-v1',
+  }],
+  title: 'New example',
+};
+
+describe('EventDefinitionEntry', () => {
+  const renderSUT = (grn_permissions = [], permissions = []) => (
+    <CurrentUserContext.Provider value={{ ...currentUser, grn_permissions, permissions }}>
+      <EventDefinitionEntry onDelete={() => {}}
+                            onDisable={() => {}}
+                            onEnable={() => {}}
+                            context={{ scheduler: {} }}
+                            eventDefinition={exampleEventDefinition} />
+    </CurrentUserContext.Provider>
+  );
+
+  it('allows sharing for owners', async () => {
+    const grnPermissions = ['entity:own:grn::::event_definition:event-definition-id'];
+    render(renderSUT(grnPermissions));
+
+    const button = screen.getAllByRole('button', { name: /Share/ })[0];
+    fireEvent.click(button);
+
+    await waitFor(() => expect(screen.queryByText('EntityShareModal content')).not.toBeNull());
+  });
+
+  it('allows sharing for admins', async () => {
+    render(renderSUT([], ['*']));
+
+    const button = screen.getAllByRole('button', { name: /Share/ })[0];
+    fireEvent.click(button);
+
+    await waitFor(() => expect(screen.queryByText('EntityShareModal content')).not.toBeNull());
+  });
+
+  it('does not allow sharing for viewer', async () => {
+    const grnPermissions = ['entity:view:grn::::event_definition:event-definition-id'];
+    render(renderSUT(grnPermissions));
+
+    expect(screen.getAllByRole('button', { name: /Share/ })[1]).toHaveAttribute('disabled');
+  });
+});


### PR DESCRIPTION
## Description
As described in https://github.com/Graylog2/graylog2-server/issues/9579 the event definitions share button is currently only enabled for admins. This PR is fixing the `ShareButton` props and adds tests to ensure that also owners of event definitions are able to share them.

Please note, this bug got already fixed in the `master` branch, but we should still create an upstream PR to add the new tests.

Fixes: https://github.com/Graylog2/graylog2-server/issues/9579

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

