### PR TITLE
Fix link for graylog-sidecar user tokens on sidecars page.

### DIFF
--- a/graylog2-web-interface/src/pages/SidecarsPage.jsx
+++ b/graylog2-web-interface/src/pages/SidecarsPage.jsx
@@ -19,7 +19,7 @@ import { useEffect, useState, useContext } from 'react';
 
 import { LinkContainer, Link } from 'components/graylog/router';
 import { ButtonToolbar, Col, Row, Button } from 'components/graylog';
-import { DocumentTitle, PageHeader, Spinner, IfPermitted } from 'components/common';
+import { DocumentTitle, PageHeader, Spinner } from 'components/common';
 import { isPermitted } from 'util/PermissionsMixin';
 import CurrentUserContext from 'contexts/CurrentUserContext';
 import UsersDomain from 'domainActions/users/UsersDomain';

--- a/graylog2-web-interface/src/pages/SidecarsPage.jsx
+++ b/graylog2-web-interface/src/pages/SidecarsPage.jsx
@@ -14,53 +14,61 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import React from 'react';
+import * as React from 'react';
+import { useEffect, useState } from 'react';
 
 import { LinkContainer, Link } from 'components/graylog/router';
 import { ButtonToolbar, Col, Row, Button } from 'components/graylog';
-import { DocumentTitle, PageHeader } from 'components/common';
+import { DocumentTitle, PageHeader, Spinner } from 'components/common';
+import UsersDomain from 'domainActions/users/UsersDomain';
 import SidecarListContainer from 'components/sidecars/sidecars/SidecarListContainer';
 import Routes from 'routing/Routes';
 
-class SidecarsPage extends React.Component {
-  render() {
-    return (
-      <DocumentTitle title="Sidecars">
-        <span>
-          <PageHeader title="Sidecars Overview">
-            <span>
-              The Graylog sidecars can reliably forward contents of log files or Windows EventLog from your servers.
-            </span>
+const SidecarsPage = () => {
+  const [sidecarUser, setSidecarUser] = useState();
 
+  useEffect(() => {
+    UsersDomain.loadByUsername('graylog-sidecar').then(setSidecarUser);
+  }, []);
+
+  return (
+    <DocumentTitle title="Sidecars">
+      <span>
+        <PageHeader title="Sidecars Overview">
+          <span>
+            The Graylog sidecars can reliably forward contents of log files or Windows EventLog from your servers.
+          </span>
+
+          {sidecarUser ? (
             <span>
               Do you need an API token for a sidecar?&ensp;
-              <Link to={Routes.SYSTEM.USERS.TOKENS.edit('graylog-sidecar')}>
+              <Link to={Routes.SYSTEM.USERS.TOKENS.edit(sidecarUser.id)}>
                 Create or reuse a token for the <em>graylog-sidecar</em> user
-              </Link>.
+              </Link>
             </span>
+          ) : <Spinner />}
 
-            <ButtonToolbar>
-              <LinkContainer to={Routes.SYSTEM.SIDECARS.OVERVIEW}>
-                <Button bsStyle="info">Overview</Button>
-              </LinkContainer>
-              <LinkContainer to={Routes.SYSTEM.SIDECARS.ADMINISTRATION}>
-                <Button bsStyle="info">Administration</Button>
-              </LinkContainer>
-              <LinkContainer to={Routes.SYSTEM.SIDECARS.CONFIGURATION}>
-                <Button bsStyle="info">Configuration</Button>
-              </LinkContainer>
-            </ButtonToolbar>
-          </PageHeader>
+          <ButtonToolbar>
+            <LinkContainer to={Routes.SYSTEM.SIDECARS.OVERVIEW}>
+              <Button bsStyle="info">Overview</Button>
+            </LinkContainer>
+            <LinkContainer to={Routes.SYSTEM.SIDECARS.ADMINISTRATION}>
+              <Button bsStyle="info">Administration</Button>
+            </LinkContainer>
+            <LinkContainer to={Routes.SYSTEM.SIDECARS.CONFIGURATION}>
+              <Button bsStyle="info">Configuration</Button>
+            </LinkContainer>
+          </ButtonToolbar>
+        </PageHeader>
 
-          <Row className="content">
-            <Col md={12}>
-              <SidecarListContainer />
-            </Col>
-          </Row>
-        </span>
-      </DocumentTitle>
-    );
-  }
-}
+        <Row className="content">
+          <Col md={12}>
+            <SidecarListContainer />
+          </Col>
+        </Row>
+      </span>
+    </DocumentTitle>
+  );
+};
 
 export default SidecarsPage;


### PR DESCRIPTION
**Please note this PR needs a backport for 4.0, we should close the referenced issue, when we merge the backport**

## Description
As described in https://github.com/Graylog2/graylog2-server/issues/9555 the link for the graylog-sidecar user tokens page on the sidecars page is currently broken. The tokens page URL is now based on the user id but we still used the username.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
