### PR TITLE
Fix pagination of synced users overview on authentication service details page

### DIFF
--- a/graylog2-web-interface/src/components/authentication/BackendDetails/SyncedUsersSection/SyncedUsersSection.jsx
+++ b/graylog2-web-interface/src/components/authentication/BackendDetails/SyncedUsersSection/SyncedUsersSection.jsx
@@ -79,7 +79,7 @@ const SyncedUsersSection = ({ roles, authenticationBackend }: Props) => {
       <p className="description">
         Found {paginatedUsers.pagination.total} synchronized users.
       </p>
-      <PaginatedList activePage={page} totalItems={paginatedUsers.pagination.total} onChange={(newQuery) => setPagination({ ...pagination, query: newQuery, page: DEFAULT_PAGINATION.page })}>
+      <PaginatedList activePage={page} totalItems={paginatedUsers.pagination.total} onChange={(newPage, newPerPage) => setPagination({ ...pagination, page: newPage, perPage: newPerPage })}>
         <DataTable className="table-hover"
                    customFilter={<SyncedUsersFilter onSearch={(newQuery) => setPagination({ ...pagination, query: newQuery, page: DEFAULT_PAGINATION.page })} />}
                    dataRowFormatter={_userOverviewItem}


### PR DESCRIPTION
## Description
As described in https://github.com/Graylog2/graylog2-server/issues/9574 the pagination of the synced users overview on the authentication service details page is currently broken. This PR is fixing the problem by providing the correct `onChange` prop for the `PaginatedList`.

Please note, this bug got already fixed in the master branch.

Fixes: #9574

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
