### PR TITLE
Unify basic `<textarea />`styles with bootstrap text area styles

### DIFF
--- a/graylog2-web-interface/src/theme/GlobalThemeStyles.jsx
+++ b/graylog2-web-interface/src/theme/GlobalThemeStyles.jsx
@@ -105,6 +105,7 @@ const GlobalThemeStyles = createGlobalStyle(({ theme }) => css`
 
   input.form-control,
   select.form-control,
+  textarea,
   textarea.form-control {
     color: ${theme.colors.input.color};
     background-color: ${theme.colors.input.background};


### PR DESCRIPTION
**This PR needs a backport for 4.0**

## Description
This PR unifies the basic `textarea` styles like font, background and border color with the bootstrap text area styles.
This fixes e.g. the scratchpad background color in dark mode (https://github.com/Graylog2/graylog2-server/issues/9607).

I thought about adding the `form-control` class to the scratchpad textarea, but this would make it harder to overwrite styles like the font color. Another benefit of this solution is that we do not have to remember this class when adding new `textarea`s.
We should also consider implementing the same change for the  `input` and `select` element selector. I did not include this change in this PR to reduce the amount of possible side effects, which becomes relevant when creating the backport for 4.0.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
