### PR TITLE
Remove no longer needed `FetchProvider` unmocking in error pages tests

### DIFF
--- a/graylog2-web-interface/src/components/errors/ReportedErrorBoundary.test.tsx
+++ b/graylog2-web-interface/src/components/errors/ReportedErrorBoundary.test.tsx
@@ -27,7 +27,6 @@ import FetchError from 'logic/errors/FetchError';
 
 import ReportedErrorBoundary from './ReportedErrorBoundary';
 
-jest.unmock('logic/rest/FetchProvider');
 jest.mock('routing/withLocation', () => (Component) => (props) => <Component {...props} location={{ pathname: '/' }} />);
 
 describe('ReportedErrorBoundary', () => {

--- a/graylog2-web-interface/src/pages/StreamPermissionErrorPage.test.tsx
+++ b/graylog2-web-interface/src/pages/StreamPermissionErrorPage.test.tsx
@@ -23,8 +23,6 @@ import FetchError from 'logic/errors/FetchError';
 
 import StreamPermissionErrorPage from './StreamPermissionErrorPage';
 
-jest.unmock('logic/rest/FetchProvider');
-
 describe('StreamPermissionErrorPage', () => {
   it('displays fetch error', () => {
     const response = { status: 403, body: { message: 'The request error message', streams: ['stream-1-id', 'stream-2-id'], type: 'MissingStreamPermission' } };

--- a/graylog2-web-interface/src/pages/UnauthorizedErrorPage.test.tsx
+++ b/graylog2-web-interface/src/pages/UnauthorizedErrorPage.test.tsx
@@ -23,8 +23,6 @@ import FetchError from 'logic/errors/FetchError';
 
 import UnauthorizedErrorPage from './UnauthorizedErrorPage';
 
-jest.unmock('logic/rest/FetchProvider');
-
 describe('UnauthorizedErrorPage', () => {
   it('displays fetch error', () => {
     suppressConsole(async () => {


### PR DESCRIPTION
## Description
In some tests we unmocked the `FetchProvider`, to be able to import the `FetchError`. Both classes shared the same file. This was not the best solution, because it resulted in the following `console.error`s when running these tests. 
```
There was an error fetching a resource: getaddrinfo ENOTFOUND undefined. Additional information: Not available
```

We recently created a separate file for the `FetchError`, which means unmocking the `FetchProvider` is no longer necessary.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
