### PR TITLE
Removing remaining `$FlowFixMe` comments.

### DIFF
--- a/graylog2-web-interface/src/components/common/Pagination.tsx
+++ b/graylog2-web-interface/src/components/common/Pagination.tsx
@@ -18,7 +18,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 // eslint-disable-next-line no-restricted-imports
 import { Pagination as BootstrapPagination } from 'react-bootstrap';
-// $FlowFixMe Need typing for react-ultimate-pagination dependency
 import { createUltimatePagination, ITEM_TYPES } from 'react-ultimate-pagination';
 import styled, { css } from 'styled-components';
 import type { StyledComponent } from 'styled-components';

--- a/graylog2-web-interface/src/components/graylog/ProgressBar.tsx
+++ b/graylog2-web-interface/src/components/graylog/ProgressBar.tsx
@@ -18,7 +18,6 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import styled, { css, keyframes } from 'styled-components';
 import type { StyledComponent } from 'styled-components';
-// $FlowFixMe removing in future iteration
 import chroma from 'chroma-js';
 
 import type { ThemeInterface } from 'theme';

--- a/graylog2-web-interface/src/components/users/UserCreate/UserCreate.tsx
+++ b/graylog2-web-interface/src/components/users/UserCreate/UserCreate.tsx
@@ -118,7 +118,6 @@ const UserCreate = () => {
                        labelClassName="col-sm-3"
                        wrapperClassName="col-sm-9"
                        label="Assign Roles">
-                  { /* $FlowFixMe: assignRole has DescriptiveItem */}
                   <RolesSelector onSubmit={_onAssignRole} assignedRolesIds={user.roles} identifier={(role) => role.name} />
                 </Input>
 

--- a/graylog2-web-interface/src/components/users/UserDetails/RolesSection.tsx
+++ b/graylog2-web-interface/src/components/users/UserDetails/RolesSection.tsx
@@ -39,7 +39,6 @@ const RolesSection = ({ user: { username } }: Props) => {
         setLoading(false);
       }
 
-      // $FlowFixMe Roles is a DescriptiveItem
       return paginatedRoles;
     });
   }, [username]);

--- a/graylog2-web-interface/src/components/users/UserEdit/RolesSection.tsx
+++ b/graylog2-web-interface/src/components/users/UserEdit/RolesSection.tsx
@@ -93,7 +93,6 @@ const RolesSection = ({ user, onSubmit }: Props) => {
     <SectionComponent title="Roles" showLoading={loading}>
       <h3>Assign Roles</h3>
       <Container>
-        { /* $FlowFixMe: assignRole has DescriptiveItem */}
         <RolesSelector onSubmit={_onAssignRole} assignedRolesIds={user.roles} identifier={(role) => role.name} />
       </Container>
 
@@ -102,11 +101,8 @@ const RolesSection = ({ user, onSubmit }: Props) => {
       </ErrorAlert>
       <h3>Selected Roles</h3>
       <Container>
-        {/* $FlowFixMe Role is a DescriptiveItem! */}
         <PaginatedItemOverview noDataText="No selected roles have been found."
-                               /* $FlowFixMe Role is a DescriptiveItem! */
                                onLoad={_onLoad}
-                               /* $FlowFixMe Role is a DescriptiveItem! */
                                overrideList={paginatedRoles}
                                onDeleteItem={onDeleteRole}
                                queryHelper={<RolesQueryHelp />} />

--- a/graylog2-web-interface/src/theme/colors.ts
+++ b/graylog2-web-interface/src/theme/colors.ts
@@ -154,25 +154,15 @@ export const colorsPropTypes = PropTypes.shape({
     textDefault: PropTypes.string,
   }),
   gray: PropTypes.shape({
-    // $FlowFixMe Non-string literal property keys not supported. [unsupported-syntax]
     10: PropTypes.string,
-    // $FlowFixMe Non-string literal property keys not supported. [unsupported-syntax]
     20: PropTypes.string,
-    // $FlowFixMe Non-string literal property keys not supported. [unsupported-syntax]
     30: PropTypes.string,
-    // $FlowFixMe Non-string literal property keys not supported. [unsupported-syntax]
     40: PropTypes.string,
-    // $FlowFixMe Non-string literal property keys not supported. [unsupported-syntax]
     50: PropTypes.string,
-    // $FlowFixMe Non-string literal property keys not supported. [unsupported-syntax]
     60: PropTypes.string,
-    // $FlowFixMe Non-string literal property keys not supported. [unsupported-syntax]
     70: PropTypes.string,
-    // $FlowFixMe Non-string literal property keys not supported. [unsupported-syntax]
     80: PropTypes.string,
-    // $FlowFixMe Non-string literal property keys not supported. [unsupported-syntax]
     90: PropTypes.string,
-    // $FlowFixMe Non-string literal property keys not supported. [unsupported-syntax]
     100: PropTypes.string,
   }),
   input: PropTypes.shape({

--- a/graylog2-web-interface/src/views/bindings.enterpriseWidgets.test.tsx
+++ b/graylog2-web-interface/src/views/bindings.enterpriseWidgets.test.tsx
@@ -29,7 +29,6 @@ describe('Views bindings enterprise widgets', () => {
   const findWidgetConfig = (type) => enterpriseWidgets.find((widgetConfig) => widgetConfig.type === type);
 
   describe('Aggregations', () => {
-    // $FlowFixMe: We are assuming here it is generally present
     const aggregationConfig: WidgetCondig = findWidgetConfig('AGGREGATION');
 
     it('is present', () => {

--- a/graylog2-web-interface/src/views/bindings.fieldActions.test.tsx
+++ b/graylog2-web-interface/src/views/bindings.fieldActions.test.tsx
@@ -83,7 +83,6 @@ describe('Views bindings field actions', () => {
   });
 
   describe('Statistics', () => {
-    // $FlowFixMe: We are assuming here it is generally present
     const action: FieldAction = findAction('statistics');
     const { isEnabled } = action;
 
@@ -126,7 +125,6 @@ describe('Views bindings field actions', () => {
   });
 
   describe('AddToAllTables', () => {
-    // $FlowFixMe: We are assuming here it is generally present
     const action: FieldAction = findAction('add-to-all-tables');
     const { isEnabled } = action;
 
@@ -178,7 +176,6 @@ describe('Views bindings field actions', () => {
   });
 
   describe('RemoveFromAllTables', () => {
-    // $FlowFixMe: We are assuming here it is generally present
     const action: FieldAction = findAction('remove-from-all-tables');
     const { isEnabled } = action;
 

--- a/graylog2-web-interface/src/views/bindings.valueActions.test.tsx
+++ b/graylog2-web-interface/src/views/bindings.valueActions.test.tsx
@@ -34,7 +34,6 @@ describe('Views bindings value actions', () => {
   const findAction = (type) => valueActions.find((binding) => binding.type === type);
 
   describe('CreateExtractor', () => {
-    // $FlowFixMe: We are assuming here it is generally present
     const action: ValueAction = findAction('create-extractor');
     const { isEnabled } = action;
 

--- a/graylog2-web-interface/src/views/components/Search.test.tsx
+++ b/graylog2-web-interface/src/views/components/Search.test.tsx
@@ -108,7 +108,7 @@ jest.mock('views/components/views/CurrentViewTypeProvider', () => jest.fn());
 jest.mock('views/hooks/SyncWithQueryParameters');
 jest.mock('routing/withLocation', () => (Component) => (props) => <Component location={{ query: {}, pathname: '', search: '' }} {...props} />);
 
-const mockPromise = <T,>(res: T): Promise<T> => {
+const mockPromise = <T, >(res: T): Promise<T> => {
   const promise = Promise.resolve(res);
 
   // @ts-ignore
@@ -138,7 +138,6 @@ describe('Search', () => {
     FieldTypesActions.all = mockAction(jest.fn(async () => {}));
     SearchMetadataActions.parseSearch = mockAction(jest.fn(() => mockPromise(SearchMetadata.empty())));
     SearchMetadataStore.listen = jest.fn(() => jest.fn());
-    // $FlowFixMe: Somehow flow does not see the `listen` property.
     SearchActions.refresh = mockAction(jest.fn(() => Promise.resolve()));
     asMock(CurrentViewTypeProvider as React.FunctionComponent).mockImplementation(({ children }) => <ViewTypeContext.Provider value={View.Type.Dashboard}>{children}</ViewTypeContext.Provider>);
   });

--- a/graylog2-web-interface/src/views/components/actions/ActionHandler.test.tsx
+++ b/graylog2-web-interface/src/views/components/actions/ActionHandler.test.tsx
@@ -84,7 +84,6 @@ describe('ActionHandler', () => {
     return handler({ queryId: 'foo', field: 'bar', value: 42, type: FieldType.Unknown, contexts: {} })
       .then(() => {
         const state: ActionComponents = setState.mock.calls[0][0];
-        // $FlowFixMe: Object.value's signature is in the way
         const component: { props: ActionComponentProps } = Object.values(state)[0];
         const { onClose } = component.props;
 

--- a/graylog2-web-interface/src/views/components/actions/ValueActions.tsx
+++ b/graylog2-web-interface/src/views/components/actions/ValueActions.tsx
@@ -77,7 +77,6 @@ class ValueActions extends React.Component<Props, State> {
   render() {
     const { children, element, field, menuContainer, queryId, type, value } = this.props;
     const { open, overflowingComponents: components } = this.state;
-    // $FlowFixMe: Object.values signature is in the way for this one
     const overflowingComponents: Array<React.ReactNode> = Object.values(components);
     const handlerArgs = { queryId, field, type, value, contexts: this.context };
     const valueActions: Array<ActionDefinition> = PluginStore.exports('valueActions')

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/AggregationControls.test.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/AggregationControls.test.tsx
@@ -69,7 +69,6 @@ describe('AggregationControls', () => {
     suppressConsole(() => {
       const { getByTestId } = render((
         <AggregationControls config={config}
-                             // $FlowFixMe: Passing `undefined` fields on purpose
                              fields={undefined}
                              onChange={() => {}}>
           {children}

--- a/graylog2-web-interface/src/views/components/contexts/DrilldownContextProvider.test.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/DrilldownContextProvider.test.tsx
@@ -110,7 +110,6 @@ describe('DrilldownContextProvider', () => {
     it('passes values from current query if present', () => {
       const query = Query.builder()
         .query(createElasticsearchQueryString('foo:"bar"'))
-        // $FlowFixMe: We know it is defined
         .filter(filtersForQuery(['onestream', 'anotherstream']))
         .timerange({ type: 'keyword', keyword: 'last year' })
         .build();

--- a/graylog2-web-interface/src/views/components/datatable/DataTable.tsx
+++ b/graylog2-web-interface/src/views/components/datatable/DataTable.tsx
@@ -78,10 +78,8 @@ const _extractColumnPivotValues = (rows): Array<Array<string>> => {
     flatten(
       rows
         .filter(({ source }) => (source === 'leaf' || source === 'non-leaf'))
-        // $FlowFixMe: Actually filtering out rows with single values
         .map(({ values }) => values),
     )
-      // $FlowFixMe: Should be safe, even if rollup is not present
       .filter(({ rollup }) => !rollup)
       .map(({ key }) => key.slice(0, -1)),
     isEqual,

--- a/graylog2-web-interface/src/views/components/datatable/Headers.test.tsx
+++ b/graylog2-web-interface/src/views/components/datatable/Headers.test.tsx
@@ -134,7 +134,6 @@ describe('Headers', () => {
 
       mount((
         <RenderHeaders series={series}
-                       // $FlowFixMe: Passing `null` fields on purpose
                        fields={null} />
       ));
     });

--- a/graylog2-web-interface/src/views/components/sidebar/create/AddWidgetButton.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/create/AddWidgetButton.tsx
@@ -147,7 +147,6 @@ class AddWidgetButton extends React.Component<Props, State> {
     const creators: Array<Creator> = PluginStore.exports('creators');
     const presets = this._createGroup(creators, 'preset');
     const generic = this._createGroup(creators, 'generic');
-    // $FlowFixMe: Object.value signature is in the way
     const components: Array<React.ReactNode> = Object.values(overflowingComponents);
 
     return (

--- a/graylog2-web-interface/src/views/components/views/MissingRequirements.tsx
+++ b/graylog2-web-interface/src/views/components/views/MissingRequirements.tsx
@@ -17,7 +17,6 @@
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
 
-// $FlowFixMe: imports from core need to be fixed in flow
 import { LinkContainer } from 'components/graylog/router';
 import type { PluginMetadata, Requirements } from 'views/logic/views/View';
 import { Col, Row, Button } from 'components/graylog';
@@ -38,7 +37,6 @@ const MissingRequirements = ({ view, missingRequirements }: Props) => (
       <p>Unfortunately executing this view is not possible. It uses the following capabilities which are not available:</p>
 
       <ul>
-        {/* $FlowFixMe: Object.entries returns value as `mixed` */}
         {Object.entries(missingRequirements).map(([require, plugin]: [string, PluginMetadata]) => (
           <li key={require}>
             <strong>{require}</strong> - included in <a href={plugin.url} target="_blank" rel="noopener noreferrer">{plugin.name}</a>

--- a/graylog2-web-interface/src/views/components/views/View.tsx
+++ b/graylog2-web-interface/src/views/components/views/View.tsx
@@ -17,7 +17,6 @@
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 
-// $FlowFixMe: imports from core need to be fixed in flow
 import { Link } from 'components/graylog/router';
 import Routes from 'routing/Routes';
 import { EntityListItem } from 'components/common';
@@ -84,7 +83,6 @@ const Requirements = ({ requires, requirementsProvided }: RequirementsProps) => 
     ? (
       <h5>
         Missing requirement(s): {Object.values(missing)
-        // $FlowFixMe: plugin is of type Plugin, not mixed.
         .map((plugin: Plugin) => <MissingRequirement key={plugin.name} plugin={plugin} />)}
       </h5>
     )

--- a/graylog2-web-interface/src/views/components/visualizations/GenericPlot.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/GenericPlot.tsx
@@ -136,7 +136,6 @@ class GenericPlot extends React.Component<Props, State> {
     if (getChartColor) {
       const color = getChartColor(e.fullData, name);
 
-      /* $FlowFixMe color is already declared as optional */
       this.setState({ legendConfig: { name, target, color } });
     }
 

--- a/graylog2-web-interface/src/views/components/visualizations/__tests__/ChartData.test.ts
+++ b/graylog2-web-interface/src/views/components/visualizations/__tests__/ChartData.test.ts
@@ -199,7 +199,6 @@ describe('Chart helper functions', () => {
         transformKeys(config.rowPivots, config.columnPivots),
         extractSeries(),
         formatSeries,
-        // $FlowFixMe: Returning different result type on purpose
         generateChart('scatter', generatorFunction),
       ]);
       const result = pipeline(input);

--- a/graylog2-web-interface/src/views/components/visualizations/__tests__/GenericPlot.test.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/__tests__/GenericPlot.test.tsx
@@ -129,7 +129,6 @@ describe('GenericPlot', () => {
       const data = fullData.find((d) => (d.name === name));
 
       if (data && data.marker && data.marker.color) {
-        // $FlowFixMe the check above ensures the presents of marker
         const { marker: { color } } = data;
 
         return color;

--- a/graylog2-web-interface/src/views/components/visualizations/pie/PieVisualization.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/pie/PieVisualization.tsx
@@ -64,10 +64,8 @@ const getChartColor = (fullDataArray, name) => {
 
   if (fullData && fullData.labels && fullData.marker && fullData.marker.colors) {
     const indexOfName = fullData.labels.indexOf(name);
-    // $FlowFixMe the check above ensures the presents of marker
     const { marker: { colors } } = fullData;
 
-    // $FlowFixMe the check above ensures the presents of colors
     return colors[indexOfName];
   }
 

--- a/graylog2-web-interface/src/views/components/widgets/MessageTable.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageTable.test.tsx
@@ -77,7 +77,6 @@ describe('MessageTable', () => {
     suppressConsole(() => {
       const wrapper = mount(<MessageTable activeQueryId={activeQueryId}
                                           config={config}
-                                          // $FlowFixMe: violating contract on purpose
                                           fields={undefined}
                                           onSortChange={() => Promise.resolve()}
                                           selectedFields={Immutable.Set()}

--- a/graylog2-web-interface/src/views/logic/aggregationbuilder/WidgetFormattingSettings.ts
+++ b/graylog2-web-interface/src/views/logic/aggregationbuilder/WidgetFormattingSettings.ts
@@ -70,7 +70,6 @@ export default class WidgetFormattingSettings {
 
   toJSON() {
     const { chartColors } = this._value;
-    // $FlowFixMe flow cannot handle Object.keys
     const chartColorJson = Object.keys(chartColors)
       .map((fieldName) => ({ field_name: fieldName, chart_color: chartColors[fieldName] }));
 

--- a/graylog2-web-interface/src/views/logic/fieldtypes/FieldTypeFor.test.ts
+++ b/graylog2-web-interface/src/views/logic/fieldtypes/FieldTypeFor.test.ts
@@ -27,7 +27,6 @@ describe('FieldTypeFor', () => {
   });
 
   it('returns `FieldType.Unknown` if field types are `undefined`', () => {
-    // $FlowFixMe: Passing `undefined` types on purpose
     expect(fieldTypeFor('', undefined)).toEqual(FieldType.Unknown);
   });
 

--- a/graylog2-web-interface/src/views/logic/fieldtypes/InferTypeForSeries.test.ts
+++ b/graylog2-web-interface/src/views/logic/fieldtypes/InferTypeForSeries.test.ts
@@ -14,8 +14,6 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-
-// $FlowFixMe: imports from core need to be fixed in flow
 import each from 'jest-each';
 
 import inferTypeForSeries from './InferTypeForSeries';
@@ -63,7 +61,6 @@ describe('InferTypeForSeries', () => {
   });
 
   it('returns unknown if field types are `undefined`', () => {
-    // $FlowFixMe: passing invalid types parameter on purpose.
     expect(inferTypeForSeries(Series.forFunction('avg(foo)'), undefined))
       .toEqual(FieldTypeMapping.create('avg(foo)', FieldType.Unknown));
   });

--- a/graylog2-web-interface/src/views/logic/fieldtypes/InferTypeForSeries.ts
+++ b/graylog2-web-interface/src/views/logic/fieldtypes/InferTypeForSeries.ts
@@ -36,9 +36,7 @@ const inferTypeForSeries = (series: Series, types: (FieldTypeMappingsList | Arra
 
   const { type, field } = definition;
 
-  // $FlowFixMe: this check should...
   if (constantTypeFunctions[type]) {
-    // $FlowFixMe: ... guard this access!
     return newMapping(constantTypeFunctions[type]());
   }
 

--- a/graylog2-web-interface/src/views/logic/parameters/LookupTableParameter.ts
+++ b/graylog2-web-interface/src/views/logic/parameters/LookupTableParameter.ts
@@ -93,7 +93,6 @@ export default class LookupTableParameter extends Parameter {
   }
 
   // static fromJSON(json: LookupTableParameterJson): Parameter {
-  // $FlowFixMe Flow can't override statics https://github.com/facebook/flow/issues/4953
   static fromJSON(json: LookupTableParameterJson): LookupTableParameter {
     // eslint-disable-next-line camelcase
     const { name, title, description, data_type, default_value, optional, lookup_table, key } = json;

--- a/graylog2-web-interface/src/views/logic/queries/QueryTitle.test.tsx
+++ b/graylog2-web-interface/src/views/logic/queries/QueryTitle.test.tsx
@@ -57,17 +57,14 @@ describe('QueryTitle', () => {
   });
 
   it('returns `undefined` if query id is `undefined`', () => {
-    // $FlowFixMe: passing invalid values on purpose
     expect(queryTitle(view, undefined)).toEqual(undefined);
   });
 
   it('returns `undefined` if view is `undefined`', () => {
-    // $FlowFixMe: passing invalid values on purpose
     expect(queryTitle(undefined, undefined)).toEqual(undefined);
   });
 
   it('returns `undefined` if search is `undefined`', () => {
-    // $FlowFixMe: passing invalid values on purpose
     expect(queryTitle(View.create(), undefined)).toEqual(undefined);
   });
 
@@ -76,10 +73,8 @@ describe('QueryTitle', () => {
       .toBuilder()
       .search(Search.create()
         .toBuilder()
-        // $FlowFixMe: passing invalid values on purpose
         .queries(undefined)
         .build())
-      // $FlowFixMe: passing invalid values on purpose
       .build(), undefined)).toEqual(undefined);
   });
 });

--- a/graylog2-web-interface/src/views/logic/searchtypes/aggregation/PivotConfigGenerator.ts
+++ b/graylog2-web-interface/src/views/logic/searchtypes/aggregation/PivotConfigGenerator.ts
@@ -110,7 +110,6 @@ export default ({ config }: { config: AggregationWidgetConfig }) => {
   const configBuilder = ConfigBuilder.create([chartConfig]);
 
   // TODO: This should go into a visualization config specific function
-  // $FlowFixMe: This is a NumberVisualizationConfig. We know so for config.visualization is 'numeric'.
   if (config.visualization === 'numeric' && config.visualizationConfig && (config.visualizationConfig as NumberVisualizationConfig).trend) {
     const trendConfig = {
       ...(generateConfig(uuid(), 'trend', config)),

--- a/graylog2-web-interface/src/views/logic/searchtypes/messages/MessageConfigGenerator.test.tsx
+++ b/graylog2-web-interface/src/views/logic/searchtypes/messages/MessageConfigGenerator.test.tsx
@@ -25,7 +25,6 @@ describe('MessageConfigGenerator', () => {
   const defaultSort = [new MessageSortConfig('timestamp', Direction.Descending)];
 
   it('generates basic search type from message widget with a default sort', () => {
-    // $FlowFixMe: We need to force this being a `MessagesWidget`
     const widget: MessagesWidget = MessagesWidget.builder()
       .config(
         MessagesWidgetConfig.builder()
@@ -43,7 +42,6 @@ describe('MessageConfigGenerator', () => {
       { id: 'decorator1', type: 'something', config: {}, stream: null, order: 0 },
       { id: 'decorator2', type: 'something else', config: {}, stream: null, order: 1 },
     ];
-    // $FlowFixMe: We need to force this being a `MessagesWidget`
     const widget: MessagesWidget = MessagesWidget.builder()
       .config(
         MessagesWidgetConfig.builder()

--- a/graylog2-web-interface/src/views/logic/valueactions/ShowDocumentsHandler.ts
+++ b/graylog2-web-interface/src/views/logic/valueactions/ShowDocumentsHandler.ts
@@ -40,7 +40,6 @@ type Arguments = {
 
 const extractFieldsFromValuePath = (valuePath: ValuePath): Array<string> => {
   return valuePath.map((item) => Object.entries(item)
-    // $FlowFixMe: We know that values are strings
     .map(([key, value]: [string, string]) => (
       key === '_exists_' ? value : key)))
     .reduce((prev, cur) => [...prev, ...cur], [])

--- a/graylog2-web-interface/src/views/pages/DashboardsPage.tsx
+++ b/graylog2-web-interface/src/views/pages/DashboardsPage.tsx
@@ -16,7 +16,6 @@
  */
 import React, { useEffect } from 'react';
 
-// $FlowFixMe: imports from core need to be fixed in flow
 import { LinkContainer } from 'components/graylog/router';
 import { Col, Row, Button } from 'components/graylog';
 import connect from 'stores/connect';

--- a/graylog2-web-interface/src/views/pages/ViewManagementPage.tsx
+++ b/graylog2-web-interface/src/views/pages/ViewManagementPage.tsx
@@ -18,7 +18,6 @@ import * as React from 'react';
 import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 
-// $FlowFixMe: imports from core need to be fixed in flow
 import { LinkContainer } from 'components/graylog/router';
 import Routes from 'routing/Routes';
 import { Col, Row, Button } from 'components/graylog';

--- a/graylog2-web-interface/src/views/stores/QueriesStore.test.tsx
+++ b/graylog2-web-interface/src/views/stores/QueriesStore.test.tsx
@@ -91,7 +91,6 @@ describe('QueriesStore', () => {
     });
 
     it('throws error if no type is given', () => {
-      // $FlowFixMe: Passing no second argument on purpose
       return QueriesActions.rangeType('query1', undefined)
         .catch((error) => expect(error).toEqual(new Error('Invalid time range type: undefined')));
     });

--- a/graylog2-web-interface/test/helpers/suppressConsole.ts
+++ b/graylog2-web-interface/test/helpers/suppressConsole.ts
@@ -26,12 +26,10 @@
 const suppressConsole = (fn: () => void) => {
   /* eslint-disable no-console */
   const originalConsoleError = console.error;
-  // $FlowFixMe: We explicitly want to overwrite `error`
   console.error = () => {};
 
   fn();
 
-  // $FlowFixMe: We explicitly want to overwrite `error`
   console.error = originalConsoleError;
   /* eslint-enable no-console */
 };


### PR DESCRIPTION
##  Description
We recently migrated from Flow to TypeScript. This PR removes the remaining `$FlowFixMe` comments since we no longer need them. There are some comments were we can discuss if we want to keep the pure text, because they provide some background information for the related code part. IMO the benefit is not so large.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)