### PR TITLE
Use empty EventSearchParameters in EventsResource by default

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/events/rest/EventsResource.java
+++ b/graylog2-server/src/main/java/org/graylog/events/rest/EventsResource.java
@@ -34,6 +34,8 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
+import static com.google.common.base.MoreObjects.firstNonNull;
+
 @Api(value = "Events", description = "Events overview and search")
 @Path("/events")
 @Produces(MediaType.APPLICATION_JSON)
@@ -52,6 +54,6 @@ public class EventsResource extends RestResource implements PluginRestResource {
     @ApiOperation("Search events")
     @NoAuditEvent("Doesn't change any data, only searches for events")
     public EventsSearchResult search(@ApiParam(name = "JSON body") EventsSearchParameters request) {
-        return searchService.search(request, getSubject());
+        return searchService.search(firstNonNull(request, EventsSearchParameters.empty()), getSubject());
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/events/search/EventsSearchParameters.java
+++ b/graylog2-server/src/main/java/org/graylog/events/search/EventsSearchParameters.java
@@ -70,6 +70,10 @@ public abstract class EventsSearchParameters {
         return Builder.create();
     }
 
+    public static EventsSearchParameters empty() {
+        return builder().build();
+    }
+
     public abstract Builder toBuilder();
 
     @AutoValue.Builder


### PR DESCRIPTION
Avoids an NPE when executing a search without payload.

