### PR TITLE
Use plugins from web modules file in dev build.

### DIFF
--- a/graylog2-web-interface/webpack.combined.config.js
+++ b/graylog2-web-interface/webpack.combined.config.js
@@ -15,6 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 const fs = require('fs');
+
 const glob = require('glob');
 const path = require('path');
 const merge = require('webpack-merge');
@@ -25,10 +26,11 @@ const WEB_MODULES = path.resolve(__dirname, './web-modules.json');
 
 const configsFromWebModule = (webModulesFile) => {
   const webModules = JSON.parse(fs.readFileSync(webModulesFile));
+
   return webModules.modules
-    .map(({ path }) => path)
-    .filter(path => path.includes('graylog-plugin'))
-    .map(path => `${path}/webpack.config.js`);
+    .map(({ path: p }) => p)
+    .filter((_path) => _path.includes('graylog-plugin'))
+    .map((_path) => `${_path}/webpack.config.js`);
 };
 
 const configsFromGlob = () => {
@@ -48,8 +50,9 @@ const configsFromGlob = () => {
   return glob.sync(pluginConfigPattern, globOptions)
     .map((config) => `${globCwd}/${config}`)
     .filter(isNotDependency);
-}
+};
 
+// eslint-disable-next-line no-nested-ternary
 const pluginConfigs = process.env.disable_plugins === 'true'
   ? []
   : fs.existsSync(WEB_MODULES)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Before this change, running `devServer` without `disable_plugins` made it use a glob (`../../graylog-plugin-*/**/webpack.config.js`) to find webpack configs of all plugins in the filesystem. This lead to issues when plugins are merely existing in the fs but are not supposed to be used. (e.g. from a previous `graylog-project` checkout)

After this change, `devServer` looks for a `web-modules.json` file (which is generated by `graylog-project` upon checkout) and uses the plugins referenced in there instead of the glob. If the file is not present, it will fall back to the old behavior of using a glob. If `web-modules.json` is regenerated while the dev server is running, it needs a restart to pick up the changes.

## Motivation and Context

This PR allows it to switch between different manifests using different
sets of plugins without issues.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.