### PR TITLE
Include microseconds in timestamps.

### DIFF
--- a/graylog2-web-interface/src/views/components/common/UserTimezoneTimestamp.jsx
+++ b/graylog2-web-interface/src/views/components/common/UserTimezoneTimestamp.jsx
@@ -25,7 +25,7 @@ const UserTimezoneTimestamp = ({ ...rest }) => {
   const currentUser = useContext(CurrentUserContext);
   const timezone = currentUser?.timezone ?? AppConfig.rootTimeZone();
 
-  return <Timestamp tz={timezone} format={DateTime.Formats.DATETIME_TZ} {...rest} />;
+  return <Timestamp tz={timezone} format={DateTime.Formats.TIMESTAMP_TZ} {...rest} />;
 };
 
 export default UserTimezoneTimestamp;

--- a/graylog2-web-interface/src/views/components/common/UserTimezoneTimestamp.test.tsx
+++ b/graylog2-web-interface/src/views/components/common/UserTimezoneTimestamp.test.tsx
@@ -1,16 +1,17 @@
 import * as React from 'react';
 import { render, screen } from 'wrappedTestingLibrary';
 
-import UserTimezoneTimestamp from './UserTimezoneTimestamp';
 import CurrentUserContext from 'contexts/CurrentUserContext';
 import { UserJSON } from 'logic/users/User';
+
+import UserTimezoneTimestamp from './UserTimezoneTimestamp';
 
 const createCurrentUserWithTz = (tz: string): UserJSON => ({
   timezone: tz,
 } as UserJSON);
 
 describe('UserTimezoneTimestamp', () => {
-  const WithTimezone = ({ children, tz }) => (
+  const WithTimezone = ({ children, tz }: { children: React.ReactNode, tz: string }) => (
     <CurrentUserContext.Provider value={createCurrentUserWithTz(tz)}>
       {children}
     </CurrentUserContext.Provider>
@@ -21,7 +22,7 @@ describe('UserTimezoneTimestamp', () => {
       <WithTimezone tz="America/New_York">
         <UserTimezoneTimestamp dateTime="2020-11-30T11:09:00.950Z" />
       </WithTimezone>
-    ))
+    ));
 
     await screen.findByText('2020-11-30 06:09:00.950 -05:00');
   });
@@ -31,7 +32,7 @@ describe('UserTimezoneTimestamp', () => {
       <WithTimezone tz={undefined}>
         <UserTimezoneTimestamp dateTime="2020-11-30T11:09:00.950Z" />
       </WithTimezone>
-    ))
+    ));
 
     await screen.findByText('2020-11-30 12:09:00.950 +01:00');
   });

--- a/graylog2-web-interface/src/views/components/common/UserTimezoneTimestamp.test.tsx
+++ b/graylog2-web-interface/src/views/components/common/UserTimezoneTimestamp.test.tsx
@@ -1,10 +1,14 @@
 import * as React from 'react';
 import { render, screen } from 'wrappedTestingLibrary';
+import asMock from 'helpers/mocking/AsMock';
 
+import AppConfig from 'util/AppConfig';
 import CurrentUserContext from 'contexts/CurrentUserContext';
 import { UserJSON } from 'logic/users/User';
 
 import UserTimezoneTimestamp from './UserTimezoneTimestamp';
+
+jest.mock('util/AppConfig');
 
 const createCurrentUserWithTz = (tz: string): UserJSON => ({
   timezone: tz,
@@ -28,12 +32,14 @@ describe('UserTimezoneTimestamp', () => {
   });
 
   it('should default to system timezone to render timestamp', async () => {
+    asMock(AppConfig.rootTimeZone).mockReturnValue('Asia/Tokyo');
+
     render((
       <WithTimezone tz={undefined}>
         <UserTimezoneTimestamp dateTime="2020-11-30T11:09:00.950Z" />
       </WithTimezone>
     ));
 
-    await screen.findByText('2020-11-30 12:09:00.950 +01:00');
+    await screen.findByText('2020-11-30 20:09:00.950 +09:00');
   });
 });

--- a/graylog2-web-interface/src/views/components/common/UserTimezoneTimestamp.test.tsx
+++ b/graylog2-web-interface/src/views/components/common/UserTimezoneTimestamp.test.tsx
@@ -1,0 +1,38 @@
+import * as React from 'react';
+import { render, screen } from 'wrappedTestingLibrary';
+
+import UserTimezoneTimestamp from './UserTimezoneTimestamp';
+import CurrentUserContext from 'contexts/CurrentUserContext';
+import { UserJSON } from 'logic/users/User';
+
+const createCurrentUserWithTz = (tz: string): UserJSON => ({
+  timezone: tz,
+} as UserJSON);
+
+describe('UserTimezoneTimestamp', () => {
+  const WithTimezone = ({ children, tz }) => (
+    <CurrentUserContext.Provider value={createCurrentUserWithTz(tz)}>
+      {children}
+    </CurrentUserContext.Provider>
+  );
+
+  it('should use current user\'s timezone to render timestamp', async () => {
+    render((
+      <WithTimezone tz="America/New_York">
+        <UserTimezoneTimestamp dateTime="2020-11-30T11:09:00.950Z" />
+      </WithTimezone>
+    ))
+
+    await screen.findByText('2020-11-30 06:09:00.950 -05:00');
+  });
+
+  it('should default to system timezone to render timestamp', async () => {
+    render((
+      <WithTimezone tz={undefined}>
+        <UserTimezoneTimestamp dateTime="2020-11-30T11:09:00.950Z" />
+      </WithTimezone>
+    ))
+
+    await screen.findByText('2020-11-30 12:09:00.950 +01:00');
+  });
+});

--- a/graylog2-web-interface/webpack/vendor-module-ids.json
+++ b/graylog2-web-interface/webpack/vendor-module-ids.json
@@ -1245,7 +1245,8 @@
       "node_modules/react-router-dom/esm/react-router-dom.js": 463,
       "node_modules/resolve-pathname/esm/resolve-pathname.js": 464,
       "node_modules/value-equal/esm/value-equal.js": 465,
-      "node_modules/react-router/node_modules/isarray/index.js": 466
+      "node_modules/react-router/node_modules/isarray/index.js": 466,
+      "node_modules/formik/node_modules/deepmerge/dist/es.js": 18
     },
     "usedIds": {
       "0": 0,


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Starting with 3.2.0, we did not display microseconds in the message table for timestamps anymore. While a microsecond timestamp is shown when message details are expanded, it is also highly useful in the collapsed table.

This PR is changing the timestamp format used and includes microseconds again.

Fixes #9604.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.