### PR TITLE
Handling unavailable `searchesClusterConfig`.

### DIFF
--- a/graylog2-web-interface/src/views/components/Search.tsx
+++ b/graylog2-web-interface/src/views/components/Search.tsx
@@ -121,8 +121,10 @@ const DashboardSearchBarWithStatus = WithSearchStatus(DashboardSearchBar);
 const ViewAdditionalContextProvider = connect(
   AdditionalContext.Provider,
   { view: ViewStore, configs: SearchConfigStore },
-  ({ view, configs: { searchesClusterConfig } }) => ({ value: { view: view.view, analysisDisabledFields: searchesClusterConfig.analysis_disabled_fields } } as { value: object}),
+  ({ view, configs: { searchesClusterConfig } }) => ({ value: { view: view.view, analysisDisabledFields: searchesClusterConfig?.analysis_disabled_fields } } as { value: object}),
 );
+
+ViewAdditionalContextProvider.displayName = 'ViewAdditionalContextProvider';
 
 const Search = ({ location }: Props) => {
   const { pathname, search } = location;


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

When a user which is missing the `clusterconfigentry:read` permission is starting a search, the `ViewAdditionalContextProvider` tries to read a key from a non-existing (because it cannot be retrieved due to the lack of the permission) object. This results in an exception being thrown.

This change is using optional chaining to handle the absence of the config object gracefully.

Fixes #9591.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

The `SearchConfigStore` was manipulated to return an object missing the `searchesClusterConfig` key. Without this change, this results in an exception, with the change in place, it does not.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.