### PR TITLE
Hide sidecars on cloud

### DIFF
--- a/graylog2-web-interface/src/components/navigation/SystemMenu.jsx
+++ b/graylog2-web-interface/src/components/navigation/SystemMenu.jsx
@@ -158,9 +158,11 @@ const SystemMenu = ({ location }) => {
       <IfPermitted permissions={['inputs:create']}>
         <NavigationLink path={Routes.SYSTEM.PIPELINES.OVERVIEW} description="Pipelines" />
       </IfPermitted>
-      <IfPermitted permissions={['inputs:edit']}>
-        <NavigationLink path={Routes.SYSTEM.SIDECARS.OVERVIEW} description="Sidecars" />
-      </IfPermitted>
+      <HideOnCloud>
+        <IfPermitted permissions={['inputs:edit']}>
+          <NavigationLink path={Routes.SYSTEM.SIDECARS.OVERVIEW} description="Sidecars" />
+        </IfPermitted>
+      </HideOnCloud>
       {pluginSystemNavigations}
     </NavDropdown>
   );

--- a/graylog2-web-interface/src/routing/AppRouter.jsx
+++ b/graylog2-web-interface/src/routing/AppRouter.jsx
@@ -358,18 +358,44 @@ const AppRouter = () => {
                         <Route exact path={Routes.SYSTEM.THREADDUMP(':nodeId')} component={ThreadDumpPage} />
                         <Route exact path={Routes.SYSTEM.ENTERPRISE} component={EnterprisePage} />
 
-                        <Route exact path={Routes.SYSTEM.SIDECARS.OVERVIEW} component={SidecarsPage} />
-                        <Route exact path={Routes.SYSTEM.SIDECARS.STATUS(':sidecarId')} component={SidecarStatusPage} />
-                        <Route exact path={Routes.SYSTEM.SIDECARS.ADMINISTRATION} component={SidecarAdministrationPage} />
-                        <Route exact path={Routes.SYSTEM.SIDECARS.CONFIGURATION} component={SidecarConfigurationPage} />
-                        <Route exact path={Routes.SYSTEM.SIDECARS.NEW_CONFIGURATION} component={SidecarNewConfigurationPage} />
-                        <Route exact
-                               path={Routes.SYSTEM.SIDECARS.EDIT_CONFIGURATION(':configurationId')}
-                               component={SidecarEditConfigurationPage} />
-                        <Route exact path={Routes.SYSTEM.SIDECARS.NEW_COLLECTOR} component={SidecarNewCollectorPage} />
-                        <Route exact
-                               path={Routes.SYSTEM.SIDECARS.EDIT_COLLECTOR(':collectorId')}
-                               component={SidecarEditCollectorPage} />
+                        {!isCloud && (
+                          <Route exact path={Routes.SYSTEM.SIDECARS.OVERVIEW} component={SidecarsPage} />
+                        )}
+                        {!isCloud && (
+                          <Route exact
+                                 path={Routes.SYSTEM.SIDECARS.STATUS(':sidecarId')}
+                                 component={SidecarStatusPage} />
+                        )}
+                        {!isCloud && (
+                          <Route exact
+                                 path={Routes.SYSTEM.SIDECARS.ADMINISTRATION}
+                                 component={SidecarAdministrationPage} />
+                        )}
+                        {!isCloud && (
+                          <Route exact
+                                 path={Routes.SYSTEM.SIDECARS.CONFIGURATION}
+                                 component={SidecarConfigurationPage} />
+                        )}
+                        {!isCloud && (
+                          <Route exact
+                                 path={Routes.SYSTEM.SIDECARS.NEW_CONFIGURATION}
+                                 component={SidecarNewConfigurationPage} />
+                        )}
+                        {!isCloud && (
+                          <Route exact
+                                 path={Routes.SYSTEM.SIDECARS.EDIT_CONFIGURATION(':configurationId')}
+                                 component={SidecarEditConfigurationPage} />
+                        )}
+                        {!isCloud && (
+                          <Route exact
+                                 path={Routes.SYSTEM.SIDECARS.NEW_COLLECTOR}
+                                 component={SidecarNewCollectorPage} />
+                        )}
+                        {!isCloud && (
+                          <Route exact
+                                 path={Routes.SYSTEM.SIDECARS.EDIT_COLLECTOR(':collectorId')}
+                                 component={SidecarEditCollectorPage} />
+                        )}
                         {standardPluginRoutes}
                         <Route path="*" component={WrappedNotFoundPage} />
                       </Switch>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
On cloud we do not need to have sidecars, so this disables the pages altogether.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We need not make sidecars available for the cloud environment.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On cloud env

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

Fixes https://github.com/Graylog2/graylog-plugin-cloud/issues/101