### PR TITLE
Handle Pulsar upstream connectivity issues

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/shared/messageq/pulsar/PulsarMessageQueueWriter.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/messageq/pulsar/PulsarMessageQueueWriter.java
@@ -88,8 +88,6 @@ public class PulsarMessageQueueWriter extends AbstractIdleService implements Mes
                 .topic(topic)
                 .producerName(name)
                 .compressionType(CompressionType.ZSTD)
-                .enableBatching(true)
-                .batchingMaxMessages(1000)
                 .batchingMaxPublishDelay(1, TimeUnit.MILLISECONDS)
                 .intercept(new MessageInterceptor())
                 .create();

--- a/graylog2-server/src/main/java/org/graylog2/shared/messageq/pulsar/PulsarMessageQueueWriter.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/messageq/pulsar/PulsarMessageQueueWriter.java
@@ -81,6 +81,8 @@ public class PulsarMessageQueueWriter extends AbstractIdleService implements Mes
 
         this.client = PulsarClient.builder()
                 .serviceUrl(serviceUrl)
+                .startingBackoffInterval(100, TimeUnit.MILLISECONDS)
+                .maxBackoffInterval(1, TimeUnit.SECONDS)
                 .build();
         this.producer = client.newProducer(Schema.BYTES)
                 .topic(topic)

--- a/graylog2-server/src/main/java/org/graylog2/shared/messageq/pulsar/PulsarMessageQueueWriter.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/messageq/pulsar/PulsarMessageQueueWriter.java
@@ -90,6 +90,7 @@ public class PulsarMessageQueueWriter extends AbstractIdleService implements Mes
                 .compressionType(CompressionType.ZSTD)
                 .batchingMaxPublishDelay(1, TimeUnit.MILLISECONDS)
                 .sendTimeout(0, TimeUnit.SECONDS)
+                .blockIfQueueFull(true)
                 .intercept(new MessageInterceptor())
                 .create();
 

--- a/graylog2-server/src/main/java/org/graylog2/shared/messageq/pulsar/PulsarMessageQueueWriter.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/messageq/pulsar/PulsarMessageQueueWriter.java
@@ -89,6 +89,7 @@ public class PulsarMessageQueueWriter extends AbstractIdleService implements Mes
                 .producerName(name)
                 .compressionType(CompressionType.ZSTD)
                 .batchingMaxPublishDelay(1, TimeUnit.MILLISECONDS)
+                .sendTimeout(0, TimeUnit.SECONDS)
                 .intercept(new MessageInterceptor())
                 .create();
 


### PR DESCRIPTION
The goal is to retry sending messages indefinitely until it succeeds. We don't want to give up on trying because we *have* to send it. Otherwise the message would be lost because we are unable to put it somewhere safe other than pulsar.

By disabling the send timeout, the pulsar producer will keep trying to send it and transparently performs reconnection attempts if the connection is broken.

The pulsar client's behaviour, if the upstream broker is unreachable, and also under adverse network conditions, appears to be satisfying. I tested stopping and restarting the broker as well as letting upstream connections and downstream connections time out during operation.

As expected, downstream connection timeouts resulted in duplicate messages being delivered. If this becomes a problem, we could try Pulsar's [message deduplication](https://pulsar.apache.org/docs/en/cookbooks-deduplication/) feature. But as we don't know the implications on the performance/resource consumption of the pulsar brokers, we should probably leave it disabled, which is default, for now.
