### PR TITLE
Let devServer proxy all "/api" requests to the server API

### DIFF
--- a/graylog2-web-interface/config.js
+++ b/graylog2-web-interface/config.js
@@ -15,7 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 window.appConfig = {
-  gl2ServerUrl: 'http://localhost:9000/api',
+  gl2ServerUrl: '/api',
   gl2AppPathPrefix: '',
   rootTimeZone: 'Europe/Berlin',
 };

--- a/graylog2-web-interface/devServer.js
+++ b/graylog2-web-interface/devServer.js
@@ -18,6 +18,7 @@ const express = require('express');
 const webpack = require('webpack');
 const compress = require('compression');
 const history = require('connect-history-api-fallback');
+const proxy = require('express-http-proxy');
 const http = require('http');
 const yargs = require('yargs');
 const webpackDevMiddleware = require('webpack-dev-middleware');
@@ -35,6 +36,15 @@ const appConfig = webpackConfig[1];
 const vendorCompiler = webpack(vendorConfig);
 const appCompiler = webpack(appConfig);
 
+
+// Proxy all "/api" requests to the server backend API.
+app.use('/api', proxy('localhost:9000', {
+  proxyReqPathResolver: function (req) {
+    // The proxy middleware removes the prefix from the path but we need it
+    // to make sure we hit the "/api" resources on the server.
+    return `/api${req.url}`;
+  }
+}));
 
 app.use(compress()); // Enables compression middleware
 app.use(history()); // Enables HTML5 History API middleware

--- a/graylog2-web-interface/devServer.js
+++ b/graylog2-web-interface/devServer.js
@@ -23,6 +23,7 @@ const http = require('http');
 const yargs = require('yargs');
 const webpackDevMiddleware = require('webpack-dev-middleware');
 const webpackHotMiddleware = require('webpack-hot-middleware');
+
 const webpackConfig = require('./webpack.bundled');
 
 const DEFAULT_HOST = '127.0.0.1';
@@ -36,14 +37,13 @@ const appConfig = webpackConfig[1];
 const vendorCompiler = webpack(vendorConfig);
 const appCompiler = webpack(appConfig);
 
-
 // Proxy all "/api" requests to the server backend API.
 app.use('/api', proxy('localhost:9000', {
-  proxyReqPathResolver: function (req) {
+  proxyReqPathResolver(req) {
     // The proxy middleware removes the prefix from the path but we need it
     // to make sure we hit the "/api" resources on the server.
     return `/api${req.url}`;
-  }
+  },
 }));
 
 app.use(compress()); // Enables compression middleware
@@ -65,16 +65,18 @@ app.use(webpackHotMiddleware(appCompiler));
 
 const server = http.createServer(app);
 
-const argv = yargs.argv;
+const { argv } = yargs;
 const host = argv.host || DEFAULT_HOST;
 const port = argv.port || DEFAULT_PORT;
 
 server
   .listen(port, host, () => {
+    // eslint-disable-next-line no-console
     console.log(`Graylog web interface listening on http://${server.address().address}:${server.address().port}!\n`);
   })
   .on('error', (error) => {
     if (error.code === 'EADDRINUSE') {
+      // eslint-disable-next-line no-console
       console.error(`Address http://${host}:${port} already in use, will use a random one instead...`);
       server.listen(0, host);
     } else {

--- a/graylog2-web-interface/package.json
+++ b/graylog2-web-interface/package.json
@@ -124,6 +124,7 @@
     "eslint-loader": "^4.0.2",
     "estraverse-fb": "^1.3.1",
     "express": "^4.16.4",
+    "express-http-proxy": "^1.6.2",
     "extract-text-webpack-plugin": "^3.0.0",
     "file-loader": "^6.0.0",
     "fork-ts-checker-webpack-plugin": "^6.0.0",

--- a/graylog2-web-interface/yarn.lock
+++ b/graylog2-web-interface/yarn.lock
@@ -5383,6 +5383,13 @@ debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   dependencies:
     ms "^2.1.1"
 
+debug@^3.0.1:
+  version "3.2.7"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"
+  integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
+  dependencies:
+    ms "^2.1.1"
+
 debug@^3.1.1, debug@^3.2.5:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
@@ -6168,7 +6175,7 @@ es6-object-assign@~1.1.0:
   resolved "https://registry.yarnpkg.com/es6-object-assign/-/es6-object-assign-1.1.0.tgz#c2c3582656247c39ea107cb1e6652b6f9f24523c"
   integrity sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw=
 
-es6-promise@^4.0.3, es6-promise@^4.2.8:
+es6-promise@^4.0.3, es6-promise@^4.1.1, es6-promise@^4.2.8:
   version "4.2.8"
   resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.8.tgz#4eb21594c972bc40553d276e510539143db53e0a"
   integrity sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==
@@ -6625,6 +6632,15 @@ expect@^25.1.0:
     jest-matcher-utils "^25.1.0"
     jest-message-util "^25.1.0"
     jest-regex-util "^25.1.0"
+
+express-http-proxy@^1.6.2:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/express-http-proxy/-/express-http-proxy-1.6.2.tgz#e87152e45958cee4b91da2fdaa20a1ffd581204a"
+  integrity sha512-soP7UXySFdLbeeMYL1foBkEoZj6HELq9BDAOCr1sLRpqjPaFruN5o6+bZeC+7U4USWIl4JMKEiIvTeKJ2WQdlQ==
+  dependencies:
+    debug "^3.0.1"
+    es6-promise "^4.1.1"
+    raw-body "^2.3.0"
 
 express@^4.16.3, express@^4.16.4, express@^4.17.1:
   version "4.17.1"
@@ -8390,17 +8406,7 @@ http-errors@1.7.2:
     statuses ">= 1.5.0 < 2"
     toidentifier "1.0.0"
 
-http-errors@~1.6.2:
-  version "1.6.3"
-  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.6.3.tgz#8b55680bb4be283a0b5bf4ea2e38580be1d9320d"
-  integrity sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=
-  dependencies:
-    depd "~1.1.2"
-    inherits "2.0.3"
-    setprototypeof "1.1.0"
-    statuses ">= 1.4.0 < 2"
-
-http-errors@~1.7.2:
+http-errors@1.7.3, http-errors@~1.7.2:
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.7.3.tgz#6c619e4f9c60308c38519498c14fbb10aacebb06"
   integrity sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==
@@ -8410,6 +8416,16 @@ http-errors@~1.7.2:
     setprototypeof "1.1.1"
     statuses ">= 1.5.0 < 2"
     toidentifier "1.0.0"
+
+http-errors@~1.6.2:
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.6.3.tgz#8b55680bb4be283a0b5bf4ea2e38580be1d9320d"
+  integrity sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=
+  dependencies:
+    depd "~1.1.2"
+    inherits "2.0.3"
+    setprototypeof "1.1.0"
+    statuses ">= 1.4.0 < 2"
 
 "http-parser-js@>=0.4.0 <0.4.11":
   version "0.4.10"
@@ -13008,6 +13024,16 @@ raw-body@2.4.0:
   dependencies:
     bytes "3.1.0"
     http-errors "1.7.2"
+    iconv-lite "0.4.24"
+    unpipe "1.0.0"
+
+raw-body@^2.3.0:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.4.1.tgz#30ac82f98bb5ae8c152e67149dac8d55153b168c"
+  integrity sha512-9WmIKF6mkvA0SLmA2Knm9+qj89e+j1zqgyn8aXGd7+nAduPoqgI9lO57SAZNn/Byzo5P7JhXTyg9PzaJbH73bA==
+  dependencies:
+    bytes "3.1.0"
+    http-errors "1.7.3"
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 


### PR DESCRIPTION
I still had this in my tree from the time we disabled CORS by default a few months ago.

This uses an express proxy middleware to forward all `/api` requests to the server backend. (similar to the "proxy" feature in [webpack-dev-server](https://webpack.js.org/configuration/dev-server/#devserverproxy))

This could simplify the development setup because CORS doesn't need to be enabled anymore.

What do you @Graylog2/frontend folks think? (I am also fine with discarding it :wink:)