### PR TITLE
Fix missing buttons on SidecarsPage (4.0 backport)

### DIFF
--- a/graylog2-web-interface/src/pages/SidecarsPage.jsx
+++ b/graylog2-web-interface/src/pages/SidecarsPage.jsx
@@ -58,8 +58,6 @@ const SidecarsPage = () => {
             </>
           )}
 
-          {!canCreateSidecarUserTokens && <></>}
-
           <ButtonToolbar>
             <LinkContainer to={Routes.SYSTEM.SIDECARS.OVERVIEW}>
               <Button bsStyle="info">Overview</Button>


### PR DESCRIPTION
Fixes #9677

(cherry picked from commit 9562c5383ee045516a387f760d585c1256ad7a7a)

