### PR TITLE
  Add state to disable or enable submit form in DataAdapterForm

### DIFF
--- a/graylog2-web-interface/src/components/lookup-tables/DataAdapterForm.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/DataAdapterForm.jsx
@@ -108,7 +108,7 @@ class DataAdapterForm extends React.Component {
       // when creating always initially auto-generate the adapter name,
       // this will be false if the user changed the adapter name manually
       generateAdapterName: create,
-      isFormExternalyValidated: true,
+      isFormDisabled: true,
       dataAdapter: {
         id: adapter.id,
         title: adapter.title,
@@ -129,8 +129,8 @@ class DataAdapterForm extends React.Component {
     }
   };
 
-  _setExternalValidationState = (formValidationState) => {
-    this.setState({ isFormExternalyValidated: formValidationState });
+  _setIsFormDisabled = (formValidationState) => {
+    this.setState({ isFormDisabled: formValidationState });
   };
 
   _validate = (adapter) => {
@@ -262,7 +262,7 @@ class DataAdapterForm extends React.Component {
   };
 
   render() {
-    const { dataAdapter, isFormExternalyValidated } = this.state;
+    const { dataAdapter, isFormDisabled } = this.state;
     const { create, type, title } = this.props;
     const adapterPlugins = PluginStore.exports('lookupTableAdapters');
 
@@ -282,7 +282,7 @@ class DataAdapterForm extends React.Component {
         updateConfig: this._updateConfig,
         validationMessage: this._validationMessage,
         validationState: this._validationState,
-        setIsFormExternalyValid: this._setExternalValidationState,
+        disableFormSubmission: this._setIsFormDisabled,
       });
 
       if (p.documentationComponent) {
@@ -363,7 +363,7 @@ class DataAdapterForm extends React.Component {
               <fieldset>
                 <Row>
                   <Col mdOffset={3} md={9}>
-                    <Button type="submit" bsStyle="success" disabled={!isFormExternalyValidated}>{create ? 'Create Adapter'
+                    <Button type="submit" bsStyle="success" disabled={!isFormDisabled}>{create ? 'Create Adapter'
                       : 'Update Adapter'}
                     </Button>
                   </Col>

--- a/graylog2-web-interface/src/components/lookup-tables/DataAdapterForm.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/DataAdapterForm.jsx
@@ -282,7 +282,7 @@ class DataAdapterForm extends React.Component {
         updateConfig: this._updateConfig,
         validationMessage: this._validationMessage,
         validationState: this._validationState,
-        disableFormSubmission: this._setIsFormDisabled,
+        setDisableFormSubmission: this._setIsFormDisabled,
       });
 
       if (p.documentationComponent) {

--- a/graylog2-web-interface/src/components/lookup-tables/DataAdapterForm.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/DataAdapterForm.jsx
@@ -108,7 +108,7 @@ class DataAdapterForm extends React.Component {
       // when creating always initially auto-generate the adapter name,
       // this will be false if the user changed the adapter name manually
       generateAdapterName: create,
-      isFormDisabled: true,
+      isFormDisabled: false,
       dataAdapter: {
         id: adapter.id,
         title: adapter.title,
@@ -363,7 +363,7 @@ class DataAdapterForm extends React.Component {
               <fieldset>
                 <Row>
                   <Col mdOffset={3} md={9}>
-                    <Button type="submit" bsStyle="success" disabled={!isFormDisabled}>{create ? 'Create Adapter'
+                    <Button type="submit" bsStyle="success" disabled={isFormDisabled}>{create ? 'Create Adapter'
                       : 'Update Adapter'}
                     </Button>
                   </Col>

--- a/graylog2-web-interface/src/components/lookup-tables/DataAdapterForm.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/DataAdapterForm.jsx
@@ -22,7 +22,7 @@ import { PluginStore } from 'graylog-web-plugin/plugin';
 import { Col, Row, Button } from 'components/graylog';
 import { Input } from 'components/bootstrap';
 import ObjectUtils from 'util/ObjectUtils';
-import FormsUtils from 'util/FormsUtils';
+import { getValueFromInput } from 'util/FormsUtils';
 import CombinedProvider from 'injection/CombinedProvider';
 import { TimeUnitInput } from 'components/common';
 
@@ -108,6 +108,7 @@ class DataAdapterForm extends React.Component {
       // when creating always initially auto-generate the adapter name,
       // this will be false if the user changed the adapter name manually
       generateAdapterName: create,
+      isFormExternalyValidated: true,
       dataAdapter: {
         id: adapter.id,
         title: adapter.title,
@@ -128,6 +129,10 @@ class DataAdapterForm extends React.Component {
     }
   };
 
+  _setExternalValidationState = (formValidationState) => {
+    this.setState({ isFormExternalyValidated: formValidationState });
+  };
+
   _validate = (adapter) => {
     const { validate } = this.props;
 
@@ -143,7 +148,7 @@ class DataAdapterForm extends React.Component {
     const { dataAdapter: dataAdapterState } = this.state;
     const dataAdapter = ObjectUtils.clone(dataAdapterState);
 
-    dataAdapter[event.target.name] = FormsUtils.getValueFromInput(event.target);
+    dataAdapter[event.target.name] = getValueFromInput(event.target);
     let { generateAdapterName } = this.state;
 
     if (generateAdapterName && event.target.name === 'title') {
@@ -164,7 +169,7 @@ class DataAdapterForm extends React.Component {
     const { dataAdapter: dataAdapterState } = this.state;
     const dataAdapter = ObjectUtils.clone(dataAdapterState);
 
-    dataAdapter.config[event.target.name] = FormsUtils.getValueFromInput(event.target);
+    dataAdapter.config[event.target.name] = getValueFromInput(event.target);
     this._validate(dataAdapter);
     this.setState({ dataAdapter: dataAdapter });
   };
@@ -257,7 +262,7 @@ class DataAdapterForm extends React.Component {
   };
 
   render() {
-    const { dataAdapter } = this.state;
+    const { dataAdapter, isFormExternalyValidated } = this.state;
     const { create, type, title } = this.props;
     const adapterPlugins = PluginStore.exports('lookupTableAdapters');
 
@@ -277,6 +282,7 @@ class DataAdapterForm extends React.Component {
         updateConfig: this._updateConfig,
         validationMessage: this._validationMessage,
         validationState: this._validationState,
+        setIsFormExternalyValid: this._setExternalValidationState,
       });
 
       if (p.documentationComponent) {
@@ -357,7 +363,7 @@ class DataAdapterForm extends React.Component {
               <fieldset>
                 <Row>
                   <Col mdOffset={3} md={9}>
-                    <Button type="submit" bsStyle="success">{create ? 'Create Adapter'
+                    <Button type="submit" bsStyle="success" disabled={!isFormExternalyValidated}>{create ? 'Create Adapter'
                       : 'Update Adapter'}
                     </Button>
                   </Col>

--- a/graylog2-web-interface/src/components/lookup-tables/DataAdapterForm.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/DataAdapterForm.jsx
@@ -129,8 +129,8 @@ class DataAdapterForm extends React.Component {
     }
   };
 
-  _setIsFormDisabled = (formValidationState) => {
-    this.setState({ isFormDisabled: formValidationState });
+  _setIsFormDisabled = (isDisabled) => {
+    this.setState({ isFormDisabled: isDisabled });
   };
 
   _validate = (adapter) => {


### PR DESCRIPTION
These changes add a new `isFormExternalyValidated`  state to  `DataAdapterForm` to allow children component to control (disable or enable) the form submit button.

/jenkins-pr-deps Graylog2/graylog-plugin-cloud#617

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
For the CSV File upload plugin, this allows the submit button to be disabled when the file is being uploaded.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

