### PR TITLE
Fix missing license header in newly commited file

### DIFF
--- a/graylog2-web-interface/src/views/components/common/UserTimezoneTimestamp.test.tsx
+++ b/graylog2-web-interface/src/views/components/common/UserTimezoneTimestamp.test.tsx
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 import * as React from 'react';
 import { render, screen } from 'wrappedTestingLibrary';
 import asMock from 'helpers/mocking/AsMock';


### PR DESCRIPTION
## Motivation
Prior to this change, we missed to add a license to a new frontend test.

## Description
This change will add this missing license
