### PR TITLE
Use MessageQueueAcknowledger instead of Journal

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/processors/PipelineInterpreter.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/processors/PipelineInterpreter.java
@@ -47,7 +47,7 @@ import org.graylog2.plugin.Messages;
 import org.graylog2.plugin.messageprocessors.MessageProcessor;
 import org.graylog2.plugin.streams.Stream;
 import org.graylog2.shared.buffers.processors.ProcessBufferProcessor;
-import org.graylog2.shared.journal.Journal;
+import org.graylog2.shared.messageq.MessageQueueAcknowledger;
 import org.graylog2.shared.metrics.MetricUtils;
 import org.graylog2.shared.utilities.ExceptionUtils;
 import org.jooq.lambda.tuple.Tuple2;
@@ -71,18 +71,18 @@ import static org.jooq.lambda.tuple.Tuple.tuple;
 public class PipelineInterpreter implements MessageProcessor {
     private static final Logger log = LoggerFactory.getLogger(PipelineInterpreter.class);
 
-    private final Journal journal;
+    private final MessageQueueAcknowledger messageQueueAcknowledger;
     private final Meter filteredOutMessages;
     private final Timer executionTime;
     private final MetricRegistry metricRegistry;
     private final ConfigurationStateUpdater stateUpdater;
 
     @Inject
-    public PipelineInterpreter(Journal journal,
+    public PipelineInterpreter(MessageQueueAcknowledger messageQueueAcknowledger,
                                MetricRegistry metricRegistry,
                                ConfigurationStateUpdater stateUpdater) {
 
-        this.journal = journal;
+        this.messageQueueAcknowledger = messageQueueAcknowledger;
         this.filteredOutMessages = metricRegistry.meter(name(ProcessBufferProcessor.class, "filteredOutMessages"));
         this.executionTime = metricRegistry.timer(name(PipelineInterpreter.class, "executionTime"));
         this.metricRegistry = metricRegistry;
@@ -175,7 +175,7 @@ public class PipelineInterpreter implements MessageProcessor {
         if (message.getFilterOut()) {
             log.debug("[{}] marked message to be discarded. Dropping message.", message.getId());
             filteredOutMessages.mark();
-            journal.markJournalOffsetCommitted(message.getJournalOffset());
+            messageQueueAcknowledger.acknowledge(message.getMessageQueueId());
         }
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/messageprocessors/MessageFilterChainProcessor.java
+++ b/graylog2-server/src/main/java/org/graylog2/messageprocessors/MessageFilterChainProcessor.java
@@ -28,7 +28,7 @@ import org.graylog2.plugin.ServerStatus;
 import org.graylog2.plugin.filters.MessageFilter;
 import org.graylog2.plugin.messageprocessors.MessageProcessor;
 import org.graylog2.shared.buffers.processors.ProcessBufferProcessor;
-import org.graylog2.shared.journal.Journal;
+import org.graylog2.shared.messageq.MessageQueueAcknowledger;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -56,17 +56,17 @@ public class MessageFilterChainProcessor implements MessageProcessor {
 
     private final List<MessageFilter> filterRegistry;
     private final MetricRegistry metricRegistry;
-    private final Journal journal;
+    private final MessageQueueAcknowledger messageQueueAcknowledger;
     private final ServerStatus serverStatus;
     private final Meter filteredOutMessages;
 
     @Inject
     public MessageFilterChainProcessor(MetricRegistry metricRegistry,
                                        Set<MessageFilter> filterRegistry,
-                                       Journal journal,
+                                       MessageQueueAcknowledger messageQueueAcknowledger,
                                        ServerStatus serverStatus) {
         this.metricRegistry = metricRegistry;
-        this.journal = journal;
+        this.messageQueueAcknowledger = messageQueueAcknowledger;
         this.serverStatus = serverStatus;
         // we need to keep this sorted properly, so that the filters run in the correct order
         this.filterRegistry = Ordering.from(new Comparator<MessageFilter>() {
@@ -103,7 +103,7 @@ public class MessageFilterChainProcessor implements MessageProcessor {
                                 msg.getId());
                         msg.setFilterOut(true);
                         filteredOutMessages.mark();
-                        journal.markJournalOffsetCommitted(msg.getJournalOffset());
+                        messageQueueAcknowledger.acknowledge(msg.getMessageQueueId());
                     }
                 } catch (Exception e) {
                     LOG.error("Could not apply filter [" + filter.getName() + "] on message <" + msg.getId() + ">: ",

--- a/graylog2-server/src/main/java/org/graylog2/outputs/BenchmarkOutput.java
+++ b/graylog2-server/src/main/java/org/graylog2/outputs/BenchmarkOutput.java
@@ -28,7 +28,7 @@ import org.graylog2.plugin.Message;
 import org.graylog2.plugin.configuration.Configuration;
 import org.graylog2.plugin.outputs.MessageOutput;
 import org.graylog2.plugin.streams.Stream;
-import org.graylog2.shared.journal.Journal;
+import org.graylog2.shared.messageq.MessageQueueAcknowledger;
 
 import javax.inject.Inject;
 import java.io.File;
@@ -36,6 +36,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
 
 import static com.codahale.metrics.MetricRegistry.name;
 
@@ -45,19 +46,19 @@ public class BenchmarkOutput implements MessageOutput {
     private final AtomicBoolean isRunning = new AtomicBoolean(false);
     private final Meter messagesWritten;
     private final CsvReporter csvReporter;
-    private final Journal journal;
+    private final MessageQueueAcknowledger messageQueueAcknowledger;
 
     @AssistedInject
     public BenchmarkOutput(final MetricRegistry metricRegistry,
-                           final Journal journal,
+                           final MessageQueueAcknowledger messageQueueAcknowledger,
                            @Assisted Stream stream,
                            @Assisted Configuration configuration) {
-        this(metricRegistry, journal);
+        this(metricRegistry, messageQueueAcknowledger);
     }
 
     @Inject
-    public BenchmarkOutput(final MetricRegistry metricRegistry, final Journal journal) {
-        this.journal = journal;
+    public BenchmarkOutput(final MetricRegistry metricRegistry, MessageQueueAcknowledger messageQueueAcknowledger) {
+        this.messageQueueAcknowledger = messageQueueAcknowledger;
         this.messagesWritten = metricRegistry.meter(name(this.getClass(), "messagesWritten"));
 
         final File directory = new File("benchmark-csv");
@@ -89,19 +90,13 @@ public class BenchmarkOutput implements MessageOutput {
 
     @Override
     public void write(Message message) throws Exception {
-        journal.markJournalOffsetCommitted(message.getJournalOffset());
+        messageQueueAcknowledger.acknowledge(message.getMessageQueueId());
         messagesWritten.mark();
     }
 
     @Override
     public void write(List<Message> messages) throws Exception {
-        long maxOffset = Long.MIN_VALUE;
-
-        for (final Message message : messages) {
-            maxOffset = Math.max(message.getJournalOffset(), maxOffset);
-        }
-
-        journal.markJournalOffsetCommitted(maxOffset);
+        messageQueueAcknowledger.acknowledge(messages.stream().map(Message::getMessageQueueId).collect(Collectors.toList()));
 
         messagesWritten.mark(messages.size());
     }

--- a/graylog2-server/src/main/java/org/graylog2/outputs/DiscardMessageOutput.java
+++ b/graylog2-server/src/main/java/org/graylog2/outputs/DiscardMessageOutput.java
@@ -22,33 +22,33 @@ import com.google.inject.assistedinject.Assisted;
 import com.google.inject.assistedinject.AssistedInject;
 import org.graylog2.plugin.Message;
 import org.graylog2.plugin.configuration.Configuration;
-import org.graylog2.plugin.configuration.ConfigurationRequest;
 import org.graylog2.plugin.outputs.MessageOutput;
 import org.graylog2.plugin.streams.Stream;
-import org.graylog2.shared.journal.Journal;
+import org.graylog2.shared.messageq.MessageQueueAcknowledger;
 
 import javax.inject.Inject;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
 
 import static com.codahale.metrics.MetricRegistry.name;
 
 public class DiscardMessageOutput implements MessageOutput {
     private final AtomicBoolean isRunning = new AtomicBoolean(false);
-    private final Journal journal;
+    private final MessageQueueAcknowledger messageQueueAcknowledger;
     private final Meter messagesDiscarded;
 
     @AssistedInject
-    public DiscardMessageOutput(final Journal journal,
+    public DiscardMessageOutput(final MessageQueueAcknowledger messageQueueAcknowledger,
                                 final MetricRegistry metricRegistry,
                                 @Assisted Stream stream,
                                 @Assisted Configuration configuration) {
-        this(journal, metricRegistry);
+        this(messageQueueAcknowledger, metricRegistry);
     }
 
     @Inject
-    public DiscardMessageOutput(final Journal journal, final MetricRegistry metricRegistry) {
-        this.journal = journal;
+    public DiscardMessageOutput(final MessageQueueAcknowledger messageQueueAcknowledger, final MetricRegistry metricRegistry) {
+        this.messageQueueAcknowledger = messageQueueAcknowledger;
         this.messagesDiscarded = metricRegistry.meter(name(this.getClass(), "messagesDiscarded"));
         isRunning.set(true);
     }
@@ -65,7 +65,7 @@ public class DiscardMessageOutput implements MessageOutput {
 
     @Override
     public void write(Message message) throws Exception {
-        journal.markJournalOffsetCommitted(message.getJournalOffset());
+        messageQueueAcknowledger.acknowledge(message.getMessageQueueId());
         messagesDiscarded.mark();
     }
 
@@ -73,11 +73,7 @@ public class DiscardMessageOutput implements MessageOutput {
     public void write(List<Message> messages) throws Exception {
         long maxOffset = Long.MIN_VALUE;
 
-        for (final Message message : messages) {
-            maxOffset = Math.max(message.getJournalOffset(), maxOffset);
-        }
-
-        journal.markJournalOffsetCommitted(maxOffset);
+        messageQueueAcknowledger.acknowledge(messages.stream().map(Message::getMessageQueueId).collect(Collectors.toList()));
         messagesDiscarded.mark(messages.size());
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/shared/buffers/processors/DecodingProcessor.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/buffers/processors/DecodingProcessor.java
@@ -98,7 +98,6 @@ public class DecodingProcessor implements EventHandler<MessageEvent> {
 
             // Mark message as processed to avoid keeping it in the journal.
             acknowledger.acknowledge(rawMessage.getMessageQueueId());
-            journal.markJournalOffsetCommitted(rawMessage.getJournalOffset());
 
             // always clear the event fields, even if they are null, to avoid later stages to process old messages.
             // basically this will make sure old messages are cleared out early.

--- a/graylog2-server/src/main/java/org/graylog2/shared/messageq/MessageQueueAcknowledger.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/messageq/MessageQueueAcknowledger.java
@@ -20,7 +20,7 @@ import java.util.List;
 
 public interface MessageQueueAcknowledger {
 
-    void acknowledge(Object messageId) throws MessageQueueException;
+    void acknowledge(Object messageId);
 
-    void acknowledge(List<Object> messageIds) throws MessageQueueException;
+    void acknowledge(List<Object> messageIds);
 }

--- a/graylog2-server/src/main/java/org/graylog2/shared/messageq/kafka/KafkaMessageQueueAcknowledger.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/messageq/kafka/KafkaMessageQueueAcknowledger.java
@@ -18,13 +18,15 @@ package org.graylog2.shared.messageq.kafka;
 
 import org.graylog2.shared.journal.KafkaJournal;
 import org.graylog2.shared.messageq.MessageQueueAcknowledger;
-import org.graylog2.shared.messageq.MessageQueueException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import java.util.List;
 import java.util.Optional;
 
 public class KafkaMessageQueueAcknowledger implements MessageQueueAcknowledger {
+    private static final Logger LOG = LoggerFactory.getLogger(KafkaMessageQueueAcknowledger.class);
     private KafkaJournal kafkaJournal;
 
     @Inject
@@ -33,16 +35,16 @@ public class KafkaMessageQueueAcknowledger implements MessageQueueAcknowledger {
     }
 
     @Override
-    public void acknowledge(Object messageId) throws MessageQueueException {
+    public void acknowledge(Object messageId) {
         if (messageId instanceof Long) {
             kafkaJournal.markJournalOffsetCommitted((Long) messageId);
         } else {
-            throw new MessageQueueException("Couldn't acknowledge unknown message type <" + messageId + ">");
+            LOG.error("Couldn't acknowledge message. Expected <" + messageId + "> to be a Long");
         }
     }
 
     @Override
-    public void acknowledge(List<Object> messageIds) throws MessageQueueException {
+    public void acknowledge(List<Object> messageIds) {
         final Optional<Long> max = messageIds.stream().filter(Long.class::isInstance).map(Long.class::cast).max(Long::compare);
         if (max.isPresent()) {
             acknowledge(max.get());

--- a/graylog2-server/src/main/java/org/graylog2/shared/messageq/pulsar/PulsarMessageQueueAcknowledger.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/messageq/pulsar/PulsarMessageQueueAcknowledger.java
@@ -17,7 +17,6 @@
 package org.graylog2.shared.messageq.pulsar;
 
 import org.graylog2.shared.messageq.MessageQueueAcknowledger;
-import org.graylog2.shared.messageq.MessageQueueException;
 
 import javax.inject.Inject;
 import java.util.List;
@@ -31,12 +30,12 @@ public class PulsarMessageQueueAcknowledger implements MessageQueueAcknowledger 
     }
 
     @Override
-    public void acknowledge(Object messageId) throws MessageQueueException {
+    public void acknowledge(Object messageId) {
         pulsarMessageQueueReader.commit(messageId);
     }
 
     @Override
-    public void acknowledge(List<Object> messageIds) throws MessageQueueException {
+    public void acknowledge(List<Object> messageIds) {
         for (Object messageId : messageIds) {
             pulsarMessageQueueReader.commit(messageId);
         }

--- a/graylog2-server/src/main/java/org/graylog2/shared/messageq/pulsar/PulsarMessageQueueReader.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/messageq/pulsar/PulsarMessageQueueReader.java
@@ -159,15 +159,15 @@ public class PulsarMessageQueueReader extends AbstractExecutionThreadService imp
     }
 
     @Override
-    public void commit(Object messageId) throws MessageQueueException {
+    public void commit(Object messageId) {
         if (messageId instanceof MessageId) {
             try {
                 consumer.acknowledge((MessageId) messageId);
             } catch (PulsarClientException e) {
-                throw new MessageQueueException("Couldn't acknowledge message", e);
+                LOG.error("Couldn't acknowledge message", e);
             }
         } else {
-            throw new MessageQueueException("Couldn't acknowledge unknown message type <" + messageId + ">");
+            LOG.error("Couldn't acknowledge message. Expected <" + messageId + "> to be a MessageId");
         }
     }
 

--- a/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/processors/PipelineInterpreterTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/processors/PipelineInterpreterTest.java
@@ -52,7 +52,7 @@ import org.graylog2.plugin.Messages;
 import org.graylog2.plugin.Tools;
 import org.graylog2.plugin.streams.Stream;
 import org.graylog2.shared.SuppressForbidden;
-import org.graylog2.shared.journal.Journal;
+import org.graylog2.shared.messageq.MessageQueueAcknowledger;
 import org.junit.Test;
 
 import java.util.Collections;
@@ -271,7 +271,7 @@ public class PipelineInterpreterTest {
                 (currentPipelines, streamPipelineConnections, ruleMetricsConfig) -> new PipelineInterpreter.State(currentPipelines, streamPipelineConnections, ruleMetricsConfig, new MetricRegistry(), 1, true),
                 false);
         return new PipelineInterpreter(
-                mock(Journal.class),
+                mock(MessageQueueAcknowledger.class),
                 new MetricRegistry(),
                 stateUpdater
         );
@@ -328,7 +328,7 @@ public class PipelineInterpreterTest {
                 (currentPipelines, streamPipelineConnections, ruleMetricsConfig) -> new PipelineInterpreter.State(currentPipelines, streamPipelineConnections, ruleMetricsConfig, new MetricRegistry(), 1, true),
                 false);
         final PipelineInterpreter interpreter = new PipelineInterpreter(
-                mock(Journal.class),
+                mock(MessageQueueAcknowledger.class),
                 metricRegistry,
                 stateUpdater
         );

--- a/graylog2-server/src/test/java/org/graylog2/messageprocessors/MessageFilterChainProcessorTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/messageprocessors/MessageFilterChainProcessorTest.java
@@ -24,7 +24,7 @@ import org.graylog2.plugin.Messages;
 import org.graylog2.plugin.ServerStatus;
 import org.graylog2.plugin.Tools;
 import org.graylog2.plugin.filters.MessageFilter;
-import org.graylog2.shared.journal.Journal;
+import org.graylog2.shared.messageq.MessageQueueAcknowledger;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.junit.Assert;
@@ -49,7 +49,7 @@ public class MessageFilterChainProcessorTest {
     @Mock
     private ServerStatus serverStatus;
     @Mock
-    private Journal journal;
+    private MessageQueueAcknowledger acknowledger;
 
     @Before
     public void setUp() throws Exception {
@@ -64,7 +64,7 @@ public class MessageFilterChainProcessorTest {
         final Set<MessageFilter> filters = ImmutableSet.of(third, first, second);
         final MessageFilterChainProcessor processor = new MessageFilterChainProcessor(new MetricRegistry(),
                                                                                       filters,
-                                                                                      journal,
+                                                                                      acknowledger,
                                                                                       serverStatus);
         final List<MessageFilter> filterRegistry = processor.getFilterRegistry();
 
@@ -78,7 +78,7 @@ public class MessageFilterChainProcessorTest {
         try {
             new MessageFilterChainProcessor(new MetricRegistry(),
                                             Collections.emptySet(),
-                                            journal,
+                                            acknowledger,
                                             serverStatus);
             Assert.fail("A processor without message filters should fail on creation");
         } catch (RuntimeException ignored) {}
@@ -113,7 +113,7 @@ public class MessageFilterChainProcessorTest {
 
         final MessageFilterChainProcessor filterTest = new MessageFilterChainProcessor(new MetricRegistry(),
                                                                                        Collections.singleton(filterOnlyFirst),
-                                                                                       journal,
+                                                                                       acknowledger,
                                                                                        serverStatus);
         Message filteredoutMessage = new Message("filtered out", "source", Tools.nowUTC());
         filteredoutMessage.setJournalOffset(1);
@@ -136,7 +136,7 @@ public class MessageFilterChainProcessorTest {
         final Set<MessageFilter> filters = ImmutableSet.of(first, second, third);
         final MessageFilterChainProcessor processor = new MessageFilterChainProcessor(new MetricRegistry(),
                 filters,
-                journal,
+                acknowledger,
                 serverStatus);
 
         final Message message = new Message("message", "source", new DateTime(2016, 1, 1, 0, 0, DateTimeZone.UTC));
@@ -153,7 +153,7 @@ public class MessageFilterChainProcessorTest {
         final Set<MessageFilter> filters = ImmutableSet.of(first, second);
         final MessageFilterChainProcessor processor = new MessageFilterChainProcessor(new MetricRegistry(),
                 filters,
-                journal,
+                acknowledger,
                 serverStatus);
 
         final Message message = new Message("message", "source", new DateTime(2016, 1, 1, 0, 0, DateTimeZone.UTC));


### PR DESCRIPTION

Log exception instead of throwing it in `acknowledge()`
We don't know how to recover from it anyhow.
So instead of handling that exception everywhere, keep it simple.
