### PR TITLE
Support for better integration of Token creation from Forwarder wizard

### DIFF
--- a/graylog2-web-interface/src/actions/users/UsersActions.js
+++ b/graylog2-web-interface/src/actions/users/UsersActions.js
@@ -40,6 +40,7 @@ export type UserUpdate = $Shape<UserCreate & {
 }>;
 
 export type Token = {
+  id: string,
   token_name: string,
   token: string,
   last_access: string,

--- a/graylog2-web-interface/src/actions/users/UsersActions.js
+++ b/graylog2-web-interface/src/actions/users/UsersActions.js
@@ -41,7 +41,7 @@ export type UserUpdate = $Shape<UserCreate & {
 
 export type Token = {
   id: string,
-  token_name: string,
+  name: string,
   token: string,
   last_access: string,
 };

--- a/graylog2-web-interface/src/components/graylog/Panel.jsx
+++ b/graylog2-web-interface/src/components/graylog/Panel.jsx
@@ -14,7 +14,7 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
 // eslint-disable-next-line no-restricted-imports
@@ -163,12 +163,17 @@ const Panel = ({
   ...props
 }) => {
   const [isExpanded, setIsExpanded] = useState(null);
+  const didRender = useRef(false);
 
   useEffect(() => {
-    setIsExpanded((defaultExpanded && expanded)
-      || (!defaultExpanded && expanded)
-      || (defaultExpanded && isExpanded === expanded));
-  }, [expanded]);
+    setIsExpanded((prevIsExpanded) => ((defaultExpanded && expanded)
+        || (!defaultExpanded && expanded)
+        || (defaultExpanded && prevIsExpanded === expanded)));
+  }, [expanded, defaultExpanded]);
+
+  useEffect(() => {
+    didRender.current = true;
+  }, []);
 
   const handleToggle = (nextIsExpanded) => {
     setIsExpanded(nextIsExpanded);
@@ -179,9 +184,9 @@ const Panel = ({
 
   if (header || footer || title || collapsible || hasDeprecatedChildren) {
     /** NOTE: Deprecated & should be removed in 4.0 */
-    useEffect(() => {
+    if (!didRender.current) {
       deprecationNotice('You have used a deprecated `Panel` prop, please check the documentation to use the latest `Panel`.');
-    }, []);
+    }
 
     return (
       /* NOTE: this exists as a deprecated render for older Panel instances */

--- a/graylog2-web-interface/src/components/graylog/Panel.jsx
+++ b/graylog2-web-interface/src/components/graylog/Panel.jsx
@@ -162,7 +162,7 @@ const Panel = ({
   onToggle,
   ...props
 }) => {
-  const [isExpanded, setIsExpanded] = useState(false);
+  const [isExpanded, setIsExpanded] = useState(null);
 
   useEffect(() => {
     setIsExpanded((defaultExpanded && expanded)
@@ -225,7 +225,7 @@ Panel.propTypes = {
    */
   defaultExpanded: PropTypes.bool,
   /**
-   * Controls the collapsed/expanded state ofthe Panel. Requires
+   * Controls the collapsed/expanded state of the Panel. Requires
    * a `Panel.Collapse` or `<Panel.Body collapsible>` child component
    * in order to actually animate out or in.
    *
@@ -249,7 +249,7 @@ Panel.propTypes = {
 Panel.defaultProps = {
   collapsible: false,
   defaultExpanded: null,
-  expanded: false,
+  expanded: null,
   footer: undefined,
   header: undefined,
   onToggle: () => {},

--- a/graylog2-web-interface/src/components/users/CreateTokenForm.jsx
+++ b/graylog2-web-interface/src/components/users/CreateTokenForm.jsx
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+// @flow strict
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import styled, { type StyledComponent } from 'styled-components';
+
+import { Button, Col, ControlLabel, FormControl, FormGroup, HelpBlock, Row } from 'components/graylog';
+import { Spinner } from 'components/common';
+
+const StyledForm: StyledComponent<{}, void, HTMLFormElement> = styled.form`
+  margin-top: 10px;
+`;
+
+const StyledControlLabel: StyledComponent<{}, void, ControlLabel> = styled(ControlLabel)`
+  margin-top: 8px;
+`;
+
+type Props = {
+  creatingToken: boolean,
+  onCreate: (tokenName: string) => void,
+};
+
+const CreateTokenForm = ({ creatingToken, onCreate }: Props) => {
+  const [tokenName, setTokenName] = useState('');
+
+  const createToken = (event) => {
+    event.preventDefault();
+    onCreate(tokenName);
+    setTokenName('');
+  };
+
+  return (
+    <StyledForm onSubmit={createToken}>
+      <FormGroup>
+        <Row>
+          <Col sm={2}>
+            <StyledControlLabel>Token Name</StyledControlLabel>
+          </Col>
+          <Col sm={4}>
+            <FormControl id="create-token-input"
+                         type="text"
+                         value={tokenName}
+                         onChange={(event) => setTokenName(event.target.value)} />
+            <HelpBlock>Descriptive name for this Token.</HelpBlock>
+          </Col>
+          <Col sm={2}>
+            <Button id="create-token"
+                    disabled={tokenName === '' || creatingToken}
+                    type="submit"
+                    bsStyle="primary">
+              {(creatingToken ? <Spinner text="Creating..." /> : 'Create Token')}
+            </Button>
+          </Col>
+        </Row>
+      </FormGroup>
+      <hr />
+    </StyledForm>
+  );
+};
+
+CreateTokenForm.propTypes = {
+  creatingToken: PropTypes.bool,
+  onCreate: PropTypes.func.isRequired,
+};
+
+CreateTokenForm.defaultProps = {
+  creatingToken: false,
+};
+
+export default CreateTokenForm;

--- a/graylog2-web-interface/src/components/users/CreateTokenForm.jsx
+++ b/graylog2-web-interface/src/components/users/CreateTokenForm.jsx
@@ -19,15 +19,17 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import styled, { type StyledComponent } from 'styled-components';
 
-import { Button, Col, ControlLabel, FormControl, FormGroup, HelpBlock, Row } from 'components/graylog';
+import { Button, ControlLabel, FormControl, FormGroup } from 'components/graylog';
 import { Spinner } from 'components/common';
 
 const StyledForm: StyledComponent<{}, void, HTMLFormElement> = styled.form`
   margin-top: 10px;
-`;
-
-const StyledControlLabel: StyledComponent<{}, void, ControlLabel> = styled(ControlLabel)`
-  margin-top: 8px;
+  &.form-inline > .form-group {
+    margin-right: 10px;
+    > input {
+      width: 300px;
+    }
+  }
 `;
 
 type Props = {
@@ -45,30 +47,20 @@ const CreateTokenForm = ({ creatingToken, onCreate }: Props) => {
   };
 
   return (
-    <StyledForm onSubmit={createToken}>
-      <FormGroup>
-        <Row>
-          <Col sm={2}>
-            <StyledControlLabel>Token Name</StyledControlLabel>
-          </Col>
-          <Col sm={4}>
-            <FormControl id="create-token-input"
-                         type="text"
-                         value={tokenName}
-                         onChange={(event) => setTokenName(event.target.value)} />
-            <HelpBlock>Descriptive name for this Token.</HelpBlock>
-          </Col>
-          <Col sm={2}>
-            <Button id="create-token"
-                    disabled={tokenName === '' || creatingToken}
-                    type="submit"
-                    bsStyle="primary">
-              {(creatingToken ? <Spinner text="Creating..." /> : 'Create Token')}
-            </Button>
-          </Col>
-        </Row>
+    <StyledForm className="form-inline" onSubmit={createToken}>
+      <FormGroup controlId="create-token-input">
+        <ControlLabel>Token Name</ControlLabel>
+        <FormControl type="text"
+                     placeholder="What is this token for?"
+                     value={tokenName}
+                     onChange={(event) => setTokenName(event.target.value)} />
       </FormGroup>
-      <hr />
+      <Button id="create-token"
+              disabled={tokenName === '' || creatingToken}
+              type="submit"
+              bsStyle="primary">
+        {(creatingToken ? <Spinner text="Creating..." /> : 'Create Token')}
+      </Button>
     </StyledForm>
   );
 };

--- a/graylog2-web-interface/src/components/users/TokenList.css
+++ b/graylog2-web-interface/src/components/users/TokenList.css
@@ -1,3 +1,0 @@
-:local(.tokenNewNameLabel) {
-    margin-top: 8px;
-}

--- a/graylog2-web-interface/src/components/users/TokenList.jsx
+++ b/graylog2-web-interface/src/components/users/TokenList.jsx
@@ -65,6 +65,7 @@ const TokenList = ({ creatingToken, deletingToken, onCreate, onDelete, tokens }:
   return (
     <span>
       <CreateTokenForm onCreate={onCreate} creatingToken={creatingToken} />
+      <hr />
       <TableList filterKeys={['name', 'token']}
                  items={List(tokens)}
                  idKey="token"

--- a/graylog2-web-interface/src/components/users/TokenList.jsx
+++ b/graylog2-web-interface/src/components/users/TokenList.jsx
@@ -19,11 +19,11 @@ import React from 'react';
 import Immutable from 'immutable';
 
 import ClipboardButton from 'components/common/ClipboardButton';
-import { Button, Row, Col, FormControl, ControlLabel, Checkbox, ButtonGroup } from 'components/graylog';
+import { Button, Checkbox, ButtonGroup } from 'components/graylog';
 import TableList from 'components/common/TableList';
 import Spinner from 'components/common/Spinner';
 
-import TokenListStyle from './TokenList.css';
+import CreateTokenForm from './CreateTokenForm';
 
 class TokenList extends React.Component {
   static propTypes = {
@@ -46,18 +46,11 @@ class TokenList extends React.Component {
     super(props);
 
     this.state = {
-      token_name: '',
       hide_tokens: true,
     };
 
-    this._onNewTokeChanged = this._onNewTokeChanged.bind(this);
     this._onShowTokensChanged = this._onShowTokensChanged.bind(this);
-    this._createToken = this._createToken.bind(this);
     this.itemActionsFactory = this.itemActionsFactory.bind(this);
-  }
-
-  _onNewTokeChanged(event) {
-    this.setState({ token_name: event.target.value });
   }
 
   _onShowTokensChanged(event) {
@@ -68,12 +61,6 @@ class TokenList extends React.Component {
     return () => {
       this.props.onDelete(token.id, token.name);
     };
-  }
-
-  _createToken(e) {
-    this.props.onCreate(this.state.token_name);
-    this.setState({ token_name: '' });
-    e.preventDefault();
   }
 
   itemActionsFactory(token) {
@@ -93,47 +80,21 @@ class TokenList extends React.Component {
   }
 
   render() {
-    const submitButton = (this.props.creatingToken ? <Spinner text="Creating..." /> : 'Create Token');
-
-    const createTokenForm = (
-      <form onSubmit={this._createToken}>
-        <div className="form-group">
-          <Row>
-            <Col sm={2}>
-              <ControlLabel className={TokenListStyle.tokenNewNameLabel}>Token Name</ControlLabel>
-            </Col>
-            <Col sm={4}>
-              <FormControl id="create-token-input"
-                           type="text"
-                           placeholder="e.g ServiceName"
-                           value={this.state.token_name}
-                           onChange={this._onNewTokeChanged} />
-            </Col>
-            <Col sm={2}>
-              <Button id="create-token"
-                      disabled={this.state.token_name === '' || this.props.creatingToken}
-                      type="submit"
-                      bsStyle="primary">{submitButton}
-              </Button>
-            </Col>
-          </Row>
-        </div>
-        <hr />
-      </form>
-    );
+    const { creatingToken, onCreate, tokens } = this.props;
+    const { hide_tokens: hideTokens } = this.state;
 
     return (
       <span>
-        {createTokenForm}
+        <CreateTokenForm onCreate={onCreate} creatingToken={creatingToken} />
         <TableList filterKeys={['name', 'token']}
-                   items={Immutable.List(this.props.tokens)}
+                   items={Immutable.List(tokens)}
                    idKey="token"
                    titleKey="name"
                    descriptionKey="token"
-                   hideDescription={this.state.hide_tokens}
+                   hideDescription={hideTokens}
                    enableBulkActions={false}
                    itemActionsFactory={this.itemActionsFactory} />
-        <Checkbox id="hide-tokens" onChange={this._onShowTokensChanged} checked={this.state.hide_tokens}>
+        <Checkbox id="hide-tokens" onChange={this._onShowTokensChanged} checked={hideTokens}>
           Hide Tokens
         </Checkbox>
       </span>


### PR DESCRIPTION
- Extract create token form into a component that we can reuse
- Update Token type definition
- Remove default `expanded` value from `Panel`, since that threw an error in the console log: https://github.com/react-bootstrap/react-bootstrap/blob/v0.33.1/src/Panel.js#L99-L101

/jenkins-pr-deps Graylog2/graylog-plugin-cloud#620