### PR TITLE
Simplify `TimeoutUnitSelect` by removing no longer needed state handling

### DIFF
--- a/graylog2-web-interface/src/components/users/TimeoutUnitSelect.tsx
+++ b/graylog2-web-interface/src/components/users/TimeoutUnitSelect.tsx
@@ -25,27 +25,17 @@ const TimeoutSelect = styled(Select)`
   width: 150px;
 `;
 
-class TimeoutUnitSelect extends React.Component {
-  options = [
-    { value: `${MS_SECOND}`, label: 'Seconds' },
-    { value: `${MS_MINUTE}`, label: 'Minutes' },
-    { value: `${MS_HOUR}`, label: 'Hours' },
-    { value: `${MS_DAY}`, label: 'Days' },
-  ];
+const OPTIONS = [
+  { value: `${MS_SECOND}`, label: 'Seconds' },
+  { value: `${MS_MINUTE}`, label: 'Minutes' },
+  { value: `${MS_HOUR}`, label: 'Hours' },
+  { value: `${MS_DAY}`, label: 'Days' },
+];
 
-  sessionTimeoutUnit: undefined | { value: string };
-
-  getValue = () => {
-    return this.sessionTimeoutUnit.value;
-  };
-
-  render() {
-    return (
-      <TimeoutSelect ref={(sessionTimeoutUnit) => { this.sessionTimeoutUnit = sessionTimeoutUnit; }}
-                     options={this.options}
-                     {...this.props} />
-    );
-  }
-}
+const TimeoutUnitSelect = (props) => (
+  <TimeoutSelect {...props}
+                 inputProps={{ 'aria-label': 'Timeout unit' }}
+                 options={OPTIONS} />
+);
 
 export default TimeoutUnitSelect;


### PR DESCRIPTION
## Description
The form which imports the `TimeoutUnitSelect` is now using `onChange` to update its state.
The `TimeoutUnitSelect` state and ref handling is no longer needed.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)