### PR TITLE
Refactor the way we access the `GranteesSelector` state in `EntityShareModal` on save.

### DIFF
--- a/graylog2-web-interface/src/components/permissions/EntityShareModal.tsx
+++ b/graylog2-web-interface/src/components/permissions/EntityShareModal.tsx
@@ -16,6 +16,7 @@
  */
 import * as React from 'react';
 import { useRef, useEffect, useState } from 'react';
+import { FormikProps } from 'formik';
 import PropTypes from 'prop-types';
 import { $PropertyType } from 'utility-types';
 
@@ -27,8 +28,8 @@ import { EntityShareStore } from 'stores/permissions/EntityShareStore';
 import { EntitySharePayload } from 'actions/permissions/EntityShareActions';
 import SharedEntity from 'logic/permissions/SharedEntity';
 import BootstrapModalConfirm from 'components/bootstrap/BootstrapModalConfirm';
-import Select from 'components/common/Select';
 
+import type { FormValues as GranteesSelectFormValues } from './GranteesSelector';
 import EntityShareSettings from './EntityShareSettings';
 
 type Props = {
@@ -44,7 +45,7 @@ const EntityShareModal = ({ description, entityId, entityType, entityTitle, enti
   const { state: entityShareState } = useStore(EntityShareStore);
   const [disableSubmit, setDisableSubmit] = useState(entityShareState?.validationResults?.failed);
   const entityGRN = createGRN(entityType, entityId);
-  const granteesSelectRef = useRef<typeof Select>();
+  const granteesSelectFormRef = useRef<FormikProps<GranteesSelectFormValues>>();
 
   useEffect(() => {
     EntityShareDomain.prepare(entityType, entityTitle, entityGRN);
@@ -52,22 +53,16 @@ const EntityShareModal = ({ description, entityId, entityType, entityTitle, enti
 
   const _handleSave = () => {
     setDisableSubmit(true);
-    const granteesSelect = granteesSelectRef?.current;
-    const granteesSelectValue = granteesSelect?.state?.value;
-    const granteesSelectOptions = granteesSelect?.props?.options;
+    const selectedGranteeId = granteesSelectFormRef.current?.values?.granteeId;
     const payload: EntitySharePayload = {
       selected_grantee_capabilities: entityShareState.selectedGranteeCapabilities,
     };
 
-    if (granteesSelectValue) {
-      const selectedOption = granteesSelectOptions?.find((option) => option.value === granteesSelectValue);
-
-      if (!selectedOption) {
-        throw Error(`Can't find ${granteesSelectValue} in grantees select options on save`);
-      }
+    if (selectedGranteeId) {
+      const selectedGrantee = entityShareState?.availableGrantees.find((grantee) => grantee.id === selectedGranteeId);
 
       // eslint-disable-next-line no-alert
-      if (!window.confirm(`"${selectedOption.label}" got selected but was never added as a collaborator. Do you want to continue anyway?`)) {
+      if (!window.confirm(`${selectedGrantee.title ? `"${selectedGrantee.title}"` : 'An entity (name not found)'} got selected but was never added as a collaborator. Do you want to continue anyway?`)) {
         setDisableSubmit(false);
 
         return;
@@ -95,7 +90,7 @@ const EntityShareModal = ({ description, entityId, entityType, entityTitle, enti
                                entityType={entityType}
                                entityTitle={entityTitle}
                                entityShareState={entityShareState}
-                               granteesSelectRef={granteesSelectRef}
+                               granteesSelectFormRef={granteesSelectFormRef}
                                setDisableSubmit={setDisableSubmit} />
         ) : (
           <Spinner />

--- a/graylog2-web-interface/src/components/permissions/EntityShareSettings.tsx
+++ b/graylog2-web-interface/src/components/permissions/EntityShareSettings.tsx
@@ -26,7 +26,6 @@ import EntityShareState from 'logic/permissions/EntityShareState';
 import SharedEntity from 'logic/permissions/SharedEntity';
 import EntityShareDomain from 'domainActions/permissions/EntityShareDomain';
 import { EntitySharePayload } from 'actions/permissions/EntityShareActions';
-import { Select } from 'components/common';
 
 import GranteesSelector, { SelectionRequest, FormValues as GranteesSelectFormValues } from './GranteesSelector';
 import GranteesList from './GranteesList';

--- a/graylog2-web-interface/src/components/permissions/EntityShareSettings.tsx
+++ b/graylog2-web-interface/src/components/permissions/EntityShareSettings.tsx
@@ -19,6 +19,7 @@ import { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { $PropertyType } from 'utility-types';
+import { FormikProps } from 'formik';
 
 import type { GRN } from 'logic/permissions/types';
 import EntityShareState from 'logic/permissions/EntityShareState';
@@ -27,7 +28,7 @@ import EntityShareDomain from 'domainActions/permissions/EntityShareDomain';
 import { EntitySharePayload } from 'actions/permissions/EntityShareActions';
 import { Select } from 'components/common';
 
-import GranteesSelector, { SelectionRequest } from './GranteesSelector';
+import GranteesSelector, { SelectionRequest, FormValues as GranteesSelectFormValues } from './GranteesSelector';
 import GranteesList from './GranteesList';
 import DependenciesWarning from './DependenciesWarning';
 import ValidationError from './ValidationError';
@@ -40,7 +41,7 @@ type Props = {
   entityTitle: $PropertyType<SharedEntity, 'title'>,
   entityShareState: EntityShareState,
   setDisableSubmit: (boolean) => void,
-  granteesSelectRef: typeof Select | null | undefined,
+  granteesSelectFormRef: React.Ref<FormikProps<GranteesSelectFormValues>>,
 };
 
 const Section = styled.div`
@@ -76,7 +77,7 @@ const EntityShareSettings = ({
   entityType,
   entityTitle,
   setDisableSubmit,
-  granteesSelectRef,
+  granteesSelectFormRef,
 }: Props) => {
   const filteredGrantees = _filterAvailableGrantees(availableGrantees, selectedGranteeCapabilities);
 
@@ -120,7 +121,7 @@ const EntityShareSettings = ({
         <GranteesSelector availableGrantees={filteredGrantees}
                           availableCapabilities={availableCapabilities}
                           onSubmit={_handleSelection}
-                          granteesSelectRef={granteesSelectRef} />
+                          formRef={granteesSelectFormRef} />
       </Section>
       <Section>
         <GranteesList activeShares={activeShares}

--- a/graylog2-web-interface/src/components/permissions/GranteesSelector.test.tsx
+++ b/graylog2-web-interface/src/components/permissions/GranteesSelector.test.tsx
@@ -25,8 +25,7 @@ describe('GranteesSelector', () => {
     const { getByText } = render(
       <GranteesSelector availableGrantees={availableGrantees}
                         availableCapabilities={availableCapabilities}
-                        onSubmit={() => Promise.resolve(mockEntityShareState)}
-                        granteesSelectRef={undefined} />,
+                        onSubmit={() => Promise.resolve(mockEntityShareState)} />,
     );
 
     const submitButton = getByText('Add Collaborator');

--- a/graylog2-web-interface/src/components/permissions/GranteesSelector.tsx
+++ b/graylog2-web-interface/src/components/permissions/GranteesSelector.tsx
@@ -37,7 +37,7 @@ export type SelectionRequest = {
 
 export type FormValues = {
   granteeId: $PropertyType<Grantee, 'id'> | undefined,
-  capabilityId: $PropertyType<Capability, 'id'> | undefined,
+  capabilityId: $PropertyType<Capability, 'id'>,
 }
 
 type Props = {

--- a/graylog2-web-interface/src/components/permissions/GranteesSelector.tsx
+++ b/graylog2-web-interface/src/components/permissions/GranteesSelector.tsx
@@ -15,7 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { Formik, Form, Field } from 'formik';
+import { Formik, FormikProps, Form, Field } from 'formik';
 import { $PropertyType } from 'utility-types';
 import styled, { StyledComponent } from 'styled-components';
 
@@ -35,11 +35,16 @@ export type SelectionRequest = {
   capabilityId: $PropertyType<Capability, 'id'>,
 };
 
+export type FormValues = {
+  granteeId: $PropertyType<Grantee, 'id'> | undefined,
+  capabilityId: $PropertyType<Capability, 'id'> | undefined,
+}
+
 type Props = {
   availableGrantees: GranteesList,
   availableCapabilities: CapabilitiesList,
   className?: string,
-  granteesSelectRef: typeof Select | null | undefined,
+  formRef?: React.Ref<FormikProps<FormValues>>,
   onSubmit: (req: SelectionRequest) => Promise<EntityShareState | null | undefined>,
 };
 
@@ -107,7 +112,7 @@ const _renderGranteesSelectOption = ({ label, granteeType }: {label: string, gra
   </GranteesSelectOption>
 );
 
-const GranteesSelector = ({ availableGrantees, availableCapabilities, className, onSubmit, granteesSelectRef }: Props) => {
+const GranteesSelector = ({ availableGrantees, availableCapabilities, className, onSubmit, formRef }: Props) => {
   const granteesOptions = _granteesOptions(availableGrantees);
   const initialCapabilityId = _initialCapabilityId(availableCapabilities);
 
@@ -118,6 +123,7 @@ const GranteesSelector = ({ availableGrantees, availableCapabilities, className,
   return (
     <div className={className}>
       <Formik onSubmit={(data, { resetForm }) => _handelSubmit(data, resetForm)}
+              innerRef={formRef}
               initialValues={{ granteeId: undefined, capabilityId: initialCapabilityId }}>
         {({ isSubmitting, isValid, errors }) => (
           <Form>
@@ -129,7 +135,6 @@ const GranteesSelector = ({ availableGrantees, availableCapabilities, className,
                                     onChange={(granteeId) => onChange({ target: { value: granteeId, name } })}
                                     optionRenderer={_renderGranteesSelectOption}
                                     options={granteesOptions}
-                                    ref={granteesSelectRef}
                                     placeholder="Search for users and teams"
                                     value={value} />
                   )}
@@ -159,6 +164,7 @@ const GranteesSelector = ({ availableGrantees, availableCapabilities, className,
 
 GranteesSelector.defaultProps = {
   className: undefined,
+  formRef: undefined,
 };
 
 export default GranteesSelector;


### PR DESCRIPTION
## Description
Previously we used the `GranteesSelector` select ref to get the component props and state when saving the entity share modal. This is not a good practice. We need to access the state to check if the "Add collaborator" form got submitted when a user tries to save the share modal. If the "Add collaborator" form is not empty we display a confirm dialog.

With these changes we are just using the `GranteesSelector` form state. We get all other necessary information from the entity share state.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)