### PR TITLE
Hide enterprise request form on cloud

### DIFF
--- a/graylog2-web-interface/src/pages/EnterprisePage.jsx
+++ b/graylog2-web-interface/src/pages/EnterprisePage.jsx
@@ -28,6 +28,7 @@ import DocumentationLink from 'components/support/DocumentationLink';
 import EnterpriseFreeLicenseForm from 'components/enterprise/EnterpriseFreeLicenseForm';
 import PluginList from 'components/enterprise/PluginList';
 import CombinedProvider from 'injection/CombinedProvider';
+import HideOnCloud from 'util/conditional/HideOnCloud';
 
 const { EnterpriseActions, EnterpriseStore } = CombinedProvider.get('Enterprise');
 
@@ -125,47 +126,49 @@ const EnterprisePage = createReactClass({
           <GraylogClusterOverview layout="compact">
             <PluginList />
           </GraylogClusterOverview>
-          <IfPermitted permissions="freelicenses:create">
-            <Row className="content">
-              <Col md={6}>
-                <GraylogEnterpriseHeader>Graylog Enterprise</GraylogEnterpriseHeader>
-                <BiggerFontSize>
-                  <p><strong>Extend Graylog’s Open Source capabilities with a free trial of Graylog Enterprise for 30 days.</strong></p>
-                  <p>
-                    Graylog Enterprise introduces productivity and compliance features designed to help organizations
-                    reduce risk while encouraging collaboration across a large number of users.
-                  </p>
+          <HideOnCloud>
+            <IfPermitted permissions="freelicenses:create">
+              <Row className="content">
+                <Col md={6}>
+                  <GraylogEnterpriseHeader>Graylog Enterprise</GraylogEnterpriseHeader>
+                  <BiggerFontSize>
+                    <p><strong>Extend Graylog’s Open Source capabilities with a free trial of Graylog Enterprise for 30 days.</strong></p>
+                    <p>
+                      Graylog Enterprise introduces productivity and compliance features designed to help organizations
+                      reduce risk while encouraging collaboration across a large number of users.
+                    </p>
 
-                  <p>Graylog Enterprise includes:</p>
+                    <p>Graylog Enterprise includes:</p>
 
-                  <EnterpriseFeatureList>
-                    <li>Automated <DocumentationLink page="archiving.html" text={<strong>archiving</strong>} /> and retention</li>
-                    <li><DocumentationLink page="auditlog.html" text={<strong>Audit logs</strong>} /> of Graylog user activity</li>
-                    <li>
-                      Alerts with <DocumentationLink page="alerts.html#filter-with-dynamic-lists-enterprise-feature" text={<strong>dynamic lists</strong>} />
-                      and <DocumentationLink page="alerts.html" text={<strong>correlation engine</strong>} /> for events
-                      to minimize the number of alerts that you need to create and maintain
-                    </li>
-                    <li>
-                      Customizable <DocumentationLink page="reporting.html" text={<strong>scheduled reporting</strong>} /> using dashboard widgets for sharing analysis outside Graylog
-                    </li>
-                    <li><DocumentationLink page="searching/parameters.html"
-                                           text={<strong>Parameterized search templates</strong>} /> enable you to
-                      combine and reuse queries
-                    </li>
-                    <li><DocumentationLink page="integrations/forwarder.html"
-                                           text={<strong>Data forwarder</strong>} /> to easily combine data from
-                      multiple Graylog instances
-                    </li>
-                    <li>And more...</li>
-                  </EnterpriseFeatureList>
-                </BiggerFontSize>
-              </Col>
-              <Col md={6}>
-                {this.renderLicenseFormContent(licenseStatus)}
-              </Col>
-            </Row>
-          </IfPermitted>
+                    <EnterpriseFeatureList>
+                      <li>Automated <DocumentationLink page="archiving.html" text={<strong>archiving</strong>} /> and retention</li>
+                      <li><DocumentationLink page="auditlog.html" text={<strong>Audit logs</strong>} /> of Graylog user activity</li>
+                      <li>
+                        Alerts with <DocumentationLink page="alerts.html#filter-with-dynamic-lists-enterprise-feature" text={<strong>dynamic lists</strong>} />
+                        {' '}and <DocumentationLink page="alerts.html" text={<strong>correlation engine</strong>} /> for events
+                        to minimize the number of alerts that you need to create and maintain
+                      </li>
+                      <li>
+                        Customizable <DocumentationLink page="reporting.html" text={<strong>scheduled reporting</strong>} /> using dashboard widgets for sharing analysis outside Graylog
+                      </li>
+                      <li><DocumentationLink page="searching/parameters.html"
+                                             text={<strong>Parameterized search templates</strong>} /> enable you to
+                        combine and reuse queries
+                      </li>
+                      <li><DocumentationLink page="integrations/forwarder.html"
+                                             text={<strong>Data forwarder</strong>} /> to easily combine data from
+                        multiple Graylog instances
+                      </li>
+                      <li>And more...</li>
+                    </EnterpriseFeatureList>
+                  </BiggerFontSize>
+                </Col>
+                <Col md={6}>
+                  {this.renderLicenseFormContent(licenseStatus)}
+                </Col>
+              </Row>
+            </IfPermitted>
+          </HideOnCloud>
         </div>
       </DocumentTitle>
     );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
We do not want to show the request enterprise form on cloud because it doesn't really make any sense to.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
If a user on cloud requests a call for enterprise it's not correct

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
By enabling cloud and looking if the form is gone

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

Fixes https://github.com/Graylog2/graylog-plugin-cloud/issues/100