### PR TITLE
Improving `connect` type inference regarding component `propTypes` and `defaultProps`.

### DIFF
--- a/graylog2-web-interface/src/components/common/URLWhiteListFormModal.tsx
+++ b/graylog2-web-interface/src/components/common/URLWhiteListFormModal.tsx
@@ -55,13 +55,16 @@ class URLWhiteListFormModal extends React.Component<Props, State> {
     newUrlEntry: PropTypes.string,
     onUpdate: PropTypes.func,
     configuration: PropTypes.object,
+    currentUser: PropTypes.exact({
+      permissions: PropTypes.arrayOf(PropTypes.string),
+    }).isRequired,
+    urlType: PropTypes.oneOf(['regex', 'literal', ''] as const),
   };
 
   static defaultProps = {
     newUrlEntry: '',
     onUpdate: () => { return undefined; },
     configuration: {},
-    // eslint-disable-next-line react/default-props-match-prop-types
     urlType: '' as const,
   }
 

--- a/graylog2-web-interface/src/components/common/URLWhiteListFormModal.tsx
+++ b/graylog2-web-interface/src/components/common/URLWhiteListFormModal.tsx
@@ -42,7 +42,7 @@ type Props = {
   newUrlEntry: string,
   onUpdate: () => void,
   configuration: {},
-  currentUser: {permissions: Array<string>},
+  currentUser: { permissions: Array<string> },
   urlType: 'regex' | 'literal' | '',
 };
 
@@ -55,15 +55,15 @@ class URLWhiteListFormModal extends React.Component<Props, State> {
     newUrlEntry: PropTypes.string,
     onUpdate: PropTypes.func,
     configuration: PropTypes.object,
-    currentUser: PropTypes.object.isRequired,
-    urlType: PropTypes.string,
+
   };
 
   static defaultProps = {
     newUrlEntry: '',
     onUpdate: () => { return undefined; },
     configuration: {},
-    urlType: '',
+    // eslint-disable-next-line react/default-props-match-prop-types
+    urlType: '' as const,
   }
 
   constructor(props) {

--- a/graylog2-web-interface/src/components/common/URLWhiteListFormModal.tsx
+++ b/graylog2-web-interface/src/components/common/URLWhiteListFormModal.tsx
@@ -55,7 +55,6 @@ class URLWhiteListFormModal extends React.Component<Props, State> {
     newUrlEntry: PropTypes.string,
     onUpdate: PropTypes.func,
     configuration: PropTypes.object,
-
   };
 
   static defaultProps = {

--- a/graylog2-web-interface/src/components/streamrules/StreamRuleForm.test.tsx
+++ b/graylog2-web-interface/src/components/streamrules/StreamRuleForm.test.tsx
@@ -32,14 +32,14 @@ describe('StreamRuleForm', () => {
   });
 
   const streamRuleTypes = [
-    { id: 1, short_desc: 'match exactly', long_desc: 'match exactly' },
-    { id: 2, short_desc: 'match regular expression', long_desc: 'match regular expression' },
-    { id: 3, short_desc: 'greater than', long_desc: 'greater than' },
-    { id: 4, short_desc: 'smaller than', long_desc: 'smaller than' },
-    { id: 5, short_desc: 'field presence', long_desc: 'field presence' },
-    { id: 6, short_desc: 'contain', long_desc: 'contain' },
-    { id: 7, short_desc: 'always match', long_desc: 'always match' },
-    { id: 8, short_desc: 'match input', long_desc: 'match input' },
+    { id: 1, short_desc: 'match exactly', long_desc: 'match exactly', name: 'Stream rule match exactly' },
+    { id: 2, short_desc: 'match regular expression', long_desc: 'match regular expression', name: 'Stream rule match regular' },
+    { id: 3, short_desc: 'greater than', long_desc: 'greater than', name: 'Stream rule greater than' },
+    { id: 4, short_desc: 'smaller than', long_desc: 'smaller than', name: 'Stream rule smaller than' },
+    { id: 5, short_desc: 'field presence', long_desc: 'field presence', name: 'Stream rule field presence' },
+    { id: 6, short_desc: 'contain', long_desc: 'contain', name: 'Stream rule contain' },
+    { id: 7, short_desc: 'always match', long_desc: 'always match', name: 'Stream rule always match' },
+    { id: 8, short_desc: 'match input', long_desc: 'match input', name: 'Stream rule match input' },
   ];
 
   const getStreamRule = (type = 1) => {

--- a/graylog2-web-interface/src/components/streamrules/StreamRuleForm.tsx
+++ b/graylog2-web-interface/src/components/streamrules/StreamRuleForm.tsx
@@ -44,6 +44,7 @@ type StreamRuleType = {
   id: number,
   short_desc: string,
   long_desc: string,
+  name: string,
 };
 
 type Props = {
@@ -51,7 +52,7 @@ type Props = {
   streamRule: StreamRule,
   streamRuleTypes: [StreamRuleType],
   title: string,
-  inputs: [],
+  inputs: Array<unknown>,
   onClose: () => void,
 };
 
@@ -62,17 +63,16 @@ type State = {
 
 class StreamRuleForm extends React.Component<Props, State> {
   static defaultProps = {
+    // eslint-disable-next-line react/default-props-match-prop-types
     streamRule: { field: '', type: 1, value: '', inverted: false, description: '' },
+    // eslint-disable-next-line react/default-props-match-prop-types
     inputs: [],
     onClose: () => {},
   };
 
   static propTypes = {
     onSubmit: PropTypes.func.isRequired,
-    streamRule: PropTypes.object,
-    streamRuleTypes: PropTypes.array.isRequired,
     title: PropTypes.string.isRequired,
-    inputs: PropTypes.array,
     onClose: PropTypes.func,
   };
 

--- a/graylog2-web-interface/src/components/streamrules/StreamRuleForm.tsx
+++ b/graylog2-web-interface/src/components/streamrules/StreamRuleForm.tsx
@@ -50,7 +50,7 @@ type StreamRuleType = {
 type Props = {
   onSubmit: (streamRuleId: string | undefined | null, currentStreamRule: StreamRule) => void,
   streamRule: StreamRule,
-  streamRuleTypes: [StreamRuleType],
+  streamRuleTypes: Array<StreamRuleType>,
   title: string,
   inputs: Array<unknown>,
   onClose: () => void,
@@ -72,6 +72,7 @@ class StreamRuleForm extends React.Component<Props, State> {
 
   static propTypes = {
     onSubmit: PropTypes.func.isRequired,
+    streamRuleTypes: PropTypes.array.isRequired,
     title: PropTypes.string.isRequired,
     onClose: PropTypes.func,
   };

--- a/graylog2-web-interface/src/stores/__tests__/connect.test.tsx
+++ b/graylog2-web-interface/src/stores/__tests__/connect.test.tsx
@@ -73,6 +73,23 @@ SimpleComponentWithDummyStore.defaultProps = {
   simpleStore: undefined,
 };
 
+// eslint-disable-next-line react/prefer-stateless-function
+class SimpleClassComponent extends React.Component<{ propWithDefault: string }> {
+  static defaultProps = {
+    propWithDefault: 'default value',
+  }
+
+  static propTypes = {
+    propWithDefault: PropTypes.string,
+  }
+
+  render() {
+    const { propWithDefault } = this.props;
+
+    return <span>{propWithDefault}</span>;
+  }
+}
+
 describe('connect()', () => {
   beforeEach(() => {
     SimpleStore.reset();
@@ -142,6 +159,20 @@ describe('connect()', () => {
     const Component = connect(() => <span>hello!</span>, { simpleStore: SimpleStore });
 
     expect(Component.displayName).toEqual('ConnectStoresWrapper[Unknown/Anonymous] stores=simpleStore');
+  });
+
+  it('types store props as optional', () => {
+    const Component = connect(() => <span>hello!</span>, { simpleStore: SimpleStore });
+    mount(<Component />);
+  });
+
+  it('types mapped props as optional', () => {
+    const Component = connect(
+      () => <span>hello!</span>,
+      { simpleStore: SimpleStore },
+      ({ simpleStore }) => ({ storeValue: simpleStore.value }),
+    );
+    mount(<Component />);
   });
 
   describe('generates `shouldComponentUpdate`', () => {

--- a/graylog2-web-interface/src/stores/__tests__/connect.test.tsx
+++ b/graylog2-web-interface/src/stores/__tests__/connect.test.tsx
@@ -73,23 +73,6 @@ SimpleComponentWithDummyStore.defaultProps = {
   simpleStore: undefined,
 };
 
-// eslint-disable-next-line react/prefer-stateless-function
-class SimpleClassComponent extends React.Component<{ propWithDefault: string }> {
-  static defaultProps = {
-    propWithDefault: 'default value',
-  }
-
-  static propTypes = {
-    propWithDefault: PropTypes.string,
-  }
-
-  render() {
-    const { propWithDefault } = this.props;
-
-    return <span>{propWithDefault}</span>;
-  }
-}
-
 describe('connect()', () => {
   beforeEach(() => {
     SimpleStore.reset();

--- a/graylog2-web-interface/src/stores/__tests__/connect.test.tsx
+++ b/graylog2-web-interface/src/stores/__tests__/connect.test.tsx
@@ -158,6 +158,21 @@ describe('connect()', () => {
     mount(<Component />);
   });
 
+  it('types props which have a default value (defaultProps) as optional', () => {
+    const BaseComponent = ({ exampleProp }: { exampleProp: string }) => <span>{exampleProp}</span>;
+
+    BaseComponent.defaultProps = {
+      exampleProp: 'hello!',
+    };
+
+    BaseComponent.propTypes = {
+      exampleProp: PropTypes.string,
+    };
+
+    const Component = connect(BaseComponent, { simpleStore: SimpleStore });
+    mount(<Component />);
+  });
+
   describe('generates `shouldComponentUpdate`', () => {
     const Component: React.ComponentType<{ someProp?: any, foo: number }> = jest.fn(() => <span>Hello!</span>);
     const SimplestStore: Store<number> = ({

--- a/graylog2-web-interface/src/stores/__tests__/connect.test.tsx
+++ b/graylog2-web-interface/src/stores/__tests__/connect.test.tsx
@@ -153,7 +153,7 @@ describe('connect()', () => {
     const Component = connect(
       () => <span>hello!</span>,
       { simpleStore: SimpleStore },
-      ({ simpleStore }) => ({ storeValue: simpleStore.value }),
+      ({ simpleStore }) => (simpleStore && { storeValue: simpleStore.value }),
     );
     mount(<Component />);
   });

--- a/graylog2-web-interface/src/stores/connect.tsx
+++ b/graylog2-web-interface/src/stores/connect.tsx
@@ -30,6 +30,8 @@ export type ExtractStoreState<Store> = Store extends StoreType<infer V> ? V : ne
 
 export type ResultType<Stores> = { [K in keyof Stores]: ExtractStoreState<Stores[K]> };
 
+type PropsWithDefaults<C extends React.ComponentType> = JSX.LibraryManagedAttributes<C, React.ComponentProps<C>>;
+
 type PropsMapper<V, R> = (props: V) => R;
 
 const id = <V, >(x: V): V => x;
@@ -79,30 +81,35 @@ export function useStore(store, propsMapper = id) {
  *
  */
 
+function connect<C extends React.ComponentType<React.ComponentProps<C>>, Stores extends object>(
+  Component: C,
+  stores: Stores
+): React.ComponentType<Optional<PropsWithDefaults<C>, keyof Stores>>;
+
 function connect<Props extends object, Stores extends object>(
     Component: React.ComponentType<Props>,
     stores: Stores
     // @ts-ignore
 ): React.ComponentType<Optional<Props, keyof Stores>>;
 
-function connect<Stores extends object, Props extends MappedProps, MappedProps extends object>(
-    Component: React.ComponentType<Props>,
+function connect<C extends React.ComponentType<React.ComponentProps<C>>, Stores extends object, MappedProps extends object>(
+    Component: C,
     stores: Stores,
     mapProps: PropsMapper<ResultType<Stores>, MappedProps>
-): React.ComponentType<Optional<Props, keyof MappedProps>>;
+): React.ComponentType<Optional<PropsWithDefaults<C>, keyof MappedProps>>;
 
 function connect<
+    C extends React.ComponentType<React.ComponentProps<C>>,
     Stores,
-    Props extends MappedProps,
     MappedProps extends object,
     >(
-  Component: React.ComponentType<Props>,
+  Component: C,
   stores: Stores,
   mapProps: PropsMapper<ResultType<Stores>, MappedProps> = (props: ResultType<Stores>) => props as MappedProps,
-): React.ComponentType<Optional<Props, keyof MappedProps>> {
+): React.ComponentType<Optional<PropsWithDefaults<C>, keyof MappedProps>> {
   const wrappedComponentName = Component.displayName || Component.name || 'Unknown/Anonymous';
 
-  class ConnectStoresWrapper extends React.Component<Optional<Props, keyof MappedProps>> {
+  class ConnectStoresWrapper extends React.Component<Optional<PropsWithDefaults<C>, keyof MappedProps>> {
     // eslint-disable-next-line react/state-in-constructor
     state: ResultType<Stores>;
 
@@ -172,7 +179,7 @@ function connect<
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const { ref, ...componentProps } = this.props;
 
-      return <Component {...nextProps as MappedProps} {...componentProps as Props} />;
+      return <Component {...nextProps as MappedProps} {...componentProps as PropsWithDefaults<C>} />;
     }
   }
 

--- a/graylog2-web-interface/src/stores/connect.tsx
+++ b/graylog2-web-interface/src/stores/connect.tsx
@@ -86,12 +86,6 @@ function connect<C extends React.ComponentType<React.ComponentProps<C>>, Stores 
   stores: Stores
 ): React.ComponentType<Optional<PropsWithDefaults<C>, keyof Stores>>;
 
-function connect<Props extends object, Stores extends object>(
-    Component: React.ComponentType<Props>,
-    stores: Stores
-    // @ts-ignore
-): React.ComponentType<Optional<Props, keyof Stores>>;
-
 function connect<C extends React.ComponentType<React.ComponentProps<C>>, Stores extends object, MappedProps extends object>(
     Component: C,
     stores: Stores,

--- a/graylog2-web-interface/src/views/components/DashboardSearchBar.tsx
+++ b/graylog2-web-interface/src/views/components/DashboardSearchBar.tsx
@@ -33,12 +33,13 @@ import ViewActionsMenu from 'views/components/ViewActionsMenu';
 import { GlobalOverrideActions, GlobalOverrideStore } from 'views/stores/GlobalOverrideStore';
 import type { QueryString, TimeRange } from 'views/logic/queries/Query';
 import TopRow from 'views/components/searchbar/TopRow';
+import { SearchesConfig } from 'components/search/SearchConfig';
 
 import DashboardSearchForm from './DashboardSearchBarForm';
 import TimeRangeInput from './searchbar/TimeRangeInput';
 
 type Props = {
-  config: any,
+  config: SearchesConfig,
   globalOverride: {
     timerange: TimeRange,
     query: QueryString,
@@ -113,7 +114,6 @@ const DashboardSearchBar = ({ config, globalOverride, disableSearch = false, onE
 };
 
 DashboardSearchBar.propTypes = {
-  config: PropTypes.object.isRequired,
   disableSearch: PropTypes.bool,
   onExecute: PropTypes.func.isRequired,
 };

--- a/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchControls.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchControls.tsx
@@ -183,10 +183,6 @@ class SavedSearchControls extends React.Component<Props, State> {
       .catch((error) => UserNotification.error(`Saving view failed: ${this._extractErrorMessage(error)}`, 'Error!'));
   };
 
-  loadSavedSearch = () => {
-    this.toggleListModal();
-  };
-
   deleteSavedSearch = (deletedView) => {
     const { viewStoreState } = this.props;
     const { view } = viewStoreState;
@@ -260,8 +256,7 @@ class SavedSearchControls extends React.Component<Props, State> {
                       <Icon name="folder" type="regular" /> Load
                     </Button>
                     {showList && (
-                      <SavedSearchList loadSavedSearch={this.loadSavedSearch}
-                                       deleteSavedSearch={this.deleteSavedSearch}
+                      <SavedSearchList deleteSavedSearch={this.deleteSavedSearch}
                                        toggleModal={this.toggleListModal} />
                     )}
                     <ShareButton entityType="search"

--- a/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchList.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchList.test.tsx
@@ -43,6 +43,7 @@ const createViewsResponse = (count = 1) => {
       total: count,
       page: count > 0 ? count : 0,
       perPage: 5,
+      count,
     },
     list: views,
   };
@@ -53,8 +54,7 @@ describe('SavedSearchList', () => {
     it('should render empty', () => {
       const views = createViewsResponse(0);
       const { baseElement } = render(<SavedSearchList toggleModal={() => {}}
-                                                      showModal
-                                                      deleteSavedSearch={() => {}}
+                                                      deleteSavedSearch={() => Promise.resolve(views[0])}
                                                       views={views} />);
 
       expect(baseElement).not.toBeNull();
@@ -63,8 +63,7 @@ describe('SavedSearchList', () => {
     it('should render with views', () => {
       const views = createViewsResponse(1);
       const { baseElement } = render(<SavedSearchList toggleModal={() => {}}
-                                                      showModal
-                                                      deleteSavedSearch={() => {}}
+                                                      deleteSavedSearch={() => Promise.resolve(views[0])}
                                                       views={views} />);
 
       expect(baseElement).not.toBeNull();
@@ -75,8 +74,7 @@ describe('SavedSearchList', () => {
       const views = createViewsResponse(1);
 
       const { getByText } = render(<SavedSearchList toggleModal={onToggleModal}
-                                                    showModal
-                                                    deleteSavedSearch={() => {}}
+                                                    deleteSavedSearch={() => Promise.resolve(views[0])}
                                                     views={views} />);
 
       const cancel = getByText('Cancel');
@@ -88,12 +86,9 @@ describe('SavedSearchList', () => {
 
     it('should call `onDelete` if saved search is deleted', () => {
       window.confirm = jest.fn(() => true);
-      const onDelete = jest.fn(() => {
-        return new Promise(() => {});
-      });
       const views = createViewsResponse(1);
+      const onDelete = jest.fn(() => Promise.resolve(views[0]));
       const { getByTestId } = render(<SavedSearchList toggleModal={() => {}}
-                                                      showModal
                                                       deleteSavedSearch={onDelete}
                                                       views={views} />);
       const deleteBtn = getByTestId('delete-foo-bar-0');
@@ -111,8 +106,7 @@ describe('SavedSearchList', () => {
       const { getByText } = render(
         <ViewLoaderContext.Provider value={onLoad}>
           <SavedSearchList toggleModal={() => {}}
-                           showModal
-                           deleteSavedSearch={() => {}}
+                           deleteSavedSearch={() => Promise.resolve(views[0])}
                            views={views} />
         </ViewLoaderContext.Provider>,
       );

--- a/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchList.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchList.tsx
@@ -58,25 +58,36 @@ const DeleteButton: StyledComponent<{}, ThemeInterface, HTMLSpanElement> = style
   right: 10px;
 `;
 
+const DEFAULT_PAGINATION = {
+  query: '',
+  page: 1,
+  perPage: 5,
+};
+
 class SavedSearchList extends React.Component<Props, State> {
   static propTypes = {
     toggleModal: PropTypes.func.isRequired,
     deleteSavedSearch: PropTypes.func.isRequired,
-    views: PropTypes.object,
   };
 
   static defaultProps = {
-    views: {},
+    // eslint-disable-next-line react/default-props-match-prop-types
+    views: {
+      list: [],
+      pagination: {
+        ...DEFAULT_PAGINATION,
+        total: undefined,
+        count: undefined,
+      },
+    },
   };
 
   constructor(props) {
     super(props);
 
     this.state = {
+      ...DEFAULT_PAGINATION,
       selectedSavedSearch: undefined,
-      query: '',
-      page: 1,
-      perPage: 5,
     };
   }
 
@@ -138,7 +149,7 @@ class SavedSearchList extends React.Component<Props, State> {
 
   render() {
     const { views, toggleModal } = this.props;
-    const { total, page, perPage = 5 } = views.pagination;
+    const { total, page, perPage } = views.pagination;
     const { selectedSavedSearch } = this.state;
     const savedSearchList = (views.list || []).map((savedSearch) => {
       return (
@@ -149,7 +160,7 @@ class SavedSearchList extends React.Component<Props, State> {
               {savedSearch.title}
               <span>
                 <DeleteButton bsSize="xsmall" bsStyle="danger" onClick={(e) => this.onDelete(e, savedSearch.id)}>
-                  <Icon name="trash" ttile="Delete" data-testid={`delete-${savedSearch.id}`} />
+                  <Icon name="trash" title="Delete" data-testid={`delete-${savedSearch.id}`} />
                 </DeleteButton>
               </span>
             </ListGroupItem>

--- a/graylog2-web-interface/src/views/components/widgets/Widget.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/Widget.test.tsx
@@ -96,11 +96,6 @@ jest.mock('./WidgetColorContext', () => ({ children }) => children);
 jest.mock('views/logic/views/Actions');
 
 describe('<Widget />', () => {
-  afterEach(() => {
-    jest.clearAllMocks();
-    jest.resetModules();
-  });
-
   const widget = WidgetModel.builder().newId()
     .type('dummy')
     .config({})
@@ -139,6 +134,15 @@ describe('<Widget />', () => {
       count: 2,
     },
   };
+
+  beforeEach(() => {
+    ViewStore.getInitialState = jest.fn(() => viewStoreState);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.resetModules();
+  });
 
   const DummyWidget = (props) => (
     <WidgetContext.Provider value={widget}>
@@ -197,7 +201,11 @@ describe('<Widget />', () => {
   });
 
   it('renders placeholder if widget type is unknown', async () => {
-    const unknownWidget = { config: {}, id: 'widgetId', type: 'i-dont-know-this-widget-type' };
+    const unknownWidget = WidgetModel.builder()
+      .id('widgetId')
+      .type('i-dont-know-this-widget-type')
+      .config({})
+      .build();
     const UnknownWidget = (props) => (
       <Widget widget={unknownWidget}
               id="widgetId"
@@ -283,7 +291,11 @@ describe('<Widget />', () => {
   });
 
   it('restores original state of widget config when clicking cancel after changes were made', () => {
-    const widgetWithConfig = { config: { foo: 42 }, id: 'widgetId', type: 'dummy' };
+    const widgetWithConfig = WidgetModel.builder()
+      .id('widgetId')
+      .type('dummy')
+      .config({ foo: 42 })
+      .build();
     const { getByText } = render(<DummyWidget editing widget={widgetWithConfig} />);
 
     WidgetActions.updateConfig = mockAction(jest.fn(async () => Immutable.OrderedMap() as Widgets));
@@ -298,11 +310,15 @@ describe('<Widget />', () => {
 
     fireEvent.click(cancelButton);
 
-    expect(WidgetActions.update).toHaveBeenCalledWith('widgetId', { config: { foo: 42 }, id: 'widgetId', type: 'dummy' });
+    expect(WidgetActions.update).toHaveBeenCalledWith('widgetId', widgetWithConfig);
   });
 
   it('does not restore original state of widget config when clicking "Finish Editing"', () => {
-    const widgetWithConfig = { config: { foo: 42 }, id: 'widgetId', type: 'dummy' };
+    const widgetWithConfig = WidgetModel.builder()
+      .id('widgetId')
+      .type('dummy')
+      .config({ foo: 42 })
+      .build();
     const { getByText } = render(<DummyWidget editing widget={widgetWithConfig} />);
 
     WidgetActions.updateConfig = mockAction(jest.fn(async () => Immutable.OrderedMap() as Widgets));
@@ -321,7 +337,11 @@ describe('<Widget />', () => {
   });
 
   it('does not display export to CSV action if widget is not a message table', () => {
-    const dummyWidget = { config: {}, id: 'widgetId', type: 'dummy' };
+    const dummyWidget = WidgetModel.builder()
+      .id('widgetId')
+      .type('dummy')
+      .config({})
+      .build();
     const { getByTestId, queryByText } = render(<DummyWidget title="Dummy Widget" widget={dummyWidget} />);
 
     const actionToggle = getByTestId('widgetActionDropDown');
@@ -332,8 +352,11 @@ describe('<Widget />', () => {
   });
 
   it('allows export to CSV for message tables', () => {
-    ViewStore.getInitialState = jest.fn(() => viewStoreState);
-    const messagesWidget = { config: {}, id: 'widgetId', type: MessagesWidget.type };
+    const messagesWidget = WidgetModel.builder()
+      .id('widgetId')
+      .type(MessagesWidget.type)
+      .config({})
+      .build();
     const { getByTestId, getByText } = render(<DummyWidget title="Dummy Widget" widget={messagesWidget} />);
 
     const actionToggle = getByTestId('widgetActionDropDown');
@@ -351,7 +374,6 @@ describe('<Widget />', () => {
     beforeEach(() => {
       // @ts-ignore
       DashboardsStore.getInitialState = jest.fn(() => dashboardState);
-      ViewStore.getInitialState = jest.fn(() => viewStoreState);
       ViewManagementActions.get = mockAction(jest.fn((async () => Promise.resolve(dashboard1.toJSON()))));
       SearchActions.get = mockAction(jest.fn(() => Promise.resolve(searchDB1.toJSON())));
       ViewManagementActions.update = mockAction(jest.fn((view) => Promise.resolve(view)));

--- a/graylog2-web-interface/src/views/components/widgets/Widget.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/Widget.tsx
@@ -138,7 +138,6 @@ class Widget extends React.Component<Props, State> {
     onSizeChange: PropTypes.func.isRequired,
     onPositionsChange: PropTypes.func.isRequired,
     title: PropTypes.string.isRequired,
-    widget: PropTypes.instanceOf(WidgetModel).isRequired,
   };
 
   static defaultProps = {

--- a/graylog2-web-interface/src/views/components/widgets/Widget.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/Widget.tsx
@@ -62,6 +62,7 @@ import MoveWidgetToTabModal from './MoveWidgetToTabModal';
 import WidgetErrorBoundary from './WidgetErrorBoundary';
 import ReplaySearchButton from './ReplaySearchButton';
 
+import CustomPropTypes from '../CustomPropTypes';
 import IfDashboard from '../dashboard/IfDashboard';
 import InteractiveContext from '../contexts/InteractiveContext';
 import IfInteractive from '../dashboard/IfInteractive';
@@ -129,6 +130,8 @@ const _editComponentForType = (type) => {
 class Widget extends React.Component<Props, State> {
   static propTypes = {
     id: PropTypes.string.isRequired,
+    view: CustomPropTypes.CurrentView.isRequired,
+    widget: PropTypes.instanceOf(WidgetModel).isRequired,
     data: PropTypes.any,
     editing: PropTypes.bool,
     errors: WidgetErrorsList,
@@ -138,6 +141,7 @@ class Widget extends React.Component<Props, State> {
     onSizeChange: PropTypes.func.isRequired,
     onPositionsChange: PropTypes.func.isRequired,
     title: PropTypes.string.isRequired,
+    position: PropTypes.instanceOf(WidgetPosition).isRequired,
   };
 
   static defaultProps = {

--- a/graylog2-web-interface/src/views/components/widgets/Widget.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/Widget.tsx
@@ -129,14 +129,6 @@ const _editComponentForType = (type) => {
 class Widget extends React.Component<Props, State> {
   static propTypes = {
     id: PropTypes.string.isRequired,
-    view: PropTypes.object.isRequired,
-    widget: PropTypes.shape({
-      id: PropTypes.string.isRequired,
-      type: PropTypes.string.isRequired,
-      computationTimeRange: PropTypes.object,
-      config: PropTypes.object.isRequired,
-      filter: PropTypes.string,
-    }).isRequired,
     data: PropTypes.any,
     editing: PropTypes.bool,
     errors: WidgetErrorsList,
@@ -146,7 +138,6 @@ class Widget extends React.Component<Props, State> {
     onSizeChange: PropTypes.func.isRequired,
     onPositionsChange: PropTypes.func.isRequired,
     title: PropTypes.string.isRequired,
-    position: PropTypes.object.isRequired,
   };
 
   static defaultProps = {

--- a/graylog2-web-interface/src/views/components/widgets/Widget.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/Widget.tsx
@@ -138,6 +138,7 @@ class Widget extends React.Component<Props, State> {
     onSizeChange: PropTypes.func.isRequired,
     onPositionsChange: PropTypes.func.isRequired,
     title: PropTypes.string.isRequired,
+    widget: PropTypes.instanceOf(WidgetModel).isRequired,
   };
 
   static defaultProps = {


### PR DESCRIPTION
## Description
This PR improves the type inference when using `connect` for a component which also uses `defaultProps`.  Previously we had a problem in the following case:

Component has a prop `exampleProp`. This prop is defined as required in the component `Prop` type, but has a default value. Since it has a default value, the `PropType`s are defining the prop as optional. When we use this component the `exampleProp` is required. With this PR the `exampleProp` is typed as optional.

There is still one case were we do not infer the props perfectly. If the mentioned `exampleProp` is an object and the TypeScript type defines its values as required, we can't define a `PropType` definition which defines as the prop optional, but the attributes are required. With the current inference all attributes are typed as optional.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

