### PR TITLE
Add new MissingDashboardPermissionException

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/exceptions/MissingDashboardPermissionException.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/exceptions/MissingDashboardPermissionException.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.shared.rest.exceptions;
+
+import java.util.Set;
+
+public class MissingDashboardPermissionException extends RuntimeException {
+
+    private Set<String> dashboardsWithMissingPermissions;
+
+    public MissingDashboardPermissionException(String errorMessage, Set<String> dashboardsWithMissingPermissions) {
+        super(errorMessage);
+        this.dashboardsWithMissingPermissions = dashboardsWithMissingPermissions;
+    }
+
+    public Set<String> streamsWithMissingPermissions() {
+        return this.dashboardsWithMissingPermissions;
+    }
+}


### PR DESCRIPTION
## Motivation
this permission will be used in the enterprise plugin
to show the user that he is lacking permissions for dashboards
when showing a report.

## Description
Add new Exeception

Needs backbort to 4.0.x

/jenkins-pr-deps Graylog2/graylog-plugin-enterprise#1963