### PR TITLE
Improvements in Token list

### DIFF
--- a/graylog2-web-interface/src/components/users/TokenList.jsx
+++ b/graylog2-web-interface/src/components/users/TokenList.jsx
@@ -78,9 +78,9 @@ const TokenList = ({ creatingToken, deletingToken, onCreate, onDelete, tokens }:
 
       <ControlledTableList>
         <ControlledTableList.Header />
-        {effectiveTokens.length === 0 && query !== '' && (
+        {effectiveTokens.length === 0 && (
           <ControlledTableList.Item>
-            <p>No tokens match the filter.</p>
+            <p>{query === '' ? 'No tokens to display.' : 'No tokens match the filter.'}</p>
           </ControlledTableList.Item>
         )}
         {effectiveTokens.map((token) => {

--- a/graylog2-web-interface/src/components/users/TokenList.jsx
+++ b/graylog2-web-interface/src/components/users/TokenList.jsx
@@ -19,7 +19,7 @@ import PropTypes from 'prop-types';
 import React, { useMemo, useState } from 'react';
 import styled from 'styled-components';
 
-import { ClipboardButton, ControlledTableList, SearchForm, Spinner } from 'components/common';
+import { ClipboardButton, ControlledTableList, Timestamp, SearchForm, Spinner } from 'components/common';
 import { Button, ButtonGroup, Col, Checkbox, Row } from 'components/graylog';
 import type { Token } from 'actions/users/UsersActions';
 
@@ -27,6 +27,12 @@ import CreateTokenForm from './CreateTokenForm';
 
 const StyledSearchForm = styled(SearchForm)`
   margin-bottom: 10px;
+`;
+
+const StyledLastAccess = styled.div`
+  color: ${(props) => props.theme.colors.gray[60]};
+  font-size: ${(props) => props.theme.fonts.size.small};
+  margin-bottom: 5px;
 `;
 
 type Props = {
@@ -78,11 +84,16 @@ const TokenList = ({ creatingToken, deletingToken, onCreate, onDelete, tokens }:
           </ControlledTableList.Item>
         )}
         {effectiveTokens.map((token) => {
+          const tokenNeverUsed = Date.parse(token.last_access) === 0;
+
           return (
             <ControlledTableList.Item key={token.id}>
               <Row className="row-sm">
                 <Col md={9}>
                   {token.name}
+                  <StyledLastAccess>
+                    {tokenNeverUsed ? 'Never used' : <>Last used <Timestamp dateTime={token.last_access} relative /></>}
+                  </StyledLastAccess>
                   {!hideTokens && <pre>{token.token}</pre>}
                 </Col>
                 <Col md={3} className="text-right">

--- a/graylog2-web-interface/src/components/users/TokenList.jsx
+++ b/graylog2-web-interface/src/components/users/TokenList.jsx
@@ -22,6 +22,7 @@ import styled from 'styled-components';
 import { ClipboardButton, ControlledTableList, Icon, Timestamp, SearchForm, Spinner } from 'components/common';
 import { Button, ButtonGroup, Col, Checkbox, Panel, Row } from 'components/graylog';
 import type { Token } from 'actions/users/UsersActions';
+import { sortByDate } from 'util/SortUtils';
 
 import CreateTokenForm from './CreateTokenForm';
 
@@ -67,7 +68,9 @@ const TokenList = ({ creatingToken, deletingToken, onCreate, onDelete, tokens }:
   const effectiveTokens = useMemo(() => {
     const queryRegex = new RegExp(query, 'i');
 
-    return tokens.filter(({ name }) => queryRegex.test(name));
+    return tokens
+      .filter(({ name }) => queryRegex.test(name))
+      .sort((token1, token2) => sortByDate(token1.last_access, token2.last_access, 'desc'));
   }, [query, tokens]);
 
   const handleTokenCreation = (tokenName) => {

--- a/graylog2-web-interface/src/components/users/TokenList.test.jsx
+++ b/graylog2-web-interface/src/components/users/TokenList.test.jsx
@@ -24,8 +24,8 @@ jest.mock('components/common/ClipboardButton', () => 'clipboard-button');
 
 describe('<TokenList />', () => {
   const tokens = [
-    { name: 'Acme', token: 'beef2001', id: 'abc1' },
-    { name: 'Hamfred', token: 'beef2002', id: 'abc2' },
+    { name: 'Acme', token: 'beef2001', id: 'abc1', last_access: '2020-12-08T16:46:00Z' },
+    { name: 'Hamfred', token: 'beef2002', id: 'abc2', last_access: '1970-01-01T00:00:00.000Z' },
   ];
 
   it('should render with empty tokens', () => {
@@ -69,5 +69,14 @@ describe('<TokenList />', () => {
     wrapper.find('input#hide-tokens').simulate('change', { target: { checked: false } });
 
     expect(wrapper.find('pre[children="beef2001"]').length).toEqual(1);
+  });
+
+  it('show include token last access time', () => {
+    const wrapper = mount(<TokenList tokens={tokens} />);
+
+    expect(wrapper.find(`time[dateTime="${tokens[0].last_access}"]`)).toHaveLength(1);
+    expect(wrapper.find('div[children="Never used"]')).toHaveLength(1);
+
+    expect(wrapper).toExist();
   });
 });

--- a/graylog2-web-interface/src/components/users/TokenList.test.jsx
+++ b/graylog2-web-interface/src/components/users/TokenList.test.jsx
@@ -64,10 +64,10 @@ describe('<TokenList />', () => {
   it('should display tokens if "Hide tokens" was unchecked', () => {
     const wrapper = mount(<TokenList tokens={tokens} />);
 
-    expect(wrapper.find('span[children="beef2001"]').length).toEqual(0);
+    expect(wrapper.find('pre[children="beef2001"]').length).toEqual(0);
 
     wrapper.find('input#hide-tokens').simulate('change', { target: { checked: false } });
 
-    expect(wrapper.find('span[children="beef2001"]').length).toEqual(1);
+    expect(wrapper.find('pre[children="beef2001"]').length).toEqual(1);
   });
 });

--- a/graylog2-web-interface/src/pages/UserTokensEditPage.jsx
+++ b/graylog2-web-interface/src/pages/UserTokensEditPage.jsx
@@ -121,14 +121,13 @@ const UserEditPage = ({ params }: Props) => {
       <Row className="content">
         <Col lg={8}>
           <Headline>Create And Edit Tokens</Headline>
-          {loadedUser && (
+          {loadedUser ? (
             <TokenList tokens={tokens}
                        onDelete={_handleTokenDelete}
                        onCreate={_handleTokenCreate}
                        creatingToken={creatingToken}
                        deletingToken={deletingTokenId} />
-          )}
-          {!loadedUser && (
+          ) : (
             <Row>
               <Col xs={12}>
                 <Spinner />

--- a/graylog2-web-interface/src/pages/UserTokensEditPage.jsx
+++ b/graylog2-web-interface/src/pages/UserTokensEditPage.jsx
@@ -74,9 +74,11 @@ const _createToken = (tokenName, userId, loadTokens, setCreatingToken) => {
 
   setCreatingToken(true);
 
-  promise.then(() => {
+  return promise.then((token) => {
     loadTokens();
     setCreatingToken(false);
+
+    return token;
   });
 };
 


### PR DESCRIPTION
This PR adds the following changes to the Token list:
- Replace [`TableList`](https://graylog2.github.io/frontend-documentation/#!/TableList) with [`ControlledTableList`](https://graylog2.github.io/frontend-documentation/#!/ControlledTableList), which gives us more flexibility to customize how to display tokens
- Add last access information to each Token, helping users to know which Tokens may not be used
- Display Token information after creation, making it easier to copy it

<img width="1126" alt="Screenshot 2020-12-09 at 12 13 46" src="https://user-images.githubusercontent.com/716185/101622968-0a37fe80-3a18-11eb-87dc-7443601a010d.png">

Refs: https://github.com/Graylog2/graylog-plugin-cloud/issues/570