### PR TITLE
Only display tokens immediately after creation

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/models/users/responses/TokenSummary.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/users/responses/TokenSummary.java
@@ -21,18 +21,25 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 import org.graylog.autovalue.WithBeanGetter;
-
-import java.util.List;
+import org.joda.time.DateTime;
 
 @JsonAutoDetect
 @AutoValue
 @WithBeanGetter
-public abstract class TokenList {
+public abstract class TokenSummary {
     @JsonProperty
-    public abstract List<TokenSummary> tokens();
+    public abstract String id();
+
+    @JsonProperty
+    public abstract String name();
+
+    @JsonProperty
+    public abstract DateTime lastAccess();
 
     @JsonCreator
-    public static TokenList create(@JsonProperty("tokens") List<TokenSummary> tokens) {
-        return new AutoValue_TokenList(tokens);
+    public static TokenSummary create(@JsonProperty("id") String id,
+                                      @JsonProperty("name") String name,
+                                      @JsonProperty("last_access") DateTime lastAccess) {
+        return new AutoValue_TokenSummary(id, name, lastAccess);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/users/UsersResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/users/UsersResource.java
@@ -46,6 +46,7 @@ import org.graylog2.rest.models.users.requests.Startpage;
 import org.graylog2.rest.models.users.requests.UpdateUserPreferences;
 import org.graylog2.rest.models.users.responses.Token;
 import org.graylog2.rest.models.users.responses.TokenList;
+import org.graylog2.rest.models.users.responses.TokenSummary;
 import org.graylog2.rest.models.users.responses.UserList;
 import org.graylog2.rest.models.users.responses.UserSummary;
 import org.graylog2.search.SearchQuery;
@@ -587,9 +588,9 @@ public class UsersResource extends RestResource {
             throw new ForbiddenException("Not allowed to list tokens for user " + username);
         }
 
-        final ImmutableList.Builder<Token> tokenList = ImmutableList.builder();
+        final ImmutableList.Builder<TokenSummary> tokenList = ImmutableList.builder();
         for (AccessToken token : accessTokenService.loadAll(user.getName())) {
-            tokenList.add(Token.create(token.getId(), token.getName(), token.getToken(), token.getLastAccess()));
+            tokenList.add(TokenSummary.create(token.getId(), token.getName(), token.getLastAccess()));
         }
 
         return TokenList.create(tokenList.build());

--- a/graylog2-web-interface/src/actions/users/UsersActions.js
+++ b/graylog2-web-interface/src/actions/users/UsersActions.js
@@ -46,6 +46,12 @@ export type Token = {
   last_access: string,
 };
 
+export type TokenSummary = {
+  id: string,
+  name: string,
+  last_access: string,
+};
+
 export type ChangePasswordRequest = {
   old_password: string,
   password: string,
@@ -63,7 +69,7 @@ export type ActionsType = {
   delete: (userId: string, fullName: string) => Promise<void>,
   changePassword: (userId: string, request: ChangePasswordRequest) => Promise<void>,
   createToken: (userId: string, tokenName: string) => Promise<Token>,
-  loadTokens: (userId: string) => Promise<Token[]>,
+  loadTokens: (userId: string) => Promise<TokenSummary[]>,
   deleteToken: (userId: string, tokenId: string, tokenName: string) => Promise<void>,
   loadUsers: () => Promise<Immutable.List<User>>,
   loadUsersPaginated: (pagination: Pagination) => Promise<PaginatedUsers>,

--- a/graylog2-web-interface/src/components/users/TokenList.jsx
+++ b/graylog2-web-interface/src/components/users/TokenList.jsx
@@ -20,7 +20,7 @@ import React, { useMemo, useState } from 'react';
 import styled from 'styled-components';
 
 import { ClipboardButton, ControlledTableList, Icon, Timestamp, SearchForm, Spinner } from 'components/common';
-import { Button, ButtonGroup, Col, Checkbox, Panel, Row } from 'components/graylog';
+import { Button, Col, Panel, Row } from 'components/graylog';
 import type { Token } from 'actions/users/UsersActions';
 import { sortByDate } from 'util/SortUtils';
 
@@ -63,7 +63,6 @@ type Props = {
 const TokenList = ({ creatingToken, deletingToken, onCreate, onDelete, tokens }: Props) => {
   const [createdToken, setCreatedToken] = useState<?Token>();
   const [query, setQuery] = useState('');
-  const [hideTokens, setHideTokens] = useState(true);
 
   const effectiveTokens = useMemo(() => {
     const queryRegex = new RegExp(query, 'i');
@@ -83,10 +82,6 @@ const TokenList = ({ creatingToken, deletingToken, onCreate, onDelete, tokens }:
     });
   };
 
-  const onShowTokensChanged = (event) => {
-    setHideTokens(event.target.checked);
-  };
-
   const deleteToken = (token) => {
     return () => {
       onDelete(token.id, token.name);
@@ -104,7 +99,7 @@ const TokenList = ({ creatingToken, deletingToken, onCreate, onDelete, tokens }:
             <Panel.Title>Token <em>{createdToken.name}</em> created!</Panel.Title>
           </Panel.Heading>
           <Panel.Body>
-            <p>This is your new token.</p>
+            <p>This is your new token. Make sure to copy it now, you will not be able to see it again.</p>
             <pre>
               {createdToken.token}
               <StyledCopyTokenButton title={<Icon name="clipboard" fixedWidth />} text={createdToken.token} bsSize="xsmall" />
@@ -139,27 +134,20 @@ const TokenList = ({ creatingToken, deletingToken, onCreate, onDelete, tokens }:
                   <StyledLastAccess>
                     {tokenNeverUsed ? 'Never used' : <>Last used <Timestamp dateTime={token.last_access} relative /></>}
                   </StyledLastAccess>
-                  {!hideTokens && <pre>{token.token}</pre>}
                 </Col>
                 <Col md={3} className="text-right">
-                  <ButtonGroup>
-                    <ClipboardButton title="Copy to clipboard" text={token.token} bsSize="xsmall" />
-                    <Button bsSize="xsmall"
-                            disabled={deletingToken === token.id}
-                            bsStyle="primary"
-                            onClick={deleteToken(token)}>
-                      {deletingToken === token.id ? <Spinner text="Deleting..." /> : 'Delete'}
-                    </Button>
-                  </ButtonGroup>
+                  <Button bsSize="xsmall"
+                          disabled={deletingToken === token.id}
+                          bsStyle="primary"
+                          onClick={deleteToken(token)}>
+                    {deletingToken === token.id ? <Spinner text="Deleting..." /> : 'Delete'}
+                  </Button>
                 </Col>
               </Row>
             </ControlledTableList.Item>
           );
         })}
       </ControlledTableList>
-      <Checkbox id="hide-tokens" onChange={onShowTokensChanged} checked={hideTokens}>
-        Hide Tokens
-      </Checkbox>
     </span>
   );
 };

--- a/graylog2-web-interface/src/components/users/TokenList.jsx
+++ b/graylog2-web-interface/src/components/users/TokenList.jsx
@@ -21,7 +21,7 @@ import styled from 'styled-components';
 
 import { ClipboardButton, ControlledTableList, Icon, Timestamp, SearchForm, Spinner } from 'components/common';
 import { Button, Col, Panel, Row } from 'components/graylog';
-import type { Token } from 'actions/users/UsersActions';
+import type { Token, TokenSummary } from 'actions/users/UsersActions';
 import { sortByDate } from 'util/SortUtils';
 
 import CreateTokenForm from './CreateTokenForm';
@@ -57,7 +57,7 @@ type Props = {
   deletingToken: ?string,
   onCreate: (tokenName: string) => Promise<Token>,
   onDelete: (tokenId: string, tokenName: string) => void,
-  tokens: Token[],
+  tokens: TokenSummary[],
 };
 
 const TokenList = ({ creatingToken, deletingToken, onCreate, onDelete, tokens }: Props) => {

--- a/graylog2-web-interface/src/components/users/TokenList.test.jsx
+++ b/graylog2-web-interface/src/components/users/TokenList.test.jsx
@@ -77,16 +77,6 @@ describe('<TokenList />', () => {
     expect(deleteFn.mock.calls.length).toBe(1);
   });
 
-  it('should display tokens if "Hide tokens" was unchecked', () => {
-    const wrapper = mount(<TokenList tokens={tokens} />);
-
-    expect(wrapper.find('pre[children="beef2001"]').length).toEqual(0);
-
-    wrapper.find('input#hide-tokens').simulate('change', { target: { checked: false } });
-
-    expect(wrapper.find('pre[children="beef2001"]').length).toEqual(1);
-  });
-
   it('show include token last access time', () => {
     const wrapper = mount(<TokenList tokens={tokens} />);
 

--- a/graylog2-web-interface/src/stores/users/UsersStore.js
+++ b/graylog2-web-interface/src/stores/users/UsersStore.js
@@ -28,7 +28,7 @@ import PaginationURL from 'util/PaginationURL';
 import UserOverview from 'logic/users/UserOverview';
 import User from 'logic/users/User';
 import UsersActions from 'actions/users/UsersActions';
-import type { ChangePasswordRequest, Token, PaginatedUsers, UserCreate, UserUpdate } from 'actions/users/UsersActions';
+import type { ChangePasswordRequest, Token, TokenSummary, PaginatedUsers, UserCreate, UserUpdate } from 'actions/users/UsersActions';
 import type { PaginatedListJSON, Pagination } from 'stores/PaginationTypes';
 
 export type PaginatedUsersResponse = PaginatedListJSON & {
@@ -103,7 +103,7 @@ const UsersStore: Store<{}> = singletonStore(
       return promise;
     },
 
-    loadTokens(userId: string): Promise<Token[]> {
+    loadTokens(userId: string): Promise<TokenSummary[]> {
       const url = qualifyUrl(ApiRoutes.UsersApiController.list_tokens(encodeURIComponent(userId)).url);
       const promise = fetch('GET', url).then((response) => response.tokens);
       UsersActions.loadTokens.promise(promise);


### PR DESCRIPTION
Remove tokens from the list tokens resource and the token list page. This means that users will only be able to see (and copy) tokens when they are created. If a token is lost, the user will need to create another one.

Please note that this only fixes the issue for cloud. We will need to port it to other branches along with other cloud-specific changes.

Fixes #9124
