### PR TITLE
Remove div wrapping GlobalThroughput in cloud

### DIFF
--- a/graylog2-web-interface/src/components/navigation/Navigation.jsx
+++ b/graylog2-web-interface/src/components/navigation/Navigation.jsx
@@ -145,9 +145,7 @@ const Navigation = ({ location }: Props) => {
 
         <Nav navbar pullRight className="header-meta-nav">
           {AppConfig.isCloud() ? (
-            <div style={{ pointerEvents: 'none' }}>
-              <GlobalThroughput />
-            </div>
+            <GlobalThroughput disabled />
           ) : (
             <LinkContainer to={Routes.SYSTEM.NODES.LIST}>
               <GlobalThroughput />


### PR DESCRIPTION
`Nav` passes some props to each one of its children, so using a div
as wrapper means that React logs a warning in the browser console log on
each render, see:
https://github.com/Graylog2/graylog2-server/pull/9729#issuecomment-741892217

Since `GlobalThroughput` returns a `NavItem` and accepts props, we can
pass the `disabled` prop to style it when it is not a link, and also
remove the warning from the console.

Refs #9729