### PR TITLE
Round traffic value on hover in Outgoing traffic chart

### DIFF
--- a/graylog2-web-interface/src/components/cluster/TrafficGraph.tsx
+++ b/graylog2-web-interface/src/components/cluster/TrafficGraph.tsx
@@ -60,6 +60,7 @@ const TrafficGraph = ({ width, traffic }: Props) => {
         text: 'Bytes',
       },
       rangemode: 'tozero',
+      hoverformat: '.4s',
       tickformat: 's',
     },
   };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Before these changes, when hovering value on the outgoing traffic chart the value was not rounded like below: 

![](https://user-images.githubusercontent.com/24830359/85564986-64463280-b637-11ea-8c93-10a7294e4c05.png)

With these changes, the value is rounded to two decimal like the example below: 

<img width="1764" alt="image" src="https://user-images.githubusercontent.com/1381455/101757127-0e772100-3ad7-11eb-93e8-d41851476aad.png">


fixes #8418


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

