### PR TITLE
Always show field sort icons in message table.

### DIFF
--- a/graylog2-web-interface/src/views/components/widgets/MessageList.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageList.test.tsx
@@ -136,8 +136,7 @@ describe('MessageList', () => {
 
     SelectedFieldsStore.getInitialState = jest.fn(() => Immutable.Set([TIMESTAMP_FIELD, 'file_name']));
     const config = MessagesWidgetConfig.builder().fields([TIMESTAMP_FIELD, 'file_name']).build();
-    const wrapper1 = mount(<MessageList editing
-                                        data={data}
+    const wrapper1 = mount(<MessageList data={data}
                                         config={config}
                                         fields={Immutable.List(fields)}
                                         setLoadingState={() => {}} />);
@@ -147,8 +146,7 @@ describe('MessageList', () => {
     const emptyConfig = MessagesWidgetConfig.builder().fields([]).build();
 
     SelectedFieldsStore.getInitialState = jest.fn(() => Immutable.Set([]));
-    const wrapper2 = mount(<MessageList editing
-                                        data={data}
+    const wrapper2 = mount(<MessageList data={data}
                                         config={emptyConfig}
                                         fields={Immutable.List(fields)}
                                         setLoadingState={() => {}} />);
@@ -159,8 +157,7 @@ describe('MessageList', () => {
   it('provides a message context for each individual entry', () => {
     const fields = [new FieldTypeMapping('file_name', new FieldType('string', ['full-text-search'], []))];
     const config = MessagesWidgetConfig.builder().fields(['file_name']).build();
-    const wrapper = mount(<MessageList editing
-                                       data={data}
+    const wrapper = mount(<MessageList data={data}
                                        fields={Immutable.List(fields)}
                                        config={config}
                                        setLoadingState={() => {}} />);
@@ -174,8 +171,7 @@ describe('MessageList', () => {
     InputsStore.getInitialState = jest.fn(() => ({ inputs: undefined }));
     const config = MessagesWidgetConfig.builder().fields([]).build();
 
-    mount(<MessageList editing
-                       data={data}
+    mount(<MessageList data={data}
                        fields={Immutable.List([])}
                        config={config}
                        setLoadingState={() => {}} />);
@@ -184,8 +180,7 @@ describe('MessageList', () => {
   it('refreshs Inputs list upon mount', () => {
     const config = MessagesWidgetConfig.builder().fields([]).build();
     const Component = () => (
-      <MessageList editing
-                   data={data}
+      <MessageList data={data}
                    fields={Immutable.List([])}
                    config={config}
                    setLoadingState={() => {}} />
@@ -200,8 +195,7 @@ describe('MessageList', () => {
     const searchTypePayload = { [data.id]: { limit: Messages.DEFAULT_LIMIT, offset: Messages.DEFAULT_LIMIT } };
     const config = MessagesWidgetConfig.builder().fields([]).build();
     const secondPageSize = 10;
-    const wrapper = mount(<MessageList editing
-                                       data={{ ...data, total: Messages.DEFAULT_LIMIT + secondPageSize }}
+    const wrapper = mount(<MessageList data={{ ...data, total: Messages.DEFAULT_LIMIT + secondPageSize }}
                                        fields={Immutable.List([])}
                                        config={config}
                                        setLoadingState={() => {}} />);
@@ -214,8 +208,7 @@ describe('MessageList', () => {
   it('disables refresh actions, when using pagination', () => {
     const config = MessagesWidgetConfig.builder().fields([]).build();
     const secondPageSize = 10;
-    const wrapper = mount(<MessageList editing
-                                       data={{ ...data, total: Messages.DEFAULT_LIMIT + secondPageSize }}
+    const wrapper = mount(<MessageList data={{ ...data, total: Messages.DEFAULT_LIMIT + secondPageSize }}
                                        fields={Immutable.List([])}
                                        config={config}
                                        setLoadingState={() => {}} />);
@@ -232,8 +225,7 @@ describe('MessageList', () => {
 
     const config = MessagesWidgetConfig.builder().fields([]).build();
     const secondPageSize = 10;
-    const wrapper = mount(<MessageList editing
-                                       data={{ ...data, total: Messages.DEFAULT_LIMIT + secondPageSize }}
+    const wrapper = mount(<MessageList data={{ ...data, total: Messages.DEFAULT_LIMIT + secondPageSize }}
                                        fields={Immutable.List([])}
                                        config={config}
                                        setLoadingState={() => {}} />);
@@ -247,8 +239,7 @@ describe('MessageList', () => {
   it('calls render completion callback after first render', () => {
     const config = MessagesWidgetConfig.builder().fields([]).build();
     const Component = () => (
-      <MessageList editing
-                   data={data}
+      <MessageList data={data}
                    fields={Immutable.List([])}
                    config={config}
                    setLoadingState={() => {}} />

--- a/graylog2-web-interface/src/views/components/widgets/MessageList.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageList.tsx
@@ -15,11 +15,9 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import PropTypes from 'prop-types';
 import * as Immutable from 'immutable';
 import styled from 'styled-components';
 import { isEmpty, get } from 'lodash';
-import ImmutablePropTypes from 'react-immutable-proptypes';
 
 import connect from 'stores/connect';
 import CombinedProvider from 'injection/CombinedProvider';
@@ -33,7 +31,6 @@ import type { TimeRange } from 'views/logic/queries/Query';
 import type { FieldTypeMappingsList } from 'views/stores/FieldTypesStore';
 import type { ViewStoreState } from 'views/stores/ViewStore';
 import { PaginatedList } from 'components/common';
-import CustomPropTypes from 'views/components/CustomPropTypes';
 import MessageTable from 'views/components/widgets/MessageTable';
 import ErrorWidget from 'views/components/widgets/ErrorWidget';
 import SortConfig from 'views/logic/aggregationbuilder/SortConfig';
@@ -75,7 +72,6 @@ type Props = {
   config: MessagesWidgetConfig,
   currentView: ViewStoreState,
   data: { messages: Array<BackendMessage>, total: number, id: string },
-  editing: boolean,
   fields: FieldTypeMappingsList,
   onConfigChange?: (MessagesWidgetConfig) => Promise<void>,
   pageSize?: number,
@@ -91,10 +87,16 @@ class MessageList extends React.Component<Props, State> {
     selectedFields: Immutable.Set<string>(),
   };
 
-  state = {
-    errors: [],
-    currentPage: 1,
-  };
+  static contextType = RenderCompletionCallback;
+
+  constructor(props: Props, context: any) {
+    super(props, context);
+
+    this.state = {
+      errors: [],
+      currentPage: 1,
+    };
+  }
 
   componentDidMount() {
     const onRenderComplete = this.context;
@@ -152,14 +154,11 @@ class MessageList extends React.Component<Props, State> {
     return onConfigChange(newConfig);
   }
 
-  static contextType = RenderCompletionCallback;
-
   render() {
     const {
       config,
       currentView: { activeQuery: activeQueryId },
       data: { messages, total: totalMessages },
-      editing,
       fields,
       pageSize,
       selectedFields,
@@ -179,7 +178,6 @@ class MessageList extends React.Component<Props, State> {
           {!hasError ? (
             <MessageTable activeQueryId={activeQueryId}
                           config={config}
-                          editing={editing}
                           fields={fields}
                           key={listKey}
                           onSortChange={this._onSortChange}
@@ -193,7 +191,6 @@ class MessageList extends React.Component<Props, State> {
   }
 }
 
-type MProps = React.ComponentProps<typeof MessageList>;
 const mapProps = (props: {
   selectedFields: SelectedFieldsStoreState,
   currentView: ViewStoreState,

--- a/graylog2-web-interface/src/views/components/widgets/MessageTable.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageTable.test.tsx
@@ -44,28 +44,27 @@ const fields = [new FieldTypeMapping('file_name', new FieldType('string', ['full
 const config = MessagesWidgetConfig.builder().fields(['file_name']).build();
 const activeQueryId = 'some-query-id';
 
+const SimpleMessageTable = (props) => (
+  <MessageTable activeQueryId={activeQueryId}
+                config={config}
+                fields={Immutable.List(fields)}
+                messages={messages}
+                onSortChange={() => Promise.resolve()}
+                selectedFields={Immutable.Set()}
+                setLoadingState={() => {}}
+                {...props} />
+);
+
 describe('MessageTable', () => {
   it('lists provided field in table head', () => {
-    const wrapper = mount(<MessageTable activeQueryId={activeQueryId}
-                                        config={config}
-                                        fields={Immutable.List(fields)}
-                                        messages={messages}
-                                        onSortChange={() => Promise.resolve()}
-                                        selectedFields={Immutable.Set()}
-                                        setLoadingState={() => {}} />);
+    const wrapper = mount(<SimpleMessageTable />);
     const th = wrapper.find('th').at(0);
 
     expect(th.text()).toContain('file_name');
   });
 
   it('renders a table entry for messages', () => {
-    const wrapper = mount(<MessageTable activeQueryId={activeQueryId}
-                                        config={config}
-                                        fields={Immutable.List(fields)}
-                                        onSortChange={() => Promise.resolve()}
-                                        selectedFields={Immutable.Set()}
-                                        setLoadingState={() => {}}
-                                        messages={messages} />);
+    const wrapper = mount(<SimpleMessageTable />);
     const messageTableEntry = wrapper.find('MessageTableEntry');
     const td = messageTableEntry.find('td').at(0);
 
@@ -75,13 +74,7 @@ describe('MessageTable', () => {
   it('renders a table entry for messages, even if fields are `undefined`', () => {
     // Suppressing console to disable props warning because of `fields` being `undefined`.
     suppressConsole(() => {
-      const wrapper = mount(<MessageTable activeQueryId={activeQueryId}
-                                          config={config}
-                                          fields={undefined}
-                                          onSortChange={() => Promise.resolve()}
-                                          selectedFields={Immutable.Set()}
-                                          setLoadingState={() => {}}
-                                          messages={messages} />);
+      const wrapper = mount(<SimpleMessageTable fields={undefined} />);
       const messageTableEntry = wrapper.find('MessageTableEntry');
 
       expect(messageTableEntry).not.toBeEmptyRender();
@@ -91,13 +84,7 @@ describe('MessageTable', () => {
   it('renders config fields in table head with correct order', () => {
     const configFields = ['gl2_receive_timestamp', 'user_id', 'gl2_source_input', 'gl2_message_id', 'ingest_time', 'http_method', 'action', 'source', 'ingest_time_hour', 'ingest_time_epoch'];
     const configWithFields = MessagesWidgetConfig.builder().fields(configFields).build();
-    const wrapper = mount(<MessageTable activeQueryId={activeQueryId}
-                                        config={configWithFields}
-                                        fields={Immutable.List(fields)}
-                                        onSortChange={() => Promise.resolve()}
-                                        selectedFields={Immutable.Set()}
-                                        setLoadingState={() => {}}
-                                        messages={messages} />);
+    const wrapper = mount(<SimpleMessageTable config={configWithFields} />);
 
     const tableHeadFields = wrapper.find('Field').map((field) => field.text());
 
@@ -109,13 +96,7 @@ describe('MessageTable', () => {
     const configWithFields = MessagesWidgetConfig.builder().fields(configFields).build();
     const wrapper = mount(
       <InteractiveContext.Provider value={false}>
-        <MessageTable activeQueryId={activeQueryId}
-                      config={configWithFields}
-                      fields={Immutable.List(fields)}
-                      onSortChange={() => Promise.resolve()}
-                      selectedFields={Immutable.Set()}
-                      setLoadingState={() => {}}
-                      messages={messages} />
+        <SimpleMessageTable config={configWithFields} />
       </InteractiveContext.Provider>,
     );
 
@@ -127,13 +108,7 @@ describe('MessageTable', () => {
   it('highlights messsage with id passed in `HighlightMessageContext`', () => {
     const wrapper = mount((
       <HighlightMessageContext.Provider value="message-id-1">
-        <MessageTable activeQueryId={activeQueryId}
-                      config={config}
-                      fields={Immutable.List(fields)}
-                      onSortChange={() => Promise.resolve()}
-                      selectedFields={Immutable.Set()}
-                      setLoadingState={() => {}}
-                      messages={messages} />
+        <SimpleMessageTable />
       </HighlightMessageContext.Provider>
     ));
 
@@ -145,18 +120,32 @@ describe('MessageTable', () => {
   it('does not highlight non-existing message id', () => {
     const wrapper = mount((
       <HighlightMessageContext.Provider value="message-id-42">
-        <MessageTable activeQueryId={activeQueryId}
-                      config={config}
-                      fields={Immutable.List(fields)}
-                      onSortChange={() => Promise.resolve()}
-                      selectedFields={Immutable.Set()}
-                      setLoadingState={() => {}}
-                      messages={messages} />
+        <SimpleMessageTable />
       </HighlightMessageContext.Provider>
     ));
 
     const highlightedMessage = wrapper.find('.message-highlight');
 
     expect(highlightedMessage).not.toExist();
+  });
+
+  it('shows sort icons next to table headers', () => {
+    const wrapper = mount(<SimpleMessageTable />);
+
+    const fieldHeader = wrapper.find('th');
+
+    expect(fieldHeader.find('FieldSortIcon')).toExist();
+  });
+
+  it('does not show sort icons in non-interactive context', () => {
+    const wrapper = mount((
+      <InteractiveContext.Provider value={false}>
+        <SimpleMessageTable />
+      </InteractiveContext.Provider>
+    ));
+
+    const fieldHeader = wrapper.find('th');
+
+    expect(fieldHeader.find('FieldSortIcon')).not.toExist();
   });
 });

--- a/graylog2-web-interface/src/views/components/widgets/MessageTable.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageTable.tsx
@@ -167,7 +167,6 @@ type State = {
 type Props = {
   activeQueryId: string,
   config: MessagesWidgetConfig,
-  editing?: boolean,
   fields: Immutable.List<FieldTypeMapping>,
   messages: Array<BackendMessage>,
   onSortChange: (newSortConfig: SortConfig[]) => Promise<void>,
@@ -175,16 +174,10 @@ type Props = {
   setLoadingState: (loading: boolean) => void,
 };
 
-type DefaultProps = {
-  editing: boolean,
-  selectedFields: Immutable.Set<string>,
-};
-
 class MessageTable extends React.Component<Props, State> {
   static propTypes = {
     activeQueryId: PropTypes.string.isRequired,
     config: CustomPropTypes.instanceOf(MessagesWidgetConfig).isRequired,
-    editing: PropTypes.bool,
     fields: CustomPropTypes.FieldListType.isRequired,
     messages: PropTypes.arrayOf(PropTypes.object).isRequired,
     onSortChange: PropTypes.func.isRequired,
@@ -192,8 +185,7 @@ class MessageTable extends React.Component<Props, State> {
     setLoadingState: PropTypes.func.isRequired,
   };
 
-  static defaultProps: DefaultProps = {
-    editing: false,
+  static defaultProps = {
     selectedFields: Immutable.Set<string>(),
   };
 

--- a/graylog2-web-interface/src/views/components/widgets/MessageTable.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageTable.tsx
@@ -35,6 +35,7 @@ import FieldSortIcon from 'views/components/widgets/FieldSortIcon';
 import Field from 'views/components/Field';
 
 import HighlightMessageContext from '../contexts/HighlightMessageContext';
+import InteractiveContext from '../contexts/InteractiveContext';
 
 const TableWrapper: StyledComponent<{}, void, HTMLDivElement> = styled.div`
   grid-row: 1;
@@ -254,7 +255,7 @@ class MessageTable extends React.Component<Props, State> {
 
   render() {
     const { expandedMessages } = this.state;
-    const { fields, activeQueryId, config, editing, onSortChange, setLoadingState } = this.props;
+    const { fields, activeQueryId, config, onSortChange, setLoadingState } = this.props;
     const formattedMessages = this._getFormattedMessages();
     const selectedFields = this._getSelectedFields();
 
@@ -272,12 +273,14 @@ class MessageTable extends React.Component<Props, State> {
                            queryId={activeQueryId}>
                       {selectedFieldName}
                     </Field>
-                    {editing && (
-                      <FieldSortIcon fieldName={selectedFieldName}
-                                     onSortChange={onSortChange}
-                                     setLoadingState={setLoadingState}
-                                     config={config} />
-                    )}
+                    <InteractiveContext.Consumer>
+                      {(interactive) => (interactive && (
+                        <FieldSortIcon fieldName={selectedFieldName}
+                                       onSortChange={onSortChange}
+                                       setLoadingState={setLoadingState}
+                                       config={config} />
+                      ))}
+                    </InteractiveContext.Consumer>
                   </th>
                 );
               })}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Before this change, the field sort icons used to change sorting of a message table were shown in edit mode only. Most users are used to change sorting outside of edit mode by clicking an icon next to the field name in the table header.

This change is showing sorting icons outside of the edit mode too, but not in non-interactive contexts.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.