### PR TITLE
Hide email sender field for Alert Notifications

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/events/notifications/types/EmailEventNotificationConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/events/notifications/types/EmailEventNotificationConfig.java
@@ -78,7 +78,6 @@ public abstract class EmailEventNotificationConfig implements EventNotificationC
     private static final String FIELD_USER_RECIPIENTS = "user_recipients";
 
     @JsonProperty(FIELD_SENDER)
-    @NotBlank
     public abstract String sender();
 
     @JsonProperty(FIELD_SUBJECT)
@@ -108,9 +107,6 @@ public abstract class EmailEventNotificationConfig implements EventNotificationC
     public ValidationResult validate() {
         final ValidationResult validation = new ValidationResult();
 
-        if (sender().isEmpty()) {
-            validation.addError(FIELD_SENDER, "Email Notification sender cannot be empty.");
-        }
         if (subject().isEmpty()) {
             validation.addError(FIELD_SUBJECT, "Email Notification subject cannot be empty.");
         }

--- a/graylog2-server/src/main/java/org/graylog2/alarmcallbacks/EmailAlarmCallback.java
+++ b/graylog2-server/src/main/java/org/graylog2/alarmcallbacks/EmailAlarmCallback.java
@@ -172,11 +172,13 @@ public class EmailAlarmCallback implements AlarmCallback {
     // I am truly sorry about this, but leaking the user list is not okay...
     private ConfigurationRequest getConfigurationRequest(Map<String, String> userNames) {
         ConfigurationRequest configurationRequest = new ConfigurationRequest();
-        configurationRequest.addField(new TextField("sender",
-                "Sender",
-                "",
-                "The sender of sent out mail alerts",
-                ConfigurationField.Optional.OPTIONAL));
+        if (!graylogConfig.isCloud()) {
+            configurationRequest.addField(new TextField("sender",
+                    "Sender",
+                    "",
+                    "The sender of sent out mail alerts",
+                    ConfigurationField.Optional.OPTIONAL));
+        }
 
         configurationRequest.addField(new TextField("subject",
                 "E-Mail Subject",

--- a/graylog2-web-interface/src/components/event-notifications/event-notification-form/EventNotificationForm.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-form/EventNotificationForm.jsx
@@ -22,7 +22,7 @@ import { PluginStore } from 'graylog-web-plugin/plugin';
 import { Alert, Button, ButtonToolbar, Col, ControlLabel, FormControl, FormGroup, HelpBlock, Row } from 'components/graylog';
 import { Select, Spinner } from 'components/common';
 import { Input } from 'components/bootstrap';
-import FormsUtils from 'util/FormsUtils';
+import { getValueFromInput } from 'util/FormsUtils';
 
 class EventNotificationForm extends React.Component {
   static propTypes = {
@@ -59,7 +59,7 @@ class EventNotificationForm extends React.Component {
     const { name } = event.target;
     const { onChange } = this.props;
 
-    onChange(name, FormsUtils.getValueFromInput(event.target));
+    onChange(name, getValueFromInput(event.target));
   };
 
   handleConfigChange = (nextConfig) => {

--- a/graylog2-web-interface/src/components/event-notifications/event-notification-form/EventNotificationForm.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-form/EventNotificationForm.jsx
@@ -146,23 +146,28 @@ class EventNotificationForm extends React.Component {
 
             {notificationFormComponent}
 
-            <FormGroup>
-              <ControlLabel>Test Notification <small className="text-muted">(Optional)</small></ControlLabel>
-              <FormControl.Static>
-                <Button bsStyle="info" bsSize="small" disabled={testResult.isLoading} onClick={this.handleTestTrigger}>
-                  {testButtonText}
-                </Button>
-              </FormControl.Static>
-              {testResult.message && (
-                <Alert bsStyle={testResult.error ? 'danger' : 'success'}>
-                  <b>{testResult.error ? 'Error: ' : 'Success: '}</b>
-                  {testResult.message}
-                </Alert>
-              )}
-              <HelpBlock>
-                Execute this Notification with a test Alert.
-              </HelpBlock>
-            </FormGroup>
+            {notificationFormComponent && (
+              <FormGroup>
+                <ControlLabel>Test Notification <small className="text-muted">(Optional)</small></ControlLabel>
+                <FormControl.Static>
+                  <Button bsStyle="info"
+                          bsSize="small"
+                          disabled={testResult.isLoading}
+                          onClick={this.handleTestTrigger}>
+                    {testButtonText}
+                  </Button>
+                </FormControl.Static>
+                {testResult.message && (
+                  <Alert bsStyle={testResult.error ? 'danger' : 'success'}>
+                    <b>{testResult.error ? 'Error: ' : 'Success: '}</b>
+                    {testResult.message}
+                  </Alert>
+                )}
+                <HelpBlock>
+                  Execute this Notification with a test Alert.
+                </HelpBlock>
+              </FormGroup>
+            )}
 
             {!embedded && (
               <ButtonToolbar>

--- a/graylog2-web-interface/src/components/event-notifications/event-notification-types/EmailNotificationForm.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-types/EmailNotificationForm.jsx
@@ -98,15 +98,6 @@ class EmailNotificationForm extends React.Component {
 
     return (
       <>
-        <Input id="notification-sender"
-               name="sender"
-               label="Sender"
-               type="text"
-               bsStyle={validation.errors.sender ? 'error' : null}
-               help={lodash.get(validation, 'errors.sender[0]', 'The email address that should be used as the notification sender.')}
-               value={config.sender || ''}
-               onChange={this.handleChange}
-               required />
         <Input id="notification-subject"
                name="subject"
                label="Subject"
@@ -116,6 +107,15 @@ class EmailNotificationForm extends React.Component {
                value={config.subject || ''}
                onChange={this.handleChange}
                required />
+        <Input id="notification-sender"
+               name="sender"
+               label={<ControlLabel>Sender <small className="text-muted">(Optional)</small></ControlLabel>}
+               type="text"
+               bsStyle={validation.errors.sender ? 'error' : null}
+               help={lodash.get(validation, 'errors.sender[0]',
+                 'The email address that should be used as the notification sender. Leave it empty to use the default sender address.')}
+               value={config.sender || ''}
+               onChange={this.handleChange} />
         <FormGroup controlId="notification-user-recipients"
                    validationState={validation.errors.recipients ? 'error' : null}>
           <ControlLabel>User recipient(s) <small className="text-muted">(Optional)</small></ControlLabel>

--- a/graylog2-web-interface/src/components/event-notifications/event-notification-types/EmailNotificationForm.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-types/EmailNotificationForm.jsx
@@ -21,7 +21,7 @@ import lodash from 'lodash';
 import { ControlLabel, FormGroup, HelpBlock } from 'components/graylog';
 import { MultiSelect, SourceCodeEditor } from 'components/common';
 import { Input } from 'components/bootstrap';
-import FormsUtils from 'util/FormsUtils';
+import { getValueFromInput } from 'util/FormsUtils';
 import HideOnCloud from 'util/conditional/HideOnCloud';
 
 // TODO: Default body template should come from the server
@@ -79,7 +79,7 @@ class EmailNotificationForm extends React.Component {
   handleChange = (event) => {
     const { name } = event.target;
 
-    this.propagateChange(name, FormsUtils.getValueFromInput(event.target));
+    this.propagateChange(name, getValueFromInput(event.target));
   };
 
   handleBodyTemplateChange = (nextValue) => {

--- a/graylog2-web-interface/src/components/event-notifications/event-notification-types/EmailNotificationForm.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-types/EmailNotificationForm.jsx
@@ -22,6 +22,7 @@ import { ControlLabel, FormGroup, HelpBlock } from 'components/graylog';
 import { MultiSelect, SourceCodeEditor } from 'components/common';
 import { Input } from 'components/bootstrap';
 import FormsUtils from 'util/FormsUtils';
+import HideOnCloud from 'util/conditional/HideOnCloud';
 
 // TODO: Default body template should come from the server
 const DEFAULT_BODY_TEMPLATE = `--- [Event Definition] ---------------------------
@@ -107,15 +108,17 @@ class EmailNotificationForm extends React.Component {
                value={config.subject || ''}
                onChange={this.handleChange}
                required />
-        <Input id="notification-sender"
-               name="sender"
-               label={<ControlLabel>Sender <small className="text-muted">(Optional)</small></ControlLabel>}
-               type="text"
-               bsStyle={validation.errors.sender ? 'error' : null}
-               help={lodash.get(validation, 'errors.sender[0]',
-                 'The email address that should be used as the notification sender. Leave it empty to use the default sender address.')}
-               value={config.sender || ''}
-               onChange={this.handleChange} />
+        <HideOnCloud>
+          <Input id="notification-sender"
+                 name="sender"
+                 label={<ControlLabel>Sender <small className="text-muted">(Optional)</small></ControlLabel>}
+                 type="text"
+                 bsStyle={validation.errors.sender ? 'error' : null}
+                 help={lodash.get(validation, 'errors.sender[0]',
+                   'The email address that should be used as the notification sender. Leave it empty to use the default sender address.')}
+                 value={config.sender || ''}
+                 onChange={this.handleChange} />
+        </HideOnCloud>
         <FormGroup controlId="notification-user-recipients"
                    validationState={validation.errors.recipients ? 'error' : null}>
           <ControlLabel>User recipient(s) <small className="text-muted">(Optional)</small></ControlLabel>


### PR DESCRIPTION
- Make `sender` field in Email Alert Notification optional, since that will use the default set in the Graylog configuration file
- Hide `sender` field in both the Email Alert Notification and the Legacy Email Alarm Callback
- Small linter and UX fixes

Fixes https://github.com/Graylog2/graylog-plugin-cloud/issues/576