### PR TITLE
Allow user access to event annotation for streams he has access to

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/Search.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/Search.java
@@ -29,7 +29,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-import org.graylog.plugins.views.search.errors.PermissionException;
 import org.graylog.plugins.views.search.views.PluginMetadataSummary;
 import org.graylog2.contentpacks.ContentPackable;
 import org.graylog2.contentpacks.EntityDescriptorIds;
@@ -162,6 +161,18 @@ public abstract class Search implements ContentPackable<SearchEntity> {
         final Set<String> searchTypeStreamIds = queries().stream()
                 .flatMap(q -> q.searchTypes().stream())
                 .map(SearchType::effectiveStreams)
+                .reduce(Collections.emptySet(), Sets::union);
+
+        return Sets.union(queryStreamIds, searchTypeStreamIds);
+    }
+
+    public Set<String> streamIdsForPermissionsCheck() {
+        final Set<String> queryStreamIds = queries().stream()
+                .map(Query::usedStreamIds)
+                .reduce(Collections.emptySet(), Sets::union);
+        final Set<String> searchTypeStreamIds = queries().stream()
+                .flatMap(q -> q.searchTypes().stream())
+                .map(SearchType::streams)
                 .reduce(Collections.emptySet(), Sets::union);
 
         return Sets.union(queryStreamIds, searchTypeStreamIds);

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/SearchExecutionGuard.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/SearchExecutionGuard.java
@@ -42,7 +42,7 @@ public class SearchExecutionGuard {
     }
 
     public void check(Search search, Predicate<String> hasReadPermissionForStream) {
-        checkUserIsPermittedToSeeStreams(search.usedStreamIds(), hasReadPermissionForStream);
+        checkUserIsPermittedToSeeStreams(search.streamIdsForPermissionsCheck(), hasReadPermissionForStream);
 
         checkMissingRequirements(search);
     }

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/SearchExecutionGuardTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/SearchExecutionGuardTest.java
@@ -21,6 +21,7 @@ import org.graylog.plugins.views.search.engine.BackendQuery;
 import org.graylog.plugins.views.search.errors.MissingCapabilitiesException;
 import org.graylog.plugins.views.search.filter.OrFilter;
 import org.graylog.plugins.views.search.filter.StreamFilter;
+import org.graylog.plugins.views.search.searchtypes.events.EventList;
 import org.graylog.plugins.views.search.views.PluginMetadataSummary;
 import org.graylog2.plugin.PluginMetaData;
 import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
@@ -29,7 +30,6 @@ import org.graylog2.shared.rest.exceptions.MissingStreamPermissionException;
 import org.junit.Before;
 import org.junit.Test;
 
-import javax.ws.rs.ForbiddenException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -115,6 +115,13 @@ public class SearchExecutionGuardTest {
         final Query query = Query.builder()
                 .id("")
                 .timerange(mock(TimeRange.class))
+                .searchTypes(
+                        ImmutableSet.of(
+                                EventList.builder()
+                                        .id("event-list")
+                                        .streams(ImmutableSet.copyOf(streamIds))
+                                        .build())
+                )
                 .query(new BackendQuery.Fallback())
                 .filter(OrFilter.or(filters))
                 .build();


### PR DESCRIPTION
## Motivation
Prior to this change, the user needed additional access to `All Events`
and `All system events` to search with Event Annotation.

## Description
This change will change the streams used to check for permission.
Instead of effective streams which contains the Event Streams,
we use the streams the user has access to. We will filter with these
streams later the result of the Event Streams request.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


Fixes #8260
