### PR TITLE
Fix version probe for ES snapshot versions

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/storage/versionprobe/VersionProbe.java
+++ b/graylog2-server/src/main/java/org/graylog2/storage/versionprobe/VersionProbe.java
@@ -97,21 +97,12 @@ public class VersionProbe {
     }
 
     private Optional<Version> parseVersion(String versionString) {
-        final String[] versionParts = versionString.split("\\.");
-        if (versionParts.length != 3) {
-            LOG.error("Unable to parse version retrieved from Elasticsearch node: " + versionString);
-            return Optional.empty();
-        }
         try {
-            final int major = Integer.parseUnsignedInt(versionParts[0]);
-            final int minor = Integer.parseUnsignedInt(versionParts[1]);
-            final int patch = Integer.parseUnsignedInt(versionParts[2]);
-
-            final Version version = Version.from(major, minor, patch);
-
-            return Optional.of(version);
-        } catch (NumberFormatException e) {
-            throw new ElasticsearchProbeException("Unable to parse version retrieved from Elasticsearch node: " + versionString, e);
+            final com.github.zafarkhaja.semver.Version version = com.github.zafarkhaja.semver.Version.valueOf(versionString);
+            return Optional.of(new Version(version));
+        } catch (Exception e) {
+            LOG.error("Unable to parse version retrieved from Elasticsearch node: <{}>", versionString, e);
+            return Optional.empty();
         }
     }
 


### PR DESCRIPTION
My machine is running elastic `7.9.3-SNAPSHOT`
which couldn't be parsed and prevented the server to start.

- Use the semver parser instead of a hand rolled version which
  cannot deal with prerelease tags

- Also, avoid throwing an exception at this point, which forever blocks
  the AtomicCache. I guess we don't complete the Future in this case.

