### PR TITLE
Remove remaining eslint-disable-camelcase comments

### DIFF
--- a/graylog2-web-interface/src/stores/PaginationTypes.ts
+++ b/graylog2-web-interface/src/stores/PaginationTypes.ts
@@ -19,7 +19,6 @@ import { $PropertyType } from 'utility-types';
 
 import type { AdditionalQueries } from 'util/PaginationURL';
 
-/* eslint-disable camelcase */
 export type PaginatedResponseType = {
   count: number,
   total: number,
@@ -35,7 +34,6 @@ export type PaginatedListJSON = {
   total: number,
   count: number,
 };
-/* eslint-enable camelcase */
 
 export type Pagination = {
   page: number,

--- a/graylog2-web-interface/src/stores/nodes/NodesStore.ts
+++ b/graylog2-web-interface/src/stores/nodes/NodesStore.ts
@@ -24,7 +24,6 @@ import CombinedProvider from 'injection/CombinedProvider';
 const { NodesActions } = CombinedProvider.get('Nodes');
 const { SessionStore } = CombinedProvider.get('Session');
 
-/* eslint-disable camelcase */
 type NodeInfo = {
   cluster_id: string,
   hostname: string,
@@ -35,7 +34,6 @@ type NodeInfo = {
   transport_address: string,
   type: 'server',
 };
-/* eslint-enable camelcase */
 
 type NodesListResponse = {
   nodes: Array<NodeInfo> | null | undefined,

--- a/graylog2-web-interface/src/stores/streams/StreamsStore.ts
+++ b/graylog2-web-interface/src/stores/streams/StreamsStore.ts
@@ -28,7 +28,6 @@ import { singletonStore } from 'views/logic/singleton';
 
 const { CurrentUserStore } = CombinedProvider.get('CurrentUser');
 
-/* eslint-disable camelcase */
 export type Stream = {
   id: string,
   title: string,
@@ -88,7 +87,6 @@ export type StreamResponse = {
   remove_matches_from_default_stream: boolean,
   index_set_id: string,
 }
-/* eslint-enable camelcase */
 
 type TestMatchResponse = {
   matches: boolean,
@@ -104,7 +102,6 @@ type StreamSummaryResponse = {
   streams: Array<Stream>,
 };
 
-/* eslint-disable camelcase */
 type PaginatedResponse = {
   pagination: {
     count: number,
@@ -115,7 +112,6 @@ type PaginatedResponse = {
   },
   streams: Array<Stream>,
 };
-/* eslint-enable camelcase */
 
 const StreamsStore = singletonStore('Streams', () => Reflux.createStore({
   listenables: [StreamsActions],


### PR DESCRIPTION
## Motivation
Prior to this change, we set the eslint config that
it does not bother us with camelcase warnings.

## Description
This change was proudly presented by sed:

`git grep -l camelcase | xargs sed -i '/camelcase/d'`

