### PR TITLE
Update Absolute time inputs to use number instead of text

### DIFF
--- a/graylog2-web-interface/src/views/components/searchbar/__snapshots__/SearchBarForm.test.tsx.snap
+++ b/graylog2-web-interface/src/views/components/searchbar/__snapshots__/SearchBarForm.test.tsx.snap
@@ -388,6 +388,7 @@ fieldset[disabled] .c3.form-control:not([type="range"]) {
 .c8 {
   padding: 0;
   background: #f3f3f3;
+  font-weight: bold;
 }
 
 .c8:not(:first-child):not(:last-child) {
@@ -397,7 +398,8 @@ fieldset[disabled] .c3.form-control:not([type="range"]) {
 }
 
 .c10 {
-  padding: 0 9px;
+  padding: 0 6px 0 9px;
+  width: 50px !important;
 }
 
 .c10.form-control:not([type="range"]) {
@@ -436,6 +438,10 @@ fieldset[disabled] .c10.form-control:not([type="range"]) {
 
 .c10.form-control:not([type="range"]) ~ .form-control-feedback.glyphicon {
   display: none;
+}
+
+.c10:last-of-type {
+  width: 60px !important;
 }
 
 .c9 {
@@ -1352,7 +1358,6 @@ fieldset[disabled] .c10.form-control:not([type="range"]) {
                 <input
                   class="c10 form-control input-sm"
                   id="from-time-hours"
-                  size="2"
                   title="from hour"
                   type="number"
                   value="10"
@@ -1365,7 +1370,6 @@ fieldset[disabled] .c10.form-control:not([type="range"]) {
                 <input
                   class="c10 form-control input-sm"
                   id="from-time-minutes"
-                  size="2"
                   title="from minutes"
                   type="number"
                   value="04"
@@ -1378,7 +1382,6 @@ fieldset[disabled] .c10.form-control:not([type="range"]) {
                 <input
                   class="c10 form-control input-sm"
                   id="from-time-seconds"
-                  size="2"
                   title="from seconds"
                   type="number"
                   value="30"
@@ -1391,7 +1394,6 @@ fieldset[disabled] .c10.form-control:not([type="range"]) {
                 <input
                   class="c10 form-control input-sm"
                   id="from-time-milliseconds"
-                  size="3"
                   title="from milliseconds"
                   type="number"
                   value="329"
@@ -1988,7 +1990,6 @@ fieldset[disabled] .c10.form-control:not([type="range"]) {
                 <input
                   class="c10 form-control input-sm"
                   id="to-time-hours"
-                  size="2"
                   title="to hour"
                   type="number"
                   value="10"
@@ -2001,7 +2002,6 @@ fieldset[disabled] .c10.form-control:not([type="range"]) {
                 <input
                   class="c10 form-control input-sm"
                   id="to-time-minutes"
-                  size="2"
                   title="to minutes"
                   type="number"
                   value="04"
@@ -2014,7 +2014,6 @@ fieldset[disabled] .c10.form-control:not([type="range"]) {
                 <input
                   class="c10 form-control input-sm"
                   id="to-time-seconds"
-                  size="2"
                   title="to seconds"
                   type="number"
                   value="30"
@@ -2027,7 +2026,6 @@ fieldset[disabled] .c10.form-control:not([type="range"]) {
                 <input
                   class="c10 form-control input-sm"
                   id="to-time-milliseconds"
-                  size="3"
                   title="to milliseconds"
                   type="number"
                   value="329"

--- a/graylog2-web-interface/src/views/components/searchbar/date-time-picker/AbsoluteRangeField.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/date-time-picker/AbsoluteRangeField.test.tsx
@@ -64,22 +64,22 @@ describe('AbsoluteRangeField', () => {
     const toggleBtn = screen.getByRole('button', { name: /toggle between beginning and end of day/i });
     fireEvent.click(toggleBtn);
 
-    const inputHour = screen.getByRole('textbox', { name: /from hour/i });
-    const inputMinutes = screen.getByRole('textbox', { name: /from minutes/i });
-    const inputSeconds = screen.getByRole('textbox', { name: /from seconds/i });
-    const inputMillsecs = screen.getByRole('textbox', { name: /from milliseconds/i });
+    const inputHour = screen.getByRole('spinbutton', { name: /from hour/i });
+    const inputMinutes = screen.getByRole('spinbutton', { name: /from minutes/i });
+    const inputSeconds = screen.getByRole('spinbutton', { name: /from seconds/i });
+    const inputMillsecs = screen.getByRole('spinbutton', { name: /from milliseconds/i });
 
-    expect(inputHour).toHaveValue('00');
-    expect(inputMinutes).toHaveValue('00');
-    expect(inputSeconds).toHaveValue('00');
-    expect(inputMillsecs).toHaveValue('000');
+    expect(inputHour).toHaveValue(0);
+    expect(inputMinutes).toHaveValue(0);
+    expect(inputSeconds).toHaveValue(0);
+    expect(inputMillsecs).toHaveValue(0);
 
     fireEvent.click(toggleBtn);
 
-    expect(inputHour).toHaveValue('23');
-    expect(inputMinutes).toHaveValue('59');
-    expect(inputSeconds).toHaveValue('59');
-    expect(inputMillsecs).toHaveValue('999');
+    expect(inputHour).toHaveValue(23);
+    expect(inputMinutes).toHaveValue(59);
+    expect(inputSeconds).toHaveValue(59);
+    expect(inputMillsecs).toHaveValue(999);
   });
 
   it('does not allow non-numeric characters', () => {
@@ -87,13 +87,13 @@ describe('AbsoluteRangeField', () => {
       <AbsoluteRangeField {...defaultProps} from />
     ));
 
-    const inputHour = screen.getByRole('textbox', { name: /from hour/i });
+    const inputHour = screen.getByRole('spinbutton', { name: /from hour/i });
 
     act(() => {
       fireEvent.change(inputHour, { target: { value: '/w!' } });
     });
 
-    expect(inputHour).toHaveValue('00');
+    expect(inputHour).toHaveValue(0);
   });
 
   it('does allow proper value', () => {
@@ -101,13 +101,13 @@ describe('AbsoluteRangeField', () => {
       <AbsoluteRangeField {...defaultProps} from />
     ));
 
-    const inputHour = screen.getByRole('textbox', { name: /from hour/i });
+    const inputHour = screen.getByRole('spinbutton', { name: /from hour/i });
 
     act(() => {
       fireEvent.change(inputHour, { target: { value: '10' } });
     });
 
-    expect(inputHour).toHaveValue('10');
+    expect(inputHour).toHaveValue(10);
   });
 
   it('does not allow numbers over their maximum', () => {
@@ -115,13 +115,13 @@ describe('AbsoluteRangeField', () => {
       <AbsoluteRangeField {...defaultProps} from />
     ));
 
-    const inputHour = screen.getByRole('textbox', { name: /from hour/i });
+    const inputHour = screen.getByRole('spinbutton', { name: /from hour/i });
 
     act(() => {
       fireEvent.change(inputHour, { target: { value: '50' } });
     });
 
-    expect(inputHour).toHaveValue('23');
+    expect(inputHour).toHaveValue(23);
   });
 
   it('does not try to parse an empty date', () => {
@@ -129,12 +129,12 @@ describe('AbsoluteRangeField', () => {
       <AbsoluteRangeField {...defaultProps} from />
     ));
 
-    const inputHour = screen.getByRole('textbox', { name: /from hour/i });
+    const inputHour = screen.getByRole('spinbutton', { name: /from hour/i });
 
     act(() => {
       fireEvent.change(inputHour, { target: { value: '' } });
     });
 
-    expect(inputHour).toHaveValue('00');
+    expect(inputHour).toHaveValue(0);
   });
 });

--- a/graylog2-web-interface/src/views/components/searchbar/date-time-picker/AbsoluteRangeField.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/date-time-picker/AbsoluteRangeField.tsx
@@ -63,6 +63,7 @@ const SetTimeOption = styled.div`
 const StyledInputAddon = styled(InputGroup.Addon)(({ theme }: {theme:DefaultTheme}) => css`
   padding: 0;
   background: ${theme.colors.variant.lightest.default};
+  font-weight: bold;
 
   &:not(:first-child):not(:last-child) {
     border-right: 0;
@@ -72,7 +73,12 @@ const StyledInputAddon = styled(InputGroup.Addon)(({ theme }: {theme:DefaultThem
 `);
 
 const StyledFormControl = styled(FormControl)`
-  padding: 0 9px;
+  padding: 0 6px 0 9px;
+  width: 50px !important;
+  
+  &:last-of-type {
+    width: 60px !important;
+  }
 `;
 
 const StyledButton = styled(Button)`
@@ -228,40 +234,36 @@ const AbsoluteRangeField = ({ disabled, limitDuration, from, currentTimeRange }:
                         <Icon name={hourIcon.current} />
                       </StyledButton>
                     </StyledInputAddon>
-                    <StyledFormControl type="text"
+                    <StyledFormControl type="number"
                                        id={`${range}-time-hours`}
                                        title={`${range} hour`}
                                        value={initialDateTime.hours ?? ''}
                                        onChange={_onChangeSetTime}
                                        onFocus={_onFocusSelect}
-                                       size={2}
                                        bsSize="sm" />
                     <StyledInputAddon>:</StyledInputAddon>
-                    <StyledFormControl type="text"
+                    <StyledFormControl type="number"
                                        id={`${range}-time-minutes`}
                                        title={`${range} minutes`}
                                        value={initialDateTime.minutes ?? ''}
                                        onChange={_onChangeSetTime}
                                        onFocus={_onFocusSelect}
-                                       size={2}
                                        bsSize="sm" />
                     <StyledInputAddon>:</StyledInputAddon>
-                    <StyledFormControl type="text"
+                    <StyledFormControl type="number"
                                        id={`${range}-time-seconds`}
                                        title={`${range} seconds`}
                                        value={initialDateTime.seconds ?? ''}
                                        onChange={_onChangeSetTime}
                                        onFocus={_onFocusSelect}
-                                       size={2}
                                        bsSize="sm" />
                     <StyledInputAddon>.</StyledInputAddon>
-                    <StyledFormControl type="text"
+                    <StyledFormControl type="number"
                                        id={`${range}-time-milliseconds`}
                                        title={`${range} milliseconds`}
                                        value={initialDateTime.milliseconds ?? ''}
                                        onChange={_onChangeSetTime}
                                        onFocus={_onFocusSelect}
-                                       size={3}
                                        bsSize="sm" />
                     <StyledInputAddon>
                       <StyledButton bsStyle="link"

--- a/graylog2-web-interface/src/views/components/searchbar/date-time-picker/RelativeTimeRangeSelector.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/date-time-picker/RelativeTimeRangeSelector.tsx
@@ -254,7 +254,7 @@ RelativeTimeRangeSelector.propTypes = {
   limitDuration: PropTypes.number,
   disabled: PropTypes.bool,
   originalTimeRange: PropTypes.shape({
-    range: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+    range: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   }).isRequired,
 };
 

--- a/graylog2-web-interface/src/views/components/searchbar/date-time-picker/__snapshots__/AbsoluteRangeField.test.tsx.snap
+++ b/graylog2-web-interface/src/views/components/searchbar/date-time-picker/__snapshots__/AbsoluteRangeField.test.tsx.snap
@@ -384,6 +384,7 @@ fieldset[disabled] .c0.form-control:not([type="range"]) {
 .c5 {
   padding: 0;
   background: #f3f3f3;
+  font-weight: bold;
 }
 
 .c5:not(:first-child):not(:last-child) {
@@ -393,7 +394,8 @@ fieldset[disabled] .c0.form-control:not([type="range"]) {
 }
 
 .c7 {
-  padding: 0 9px;
+  padding: 0 6px 0 9px;
+  width: 50px !important;
 }
 
 .c7.form-control:not([type="range"]) {
@@ -432,6 +434,10 @@ fieldset[disabled] .c7.form-control:not([type="range"]) {
 
 .c7.form-control:not([type="range"]) ~ .form-control-feedback.glyphicon {
   display: none;
+}
+
+.c7:last-of-type {
+  width: 60px !important;
 }
 
 .c6 {
@@ -1286,7 +1292,6 @@ fieldset[disabled] .c7.form-control:not([type="range"]) {
             <input
               class="c7 form-control input-sm"
               id="from-time-hours"
-              size="2"
               title="from hour"
               type="number"
               value="06"
@@ -1299,7 +1304,6 @@ fieldset[disabled] .c7.form-control:not([type="range"]) {
             <input
               class="c7 form-control input-sm"
               id="from-time-minutes"
-              size="2"
               title="from minutes"
               type="number"
               value="15"
@@ -1312,7 +1316,6 @@ fieldset[disabled] .c7.form-control:not([type="range"]) {
             <input
               class="c7 form-control input-sm"
               id="from-time-seconds"
-              size="2"
               title="from seconds"
               type="number"
               value="00"
@@ -1325,7 +1328,6 @@ fieldset[disabled] .c7.form-control:not([type="range"]) {
             <input
               class="c7 form-control input-sm"
               id="from-time-milliseconds"
-              size="3"
               title="from milliseconds"
               type="number"
               value="000"

--- a/graylog2-web-interface/src/views/components/searchbar/date-time-picker/__snapshots__/AbsoluteTimeRangeSelector.test.tsx.snap
+++ b/graylog2-web-interface/src/views/components/searchbar/date-time-picker/__snapshots__/AbsoluteTimeRangeSelector.test.tsx.snap
@@ -384,6 +384,7 @@ fieldset[disabled] .c2.form-control:not([type="range"]) {
 .c7 {
   padding: 0;
   background: #f3f3f3;
+  font-weight: bold;
 }
 
 .c7:not(:first-child):not(:last-child) {
@@ -393,7 +394,8 @@ fieldset[disabled] .c2.form-control:not([type="range"]) {
 }
 
 .c9 {
-  padding: 0 9px;
+  padding: 0 6px 0 9px;
+  width: 50px !important;
 }
 
 .c9.form-control:not([type="range"]) {
@@ -432,6 +434,10 @@ fieldset[disabled] .c9.form-control:not([type="range"]) {
 
 .c9.form-control:not([type="range"]) ~ .form-control-feedback.glyphicon {
   display: none;
+}
+
+.c9:last-of-type {
+  width: 60px !important;
 }
 
 .c8 {
@@ -1347,7 +1353,6 @@ fieldset[disabled] .c9.form-control:not([type="range"]) {
                 <input
                   class="c9 form-control input-sm"
                   id="from-time-hours"
-                  size="2"
                   title="from hour"
                   type="number"
                   value="06"
@@ -1360,7 +1365,6 @@ fieldset[disabled] .c9.form-control:not([type="range"]) {
                 <input
                   class="c9 form-control input-sm"
                   id="from-time-minutes"
-                  size="2"
                   title="from minutes"
                   type="number"
                   value="15"
@@ -1373,7 +1377,6 @@ fieldset[disabled] .c9.form-control:not([type="range"]) {
                 <input
                   class="c9 form-control input-sm"
                   id="from-time-seconds"
-                  size="2"
                   title="from seconds"
                   type="number"
                   value="00"
@@ -1386,7 +1389,6 @@ fieldset[disabled] .c9.form-control:not([type="range"]) {
                 <input
                   class="c9 form-control input-sm"
                   id="from-time-milliseconds"
-                  size="3"
                   title="from milliseconds"
                   type="number"
                   value="000"
@@ -1699,7 +1701,7 @@ fieldset[disabled] .c9.form-control:not([type="range"]) {
                         aria-disabled="false"
                         aria-label="Thu Dec 10 2020"
                         aria-selected="false"
-                        class="DayPicker-Day DayPicker-Day--today"
+                        class="DayPicker-Day"
                         role="gridcell"
                         tabindex="-1"
                       >
@@ -1709,7 +1711,7 @@ fieldset[disabled] .c9.form-control:not([type="range"]) {
                         aria-disabled="false"
                         aria-label="Fri Dec 11 2020"
                         aria-selected="false"
-                        class="DayPicker-Day"
+                        class="DayPicker-Day DayPicker-Day--today"
                         role="gridcell"
                         tabindex="-1"
                       >
@@ -1983,7 +1985,6 @@ fieldset[disabled] .c9.form-control:not([type="range"]) {
                 <input
                   class="c9 form-control input-sm"
                   id="to-time-hours"
-                  size="2"
                   title="to hour"
                   type="number"
                   value="NaN"
@@ -1996,7 +1997,6 @@ fieldset[disabled] .c9.form-control:not([type="range"]) {
                 <input
                   class="c9 form-control input-sm"
                   id="to-time-minutes"
-                  size="2"
                   title="to minutes"
                   type="number"
                   value="NaN"
@@ -2009,7 +2009,6 @@ fieldset[disabled] .c9.form-control:not([type="range"]) {
                 <input
                   class="c9 form-control input-sm"
                   id="to-time-seconds"
-                  size="2"
                   title="to seconds"
                   type="number"
                   value="NaN"
@@ -2022,7 +2021,6 @@ fieldset[disabled] .c9.form-control:not([type="range"]) {
                 <input
                   class="c9 form-control input-sm"
                   id="to-time-milliseconds"
-                  size="3"
                   title="to milliseconds"
                   type="number"
                   value="NaN"


### PR DESCRIPTION
Allows for using number inputs so time can be driven with keyboard up/down buttons.