### PR TITLE
Fix deserialization of incomplete AlertReceivers objects

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/models/alarmcallbacks/requests/AlertReceivers.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/alarmcallbacks/requests/AlertReceivers.java
@@ -19,14 +19,20 @@ package org.graylog2.rest.models.alarmcallbacks.requests;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
 import org.graylog.autovalue.WithBeanGetter;
 
+import javax.annotation.Nullable;
+import java.util.Collections;
 import java.util.List;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
 
 @AutoValue
 @WithBeanGetter
 @JsonAutoDetect
+@JsonDeserialize(builder = AlertReceivers.Builder.class)
 public abstract class AlertReceivers {
     @JsonProperty("emails")
     public abstract List<String> emails();
@@ -34,9 +40,32 @@ public abstract class AlertReceivers {
     @JsonProperty("users")
     public abstract List<String> users();
 
-    @JsonCreator
-    public static AlertReceivers create(@JsonProperty("emails") List<String> emails,
-                                        @JsonProperty("users") List<String> users) {
-        return new AutoValue_AlertReceivers(emails, users);
+    public static AlertReceivers create(@Nullable List<String> emails, @Nullable List<String> users) {
+        return builder()
+                .emails(firstNonNull(emails, Collections.emptyList()))
+                .users(firstNonNull(users, Collections.emptyList()))
+                .build();
+    }
+
+    public static Builder builder() {
+        return Builder.create();
+    }
+
+    @AutoValue.Builder
+    public abstract static class Builder {
+        @JsonCreator
+        public static Builder create() {
+            return new AutoValue_AlertReceivers.Builder()
+                    .emails(Collections.emptyList())
+                    .users(Collections.emptyList());
+        }
+
+        @JsonProperty("emails")
+        public abstract Builder emails(List<String> emails);
+
+        @JsonProperty("users")
+        public abstract Builder users(List<String> users);
+
+        public abstract AlertReceivers build();
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/StreamResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/StreamResource.java
@@ -531,10 +531,7 @@ public class StreamResource extends RestResource {
             stream.getDisabled(),
             stream.getStreamRules(),
             alertConditions,
-            AlertReceivers.create(
-                firstNonNull(emailAlertReceivers, Collections.emptyList()),
-                firstNonNull(usersAlertReceivers, Collections.emptyList())
-            ),
+            AlertReceivers.create(emailAlertReceivers, usersAlertReceivers),
             stream.getTitle(),
             stream.getContentPack(),
             stream.isDefaultStream(),


### PR DESCRIPTION
The new paginated endpoint in StreamResource is using mongojack to
deserialize the database objects. In some setups the AlertReceivers
object in the database might not be complete.

Change AlertReceivers to use defaults for missing values.

Fixes #9637

This needs to be cherry picked into 4.0 once it's merged.