### PR TITLE
Add HTML emails compatibility for alerts notifications

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/events/contentpack/entities/EmailEventNotificationConfigEntity.java
+++ b/graylog2-server/src/main/java/org/graylog/events/contentpack/entities/EmailEventNotificationConfigEntity.java
@@ -38,6 +38,7 @@ public abstract class EmailEventNotificationConfigEntity implements EventNotific
     private static final String FIELD_SENDER = "sender";
     private static final String FIELD_SUBJECT = "subject";
     private static final String FIELD_BODY_TEMPLATE = "body_template";
+    private static final String FIELD_HTML_BODY_TEMPLATE = "html_body_template";
     private static final String FIELD_EMAIL_RECIPIENTS = "email_recipients";
     private static final String FIELD_USER_RECIPIENTS = "user_recipients";
 
@@ -49,6 +50,9 @@ public abstract class EmailEventNotificationConfigEntity implements EventNotific
 
     @JsonProperty(FIELD_BODY_TEMPLATE)
     public abstract ValueReference bodyTemplate();
+
+    @JsonProperty(FIELD_HTML_BODY_TEMPLATE)
+    public abstract ValueReference htmlBodyTemplate();
 
     @JsonProperty(FIELD_EMAIL_RECIPIENTS)
     public abstract Set<String> emailRecipients();
@@ -80,6 +84,9 @@ public abstract class EmailEventNotificationConfigEntity implements EventNotific
         @JsonProperty(FIELD_BODY_TEMPLATE)
         public abstract Builder bodyTemplate(ValueReference bodyTemplate);
 
+        @JsonProperty(FIELD_HTML_BODY_TEMPLATE)
+        public abstract Builder htmlBodyTemplate(ValueReference htmlBodyTemplate);
+
         @JsonProperty(FIELD_EMAIL_RECIPIENTS)
         public abstract Builder emailRecipients(Set<String> emailRecipients);
 
@@ -95,6 +102,7 @@ public abstract class EmailEventNotificationConfigEntity implements EventNotific
                 .sender(sender().asString(parameters))
                 .subject(subject().asString(parameters))
                 .bodyTemplate(bodyTemplate().asString())
+                .htmlBodyTemplate(htmlBodyTemplate().asString())
                 .emailRecipients(emailRecipients())
                 .userRecipients(userRecipients())
                 .build();

--- a/graylog2-server/src/main/java/org/graylog/events/contentpack/entities/EmailEventNotificationConfigEntity.java
+++ b/graylog2-server/src/main/java/org/graylog/events/contentpack/entities/EmailEventNotificationConfigEntity.java
@@ -72,7 +72,8 @@ public abstract class EmailEventNotificationConfigEntity implements EventNotific
         @JsonCreator
         public static Builder create() {
             return new AutoValue_EmailEventNotificationConfigEntity.Builder()
-                    .type(TYPE_NAME);
+                    .type(TYPE_NAME)
+                    .htmlBodyTemplate(ValueReference.of(""));
         }
 
         @JsonProperty(FIELD_SENDER)

--- a/graylog2-server/src/main/java/org/graylog/events/notifications/types/EmailEventNotificationConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/events/notifications/types/EmailEventNotificationConfig.java
@@ -71,35 +71,6 @@ public abstract class EmailEventNotificationConfig implements EventNotificationC
             "${end}\n" +
             "\n";
 
-    static final String DEFAULT_HTML_BODY_TEMPLATE = "<table width=\"100%\" border=\"0\" cellpadding=\"10\" cellspacing=\"0\" style=\"background-color:#f9f9f9;border:none;line-height:1.2\"><tbody>" +
-            "<tr style=\"line-height:1.5\"><th colspan=\"2\" style=\"background-color:#e6e6e6\">Event Definition</th></tr>" +
-            "<tr><td width=\"200px\">Title</td><td>${event_definition_title}</td></tr>" +
-            "<tr><td>Description</td><td>${event_definition_description}</td></tr>" +
-            "<tr><td>Type</td><td>${event_definition_type}</td></tr>" +
-            "</tbody></table>" +
-            "<br /><table width=\"100%\" border=\"0\" cellpadding=\"10\" cellspacing=\"0\" style=\"background-color:#f9f9f9;border:none;line-height:1.2\"><tbody>" +
-            "<tr><th colspan=\"2\" style=\"background-color:#e6e6e6;line-height:1.5\">Event</th></tr>" +
-            "<tr><td width=\"200px\">Timestamp</td><td>${event.timestamp}</td></tr>" +
-            "<tr><td>Message</td><td>${event.message}</td></tr>" +
-            "<tr><td>Source</td><td>${event.source}</td></tr>" +
-            "<tr><td>Key</td><td>${event.key}</td></tr>" +
-            "<tr><td>Priority</td><td>${event.priority}</td></tr>" +
-            "<tr><td>Alert</td><td>${event.alert}</td></tr>" +
-            "<tr><td>Timestamp Processing</td><td>${event.timestamp}</td></tr>" +
-            "<tr><td>Timerange Start</td><td>${event.timerange_start}</td></tr>" +
-            "<tr><td>Timerange End</td><td>${event.timerange_end}</td></tr>" +
-            "<tr><td>Source Streams</td><td>${event.source_streams}</td></tr>" +
-            "<tr><td>Fields</td><td><ul style=\"list-style-type:square;\">${foreach event.fields field}<li>${field.key}:${field.value}</li>${end}<ul></td></tr>" +
-            "</tbody></table>" +
-            "${if backlog}" +
-            "<br /><table width=\"100%\" border=\"0\" cellpadding=\"10\" cellspacing=\"0\" style=\"background-color:#f9f9f9;border:none;line-height:1.2\"><tbody>" +
-            "<tr><th style=\"background-color:#e6e6e6;line-height:1.5\">Backlog (Last messages accounting for this alert)</th></tr>" +
-            "${foreach backlog message}" +
-            "<tr><td>${message}</td></tr>" +
-            "${end}" +
-            "</tbody></table>" +
-            "${end}";
-
     private static final String FIELD_SENDER = "sender";
     private static final String FIELD_SUBJECT = "subject";
     private static final String FIELD_BODY_TEMPLATE = "body_template";
@@ -167,7 +138,7 @@ public abstract class EmailEventNotificationConfig implements EventNotificationC
                     .emailRecipients(ImmutableSet.of())
                     .userRecipients(ImmutableSet.of())
                     .bodyTemplate(DEFAULT_BODY_TEMPLATE)
-                    .htmlBodyTemplate(DEFAULT_HTML_BODY_TEMPLATE);
+                    .htmlBodyTemplate("");
         }
 
         @JsonProperty(FIELD_SENDER)

--- a/graylog2-server/src/main/java/org/graylog/events/notifications/types/EmailSender.java
+++ b/graylog2-server/src/main/java/org/graylog/events/notifications/types/EmailSender.java
@@ -105,13 +105,7 @@ public class EmailSender {
 
     @VisibleForTesting
     private String buildHtmlBody(EmailEventNotificationConfig config, Map<String, Object> model) {
-        final String template;
-        if (isNullOrEmpty(config.htmlBodyTemplate())) {
-            template = formatHtmlBody(EmailEventNotificationConfig.DEFAULT_HTML_BODY_TEMPLATE);
-        } else {
-            template = formatHtmlBody(config.htmlBodyTemplate());
-        }
-        return this.templateEngine.transform(template, model);
+        return this.templateEngine.transform(config.htmlBodyTemplate(), model);
     }
 
     private String formatHtmlBody(String bodyContent) {

--- a/graylog2-server/src/test/java/org/graylog/events/notifications/NotificationDtoTest.java
+++ b/graylog2-server/src/test/java/org/graylog/events/notifications/NotificationDtoTest.java
@@ -46,6 +46,7 @@ public class NotificationDtoTest {
                         .sender("foo@graylog.org")
                         .subject("foo")
                         .bodyTemplate("bar")
+                        .htmlBodyTemplate("baz")
                         .emailRecipients(Sets.newHashSet("foo@graylog.org"))
                         .build())
                 .build();
@@ -99,12 +100,13 @@ public class NotificationDtoTest {
                 .sender("")
                 .subject("")
                 .bodyTemplate("")
+                .htmlBodyTemplate("")
                 .build();
         final NotificationDto emptyNotification = getEmailNotification().toBuilder().config(emptyConfig).build();
         final ValidationResult validationResult = emptyNotification.validate();
         assertThat(validationResult.failed()).isTrue();
         assertThat(validationResult.getErrors().size()).isEqualTo(4);
-        assertThat(validationResult.getErrors()).containsOnlyKeys("subject", "sender", "body_template", "recipients");
+        assertThat(validationResult.getErrors()).containsOnlyKeys("subject", "sender", "body", "recipients");
     }
 
     @Test

--- a/graylog2-server/src/test/resources/org/graylog/events/contentpack/facade/NotificationFacadeTest.json
+++ b/graylog2-server/src/test/resources/org/graylog/events/contentpack/facade/NotificationFacadeTest.json
@@ -11,6 +11,7 @@
         "sender" : "konrad.merz@example.org",
         "subject" : "Graylog event notification: ${event_definition_title}",
         "body_template" : "--- [Event Definition] ---------------------------\nTitle:       ${event_definition_title}\nDescription: ${event_definition_description}\nType:        ${event_definition_type}\n--- [Event] --------------------------------------\nTimestamp:            ${event.timestamp}\nMessage:              ${event.message}\nSource:               ${event.source}\nKey:                  ${event.key}\nPriority:             ${event.priority}\nAlert:                ${event.alert}\nTimestamp Processing: ${event.timestamp}\nTimerange Start:      ${event.timerange_start}\nTimerange End:        ${event.timerange_end}\nFields:\n${foreach event.fields field}  ${field.key}: ${field.value}\n${end}\n${if backlog}\n--- [Backlog] ------------------------------------\nLast messages accounting for this alert:\n${foreach backlog message}\n${message}\n${end}\n${end}\n",
+        "html_body_template": "<table><tbody><tr><td>Title</td><td>${event_definition_title}</td></tr></tbody></table>",
         "email_recipients" : [
           "example@example.org"
         ],

--- a/graylog2-web-interface/src/components/event-notifications/event-notification-details/EmailNotificationDetails.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-details/EmailNotificationDetails.jsx
@@ -34,6 +34,12 @@ const EmailNotificationDetails = ({ notification }) => (
                            {notification.config.body_template || <em>Empty body</em>}
                          </Well>
                        )} />
+    <ReadOnlyFormGroup label="Email HTML Body"
+                       value={(
+                         <Well bsSize="small" className={styles.bodyPreview}>
+                           {notification.config.html_body_template || <em>Empty body</em>}
+                         </Well>
+                       )} />
   </>
 );
 

--- a/graylog2-web-interface/src/components/event-notifications/event-notification-types/EmailNotificationForm.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-types/EmailNotificationForm.jsx
@@ -50,6 +50,36 @@ Last messages accounting for this alert:
 \${end}
 `;
 
+const DEFAULT_HTML_BODY_TEMPLATE = `<table width="100%" border="0" cellpadding="10" cellspacing="0" style="background-color:#f9f9f9;border:none;line-height:1.2"><tbody>
+<tr style="line-height:1.5"><th colspan="2" style="background-color:#e6e6e6">Event Definition</th></tr>
+<tr><td width="200px">Title</td><td>\${event_definition_title}</td></tr>
+<tr><td>Description</td><td>\${event_definition_description}</td></tr>
+<tr><td>Type</td><td>\${event_definition_type}</td></tr>
+</tbody></table>
+<br /><table width="100%" border="0" cellpadding="10" cellspacing="0" style="background-color:#f9f9f9;border:none;line-height:1.2"><tbody>
+<tr><th colspan="2" style="background-color:#e6e6e6;line-height:1.5">Event</th></tr>
+<tr><td width="200px">Timestamp</td><td>\${event.timestamp}</td></tr>
+<tr><td>Message</td><td>\${event.message}</td></tr>
+<tr><td>Source</td><td>\${event.source}</td></tr>
+<tr><td>Key</td><td>\${event.key}</td></tr>
+<tr><td>Priority</td><td>\${event.priority}</td></tr>
+<tr><td>Alert</td><td>\${event.alert}</td></tr>
+<tr><td>Timestamp Processing</td><td>\${event.timestamp}</td></tr>
+<tr><td>Timerange Start</td><td>\${event.timerange_start}</td></tr>
+<tr><td>Timerange End</td><td>\${event.timerange_end}</td></tr>
+<tr><td>Source Streams</td><td>\${event.source_streams}</td></tr>
+<tr><td>Fields</td><td><ul style="list-style-type:square;">\${foreach event.fields field}<li>\${field.key}:\${field.value}</li>\${end}<ul></td></tr>
+</tbody></table>
+\${if backlog}
+<br /><table width="100%" border="0" cellpadding="10" cellspacing="0" style="background-color:#f9f9f9;border:none;line-height:1.2"><tbody>
+<tr><th style="background-color:#e6e6e6;line-height:1.5">Backlog (Last messages accounting for this alert)</th></tr>
+\${foreach backlog message}
+<tr><td>\${message}</td></tr>
+\${end}
+</tbody></table>
+\${end}
+`;
+
 class EmailNotificationForm extends React.Component {
   static propTypes = {
     config: PropTypes.object.isRequired,
@@ -63,7 +93,7 @@ class EmailNotificationForm extends React.Component {
     // eslint-disable-next-line no-template-curly-in-string
     subject: 'Graylog event notification: ${event_definition_title}', // TODO: Default subject should come from the server
     body_template: DEFAULT_BODY_TEMPLATE, // TODO: Default body template should come from the server
-    html_body_template: '',
+    html_body_template: DEFAULT_HTML_BODY_TEMPLATE,
     user_recipients: [],
     email_recipients: [],
   };

--- a/graylog2-web-interface/src/components/event-notifications/event-notification-types/EmailNotificationForm.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-types/EmailNotificationForm.jsx
@@ -50,6 +50,37 @@ Last messages accounting for this alert:
 \${end}
 `;
 
+// TODO: Default html body template should come from the server
+const DEFAULT_HTML_BODY_TEMPLATE = `<table width="100%" border="0" cellpadding="10" cellspacing="0" style="background-color:#f9f9f9;border:none;line-height:1.2"><tbody>
+<tr style="line-height:1.5"><th colspan="2" style="background-color:#e6e6e6">Event Definition</th></tr>
+<tr><td width="200px">Title</td><td>\${event_definition_title}</td></tr>
+<tr><td>Description</td><td>\${event_definition_description}</td></tr>
+<tr><td>Type</td><td>\${event_definition_type}</td></tr>
+</tbody></table>
+<br /><table width="100%" border="0" cellpadding="10" cellspacing="0" style="background-color:#f9f9f9;border:none;line-height:1.2"><tbody>
+<tr><th colspan="2" style="background-color:#e6e6e6;line-height:1.5">Event</th></tr>
+<tr><td width="200px">Timestamp</td><td>\${event.timestamp}</td></tr>
+<tr><td>Message</td><td>\${event.message}</td></tr>
+<tr><td>Source</td><td>\${event.source}</td></tr>
+<tr><td>Key</td><td>\${event.key}</td></tr>
+<tr><td>Priority</td><td>\${event.priority}</td></tr>
+<tr><td>Alert</td><td>\${event.alert}</td></tr>
+<tr><td>Timestamp Processing</td><td>\${event.timestamp}</td></tr>
+<tr><td>Timerange Start</td><td>\${event.timerange_start}</td></tr>
+<tr><td>Timerange End</td><td>\${event.timerange_end}</td></tr>
+<tr><td>Source Streams</td><td>\${event.source_streams}</td></tr>
+<tr><td>Fields</td><td><ul style="list-style-type:square;">\${foreach event.fields field}<li>\${field.key}:\${field.value}</li>\${end}<ul></td></tr>
+</tbody></table>
+\${if backlog}
+<br /><table width="100%" border="0" cellpadding="10" cellspacing="0" style="background-color:#f9f9f9;border:none;line-height:1.2"><tbody>
+<tr><th style="background-color:#e6e6e6;line-height:1.5">Backlog (Last messages accounting for this alert)</th></tr>
+\${foreach backlog message}
+<tr><td>\${message}</td></tr>
+\${end}
+</tbody></table>
+\${end}
+`;
+
 class EmailNotificationForm extends React.Component {
   static propTypes = {
     config: PropTypes.object.isRequired,
@@ -63,6 +94,7 @@ class EmailNotificationForm extends React.Component {
     // eslint-disable-next-line no-template-curly-in-string
     subject: 'Graylog event notification: ${event_definition_title}', // TODO: Default subject should come from the server
     body_template: DEFAULT_BODY_TEMPLATE, // TODO: Default body template should come from the server
+    html_body_template: DEFAULT_HTML_BODY_TEMPLATE, // TODO: Default html body template should come from the server
     user_recipients: [],
     email_recipients: [],
   };
@@ -83,6 +115,10 @@ class EmailNotificationForm extends React.Component {
 
   handleBodyTemplateChange = (nextValue) => {
     this.propagateChange('body_template', nextValue);
+  };
+
+  handleHtmlBodyTemplateChange = (nextValue) => {
+    this.propagateChange('html_body_template', nextValue);
   };
 
   handleRecipientsChange = (key) => {
@@ -144,7 +180,7 @@ class EmailNotificationForm extends React.Component {
           </HelpBlock>
         </FormGroup>
         <FormGroup controlId="notification-body-template"
-                   validationState={validation.errors.body_template ? 'error' : null}>
+                   validationState={validation.errors.body ? 'error' : null}>
           <ControlLabel>Body Template</ControlLabel>
           <SourceCodeEditor id="notification-body-template"
                             mode="text"
@@ -152,7 +188,19 @@ class EmailNotificationForm extends React.Component {
                             value={config.body_template || ''}
                             onChange={this.handleBodyTemplateChange} />
           <HelpBlock>
-            {lodash.get(validation, 'errors.body_template[0]', 'The template that will be used to generate the email body.')}
+            {lodash.get(validation, 'errors.body[0]', 'The template that will be used to generate the email body.')}
+          </HelpBlock>
+        </FormGroup>
+        <FormGroup controlId="notification-body-template"
+                   validationState={validation.errors.body ? 'error' : null}>
+          <ControlLabel>HTML Body Template</ControlLabel>
+          <SourceCodeEditor id="notification-html-body-template"
+                            mode="text"
+                            theme="light"
+                            value={config.html_body_template || ''}
+                            onChange={this.handleHtmlBodyTemplateChange} />
+          <HelpBlock>
+            {lodash.get(validation, 'errors.body[0]', 'The template that will be used to generate the email HTML body.')}
           </HelpBlock>
         </FormGroup>
       </>

--- a/graylog2-web-interface/src/components/event-notifications/event-notification-types/EmailNotificationForm.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-types/EmailNotificationForm.jsx
@@ -50,37 +50,6 @@ Last messages accounting for this alert:
 \${end}
 `;
 
-// TODO: Default html body template should come from the server
-const DEFAULT_HTML_BODY_TEMPLATE = `<table width="100%" border="0" cellpadding="10" cellspacing="0" style="background-color:#f9f9f9;border:none;line-height:1.2"><tbody>
-<tr style="line-height:1.5"><th colspan="2" style="background-color:#e6e6e6">Event Definition</th></tr>
-<tr><td width="200px">Title</td><td>\${event_definition_title}</td></tr>
-<tr><td>Description</td><td>\${event_definition_description}</td></tr>
-<tr><td>Type</td><td>\${event_definition_type}</td></tr>
-</tbody></table>
-<br /><table width="100%" border="0" cellpadding="10" cellspacing="0" style="background-color:#f9f9f9;border:none;line-height:1.2"><tbody>
-<tr><th colspan="2" style="background-color:#e6e6e6;line-height:1.5">Event</th></tr>
-<tr><td width="200px">Timestamp</td><td>\${event.timestamp}</td></tr>
-<tr><td>Message</td><td>\${event.message}</td></tr>
-<tr><td>Source</td><td>\${event.source}</td></tr>
-<tr><td>Key</td><td>\${event.key}</td></tr>
-<tr><td>Priority</td><td>\${event.priority}</td></tr>
-<tr><td>Alert</td><td>\${event.alert}</td></tr>
-<tr><td>Timestamp Processing</td><td>\${event.timestamp}</td></tr>
-<tr><td>Timerange Start</td><td>\${event.timerange_start}</td></tr>
-<tr><td>Timerange End</td><td>\${event.timerange_end}</td></tr>
-<tr><td>Source Streams</td><td>\${event.source_streams}</td></tr>
-<tr><td>Fields</td><td><ul style="list-style-type:square;">\${foreach event.fields field}<li>\${field.key}:\${field.value}</li>\${end}<ul></td></tr>
-</tbody></table>
-\${if backlog}
-<br /><table width="100%" border="0" cellpadding="10" cellspacing="0" style="background-color:#f9f9f9;border:none;line-height:1.2"><tbody>
-<tr><th style="background-color:#e6e6e6;line-height:1.5">Backlog (Last messages accounting for this alert)</th></tr>
-\${foreach backlog message}
-<tr><td>\${message}</td></tr>
-\${end}
-</tbody></table>
-\${end}
-`;
-
 class EmailNotificationForm extends React.Component {
   static propTypes = {
     config: PropTypes.object.isRequired,
@@ -94,7 +63,7 @@ class EmailNotificationForm extends React.Component {
     // eslint-disable-next-line no-template-curly-in-string
     subject: 'Graylog event notification: ${event_definition_title}', // TODO: Default subject should come from the server
     body_template: DEFAULT_BODY_TEMPLATE, // TODO: Default body template should come from the server
-    html_body_template: DEFAULT_HTML_BODY_TEMPLATE, // TODO: Default html body template should come from the server
+    html_body_template: '',
     user_recipients: [],
     email_recipients: [],
   };

--- a/graylog2-web-interface/src/components/event-notifications/event-notification-types/EmailNotificationSummary.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-types/EmailNotificationSummary.jsx
@@ -65,6 +65,14 @@ class EmailNotificationSummary extends React.Component {
               </Well>
             </td>
           </tr>
+          <tr>
+            <td>Email HTML Body</td>
+            <td>
+              <Well bsSize="small" className={styles.bodyPreview}>
+                {notification.config.html_body_template || <em>Empty HTML body</em>}
+              </Well>
+            </td>
+          </tr>
         </>
       </CommonNotificationSummary>
     );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added a new html body field in email notification form so users can send html emails. 

- If html body is set the emails will be multi-part emails with both plaintext and html parts (if plaintext body is left empty it will use default template). 
- If only plaintext body is set, it will behave like before (only plaintext email)
- If both are empty a form validation error will appear to at least fill one of them.

## Motivation and Context
Implements #4569 

## How Has This Been Tested?
I configured an event definition and a new email notification with html body and forced the event to trigger

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

