### PR TITLE
Unblock JobSchedulerService on shutdown

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/plugin/ServerStatus.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/ServerStatus.java
@@ -153,7 +153,9 @@ public class ServerStatus {
      * Blocks until the server enters the RUNNING state and then executes the given Runnable.
      * <p>
      * <b>This method is not interruptible while waiting for the server to enter the RUNNING state.</b>
+     * @deprecated Preferably use {@link #awaitRunning()} instead, which is interruptible.
      */
+    @Deprecated
     public void awaitRunning(final Runnable runnable) {
         LOG.debug("Waiting for server to enter RUNNING state");
         Uninterruptibles.awaitUninterruptibly(runningLatch);

--- a/graylog2-server/src/main/java/org/graylog2/plugin/ServerStatus.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/ServerStatus.java
@@ -149,6 +149,11 @@ public class ServerStatus {
         publishLifecycle(Lifecycle.OVERRIDE_LB_THROTTLED);
     }
 
+    /**
+     * Blocks until the server enters the RUNNING state and then executes the given Runnable.
+     * <p>
+     * <b>This method is not interruptible while waiting for the server to enter the RUNNING state.</b>
+     */
     public void awaitRunning(final Runnable runnable) {
         LOG.debug("Waiting for server to enter RUNNING state");
         Uninterruptibles.awaitUninterruptibly(runningLatch);
@@ -160,6 +165,15 @@ public class ServerStatus {
         } catch (Exception e) {
             LOG.error("awaitRunning callback failed", e);
         }
+    }
+
+    /**
+     * Blocks until the server enters the RUNNING state.
+     * @throws InterruptedException if the thread is interrupted while waiting for the server to enter the RUNNING
+     * state.
+     */
+    public void awaitRunning() throws InterruptedException {
+        runningLatch.await();
     }
 
     public DateTime getStartedAt() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This change adds an interruptible implementation to wait for the server
reaching the RUNNING state. The new method is then used in the
JobSchedulerService. Upon shutdown, the execution thread of the
JobSchedulerService is interrupted so that the service can
properly terminate.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The JobSchedulerService blocks in its run method until the server
reaches the running state. It cannot be unblocked even when interrupting
the execution thread. So if one of the other services fails during
startup, the service manager is unable to shutdown the
JobSchedulerService.

Fixes #8742 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually tested with the following steps:

1. Make the `JerseyService` fail on startup by setting the following `graylog.conf`:
```
http_bind_address = 255.255.255.255:9999
```
2. Start the Graylog server. Without the fix, the server will enter the shutdown sequence but the process will never terminate. With the fix, the server will terminate.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

