### PR TITLE
Fix order of tabs in dashboard after install

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/ViewDTO.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/ViewDTO.java
@@ -18,18 +18,12 @@ package org.graylog.plugins.views.search.views;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableSet;
 import org.graylog.autovalue.WithBeanGetter;
-import org.graylog.plugins.views.search.Search;
 import org.graylog2.contentpacks.ContentPackable;
 import org.graylog2.contentpacks.EntityDescriptorIds;
-import org.graylog2.contentpacks.model.ModelId;
-import org.graylog2.contentpacks.model.entities.EntityDescriptor;
-import org.graylog2.contentpacks.model.entities.EntityV1;
-import org.graylog2.contentpacks.model.entities.SearchEntity;
 import org.graylog2.contentpacks.model.entities.ViewEntity;
 import org.graylog2.contentpacks.model.entities.ViewStateEntity;
 import org.graylog2.contentpacks.model.entities.references.ValueReference;
@@ -42,7 +36,7 @@ import javax.annotation.Nullable;
 import javax.validation.constraints.NotBlank;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -198,7 +192,7 @@ public abstract class ViewDTO implements ContentPackable<ViewEntity.Builder> {
 
     @Override
     public ViewEntity.Builder toContentPackEntity(EntityDescriptorIds entityDescriptorIds) {
-        final Map<String, ViewStateEntity> viewStateMap = new HashMap<>(this.state().size());
+        final Map<String, ViewStateEntity> viewStateMap = new LinkedHashMap<>(this.state().size());
         for (Map.Entry<String, ViewStateDTO> entry : this.state().entrySet()) {
             final ViewStateDTO viewStateDTO = entry.getValue();
             final ViewStateEntity viewStateEntity = viewStateDTO.toContentPackEntity(entityDescriptorIds);

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/ViewFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/ViewFacade.java
@@ -47,7 +47,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
@@ -126,7 +126,7 @@ public abstract class ViewFacade implements EntityFacade<ViewDTO> {
                                          Map<String, ValueReference> parameters,
                                          Map<EntityDescriptor, Object> nativeEntities, User user) {
         final ViewEntity viewEntity = objectMapper.convertValue(entityV1.data(), ViewEntity.class);
-        final Map<String, ViewStateDTO> viewStateMap = new HashMap<>(viewEntity.state().size());
+        final Map<String, ViewStateDTO> viewStateMap = new LinkedHashMap<>(viewEntity.state().size());
         for (Map.Entry<String, ViewStateEntity> entry : viewEntity.state().entrySet()) {
             final ViewStateEntity entity = entry.getValue();
             viewStateMap.put(entry.getKey(), entity.toNativeEntity(parameters, nativeEntities));

--- a/graylog2-web-interface/src/views/stores/QueryIdsStore.js
+++ b/graylog2-web-interface/src/views/stores/QueryIdsStore.js
@@ -34,7 +34,6 @@ export const QueryIdsStore = singletonStore(
     },
     onViewsStoreUpdate(view) {
       const newState = view?.view?.state?.keySeq().toList();
-      console.log('newState', newState);
 
       if (!isEqual(this.state, newState)) {
         this.state = newState;

--- a/graylog2-web-interface/src/views/stores/QueryIdsStore.js
+++ b/graylog2-web-interface/src/views/stores/QueryIdsStore.js
@@ -19,7 +19,7 @@ import { isEqual } from 'lodash';
 
 import { singletonStore } from 'views/logic/singleton';
 
-import { QueriesStore } from './QueriesStore';
+import { ViewStore } from './ViewStore';
 
 // eslint-disable-next-line import/prefer-default-export
 export const QueryIdsStore = singletonStore(
@@ -27,13 +27,14 @@ export const QueryIdsStore = singletonStore(
   () => Reflux.createStore({
     state: {},
     init() {
-      this.listenTo(QueriesStore, this.onQueriesStoreUpdate, this.onQueriesStoreUpdate);
+      this.listenTo(ViewStore, this.onViewsStoreUpdate, this.onViewsStoreUpdate);
     },
     getInitialState() {
       return this._state();
     },
-    onQueriesStoreUpdate(queries) {
-      const newState = queries.keySeq().toList();
+    onViewsStoreUpdate(view) {
+      const newState = view?.view?.state?.keySeq().toList();
+      console.log('newState', newState);
 
       if (!isEqual(this.state, newState)) {
         this.state = newState;

--- a/graylog2-web-interface/src/views/stores/ViewStore.test.ts
+++ b/graylog2-web-interface/src/views/stores/ViewStore.test.ts
@@ -40,14 +40,11 @@ jest.mock('views/logic/Widgets', () => ({
 jest.mock('logic/rest/FetchProvider', () => jest.fn(() => Promise.resolve()));
 
 describe('ViewStore', () => {
-  const dummySearch = Search.create()
-    .toBuilder()
-    .queries([
-      Query.builder().id('firstQueryId').build(),
-      Query.builder().id('secondQueryId').build(),
-    ])
-    .build();
-  const dummyView = View.builder().search(dummySearch).build();
+  const dummyState = Immutable.OrderedMap({
+    firstQueryId: ViewState.builder().build(),
+    secondQueryId: ViewState.builder().build(),
+  });
+  const dummyView = View.builder().state(dummyState).build();
 
   it('.load should select first query if activeQuery is not set', () => ViewActions.load(dummyView)
     .then((state) => expect(state.activeQuery).toBe('firstQueryId')));
@@ -77,6 +74,7 @@ describe('ViewStore', () => {
       .newId()
       .title('Initial title')
       .description('Initail description')
+      .state(dummyState)
       .summary('Initial summary')
       .build();
 
@@ -105,7 +103,10 @@ describe('ViewStore', () => {
 
     it('resets dirty flag when an existing view is updated', () => {
       const search = Search.create();
-      const newView = View.builder().newId().search(search).build();
+      const newView = View.builder().newId()
+        .state(dummyState)
+        .search(search)
+        .build();
 
       return ViewActions.load(newView)
         .then(() => ViewActions.search(search.toBuilder().newId().build()))

--- a/graylog2-web-interface/src/views/stores/ViewStore.ts
+++ b/graylog2-web-interface/src/views/stores/ViewStore.ts
@@ -156,9 +156,9 @@ export const ViewStore: ViewStoreType = singletonStore(
 
       /* Select selected query (activeQuery) or first query in view (for now).
          Selected query might become a property on the view later. */
-      const queries = get(view, 'search.queries', Immutable.List());
-      const firstQueryId = get(queries.first(), 'id');
-      const selectedQuery = this.activeQuery && queries.find((q) => (q.id === this.activeQuery)) ? this.activeQuery : firstQueryId;
+      const queries = view.state.keySeq().toList();
+      const firstQueryId = queries.first();
+      const selectedQuery = this.activeQuery && queries.find((id) => (id === this.activeQuery)) ? this.activeQuery : firstQueryId;
 
       this.selectQuery(selectedQuery);
       this.isNew = isNew;


### PR DESCRIPTION
## Motivation
Prior to this change, a dashboard installed by a content pack had a
tabs in a random order. Since we cannot change the order of the tabs
this is quite inconvinient for the user.

## Description
This change will do mutiple steps to fix that:
- Use a LinkedHashMap to ensure the order stays fix during content pack
  creation.
- Instead of using the serach QueryIds we use the views QueryIds which
  we previously fixed in the order.
- When loading a view and selecting the activeQuery we also use the
  view.state queryids instead of the search ones.

Fixes #8264

## How Has This Been Tested?
1. Create a Dashboard
1. Create multiple Tabs with names [ 1, 2, 3, 4, 5 ]
1. Create a content pack with this Dashboard
1. Install that dashboard
1. Ensure the tabs order is still the same.


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)