### PR TITLE
Add isCloud helper method on plugin module

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/plugin/PluginModule.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/PluginModule.java
@@ -323,4 +323,12 @@ public abstract class PluginModule extends Graylog2Module {
         authServiceBackendBinder().addBinding(name).to(factoryClass);
         registerJacksonSubtype(configClass, name);
     }
+
+    /**
+     * @return A boolean indicating if the plugin is being loaded on Graylog Cloud.
+     * The graylog.cloud system property is set in the startup sequence of the Graylog Cloud Plugin.
+     */
+    protected boolean isCloud() {
+        return Boolean.parseBoolean(System.getProperty("graylog.cloud"));
+    }
 }


### PR DESCRIPTION
This let plugins decide which extensions to register when the Graylog configuration is not yet available. See https://github.com/Graylog2/graylog-plugin-integrations/pull/657#issuecomment-736662717 for more information.

Refs https://github.com/Graylog2/graylog-plugin-cloud/issues/619