### PR TITLE
Show timezone setting to the user

### DIFF
--- a/graylog2-web-interface/src/components/users/UserDetails/UserDetails.jsx
+++ b/graylog2-web-interface/src/components/users/UserDetails/UserDetails.jsx
@@ -45,9 +45,7 @@ const UserDetails = ({ user }: Props) => {
         <IfPermitted permissions={`users:edit:${user.username}`}>
           <div>
             <ProfileSection user={user} />
-            <IfPermitted permissions="*">
-              <SettingsSection user={user} />
-            </IfPermitted>
+            <SettingsSection user={user} />
             <PreferencesSection user={user} />
           </div>
           <div>

--- a/graylog2-web-interface/src/components/users/UserEdit/SettingsSection.jsx
+++ b/graylog2-web-interface/src/components/users/UserEdit/SettingsSection.jsx
@@ -24,6 +24,7 @@ import SectionComponent from 'components/common/Section/SectionComponent';
 
 import TimezoneFormGroup from '../UserCreate/TimezoneFormGroup';
 import TimeoutFormGroup from '../UserCreate/TimeoutFormGroup';
+import { IfPermitted } from '../../common';
 
 type Props = {
   user: User,
@@ -42,7 +43,9 @@ const SettingsSection = ({
             initialValues={{ timezone, session_timeout_ms: sessionTimeoutMs }}>
       {({ isSubmitting, isValid }) => (
         <Form className="form form-horizontal">
-          <TimeoutFormGroup />
+          <IfPermitted permissions="*">
+            <TimeoutFormGroup />
+          </IfPermitted>
           <TimezoneFormGroup />
           <Row className="no-bm">
             <Col xs={12}>

--- a/graylog2-web-interface/src/components/users/UserEdit/SettingsSection.test.jsx
+++ b/graylog2-web-interface/src/components/users/UserEdit/SettingsSection.test.jsx
@@ -17,8 +17,10 @@
 // @flow strict
 import * as React from 'react';
 import { render, fireEvent, waitFor, screen, act } from 'wrappedTestingLibrary';
-import { alice } from 'fixtures/users';
+import { alice, admin } from 'fixtures/users';
 import selectEvent from 'react-select-event';
+
+import CurrentUserContext from 'contexts/CurrentUserContext';
 
 import SettingsSection from './SettingsSection';
 
@@ -46,7 +48,12 @@ describe('<SettingsSection />', () => {
 
   it('should allow session timeout name and timezone change', async () => {
     const onSubmitStub = jest.fn();
-    render(<SettingsSection user={exampleUser} onSubmit={(data) => onSubmitStub(data)} />);
+
+    render(
+      <CurrentUserContext.Provider value={admin}>
+        <SettingsSection user={exampleUser} onSubmit={(data) => onSubmitStub(data)} />
+      </CurrentUserContext.Provider>,
+    );
 
     const timeoutAmountInput = screen.getByPlaceholderText('Timeout amount');
     const timezoneSelect = screen.getByLabelText('Time Zone');

--- a/graylog2-web-interface/src/components/users/UserEdit/UserEdit.jsx
+++ b/graylog2-web-interface/src/components/users/UserEdit/UserEdit.jsx
@@ -78,10 +78,8 @@ const UserEdit = ({ user }: Props) => {
           <ProfileSection user={user}
                           onSubmit={(data) => _updateUser(data, currentUser, user.id, user.fullName)} />
           ) }
-          <IfPermitted permissions="*">
-            <SettingsSection user={user}
-                             onSubmit={(data) => _updateUser(data, currentUser, user.id, user.fullName)} />
-          </IfPermitted>
+          <SettingsSection user={user}
+                           onSubmit={(data) => _updateUser(data, currentUser, user.id, user.fullName)} />
           <IfPermitted permissions={`users:passwordchange:${user.username}`}>
             { !user.external && <PasswordSection user={user} /> }
           </IfPermitted>


### PR DESCRIPTION
## Motivation
Prior to this change, the user was not able to change his own timezone
settings since they were hidden to him.
    
## Description
This change will show the settings to the user so he can edit them.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Fixes #9813

