### PR TITLE
Add common Okta version to parent POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,6 +137,7 @@
         <netty.version>4.1.52.Final</netty.version>
         <netty-tcnative-boringssl-static.version>2.0.34.Final</netty-tcnative-boringssl-static.version>
         <okhttp.version>3.14.6</okhttp.version>
+        <okta-sdk.version>3.0.1</okta-sdk.version>
         <opencsv.version>2.3</opencsv.version>
         <os-platform-finder.version>1.2.3</os-platform-finder.version>
         <pkts.version>3.0.5</pkts.version>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add common Okta version to parent POM so that the same version can be used across all plugins.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Initially, this will be used to solve a version conflict between the Enterprise Integrations and Cloud plugin usages of the Okta SDK.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This change has no affect on functionality until it is subsequently used within plugins.
