### PR TITLE
Cloud backport: Add common Okta version to parent POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,6 +137,7 @@
         <netty.version>4.1.52.Final</netty.version>
         <netty-tcnative-boringssl-static.version>2.0.34.Final</netty-tcnative-boringssl-static.version>
         <okhttp.version>3.14.6</okhttp.version>
+        <okta-sdk.version>3.0.1</okta-sdk.version>
         <opencsv.version>2.3</opencsv.version>
         <os-platform-finder.version>1.2.3</os-platform-finder.version>
         <pkts.version>3.0.5</pkts.version>


### PR DESCRIPTION
Backport #9821 to `cloud-4.0`