### PR TITLE
Use plotlys colorscales for Heatmap Aggregation

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/ViewsBindings.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/ViewsBindings.java
@@ -76,6 +76,7 @@ import org.graylog.plugins.views.search.views.widgets.aggregation.AggregationCon
 import org.graylog.plugins.views.search.views.widgets.aggregation.AreaVisualizationConfigDTO;
 import org.graylog.plugins.views.search.views.widgets.aggregation.AutoIntervalDTO;
 import org.graylog.plugins.views.search.views.widgets.aggregation.BarVisualizationConfigDTO;
+import org.graylog.plugins.views.search.views.widgets.aggregation.HeatmapVisualizationConfigDTO;
 import org.graylog.plugins.views.search.views.widgets.aggregation.LineVisualizationConfigDTO;
 import org.graylog.plugins.views.search.views.widgets.aggregation.NumberVisualizationConfigDTO;
 import org.graylog.plugins.views.search.views.widgets.aggregation.TimeHistogramConfigDTO;
@@ -205,6 +206,7 @@ public class ViewsBindings extends ViewsModule {
         registerJacksonSubtype(NumberVisualizationConfigDTO.class);
         registerJacksonSubtype(LineVisualizationConfigDTO.class);
         registerJacksonSubtype(AreaVisualizationConfigDTO.class);
+        registerJacksonSubtype(HeatmapVisualizationConfigDTO.class);
     }
 
     private void registerParameterSubtypes() {

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/widgets/aggregation/HeatmapVisualizationConfigDTO.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/widgets/aggregation/HeatmapVisualizationConfigDTO.java
@@ -36,6 +36,7 @@ public abstract class HeatmapVisualizationConfigDTO implements VisualizationConf
     private static final String FIELD_Z_MIN = "z_min";
     private static final String FIELD_Z_MAX = "z_max";
     private static final String FIELD_DEFAULT_VALUE = "default_value";
+    private static final String FIELD_USE_SMALLEST_AS_DEFAULT = "use_smallest_as_default";
 
     @JsonProperty(FIELD_COLOR_SCALE)
     public abstract String colorScale();
@@ -55,11 +56,11 @@ public abstract class HeatmapVisualizationConfigDTO implements VisualizationConf
     @JsonProperty(FIELD_DEFAULT_VALUE)
     public abstract Optional<Long> defaultValue();
 
+    @JsonProperty(FIELD_USE_SMALLEST_AS_DEFAULT)
+    public abstract boolean useSmallestAsDefault();
+
     public static Builder builder() {
-        return Builder.create()
-                .colorScale("Viridis")
-                .reverseScale(false)
-                .autoScale(true);
+        return Builder.create();
     }
 
     public abstract Builder toBuilder();
@@ -69,7 +70,11 @@ public abstract class HeatmapVisualizationConfigDTO implements VisualizationConf
 
         @JsonCreator
         public static Builder create() {
-            return new AutoValue_HeatmapVisualizationConfigDTO.Builder();
+            return new AutoValue_HeatmapVisualizationConfigDTO.Builder()
+                    .colorScale("Viridis")
+                    .reverseScale(false)
+                    .useSmallestAsDefault(false)
+                    .autoScale(true);
         }
 
         @JsonProperty(FIELD_COLOR_SCALE)
@@ -89,6 +94,9 @@ public abstract class HeatmapVisualizationConfigDTO implements VisualizationConf
 
         @JsonProperty(FIELD_DEFAULT_VALUE)
         public abstract Builder defaultValue(@Nullable Long defaultValue);
+
+        @JsonProperty(FIELD_USE_SMALLEST_AS_DEFAULT)
+        public abstract Builder useSmallestAsDefault(boolean useSmallestAsDefault);
 
         public abstract HeatmapVisualizationConfigDTO build();
     }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/widgets/aggregation/HeatmapVisualizationConfigDTO.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/widgets/aggregation/HeatmapVisualizationConfigDTO.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.views.search.views.widgets.aggregation;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.auto.value.AutoValue;
+import com.mongodb.lang.Nullable;
+
+import java.util.Optional;
+
+@AutoValue
+@JsonTypeName(HeatmapVisualizationConfigDTO.NAME)
+@JsonDeserialize(builder = HeatmapVisualizationConfigDTO.Builder.class)
+public abstract class HeatmapVisualizationConfigDTO implements VisualizationConfigDTO {
+    public static final String NAME = "heatmap";
+    private static final String FIELD_COLOR_SCALE = "color_scale";
+    private static final String FIELD_REVERSE_SCALE = "reverse_scale";
+    private static final String FIELD_AUTO_SCALE = "auto_scale";
+    private static final String FIELD_Z_MIN = "z_min";
+    private static final String FIELD_Z_MAX = "z_max";
+    private static final String FIELD_DEFAULT_VALUE = "default_value";
+
+    @JsonProperty(FIELD_COLOR_SCALE)
+    public abstract String colorScale();
+
+    @JsonProperty(FIELD_REVERSE_SCALE)
+    public abstract boolean reverseScale();
+
+    @JsonProperty(FIELD_AUTO_SCALE)
+    public abstract boolean autoScale();
+
+    @JsonProperty(FIELD_Z_MIN)
+    public abstract Optional<String> zMin();
+
+    @JsonProperty(FIELD_Z_MAX)
+    public abstract Optional<String> zMax();
+
+    @JsonProperty(FIELD_DEFAULT_VALUE)
+    public abstract Optional<Long> defaultValue();
+
+    public static Builder builder() {
+        return Builder.create()
+                .colorScale("Viridis")
+                .reverseScale(false)
+                .autoScale(true);
+    }
+
+    public abstract Builder toBuilder();
+
+    @AutoValue.Builder
+    public static abstract class Builder {
+
+        @JsonCreator
+        public static Builder create() {
+            return new AutoValue_HeatmapVisualizationConfigDTO.Builder();
+        }
+
+        @JsonProperty(FIELD_COLOR_SCALE)
+        public abstract Builder colorScale(String colorScale);
+
+        @JsonProperty(FIELD_REVERSE_SCALE)
+        public abstract Builder reverseScale(boolean reverseScale);
+
+        @JsonProperty(FIELD_AUTO_SCALE)
+        public abstract Builder autoScale(boolean autoScale);
+
+        @JsonProperty(FIELD_Z_MIN)
+        public abstract Builder zMin(@Nullable String zMin);
+
+        @JsonProperty(FIELD_Z_MAX)
+        public abstract Builder zMax(@Nullable String zMax);
+
+        @JsonProperty(FIELD_DEFAULT_VALUE)
+        public abstract Builder defaultValue(@Nullable Long defaultValue);
+
+        public abstract HeatmapVisualizationConfigDTO build();
+    }
+}

--- a/graylog2-web-interface/src/views/bindings.tsx
+++ b/graylog2-web-interface/src/views/bindings.tsx
@@ -80,6 +80,7 @@ import {
 import ShowDashboardInBigDisplayMode from 'views/pages/ShowDashboardInBigDisplayMode';
 import LookupTableParameter from 'views/logic/parameters/LookupTableParameter';
 import HeatmapVisualizationConfiguration from 'views/components/aggregationbuilder/HeatmapVisualizationConfiguration';
+import HeatmapVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/HeatmapVisualizationConfig';
 
 import type { ActionHandlerArguments } from './components/actions/ActionHandler';
 import NumberVisualizationConfig from './logic/aggregationbuilder/visualizations/NumberVisualizationConfig';
@@ -103,6 +104,7 @@ VisualizationConfig.registerSubtype(BarVisualization.type, BarVisualizationConfi
 VisualizationConfig.registerSubtype(NumberVisualization.type, NumberVisualizationConfig);
 VisualizationConfig.registerSubtype(LineVisualization.type, LineVisualizationConfig);
 VisualizationConfig.registerSubtype(AreaVisualization.type, AreaVisualizationConfig);
+VisualizationConfig.registerSubtype(HeatmapVisualization.type, HeatmapVisualizationConfig);
 
 Parameter.registerSubtype(ValueParameter.type, ValueParameter);
 Parameter.registerSubtype(LookupTableParameter.type, LookupTableParameter);

--- a/graylog2-web-interface/src/views/bindings.tsx
+++ b/graylog2-web-interface/src/views/bindings.tsx
@@ -79,6 +79,7 @@ import {
 } from 'views/Constants';
 import ShowDashboardInBigDisplayMode from 'views/pages/ShowDashboardInBigDisplayMode';
 import LookupTableParameter from 'views/logic/parameters/LookupTableParameter';
+import HeatmapVisualizationConfiguration from 'views/components/aggregationbuilder/HeatmapVisualizationConfiguration';
 
 import type { ActionHandlerArguments } from './components/actions/ActionHandler';
 import NumberVisualizationConfig from './logic/aggregationbuilder/visualizations/NumberVisualizationConfig';
@@ -338,6 +339,10 @@ export default {
     {
       type: NumberVisualization.type,
       component: NumberVisualizationConfiguration,
+    },
+    {
+      type: HeatmapVisualization.type,
+      component: HeatmapVisualizationConfiguration,
     },
   ],
   creators: [

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/HeatmapVisualizationConfiguration.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/HeatmapVisualizationConfiguration.tsx
@@ -15,7 +15,8 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import React, { useCallback } from 'react';
-import { capitalize } from 'lodash';
+
+import { Checkbox } from 'components/graylog';
 
 import HeatmapVisualizationConfig, { COLORSCALES } from 'views/logic/aggregationbuilder/visualizations/HeatmapVisualizationConfig';
 
@@ -30,15 +31,19 @@ const _makeOption = (value) => ({ label: value, value });
 const colorScalesOptions = COLORSCALES.map(_makeOption);
 
 const HeatmapVisualizationConfiguration = ({ config = HeatmapVisualizationConfig.empty(), onChange }: Props) => {
-  const _onChange = useCallback(({ value }) => onChange(config.toBuilder().colorScale(value).build()), [config, onChange]);
+  const _onColorScaleChange = useCallback(({ value }) => onChange(config.toBuilder().colorScale(value).build()), [config, onChange]);
+  const _onReverseScaleChange = useCallback((e) => onChange(config.toBuilder().reverseScale(e.target.checked).build()), [config, onChange]);
 
   return (
     <>
       <span>Color Scheme</span>
       <Select placeholder="Select Color Scheme"
-              onChange={_onChange}
+              onChange={_onColorScaleChange}
               options={colorScalesOptions}
               value={_makeOption(config.colorScale)} />
+      <span>Reverse Scale</span>
+      <Checkbox onChange={_onReverseScaleChange}
+                checked={config.reverseScale} />
     </>
   );
 };

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/HeatmapVisualizationConfiguration.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/HeatmapVisualizationConfiguration.tsx
@@ -103,6 +103,7 @@ const HeatmapVisualizationConfiguration = ({ config = HeatmapVisualizationConfig
       <Select placeholder="Select Color Scheme"
               onChange={_onColorScaleChange}
               options={colorScalesOptions}
+              isClearable={false}
               value={_makeOption(config.colorScale)} />
       <Checkbox onChange={_onReverseScaleChange}
                 checked={config.reverseScale}>

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/HeatmapVisualizationConfiguration.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/HeatmapVisualizationConfiguration.tsx
@@ -90,6 +90,7 @@ const HeatmapVisualizationConfiguration = ({ config = HeatmapVisualizationConfig
   const _onAutoScaleChange = useCallback((e) => onChange(config.toBuilder().autoScale(e.target.checked).build()), [config, onChange]);
   const _onZminChange = useCallback((e) => onChange(config.toBuilder().zMin(_parseEvent(e)).build()), [config, onChange]);
   const _onZmaxChange = useCallback((e) => onChange(config.toBuilder().zMax(_parseEvent(e)).build()), [config, onChange]);
+  const _onUseSmallestAsDefaultChange = useCallback((e) => onChange(config.toBuilder().useSmallestAsDefault(e.target.checked).build()), [config, onChange]);
   const _onDefaultValueChange = useCallback((e) => onChange(config.toBuilder().defaultValue(_parseEvent(e)).build()), [config, onChange]);
 
   return (
@@ -121,9 +122,14 @@ const HeatmapVisualizationConfiguration = ({ config = HeatmapVisualizationConfig
                    error={errors.zmax}
                    onChange={_onZmaxChange}
                    label="Max" />
+      <Checkbox onChange={_onUseSmallestAsDefaultChange}
+                checked={config.useSmallestAsDefault}>
+        Use smallest as default
+      </Checkbox>
       <StyledInput type="number"
                    id="default_value"
                    error={errors.defaultValue}
+                   disabled={config.useSmallestAsDefault}
                    onChange={_onDefaultValueChange}
                    label="Default Value" />
     </>

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/HeatmapVisualizationConfiguration.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/HeatmapVisualizationConfiguration.tsx
@@ -19,7 +19,7 @@ import styled from 'styled-components';
 
 import { Checkbox } from 'components/graylog';
 import { Input } from 'components/bootstrap';
-import HeatmapVisualizationConfig, { COLORSCALES } from 'views/logic/aggregationbuilder/visualizations/HeatmapVisualizationConfig';
+import HeatmapVisualizationConfig, { COLORSCALES, Builder as HeatmapConfigBuilder } from 'views/logic/aggregationbuilder/visualizations/HeatmapVisualizationConfig';
 
 import Select from '../Select';
 
@@ -85,13 +85,17 @@ const HeatmapVisualizationConfiguration = ({ config = HeatmapVisualizationConfig
       onChangeFunc(newConfig);
     }
   }, [onChangeFunc]);
-  const _onColorScaleChange = useCallback(({ value }) => onChange(config.toBuilder().colorScale(value).build()), [config, onChange]);
-  const _onReverseScaleChange = useCallback((e) => onChange(config.toBuilder().reverseScale(e.target.checked).build()), [config, onChange]);
-  const _onAutoScaleChange = useCallback((e) => onChange(config.toBuilder().autoScale(e.target.checked).build()), [config, onChange]);
-  const _onZminChange = useCallback((e) => onChange(config.toBuilder().zMin(_parseEvent(e)).build()), [config, onChange]);
-  const _onZmaxChange = useCallback((e) => onChange(config.toBuilder().zMax(_parseEvent(e)).build()), [config, onChange]);
-  const _onUseSmallestAsDefaultChange = useCallback((e) => onChange(config.toBuilder().useSmallestAsDefault(e.target.checked).build()), [config, onChange]);
-  const _onDefaultValueChange = useCallback((e) => onChange(config.toBuilder().defaultValue(_parseEvent(e)).build()), [config, onChange]);
+  const modifyConfig = useCallback((fn: (HeatmapConfigBuilder) => HeatmapConfigBuilder) => {
+    onChange(fn(config.toBuilder()).build());
+  }, [config, onChange]);
+
+  const _onColorScaleChange = useCallback(({ value }) => modifyConfig((builder: HeatmapConfigBuilder) => builder.colorScale(value)), [modifyConfig]);
+  const _onReverseScaleChange = useCallback((e) => modifyConfig((builder: HeatmapConfigBuilder) => builder.reverseScale(e.target.checked)), [modifyConfig]);
+  const _onAutoScaleChange = useCallback((e) => modifyConfig((builder: HeatmapConfigBuilder) => builder.autoScale(e.target.checked)), [modifyConfig]);
+  const _onZminChange = useCallback((e) => modifyConfig((builder: HeatmapConfigBuilder) => builder.zMin(_parseEvent(e))), [modifyConfig]);
+  const _onZmaxChange = useCallback((e) => modifyConfig((builder: HeatmapConfigBuilder) => builder.zMax(_parseEvent(e))), [modifyConfig]);
+  const _onUseSmallestAsDefaultChange = useCallback((e) => modifyConfig((builder: HeatmapConfigBuilder) => builder.useSmallestAsDefault(e.target.checked)), [modifyConfig]);
+  const _onDefaultValueChange = useCallback((e) => modifyConfig((builder: HeatmapConfigBuilder) => builder.defaultValue(_parseEvent(e))), [modifyConfig]);
 
   return (
     <>

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/HeatmapVisualizationConfiguration.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/HeatmapVisualizationConfiguration.tsx
@@ -14,7 +14,7 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import React, { useCallback } from 'react';
+import React, { useCallback, useState } from 'react';
 import styled from 'styled-components';
 
 import { Checkbox } from 'components/graylog';
@@ -37,18 +37,60 @@ type Props = {
 const _makeOption = (value) => ({ label: value, value });
 const colorScalesOptions = COLORSCALES.map(_makeOption);
 
-const _validateConfig = (config: HeatmapVisualizationConfig, setErrors) => {
-
+type Error = {
+  zmin?: string,
+  zmax?: string,
+  defaultValue?: string,
 }
 
-const HeatmapVisualizationConfiguration = ({ config = HeatmapVisualizationConfig.empty(), onChange }: Props) => {
+const _validateConfig = (config: HeatmapVisualizationConfig, setErrors): boolean => {
+  const { zMax, zMin, defaultValue } = config;
+  const errors = {} as Error;
+
+  if (zMin || zMax) {
+    if (zMin >= zMax) {
+      errors.zmin = 'Min is bigger than Max';
+    }
+
+    if (zMax <= zMin) {
+      errors.zmin = 'Max is smaller than Min';
+    }
+
+    if (defaultValue) {
+      if (defaultValue > zMax || defaultValue < zMin) {
+        errors.defaultValue = 'Default Value is out of range from Min and Max';
+      }
+    }
+  }
+
+  setErrors(errors);
+
+  return Object.keys(errors).length <= 0;
+};
+
+const _parseEvent = (event) => {
+  const { value } = event.target;
+
+  if (value === undefined) {
+    return undefined;
+  }
+
+  return parseFloat(value);
+};
+
+const HeatmapVisualizationConfiguration = ({ config = HeatmapVisualizationConfig.empty(), onChange: onChangeFunc }: Props) => {
+  const [errors, setErrors] = useState<Error>({});
+  const onChange = useCallback((newConfig) => {
+    if (_validateConfig(newConfig, setErrors)) {
+      onChangeFunc(newConfig);
+    }
+  }, [onChangeFunc]);
   const _onColorScaleChange = useCallback(({ value }) => onChange(config.toBuilder().colorScale(value).build()), [config, onChange]);
   const _onReverseScaleChange = useCallback((e) => onChange(config.toBuilder().reverseScale(e.target.checked).build()), [config, onChange]);
-  const _onDefaultValueChange = useCallback((e) => onChange(config.toBuilder().defaultValue(e.target.value).build()), [config, onChange]);
   const _onAutoScaleChange = useCallback((e) => onChange(config.toBuilder().autoScale(e.target.checked).build()), [config, onChange]);
-  const _onZminChange = useCallback((e) => onChange(config.toBuilder().zMin(e.target.value).build()), [config, onChange]);
-  const _onZmidChange = useCallback((e) => onChange(config.toBuilder().zMid(e.target.value).build()), [config, onChange]);
-  const _onZmaxChange = useCallback((e) => onChange(config.toBuilder().zMax(e.target.value).build()), [config, onChange]);
+  const _onZminChange = useCallback((e) => onChange(config.toBuilder().zMin(_parseEvent(e)).build()), [config, onChange]);
+  const _onZmaxChange = useCallback((e) => onChange(config.toBuilder().zMax(_parseEvent(e)).build()), [config, onChange]);
+  const _onDefaultValueChange = useCallback((e) => onChange(config.toBuilder().defaultValue(_parseEvent(e)).build()), [config, onChange]);
 
   return (
     <>
@@ -57,11 +99,6 @@ const HeatmapVisualizationConfiguration = ({ config = HeatmapVisualizationConfig
               onChange={_onColorScaleChange}
               options={colorScalesOptions}
               value={_makeOption(config.colorScale)} />
-      <span>Default</span>
-      <StyledInput type="number"
-                   onChange={_onDefaultValueChange}
-                   label="Default Value" />
-      <span>Scale settings</span>
       <Checkbox onChange={_onReverseScaleChange}
                 checked={config.reverseScale}>
         Reverse Scale
@@ -72,14 +109,23 @@ const HeatmapVisualizationConfiguration = ({ config = HeatmapVisualizationConfig
       </Checkbox>
       <StyledInput type="number"
                    disabled={config.autoScale}
+                   id="zmin"
                    onChange={_onZminChange}
                    value={config.zMin}
+                   error={errors.zmin}
                    label="Min" />
       <StyledInput type="number"
                    disabled={config.autoScale}
+                   id="zmax"
                    value={config.zMax}
+                   error={errors.zmax}
                    onChange={_onZmaxChange}
                    label="Max" />
+      <StyledInput type="number"
+                   id="default_value"
+                   error={errors.defaultValue}
+                   onChange={_onDefaultValueChange}
+                   label="Default Value" />
     </>
   );
 };

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/HeatmapVisualizationConfiguration.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/HeatmapVisualizationConfiguration.tsx
@@ -15,12 +15,19 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import React, { useCallback } from 'react';
+import styled from 'styled-components';
 
 import { Checkbox } from 'components/graylog';
-
+import { Input } from 'components/bootstrap';
 import HeatmapVisualizationConfig, { COLORSCALES } from 'views/logic/aggregationbuilder/visualizations/HeatmapVisualizationConfig';
 
 import Select from '../Select';
+
+const StyledInput = styled(Input)`
+  > label {
+    font-weight: normal;
+  }
+`;
 
 type Props = {
   onChange: (config: HeatmapVisualizationConfig) => void,
@@ -30,9 +37,18 @@ type Props = {
 const _makeOption = (value) => ({ label: value, value });
 const colorScalesOptions = COLORSCALES.map(_makeOption);
 
+const _validateConfig = (config: HeatmapVisualizationConfig, setErrors) => {
+
+}
+
 const HeatmapVisualizationConfiguration = ({ config = HeatmapVisualizationConfig.empty(), onChange }: Props) => {
   const _onColorScaleChange = useCallback(({ value }) => onChange(config.toBuilder().colorScale(value).build()), [config, onChange]);
   const _onReverseScaleChange = useCallback((e) => onChange(config.toBuilder().reverseScale(e.target.checked).build()), [config, onChange]);
+  const _onDefaultValueChange = useCallback((e) => onChange(config.toBuilder().defaultValue(e.target.value).build()), [config, onChange]);
+  const _onAutoScaleChange = useCallback((e) => onChange(config.toBuilder().autoScale(e.target.checked).build()), [config, onChange]);
+  const _onZminChange = useCallback((e) => onChange(config.toBuilder().zMin(e.target.value).build()), [config, onChange]);
+  const _onZmidChange = useCallback((e) => onChange(config.toBuilder().zMid(e.target.value).build()), [config, onChange]);
+  const _onZmaxChange = useCallback((e) => onChange(config.toBuilder().zMax(e.target.value).build()), [config, onChange]);
 
   return (
     <>
@@ -41,9 +57,29 @@ const HeatmapVisualizationConfiguration = ({ config = HeatmapVisualizationConfig
               onChange={_onColorScaleChange}
               options={colorScalesOptions}
               value={_makeOption(config.colorScale)} />
-      <span>Reverse Scale</span>
+      <span>Default</span>
+      <StyledInput type="number"
+                   onChange={_onDefaultValueChange}
+                   label="Default Value" />
+      <span>Scale settings</span>
       <Checkbox onChange={_onReverseScaleChange}
-                checked={config.reverseScale} />
+                checked={config.reverseScale}>
+        Reverse Scale
+      </Checkbox>
+      <Checkbox onChange={_onAutoScaleChange}
+                checked={config.autoScale}>
+        Auto Scale
+      </Checkbox>
+      <StyledInput type="number"
+                   disabled={config.autoScale}
+                   onChange={_onZminChange}
+                   value={config.zMin}
+                   label="Min" />
+      <StyledInput type="number"
+                   disabled={config.autoScale}
+                   value={config.zMax}
+                   onChange={_onZmaxChange}
+                   label="Max" />
     </>
   );
 };

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/HeatmapVisualizationConfiguration.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/HeatmapVisualizationConfiguration.tsx
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import React, { useCallback } from 'react';
+import { capitalize } from 'lodash';
+
+import HeatmapVisualizationConfig, { COLORSCALES } from 'views/logic/aggregationbuilder/visualizations/HeatmapVisualizationConfig';
+
+import Select from '../Select';
+
+type Props = {
+  onChange: (config: HeatmapVisualizationConfig) => void,
+  config: HeatmapVisualizationConfig,
+};
+
+const _makeOption = (value) => ({ label: value, value });
+const colorScalesOptions = COLORSCALES.map(_makeOption);
+
+const HeatmapVisualizationConfiguration = ({ config = HeatmapVisualizationConfig.empty(), onChange }: Props) => {
+  const _onChange = useCallback(({ value }) => onChange(config.toBuilder().colorScale(value).build()), [config, onChange]);
+
+  return (
+    <>
+      <span>Color Scheme</span>
+      <Select placeholder="Select Color Scheme"
+              onChange={_onChange}
+              options={colorScalesOptions}
+              value={_makeOption(config.colorScale)} />
+    </>
+  );
+};
+
+export default HeatmapVisualizationConfiguration;

--- a/graylog2-web-interface/src/views/components/visualizations/ChartData.ts
+++ b/graylog2-web-interface/src/views/components/visualizations/ChartData.ts
@@ -39,6 +39,7 @@ export type ChartDefinition = {
   },
   customdata?: any,
   colorscale?: [number, string][],
+  reversescale?: boolean,
 };
 
 export type ChartData = [any, Array<Key>, Array<any>, Array<Array<any>>];

--- a/graylog2-web-interface/src/views/components/visualizations/ChartData.ts
+++ b/graylog2-web-interface/src/views/components/visualizations/ChartData.ts
@@ -40,6 +40,8 @@ export type ChartDefinition = {
   customdata?: any,
   colorscale?: [number, string][],
   reversescale?: boolean,
+  zmin?: boolean,
+  zmax?: boolean,
 };
 
 export type ChartData = [any, Array<Key>, Array<any>, Array<Array<any>>];

--- a/graylog2-web-interface/src/views/components/visualizations/heatmap/HeatmapVisualization.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/heatmap/HeatmapVisualization.tsx
@@ -87,7 +87,7 @@ const _formatSeries = (visualizationConfig) => ({ valuesBySeries, xLabels }: {va
   // We need to transpose the z matrix, because we are changing the x and y label in the generator function
   const defaultValue = visualizationConfig.useSmallestAsDefault
     ? _findSmallestValue(valuesFoundBySeries)
-    : visualizationConfig.defaultValue ?? 'None';
+    : (visualizationConfig.defaultValue ?? 'None');
   const z = _transposeMatrix(_fillUpMatrix(valuesFoundBySeries, xLabels, defaultValue));
   const yLabels = Object.keys(valuesBySeries);
 
@@ -120,7 +120,6 @@ const _chartLayout = (heatmapData) => {
   return {
     yaxis: axisConfig,
     xaxis: axisConfig,
-    // plot_bgcolor: hasContent ? BG_COLOR : 'transparent',
     margin: {
       b: 40,
     },

--- a/graylog2-web-interface/src/views/components/visualizations/heatmap/HeatmapVisualization.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/heatmap/HeatmapVisualization.tsx
@@ -78,11 +78,17 @@ const _transposeMatrix = (z: Array<Array<any>> = []) => {
   return z[0].map((_, c) => { return z.map((r) => { return r[c]; }); });
 };
 
+const _findSmallestValue = (valuesFound: Array<Array<number>>) => valuesFound.reduce((result, valueArray) => valueArray.reduce((acc, value) => (acc > value ? value : acc), result), valuesFound[0][0]);
+
 const _formatSeries = (visualizationConfig) => ({ valuesBySeries, xLabels }: {valuesBySeries: ValuesBySeries, xLabels: Array<any>}): ExtractedSeries => {
+  const valuesFoundBySeries = values(valuesBySeries);
   // When using the hovertemplate, we need to provie a value for empty z values.
   // Otherwise plotly would throw errors when hovering over a field.
   // We need to transpose the z matrix, because we are changing the x and y label in the generator function
-  const z = _transposeMatrix(_fillUpMatrix(values(valuesBySeries), xLabels, visualizationConfig.defaultValue));
+  const defaultValue = visualizationConfig.useSmallestAsDefault
+    ? _findSmallestValue(valuesFoundBySeries)
+    : visualizationConfig.defaultValue ?? 'None';
+  const z = _transposeMatrix(_fillUpMatrix(valuesFoundBySeries, xLabels, defaultValue));
   const yLabels = Object.keys(valuesBySeries);
 
   return [[

--- a/graylog2-web-interface/src/views/components/visualizations/heatmap/HeatmapVisualization.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/heatmap/HeatmapVisualization.tsx
@@ -39,7 +39,7 @@ const _generateSeriesTitles = (config, x, y) => {
   return y.map(() => columnSeriesTitles);
 };
 
-const _heatmapGenerateSeries = (type, name, x, y, z, idx, total, config, colorscale): ChartDefinition => {
+const _heatmapGenerateSeries = (type, name, x, y, z, idx, total, config, visualizationConfig): ChartDefinition => {
   const xAxisTitle = get(config, ['rowPivots', idx, 'field']);
   const yAxisTitle = get(config, ['columnPivots', idx, 'field']);
   const zSeriesTitles = _generateSeriesTitles(config, y, x);
@@ -54,11 +54,12 @@ const _heatmapGenerateSeries = (type, name, x, y, z, idx, total, config, colorsc
     text: zSeriesTitles,
     customdata: z,
     hovertemplate,
-    colorscale: colorscale,
+    colorscale: visualizationConfig.colorScale,
+    reversescale: visualizationConfig.reverseScale,
   };
 };
 
-const _generateSeries = (colorscale) => (type, name, x, y, z, idx, total, config) => _heatmapGenerateSeries(type, name, x, y, z, idx, total, config, colorscale);
+const _generateSeries = (visualizationConfig) => (type, name, x, y, z, idx, total, config) => _heatmapGenerateSeries(type, name, x, y, z, idx, total, config, visualizationConfig);
 
 const _fillUpMatrix = (z: Array<Array<any>>, xLabels: Array<any>) => {
   const defaultValue = 'None';
@@ -124,7 +125,7 @@ const _leafSourceMatcher = ({ source }) => source.endsWith('leaf') && source !==
 const HeatmapVisualization: VisualizationComponent = makeVisualization(({ config, data }: VisualizationComponentProps) => {
   const visualizationConfig = (config.visualizationConfig || HeatmapVisualizationConfig.empty()) as HeatmapVisualizationConfig;
   const rows = data.chart || Object.values(data)[0];
-  const heatmapData = chartData(config, rows, 'heatmap', _generateSeries(visualizationConfig.colorScale), _formatSeries, _leafSourceMatcher);
+  const heatmapData = chartData(config, rows, 'heatmap', _generateSeries(visualizationConfig), _formatSeries, _leafSourceMatcher);
   const layout = _chartLayout(heatmapData);
 
   return (

--- a/graylog2-web-interface/src/views/components/visualizations/heatmap/HeatmapVisualization.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/heatmap/HeatmapVisualization.tsx
@@ -20,35 +20,11 @@ import { values, merge, fill, find, isEmpty, get } from 'lodash';
 import { AggregationType, AggregationResult } from 'views/components/aggregationbuilder/AggregationBuilderPropTypes';
 import type { VisualizationComponent, VisualizationComponentProps } from 'views/components/aggregationbuilder/AggregationBuilder';
 import { makeVisualization } from 'views/components/aggregationbuilder/AggregationBuilder';
+import HeatmapVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/HeatmapVisualizationConfig';
 
 import type { ChartDefinition, ExtractedSeries } from '../ChartData';
 import GenericPlot from '../GenericPlot';
 import { chartData, ValuesBySeries } from '../ChartData';
-
-const BG_COLOR = '#440154';
-
-const COLORSCALE: [number, string][] = [
-  [0.00, BG_COLOR],
-  [0.05, '#481567'],
-  [0.10, '#483677'],
-  [0.15, '#453781'],
-  [0.20, '#404788'],
-  [0.30, '#39568c'],
-  [0.35, '#33638d'],
-  [0.40, '#2d708e'],
-  [0.45, '#287d8e'],
-  [0.50, '#238a8d'],
-  [0.55, '#1f968b'],
-  [0.60, '#20a387'],
-  [0.65, '#29af7f'],
-  [0.70, '#3cbb75'],
-  [0.75, '#55c667'],
-  [0.80, '#73d055'],
-  [0.85, '#95d840'],
-  [0.90, '#b8de29'],
-  [0.95, '#dce319'],
-  [1.00, '#fde725'],
-];
 
 const _generateSeriesTitles = (config, x, y) => {
   const seriesTitles = config.series.map((s) => s.function);
@@ -63,7 +39,7 @@ const _generateSeriesTitles = (config, x, y) => {
   return y.map(() => columnSeriesTitles);
 };
 
-const _generateSeries = (type, name, x, y, z, idx, total, config): ChartDefinition => {
+const _heatmapGenerateSeries = (type, name, x, y, z, idx, total, config, colorscale): ChartDefinition => {
   const xAxisTitle = get(config, ['rowPivots', idx, 'field']);
   const yAxisTitle = get(config, ['columnPivots', idx, 'field']);
   const zSeriesTitles = _generateSeriesTitles(config, y, x);
@@ -78,9 +54,11 @@ const _generateSeries = (type, name, x, y, z, idx, total, config): ChartDefiniti
     text: zSeriesTitles,
     customdata: z,
     hovertemplate,
-    colorscale: COLORSCALE,
+    colorscale: colorscale,
   };
 };
+
+const _generateSeries = (colorscale) => (type, name, x, y, z, idx, total, config) => _heatmapGenerateSeries(type, name, x, y, z, idx, total, config, colorscale);
 
 const _fillUpMatrix = (z: Array<Array<any>>, xLabels: Array<any>) => {
   const defaultValue = 'None';
@@ -134,7 +112,7 @@ const _chartLayout = (heatmapData) => {
   return {
     yaxis: axisConfig,
     xaxis: axisConfig,
-    plot_bgcolor: hasContent ? BG_COLOR : 'transparent',
+    // plot_bgcolor: hasContent ? BG_COLOR : 'transparent',
     margin: {
       b: 40,
     },
@@ -144,8 +122,9 @@ const _chartLayout = (heatmapData) => {
 const _leafSourceMatcher = ({ source }) => source.endsWith('leaf') && source !== 'row-leaf';
 
 const HeatmapVisualization: VisualizationComponent = makeVisualization(({ config, data }: VisualizationComponentProps) => {
+  const visualizationConfig = (config.visualizationConfig || HeatmapVisualizationConfig.empty()) as HeatmapVisualizationConfig;
   const rows = data.chart || Object.values(data)[0];
-  const heatmapData = chartData(config, rows, 'heatmap', _generateSeries, _formatSeries, _leafSourceMatcher);
+  const heatmapData = chartData(config, rows, 'heatmap', _generateSeries(visualizationConfig.colorScale), _formatSeries, _leafSourceMatcher);
   const layout = _chartLayout(heatmapData);
 
   return (

--- a/graylog2-web-interface/src/views/components/visualizations/heatmap/__tests__/HeatmapVisualization.test.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/heatmap/__tests__/HeatmapVisualization.test.tsx
@@ -41,7 +41,7 @@ describe('HeatmapVisualization', () => {
       .visualization('heatmap')
       .build();
     const effectiveTimerange: AbsoluteTimeRange = { type: 'absolute', from: '2019-10-22T11:54:35.850Z', to: '2019-10-29T11:53:50.000Z' };
-    const plotLayout = { yaxis: { type: 'category', fixedrange: true }, xaxis: { type: 'category', fixedrange: true }, plot_bgcolor: '#440154', margin: { b: 40 } };
+    const plotLayout = { yaxis: { type: 'category', fixedrange: true }, xaxis: { type: 'category', fixedrange: true }, margin: { b: 40 } };
     const plotChartData = [
       {
         type: 'heatmap',
@@ -52,7 +52,8 @@ describe('HeatmapVisualization', () => {
         text: [['count()', 'count()', 'count()', 'count()'], ['count()', 'count()', 'count()', 'count()']],
         customdata: [[217, 'None', 213, 'None'], ['None', 217, 'None', 230]],
         hovertemplate: 'hour: %{y}<br>http_status: %{x}<br>%{text}: %{customdata}<extra></extra>',
-        colorscale: [[0, '#440154'], [0.05, '#481567'], [0.1, '#483677'], [0.15, '#453781'], [0.2, '#404788'], [0.3, '#39568c'], [0.35, '#33638d'], [0.4, '#2d708e'], [0.45, '#287d8e'], [0.5, '#238a8d'], [0.55, '#1f968b'], [0.6, '#20a387'], [0.65, '#29af7f'], [0.7, '#3cbb75'], [0.75, '#55c667'], [0.8, '#73d055'], [0.85, '#95d840'], [0.9, '#b8de29'], [0.95, '#dce319'], [1, '#fde725']],
+        colorscale: 'Viridis',
+        reversescale: false,
       },
     ];
 

--- a/graylog2-web-interface/src/views/logic/aggregationbuilder/AggregationWidgetConfig.ts
+++ b/graylog2-web-interface/src/views/logic/aggregationbuilder/AggregationWidgetConfig.ts
@@ -124,7 +124,7 @@ export default class AggregationWidgetConfig extends WidgetConfig {
   }
 
   static builder() {
-    // eslint-disable-next-line no-use-before-define
+    // eslint-disable-next-line no-use-before-define,@typescript-eslint/no-use-before-define
     return new Builder()
       .rowPivots([])
       .columnPivots([])
@@ -135,7 +135,7 @@ export default class AggregationWidgetConfig extends WidgetConfig {
   }
 
   toBuilder() {
-    // eslint-disable-next-line no-use-before-define
+    // eslint-disable-next-line no-use-before-define,@typescript-eslint/no-use-before-define
     return new Builder(Immutable.Map(this._value));
   }
 
@@ -206,7 +206,7 @@ export default class AggregationWidgetConfig extends WidgetConfig {
       event_annotation,
     } = value;
 
-    // eslint-disable-next-line no-use-before-define
+    // eslint-disable-next-line no-use-before-define,@typescript-eslint/no-use-before-define
     return new Builder()
       .columnPivots(column_pivots.map(Pivot.fromJSON))
       .rowPivots(row_pivots.map(Pivot.fromJSON))

--- a/graylog2-web-interface/src/views/logic/aggregationbuilder/AggregationWidgetConfig.ts
+++ b/graylog2-web-interface/src/views/logic/aggregationbuilder/AggregationWidgetConfig.ts
@@ -186,7 +186,7 @@ export default class AggregationWidgetConfig extends WidgetConfig {
 
   equalsForSearch(other: any) {
     if (other instanceof AggregationWidgetConfig) {
-      return ['rowPivots', 'columnPivots', 'series', 'sort', 'rollup', 'eventAnnotation', 'visualizationConfig']
+      return ['rowPivots', 'columnPivots', 'series', 'sort', 'rollup', 'eventAnnotation']
         .every((key) => isEqualForSearch(this[key], other[key]));
     }
 

--- a/graylog2-web-interface/src/views/logic/aggregationbuilder/visualizations/HeatmapVisualizationConfig.ts
+++ b/graylog2-web-interface/src/views/logic/aggregationbuilder/visualizations/HeatmapVisualizationConfig.ts
@@ -46,6 +46,7 @@ type InternalState = {
   autoScale: boolean,
   zMin: number | undefined | null,
   zMax: number | undefined | null,
+  useSmallestAsDefault: boolean,
   defaultValue: number | undefined | null,
 };
 
@@ -55,6 +56,7 @@ export type HeatmapVisualizationConfigJSON = {
   auto_scale: boolean,
   z_min: number | undefined | null,
   z_max: number | undefined | null,
+  use_smallest_as_default: boolean,
   default_value: number | undefined | null,
 }
 
@@ -67,6 +69,7 @@ export default class HeatmapVisualizationConfig extends VisualizationConfig {
     autoScale: InternalState['autoScale'],
     zMin: InternalState['zMin'],
     zMax: InternalState['zMax'],
+    useSmallestAsDefault: InternalState['useSmallestAsDefault'],
     defaultValue: InternalState['defaultValue'],
   ) {
     super();
@@ -77,6 +80,7 @@ export default class HeatmapVisualizationConfig extends VisualizationConfig {
       autoScale,
       zMax,
       zMin,
+      useSmallestAsDefault,
       defaultValue,
     };
   }
@@ -105,6 +109,10 @@ export default class HeatmapVisualizationConfig extends VisualizationConfig {
     return this._value.defaultValue;
   }
 
+  get useSmallestAsDefault() {
+    return this._value.useSmallestAsDefault;
+  }
+
   toBuilder() {
     // eslint-disable-next-line @typescript-eslint/no-use-before-define
     return new Builder(Immutable.Map(this._value));
@@ -116,6 +124,7 @@ export default class HeatmapVisualizationConfig extends VisualizationConfig {
     autoScale: InternalState['autoScale'],
     zMin: InternalState['zMin'],
     zMax: InternalState['zMax'],
+    useSmallestAsDefault: InternalState['useSmallestAsDefault'],
     defaultValue: InternalState['defaultValue'],
   ) {
     return new HeatmapVisualizationConfig(
@@ -124,6 +133,7 @@ export default class HeatmapVisualizationConfig extends VisualizationConfig {
       autoScale,
       zMin,
       zMax,
+      useSmallestAsDefault,
       defaultValue,
     );
   }
@@ -135,6 +145,7 @@ export default class HeatmapVisualizationConfig extends VisualizationConfig {
       true,
       undefined,
       undefined,
+      false,
       undefined,
     );
   }
@@ -146,6 +157,7 @@ export default class HeatmapVisualizationConfig extends VisualizationConfig {
       autoScale: auto_scale,
       zMin: z_min,
       zMax: z_max,
+      useSmallestAsDefault: use_smallest_as_default,
       defaultValue: default_value,
     } = this._value;
 
@@ -155,6 +167,7 @@ export default class HeatmapVisualizationConfig extends VisualizationConfig {
       auto_scale,
       z_min,
       z_max,
+      use_smallest_as_default,
       default_value,
     };
   }
@@ -165,6 +178,7 @@ export default class HeatmapVisualizationConfig extends VisualizationConfig {
     auto_scale: true,
     z_min: undefined,
     z_max: undefined,
+    use_smallest_as_default: false,
     default_value: undefined,
   }) {
     const {
@@ -173,10 +187,11 @@ export default class HeatmapVisualizationConfig extends VisualizationConfig {
       auto_scale: autoScale,
       z_min: zMin,
       z_max: zMax,
+      use_smallest_as_default: useSmallestAsDefault,
       default_value: defaultValue,
     } = value;
 
-    return HeatmapVisualizationConfig.create(colorScale, reverseScale, autoScale, zMin, zMax, defaultValue);
+    return HeatmapVisualizationConfig.create(colorScale, reverseScale, autoScale, zMin, zMax, useSmallestAsDefault, defaultValue);
   }
 }
 
@@ -209,6 +224,10 @@ class Builder {
     return new Builder(this.value.set('zMax', value));
   }
 
+  useSmallestAsDefault(value: InternalState['useSmallestAsDefault']) {
+    return new Builder(this.value.set('useSmallestAsDefault', value));
+  }
+
   defaultValue(value: InternalState['defaultValue']) {
     return new Builder(this.value.set('defaultValue', value));
   }
@@ -220,9 +239,10 @@ class Builder {
       autoScale,
       zMin,
       zMax,
+      useSmallestAsDefault,
       defaultValue,
     } = this.value.toObject();
 
-    return new HeatmapVisualizationConfig(colorScale, reverseScale, autoScale, zMin, zMax, defaultValue);
+    return new HeatmapVisualizationConfig(colorScale, reverseScale, autoScale, zMin, zMax, useSmallestAsDefault, defaultValue);
   }
 }

--- a/graylog2-web-interface/src/views/logic/aggregationbuilder/visualizations/HeatmapVisualizationConfig.ts
+++ b/graylog2-web-interface/src/views/logic/aggregationbuilder/visualizations/HeatmapVisualizationConfig.ts
@@ -18,27 +18,10 @@ import * as Immutable from 'immutable';
 
 import VisualizationConfig from 'views/logic/aggregationbuilder/visualizations/VisualizationConfig';
 
-type ColorScale =
-    'Greys'
-  | 'YlGnBu'
-  | 'Greens'
-  | 'YlOrRd'
-  | 'Bluered'
-  | 'RdBu'
-  | 'Reds'
-  | 'Blues'
-  | 'Picnic'
-  | 'Rainbow'
-  | 'Portland'
-  | 'Jet'
-  | 'Hot'
-  | 'Blackbody'
-  | 'Earth'
-  | 'Electric'
-  | 'Viridis'
-  | 'Cividis';
+export const COLORSCALES = ['Greys', 'YlGnBu', 'Greens', 'YlOrRd', 'Bluered', 'RdBu', 'Reds', 'Blues', 'Picnic',
+  'Rainbow', 'Portland', 'Jet', 'Hot', 'Blackbody', 'Earth', 'Electric', 'Viridis', 'Cividis'];
 
-export const COLORSCALES = ['Greys', 'YlGnBu', 'Greens', 'YlOrRd', 'Bluered', 'RdBu', 'Reds', 'Blues', 'Picnic', 'Rainbow', 'Portland', 'Jet', 'Hot', 'Blackbody', 'Earth', 'Electric', 'Viridis', 'Cividis'];
+type ColorScale = typeof COLORSCALES[number];
 
 type InternalState = {
   colorScale: ColorScale;
@@ -197,7 +180,7 @@ export default class HeatmapVisualizationConfig extends VisualizationConfig {
 
 type BuilderState = Immutable.Map<string, any>;
 
-class Builder {
+export class Builder {
   value: BuilderState;
 
   constructor(value: BuilderState = Immutable.Map()) {

--- a/graylog2-web-interface/src/views/logic/aggregationbuilder/visualizations/HeatmapVisualizationConfig.ts
+++ b/graylog2-web-interface/src/views/logic/aggregationbuilder/visualizations/HeatmapVisualizationConfig.ts
@@ -45,7 +45,6 @@ type InternalState = {
   reverseScale: boolean;
   autoScale: boolean,
   zMin: number | undefined | null,
-  zMid: number | undefined | null,
   zMax: number | undefined | null,
   defaultValue: number | undefined | null,
 };
@@ -55,7 +54,6 @@ export type HeatmapVisualizationConfigJSON = {
   reverse_scale: boolean;
   auto_scale: boolean,
   z_min: number | undefined | null,
-  z_mid: number | undefined | null,
   z_max: number | undefined | null,
   default_value: number | undefined | null,
 }
@@ -68,7 +66,6 @@ export default class HeatmapVisualizationConfig extends VisualizationConfig {
     reverseScale: InternalState['reverseScale'],
     autoScale: InternalState['autoScale'],
     zMin: InternalState['zMin'],
-    zMid: InternalState['zMid'],
     zMax: InternalState['zMax'],
     defaultValue: InternalState['defaultValue'],
   ) {
@@ -79,7 +76,6 @@ export default class HeatmapVisualizationConfig extends VisualizationConfig {
       reverseScale,
       autoScale,
       zMax,
-      zMid,
       zMin,
       defaultValue,
     };
@@ -101,10 +97,6 @@ export default class HeatmapVisualizationConfig extends VisualizationConfig {
     return this._value.zMin;
   }
 
-  get zMid() {
-    return this._value.zMid;
-  }
-
   get zMax() {
     return this._value.zMax;
   }
@@ -123,7 +115,6 @@ export default class HeatmapVisualizationConfig extends VisualizationConfig {
     reverseScale: InternalState['reverseScale'],
     autoScale: InternalState['autoScale'],
     zMin: InternalState['zMin'],
-    zMid: InternalState['zMid'],
     zMax: InternalState['zMax'],
     defaultValue: InternalState['defaultValue'],
   ) {
@@ -132,7 +123,6 @@ export default class HeatmapVisualizationConfig extends VisualizationConfig {
       reverseScale,
       autoScale,
       zMin,
-      zMid,
       zMax,
       defaultValue,
     );
@@ -146,7 +136,6 @@ export default class HeatmapVisualizationConfig extends VisualizationConfig {
       undefined,
       undefined,
       undefined,
-      undefined,
     );
   }
 
@@ -156,7 +145,6 @@ export default class HeatmapVisualizationConfig extends VisualizationConfig {
       reverseScale: reverse_scale,
       autoScale: auto_scale,
       zMin: z_min,
-      zMid: z_mid,
       zMax: z_max,
       defaultValue: default_value,
     } = this._value;
@@ -166,7 +154,6 @@ export default class HeatmapVisualizationConfig extends VisualizationConfig {
       reverse_scale,
       auto_scale,
       z_min,
-      z_mid,
       z_max,
       default_value,
     };
@@ -177,7 +164,6 @@ export default class HeatmapVisualizationConfig extends VisualizationConfig {
     reverse_scale: false,
     auto_scale: true,
     z_min: undefined,
-    z_mid: undefined,
     z_max: undefined,
     default_value: undefined,
   }) {
@@ -186,12 +172,11 @@ export default class HeatmapVisualizationConfig extends VisualizationConfig {
       reverse_scale: reverseScale,
       auto_scale: autoScale,
       z_min: zMin,
-      z_mid: zMid,
       z_max: zMax,
       default_value: defaultValue,
     } = value;
 
-    return HeatmapVisualizationConfig.create(colorScale, reverseScale, autoScale, zMin, zMid, zMax, defaultValue);
+    return HeatmapVisualizationConfig.create(colorScale, reverseScale, autoScale, zMin, zMax, defaultValue);
   }
 }
 
@@ -220,10 +205,6 @@ class Builder {
     return new Builder(this.value.set('zMin', value));
   }
 
-  zMid(value: InternalState['zMid']) {
-    return new Builder(this.value.set('zMid', value));
-  }
-
   zMax(value: InternalState['zMax']) {
     return new Builder(this.value.set('zMax', value));
   }
@@ -238,11 +219,10 @@ class Builder {
       reverseScale,
       autoScale,
       zMin,
-      zMid,
       zMax,
       defaultValue,
     } = this.value.toObject();
 
-    return new HeatmapVisualizationConfig(colorScale, reverseScale, autoScale, zMin, zMid, zMax, defaultValue);
+    return new HeatmapVisualizationConfig(colorScale, reverseScale, autoScale, zMin, zMax, defaultValue);
   }
 }

--- a/graylog2-web-interface/src/views/logic/aggregationbuilder/visualizations/HeatmapVisualizationConfig.ts
+++ b/graylog2-web-interface/src/views/logic/aggregationbuilder/visualizations/HeatmapVisualizationConfig.ts
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as Immutable from 'immutable';
+
+import VisualizationConfig from 'views/logic/aggregationbuilder/visualizations/VisualizationConfig';
+
+type ColorScale =
+    'Greys'
+  | 'YlGnBu'
+  | 'Greens'
+  | 'YlOrRd'
+  | 'Bluered'
+  | 'RdBu'
+  | 'Reds'
+  | 'Blues'
+  | 'Picnic'
+  | 'Rainbow'
+  | 'Portland'
+  | 'Jet'
+  | 'Hot'
+  | 'Blackbody'
+  | 'Earth'
+  | 'Electric'
+  | 'Viridis'
+  | 'Cividis';
+
+export const COLORSCALES = ['Greys', 'YlGnBu', 'Greens', 'YlOrRd', 'Bluered', 'RdBu', 'Reds', 'Blues', 'Picnic', 'Rainbow', 'Portland', 'Jet', 'Hot', 'Blackbody', 'Earth', 'Electric', 'Viridis', 'Cividis'];
+
+type InternalState = {
+  colorScale: ColorScale;
+};
+
+export type HeatmapVisualizationConfigJSON = {
+  color_scale: ColorScale;
+}
+
+export default class HeatmapVisualizationConfig extends VisualizationConfig {
+  private readonly _value: InternalState;
+
+  constructor(colorScale: InternalState['colorScale']) {
+    super();
+
+    this._value = { colorScale };
+  }
+
+  get colorScale() {
+    return this._value.colorScale;
+  }
+
+  toBuilder() {
+    return new Builder(Immutable.Map(this._value));
+  }
+
+  static create(colorScale: InternalState['colorScale']) {
+    return new HeatmapVisualizationConfig(colorScale);
+  }
+
+  static empty() {
+    return new HeatmapVisualizationConfig('Viridis');
+  }
+
+  toJSON() {
+    const { colorScale } = this._value;
+
+    return { colorScale };
+  }
+
+  static fromJSON(type: string, value: HeatmapVisualizationConfigJSON = { color_scale: 'Viridis' }) {
+    const { color_scale: colorScale } = value;
+
+    return HeatmapVisualizationConfig.create(colorScale);
+  }
+
+}
+
+type BuilderState = Immutable.Map<string, any>;
+
+class Builder {
+  value: BuilderState;
+
+  constructor(value: BuilderState = Immutable.Map()) {
+    this.value = value;
+  }
+
+  colorScale(value: InternalState['colorScale']) {
+    return new Builder(this.value.set('colorScale', value));
+  }
+
+  build() {
+    const { colorScale } = this.value.toObject();
+
+    return new HeatmapVisualizationConfig(colorScale);
+  }
+}

--- a/graylog2-web-interface/src/views/logic/aggregationbuilder/visualizations/HeatmapVisualizationConfig.ts
+++ b/graylog2-web-interface/src/views/logic/aggregationbuilder/visualizations/HeatmapVisualizationConfig.ts
@@ -43,58 +43,155 @@ export const COLORSCALES = ['Greys', 'YlGnBu', 'Greens', 'YlOrRd', 'Bluered', 'R
 type InternalState = {
   colorScale: ColorScale;
   reverseScale: boolean;
+  autoScale: boolean,
+  zMin: number | undefined | null,
+  zMid: number | undefined | null,
+  zMax: number | undefined | null,
+  defaultValue: number | undefined | null,
 };
 
 export type HeatmapVisualizationConfigJSON = {
   color_scale: ColorScale;
   reverse_scale: boolean;
+  auto_scale: boolean,
+  z_min: number | undefined | null,
+  z_mid: number | undefined | null,
+  z_max: number | undefined | null,
+  default_value: number | undefined | null,
 }
 
 export default class HeatmapVisualizationConfig extends VisualizationConfig {
   private readonly _value: InternalState;
 
-  constructor(colorScale: InternalState['colorScale'], reverseScale: InternalState['reverseScale']) {
+  constructor(
+    colorScale: InternalState['colorScale'],
+    reverseScale: InternalState['reverseScale'],
+    autoScale: InternalState['autoScale'],
+    zMin: InternalState['zMin'],
+    zMid: InternalState['zMid'],
+    zMax: InternalState['zMax'],
+    defaultValue: InternalState['defaultValue'],
+  ) {
     super();
 
-    this._value = { colorScale, reverseScale };
+    this._value = {
+      colorScale,
+      reverseScale,
+      autoScale,
+      zMax,
+      zMid,
+      zMin,
+      defaultValue,
+    };
   }
 
   get colorScale() {
     return this._value.colorScale;
   }
 
-  get reverseScale () {
+  get reverseScale() {
     return this._value.reverseScale;
   }
 
+  get autoScale() {
+    return this._value.autoScale;
+  }
+
+  get zMin() {
+    return this._value.zMin;
+  }
+
+  get zMid() {
+    return this._value.zMid;
+  }
+
+  get zMax() {
+    return this._value.zMax;
+  }
+
+  get defaultValue() {
+    return this._value.defaultValue;
+  }
+
   toBuilder() {
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
     return new Builder(Immutable.Map(this._value));
   }
 
-  static create(colorScale: InternalState['colorScale'], reverseScale: InternalState['reverseScale']) {
-    return new HeatmapVisualizationConfig(colorScale, reverseScale);
+  static create(
+    colorScale: InternalState['colorScale'],
+    reverseScale: InternalState['reverseScale'],
+    autoScale: InternalState['autoScale'],
+    zMin: InternalState['zMin'],
+    zMid: InternalState['zMid'],
+    zMax: InternalState['zMax'],
+    defaultValue: InternalState['defaultValue'],
+  ) {
+    return new HeatmapVisualizationConfig(
+      colorScale,
+      reverseScale,
+      autoScale,
+      zMin,
+      zMid,
+      zMax,
+      defaultValue,
+    );
   }
 
   static empty() {
-    return new HeatmapVisualizationConfig('Viridis', false);
+    return new HeatmapVisualizationConfig(
+      'Viridis',
+      false,
+      true,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+    );
   }
 
   toJSON(): HeatmapVisualizationConfigJSON {
     const {
       colorScale: color_scale,
       reverseScale: reverse_scale,
+      autoScale: auto_scale,
+      zMin: z_min,
+      zMid: z_mid,
+      zMax: z_max,
+      defaultValue: default_value,
     } = this._value;
 
-    return { color_scale, reverse_scale };
+    return {
+      color_scale,
+      reverse_scale,
+      auto_scale,
+      z_min,
+      z_mid,
+      z_max,
+      default_value,
+    };
   }
 
-  static fromJSON(type: string, value: HeatmapVisualizationConfigJSON = { color_scale: 'Viridis', reverse_scale: false }) {
+  static fromJSON(type: string, value: HeatmapVisualizationConfigJSON = {
+    color_scale: 'Viridis',
+    reverse_scale: false,
+    auto_scale: true,
+    z_min: undefined,
+    z_mid: undefined,
+    z_max: undefined,
+    default_value: undefined,
+  }) {
     const {
       color_scale: colorScale,
       reverse_scale: reverseScale,
+      auto_scale: autoScale,
+      z_min: zMin,
+      z_mid: zMid,
+      z_max: zMax,
+      default_value: defaultValue,
     } = value;
 
-    return HeatmapVisualizationConfig.create(colorScale, reverseScale);
+    return HeatmapVisualizationConfig.create(colorScale, reverseScale, autoScale, zMin, zMid, zMax, defaultValue);
   }
 }
 
@@ -115,9 +212,37 @@ class Builder {
     return new Builder(this.value.set('reverseScale', value));
   }
 
-  build() {
-    const { colorScale, reverseScale } = this.value.toObject();
+  autoScale(value: InternalState['autoScale']) {
+    return new Builder(this.value.set('autoScale', value));
+  }
 
-    return new HeatmapVisualizationConfig(colorScale, reverseScale);
+  zMin(value: InternalState['zMin']) {
+    return new Builder(this.value.set('zMin', value));
+  }
+
+  zMid(value: InternalState['zMid']) {
+    return new Builder(this.value.set('zMid', value));
+  }
+
+  zMax(value: InternalState['zMax']) {
+    return new Builder(this.value.set('zMax', value));
+  }
+
+  defaultValue(value: InternalState['defaultValue']) {
+    return new Builder(this.value.set('defaultValue', value));
+  }
+
+  build() {
+    const {
+      colorScale,
+      reverseScale,
+      autoScale,
+      zMin,
+      zMid,
+      zMax,
+      defaultValue,
+    } = this.value.toObject();
+
+    return new HeatmapVisualizationConfig(colorScale, reverseScale, autoScale, zMin, zMid, zMax, defaultValue);
   }
 }

--- a/graylog2-web-interface/src/views/logic/aggregationbuilder/visualizations/HeatmapVisualizationConfig.ts
+++ b/graylog2-web-interface/src/views/logic/aggregationbuilder/visualizations/HeatmapVisualizationConfig.ts
@@ -42,49 +42,60 @@ export const COLORSCALES = ['Greys', 'YlGnBu', 'Greens', 'YlOrRd', 'Bluered', 'R
 
 type InternalState = {
   colorScale: ColorScale;
+  reverseScale: boolean;
 };
 
 export type HeatmapVisualizationConfigJSON = {
   color_scale: ColorScale;
+  reverse_scale: boolean;
 }
 
 export default class HeatmapVisualizationConfig extends VisualizationConfig {
   private readonly _value: InternalState;
 
-  constructor(colorScale: InternalState['colorScale']) {
+  constructor(colorScale: InternalState['colorScale'], reverseScale: InternalState['reverseScale']) {
     super();
 
-    this._value = { colorScale };
+    this._value = { colorScale, reverseScale };
   }
 
   get colorScale() {
     return this._value.colorScale;
   }
 
+  get reverseScale () {
+    return this._value.reverseScale;
+  }
+
   toBuilder() {
     return new Builder(Immutable.Map(this._value));
   }
 
-  static create(colorScale: InternalState['colorScale']) {
-    return new HeatmapVisualizationConfig(colorScale);
+  static create(colorScale: InternalState['colorScale'], reverseScale: InternalState['reverseScale']) {
+    return new HeatmapVisualizationConfig(colorScale, reverseScale);
   }
 
   static empty() {
-    return new HeatmapVisualizationConfig('Viridis');
+    return new HeatmapVisualizationConfig('Viridis', false);
   }
 
-  toJSON() {
-    const { colorScale } = this._value;
+  toJSON(): HeatmapVisualizationConfigJSON {
+    const {
+      colorScale: color_scale,
+      reverseScale: reverse_scale,
+    } = this._value;
 
-    return { colorScale };
+    return { color_scale, reverse_scale };
   }
 
-  static fromJSON(type: string, value: HeatmapVisualizationConfigJSON = { color_scale: 'Viridis' }) {
-    const { color_scale: colorScale } = value;
+  static fromJSON(type: string, value: HeatmapVisualizationConfigJSON = { color_scale: 'Viridis', reverse_scale: false }) {
+    const {
+      color_scale: colorScale,
+      reverse_scale: reverseScale,
+    } = value;
 
-    return HeatmapVisualizationConfig.create(colorScale);
+    return HeatmapVisualizationConfig.create(colorScale, reverseScale);
   }
-
 }
 
 type BuilderState = Immutable.Map<string, any>;
@@ -100,9 +111,13 @@ class Builder {
     return new Builder(this.value.set('colorScale', value));
   }
 
-  build() {
-    const { colorScale } = this.value.toObject();
+  reverseScale(value: InternalState['reverseScale']) {
+    return new Builder(this.value.set('reverseScale', value));
+  }
 
-    return new HeatmapVisualizationConfig(colorScale);
+  build() {
+    const { colorScale, reverseScale } = this.value.toObject();
+
+    return new HeatmapVisualizationConfig(colorScale, reverseScale);
   }
 }


### PR DESCRIPTION
## Motivation and Context
Plotly provides a list of predefined colorscales for its Heatmap. Instead of hard coding a single color scale
we should provide that list to the use so he can use a colorscale matching to his data.
Also it is often useful to define the range of the scale. For example if we have 100 data points in the range from 1 to 10
and 2 data points in the range 60 to 70, the range of the colorscale is defined from 1 to 70. The 100 data points are now invisible.
If the user now selects the data range from 1 to 11 the 2 data point 2 with 60 and 70 will now still look out but the rest is more
readable.

## Description
- Add a select where we list the colorscales poltly accepts
- Add a Min and Max field so the user can enter the range of the scale
- Add Autoscale which enables of disables the Min, Max fields
- Add a default value which will be rendered if a undefined value was found, until now we used 'None' and draw the hard
  coded background, but we do not have it any longer, so the background will now 
- Add a checkbox to automatically set the default to the smallest value.

![Heatmap-Scale](https://user-images.githubusercontent.com/448763/102766353-4a836f00-437e-11eb-9f3a-c3cd0ca35b25.gif)

## How Has This Been Tested?
- Created a Heatmap and run through all possible values

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


