### PR TITLE
Save focused widget id in url

### DIFF
--- a/graylog2-web-interface/src/views/components/contexts/WidgetFocusProvider.test.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/WidgetFocusProvider.test.tsx
@@ -66,7 +66,7 @@ describe('WidgetFocusProvider', () => {
     fireEvent.click(button);
 
     await waitFor(() => {
-      expect(mockHistoryReplace).toBeCalledWith('/?focused=click');
+      expect(mockHistoryReplace).toBeCalledWith('?focused=click');
     });
   });
 

--- a/graylog2-web-interface/src/views/components/contexts/WidgetFocusProvider.test.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/WidgetFocusProvider.test.tsx
@@ -17,6 +17,7 @@
 import * as React from 'react';
 import { useContext } from 'react';
 import { render, screen, fireEvent, waitFor } from 'wrappedTestingLibrary';
+import { useLocation } from 'react-router-dom';
 
 import WidgetFocusProvider from 'views/components/contexts/WidgetFocusProvider';
 import WidgetFocusContext from 'views/components/contexts/WidgetFocusContext';
@@ -28,10 +29,10 @@ jest.mock('react-router-dom', () => ({
   useHistory: () => ({
     replace: mockHistoryReplace,
   }),
-  useLocation: () => ({
+  useLocation: jest.fn(() => ({
     pathname: '',
     search: '?focused=clack',
-  }),
+  })),
 }));
 
 jest.mock('stores/connect', () => ({
@@ -71,6 +72,11 @@ describe('WidgetFocusProvider', () => {
   });
 
   it('should set focused widget from url', () => {
+    useLocation.mockReturnValue({
+      pathname: '',
+      search: 'focused=clack',
+    });
+
     renderSUT();
     const div = screen.getByText('clack');
 

--- a/graylog2-web-interface/src/views/components/contexts/WidgetFocusProvider.test.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/WidgetFocusProvider.test.tsx
@@ -28,16 +28,27 @@ jest.mock('react-router-dom', () => ({
   useHistory: () => ({
     replace: mockHistoryReplace,
   }),
+  useLocation: () => ({
+    pathname: '',
+    search: '?focused=clack',
+  }),
+}));
+
+jest.mock('stores/connect', () => ({
+  useStore: jest.fn(() => ({
+    has: jest.fn(() => true),
+  })),
 }));
 
 describe('WidgetFocusProvider', () => {
   const renderSUT = () => {
     const Consumer = () => {
-      const { setFocusedWidget } = useContext(WidgetFocusContext);
+      const { setFocusedWidget, focusedWidget } = useContext(WidgetFocusContext);
 
       return (
         <>
           <button type="button" onClick={() => setFocusedWidget('click')}>Click</button>
+          <div>{focusedWidget}</div>
         </>
       );
     };
@@ -57,5 +68,12 @@ describe('WidgetFocusProvider', () => {
     await waitFor(() => {
       expect(mockHistoryReplace).toBeCalledWith('/?focused=click');
     });
+  });
+
+  it('should set focused widget from url', () => {
+    renderSUT();
+    const div = screen.getByText('clack');
+
+    expect(div).not.toBeEmptyDOMElement();
   });
 });

--- a/graylog2-web-interface/src/views/components/contexts/WidgetFocusProvider.test.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/WidgetFocusProvider.test.tsx
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import { useContext } from 'react';
+import { render, screen, fireEvent, waitFor } from 'wrappedTestingLibrary';
+
+import WidgetFocusProvider from 'views/components/contexts/WidgetFocusProvider';
+import WidgetFocusContext from 'views/components/contexts/WidgetFocusContext';
+
+const mockHistoryReplace = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useHistory: () => ({
+    replace: mockHistoryReplace,
+  }),
+}));
+
+describe('WidgetFocusProvider', () => {
+  const renderSUT = () => {
+    const Consumer = () => {
+      const { setFocusedWidget } = useContext(WidgetFocusContext);
+
+      return (
+        <>
+          <button type="button" onClick={() => setFocusedWidget('click')}>Click</button>
+        </>
+      );
+    };
+
+    render(
+      <WidgetFocusProvider>
+        <Consumer />
+      </WidgetFocusProvider>,
+    );
+  };
+
+  it('should update url', async () => {
+    renderSUT();
+    const button = await screen.getByText('Click');
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(mockHistoryReplace).toBeCalledWith('/?focused=click');
+    });
+  });
+});

--- a/graylog2-web-interface/src/views/components/contexts/WidgetFocusProvider.test.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/WidgetFocusProvider.test.tsx
@@ -71,15 +71,13 @@ describe('WidgetFocusProvider', () => {
     });
   });
 
-  it('should set focused widget from url', () => {
+  it('should set focused widget from url', async () => {
     useLocation.mockReturnValue({
       pathname: '',
       search: 'focused=clack',
     });
 
     renderSUT();
-    const div = screen.getByText('clack');
-
-    expect(div).not.toBeEmptyDOMElement();
+    await screen.findByText('clack');
   });
 });

--- a/graylog2-web-interface/src/views/components/contexts/WidgetFocusProvider.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/WidgetFocusProvider.tsx
@@ -15,16 +15,47 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
+import { useLocation, useHistory } from 'react-router-dom';
 import PropTypes from 'prop-types';
+import URI from 'urijs';
 
 import { useStore } from 'stores/connect';
 import { WidgetStore } from 'views/stores/WidgetStore';
 import WidgetFocusContext from 'views/components/contexts/WidgetFocusContext';
 
+const _syncWithQuery = (query: string, focusedWidget: string) => {
+  const baseUri = new URI(query)
+    .removeSearch('focused');
+
+  if (focusedWidget) {
+    return baseUri.setSearch('focused', focusedWidget).toString();
+  }
+
+  return baseUri.toString();
+};
+
+const getFocusedWidgetFromSearch = (search: string) => {
+  const uri = new URI(search);
+  const { focused } = uri.search(true);
+
+  return focused;
+};
+
 const WidgetFocusProvider = ({ children }: { children: React.ReactNode }): React.ReactElement => {
-  const [focusedWidget, setFocusedWidget] = useState(undefined);
+  const { search, pathname } = useLocation();
+  const query = pathname + search;
+  const history = useHistory();
+  const [focusedWidget, setFocusedWidget] = useState<string | undefined>();
   const widgets = useStore(WidgetStore);
+
+  useEffect(() => {
+    const paramFocusedWidget = getFocusedWidgetFromSearch(search);
+
+    if (paramFocusedWidget && focusedWidget !== paramFocusedWidget) {
+      setFocusedWidget(paramFocusedWidget);
+    }
+  }, [focusedWidget, search]);
 
   useEffect(() => {
     if (focusedWidget && !widgets.has(focusedWidget)) {
@@ -32,10 +63,15 @@ const WidgetFocusProvider = ({ children }: { children: React.ReactNode }): React
     }
   }, [focusedWidget, widgets]);
 
-  const updateFocus = (widgetId: string | undefined | null) => (
-    widgetId === focusedWidget
-      ? setFocusedWidget(undefined)
-      : setFocusedWidget(widgetId));
+  const updateFocus = useCallback((widgetId: string | undefined | null) => {
+    const newFocus = widgetId === focusedWidget
+      ? undefined
+      : widgetId;
+    const newURI = _syncWithQuery(query, newFocus);
+    history.replace(newURI);
+
+    setFocusedWidget(newFocus);
+  }, [focusedWidget, history, query]);
 
   return (
     <WidgetFocusContext.Provider value={{ focusedWidget, setFocusedWidget: updateFocus }}>

--- a/graylog2-web-interface/src/views/components/contexts/WidgetFocusProvider.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/WidgetFocusProvider.tsx
@@ -21,6 +21,7 @@ import PropTypes from 'prop-types';
 import URI from 'urijs';
 
 import { useStore } from 'stores/connect';
+import useQuery from 'routing/useQuery';
 import { WidgetStore } from 'views/stores/WidgetStore';
 import WidgetFocusContext from 'views/components/contexts/WidgetFocusContext';
 
@@ -35,11 +36,14 @@ const _syncWithQuery = (query: string, focusedWidget: string) => {
   return baseUri.toString();
 };
 
-const getFocusedWidgetFromSearch = (search: string) => {
-  const uri = new URI(search);
-  const { focused } = uri.search(true);
+const useFocusWidgetIdFromParam = (focusedWidget, setFocusedWidget) => {
+  const { focused: paramFocusedWidget } = useQuery();
 
-  return focused;
+  useEffect(() => {
+    if (focusedWidget !== paramFocusedWidget) {
+      setFocusedWidget(paramFocusedWidget);
+    }
+  }, [focusedWidget, paramFocusedWidget, setFocusedWidget]);
 };
 
 const WidgetFocusProvider = ({ children }: { children: React.ReactNode }): React.ReactElement => {
@@ -49,13 +53,7 @@ const WidgetFocusProvider = ({ children }: { children: React.ReactNode }): React
   const [focusedWidget, setFocusedWidget] = useState<string | undefined>();
   const widgets = useStore(WidgetStore);
 
-  useEffect(() => {
-    const paramFocusedWidget = getFocusedWidgetFromSearch(search);
-
-    if (paramFocusedWidget && focusedWidget !== paramFocusedWidget) {
-      setFocusedWidget(paramFocusedWidget);
-    }
-  }, [focusedWidget, search]);
+  useFocusWidgetIdFromParam(focusedWidget, setFocusedWidget);
 
   useEffect(() => {
     if (focusedWidget && !widgets.has(focusedWidget)) {
@@ -68,9 +66,8 @@ const WidgetFocusProvider = ({ children }: { children: React.ReactNode }): React
       ? undefined
       : widgetId;
     const newURI = _syncWithQuery(query, newFocus);
-    history.replace(newURI);
 
-    setFocusedWidget(newFocus);
+    history.replace(newURI);
   }, [focusedWidget, history, query]);
 
   return (


### PR DESCRIPTION
## Motivation
Prior to this change, we did not save the state
of the focused widget in the url.

## Description
This change will sync the focused widget id with the
url so a user can copy and past the state to another
user.

## How Has This Been Tested?
1. Focus a widget
2. Copy url
3. open a new tab 
4. paste url

Fixes #9728 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)