### PR TITLE
Custom chart legend

### DIFF
--- a/graylog2-web-interface/src/components/common/ColorPicker.jsx
+++ b/graylog2-web-interface/src/components/common/ColorPicker.jsx
@@ -14,24 +14,33 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import React from 'react';
-import createReactClass from 'create-react-class';
+import * as React from 'react';
+import { useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { SwatchesPicker } from 'react-color';
 
 /**
  * Color picker component that let the user select a color from a list of 95 colors grouped by hue.
  */
-const ColorPicker = createReactClass({
-  propTypes: {
-    /** Indicates the selected color in hexadecimal format. */
-    color: PropTypes.string,
-    /**
+const ColorPicker = ({ onChange, ...rest }) => {
+  const onColorChange = useCallback((color, event) => {
+    onChange(color.hex, event);
+  }, [onChange]);
+
+  return (
+    <SwatchesPicker {...rest} onChange={onColorChange} />
+  );
+};
+
+ColorPicker.propTypes = {
+  /** Indicates the selected color in hexadecimal format. */
+  color: PropTypes.string,
+  /**
      * Color palette in hexadecimal format. By default it uses the color palette defined by react-color,
      * including 95 colors to pick from.
      */
-    colors: PropTypes.array,
-    /**
+  colors: PropTypes.array,
+  /**
      * Height of the color picker in pixels. By default it displays 2 rows of colors and the first color
      * of the third row, indicating users that they can scroll through the list:
      *
@@ -39,39 +48,26 @@ const ColorPicker = createReactClass({
      *
      * You can set `Infinity` as `height` if you don't want the component to scroll.
      */
-    height: PropTypes.number,
-    /**
+  height: PropTypes.number,
+  /**
      * Width of the color picker in pixels. By default it displays 5 columns of colors:
      *
      * `50px width per color column * 5 columns + 22px of padding = 272px`
      */
-    width: PropTypes.number,
-    /**
+  width: PropTypes.number,
+  /**
      * Function that will be called when the selected color changes.
      * The function receives the color in hexadecimal format as first
      * argument and the event as the second argument.
      */
-    onChange: PropTypes.func.isRequired,
-  },
+  onChange: PropTypes.func.isRequired,
+};
 
-  getDefaultProps() {
-    return {
-      color: undefined,
-      colors: undefined, // Use default color palette.
-      height: (135 * 2) + 24 + 16, // 135px color row * 2 rows + 24px first color 3rd row + 16px padding
-      width: (50 * 5) + 16 + 6, // 50px color columns * 5 columns + 22px padding
-    };
-  },
-
-  onColorChange(color, event) {
-    this.props.onChange(color.hex, event);
-  },
-
-  render() {
-    return (
-      <SwatchesPicker {...this.props} onChange={this.onColorChange} />
-    );
-  },
-});
+ColorPicker.defaultProps = {
+  color: undefined,
+  colors: undefined, // Use default color palette.
+  height: (135 * 2) + 24 + 16, // 135px color row * 2 rows + 24px first color 3rd row + 16px padding
+  width: (50 * 5), // 50px color columns * 5 columns
+};
 
 export default ColorPicker;

--- a/graylog2-web-interface/src/views/components/visualizations/ChartColorContext.ts
+++ b/graylog2-web-interface/src/views/components/visualizations/ChartColorContext.ts
@@ -17,12 +17,13 @@
 import * as React from 'react';
 
 import { singleton } from 'views/logic/singleton';
+import ColorMapper from 'views/components/visualizations/ColorMapper';
 
-export type ChartColorMap = { [key: string]: string };
+export type ChartColorMap = ColorMapper;
 export type ChangeColorFunction = (value: string, color: string) => Promise<unknown>;
 
 const ChartColorContext = React.createContext<{ colors: ChartColorMap, setColor: ChangeColorFunction }>({
-  colors: {},
+  colors: ColorMapper.create(),
   setColor: () => Promise.resolve([]),
 });
 export default singleton('views.components.visualizations.ChartColorContext', () => ChartColorContext);

--- a/graylog2-web-interface/src/views/components/visualizations/ColorMapper.ts
+++ b/graylog2-web-interface/src/views/components/visualizations/ColorMapper.ts
@@ -28,8 +28,12 @@ class ColorMapper {
     this._currentDefaultColor = colorIndex;
   }
 
-  private _nextFreeColor() {
+  private _incrementColor() {
     this._currentDefaultColor = (this._currentDefaultColor + 1) % defaultChartColors.length;
+  }
+
+  private _nextFreeColor() {
+    this._incrementColor();
 
     return defaultChartColors[this._currentDefaultColor];
   }
@@ -38,6 +42,8 @@ class ColorMapper {
     const color = this._value.get(name);
 
     if (color) {
+      this._incrementColor();
+
       return color;
     }
 

--- a/graylog2-web-interface/src/views/components/visualizations/ColorMapper.ts
+++ b/graylog2-web-interface/src/views/components/visualizations/ColorMapper.ts
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import { Map } from 'immutable';
+
+import { defaultChartColors } from 'views/components/visualizations/Colors';
+
+class ColorMapper {
+  private _value: Map<string, string>;
+
+  private _currentDefaultColor: number;
+
+  constructor(colorMap = Map<string, string>(), colorIndex = -1) {
+    this._value = colorMap;
+    this._currentDefaultColor = colorIndex;
+  }
+
+  private _nextFreeColor() {
+    this._currentDefaultColor = (this._currentDefaultColor + 1) % defaultChartColors.length;
+
+    return defaultChartColors[this._currentDefaultColor];
+  }
+
+  get(name) {
+    const color = this._value.get(name);
+
+    if (color) {
+      return color;
+    }
+
+    const newColor = this._nextFreeColor();
+    this._value = this._value.set(name, newColor);
+
+    return newColor;
+  }
+
+  set(name, color) {
+    this._value = this._value.set(name, color);
+  }
+
+  toBuilder() {
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
+    return new Builder(this._value, this._currentDefaultColor);
+  }
+
+  static builder() {
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
+    return new Builder();
+  }
+
+  static create(value = Map<string, string>()) {
+    return new ColorMapper(value);
+  }
+}
+
+class Builder {
+  private value: Map<string, string>;
+
+  private colorIndex: number;
+
+  constructor(value = Map<string, string>(), colorIndex = -1) {
+    this.value = value;
+    this.colorIndex = colorIndex;
+  }
+
+  set(name, color) {
+    return new Builder(this.value.set(name, color));
+  }
+
+  build() {
+    return new ColorMapper(this.value, this.colorIndex);
+  }
+}
+
+export default ColorMapper;

--- a/graylog2-web-interface/src/views/components/visualizations/Colors.ts
+++ b/graylog2-web-interface/src/views/components/visualizations/Colors.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+const reds = ['#b71c1c', '#ce5246', '#e27c72', '#f3a4a1', '#ffcdd2'];
+const pinks = ['#880e4f', '#a5426d', '#c16b8d', '#dd93ae', '#f8bbd0'];
+const purples = ['#4a148c', '#7240a3', '#9869b9', '#bc93d0', '#e1bee7'];
+const darkpurples = ['#311b92', '#6044a8', '#876dbe', '#ad98d3', '#d1c4e9'];
+
+const darkblues = ['#1a237e', '#4e4998', '#7772b3', '#9e9dce', '#c5cae9'];
+const blues = ['#0d47a1', '#4b6ab7', '#738fce', '#97b5e4', '#bbdefb'];
+const lightblues = ['#01579b', '#4478b3', '#6b9bcb', '#8fbfe3', '#b3e5fc'];
+const cyans = ['#006064', '#3a8185', '#62a3a8', '#8ac6cc', '#b2ebf2'];
+
+const darkgreens = ['#004d40', '#356f64', '#5e9389', '#87b8b1', '#b2dfdb'];
+const greens = ['#194d33', '#447155', '#6e967a', '#9abda1', '#c8e6c9'];
+const lightgreens = ['#33691e', '#5d8947', '#87a970', '#b1cb9b', '#dcedc8'];
+const dirtyyellow = ['#827717', '#9e9544', '#bab36d', '#d5d398', '#f0f4c3'];
+
+const lightorange = ['#f57f17', '#fd9e48', '#ffbe73', '#ffdc9c', '#fff9c4'];
+const orange = ['#ff6f00', '#ff943f', '#ffb368', '#ffd08e', '#ffecb3'];
+const darkorange = ['#e65100', '#f17837', '#fa9c5f', '#febe88', '#ffe0b2'];
+const darkred = ['#bf360c', '#d35f39', '#e58463', '#f4a88f', '#ffccbc'];
+
+const brown = ['#3e2723', '#624c48', '#877470', '#af9f9b', '#d7ccc8'];
+const gray = ['#263238', '#4c575d', '#758085', '#a1abb0', '#cfd8dc'];
+const black = ['#000000', '#3b3b3b', '#777777', '#b9b9b9', '#ffffff'];
+
+export const colors = [
+  reds, pinks, purples, darkpurples,
+  darkblues, blues, lightblues, cyans,
+  darkgreens, greens, lightgreens, dirtyyellow,
+  lightorange, orange, darkorange, darkred,
+  brown, gray, black,
+];
+
+export const defaultChartColors = [
+  lightblues[1],
+  lightorange[1],
+  lightgreens[1],
+  reds[1],
+  purples[1],
+  brown[1],
+  pinks[1],
+  lightorange[3],
+  cyans[3],
+];

--- a/graylog2-web-interface/src/views/components/visualizations/Colors.ts
+++ b/graylog2-web-interface/src/views/components/visualizations/Colors.ts
@@ -56,4 +56,11 @@ export const defaultChartColors = [
   pinks[1],
   lightorange[3],
   cyans[3],
+  darkblues[0],
+  darkorange[0],
+  darkgreens[0],
+  darkpurples[0],
+  gray[2],
+  purples[4],
+  darkred[0],
 ];

--- a/graylog2-web-interface/src/views/components/visualizations/GenericPlot.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/GenericPlot.tsx
@@ -27,12 +27,10 @@ import { colors as defaultColors } from 'views/components/visualizations/Colors'
 import ColorMapper from 'views/components/visualizations/ColorMapper';
 
 import ChartColorContext from './ChartColorContext';
+import styles from './GenericPlot.lazy.css';
 
 import InteractiveContext from '../contexts/InteractiveContext';
 import RenderCompletionCallback from '../widgets/RenderCompletionCallback';
-
-// eslint-disable-next-line import/no-webpack-loader-syntax
-import styles from '!style/useable!css!./GenericPlot.css';
 
 type LegendConfig = {
   name: string,

--- a/graylog2-web-interface/src/views/components/visualizations/GenericPlot.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/GenericPlot.tsx
@@ -23,12 +23,16 @@ import { Overlay, RootCloseWrapper } from 'react-overlays';
 import { Popover } from 'components/graylog';
 import ColorPicker from 'components/common/ColorPicker';
 import Plot from 'views/components/visualizations/plotly/AsyncPlot';
+import { colors as defaultColors } from 'views/components/visualizations/Colors';
+import ColorMapper from 'views/components/visualizations/ColorMapper';
 
 import ChartColorContext from './ChartColorContext';
-import styles from './GenericPlot.lazy.css';
 
 import InteractiveContext from '../contexts/InteractiveContext';
 import RenderCompletionCallback from '../widgets/RenderCompletionCallback';
+
+// eslint-disable-next-line import/no-webpack-loader-syntax
+import styles from '!style/useable!css!./GenericPlot.css';
 
 type LegendConfig = {
   name: string,
@@ -65,7 +69,7 @@ type Props = {
   getChartColor?: (data: Array<ChartConfig>, name: string) => string | undefined | null,
   layout: {},
   onZoom: (from: string, to: string) => boolean,
-  setChartColor?: (data: ChartConfig, color: ColorMap) => ChartColor,
+  setChartColor?: (data: ChartConfig, color: ColorMapper) => ChartColor,
 };
 
 type GenericPlotProps = Props & { theme: DefaultTheme };
@@ -251,6 +255,7 @@ class GenericPlot extends React.Component<GenericPlotProps, State> {
                                      title={`Configuration for ${legendConfig.name}`}
                                      className={styles.locals.customPopover}>
                               <ColorPicker color={legendConfig.color}
+                                           colors={defaultColors}
                                            onChange={(newColor) => this._onColorSelect(setColor, legendConfig.name, newColor)} />
                             </Popover>
                           </Overlay>

--- a/graylog2-web-interface/src/views/components/visualizations/PlotLegend.test.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/PlotLegend.test.tsx
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import { render, screen, fireEvent, waitFor } from 'wrappedTestingLibrary';
+import { StoreMock as MockStore } from 'helpers/mocking';
+
+import PlotLegend from 'views/components/visualizations/PlotLegend';
+import ColorMapper from 'views/components/visualizations/ColorMapper';
+import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
+import Pivot from 'views/logic/aggregationbuilder/Pivot';
+
+import ChartColorContext from './ChartColorContext';
+
+jest.mock('views/stores/CurrentViewStateStore', () => ({
+  CurrentViewStateStore: MockStore(
+    ['getInitialState', () => {
+      return {
+        activeQuery: 'active-query-id',
+      };
+    },
+    ],
+  ),
+}));
+
+const colors = ColorMapper.create();
+const setColor = jest.fn();
+const chartData = [
+  { name: 'name1' },
+  { name: 'name2' },
+  { name: 'name3' },
+];
+const columnPivots = [Pivot.create('field1', 'unknown')];
+const config = AggregationWidgetConfig.builder().columnPivots(columnPivots).build();
+
+// eslint-disable-next-line react/require-default-props
+const SUT = ({ chartDataProp = chartData }: { chartDataProp?: Array<{ name: string }>}) => (
+  <ChartColorContext.Provider value={{ colors, setColor }}>
+    <PlotLegend config={config} chartData={chartDataProp}>
+      <div>Plot</div>
+    </PlotLegend>
+  </ChartColorContext.Provider>
+);
+
+describe('PlotLegend', () => {
+  it('should render the plot legend', async () => {
+    render(<SUT />);
+    await screen.findByText('name1');
+    await screen.findByText('name2');
+    await screen.findByText('name3');
+  });
+
+  it('should render the color hint', async () => {
+    render(<SUT />);
+    await screen.findAllByLabelText('Color Hint');
+  });
+
+  it('should set a color when clicking on the color hing', async () => {
+    render(<SUT />);
+    const colorHints = await screen.findAllByLabelText('Color Hint');
+    fireEvent.click(colorHints[0]);
+
+    await screen.getByText('Configuration for name1');
+    const color = screen.getByTitle('#b71c1c');
+    fireEvent.click(color);
+
+    waitFor(() => {
+      expect(setColor).toBeCalledWith('name1', '#b71c1c');
+    });
+  });
+
+  it('should open the value context menu', async () => {
+    render(<SUT />);
+
+    const value = await screen.findByText('name1');
+    fireEvent.click(value);
+
+    await screen.findByText('Actions');
+  });
+
+  it('should render with a lot of values', async () => {
+    const charDataProp = [1, 2, 3, 4, 5, 6, 7, 8, 10, 11].map((i) => ({ name: `name${i}` }));
+    render(<SUT chartDataProp={charDataProp} />);
+    await screen.findByText('name1');
+    await screen.findByText('name11');
+  });
+});

--- a/graylog2-web-interface/src/views/components/visualizations/PlotLegend.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/PlotLegend.tsx
@@ -95,7 +95,14 @@ const PlotLegend = ({ children, config, chartData }: Props) => {
 
   const chunkCells = (cells, columnCount) => {
     const { length } = cells;
-    const rowCount = Math.round(length / columnCount) + 1;
+    let rowCount;
+
+    if (length <= columnCount) {
+      rowCount = 1;
+    } else {
+      rowCount = Math.round(length / columnCount) + 1;
+    }
+
     const result = new Array(rowCount);
 
     for (let row = 0; row < rowCount; row += 1) {

--- a/graylog2-web-interface/src/views/components/visualizations/PlotLegend.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/PlotLegend.tsx
@@ -39,14 +39,14 @@ const ColorHint = styled.div(({ color }) => `
 const Container = styled.div`
   display: grid;
   grid-template-columns: 1fr;
-  grid-template-rows: auto min-content;
+  grid-template-rows: 4fr auto;
   grid-template-areas: "." ".";
   height: 100%;
 `;
 
 const LegendContainer = styled.div`
   padding: 5px;
-  max-height: 80px;
+  max-height: 100px;
   overflow: auto;
 `;
 

--- a/graylog2-web-interface/src/views/components/visualizations/PlotLegend.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/PlotLegend.tsx
@@ -15,8 +15,8 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import styled from 'styled-components';
 import { useContext } from 'react';
+import styled from 'styled-components';
 
 import Value from 'views/components/Value';
 import { useStore } from 'stores/connect';
@@ -39,23 +39,30 @@ const Container = styled.div`
   height: 100%;
 `;
 
-const Legend = styled.div`
+const LegendContainer = styled.div`
   padding: 5px;
   max-height: 80px;
   overflow: auto;
-  display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
-  justify-content: flex-start;
-  align-items: stretch;
-  align-content: stretch;
+`;
+
+const Legend = styled.div`
+  display: table;
+  width: 100%;
+`;
+
+const LegendRow = styled.div`
+  display: table-row;
+`;
+
+const LegendCell = styled.div`
+  padding: 4px;
+  display: table-cell;
 `;
 
 const LegendEntry = styled.div`
-  margin: 4px;
   display: flex;
-  margin-right: 22px;
 `;
+
 const ValueContainer = styled.div`
   margin-left: 8px; 
   line-height: 12px;
@@ -70,30 +77,71 @@ type Props = {
 const PlotLegend = ({ children, config, chartData }: Props) => {
   const { columnPivots } = config;
   const fields = columnPivots.map(({ field }) => field);
-  const values = chartData.map(({ name }) => name);
+  const values: Array<string> = chartData.map(({ name }) => name);
   const { activeQuery } = useStore(CurrentViewStateStore);
   const { colors } = useContext(ChartColorContext);
 
-  const result = values.map((value) => {
-    let val = value;
+  const chunkCells = (cells, columnCount) => {
+    const { length } = cells;
+    const rowCount = Math.round(length / columnCount) + 1;
+    const result = new Array(rowCount);
+
+    for (let row = 0; row < rowCount; row += 1) {
+      result[row] = [];
+
+      for (let column = 0; column < columnCount; column += 1) {
+        if (cells[(rowCount * column) + row]) {
+          result[row][column] = cells[(rowCount * column) + row];
+        }
+      }
+    }
+
+    return result;
+  };
+
+  const stringLenSort = (s1: string, s2: string) => {
+    if (s1.length < s2.length) {
+      return -1;
+    }
+
+    if (s1.length === s2.length) {
+      return 0;
+    }
+
+    return 1;
+  };
+
+  const tableCells = values.sort(stringLenSort).map((value) => {
+    let val: React.ReactNode = value;
+
     if (fields.length === 1) {
       val = (<Value type={FieldType.Unknown} value={value} field={fields[0]} queryId={activeQuery}>{value}</Value>);
     }
 
     return (
-      <LegendEntry>
-        <ColorHint color={colors.get(value)} />
-        <ValueContainer>
-          {val}
-        </ValueContainer>
-      </LegendEntry>
+      <LegendCell key={value}>
+        <LegendEntry>
+          <ColorHint color={colors.get(value)} />
+          <ValueContainer>
+            {val}
+          </ValueContainer>
+        </LegendEntry>
+      </LegendCell>
     );
   });
+
+  const result = chunkCells(tableCells, 5).map((cells) => (
+    <LegendRow>
+      {cells}
+    </LegendRow>
+  ));
 
   return (
     <Container>
       {children}
-      <Legend>{result}</Legend>
+      <LegendContainer>
+        <Legend>{result}</Legend>
+      </LegendContainer>
     </Container>
   );
 };

--- a/graylog2-web-interface/src/views/components/visualizations/PlotLegend.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/PlotLegend.tsx
@@ -88,7 +88,6 @@ type ColorPickerConfig = {
 const PlotLegend = ({ children, config, chartData }: Props) => {
   const [colorPickerConfig, setColorPickerConfig] = useState<ColorPickerConfig | undefined>();
   const { columnPivots } = config;
-  const fields = columnPivots.map(({ field }) => field);
   const values: Array<string> = chartData.map(({ name }) => name);
   const { activeQuery } = useStore(CurrentViewStateStore);
   const { colors, setColor } = useContext(ChartColorContext);
@@ -144,14 +143,14 @@ const PlotLegend = ({ children, config, chartData }: Props) => {
   const tableCells = values.sort(stringLenSort).map((value) => {
     let val: React.ReactNode = value;
 
-    if (fields.length === 1) {
-      val = (<Value type={FieldType.Unknown} value={value} field={fields[0]} queryId={activeQuery}>{value}</Value>);
+    if (columnPivots.length === 1) {
+      val = (<Value type={FieldType.Unknown} value={value} field={columnPivots[0].field} queryId={activeQuery}>{value}</Value>);
     }
 
     return (
       <LegendCell key={value}>
         <LegendEntry>
-          <ColorHint onClick={_onOpenColorPicker(value)} color={colors.get(value)} />
+          <ColorHint aria-label="Color Hint" onClick={_onOpenColorPicker(value)} color={colors.get(value)} />
           <ValueContainer>
             {val}
           </ValueContainer>
@@ -160,8 +159,9 @@ const PlotLegend = ({ children, config, chartData }: Props) => {
     );
   });
 
-  const result = chunkCells(tableCells, 5).map((cells) => (
-    <LegendRow>
+  const result = chunkCells(tableCells, 5).map((cells, index) => (
+    // eslint-disable-next-line react/no-array-index-key
+    <LegendRow key={index}>
       {cells}
     </LegendRow>
   ));

--- a/graylog2-web-interface/src/views/components/visualizations/PlotLegend.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/PlotLegend.tsx
@@ -31,7 +31,8 @@ import { colors as defaultColors } from 'views/components/visualizations/Colors'
 
 const ColorHint = styled.div(({ color }) => `
   cursor: pointer;
-  background: ${color};
+  background-color: ${color} !important;
+  -webkit-print-color-adjust: exact !important;
   width: 12px;
   height: 12px;
 `);

--- a/graylog2-web-interface/src/views/components/visualizations/PlotLegend.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/PlotLegend.tsx
@@ -70,7 +70,7 @@ const LegendEntry = styled.div`
 `;
 
 const ValueContainer = styled.div`
-  margin-left: 8px; 
+  margin-left: 8px;
   line-height: 12px;
 `;
 

--- a/graylog2-web-interface/src/views/components/visualizations/PlotLegend.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/PlotLegend.tsx
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import styled from 'styled-components';
+import { useContext } from 'react';
+
+import Value from 'views/components/Value';
+import { useStore } from 'stores/connect';
+import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
+import ChartColorContext from 'views/components/visualizations/ChartColorContext';
+import { CurrentViewStateStore } from 'views/stores/CurrentViewStateStore';
+import FieldType from 'views/logic/fieldtypes/FieldType';
+
+const ColorHint = styled.div(({ color }) => `
+  background: ${color};
+  width: 12px;
+  height: 12px;
+`);
+
+const Container = styled.div`
+  display: grid;
+  grid-template-columns: 1fr;
+  grid-template-rows: auto min-content;
+  grid-template-areas: "." ".";
+  height: 100%;
+`;
+
+const Legend = styled.div`
+  padding: 5px;
+  max-height: 80px;
+  overflow: auto;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  justify-content: flex-start;
+  align-items: stretch;
+  align-content: stretch;
+`;
+
+const LegendEntry = styled.div`
+  margin: 4px;
+  display: flex;
+  margin-right: 22px;
+`;
+const ValueContainer = styled.div`
+  margin-left: 8px; 
+  line-height: 12px;
+`;
+
+type Props = {
+  children: React.ReactNode,
+  config: AggregationWidgetConfig,
+  chartData: any,
+};
+
+const PlotLegend = ({ children, config, chartData }: Props) => {
+  const { columnPivots } = config;
+  const fields = columnPivots.map(({ field }) => field);
+  const values = chartData.map(({ name }) => name);
+  const { activeQuery } = useStore(CurrentViewStateStore);
+  const { colors } = useContext(ChartColorContext);
+
+  const result = values.map((value) => {
+    let val = value;
+    if (fields.length === 1) {
+      val = (<Value type={FieldType.Unknown} value={value} field={fields[0]} queryId={activeQuery}>{value}</Value>);
+    }
+
+    return (
+      <LegendEntry>
+        <ColorHint color={colors.get(value)} />
+        <ValueContainer>
+          {val}
+        </ValueContainer>
+      </LegendEntry>
+    );
+  });
+
+  return (
+    <Container>
+      {children}
+      <Legend>{result}</Legend>
+    </Container>
+  );
+};
+
+export default PlotLegend;

--- a/graylog2-web-interface/src/views/components/visualizations/PlotLegend.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/PlotLegend.tsx
@@ -78,6 +78,7 @@ type Props = {
   children: React.ReactNode,
   config: AggregationWidgetConfig,
   chartData: any,
+  labelMapper?: (data: Array<any>) => Array<string> | undefined | null,
 };
 
 type ColorPickerConfig = {
@@ -85,10 +86,12 @@ type ColorPickerConfig = {
   target: EventTarget,
 };
 
-const PlotLegend = ({ children, config, chartData }: Props) => {
+const defaultLabelMapper = (data: Array<{ name: string }>) => data.map(({ name }) => name);
+
+const PlotLegend = ({ children, config, chartData, labelMapper = defaultLabelMapper }: Props) => {
   const [colorPickerConfig, setColorPickerConfig] = useState<ColorPickerConfig | undefined>();
   const { columnPivots } = config;
-  const values: Array<string> = chartData.map(({ name }) => name);
+  const labels: Array<string> = labelMapper(chartData);
   const { activeQuery } = useStore(CurrentViewStateStore);
   const { colors, setColor } = useContext(ChartColorContext);
 
@@ -140,7 +143,7 @@ const PlotLegend = ({ children, config, chartData }: Props) => {
     setColorPickerConfig(undefined);
   }, [setColor]);
 
-  const tableCells = values.sort(stringLenSort).map((value) => {
+  const tableCells = labels.sort(stringLenSort).map((value) => {
     let val: React.ReactNode = value;
 
     if (columnPivots.length === 1) {
@@ -189,6 +192,10 @@ const PlotLegend = ({ children, config, chartData }: Props) => {
       )}
     </Container>
   );
+};
+
+PlotLegend.defaultProps = {
+  labelMapper: defaultLabelMapper,
 };
 
 export default PlotLegend;

--- a/graylog2-web-interface/src/views/components/visualizations/XYPlot.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/XYPlot.tsx
@@ -28,6 +28,7 @@ import Query from 'views/logic/queries/Query';
 import type { ViewType } from 'views/logic/views/View';
 import CurrentUserContext from 'contexts/CurrentUserContext';
 import ColorMapper from 'views/components/visualizations/ColorMapper';
+import PlotLegend from 'views/components/visualizations/PlotLegend';
 
 import GenericPlot from './GenericPlot';
 import OnZoom from './OnZoom';
@@ -80,7 +81,8 @@ const XYPlot = ({
   const defaultLayout: {
     yaxis: { fixedrange?: boolean},
     legend?: {y?: number},
-  } = { yaxis };
+    showlegend: boolean,
+  } = { yaxis, showlegend: false };
 
   if (height) {
     defaultLayout.legend = { y: yLegendPosition(height) };
@@ -110,11 +112,13 @@ const XYPlot = ({
   }
 
   return (
-    <GenericPlot chartData={chartData}
-                 layout={layout}
-                 onZoom={_onZoom}
-                 getChartColor={getChartColor}
-                 setChartColor={setChartColor} />
+    <PlotLegend config={config} chartData={chartData}>
+      <GenericPlot chartData={chartData}
+                   layout={layout}
+                   onZoom={_onZoom}
+                   getChartColor={getChartColor}
+                   setChartColor={setChartColor} />
+    </PlotLegend>
   );
 };
 

--- a/graylog2-web-interface/src/views/components/visualizations/XYPlot.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/XYPlot.tsx
@@ -27,10 +27,11 @@ import { CurrentQueryStore } from 'views/stores/CurrentQueryStore';
 import Query from 'views/logic/queries/Query';
 import type { ViewType } from 'views/logic/views/View';
 import CurrentUserContext from 'contexts/CurrentUserContext';
+import ColorMapper from 'views/components/visualizations/ColorMapper';
 
 import GenericPlot from './GenericPlot';
 import OnZoom from './OnZoom';
-import type { ChartColor, ChartConfig, ColorMap } from './GenericPlot';
+import type { ChartColor, ChartConfig } from './GenericPlot';
 
 import CustomPropTypes from '../CustomPropTypes';
 import ViewTypeContext from '../contexts/ViewTypeContext';
@@ -45,7 +46,7 @@ export type Props = {
   },
   getChartColor?: (data: Array<ChartConfig>, name: string) => (string | undefined | null),
   height?: number;
-  setChartColor?: (config: ChartConfig, color: ColorMap) => ChartColor,
+  setChartColor?: (config: ChartConfig, color: ColorMapper) => ChartColor,
   plotLayout?: any,
   onZoom?: (query: Query, from: string, to: string, viewType: ViewType | undefined | null) => boolean,
 };

--- a/graylog2-web-interface/src/views/components/visualizations/__tests__/GenericPlot.test.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/__tests__/GenericPlot.test.tsx
@@ -19,6 +19,8 @@ import type { HTMLAttributes } from 'enzyme';
 import { mount } from 'wrappedEnzyme';
 import { PlotParams } from 'react-plotly.js';
 
+import ColorMapper from 'views/components/visualizations/ColorMapper';
+
 import ChartColorContext from '../ChartColorContext';
 import GenericPlot from '../GenericPlot';
 import RenderCompletionCallback from '../../widgets/RenderCompletionCallback';
@@ -112,12 +114,10 @@ describe('GenericPlot', () => {
 
   it('extracts series color from context', () => {
     const lens = {
-      colors: {
-        'count()': '#783a8e',
-      },
+      colors: ColorMapper.builder().set('count()', '#783a8e').build(),
       setColor: jest.fn(),
     };
-    const setChartColor = (chart, colors) => ({ marker: { color: colors[chart.name] } });
+    const setChartColor = (chart, colors) => ({ marker: { color: colors.get(chart.name) } });
     const wrapper = mount((
       <ChartColorContext.Provider value={lens}>
         <GenericPlot chartData={[{ x: 23, name: 'count()' }, { x: 42, name: 'sum(bytes)' }]} setChartColor={setChartColor} />
@@ -127,7 +127,7 @@ describe('GenericPlot', () => {
     const { data: newChartData } = wrapper.find('PlotlyComponent').props() as HTMLAttributes & PlotParams;
 
     expect(newChartData.find((chart) => chart.name === 'count()').marker.color).toEqual('#783a8e');
-    expect(newChartData.find((chart) => chart.name === 'sum(bytes)').marker.color).toBeUndefined();
+    expect(newChartData.find((chart) => chart.name === 'sum(bytes)').marker.color).toEqual('#fd9e48');
   });
 
   describe('has color picker', () => {
@@ -190,7 +190,7 @@ describe('GenericPlot', () => {
 
     it('calling onChange when new color is selected', () => {
       const lens = {
-        colors: {},
+        colors: ColorMapper.create(),
         setColor: jest.fn(() => Promise.resolve([])),
       };
       let genericPlot = null;

--- a/graylog2-web-interface/src/views/components/visualizations/__tests__/XYPlot.test.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/__tests__/XYPlot.test.tsx
@@ -21,6 +21,7 @@ import mockComponent from 'helpers/mocking/MockComponent';
 import { viewsManager } from 'fixtures/users';
 import asMock from 'helpers/mocking/AsMock';
 import { $PropertyType } from 'utility-types';
+import { StoreMock as MockStore } from 'helpers/mocking';
 
 import type { UserJSON } from 'logic/users/User';
 import CurrentUserContext from 'contexts/CurrentUserContext';
@@ -32,8 +33,20 @@ import { QueriesActions } from 'views/stores/QueriesStore';
 import { SearchActions } from 'views/stores/SearchStore';
 import CurrentUserStore from 'stores/users/CurrentUserStore';
 
+jest.mock('views/stores/CurrentViewStateStore', () => ({
+  CurrentViewStateStore: MockStore(
+    ['getInitialState', () => {
+      return {
+        activeQuery: 'active-query-id',
+      };
+    },
+    ],
+  ),
+}));
+
 jest.mock('stores/users/CurrentUserStore', () => ({
   get: jest.fn(),
+  listen: jest.fn(),
 }));
 
 jest.mock('views/stores/SearchStore', () => ({
@@ -44,7 +57,6 @@ jest.mock('views/stores/SearchStore', () => ({
   },
 }));
 
-jest.mock('stores/connect', () => (x) => x);
 jest.mock('../GenericPlot', () => mockComponent('GenericPlot'));
 jest.mock('views/stores/QueriesStore');
 
@@ -54,7 +66,7 @@ describe('XYPlot', () => {
   const config = AggregationWidgetConfig.builder().rowPivots([timestampPivot]).build();
   const getChartColor = () => undefined;
   const setChartColor = () => ({});
-  const chartData = [{ y: [23, 42] }];
+  const chartData = [{ y: [23, 42], name: 'count()' }];
   type SimpleXYPlotProps = {
     currentUser?: UserJSON,
     config?: $PropertyType<XYPlotProps, 'chartData'>,
@@ -105,6 +117,7 @@ describe('XYPlot', () => {
     expect(genericPlot).toHaveProp('layout', {
       yaxis: { fixedrange: true, rangemode: 'tozero', tickformat: ',g' },
       xaxis: { fixedrange: true },
+      showlegend: false,
     });
 
     expect(genericPlot).toHaveProp('chartData', chartData);

--- a/graylog2-web-interface/src/views/components/visualizations/area/AreaVisualization.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/area/AreaVisualization.tsx
@@ -40,7 +40,7 @@ const getChartColor = (fullData, name) => {
   return undefined;
 };
 
-const setChartColor = (chart, colors) => ({ line: { color: colors[chart.name] } });
+const setChartColor = (chart, colors) => ({ line: { color: colors.get(chart.name) } });
 
 const AreaVisualization: VisualizationComponent = makeVisualization(({ config, data, effectiveTimerange, height }: VisualizationComponentProps) => {
   const visualizationConfig = (config.visualizationConfig || AreaVisualizationConfig.empty()) as AreaVisualizationConfig;

--- a/graylog2-web-interface/src/views/components/visualizations/bar/BarVisualization.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/bar/BarVisualization.tsx
@@ -48,7 +48,7 @@ const getChartColor = (fullData, name) => {
   return undefined;
 };
 
-const setChartColor = (chart, colors) => ({ marker: { color: colors[chart.name] } });
+const setChartColor = (chart, colors) => ({ marker: { color: colors.get(chart.name) } });
 
 const defineSingleDateBarWidth = (chartDataResult, config, timeRangeFrom: string, timeRangeTo: string) => {
   const barWidth = 0.03; // width in percentage, relative to chart width

--- a/graylog2-web-interface/src/views/components/visualizations/line/LineVisualization.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/line/LineVisualization.tsx
@@ -40,7 +40,7 @@ const getChartColor = (fullData, name) => {
   return undefined;
 };
 
-const setChartColor = (chart, colors) => ({ line: { color: colors[chart.name] } });
+const setChartColor = (chart, colors) => ({ line: { color: colors.get(chart.name) } });
 
 const LineVisualization: VisualizationComponent = makeVisualization(({ config, data, effectiveTimerange, height }: VisualizationComponentProps) => {
   const visualizationConfig = (config.visualizationConfig || LineVisualizationConfig.empty()) as LineVisualizationConfig;

--- a/graylog2-web-interface/src/views/components/visualizations/pie/PieVisualization.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/pie/PieVisualization.tsx
@@ -73,7 +73,7 @@ const getChartColor = (fullDataArray, name) => {
 };
 
 const setChartColor = (chart, colorMap) => {
-  const colors = chart.labels.map((label) => colorMap[label]);
+  const colors = chart.labels.map((label) => colorMap.get(label));
 
   return { marker: { colors } };
 };

--- a/graylog2-web-interface/src/views/components/visualizations/pie/PieVisualization.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/pie/PieVisualization.tsx
@@ -15,6 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
+import { union } from 'lodash';
 
 import { AggregationType, AggregationResult } from 'views/components/aggregationbuilder/AggregationBuilderPropTypes';
 import type {
@@ -22,6 +23,7 @@ import type {
   VisualizationComponentProps,
 } from 'views/components/aggregationbuilder/AggregationBuilder';
 import { makeVisualization } from 'views/components/aggregationbuilder/AggregationBuilder';
+import PlotLegend from 'views/components/visualizations/PlotLegend';
 
 import GenericPlot from '../GenericPlot';
 import { chartData } from '../ChartData';
@@ -78,11 +80,22 @@ const setChartColor = (chart, colorMap) => {
   return { marker: { colors } };
 };
 
-const PieVisualization: VisualizationComponent = makeVisualization(({ config, data }: VisualizationComponentProps) => (
-  <GenericPlot chartData={chartData(config, data.chart || Object.values(data)[0], 'pie', _generateSeries)}
-               getChartColor={getChartColor}
-               setChartColor={setChartColor} />
-), 'pie');
+const labelMapper = (data: Array<{ labels: Array<string>}>) => data.reduce((acc, { labels }) => {
+  return union(acc, labels);
+}, []);
+
+const PieVisualization: VisualizationComponent = makeVisualization(({ config, data }: VisualizationComponentProps) => {
+  const transformedData = chartData(config, data.chart || Object.values(data)[0], 'pie', _generateSeries);
+
+  return (
+    <PlotLegend config={config} chartData={transformedData} labelMapper={labelMapper}>
+      <GenericPlot chartData={transformedData}
+                   layout={{ showlegend: false }}
+                   getChartColor={getChartColor}
+                   setChartColor={setChartColor} />
+    </PlotLegend>
+  );
+}, 'pie');
 
 PieVisualization.propTypes = {
   config: AggregationType.isRequired,

--- a/graylog2-web-interface/src/views/components/widgets/MeasureDimensions.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/MeasureDimensions.tsx
@@ -60,7 +60,7 @@ const MeasureDimensions = createReactClass({
 
   render() {
     return (
-      <span ref={(node) => { this.container = node; }} style={{ display: 'block', height: '100%' }}>
+      <span ref={(node) => { this.container = node; }} style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
         {this._renderChildren()}
       </span>
     );

--- a/graylog2-web-interface/src/views/components/widgets/MeasureDimensions.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/MeasureDimensions.tsx
@@ -18,7 +18,7 @@ import * as React from 'react';
 import { useState, useEffect, useRef, useCallback } from 'react';
 
 type Props = {
-  children: React.ReactElement,
+  children: React.ReactElement | React.ReactElement[],
 };
 
 const MeasureDimensions = ({ children }: Props) => {

--- a/graylog2-web-interface/src/views/components/widgets/WidgetColorContext.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/WidgetColorContext.test.tsx
@@ -62,7 +62,8 @@ describe('WidgetColorContext', () => {
   it('extracts coloring rules for current widget', () => {
     const { colors } = container.props();
 
-    expect(colors).toEqual({ localhost: '#171EFE', 'sum(bytes)': '#affe42' });
+    expect(colors.get('localhost')).toEqual('#171EFE');
+    expect(colors.get('sum(bytes)')).toEqual('#affe42');
   });
 
   it('supplies setter for color of current widget', () => {

--- a/graylog2-web-interface/src/views/components/widgets/WidgetColorContext.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/WidgetColorContext.tsx
@@ -20,6 +20,7 @@ import PropTypes from 'prop-types';
 import connect from 'stores/connect';
 import { ChartColorRulesStore, ChartColorRulesActions } from 'views/stores/ChartColorRulesStore';
 import type { ColorRule } from 'views/stores/ChartColorRulesStore';
+import ColorMapper from 'views/components/visualizations/ColorMapper';
 
 import ChartColorContext from '../visualizations/ChartColorContext';
 
@@ -30,9 +31,17 @@ type Props = {
 };
 
 const WidgetColorContext = ({ children, colorRules, id }: Props) => {
-  const colorRulesForWidget = colorRules.filter(({ widgetId }) => (widgetId === id))
-    .reduce((prev, { name, color }) => ({ ...prev, [name]: color }), {});
-  const setColor = (name, color) => ChartColorRulesActions.set(id, name, color);
+  const colorMapperBuilder = ColorMapper.builder();
+  const colorRulesForWidgetBuilder = colorRules.filter(({ widgetId }) => (widgetId === id))
+    .reduce((prev, { name, color }) => (prev.set(name, color)), colorMapperBuilder);
+  const colorRulesForWidget = colorRulesForWidgetBuilder.build();
+
+  const setColor = (name, color) => {
+    colorRulesForWidget.set(name, color);
+
+    return ChartColorRulesActions.set(id, name, color);
+  };
+
   const contextValue = { colors: colorRulesForWidget, setColor };
 
   return (


### PR DESCRIPTION
## Motivation and Context
The user wants to be able to change the query not only from the query bar and message list, but also from a aggregation widget.
For that the legend which is displaying the fields values is a good starting point.

## Description
- Create our own custom plot legend so we can handle the onClick event for color hint and the value separably
- To provide the colors for the charts we introduce a ColorMapper which will take care of the default colors and saved colors 

## Screenshots (if appropriate):
![value-actions-in-chart](https://user-images.githubusercontent.com/448763/104187982-dbe37f80-5418-11eb-8c64-69ef5a648efe.gif)

Fixes #6612 
Fixes #7207 by keeping track of field to color map thoughout the session

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)