### PR TITLE
Retry read timeouts for Elasticsearch.

### DIFF
--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/jest/GraylogJestRetryHandler.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/jest/GraylogJestRetryHandler.java
@@ -25,6 +25,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.net.ssl.SSLException;
 import java.net.SocketException;
+import java.net.SocketTimeoutException;
 import java.net.UnknownHostException;
 import java.util.Arrays;
 import java.util.Collection;
@@ -36,6 +37,7 @@ public class GraylogJestRetryHandler implements JestRetryHandler<HttpUriRequest>
     private final Collection<Class<? extends Exception>> exceptionClasses = Arrays.asList(
         UnknownHostException.class,
         SocketException.class,
+        SocketTimeoutException.class,
         ConnectionClosedException.class,
         SSLException.class);
 

--- a/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/jest/GraylogJestRetryHandlerTest.java
+++ b/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/jest/GraylogJestRetryHandlerTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.storage.elasticsearch6.jest;
+
+import io.searchbox.client.JestRetryHandler;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.net.SocketTimeoutException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GraylogJestRetryHandlerTest {
+    private JestRetryHandler<HttpUriRequest> retryHandler;
+
+    @BeforeEach
+    void setUp() {
+        this.retryHandler = new GraylogJestRetryHandler(3);
+    }
+
+    @Test
+    void retriesSocketTimeouts() {
+        assertThat(this.retryHandler.retryRequest(new SocketTimeoutException(), 0, new HttpGet("http://localhost"))).isTrue();
+    }
+}

--- a/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/jest/GraylogJestRetryHandlerTest.java
+++ b/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/jest/GraylogJestRetryHandlerTest.java
@@ -14,22 +14,7 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-/**
- * This file is part of Graylog.
- *
- * Graylog is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * Graylog is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
- */
+
 package org.graylog.storage.elasticsearch6.jest;
 
 import io.searchbox.client.JestRetryHandler;


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Before this change, the retry strategy used for ES requests did not retry for instances of `SocketTimeoutException`, raised in case of read timeouts. This resulted in exceptions being raised when individual nodes were not responding and node discovery was not used. This was e.g. being noticable when performing searches and 1 of 3 nodes was failing, so every 3rd search request was timing out and returning an error instead of being retried and successful and just taking longer.

This change is adding this class to the exceptions being retried, so any request that goes out to a node which is not responding on time is retried.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.