### PR TITLE
Fix page size change selector in Content Pack list

### DIFF
--- a/graylog2-web-interface/src/components/content-packs/ContentPacksList.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPacksList.jsx
@@ -175,8 +175,8 @@ class ContentPacksList extends React.Component {
     this.setState({ filteredContentPacks: filteredItems });
   }
 
-  _itemsShownChange(pageSize) {
-    this.setState({ pageSize: Number(pageSize), currentPage: 1 });
+  _itemsShownChange(event) {
+    this.setState({ pageSize: Number(event.target.value), currentPage: 1 });
   }
 
   _onChangePage(nextPage) {


### PR DESCRIPTION
The `PageSizeSelect` component passes an event as argument to its `onChange` function but but we were expecting a string containing a number. This change fixes that by extracting the value from the received event.

Fixes #9629