### PR TITLE
Fix pattern used to identify parameters in search/dashboard query strings.

### DIFF
--- a/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/views/ElasticsearchBackendErrorHandlingTest.java
+++ b/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/views/ElasticsearchBackendErrorHandlingTest.java
@@ -21,19 +21,18 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.searchbox.client.JestClient;
 import io.searchbox.core.MultiSearchResult;
-import org.graylog.shaded.elasticsearch5.org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.graylog.plugins.views.search.Query;
 import org.graylog.plugins.views.search.QueryResult;
 import org.graylog.plugins.views.search.Search;
 import org.graylog.plugins.views.search.SearchJob;
 import org.graylog.plugins.views.search.SearchType;
-import org.graylog.plugins.views.search.elasticsearch.QueryStringDecorators;
 import org.graylog.plugins.views.search.elasticsearch.ElasticsearchQueryString;
 import org.graylog.plugins.views.search.elasticsearch.FieldTypesLookup;
 import org.graylog.plugins.views.search.elasticsearch.IndexLookup;
-import org.graylog.plugins.views.search.elasticsearch.QueryStringParser;
-import org.graylog.storage.elasticsearch6.views.searchtypes.ESSearchTypeHandler;
+import org.graylog.plugins.views.search.elasticsearch.QueryStringDecorators;
 import org.graylog.plugins.views.search.errors.SearchError;
+import org.graylog.shaded.elasticsearch5.org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.graylog.storage.elasticsearch6.views.searchtypes.ESSearchTypeHandler;
 import org.graylog2.indexer.ElasticsearchException;
 import org.graylog2.plugin.indexer.searches.timeranges.RelativeRange;
 import org.junit.Before;
@@ -81,7 +80,6 @@ public class ElasticsearchBackendErrorHandlingTest extends ElasticsearchBackendT
                 ImmutableMap.of(
                         "dummy", () -> mock(DummyHandler.class)
                 ),
-                new QueryStringParser(),
                 jestClient,
                 indexLookup,
                 new QueryStringDecorators(Collections.emptySet()),

--- a/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/views/ElasticsearchBackendGeneratedRequestTestBase.java
+++ b/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/views/ElasticsearchBackendGeneratedRequestTestBase.java
@@ -25,21 +25,20 @@ import org.graylog.plugins.views.search.QueryResult;
 import org.graylog.plugins.views.search.Search;
 import org.graylog.plugins.views.search.SearchJob;
 import org.graylog.plugins.views.search.SearchType;
-import org.graylog.plugins.views.search.elasticsearch.QueryStringDecorators;
 import org.graylog.plugins.views.search.elasticsearch.FieldTypesLookup;
 import org.graylog.plugins.views.search.elasticsearch.IndexLookup;
-import org.graylog.plugins.views.search.elasticsearch.QueryStringParser;
+import org.graylog.plugins.views.search.elasticsearch.QueryStringDecorators;
+import org.graylog.plugins.views.search.searchtypes.pivot.BucketSpec;
+import org.graylog.plugins.views.search.searchtypes.pivot.Pivot;
+import org.graylog.plugins.views.search.searchtypes.pivot.SeriesSpec;
+import org.graylog.plugins.views.search.searchtypes.pivot.series.Average;
+import org.graylog.plugins.views.search.searchtypes.pivot.series.Max;
 import org.graylog.storage.elasticsearch6.views.searchtypes.ESSearchTypeHandler;
 import org.graylog.storage.elasticsearch6.views.searchtypes.pivot.ESPivot;
 import org.graylog.storage.elasticsearch6.views.searchtypes.pivot.ESPivotBucketSpecHandler;
 import org.graylog.storage.elasticsearch6.views.searchtypes.pivot.ESPivotSeriesSpecHandler;
 import org.graylog.storage.elasticsearch6.views.searchtypes.pivot.series.ESAverageHandler;
 import org.graylog.storage.elasticsearch6.views.searchtypes.pivot.series.ESMaxHandler;
-import org.graylog.plugins.views.search.searchtypes.pivot.BucketSpec;
-import org.graylog.plugins.views.search.searchtypes.pivot.Pivot;
-import org.graylog.plugins.views.search.searchtypes.pivot.SeriesSpec;
-import org.graylog.plugins.views.search.searchtypes.pivot.series.Average;
-import org.graylog.plugins.views.search.searchtypes.pivot.series.Max;
 import org.graylog2.plugin.indexer.searches.timeranges.AbsoluteRange;
 import org.graylog2.plugin.indexer.searches.timeranges.InvalidRangeParametersException;
 import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
@@ -63,7 +62,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 public class ElasticsearchBackendGeneratedRequestTestBase extends ElasticsearchBackendTestBase {
-    protected static final QueryStringParser queryStringParser = new QueryStringParser();
 
     @Rule
     public MockitoRule rule = MockitoJUnit.rule();
@@ -93,7 +91,6 @@ public class ElasticsearchBackendGeneratedRequestTestBase extends ElasticsearchB
         elasticSearchTypeHandlers.put(Pivot.NAME, () -> new ESPivot(bucketHandlers, seriesHandlers));
 
         this.elasticsearchBackend = new ElasticsearchBackend(elasticSearchTypeHandlers,
-                queryStringParser,
                 jestClient,
                 indexLookup,
                 new QueryStringDecorators.Fake(),

--- a/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/views/ElasticsearchBackendQueryStringDecoratorsTest.java
+++ b/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/views/ElasticsearchBackendQueryStringDecoratorsTest.java
@@ -28,7 +28,6 @@ import org.graylog.plugins.views.search.elasticsearch.ElasticsearchQueryString;
 import org.graylog.plugins.views.search.elasticsearch.FieldTypesLookup;
 import org.graylog.plugins.views.search.elasticsearch.IndexLookup;
 import org.graylog.plugins.views.search.elasticsearch.QueryStringDecorators;
-import org.graylog.plugins.views.search.elasticsearch.QueryStringParser;
 import org.graylog.plugins.views.search.engine.QueryStringDecorator;
 import org.graylog2.plugin.indexer.searches.timeranges.InvalidRangeParametersException;
 import org.graylog2.plugin.indexer.searches.timeranges.RelativeRange;
@@ -56,7 +55,6 @@ class ElasticsearchBackendQueryStringDecoratorsTest {
         final FieldTypesLookup fieldTypesLookup = mock(FieldTypesLookup.class);
         this.backend = new ElasticsearchBackend(
                 Collections.emptyMap(),
-                new QueryStringParser(),
                 mock(JestClient.class),
                 mock(IndexLookup.class),
                 new QueryStringDecorators(decorators),

--- a/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/views/ElasticsearchBackendTest.java
+++ b/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/views/ElasticsearchBackendTest.java
@@ -19,28 +19,23 @@ package org.graylog.storage.elasticsearch6.views;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import org.graylog.plugins.views.search.Query;
-import org.graylog.plugins.views.search.QueryMetadata;
 import org.graylog.plugins.views.search.QueryResult;
 import org.graylog.plugins.views.search.Search;
 import org.graylog.plugins.views.search.SearchJob;
 import org.graylog.plugins.views.search.SearchType;
-import org.graylog.plugins.views.search.elasticsearch.QueryStringDecorators;
 import org.graylog.plugins.views.search.elasticsearch.ElasticsearchQueryString;
 import org.graylog.plugins.views.search.elasticsearch.FieldTypesLookup;
 import org.graylog.plugins.views.search.elasticsearch.IndexLookup;
+import org.graylog.plugins.views.search.elasticsearch.QueryStringDecorators;
 import org.graylog.plugins.views.search.elasticsearch.QueryStringParser;
+import org.graylog.plugins.views.search.searchtypes.MessageList;
 import org.graylog.storage.elasticsearch6.views.searchtypes.ESMessageList;
 import org.graylog.storage.elasticsearch6.views.searchtypes.ESSearchTypeHandler;
-import org.graylog.plugins.views.search.filter.AndFilter;
-import org.graylog.plugins.views.search.filter.QueryStringFilter;
-import org.graylog.plugins.views.search.searchtypes.MessageList;
-import org.graylog.plugins.views.search.searchtypes.pivot.Pivot;
 import org.graylog2.plugin.indexer.searches.timeranges.RelativeRange;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import javax.inject.Provider;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Map;
 
@@ -59,52 +54,11 @@ public class ElasticsearchBackendTest {
         final FieldTypesLookup fieldTypesLookup = mock(FieldTypesLookup.class);
         final QueryStringParser queryStringParser = new QueryStringParser();
         backend = new ElasticsearchBackend(handlers,
-                queryStringParser,
                 null,
                 mock(IndexLookup.class),
                 new QueryStringDecorators.Fake(),
                 (elasticsearchBackend, ssb, job, query, results) -> new ESGeneratedQueryContext(elasticsearchBackend, ssb, job, query, results, fieldTypesLookup),
                 false);
-    }
-
-    @Test
-    public void parse() throws Exception {
-        final QueryMetadata queryMetadata = backend.parse(ImmutableSet.of(), Query.builder()
-                .id("abc123")
-                .query(ElasticsearchQueryString.builder().queryString("user_name:$username$ http_method:$foo$").build())
-                .timerange(RelativeRange.create(600))
-                .build());
-
-        assertThat(queryMetadata.usedParameterNames())
-                .containsOnly("username", "foo");
-    }
-
-    @Test
-    public void parseAlsoConsidersWidgetFilters() throws Exception {
-        final SearchType searchType1 = Pivot.builder()
-                .id("searchType1")
-                .filter(QueryStringFilter.builder().query("source:$bar$").build())
-                .series(new ArrayList<>())
-                .rollup(false)
-                .build();
-        final SearchType searchType2 = Pivot.builder()
-                .id("searchType2")
-                .filter(AndFilter.builder().filters(ImmutableSet.of(
-                        QueryStringFilter.builder().query("http_action:$baz$").build(),
-                        QueryStringFilter.builder().query("source:localhost").build()
-                )).build())
-                .series(new ArrayList<>())
-                .rollup(false)
-                .build();
-        final QueryMetadata queryMetadata = backend.parse(ImmutableSet.of(), Query.builder()
-                .id("abc123")
-                .query(ElasticsearchQueryString.builder().queryString("user_name:$username$ http_method:$foo$").build())
-                .timerange(RelativeRange.create(600))
-                .searchTypes(ImmutableSet.of(searchType1, searchType2))
-                .build());
-
-        assertThat(queryMetadata.usedParameterNames())
-                .containsOnly("username", "foo", "bar", "baz");
     }
 
     @Test

--- a/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/views/ElasticsearchBackendUsingCorrectIndicesTest.java
+++ b/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/views/ElasticsearchBackendUsingCorrectIndicesTest.java
@@ -24,16 +24,15 @@ import org.graylog.plugins.views.search.Query;
 import org.graylog.plugins.views.search.Search;
 import org.graylog.plugins.views.search.SearchJob;
 import org.graylog.plugins.views.search.SearchType;
-import org.graylog.plugins.views.search.elasticsearch.QueryStringDecorators;
 import org.graylog.plugins.views.search.elasticsearch.ElasticsearchQueryString;
 import org.graylog.plugins.views.search.elasticsearch.FieldTypesLookup;
 import org.graylog.plugins.views.search.elasticsearch.IndexLookup;
-import org.graylog.plugins.views.search.elasticsearch.QueryStringParser;
-import org.graylog.storage.elasticsearch6.views.searchtypes.ESMessageList;
-import org.graylog.storage.elasticsearch6.views.searchtypes.ESSearchTypeHandler;
+import org.graylog.plugins.views.search.elasticsearch.QueryStringDecorators;
 import org.graylog.plugins.views.search.filter.AndFilter;
 import org.graylog.plugins.views.search.filter.StreamFilter;
 import org.graylog.plugins.views.search.searchtypes.MessageList;
+import org.graylog.storage.elasticsearch6.views.searchtypes.ESMessageList;
+import org.graylog.storage.elasticsearch6.views.searchtypes.ESSearchTypeHandler;
 import org.graylog2.plugin.indexer.searches.timeranges.RelativeRange;
 import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
 import org.joda.time.DateTimeUtils;
@@ -62,7 +61,6 @@ public class ElasticsearchBackendUsingCorrectIndicesTest extends ElasticsearchBa
     private static Map<String, Provider<ESSearchTypeHandler<? extends SearchType>>> handlers = ImmutableMap.of(
             MessageList.NAME, () -> new ESMessageList(new QueryStringDecorators.Fake())
     );
-    private static final QueryStringParser queryStringParser = new QueryStringParser();
 
     @Rule
     public MockitoRule rule = MockitoJUnit.rule();
@@ -87,7 +85,6 @@ public class ElasticsearchBackendUsingCorrectIndicesTest extends ElasticsearchBa
 
         final FieldTypesLookup fieldTypesLookup = mock(FieldTypesLookup.class);
         this.backend = new ElasticsearchBackend(handlers,
-                queryStringParser,
                 jestClient,
                 indexLookup,
                 new QueryStringDecorators.Fake(),

--- a/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/views/QueryPlanTest.java
+++ b/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/views/QueryPlanTest.java
@@ -28,6 +28,7 @@ import org.graylog.plugins.views.search.elasticsearch.IndexLookup;
 import org.graylog.plugins.views.search.elasticsearch.QueryStringDecorators;
 import org.graylog.plugins.views.search.elasticsearch.QueryStringParser;
 import org.graylog.plugins.views.search.engine.QueryEngine;
+import org.graylog.plugins.views.search.engine.QueryParser;
 import org.graylog.plugins.views.search.engine.QueryPlan;
 import org.graylog.plugins.views.search.searchtypes.MessageList;
 import org.graylog.storage.elasticsearch6.views.searchtypes.ESMessageList;
@@ -55,15 +56,13 @@ public class QueryPlanTest {
         handlers.put(MessageList.NAME, () -> new ESMessageList(new QueryStringDecorators.Fake()));
 
         final FieldTypesLookup fieldTypesLookup = mock(FieldTypesLookup.class);
-        final QueryStringParser queryStringParser = new QueryStringParser();
         ElasticsearchBackend backend = new ElasticsearchBackend(handlers,
-                queryStringParser,
                 null,
                 mock(IndexLookup.class),
                 new QueryStringDecorators.Fake(),
                 (elasticsearchBackend, ssb, job, query, results) -> new ESGeneratedQueryContext(elasticsearchBackend, ssb, job, query, results, fieldTypesLookup),
                 false);
-        queryEngine = new QueryEngine(backend, Collections.emptySet());
+        queryEngine = new QueryEngine(backend, Collections.emptySet(), new QueryParser(new QueryStringParser()));
     }
 
     private static String randomUUID() {

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackend.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackend.java
@@ -16,23 +16,17 @@
  */
 package org.graylog.storage.elasticsearch7.views;
 
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
-import com.google.common.graph.Traverser;
 import com.google.inject.name.Named;
 import org.graylog.plugins.views.search.Filter;
 import org.graylog.plugins.views.search.GlobalOverride;
-import org.graylog.plugins.views.search.Parameter;
 import org.graylog.plugins.views.search.Query;
-import org.graylog.plugins.views.search.QueryMetadata;
 import org.graylog.plugins.views.search.QueryResult;
 import org.graylog.plugins.views.search.SearchJob;
 import org.graylog.plugins.views.search.SearchType;
 import org.graylog.plugins.views.search.elasticsearch.ElasticsearchQueryString;
 import org.graylog.plugins.views.search.elasticsearch.IndexLookup;
 import org.graylog.plugins.views.search.elasticsearch.QueryStringDecorators;
-import org.graylog.plugins.views.search.elasticsearch.QueryStringParser;
 import org.graylog.plugins.views.search.engine.QueryBackend;
 import org.graylog.plugins.views.search.errors.SearchTypeError;
 import org.graylog.plugins.views.search.errors.SearchTypeErrorParser;
@@ -71,16 +65,11 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
-
-import static com.google.common.base.MoreObjects.firstNonNull;
-import static com.google.common.base.Preconditions.checkArgument;
 
 public class ElasticsearchBackend implements QueryBackend<ESGeneratedQueryContext> {
     private static final Logger LOG = LoggerFactory.getLogger(ElasticsearchBackend.class);
 
     private final Map<String, Provider<ESSearchTypeHandler<? extends SearchType>>> elasticsearchSearchTypeHandlers;
-    private final QueryStringParser queryStringParser;
     private final ElasticsearchClient client;
     private final IndexLookup indexLookup;
     private final QueryStringDecorators queryStringDecorators;
@@ -89,14 +78,12 @@ public class ElasticsearchBackend implements QueryBackend<ESGeneratedQueryContex
 
     @Inject
     public ElasticsearchBackend(Map<String, Provider<ESSearchTypeHandler<? extends SearchType>>> elasticsearchSearchTypeHandlers,
-                                QueryStringParser queryStringParser,
                                 ElasticsearchClient client,
                                 IndexLookup indexLookup,
                                 QueryStringDecorators queryStringDecorators,
                                 ESGeneratedQueryContext.Factory queryContextFactory,
                                 @Named("allow_leading_wildcard_searches") boolean allowLeadingWildcard) {
         this.elasticsearchSearchTypeHandlers = elasticsearchSearchTypeHandlers;
-        this.queryStringParser = queryStringParser;
         this.client = client;
         this.indexLookup = indexLookup;
 
@@ -315,44 +302,5 @@ public class ElasticsearchBackend implements QueryBackend<ESGeneratedQueryContex
         }
 
         return Optional.empty();
-    }
-
-    @SuppressWarnings("UnstableApiUsage")
-    private Set<String> queryStringsFromFilter(Filter entry) {
-        if (entry != null) {
-            final Traverser<Filter> filterTraverser = Traverser.forTree(filter -> firstNonNull(filter.filters(), Collections.emptySet()));
-            return StreamSupport.stream(filterTraverser.breadthFirst(entry).spliterator(), false)
-                    .filter(filter -> filter instanceof QueryStringFilter)
-                    .map(queryStringFilter -> ((QueryStringFilter) queryStringFilter).query())
-                    .filter(Objects::nonNull)
-                    .collect(Collectors.toSet());
-        }
-        return Collections.emptySet();
-    }
-
-    @Override
-    public QueryMetadata parse(ImmutableSet<Parameter> declaredParameters, Query query) {
-        checkArgument(query.query() instanceof ElasticsearchQueryString);
-        final String mainQueryString = ((ElasticsearchQueryString) query.query()).queryString();
-        final java.util.stream.Stream<String> queryStringStreams = java.util.stream.Stream.concat(
-                java.util.stream.Stream.of(mainQueryString),
-                query.searchTypes().stream().flatMap(this::queryStringsFromSearchType)
-        );
-
-        return queryStringStreams
-                .map(queryStringParser::parse)
-                .reduce(QueryMetadata.builder().build(), (meta1, meta2) -> QueryMetadata.builder().usedParameterNames(
-                        Sets.union(meta1.usedParameterNames(), meta2.usedParameterNames())
-                ).build());
-    }
-
-    private java.util.stream.Stream<String> queryStringsFromSearchType(SearchType searchType) {
-        return java.util.stream.Stream.concat(
-                searchType.query().filter(query -> query instanceof ElasticsearchQueryString)
-                        .map(query -> ((ElasticsearchQueryString) query).queryString())
-                        .map(java.util.stream.Stream::of)
-                        .orElse(java.util.stream.Stream.empty()),
-                queryStringsFromFilter(searchType.filter()).stream()
-        );
     }
 }

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackendErrorHandlingTest.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackendErrorHandlingTest.java
@@ -27,7 +27,6 @@ import org.graylog.plugins.views.search.elasticsearch.ElasticsearchQueryString;
 import org.graylog.plugins.views.search.elasticsearch.FieldTypesLookup;
 import org.graylog.plugins.views.search.elasticsearch.IndexLookup;
 import org.graylog.plugins.views.search.elasticsearch.QueryStringDecorators;
-import org.graylog.plugins.views.search.elasticsearch.QueryStringParser;
 import org.graylog.plugins.views.search.errors.SearchError;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.search.MultiSearchResponse;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.builder.SearchSourceBuilder;
@@ -79,7 +78,6 @@ public class ElasticsearchBackendErrorHandlingTest {
                 ImmutableMap.of(
                         "dummy", () -> mock(DummyHandler.class)
                 ),
-                new QueryStringParser(),
                 client,
                 indexLookup,
                 new QueryStringDecorators(Collections.emptySet()),

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackendGeneratedRequestTestBase.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackendGeneratedRequestTestBase.java
@@ -25,7 +25,6 @@ import org.graylog.plugins.views.search.SearchType;
 import org.graylog.plugins.views.search.elasticsearch.FieldTypesLookup;
 import org.graylog.plugins.views.search.elasticsearch.IndexLookup;
 import org.graylog.plugins.views.search.elasticsearch.QueryStringDecorators;
-import org.graylog.plugins.views.search.elasticsearch.QueryStringParser;
 import org.graylog.plugins.views.search.searchtypes.pivot.BucketSpec;
 import org.graylog.plugins.views.search.searchtypes.pivot.Pivot;
 import org.graylog.plugins.views.search.searchtypes.pivot.SeriesSpec;
@@ -63,8 +62,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 public class ElasticsearchBackendGeneratedRequestTestBase {
-    protected static final QueryStringParser queryStringParser = new QueryStringParser();
-
     @Rule
     public MockitoRule rule = MockitoJUnit.rule();
 
@@ -94,7 +91,6 @@ public class ElasticsearchBackendGeneratedRequestTestBase {
         elasticSearchTypeHandlers.put(Pivot.NAME, () -> new ESPivot(bucketHandlers, seriesHandlers));
 
         this.elasticsearchBackend = new ElasticsearchBackend(elasticSearchTypeHandlers,
-                queryStringParser,
                 client,
                 indexLookup,
                 new QueryStringDecorators.Fake(),

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackendQueryStringDecoratorsTest.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackendQueryStringDecoratorsTest.java
@@ -27,7 +27,6 @@ import org.graylog.plugins.views.search.elasticsearch.ElasticsearchQueryString;
 import org.graylog.plugins.views.search.elasticsearch.FieldTypesLookup;
 import org.graylog.plugins.views.search.elasticsearch.IndexLookup;
 import org.graylog.plugins.views.search.elasticsearch.QueryStringDecorators;
-import org.graylog.plugins.views.search.elasticsearch.QueryStringParser;
 import org.graylog.plugins.views.search.engine.QueryStringDecorator;
 import org.graylog.storage.elasticsearch7.ElasticsearchClient;
 import org.graylog2.plugin.indexer.searches.timeranges.InvalidRangeParametersException;
@@ -56,7 +55,6 @@ class ElasticsearchBackendQueryStringDecoratorsTest {
         final FieldTypesLookup fieldTypesLookup = mock(FieldTypesLookup.class);
         this.backend = new ElasticsearchBackend(
                 Collections.emptyMap(),
-                new QueryStringParser(),
                 mock(ElasticsearchClient.class),
                 mock(IndexLookup.class),
                 new QueryStringDecorators(decorators),

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackendUsingCorrectIndicesTest.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackendUsingCorrectIndicesTest.java
@@ -26,7 +26,6 @@ import org.graylog.plugins.views.search.elasticsearch.ElasticsearchQueryString;
 import org.graylog.plugins.views.search.elasticsearch.FieldTypesLookup;
 import org.graylog.plugins.views.search.elasticsearch.IndexLookup;
 import org.graylog.plugins.views.search.elasticsearch.QueryStringDecorators;
-import org.graylog.plugins.views.search.elasticsearch.QueryStringParser;
 import org.graylog.plugins.views.search.filter.AndFilter;
 import org.graylog.plugins.views.search.filter.StreamFilter;
 import org.graylog.plugins.views.search.searchtypes.MessageList;
@@ -68,7 +67,6 @@ public class ElasticsearchBackendUsingCorrectIndicesTest {
     private static Map<String, Provider<ESSearchTypeHandler<? extends SearchType>>> handlers = ImmutableMap.of(
             MessageList.NAME, () -> new ESMessageList(new QueryStringDecorators.Fake())
     );
-    private static final QueryStringParser queryStringParser = new QueryStringParser();
 
     @Rule
     public MockitoRule rule = MockitoJUnit.rule();
@@ -96,7 +94,6 @@ public class ElasticsearchBackendUsingCorrectIndicesTest {
 
         final FieldTypesLookup fieldTypesLookup = mock(FieldTypesLookup.class);
         this.backend = new ElasticsearchBackend(handlers,
-                queryStringParser,
                 client,
                 indexLookup,
                 new QueryStringDecorators.Fake(),

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/QueryPlanTest.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/QueryPlanTest.java
@@ -28,6 +28,7 @@ import org.graylog.plugins.views.search.elasticsearch.IndexLookup;
 import org.graylog.plugins.views.search.elasticsearch.QueryStringDecorators;
 import org.graylog.plugins.views.search.elasticsearch.QueryStringParser;
 import org.graylog.plugins.views.search.engine.QueryEngine;
+import org.graylog.plugins.views.search.engine.QueryParser;
 import org.graylog.plugins.views.search.engine.QueryPlan;
 import org.graylog.plugins.views.search.searchtypes.MessageList;
 import org.graylog.storage.elasticsearch7.views.searchtypes.ESMessageList;
@@ -57,13 +58,12 @@ public class QueryPlanTest {
         final FieldTypesLookup fieldTypesLookup = mock(FieldTypesLookup.class);
         final QueryStringParser queryStringParser = new QueryStringParser();
         ElasticsearchBackend backend = new ElasticsearchBackend(handlers,
-                queryStringParser,
                 null,
                 mock(IndexLookup.class),
                 new QueryStringDecorators.Fake(),
                 (elasticsearchBackend, ssb, job, query, results) -> new ESGeneratedQueryContext(elasticsearchBackend, ssb, job, query, results, fieldTypesLookup),
                 false);
-        queryEngine = new QueryEngine(backend, Collections.emptySet());
+        queryEngine = new QueryEngine(backend, Collections.emptySet(), new QueryParser(queryStringParser));
     }
 
     private static String randomUUID() {

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/elasticsearch/QueryStringParser.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/elasticsearch/QueryStringParser.java
@@ -26,7 +26,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class QueryStringParser {
-    private static final Pattern PLACEHOLDER_PATTERN = Pattern.compile("\\$(.+?)\\$");
+    private static final Pattern PLACEHOLDER_PATTERN = Pattern.compile("\\$([a-zA-Z_]\\w*)\\$");
 
     public QueryMetadata parse(String queryString) {
         if (Strings.isNullOrEmpty(queryString)) {

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/engine/QueryBackend.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/engine/QueryBackend.java
@@ -17,11 +17,8 @@
 package org.graylog.plugins.views.search.engine;
 
 import com.google.common.base.Stopwatch;
-import com.google.common.collect.ImmutableSet;
 import org.graylog.plugins.views.search.GlobalOverride;
-import org.graylog.plugins.views.search.Parameter;
 import org.graylog.plugins.views.search.Query;
-import org.graylog.plugins.views.search.QueryMetadata;
 import org.graylog.plugins.views.search.QueryResult;
 import org.graylog.plugins.views.search.SearchJob;
 import org.graylog.plugins.views.search.errors.QueryError;
@@ -113,12 +110,4 @@ public interface QueryBackend<T extends GeneratedQueryContext> {
      * @throws RuntimeException if the query could not be executed for some reason
      */
     QueryResult doRun(SearchJob job, Query query, T queryContext, Set<QueryResult> predecessorResults);
-
-    /**
-     * Parse the query and return structural information about it.
-     * <p>
-     * This method decomposes the backend-specific query and returns information about used parameters, optionally the
-     * AST for syntax highlight and other information the UI can use to offer help.
-     */
-    QueryMetadata parse(ImmutableSet<Parameter> parameters, Query query);
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/engine/QueryEngine.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/engine/QueryEngine.java
@@ -87,7 +87,7 @@ public class QueryEngine {
     }
 
     public QueryMetadata parse(Search search, Query query) {
-        final QueryMetadata parsedMetadata = queryParser.parse(search.parameters(), query);
+        final QueryMetadata parsedMetadata = queryParser.parse(query);
 
         return this.queryMetadataDecorators.stream()
                 .reduce((decorator1, decorator2) -> (s, q, metadata) -> decorator1.decorate(s, q, decorator2.decorate(s, q, metadata)))

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/engine/QueryParser.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/engine/QueryParser.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.views.search.engine;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import com.google.common.graph.Traverser;
+import org.graylog.plugins.views.search.Filter;
+import org.graylog.plugins.views.search.Parameter;
+import org.graylog.plugins.views.search.Query;
+import org.graylog.plugins.views.search.QueryMetadata;
+import org.graylog.plugins.views.search.SearchType;
+import org.graylog.plugins.views.search.elasticsearch.ElasticsearchQueryString;
+import org.graylog.plugins.views.search.elasticsearch.QueryStringParser;
+import org.graylog.plugins.views.search.filter.QueryStringFilter;
+
+import java.util.Collections;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.google.common.base.Preconditions.checkArgument;
+
+public class QueryParser {
+    private final QueryStringParser queryStringParser;
+
+    public QueryParser(QueryStringParser queryStringParser) {
+        this.queryStringParser = queryStringParser;
+    }
+
+    public QueryMetadata parse(ImmutableSet<Parameter> declaredParameters, Query query) {
+        checkArgument(query.query() instanceof ElasticsearchQueryString);
+        final String mainQueryString = ((ElasticsearchQueryString) query.query()).queryString();
+        final java.util.stream.Stream<String> queryStringStreams = java.util.stream.Stream.concat(
+                java.util.stream.Stream.of(mainQueryString),
+                query.searchTypes().stream().flatMap(this::queryStringsFromSearchType)
+        );
+
+        return queryStringStreams
+                .map(queryStringParser::parse)
+                .reduce(QueryMetadata.builder().build(), (meta1, meta2) -> QueryMetadata.builder().usedParameterNames(
+                        Sets.union(meta1.usedParameterNames(), meta2.usedParameterNames())
+                ).build());
+    }
+
+
+    private java.util.stream.Stream<String> queryStringsFromSearchType(SearchType searchType) {
+        return java.util.stream.Stream.concat(
+                searchType.query().filter(query -> query instanceof ElasticsearchQueryString)
+                        .map(query -> ((ElasticsearchQueryString) query).queryString())
+                        .map(java.util.stream.Stream::of)
+                        .orElse(java.util.stream.Stream.empty()),
+                queryStringsFromFilter(searchType.filter()).stream()
+        );
+    }
+
+    private Set<String> queryStringsFromFilter(Filter entry) {
+        if (entry != null) {
+            final Traverser<Filter> filterTraverser = Traverser.forTree(filter -> firstNonNull(filter.filters(), Collections.emptySet()));
+            return StreamSupport.stream(filterTraverser.breadthFirst(entry).spliterator(), false)
+                    .filter(filter -> filter instanceof QueryStringFilter)
+                    .map(queryStringFilter -> ((QueryStringFilter) queryStringFilter).query())
+                    .filter(Objects::nonNull)
+                    .collect(Collectors.toSet());
+        }
+        return Collections.emptySet();
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/engine/QueryParser.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/engine/QueryParser.java
@@ -16,11 +16,9 @@
  */
 package org.graylog.plugins.views.search.engine;
 
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import com.google.common.graph.Traverser;
 import org.graylog.plugins.views.search.Filter;
-import org.graylog.plugins.views.search.Parameter;
 import org.graylog.plugins.views.search.Query;
 import org.graylog.plugins.views.search.QueryMetadata;
 import org.graylog.plugins.views.search.SearchType;
@@ -28,6 +26,7 @@ import org.graylog.plugins.views.search.elasticsearch.ElasticsearchQueryString;
 import org.graylog.plugins.views.search.elasticsearch.QueryStringParser;
 import org.graylog.plugins.views.search.filter.QueryStringFilter;
 
+import javax.inject.Inject;
 import java.util.Collections;
 import java.util.Objects;
 import java.util.Set;
@@ -40,11 +39,12 @@ import static com.google.common.base.Preconditions.checkArgument;
 public class QueryParser {
     private final QueryStringParser queryStringParser;
 
+    @Inject
     public QueryParser(QueryStringParser queryStringParser) {
         this.queryStringParser = queryStringParser;
     }
 
-    public QueryMetadata parse(ImmutableSet<Parameter> declaredParameters, Query query) {
+    public QueryMetadata parse(Query query) {
         checkArgument(query.query() instanceof ElasticsearchQueryString);
         final String mainQueryString = ((ElasticsearchQueryString) query.query()).queryString();
         final java.util.stream.Stream<String> queryStringStreams = java.util.stream.Stream.concat(

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/elasticsearch/QueryStringParserTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/elasticsearch/QueryStringParserTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.views.search.elasticsearch;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class QueryStringParserTest {
+    private final static QueryStringParser queryStringParser = new QueryStringParser();
+
+    @Test
+    void testSimpleParsing() {
+        assertThat(parse("foo:bar AND some:value")).isEmpty();
+        assertThat(parse("foo:$bar$ AND some:value")).containsExactly("bar");
+        assertThat(parse("foo:$bar$ AND some:$value$")).containsExactlyInAnyOrder("value", "bar");
+        assertThat(parse("foo:bar$")).isEmpty();
+        assertThat(parse("foo:bar$ OR foo:$baz")).isEmpty();
+        assertThat(parse("foo:bar$ OR foo:$baz$")).containsExactly("baz");
+        assertThat(parse("foo:bar$ AND baz$:$baz$")).containsExactly("baz");
+    }
+
+    private Set<String> parse(String query) {
+        return queryStringParser.parse(query).usedParameterNames();
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/elasticsearch/QueryStringParserTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/elasticsearch/QueryStringParserTest.java
@@ -30,10 +30,35 @@ public class QueryStringParserTest {
         assertThat(parse("foo:bar AND some:value")).isEmpty();
         assertThat(parse("foo:$bar$ AND some:value")).containsExactly("bar");
         assertThat(parse("foo:$bar$ AND some:$value$")).containsExactlyInAnyOrder("value", "bar");
+    }
+
+    @Test
+    void testStringsContainingDollars() {
         assertThat(parse("foo:bar$")).isEmpty();
         assertThat(parse("foo:bar$ OR foo:$baz")).isEmpty();
         assertThat(parse("foo:bar$ OR foo:$baz$")).containsExactly("baz");
+        assertThat(parse("foo:$bar$ OR foo:$baz")).containsExactly("bar");
         assertThat(parse("foo:bar$ AND baz$:$baz$")).containsExactly("baz");
+        assertThat(parse("foo:$$")).isEmpty();
+        assertThat(parse("foo:$foo$ AND bar:$$")).containsExactly("foo");
+    }
+
+    @Test
+    void testCharacterSpaceOfParameterNames() {
+        assertThat(parse("foo:$some parameter$")).isEmpty();
+        assertThat(parse("foo:$some-parameter$")).isEmpty();
+        assertThat(parse("foo:$some/parameter$")).isEmpty();
+        assertThat(parse("foo:$some42parameter$")).containsExactly("some42parameter");
+        assertThat(parse("foo:$42parameter$")).isEmpty();
+        assertThat(parse("foo:$parameter42$")).containsExactly("parameter42");
+        assertThat(parse("foo:$someparameter$")).containsExactly("someparameter");
+        assertThat(parse("foo:$some_parameter$")).containsExactly("some_parameter");
+        assertThat(parse("foo:$_someparameter$")).containsExactly("_someparameter");
+        assertThat(parse("foo:$_someparameter_$")).containsExactly("_someparameter_");
+        assertThat(parse("foo:$_someparameter_$")).containsExactly("_someparameter_");
+        assertThat(parse("foo:$_$")).containsExactly("_");
+        assertThat(parse("foo:$s$")).containsExactly("s");
+        assertThat(parse("foo:$9$")).isEmpty();
     }
 
     private Set<String> parse(String query) {

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/engine/QueryParserTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/engine/QueryParserTest.java
@@ -31,9 +31,8 @@ import org.junit.Test;
 import java.util.ArrayList;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
-class QueryParserTest {
+public class QueryParserTest {
     private static QueryParser queryParser = new QueryParser(new QueryStringParser());
 
     @Test
@@ -45,7 +44,7 @@ class QueryParserTest {
                 .build());
 
         assertThat(queryMetadata.usedParameterNames())
-                .containsOnly("username", "foo");
+                .containsExactlyInAnyOrder("username", "foo");
     }
 
     @Test
@@ -73,6 +72,6 @@ class QueryParserTest {
                 .build());
 
         assertThat(queryMetadata.usedParameterNames())
-                .containsOnly("username", "foo", "bar", "baz");
+                .containsExactlyInAnyOrder("username", "foo", "bar", "baz");
     }
 }

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/engine/QueryParserTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/engine/QueryParserTest.java
@@ -37,7 +37,7 @@ public class QueryParserTest {
 
     @Test
     public void parse() throws Exception {
-        final QueryMetadata queryMetadata = queryParser.parse(ImmutableSet.of(), Query.builder()
+        final QueryMetadata queryMetadata = queryParser.parse(Query.builder()
                 .id("abc123")
                 .query(ElasticsearchQueryString.builder().queryString("user_name:$username$ http_method:$foo$").build())
                 .timerange(RelativeRange.create(600))
@@ -64,7 +64,7 @@ public class QueryParserTest {
                 .series(new ArrayList<>())
                 .rollup(false)
                 .build();
-        final QueryMetadata queryMetadata = queryParser.parse(ImmutableSet.of(), Query.builder()
+        final QueryMetadata queryMetadata = queryParser.parse(Query.builder()
                 .id("abc123")
                 .query(ElasticsearchQueryString.builder().queryString("user_name:$username$ http_method:$foo$").build())
                 .timerange(RelativeRange.create(600))

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/engine/QueryParserTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/engine/QueryParserTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.views.search.engine;
+
+import com.google.common.collect.ImmutableSet;
+import org.graylog.plugins.views.search.Query;
+import org.graylog.plugins.views.search.QueryMetadata;
+import org.graylog.plugins.views.search.SearchType;
+import org.graylog.plugins.views.search.elasticsearch.ElasticsearchQueryString;
+import org.graylog.plugins.views.search.elasticsearch.QueryStringParser;
+import org.graylog.plugins.views.search.filter.AndFilter;
+import org.graylog.plugins.views.search.filter.QueryStringFilter;
+import org.graylog.plugins.views.search.searchtypes.pivot.Pivot;
+import org.graylog2.plugin.indexer.searches.timeranges.RelativeRange;
+import org.junit.Test;
+
+import java.util.ArrayList;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class QueryParserTest {
+    private static QueryParser queryParser = new QueryParser(new QueryStringParser());
+
+    @Test
+    public void parse() throws Exception {
+        final QueryMetadata queryMetadata = queryParser.parse(ImmutableSet.of(), Query.builder()
+                .id("abc123")
+                .query(ElasticsearchQueryString.builder().queryString("user_name:$username$ http_method:$foo$").build())
+                .timerange(RelativeRange.create(600))
+                .build());
+
+        assertThat(queryMetadata.usedParameterNames())
+                .containsOnly("username", "foo");
+    }
+
+    @Test
+    public void parseAlsoConsidersWidgetFilters() throws Exception {
+        final SearchType searchType1 = Pivot.builder()
+                .id("searchType1")
+                .filter(QueryStringFilter.builder().query("source:$bar$").build())
+                .series(new ArrayList<>())
+                .rollup(false)
+                .build();
+        final SearchType searchType2 = Pivot.builder()
+                .id("searchType2")
+                .filter(AndFilter.builder().filters(ImmutableSet.of(
+                        QueryStringFilter.builder().query("http_action:$baz$").build(),
+                        QueryStringFilter.builder().query("source:localhost").build()
+                )).build())
+                .series(new ArrayList<>())
+                .rollup(false)
+                .build();
+        final QueryMetadata queryMetadata = queryParser.parse(ImmutableSet.of(), Query.builder()
+                .id("abc123")
+                .query(ElasticsearchQueryString.builder().queryString("user_name:$username$ http_method:$foo$").build())
+                .timerange(RelativeRange.create(600))
+                .searchTypes(ImmutableSet.of(searchType1, searchType2))
+                .build());
+
+        assertThat(queryMetadata.usedParameterNames())
+                .containsOnly("username", "foo", "bar", "baz");
+    }
+}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
## Motivation and Context

**Note:** This PR needs to be backported to `3.3` and `4.0`.

Before this change, a user could write or generate a query string that contains two `$` characters in unrelated places (e.g. because a field name or value contains it), leading to an undeclared parameter being incorrectly identified. An example for this is a query string of

```
foo:bar$ AND some:$value
```

This PR is fixing the regex used to identify parameters in query strings. The regex is now checking for two `$` enclosing a group of alphanumerical (`a-z`, `A-Z`, `0-9` & `_`) characters instead of a group of _any_ characters. This also matches the description in the frontend, which was already showing this specification although it was not enforced like this in the backend.

This PR (for `master`) also includes a refactoring that extracts a `QueryParser` class in order to consolidate backend(ES6/ES7)-agnostic code that was previously duplicated for both storage modules. That refactoring should be left out for the backports.

Fixes #9497.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

/jenkins-pr-deps Graylog2/graylog-plugin-enterprise#1999