### PR TITLE
Do not set invalid widget id as a focused widget

### DIFF
--- a/graylog2-web-interface/src/views/components/contexts/WidgetFocusProvider.test.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/WidgetFocusProvider.test.tsx
@@ -18,8 +18,9 @@ import * as React from 'react';
 import { useContext } from 'react';
 import { render, screen, fireEvent, waitFor } from 'wrappedTestingLibrary';
 import { useLocation } from 'react-router-dom';
-import { useStore } from 'stores/connect';
+import { asMock } from 'helpers/mocking';
 
+import { useStore } from 'stores/connect';
 import WidgetFocusProvider from 'views/components/contexts/WidgetFocusProvider';
 import WidgetFocusContext from 'views/components/contexts/WidgetFocusContext';
 
@@ -83,8 +84,7 @@ describe('WidgetFocusProvider', () => {
   });
 
   it('should not set focused widget from url if the widget does not exist', async () => {
-    // @ts-ignore this is already mocked above.
-    useStore.mockReturnValue({
+    asMock(useStore).mockReturnValue({
       has: jest.fn(() => false),
     });
 

--- a/graylog2-web-interface/src/views/components/contexts/WidgetFocusProvider.test.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/WidgetFocusProvider.test.tsx
@@ -15,14 +15,16 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
+import { Map } from 'immutable';
 import { useContext } from 'react';
 import { render, screen, fireEvent, waitFor } from 'wrappedTestingLibrary';
 import { useLocation } from 'react-router-dom';
 import { asMock } from 'helpers/mocking';
 
-import { useStore } from 'stores/connect';
+import { WidgetStore } from 'views/stores/WidgetStore';
 import WidgetFocusProvider from 'views/components/contexts/WidgetFocusProvider';
 import WidgetFocusContext from 'views/components/contexts/WidgetFocusContext';
+import Widget from 'views/logic/widgets/Widget';
 
 const mockHistoryReplace = jest.fn();
 
@@ -37,10 +39,11 @@ jest.mock('react-router-dom', () => ({
   })),
 }));
 
-jest.mock('stores/connect', () => ({
-  useStore: jest.fn(() => ({
-    has: jest.fn(() => true),
-  })),
+jest.mock('views/stores/WidgetStore', () => ({
+  WidgetStore: {
+    getInitialState: jest.fn(() => ({ has: jest.fn(() => true) })),
+    listen: jest.fn(),
+  },
 }));
 
 describe('WidgetFocusProvider', () => {
@@ -74,6 +77,8 @@ describe('WidgetFocusProvider', () => {
   });
 
   it('should set focused widget from url', async () => {
+    asMock(WidgetStore.getInitialState).mockReturnValue(Map({ clack: Widget.builder().build() }));
+
     useLocation.mockReturnValue({
       pathname: '',
       search: 'focused=clack',
@@ -84,9 +89,7 @@ describe('WidgetFocusProvider', () => {
   });
 
   it('should not set focused widget from url if the widget does not exist', async () => {
-    asMock(useStore).mockReturnValue({
-      has: jest.fn(() => false),
-    });
+    asMock(WidgetStore.getInitialState).mockReturnValue(Map());
 
     useLocation.mockReturnValue({
       pathname: '',

--- a/graylog2-web-interface/src/views/components/contexts/WidgetFocusProvider.test.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/WidgetFocusProvider.test.tsx
@@ -18,6 +18,7 @@ import * as React from 'react';
 import { useContext } from 'react';
 import { render, screen, fireEvent, waitFor } from 'wrappedTestingLibrary';
 import { useLocation } from 'react-router-dom';
+import { useStore } from 'stores/connect';
 
 import WidgetFocusProvider from 'views/components/contexts/WidgetFocusProvider';
 import WidgetFocusContext from 'views/components/contexts/WidgetFocusContext';
@@ -79,5 +80,24 @@ describe('WidgetFocusProvider', () => {
 
     renderSUT();
     await screen.findByText('clack');
+  });
+
+  it('should not set focused widget from url if the widget does not exist', async () => {
+    // @ts-ignore this is already mocked above.
+    useStore.mockReturnValue({
+      has: jest.fn(() => false),
+    });
+
+    useLocation.mockReturnValue({
+      pathname: '',
+      search: 'focused=clack',
+    });
+
+    renderSUT();
+    const clack = screen.findByText('clack');
+
+    waitFor(() => {
+      expect(clack).toBeEmptyDOMElement();
+    });
   });
 });

--- a/graylog2-web-interface/src/views/components/contexts/WidgetFocusProvider.test.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/WidgetFocusProvider.test.tsx
@@ -51,7 +51,7 @@ describe('WidgetFocusProvider', () => {
       return (
         <>
           <button type="button" onClick={() => setFocusedWidget('click')}>Click</button>
-          <div>{focusedWidget}</div>
+          <div>{focusedWidget || 'No focus widget set'}</div>
         </>
       );
     };
@@ -94,10 +94,6 @@ describe('WidgetFocusProvider', () => {
     });
 
     renderSUT();
-    const clack = screen.findByText('clack');
-
-    waitFor(() => {
-      expect(clack).toBeEmptyDOMElement();
-    });
+    await screen.findByText('No focus widget set');
   });
 });

--- a/graylog2-web-interface/src/views/components/contexts/WidgetFocusProvider.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/WidgetFocusProvider.tsx
@@ -36,14 +36,18 @@ const _syncWithQuery = (query: string, focusedWidget: string) => {
   return baseUri.toString();
 };
 
-const useFocusWidgetIdFromParam = (focusedWidget, setFocusedWidget) => {
+const useFocusWidgetIdFromParam = (focusedWidget, setFocusedWidget, widgets) => {
   const { focused: paramFocusedWidget } = useQuery();
 
   useEffect(() => {
     if (focusedWidget !== paramFocusedWidget) {
+      if (paramFocusedWidget && !widgets.has(paramFocusedWidget)) {
+        return;
+      }
+
       setFocusedWidget(paramFocusedWidget);
     }
-  }, [focusedWidget, paramFocusedWidget, setFocusedWidget]);
+  }, [focusedWidget, paramFocusedWidget, setFocusedWidget, widgets]);
 };
 
 const WidgetFocusProvider = ({ children }: { children: React.ReactNode }): React.ReactElement => {
@@ -53,7 +57,7 @@ const WidgetFocusProvider = ({ children }: { children: React.ReactNode }): React
   const [focusedWidget, setFocusedWidget] = useState<string | undefined>();
   const widgets = useStore(WidgetStore);
 
-  useFocusWidgetIdFromParam(focusedWidget, setFocusedWidget);
+  useFocusWidgetIdFromParam(focusedWidget, setFocusedWidget, widgets);
 
   useEffect(() => {
     if (focusedWidget && !widgets.has(focusedWidget)) {


### PR DESCRIPTION
## Motivation
Prior to this change, when the URL contained a widget id which was not
part of the current widget set an error occured.

## Description
This change will check if the widget id of the URL belongs to an
existing widget before setting the focusedWidget.

## How Has This Been Tested?
- Open Search
- Focus widget and change id in the URL
- Reload page

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Fixes #9881