### PR TITLE
Change permission for sidecars in systems menu

### DIFF
--- a/graylog2-web-interface/src/components/navigation/SystemMenu.jsx
+++ b/graylog2-web-interface/src/components/navigation/SystemMenu.jsx
@@ -149,7 +149,7 @@ const SystemMenu = ({ location }) => {
       <IfPermitted permissions={['inputs:create']}>
         <NavigationLink path={Routes.SYSTEM.PIPELINES.OVERVIEW} description="Pipelines" />
       </IfPermitted>
-      <IfPermitted permissions={['inputs:edit']}>
+      <IfPermitted permissions={['sidecars:read']}>
         <NavigationLink path={Routes.SYSTEM.SIDECARS.OVERVIEW} description="Sidecars" />
       </IfPermitted>
       {pluginSystemNavigations}

--- a/graylog2-web-interface/src/components/navigation/SystemMenu.test.tsx
+++ b/graylog2-web-interface/src/components/navigation/SystemMenu.test.tsx
@@ -86,7 +86,8 @@ describe('SystemMenu', () => {
     ${['users:list']}              | ${3}  | ${['Users and Teams']}
     ${['roles:read']}              | ${3}  | ${['Roles']}
     ${['dashboards:create', 'inputs:create', 'streams:create']} | ${4}  | ${['Content Packs']}
-    ${['inputs:edit']}             | ${4}  | ${['Lookup Tables', 'Sidecars']}
+    ${['inputs:edit']}             | ${3}  | ${['Lookup Tables']}
+    ${['sidecars:read']}           | ${3}  | ${['Sidecars']}
     ${['inputs:create']}           | ${3}  | ${['Pipelines']}
   `('shows $links for user with $permissions permissions', verifyPermissions);
   });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The current permission requirement in systems menu does not reflect the sidecars permissions.

## Description
<!--- Describe your changes in detail -->
At the moment for users to see the sidecars menu item in the systems menu, you'd need to have `inputs:edit`. `sidecars:read` would be plenty enough to see this menu item.

## Motivation and Context
As mentioned in #7474 a user with sidecar related permission should be able to see the sidecar menu item.

After a brief discussion with @mpfz0r we decided that changing the permission to `sidecars:read` would be good.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
By creating a user with `sidecars:read` as a permission and logging in with that account.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

