### PR TITLE
Fix pattern used to identify parameters in search/dashboard query strings. (3.3)

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/elasticsearch/QueryStringParser.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/elasticsearch/QueryStringParser.java
@@ -27,7 +27,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class QueryStringParser {
-    private static final Pattern PLACEHOLDER_PATTERN = Pattern.compile("\\$(.+?)\\$");
+    private static final Pattern PLACEHOLDER_PATTERN = Pattern.compile("\\$([a-zA-Z_]\\w*)\\$");
 
     public QueryMetadata parse(String queryString) {
         if (Strings.isNullOrEmpty(queryString)) {

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/elasticsearch/QueryStringParserTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/elasticsearch/QueryStringParserTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.views.search.elasticsearch;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class QueryStringParserTest {
+    private final static QueryStringParser queryStringParser = new QueryStringParser();
+
+    @Test
+    void testSimpleParsing() {
+        assertThat(parse("foo:bar AND some:value")).isEmpty();
+        assertThat(parse("foo:$bar$ AND some:value")).containsExactly("bar");
+        assertThat(parse("foo:$bar$ AND some:$value$")).containsExactlyInAnyOrder("value", "bar");
+        assertThat(parse("foo:bar$")).isEmpty();
+        assertThat(parse("foo:bar$ OR foo:$baz")).isEmpty();
+        assertThat(parse("foo:bar$ OR foo:$baz$")).containsExactly("baz");
+        assertThat(parse("foo:bar$ AND baz$:$baz$")).containsExactly("baz");
+    }
+
+    private Set<String> parse(String query) {
+        return queryStringParser.parse(query).usedParameterNames();
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/elasticsearch/QueryStringParserTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/elasticsearch/QueryStringParserTest.java
@@ -30,10 +30,35 @@ public class QueryStringParserTest {
         assertThat(parse("foo:bar AND some:value")).isEmpty();
         assertThat(parse("foo:$bar$ AND some:value")).containsExactly("bar");
         assertThat(parse("foo:$bar$ AND some:$value$")).containsExactlyInAnyOrder("value", "bar");
+    }
+
+    @Test
+    void testStringsContainingDollars() {
         assertThat(parse("foo:bar$")).isEmpty();
         assertThat(parse("foo:bar$ OR foo:$baz")).isEmpty();
         assertThat(parse("foo:bar$ OR foo:$baz$")).containsExactly("baz");
+        assertThat(parse("foo:$bar$ OR foo:$baz")).containsExactly("bar");
         assertThat(parse("foo:bar$ AND baz$:$baz$")).containsExactly("baz");
+        assertThat(parse("foo:$$")).isEmpty();
+        assertThat(parse("foo:$foo$ AND bar:$$")).containsExactly("foo");
+    }
+
+    @Test
+    void testCharacterSpaceOfParameterNames() {
+        assertThat(parse("foo:$some parameter$")).isEmpty();
+        assertThat(parse("foo:$some-parameter$")).isEmpty();
+        assertThat(parse("foo:$some/parameter$")).isEmpty();
+        assertThat(parse("foo:$some42parameter$")).containsExactly("some42parameter");
+        assertThat(parse("foo:$42parameter$")).isEmpty();
+        assertThat(parse("foo:$parameter42$")).containsExactly("parameter42");
+        assertThat(parse("foo:$someparameter$")).containsExactly("someparameter");
+        assertThat(parse("foo:$some_parameter$")).containsExactly("some_parameter");
+        assertThat(parse("foo:$_someparameter$")).containsExactly("_someparameter");
+        assertThat(parse("foo:$_someparameter_$")).containsExactly("_someparameter_");
+        assertThat(parse("foo:$_someparameter_$")).containsExactly("_someparameter_");
+        assertThat(parse("foo:$_$")).containsExactly("_");
+        assertThat(parse("foo:$s$")).containsExactly("s");
+        assertThat(parse("foo:$9$")).isEmpty();
     }
 
     private Set<String> parse(String query) {

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/elasticsearch/QueryStringParserTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/elasticsearch/QueryStringParserTest.java
@@ -1,18 +1,18 @@
-/*
- * Copyright (C) 2020 Graylog, Inc.
+/**
+ * This file is part of Graylog.
  *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the Server Side Public License, version 1,
- * as published by MongoDB, Inc.
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * Graylog is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * Server Side Public License for more details.
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the Server Side Public License
- * along with this program. If not, see
- * <http://www.mongodb.com/licensing/server-side-public-license>.
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
  */
 package org.graylog.plugins.views.search.elasticsearch;
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Before this change, a user could write or generate a query string that contains two `$` characters in unrelated places (e.g. because a field name or value contains it), leading to an undeclared parameter being incorrectly identified. An example for this is a query string of

```
foo:bar$ AND some:$value
```

This PR is fixing the regex used to identify parameters in query strings. The regex is now checking for two `$` enclosing a group of alphanumerical (`a-z`, `A-Z`, `0-9` & `_`) characters instead of a group of _any_ characters. This also matches the description in the frontend, which was already showing this specification although it was not enforced like this in the backend.

Fixes #9497.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.