### PR TITLE
Support relative time range "until" value in date time picker.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/engine/QueryBackend.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/engine/QueryBackend.java
@@ -50,7 +50,7 @@ public interface QueryBackend<T extends GeneratedQueryContext> {
     T generate(SearchJob job, Query query, Set<QueryResult> predecessorResults);
 
     default boolean isAllMessages(TimeRange timeRange) {
-        return timeRange instanceof RelativeRange && ((RelativeRange)timeRange).range() == 0;
+        return timeRange instanceof RelativeRange && ((RelativeRange)timeRange).isAllMessages();
     }
 
     default AbsoluteRange effectiveTimeRangeForResult(Query query, QueryResult queryResult) {

--- a/graylog2-server/src/main/java/org/graylog2/plugin/indexer/searches/timeranges/RelativeRange.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/indexer/searches/timeranges/RelativeRange.java
@@ -18,19 +18,21 @@ package org.graylog2.plugin.indexer.searches.timeranges;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
-import com.google.common.collect.ImmutableMap;
 import org.graylog2.plugin.Tools;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
-import org.joda.time.Seconds;
 
-import java.util.Map;
+import java.util.OptionalInt;
 
 @AutoValue
 @JsonTypeName(RelativeRange.RELATIVE)
+@JsonInclude(JsonInclude.Include.NON_ABSENT)
+@JsonDeserialize(builder = RelativeRange.Builder.class)
 public abstract class RelativeRange extends TimeRange {
 
     public static final String RELATIVE = "relative";
@@ -40,56 +42,97 @@ public abstract class RelativeRange extends TimeRange {
     public abstract String type();
 
     @JsonProperty
-    public abstract int range();
+    public abstract OptionalInt range();
+
+    @JsonProperty
+    public abstract OptionalInt from();
+
+    @JsonProperty
+    public abstract OptionalInt to();
 
     public int getRange() {
-        return range();
+        return range().orElse(0);
     }
 
     @Override
     @JsonIgnore
     public DateTime getFrom() {
         // TODO this should be computed once
-        if (range() > 0) {
-            return Tools.nowUTC().minus(Seconds.seconds(range()));
+        if (range().isPresent()) {
+            final int range = range().getAsInt();
+            return range > 0
+                ? Tools.nowUTC().minusSeconds(range().getAsInt())
+                : new DateTime(0, DateTimeZone.UTC);
         }
-        return new DateTime(0, DateTimeZone.UTC);
+
+        return Tools.nowUTC().minusSeconds(from().orElseThrow(() -> new IllegalStateException("Neither `range` nor `from` specified!")));
     }
 
     @Override
     @JsonIgnore
     public DateTime getTo() {
         // TODO this should be fixed
-        return Tools.nowUTC();
+        if (range().isPresent()) {
+            return Tools.nowUTC();
+        }
+
+        return Tools.nowUTC().minusSeconds(to().orElseThrow(() -> new IllegalStateException("Neither `range` nor `to` specified!")));
     }
 
-    @JsonCreator
-    public static RelativeRange create(@JsonProperty("type") String type, @JsonProperty("range") int range) throws InvalidRangeParametersException {
-        return builder().type(type).checkRange(range).build();
+    @JsonIgnore
+    public boolean isAllMessages() {
+        return range().orElse(-1) == 0;
     }
 
     public static RelativeRange create(int range) throws InvalidRangeParametersException {
-        return create(RELATIVE, range);
-    }
-
-    public static Builder builder() {
-        return new AutoValue_RelativeRange.Builder();
+        return Builder.builder()
+                .range(range)
+                .build();
     }
 
     @AutoValue.Builder
     public abstract static class Builder {
-        public abstract RelativeRange build();
+        abstract RelativeRange autoBuild();
 
+        @JsonProperty("type")
         public abstract Builder type(String type);
 
+        @JsonProperty("range")
         public abstract Builder range(int range);
+        abstract OptionalInt range();
 
-        // TODO replace with custom build()
-        public Builder checkRange(int range) throws InvalidRangeParametersException {
-            if (range < 0) {
-                throw new InvalidRangeParametersException("Range must not be negative");
+        @JsonProperty("from")
+        public abstract Builder from(int from);
+        abstract OptionalInt from();
+
+        @JsonProperty("to")
+        public abstract Builder to(int to);
+        abstract OptionalInt to();
+
+        public RelativeRange build() throws InvalidRangeParametersException {
+            if (range().isPresent() && (from().isPresent() || to().isPresent())) {
+                throw new InvalidRangeParametersException("Either `range` OR `from`/`to` must be specifed, not both!");
             }
-            return range(range);
+
+            if (range().isPresent()) {
+                if (range().getAsInt() < 0) {
+                    throw new InvalidRangeParametersException("Range must not be negative");
+                }
+            }
+
+            if ((from().isPresent() && !to().isPresent()) || (to().isPresent() && !from().isPresent())) {
+                throw new InvalidRangeParametersException("Both `from` and `to` must be specified!");
+            }
+
+            if ((from().isPresent() && to().isPresent()) && (to().getAsInt() > from().getAsInt())) {
+                throw new InvalidRangeParametersException("`from` must be greater than `to`!");
+            }
+            return autoBuild();
+        }
+
+        @JsonCreator
+        public static Builder builder() {
+            return new AutoValue_RelativeRange.Builder().type(RELATIVE);
         }
     }
 

--- a/graylog2-web-interface/src/views/Constants.ts
+++ b/graylog2-web-interface/src/views/Constants.ts
@@ -33,7 +33,8 @@ export const Messages = {
 };
 
 export const DEFAULT_RANGE_TYPE = 'relative';
-export const DEFAULT_TIMERANGE: RelativeTimeRange = { type: DEFAULT_RANGE_TYPE, range: 300 };
+export const DEFAULT_TIMERANGE: RelativeTimeRange = { type: DEFAULT_RANGE_TYPE, range: 300, offset: undefined };
+export const DEFAULT_OFFSET_RANGE: RelativeTimeRange['offset'] = DEFAULT_TIMERANGE.range - 60;
 
 export const DEFAULT_HIGHLIGHT_COLOR = '#ffec3d';
 export const DEFAULT_CUSTOM_HIGHLIGHT_RANGE = chroma.scale(['lightyellow', 'lightgreen', 'lightblue', 'red'])
@@ -50,6 +51,25 @@ export const TimeUnits = {
 };
 
 export type TimeUnit = keyof typeof TimeUnits;
+
+export const RELATIVE_RANGE_TYPES = [
+  {
+    type: 'seconds',
+    label: 'Seconds',
+  }, {
+    type: 'minutes',
+    label: 'Minutes',
+  }, {
+    type: 'hours',
+    label: 'Hours',
+  }, {
+    type: 'days',
+    label: 'Days',
+  }, {
+    type: 'weeks',
+    label: 'Weeks',
+  },
+] as const;
 
 export const viewsPath = '/views';
 export const showViewsPath = `${viewsPath}/:viewId`;

--- a/graylog2-web-interface/src/views/components/TimerangeForForm.ts
+++ b/graylog2-web-interface/src/views/components/TimerangeForForm.ts
@@ -35,6 +35,7 @@ export const onSubmittingTimerange = (timerange: TimeRange): TimeRange => {
       return {
         type: timerange.type,
         range: timerange.range,
+        offset: timerange.offset,
       };
     case 'keyword':
       return timerange;

--- a/graylog2-web-interface/src/views/components/TimerangeForForm.ts
+++ b/graylog2-web-interface/src/views/components/TimerangeForForm.ts
@@ -57,6 +57,7 @@ export const onInitializingTimerange = (timerange: TimeRange): TimeRange => {
       return {
         type: timerange.type,
         range: timerange.range,
+        offset: timerange.offset,
       };
     case 'keyword':
       return timerange;

--- a/graylog2-web-interface/src/views/components/searchbar/SearchBarForm.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/SearchBarForm.tsx
@@ -17,6 +17,7 @@
 import * as React from 'react';
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
+import moment from 'moment';
 import { useCallback } from 'react';
 import { Form, Formik } from 'formik';
 import { isFunction } from 'lodash';
@@ -58,7 +59,11 @@ export const dateTimeValidate = (values) => {
 
   if (nextTimeRange?.type === 'relative') {
     if (!(limitDuration === 0 || (nextTimeRange.range <= limitDuration && limitDuration !== 0))) {
-      errors.nextTimeRange = { range: 'Range is outside limit duration.' };
+      errors.nextTimeRange = { range: `Admin has limited searching to ${moment.duration(-limitDuration, 'seconds').humanize(true)}` };
+    }
+
+    if (nextTimeRange.offset >= nextTimeRange.range) {
+      errors.nextTimeRange = { ...errors.nextTimeRange, offset: 'Range end must be after range start' };
     }
   }
 

--- a/graylog2-web-interface/src/views/components/searchbar/SearchBarForm.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/SearchBarForm.tsx
@@ -37,6 +37,7 @@ export const dateTimeValidate = (values) => {
     from?: string,
     to?: string,
     range?: string,
+    offset?: string
   } } = {};
 
   const { limitDuration, nextTimeRange } = values;

--- a/graylog2-web-interface/src/views/components/searchbar/TimeRangeDisplay.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/TimeRangeDisplay.tsx
@@ -52,8 +52,15 @@ const TimeRangeWrapper = styled.p(({ theme }) => css`
   }
 `);
 
+const readableTimeRange = (range: number, placeholder: string) => {
+  return !range ? placeholder : moment()
+    .subtract(range * 1000)
+    .fromNow();
+};
+
 const dateOutput = (timerange: TimeRange) => {
   let from = EMPTY_RANGE;
+  let until = EMPTY_RANGE;
 
   if (!timerange) {
     return EMPTY_OUTPUT;
@@ -61,13 +68,12 @@ const dateOutput = (timerange: TimeRange) => {
 
   switch (timerange.type) {
     case 'relative':
-      from = !timerange.range ? 'All Time' : moment()
-        .subtract(timerange.range * 1000)
-        .fromNow();
+      from = readableTimeRange(timerange.range, 'All Time');
+      until = readableTimeRange(timerange.offset, 'Now');
 
       return {
         from,
-        until: 'Now',
+        until,
       };
 
     case 'absolute':

--- a/graylog2-web-interface/src/views/components/searchbar/__snapshots__/SearchBarForm.test.tsx.snap
+++ b/graylog2-web-interface/src/views/components/searchbar/__snapshots__/SearchBarForm.test.tsx.snap
@@ -385,18 +385,6 @@ fieldset[disabled] .c3.form-control:not([type="range"]) {
   padding: 0 3px;
 }
 
-.c8 {
-  padding: 0;
-  background: #f3f3f3;
-  font-weight: bold;
-}
-
-.c8:not(:first-child):not(:last-child) {
-  border-right: 0;
-  border-left: 0;
-  padding: 0 3px;
-}
-
 .c10 {
   padding: 0 6px 0 9px;
   width: 50px !important;
@@ -442,6 +430,18 @@ fieldset[disabled] .c10.form-control:not([type="range"]) {
 
 .c10:last-of-type {
   width: 60px !important;
+}
+
+.c8 {
+  padding: 0;
+  background: #f3f3f3;
+  font-weight: bold;
+}
+
+.c8:not(:first-child):not(:last-child) {
+  border-right: 0;
+  border-left: 0;
+  padding: 0 3px;
 }
 
 .c9 {
@@ -729,6 +729,14 @@ fieldset[disabled] .c10.form-control:not([type="range"]) {
   color: rgb(88,73,5);
 }
 
+.c11 {
+  color: #990606;
+  font-size: 0.79rem;
+  font-style: italic;
+  padding: 3px 3px 9px;
+  height: 1.5em;
+}
+
 .c1 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -766,7 +774,7 @@ fieldset[disabled] .c10.form-control:not([type="range"]) {
   padding-bottom: 0;
 }
 
-.c11 {
+.c12 {
   -webkit-flex: 0.75;
   -ms-flex: 0.75;
   flex: 0.75;
@@ -794,537 +802,535 @@ fieldset[disabled] .c10.form-control:not([type="range"]) {
       <div
         class="c2"
       >
-        <div>
-          <div
-            class="form-group"
-          >
-            <span>
+        <div
+          class="form-group"
+        >
+          <span>
+            <span
+              class="input-group"
+            >
+              <input
+                autocomplete="off"
+                class="c3 mousetrap form-control"
+                id="date-input-nextTimeRange[from]"
+                label=""
+                name="nextTimeRange[from]"
+                placeholder="YYYY-MM-DD HH:mm:ss"
+                type="text"
+                value="2020-01-16 10:04:30.329"
+              />
               <span
-                class="input-group"
+                class="input-group-btn"
               >
-                <input
-                  autocomplete="off"
-                  class="c3 form-control"
-                  id="date-input-nextTimeRange[from]"
-                  label=""
-                  name="nextTimeRange[from]"
-                  placeholder="YYYY-MM-DD HH:mm:ss"
-                  type="text"
-                  value="2020-01-16 10:04:30.329"
-                />
-                <span
-                  class="input-group-btn"
+                <button
+                  class="c4 btn btn-default"
+                  title="Insert current date"
+                  type="button"
                 >
-                  <button
-                    class="c4 btn btn-default"
-                    title="Insert current date"
-                    type="button"
-                  >
-                    <svg
-                      class="svg-inline--fa fa-magic"
-                    />
-                  </button>
-                </span>
+                  <svg
+                    class="svg-inline--fa fa-magic"
+                  />
+                </button>
               </span>
             </span>
-          </div>
+          </span>
+        </div>
+        <div
+          class="DayPicker c5"
+          lang="en"
+        >
           <div
-            class="DayPicker c5"
-            lang="en"
+            class="DayPicker-wrapper"
+            tabindex="0"
           >
             <div
-              class="DayPicker-wrapper"
-              tabindex="0"
+              class="DayPicker-NavBar"
+            >
+              <span
+                aria-label="Previous Month"
+                class="DayPicker-NavButton DayPicker-NavButton--prev"
+                role="button"
+                tabindex="0"
+              />
+              <span
+                aria-label="Next Month"
+                class="DayPicker-NavButton DayPicker-NavButton--next"
+                role="button"
+                tabindex="0"
+              />
+            </div>
+            <div
+              class="DayPicker-Months"
             >
               <div
-                class="DayPicker-NavBar"
-              >
-                <span
-                  aria-label="Previous Month"
-                  class="DayPicker-NavButton DayPicker-NavButton--prev"
-                  role="button"
-                  tabindex="0"
-                />
-                <span
-                  aria-label="Next Month"
-                  class="DayPicker-NavButton DayPicker-NavButton--next"
-                  role="button"
-                  tabindex="0"
-                />
-              </div>
-              <div
-                class="DayPicker-Months"
+                class="DayPicker-Month"
+                role="grid"
               >
                 <div
-                  class="DayPicker-Month"
-                  role="grid"
+                  class="DayPicker-Caption"
+                  role="heading"
+                >
+                  <div>
+                    January 2020
+                  </div>
+                </div>
+                <div
+                  class="DayPicker-Weekdays"
+                  role="rowgroup"
                 >
                   <div
-                    class="DayPicker-Caption"
-                    role="heading"
+                    class="DayPicker-WeekdaysRow"
+                    role="row"
                   >
-                    <div>
-                      January 2020
+                    <div
+                      class="DayPicker-Weekday"
+                      role="columnheader"
+                    >
+                      <abbr
+                        title="Sunday"
+                      >
+                        Su
+                      </abbr>
+                    </div>
+                    <div
+                      class="DayPicker-Weekday"
+                      role="columnheader"
+                    >
+                      <abbr
+                        title="Monday"
+                      >
+                        Mo
+                      </abbr>
+                    </div>
+                    <div
+                      class="DayPicker-Weekday"
+                      role="columnheader"
+                    >
+                      <abbr
+                        title="Tuesday"
+                      >
+                        Tu
+                      </abbr>
+                    </div>
+                    <div
+                      class="DayPicker-Weekday"
+                      role="columnheader"
+                    >
+                      <abbr
+                        title="Wednesday"
+                      >
+                        We
+                      </abbr>
+                    </div>
+                    <div
+                      class="DayPicker-Weekday"
+                      role="columnheader"
+                    >
+                      <abbr
+                        title="Thursday"
+                      >
+                        Th
+                      </abbr>
+                    </div>
+                    <div
+                      class="DayPicker-Weekday"
+                      role="columnheader"
+                    >
+                      <abbr
+                        title="Friday"
+                      >
+                        Fr
+                      </abbr>
+                    </div>
+                    <div
+                      class="DayPicker-Weekday"
+                      role="columnheader"
+                    >
+                      <abbr
+                        title="Saturday"
+                      >
+                        Sa
+                      </abbr>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="DayPicker-Body"
+                  role="rowgroup"
+                >
+                  <div
+                    class="DayPicker-Week"
+                    role="row"
+                  >
+                    <div
+                      aria-disabled="true"
+                      aria-label="Sun Dec 29 2019"
+                      aria-selected="false"
+                      class="DayPicker-Day DayPicker-Day--disabled DayPicker-Day--outside"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      29
+                    </div>
+                    <div
+                      aria-disabled="true"
+                      aria-label="Mon Dec 30 2019"
+                      aria-selected="false"
+                      class="DayPicker-Day DayPicker-Day--disabled DayPicker-Day--outside"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      30
+                    </div>
+                    <div
+                      aria-disabled="true"
+                      aria-label="Tue Dec 31 2019"
+                      aria-selected="false"
+                      class="DayPicker-Day DayPicker-Day--disabled DayPicker-Day--outside"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      31
+                    </div>
+                    <div
+                      aria-disabled="true"
+                      aria-label="Wed Jan 01 2020"
+                      aria-selected="false"
+                      class="DayPicker-Day DayPicker-Day--disabled"
+                      role="gridcell"
+                      tabindex="0"
+                    >
+                      1
+                    </div>
+                    <div
+                      aria-disabled="true"
+                      aria-label="Thu Jan 02 2020"
+                      aria-selected="false"
+                      class="DayPicker-Day DayPicker-Day--disabled"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      2
+                    </div>
+                    <div
+                      aria-disabled="true"
+                      aria-label="Fri Jan 03 2020"
+                      aria-selected="false"
+                      class="DayPicker-Day DayPicker-Day--disabled"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      3
+                    </div>
+                    <div
+                      aria-disabled="true"
+                      aria-label="Sat Jan 04 2020"
+                      aria-selected="false"
+                      class="DayPicker-Day DayPicker-Day--disabled"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      4
                     </div>
                   </div>
                   <div
-                    class="DayPicker-Weekdays"
-                    role="rowgroup"
+                    class="DayPicker-Week"
+                    role="row"
                   >
                     <div
-                      class="DayPicker-WeekdaysRow"
-                      role="row"
+                      aria-disabled="true"
+                      aria-label="Sun Jan 05 2020"
+                      aria-selected="false"
+                      class="DayPicker-Day DayPicker-Day--disabled"
+                      role="gridcell"
+                      tabindex="-1"
                     >
-                      <div
-                        class="DayPicker-Weekday"
-                        role="columnheader"
-                      >
-                        <abbr
-                          title="Sunday"
-                        >
-                          Su
-                        </abbr>
-                      </div>
-                      <div
-                        class="DayPicker-Weekday"
-                        role="columnheader"
-                      >
-                        <abbr
-                          title="Monday"
-                        >
-                          Mo
-                        </abbr>
-                      </div>
-                      <div
-                        class="DayPicker-Weekday"
-                        role="columnheader"
-                      >
-                        <abbr
-                          title="Tuesday"
-                        >
-                          Tu
-                        </abbr>
-                      </div>
-                      <div
-                        class="DayPicker-Weekday"
-                        role="columnheader"
-                      >
-                        <abbr
-                          title="Wednesday"
-                        >
-                          We
-                        </abbr>
-                      </div>
-                      <div
-                        class="DayPicker-Weekday"
-                        role="columnheader"
-                      >
-                        <abbr
-                          title="Thursday"
-                        >
-                          Th
-                        </abbr>
-                      </div>
-                      <div
-                        class="DayPicker-Weekday"
-                        role="columnheader"
-                      >
-                        <abbr
-                          title="Friday"
-                        >
-                          Fr
-                        </abbr>
-                      </div>
-                      <div
-                        class="DayPicker-Weekday"
-                        role="columnheader"
-                      >
-                        <abbr
-                          title="Saturday"
-                        >
-                          Sa
-                        </abbr>
-                      </div>
+                      5
+                    </div>
+                    <div
+                      aria-disabled="true"
+                      aria-label="Mon Jan 06 2020"
+                      aria-selected="false"
+                      class="DayPicker-Day DayPicker-Day--disabled"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      6
+                    </div>
+                    <div
+                      aria-disabled="true"
+                      aria-label="Tue Jan 07 2020"
+                      aria-selected="false"
+                      class="DayPicker-Day DayPicker-Day--disabled"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      7
+                    </div>
+                    <div
+                      aria-disabled="true"
+                      aria-label="Wed Jan 08 2020"
+                      aria-selected="false"
+                      class="DayPicker-Day DayPicker-Day--disabled"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      8
+                    </div>
+                    <div
+                      aria-disabled="true"
+                      aria-label="Thu Jan 09 2020"
+                      aria-selected="false"
+                      class="DayPicker-Day DayPicker-Day--disabled"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      9
+                    </div>
+                    <div
+                      aria-disabled="true"
+                      aria-label="Fri Jan 10 2020"
+                      aria-selected="false"
+                      class="DayPicker-Day DayPicker-Day--disabled"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      10
+                    </div>
+                    <div
+                      aria-disabled="true"
+                      aria-label="Sat Jan 11 2020"
+                      aria-selected="false"
+                      class="DayPicker-Day DayPicker-Day--disabled"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      11
                     </div>
                   </div>
                   <div
-                    class="DayPicker-Body"
-                    role="rowgroup"
+                    class="DayPicker-Week"
+                    role="row"
                   >
                     <div
-                      class="DayPicker-Week"
-                      role="row"
+                      aria-disabled="true"
+                      aria-label="Sun Jan 12 2020"
+                      aria-selected="false"
+                      class="DayPicker-Day DayPicker-Day--disabled"
+                      role="gridcell"
+                      tabindex="-1"
                     >
-                      <div
-                        aria-disabled="true"
-                        aria-label="Sun Dec 29 2019"
-                        aria-selected="false"
-                        class="DayPicker-Day DayPicker-Day--outside"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        29
-                      </div>
-                      <div
-                        aria-disabled="true"
-                        aria-label="Mon Dec 30 2019"
-                        aria-selected="false"
-                        class="DayPicker-Day DayPicker-Day--outside"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        30
-                      </div>
-                      <div
-                        aria-disabled="true"
-                        aria-label="Tue Dec 31 2019"
-                        aria-selected="false"
-                        class="DayPicker-Day DayPicker-Day--outside"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        31
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Wed Jan 01 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="0"
-                      >
-                        1
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Thu Jan 02 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        2
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Fri Jan 03 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        3
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Sat Jan 04 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        4
-                      </div>
+                      12
                     </div>
                     <div
-                      class="DayPicker-Week"
-                      role="row"
+                      aria-disabled="true"
+                      aria-label="Mon Jan 13 2020"
+                      aria-selected="false"
+                      class="DayPicker-Day DayPicker-Day--disabled"
+                      role="gridcell"
+                      tabindex="-1"
                     >
-                      <div
-                        aria-disabled="false"
-                        aria-label="Sun Jan 05 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        5
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Mon Jan 06 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        6
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Tue Jan 07 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        7
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Wed Jan 08 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        8
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Thu Jan 09 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        9
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Fri Jan 10 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        10
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Sat Jan 11 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        11
-                      </div>
+                      13
                     </div>
                     <div
-                      class="DayPicker-Week"
-                      role="row"
+                      aria-disabled="true"
+                      aria-label="Tue Jan 14 2020"
+                      aria-selected="false"
+                      class="DayPicker-Day DayPicker-Day--disabled"
+                      role="gridcell"
+                      tabindex="-1"
                     >
-                      <div
-                        aria-disabled="false"
-                        aria-label="Sun Jan 12 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        12
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Mon Jan 13 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        13
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Tue Jan 14 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        14
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Wed Jan 15 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        15
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Thu Jan 16 2020"
-                        aria-selected="true"
-                        class="DayPicker-Day DayPicker-Day--selected"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        16
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Fri Jan 17 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        17
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Sat Jan 18 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        18
-                      </div>
+                      14
                     </div>
                     <div
-                      class="DayPicker-Week"
-                      role="row"
+                      aria-disabled="true"
+                      aria-label="Wed Jan 15 2020"
+                      aria-selected="false"
+                      class="DayPicker-Day DayPicker-Day--disabled"
+                      role="gridcell"
+                      tabindex="-1"
                     >
-                      <div
-                        aria-disabled="false"
-                        aria-label="Sun Jan 19 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        19
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Mon Jan 20 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        20
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Tue Jan 21 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        21
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Wed Jan 22 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        22
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Thu Jan 23 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        23
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Fri Jan 24 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        24
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Sat Jan 25 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        25
-                      </div>
+                      15
                     </div>
                     <div
-                      class="DayPicker-Week"
-                      role="row"
+                      aria-disabled="false"
+                      aria-label="Thu Jan 16 2020"
+                      aria-selected="true"
+                      class="DayPicker-Day DayPicker-Day--selected"
+                      role="gridcell"
+                      tabindex="-1"
                     >
-                      <div
-                        aria-disabled="false"
-                        aria-label="Sun Jan 26 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        26
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Mon Jan 27 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        27
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Tue Jan 28 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        28
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Wed Jan 29 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        29
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Thu Jan 30 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        30
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Fri Jan 31 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        31
-                      </div>
-                      <div
-                        aria-disabled="true"
-                        aria-label="Sat Feb 01 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day DayPicker-Day--outside"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        1
-                      </div>
+                      16
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Fri Jan 17 2020"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      17
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Sat Jan 18 2020"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      18
+                    </div>
+                  </div>
+                  <div
+                    class="DayPicker-Week"
+                    role="row"
+                  >
+                    <div
+                      aria-disabled="false"
+                      aria-label="Sun Jan 19 2020"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      19
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Mon Jan 20 2020"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      20
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Tue Jan 21 2020"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      21
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Wed Jan 22 2020"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      22
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Thu Jan 23 2020"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      23
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Fri Jan 24 2020"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      24
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Sat Jan 25 2020"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      25
+                    </div>
+                  </div>
+                  <div
+                    class="DayPicker-Week"
+                    role="row"
+                  >
+                    <div
+                      aria-disabled="false"
+                      aria-label="Sun Jan 26 2020"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      26
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Mon Jan 27 2020"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      27
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Tue Jan 28 2020"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      28
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Wed Jan 29 2020"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      29
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Thu Jan 30 2020"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      30
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Fri Jan 31 2020"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      31
+                    </div>
+                    <div
+                      aria-disabled="true"
+                      aria-label="Sat Feb 01 2020"
+                      aria-selected="false"
+                      class="DayPicker-Day DayPicker-Day--outside"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      1
                     </div>
                   </div>
                 </div>
@@ -1332,92 +1338,95 @@ fieldset[disabled] .c10.form-control:not([type="range"]) {
             </div>
           </div>
         </div>
-        <div>
+        <div
+          class="c6"
+        >
           <div
-            class="c6"
+            class="form-group"
           >
-            <div
-              class="form-group"
+            <span
+              class="input-group"
             >
               <span
-                class="input-group"
+                class="c7 input-group-addon c8"
               >
-                <span
-                  class="c7 input-group-addon c8"
+                <button
+                  class="c9 btn btn-sm btn-link"
+                  title="Toggle between beginning and end of day"
+                  type="button"
                 >
-                  <button
-                    class="c9 btn btn-sm btn-link"
-                    title="Toggle between beginning and end of day"
-                    type="button"
-                  >
-                    <svg
-                      class="svg-inline--fa fa-hourglass-half"
-                    />
-                  </button>
-                </span>
-                <input
-                  class="c10 form-control input-sm"
-                  id="from-time-hours"
-                  title="from hour"
-                  type="number"
-                  value="10"
-                />
-                <span
-                  class="c7 input-group-addon c8"
-                >
-                  :
-                </span>
-                <input
-                  class="c10 form-control input-sm"
-                  id="from-time-minutes"
-                  title="from minutes"
-                  type="number"
-                  value="04"
-                />
-                <span
-                  class="c7 input-group-addon c8"
-                >
-                  :
-                </span>
-                <input
-                  class="c10 form-control input-sm"
-                  id="from-time-seconds"
-                  title="from seconds"
-                  type="number"
-                  value="30"
-                />
-                <span
-                  class="c7 input-group-addon c8"
-                >
-                  .
-                </span>
-                <input
-                  class="c10 form-control input-sm"
-                  id="from-time-milliseconds"
-                  title="from milliseconds"
-                  type="number"
-                  value="329"
-                />
-                <span
-                  class="c7 input-group-addon c8"
-                >
-                  <button
-                    class="c9 btn btn-sm btn-link"
-                    title="Set to current local time"
-                    type="button"
-                  >
-                    <svg
-                      class="svg-inline--fa fa-magic"
-                    />
-                  </button>
-                </span>
+                  <svg
+                    class="svg-inline--fa fa-hourglass-half"
+                  />
+                </button>
               </span>
-            </div>
+              <input
+                class="c10 form-control input-sm"
+                id="from-time-hours"
+                title="from hour"
+                type="number"
+                value="10"
+              />
+              <span
+                class="c7 input-group-addon c8"
+              >
+                :
+              </span>
+              <input
+                class="c10 form-control input-sm"
+                id="from-time-minutes"
+                title="from minutes"
+                type="number"
+                value="04"
+              />
+              <span
+                class="c7 input-group-addon c8"
+              >
+                :
+              </span>
+              <input
+                class="c10 form-control input-sm"
+                id="from-time-seconds"
+                title="from seconds"
+                type="number"
+                value="30"
+              />
+              <span
+                class="c7 input-group-addon c8"
+              >
+                .
+              </span>
+              <input
+                class="c10 form-control input-sm"
+                id="from-time-milliseconds"
+                title="from milliseconds"
+                type="number"
+                value="329"
+              />
+              <span
+                class="c7 input-group-addon c8"
+              >
+                <button
+                  class="c9 btn btn-sm btn-link"
+                  title="Set to current local time"
+                  type="button"
+                >
+                  <svg
+                    class="svg-inline--fa fa-magic"
+                  />
+                </button>
+              </span>
+            </span>
           </div>
         </div>
+        <span
+          class="c11"
+        >
+           
+        </span>
       </div>
       <div
-        class="c11"
+        class="c12"
       >
         <svg
           class="svg-inline--fa fa-arrow-right"
@@ -1426,537 +1435,535 @@ fieldset[disabled] .c10.form-control:not([type="range"]) {
       <div
         class="c2"
       >
-        <div>
-          <div
-            class="form-group"
-          >
-            <span>
+        <div
+          class="form-group"
+        >
+          <span>
+            <span
+              class="input-group"
+            >
+              <input
+                autocomplete="off"
+                class="c3 mousetrap form-control"
+                id="date-input-nextTimeRange[to]"
+                label=""
+                name="nextTimeRange[to]"
+                placeholder="YYYY-MM-DD HH:mm:ss"
+                type="text"
+                value="2020-01-17 10:04:30.329"
+              />
               <span
-                class="input-group"
+                class="input-group-btn"
               >
-                <input
-                  autocomplete="off"
-                  class="c3 form-control"
-                  id="date-input-nextTimeRange[to]"
-                  label=""
-                  name="nextTimeRange[to]"
-                  placeholder="YYYY-MM-DD HH:mm:ss"
-                  type="text"
-                  value="2020-01-17 10:04:30.329"
-                />
-                <span
-                  class="input-group-btn"
+                <button
+                  class="c4 btn btn-default"
+                  title="Insert current date"
+                  type="button"
                 >
-                  <button
-                    class="c4 btn btn-default"
-                    title="Insert current date"
-                    type="button"
-                  >
-                    <svg
-                      class="svg-inline--fa fa-magic"
-                    />
-                  </button>
-                </span>
+                  <svg
+                    class="svg-inline--fa fa-magic"
+                  />
+                </button>
               </span>
             </span>
-          </div>
+          </span>
+        </div>
+        <div
+          class="DayPicker c5"
+          lang="en"
+        >
           <div
-            class="DayPicker c5"
-            lang="en"
+            class="DayPicker-wrapper"
+            tabindex="0"
           >
             <div
-              class="DayPicker-wrapper"
-              tabindex="0"
+              class="DayPicker-NavBar"
+            >
+              <span
+                aria-label="Previous Month"
+                class="DayPicker-NavButton DayPicker-NavButton--prev"
+                role="button"
+                tabindex="0"
+              />
+              <span
+                aria-label="Next Month"
+                class="DayPicker-NavButton DayPicker-NavButton--next"
+                role="button"
+                tabindex="0"
+              />
+            </div>
+            <div
+              class="DayPicker-Months"
             >
               <div
-                class="DayPicker-NavBar"
-              >
-                <span
-                  aria-label="Previous Month"
-                  class="DayPicker-NavButton DayPicker-NavButton--prev"
-                  role="button"
-                  tabindex="0"
-                />
-                <span
-                  aria-label="Next Month"
-                  class="DayPicker-NavButton DayPicker-NavButton--next"
-                  role="button"
-                  tabindex="0"
-                />
-              </div>
-              <div
-                class="DayPicker-Months"
+                class="DayPicker-Month"
+                role="grid"
               >
                 <div
-                  class="DayPicker-Month"
-                  role="grid"
+                  class="DayPicker-Caption"
+                  role="heading"
+                >
+                  <div>
+                    January 2020
+                  </div>
+                </div>
+                <div
+                  class="DayPicker-Weekdays"
+                  role="rowgroup"
                 >
                   <div
-                    class="DayPicker-Caption"
-                    role="heading"
+                    class="DayPicker-WeekdaysRow"
+                    role="row"
                   >
-                    <div>
-                      January 2020
+                    <div
+                      class="DayPicker-Weekday"
+                      role="columnheader"
+                    >
+                      <abbr
+                        title="Sunday"
+                      >
+                        Su
+                      </abbr>
+                    </div>
+                    <div
+                      class="DayPicker-Weekday"
+                      role="columnheader"
+                    >
+                      <abbr
+                        title="Monday"
+                      >
+                        Mo
+                      </abbr>
+                    </div>
+                    <div
+                      class="DayPicker-Weekday"
+                      role="columnheader"
+                    >
+                      <abbr
+                        title="Tuesday"
+                      >
+                        Tu
+                      </abbr>
+                    </div>
+                    <div
+                      class="DayPicker-Weekday"
+                      role="columnheader"
+                    >
+                      <abbr
+                        title="Wednesday"
+                      >
+                        We
+                      </abbr>
+                    </div>
+                    <div
+                      class="DayPicker-Weekday"
+                      role="columnheader"
+                    >
+                      <abbr
+                        title="Thursday"
+                      >
+                        Th
+                      </abbr>
+                    </div>
+                    <div
+                      class="DayPicker-Weekday"
+                      role="columnheader"
+                    >
+                      <abbr
+                        title="Friday"
+                      >
+                        Fr
+                      </abbr>
+                    </div>
+                    <div
+                      class="DayPicker-Weekday"
+                      role="columnheader"
+                    >
+                      <abbr
+                        title="Saturday"
+                      >
+                        Sa
+                      </abbr>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="DayPicker-Body"
+                  role="rowgroup"
+                >
+                  <div
+                    class="DayPicker-Week"
+                    role="row"
+                  >
+                    <div
+                      aria-disabled="true"
+                      aria-label="Sun Dec 29 2019"
+                      aria-selected="false"
+                      class="DayPicker-Day DayPicker-Day--disabled DayPicker-Day--outside"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      29
+                    </div>
+                    <div
+                      aria-disabled="true"
+                      aria-label="Mon Dec 30 2019"
+                      aria-selected="false"
+                      class="DayPicker-Day DayPicker-Day--disabled DayPicker-Day--outside"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      30
+                    </div>
+                    <div
+                      aria-disabled="true"
+                      aria-label="Tue Dec 31 2019"
+                      aria-selected="false"
+                      class="DayPicker-Day DayPicker-Day--disabled DayPicker-Day--outside"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      31
+                    </div>
+                    <div
+                      aria-disabled="true"
+                      aria-label="Wed Jan 01 2020"
+                      aria-selected="false"
+                      class="DayPicker-Day DayPicker-Day--disabled"
+                      role="gridcell"
+                      tabindex="0"
+                    >
+                      1
+                    </div>
+                    <div
+                      aria-disabled="true"
+                      aria-label="Thu Jan 02 2020"
+                      aria-selected="false"
+                      class="DayPicker-Day DayPicker-Day--disabled"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      2
+                    </div>
+                    <div
+                      aria-disabled="true"
+                      aria-label="Fri Jan 03 2020"
+                      aria-selected="false"
+                      class="DayPicker-Day DayPicker-Day--disabled"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      3
+                    </div>
+                    <div
+                      aria-disabled="true"
+                      aria-label="Sat Jan 04 2020"
+                      aria-selected="false"
+                      class="DayPicker-Day DayPicker-Day--disabled"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      4
                     </div>
                   </div>
                   <div
-                    class="DayPicker-Weekdays"
-                    role="rowgroup"
+                    class="DayPicker-Week"
+                    role="row"
                   >
                     <div
-                      class="DayPicker-WeekdaysRow"
-                      role="row"
+                      aria-disabled="true"
+                      aria-label="Sun Jan 05 2020"
+                      aria-selected="false"
+                      class="DayPicker-Day DayPicker-Day--disabled"
+                      role="gridcell"
+                      tabindex="-1"
                     >
-                      <div
-                        class="DayPicker-Weekday"
-                        role="columnheader"
-                      >
-                        <abbr
-                          title="Sunday"
-                        >
-                          Su
-                        </abbr>
-                      </div>
-                      <div
-                        class="DayPicker-Weekday"
-                        role="columnheader"
-                      >
-                        <abbr
-                          title="Monday"
-                        >
-                          Mo
-                        </abbr>
-                      </div>
-                      <div
-                        class="DayPicker-Weekday"
-                        role="columnheader"
-                      >
-                        <abbr
-                          title="Tuesday"
-                        >
-                          Tu
-                        </abbr>
-                      </div>
-                      <div
-                        class="DayPicker-Weekday"
-                        role="columnheader"
-                      >
-                        <abbr
-                          title="Wednesday"
-                        >
-                          We
-                        </abbr>
-                      </div>
-                      <div
-                        class="DayPicker-Weekday"
-                        role="columnheader"
-                      >
-                        <abbr
-                          title="Thursday"
-                        >
-                          Th
-                        </abbr>
-                      </div>
-                      <div
-                        class="DayPicker-Weekday"
-                        role="columnheader"
-                      >
-                        <abbr
-                          title="Friday"
-                        >
-                          Fr
-                        </abbr>
-                      </div>
-                      <div
-                        class="DayPicker-Weekday"
-                        role="columnheader"
-                      >
-                        <abbr
-                          title="Saturday"
-                        >
-                          Sa
-                        </abbr>
-                      </div>
+                      5
+                    </div>
+                    <div
+                      aria-disabled="true"
+                      aria-label="Mon Jan 06 2020"
+                      aria-selected="false"
+                      class="DayPicker-Day DayPicker-Day--disabled"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      6
+                    </div>
+                    <div
+                      aria-disabled="true"
+                      aria-label="Tue Jan 07 2020"
+                      aria-selected="false"
+                      class="DayPicker-Day DayPicker-Day--disabled"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      7
+                    </div>
+                    <div
+                      aria-disabled="true"
+                      aria-label="Wed Jan 08 2020"
+                      aria-selected="false"
+                      class="DayPicker-Day DayPicker-Day--disabled"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      8
+                    </div>
+                    <div
+                      aria-disabled="true"
+                      aria-label="Thu Jan 09 2020"
+                      aria-selected="false"
+                      class="DayPicker-Day DayPicker-Day--disabled"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      9
+                    </div>
+                    <div
+                      aria-disabled="true"
+                      aria-label="Fri Jan 10 2020"
+                      aria-selected="false"
+                      class="DayPicker-Day DayPicker-Day--disabled"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      10
+                    </div>
+                    <div
+                      aria-disabled="true"
+                      aria-label="Sat Jan 11 2020"
+                      aria-selected="false"
+                      class="DayPicker-Day DayPicker-Day--disabled"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      11
                     </div>
                   </div>
                   <div
-                    class="DayPicker-Body"
-                    role="rowgroup"
+                    class="DayPicker-Week"
+                    role="row"
                   >
                     <div
-                      class="DayPicker-Week"
-                      role="row"
+                      aria-disabled="true"
+                      aria-label="Sun Jan 12 2020"
+                      aria-selected="false"
+                      class="DayPicker-Day DayPicker-Day--disabled"
+                      role="gridcell"
+                      tabindex="-1"
                     >
-                      <div
-                        aria-disabled="true"
-                        aria-label="Sun Dec 29 2019"
-                        aria-selected="false"
-                        class="DayPicker-Day DayPicker-Day--disabled DayPicker-Day--outside"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        29
-                      </div>
-                      <div
-                        aria-disabled="true"
-                        aria-label="Mon Dec 30 2019"
-                        aria-selected="false"
-                        class="DayPicker-Day DayPicker-Day--disabled DayPicker-Day--outside"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        30
-                      </div>
-                      <div
-                        aria-disabled="true"
-                        aria-label="Tue Dec 31 2019"
-                        aria-selected="false"
-                        class="DayPicker-Day DayPicker-Day--disabled DayPicker-Day--outside"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        31
-                      </div>
-                      <div
-                        aria-disabled="true"
-                        aria-label="Wed Jan 01 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day DayPicker-Day--disabled"
-                        role="gridcell"
-                        tabindex="0"
-                      >
-                        1
-                      </div>
-                      <div
-                        aria-disabled="true"
-                        aria-label="Thu Jan 02 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day DayPicker-Day--disabled"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        2
-                      </div>
-                      <div
-                        aria-disabled="true"
-                        aria-label="Fri Jan 03 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day DayPicker-Day--disabled"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        3
-                      </div>
-                      <div
-                        aria-disabled="true"
-                        aria-label="Sat Jan 04 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day DayPicker-Day--disabled"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        4
-                      </div>
+                      12
                     </div>
                     <div
-                      class="DayPicker-Week"
-                      role="row"
+                      aria-disabled="true"
+                      aria-label="Mon Jan 13 2020"
+                      aria-selected="false"
+                      class="DayPicker-Day DayPicker-Day--disabled"
+                      role="gridcell"
+                      tabindex="-1"
                     >
-                      <div
-                        aria-disabled="true"
-                        aria-label="Sun Jan 05 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day DayPicker-Day--disabled"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        5
-                      </div>
-                      <div
-                        aria-disabled="true"
-                        aria-label="Mon Jan 06 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day DayPicker-Day--disabled"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        6
-                      </div>
-                      <div
-                        aria-disabled="true"
-                        aria-label="Tue Jan 07 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day DayPicker-Day--disabled"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        7
-                      </div>
-                      <div
-                        aria-disabled="true"
-                        aria-label="Wed Jan 08 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day DayPicker-Day--disabled"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        8
-                      </div>
-                      <div
-                        aria-disabled="true"
-                        aria-label="Thu Jan 09 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day DayPicker-Day--disabled"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        9
-                      </div>
-                      <div
-                        aria-disabled="true"
-                        aria-label="Fri Jan 10 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day DayPicker-Day--disabled"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        10
-                      </div>
-                      <div
-                        aria-disabled="true"
-                        aria-label="Sat Jan 11 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day DayPicker-Day--disabled"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        11
-                      </div>
+                      13
                     </div>
                     <div
-                      class="DayPicker-Week"
-                      role="row"
+                      aria-disabled="true"
+                      aria-label="Tue Jan 14 2020"
+                      aria-selected="false"
+                      class="DayPicker-Day DayPicker-Day--disabled"
+                      role="gridcell"
+                      tabindex="-1"
                     >
-                      <div
-                        aria-disabled="true"
-                        aria-label="Sun Jan 12 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day DayPicker-Day--disabled"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        12
-                      </div>
-                      <div
-                        aria-disabled="true"
-                        aria-label="Mon Jan 13 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day DayPicker-Day--disabled"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        13
-                      </div>
-                      <div
-                        aria-disabled="true"
-                        aria-label="Tue Jan 14 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day DayPicker-Day--disabled"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        14
-                      </div>
-                      <div
-                        aria-disabled="true"
-                        aria-label="Wed Jan 15 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day DayPicker-Day--disabled"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        15
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Thu Jan 16 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        16
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Fri Jan 17 2020"
-                        aria-selected="true"
-                        class="DayPicker-Day DayPicker-Day--selected"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        17
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Sat Jan 18 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        18
-                      </div>
+                      14
                     </div>
                     <div
-                      class="DayPicker-Week"
-                      role="row"
+                      aria-disabled="true"
+                      aria-label="Wed Jan 15 2020"
+                      aria-selected="false"
+                      class="DayPicker-Day DayPicker-Day--disabled"
+                      role="gridcell"
+                      tabindex="-1"
                     >
-                      <div
-                        aria-disabled="false"
-                        aria-label="Sun Jan 19 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        19
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Mon Jan 20 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        20
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Tue Jan 21 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        21
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Wed Jan 22 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        22
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Thu Jan 23 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        23
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Fri Jan 24 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        24
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Sat Jan 25 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        25
-                      </div>
+                      15
                     </div>
                     <div
-                      class="DayPicker-Week"
-                      role="row"
+                      aria-disabled="false"
+                      aria-label="Thu Jan 16 2020"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
                     >
-                      <div
-                        aria-disabled="false"
-                        aria-label="Sun Jan 26 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        26
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Mon Jan 27 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        27
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Tue Jan 28 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        28
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Wed Jan 29 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        29
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Thu Jan 30 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        30
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Fri Jan 31 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        31
-                      </div>
-                      <div
-                        aria-disabled="true"
-                        aria-label="Sat Feb 01 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day DayPicker-Day--outside"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        1
-                      </div>
+                      16
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Fri Jan 17 2020"
+                      aria-selected="true"
+                      class="DayPicker-Day DayPicker-Day--selected"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      17
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Sat Jan 18 2020"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      18
+                    </div>
+                  </div>
+                  <div
+                    class="DayPicker-Week"
+                    role="row"
+                  >
+                    <div
+                      aria-disabled="false"
+                      aria-label="Sun Jan 19 2020"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      19
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Mon Jan 20 2020"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      20
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Tue Jan 21 2020"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      21
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Wed Jan 22 2020"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      22
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Thu Jan 23 2020"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      23
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Fri Jan 24 2020"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      24
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Sat Jan 25 2020"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      25
+                    </div>
+                  </div>
+                  <div
+                    class="DayPicker-Week"
+                    role="row"
+                  >
+                    <div
+                      aria-disabled="false"
+                      aria-label="Sun Jan 26 2020"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      26
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Mon Jan 27 2020"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      27
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Tue Jan 28 2020"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      28
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Wed Jan 29 2020"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      29
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Thu Jan 30 2020"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      30
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Fri Jan 31 2020"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      31
+                    </div>
+                    <div
+                      aria-disabled="true"
+                      aria-label="Sat Feb 01 2020"
+                      aria-selected="false"
+                      class="DayPicker-Day DayPicker-Day--outside"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      1
                     </div>
                   </div>
                 </div>
@@ -1964,89 +1971,92 @@ fieldset[disabled] .c10.form-control:not([type="range"]) {
             </div>
           </div>
         </div>
-        <div>
+        <div
+          class="c6"
+        >
           <div
-            class="c6"
+            class="form-group"
           >
-            <div
-              class="form-group"
+            <span
+              class="input-group"
             >
               <span
-                class="input-group"
+                class="c7 input-group-addon c8"
               >
-                <span
-                  class="c7 input-group-addon c8"
+                <button
+                  class="c9 btn btn-sm btn-link"
+                  title="Toggle between beginning and end of day"
+                  type="button"
                 >
-                  <button
-                    class="c9 btn btn-sm btn-link"
-                    title="Toggle between beginning and end of day"
-                    type="button"
-                  >
-                    <svg
-                      class="svg-inline--fa fa-hourglass-half"
-                    />
-                  </button>
-                </span>
-                <input
-                  class="c10 form-control input-sm"
-                  id="to-time-hours"
-                  title="to hour"
-                  type="number"
-                  value="10"
-                />
-                <span
-                  class="c7 input-group-addon c8"
-                >
-                  :
-                </span>
-                <input
-                  class="c10 form-control input-sm"
-                  id="to-time-minutes"
-                  title="to minutes"
-                  type="number"
-                  value="04"
-                />
-                <span
-                  class="c7 input-group-addon c8"
-                >
-                  :
-                </span>
-                <input
-                  class="c10 form-control input-sm"
-                  id="to-time-seconds"
-                  title="to seconds"
-                  type="number"
-                  value="30"
-                />
-                <span
-                  class="c7 input-group-addon c8"
-                >
-                  .
-                </span>
-                <input
-                  class="c10 form-control input-sm"
-                  id="to-time-milliseconds"
-                  title="to milliseconds"
-                  type="number"
-                  value="329"
-                />
-                <span
-                  class="c7 input-group-addon c8"
-                >
-                  <button
-                    class="c9 btn btn-sm btn-link"
-                    title="Set to current local time"
-                    type="button"
-                  >
-                    <svg
-                      class="svg-inline--fa fa-magic"
-                    />
-                  </button>
-                </span>
+                  <svg
+                    class="svg-inline--fa fa-hourglass-half"
+                  />
+                </button>
               </span>
-            </div>
+              <input
+                class="c10 form-control input-sm"
+                id="to-time-hours"
+                title="to hour"
+                type="number"
+                value="10"
+              />
+              <span
+                class="c7 input-group-addon c8"
+              >
+                :
+              </span>
+              <input
+                class="c10 form-control input-sm"
+                id="to-time-minutes"
+                title="to minutes"
+                type="number"
+                value="04"
+              />
+              <span
+                class="c7 input-group-addon c8"
+              >
+                :
+              </span>
+              <input
+                class="c10 form-control input-sm"
+                id="to-time-seconds"
+                title="to seconds"
+                type="number"
+                value="30"
+              />
+              <span
+                class="c7 input-group-addon c8"
+              >
+                .
+              </span>
+              <input
+                class="c10 form-control input-sm"
+                id="to-time-milliseconds"
+                title="to milliseconds"
+                type="number"
+                value="329"
+              />
+              <span
+                class="c7 input-group-addon c8"
+              >
+                <button
+                  class="c9 btn btn-sm btn-link"
+                  title="Set to current local time"
+                  type="button"
+                >
+                  <svg
+                    class="svg-inline--fa fa-magic"
+                  />
+                </button>
+              </span>
+            </span>
           </div>
         </div>
+        <span
+          class="c11"
+        >
+           
+        </span>
       </div>
     </div>
   </form>

--- a/graylog2-web-interface/src/views/components/searchbar/date-time-picker/RelativeTimeRangeField.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/date-time-picker/RelativeTimeRangeField.tsx
@@ -82,7 +82,8 @@ type Props = {
   disabled: boolean,
   name: string,
   originalTimeRange: TimeRange,
-  title: string
+  title: string,
+  valueInputTitle: string,
 }
 
 const RelativeTimeRangeField = ({
@@ -94,6 +95,7 @@ const RelativeTimeRangeField = ({
   name,
   originalTimeRange,
   title,
+  valueInputTitle,
 }: Props) => {
   return (
     <Field name={name}>
@@ -147,13 +149,13 @@ const RelativeTimeRangeField = ({
             </RangeCheck>
             <InputWrap>
               <Input id={`${name}-value`}
-                     name={`${name}-from-value`}
+                     name={`${name}-value`}
                      disabled={disabled || fromValue.rangeAllTime}
                      type="number"
                      min="1"
                      value={fromValue.rangeValue}
                      className="mousetrap"
-                     title="Set the range value"
+                     title={valueInputTitle}
                      onChange={_onChangeTime}
                      bsStyle={error ? 'error' : null} />
             </InputWrap>

--- a/graylog2-web-interface/src/views/components/searchbar/date-time-picker/RelativeTimeRangeField.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/date-time-picker/RelativeTimeRangeField.tsx
@@ -1,0 +1,183 @@
+import * as React from 'react';
+import { Field } from 'formik';
+import styled, { css } from 'styled-components';
+import moment from 'moment';
+import { RelativeTimeRange, TimeRange } from 'src/views/logic/queries/Query';
+
+import Input from 'components/bootstrap/Input';
+import { Select } from 'components/common';
+import { RELATIVE_RANGE_TYPES } from 'views/Constants';
+
+const RangeWrapper = styled.div`
+  flex: 4;
+  align-items: center;
+  display: grid;
+  grid-template-columns: max-content repeat(5, 1fr) max-content;
+  grid-template-rows: repeat(2, 1fr) minmax(1.5em, auto);
+  grid-column-gap: 0;
+  grid-row-gap: 0;
+`;
+
+const InputWrap = styled.div`
+  grid-area: 2 / 1 / 3 / 3;
+  position: relative;
+  
+  .form-group {
+    margin: 0;
+  }
+`;
+
+const StyledSelect = styled(Select)`
+  grid-area: 2 / 3 / 3 / 7;
+  margin: 0 12px;
+`;
+
+const RangeTitle = styled.h3`
+  grid-area: 1 / 1 / 2 / 2;
+`;
+
+const Ago = styled.span(({ theme }) => css`
+  grid-area: 2 / 7 / 3 / 8;
+  font-size: ${theme.fonts.size.large};
+
+  ::after {
+    content: 'ago';
+  }
+`);
+
+const RangeCheck = styled.label(({ theme }) => css`
+  font-size: ${theme.fonts.size.small};
+  grid-area: 1 / 2 / 2 / 8;
+  margin-left: 15px;
+  font-weight: normal;
+  align-self: self-end;
+  
+  &.shortened {
+    grid-area: 1 / 2 / 2 / 4;
+    text-decoration: line-through;
+    cursor: not-allowed;
+  }
+  
+  input {
+    margin-right: 6px;
+  }
+`);
+
+const ErrorMessage = styled.span(({ theme }) => css`
+  color: ${theme.colors.variant.dark.danger};
+  grid-area: 3 / 1 / 3 / 8;
+  font-size: ${theme.fonts.size.tiny};
+  font-style: italic;
+  padding: 3px;
+`);
+
+type Props = {
+  availableRangeTypes: Array<{
+    label: 'Seconds' | 'Minutes' | 'Hours' | 'Days' | 'Weeks';
+    value: 'seconds' | 'minutes' | 'hours' | 'days' | 'weeks';
+  }>,
+  unsetRangeLabel: string,
+  defaultRange: RelativeTimeRange['range'],
+  disabled: boolean,
+  limitDuration: number,
+  name: string,
+  originalTimeRange: TimeRange,
+  title: string
+}
+
+const RelativeTimeRangeField = ({
+  availableRangeTypes,
+  unsetRangeLabel,
+  defaultRange,
+  disabled,
+  limitDuration,
+  name,
+  originalTimeRange,
+  title,
+}: Props) => {
+  return (
+    <Field name={name}>
+      {({ field: { value, onChange }, meta: { error } }) => {
+        const fromValue = RELATIVE_RANGE_TYPES.map(({ type }) => {
+          const isNotSpecified = value === 0 || value === undefined;
+          const diff = moment.duration(value, 'seconds').as(type);
+
+          if (diff - Math.floor(diff) === 0) {
+            return {
+              ...originalTimeRange,
+              rangeValue: diff || 0,
+              rangeType: isNotSpecified ? 'seconds' : type,
+              rangeAllTime: isNotSpecified,
+              range: value,
+            };
+          }
+
+          return null;
+        }).filter(Boolean).pop();
+
+        const _onChange = (nextValue) => onChange({ target: { name, value: nextValue } });
+
+        const _onChangeTime = (event) => {
+          const newTimeValue = moment.duration(event.target.value || 1, fromValue.rangeType).asSeconds();
+
+          _onChange(newTimeValue);
+        };
+
+        const _onChangeType = (type) => {
+          const newTimeValue = moment.duration(fromValue.rangeValue, type).asSeconds();
+
+          _onChange(newTimeValue);
+        };
+
+        const _onCheckAllTime = (event) => {
+          _onChange(event.target.checked ? 0 : defaultRange);
+        };
+
+        return (
+          <RangeWrapper>
+            <RangeTitle>{title}</RangeTitle>
+            <RangeCheck htmlFor={`${name}-not-a-range`} className={limitDuration !== 0 && 'shortened'}>
+              <input type="checkbox"
+                     id={`${name}-not-a-range`}
+                     value="0"
+                     className="mousetrap"
+                     checked={fromValue.rangeAllTime}
+                     onChange={_onCheckAllTime}
+                     disabled={limitDuration !== 0} />{unsetRangeLabel}
+            </RangeCheck>
+            <InputWrap>
+              <Input id={`${name}-value`}
+                     name={`${name}-from-value`}
+                     disabled={disabled || fromValue.rangeAllTime}
+                     type="number"
+                     min="1"
+                     value={fromValue.rangeValue}
+                     className="mousetrap"
+                     title="Set the range value"
+                     onChange={_onChangeTime}
+                     bsStyle={error ? 'error' : null} />
+            </InputWrap>
+            <StyledSelect id={`${name}-length`}
+                          name={`${name}-length`}
+                          disabled={disabled || fromValue.rangeAllTime}
+                          value={fromValue.rangeType}
+                          options={availableRangeTypes}
+                          inputProps={{ className: 'mousetrap' }}
+                          placeholder="Select a range length"
+                          onChange={_onChangeType}
+                          clearable={false} />
+
+            <Ago />
+            {error && (
+              <ErrorMessage>
+                Admin has limited searching to {moment.duration(-limitDuration, 'seconds').humanize(true)}
+              </ErrorMessage>
+            )}
+          </RangeWrapper>
+        );
+      }}
+    </Field>
+  );
+};
+
+export default RelativeTimeRangeField;

--- a/graylog2-web-interface/src/views/components/searchbar/date-time-picker/RelativeTimeRangeField.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/date-time-picker/RelativeTimeRangeField.tsx
@@ -76,10 +76,10 @@ type Props = {
     label: 'Seconds' | 'Minutes' | 'Hours' | 'Days' | 'Weeks';
     value: 'seconds' | 'minutes' | 'hours' | 'days' | 'weeks';
   }>,
+  disableUnsetRange?: boolean,
   unsetRangeLabel: string,
   defaultRange: RelativeTimeRange['range'],
   disabled: boolean,
-  limitDuration: number,
   name: string,
   originalTimeRange: TimeRange,
   title: string
@@ -87,10 +87,10 @@ type Props = {
 
 const RelativeTimeRangeField = ({
   availableRangeTypes,
+  disableUnsetRange,
   unsetRangeLabel,
   defaultRange,
   disabled,
-  limitDuration,
   name,
   originalTimeRange,
   title,
@@ -136,14 +136,14 @@ const RelativeTimeRangeField = ({
         return (
           <RangeWrapper>
             <RangeTitle>{title}</RangeTitle>
-            <RangeCheck htmlFor={`${name}-not-a-range`} className={limitDuration !== 0 && 'shortened'}>
+            <RangeCheck htmlFor={`${name}-not-a-range`} className={disableUnsetRange && 'shortened'}>
               <input type="checkbox"
                      id={`${name}-not-a-range`}
                      value="0"
                      className="mousetrap"
                      checked={fromValue.rangeAllTime}
                      onChange={_onCheckAllTime}
-                     disabled={limitDuration !== 0} />{unsetRangeLabel}
+                     disabled={disableUnsetRange} />{unsetRangeLabel}
             </RangeCheck>
             <InputWrap>
               <Input id={`${name}-value`}
@@ -170,7 +170,7 @@ const RelativeTimeRangeField = ({
             <Ago />
             {error && (
               <ErrorMessage>
-                Admin has limited searching to {moment.duration(-limitDuration, 'seconds').humanize(true)}
+                {error}
               </ErrorMessage>
             )}
           </RangeWrapper>
@@ -178,6 +178,10 @@ const RelativeTimeRangeField = ({
       }}
     </Field>
   );
+};
+
+RelativeTimeRangeField.defaultProps = {
+  disableUnsetRange: false,
 };
 
 export default RelativeTimeRangeField;

--- a/graylog2-web-interface/src/views/components/searchbar/date-time-picker/RelativeTimeRangeSelector.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/date-time-picker/RelativeTimeRangeSelector.test.tsx
@@ -18,6 +18,8 @@ import React from 'react';
 import { fireEvent, render, screen } from 'wrappedTestingLibrary';
 import { Formik, Form } from 'formik';
 
+import type { TimeRange } from 'views/logic/queries/Query';
+
 import OriginalRelativeTimeRangeSelector from './RelativeTimeRangeSelector';
 
 const defaultProps = {
@@ -27,7 +29,7 @@ const defaultProps = {
     type: 'relative',
     range: 3600,
   },
-};
+} as const;
 
 const initialValues = {
   nextTimeRange: defaultProps.originalTimeRange,
@@ -36,9 +38,7 @@ const initialValues = {
 type Props = {
   disabled: boolean,
   limitDuration: number,
-  originalTimeRange: {
-    range: string | number,
-  },
+  originalTimeRange: TimeRange,
 };
 
 const RelativeTimeRangeSelector = (allProps: Props) => (

--- a/graylog2-web-interface/src/views/components/searchbar/date-time-picker/RelativeTimeRangeSelector.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/date-time-picker/RelativeTimeRangeSelector.test.tsx
@@ -55,7 +55,7 @@ describe('RelativeTimeRangeSelector', () => {
   it('renders originalTimeRange value', () => {
     render(<RelativeTimeRangeSelector {...defaultProps} />);
 
-    const spinbutton = screen.getByRole('spinbutton', { name: /set the range value/i });
+    const spinbutton = screen.getByRole('spinbutton', { name: /set the range start value/i });
 
     expect(spinbutton).toBeInTheDocument();
     expect(spinbutton).toHaveValue(1);
@@ -71,7 +71,7 @@ describe('RelativeTimeRangeSelector', () => {
     render(<RelativeTimeRangeSelector {...defaultProps} />);
 
     const allTimeCheckbox = screen.getByRole('checkbox', { name: /All Time/i });
-    const rangeValue = screen.getByRole('spinbutton', { name: /set the range value/i });
+    const rangeValue = screen.getByRole('spinbutton', { name: /set the range start value/i });
 
     expect(rangeValue).not.toBeDisabled();
 

--- a/graylog2-web-interface/src/views/components/searchbar/date-time-picker/RelativeTimeRangeSelector.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/date-time-picker/RelativeTimeRangeSelector.tsx
@@ -79,9 +79,10 @@ const RelativeTimeRangeSelector = ({ disabled, originalTimeRange, limitDuration 
                               availableRangeTypes={availableRangeTypes}
                               disabled={disabled}
                               disableUnsetRange={limitDuration !== 0}
-                              unsetRangeLabel="All Time"
                               defaultRange={defaultRange}
-                              title="From:" />
+                              unsetRangeLabel="All Time"
+                              title="From:"
+                              valueInputTitle="Set the range start value" />
 
       <StyledIcon name="arrow-right" />
 
@@ -91,7 +92,8 @@ const RelativeTimeRangeSelector = ({ disabled, originalTimeRange, limitDuration 
                               defaultRange={defaultOffset}
                               disabled={disabled}
                               unsetRangeLabel="Now"
-                              title="Until:" />
+                              title="Until:"
+                              valueInputTitle="Set the range end value" />
     </RelativeWrapper>
   );
 };

--- a/graylog2-web-interface/src/views/components/searchbar/date-time-picker/RelativeTimeRangeSelector.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/date-time-picker/RelativeTimeRangeSelector.tsx
@@ -100,9 +100,6 @@ const RelativeTimeRangeSelector = ({ disabled, originalTimeRange, limitDuration 
 RelativeTimeRangeSelector.propTypes = {
   limitDuration: PropTypes.number,
   disabled: PropTypes.bool,
-  originalTimeRange: PropTypes.shape({
-    range: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  }).isRequired,
 };
 
 RelativeTimeRangeSelector.defaultProps = {

--- a/graylog2-web-interface/src/views/components/searchbar/date-time-picker/RelativeTimeRangeSelector.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/date-time-picker/RelativeTimeRangeSelector.tsx
@@ -78,8 +78,8 @@ const RelativeTimeRangeSelector = ({ disabled, originalTimeRange, limitDuration 
                               name="nextTimeRange.range"
                               availableRangeTypes={availableRangeTypes}
                               disabled={disabled}
+                              disableUnsetRange={limitDuration !== 0}
                               unsetRangeLabel="All Time"
-                              limitDuration={limitDuration}
                               defaultRange={defaultRange}
                               title="From:" />
 
@@ -91,7 +91,6 @@ const RelativeTimeRangeSelector = ({ disabled, originalTimeRange, limitDuration 
                               defaultRange={defaultOffset}
                               disabled={disabled}
                               unsetRangeLabel="Now"
-                              limitDuration={limitDuration}
                               title="Until:" />
     </RelativeWrapper>
   );

--- a/graylog2-web-interface/src/views/components/searchbar/date-time-picker/RelativeTimeRangeSelector.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/date-time-picker/RelativeTimeRangeSelector.tsx
@@ -17,39 +17,19 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment';
-import { Field } from 'formik';
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
+import { TimeRange } from 'src/views/logic/queries/Query';
 
-import Input from 'components/bootstrap/Input';
-import { Icon, Select } from 'components/common';
-import { DEFAULT_TIMERANGE } from 'views/Constants';
+import { RELATIVE_RANGE_TYPES, DEFAULT_TIMERANGE, DEFAULT_OFFSET_RANGE } from 'views/Constants';
+import { Icon } from 'components/common';
+
+import RelativeTimeRangeField from './RelativeTimeRangeField';
 
 type Props = {
   disabled: boolean,
-  originalTimeRange: {
-    range: string | number,
-  },
+  originalTimeRange: TimeRange,
   limitDuration: number,
 };
-
-const RANGE_TYPES = [
-  {
-    type: 'seconds',
-    label: 'Seconds',
-  }, {
-    type: 'minutes',
-    label: 'Minutes',
-  }, {
-    type: 'hours',
-    label: 'Hours',
-  }, {
-    type: 'days',
-    label: 'Days',
-  }, {
-    type: 'weeks',
-    label: 'Weeks',
-  },
-] as const;
 
 const RelativeWrapper = styled.div`
   display: flex;
@@ -57,74 +37,11 @@ const RelativeWrapper = styled.div`
   justify-content: space-around;
 `;
 
-const RangeWrapper = styled.div`
-  flex: 4;
-  align-items: center;
-  display: grid;
-  grid-template-columns: max-content repeat(5, 1fr) max-content;
-  grid-template-rows: repeat(2, 1fr) minmax(1.5em, auto);
-  grid-column-gap: 0;
-  grid-row-gap: 0;
-`;
-
-const InputWrap = styled.div`
-  grid-area: 2 / 1 / 3 / 3;
-  position: relative;
-  
-  .form-group {
-    margin: 0;
-  }
-`;
-
-const StyledSelect = styled(Select)`
-  grid-area: 2 / 3 / 3 / 7;
-  margin: 0 12px;
-`;
-
 const StyledIcon = styled(Icon)`
   flex: 0.75;
 `;
 
-const RangeTitle = styled.h3`
-  grid-area: 1 / 1 / 2 / 2;
-`;
-
-const Ago = styled.span(({ theme }) => css`
-  grid-area: 2 / 7 / 3 / 8;
-  font-size: ${theme.fonts.size.large};
-
-  ::after {
-    content: 'ago';
-  }
-`);
-
-const RangeCheck = styled.label(({ theme }) => css`
-  font-size: ${theme.fonts.size.small};
-  grid-area: 1 / 2 / 2 / 8;
-  margin-left: 15px;
-  font-weight: normal;
-  align-self: self-end;
-  
-  &.shortened {
-    grid-area: 1 / 2 / 2 / 4;
-    text-decoration: line-through;
-    cursor: not-allowed;
-  }
-  
-  input {
-    margin-right: 6px;
-  }
-`);
-
-const ErrorMessage = styled.span(({ theme }) => css`
-  color: ${theme.colors.variant.dark.danger};
-  grid-area: 3 / 1 / 3 / 8;
-  font-size: ${theme.fonts.size.tiny};
-  font-style: italic;
-  padding: 3px;
-`);
-
-const buildRangeTypes = (limitDuration) => RANGE_TYPES.map(({ label, type }) => {
+const buildRangeTypes = (limitDuration) => RELATIVE_RANGE_TYPES.map(({ label, type }) => {
   const typeDuration = moment.duration(1, type).asSeconds();
 
   if (limitDuration === 0 || typeDuration <= limitDuration) {
@@ -134,123 +51,48 @@ const buildRangeTypes = (limitDuration) => RANGE_TYPES.map(({ label, type }) => 
   return null;
 }).filter(Boolean);
 
+const getDefaultRange = (originalTimeRange) => {
+  if ('range' in originalTimeRange && originalTimeRange.range) {
+    return originalTimeRange.range;
+  }
+
+  return DEFAULT_TIMERANGE.range;
+};
+
+const getDefaultOffset = (originalTimeRange) => {
+  if ('offset' in originalTimeRange && originalTimeRange.offset) {
+    return originalTimeRange.offset;
+  }
+
+  return DEFAULT_OFFSET_RANGE;
+};
+
 const RelativeTimeRangeSelector = ({ disabled, originalTimeRange, limitDuration }: Props) => {
   const availableRangeTypes = buildRangeTypes(limitDuration);
+  const defaultRange = getDefaultRange(originalTimeRange);
+  const defaultOffset = getDefaultOffset(originalTimeRange);
 
   return (
     <RelativeWrapper>
-      <Field name="nextTimeRange.range">
-        {({ field: { value, onChange, name }, meta: { error } }) => {
-          const fromValue = RANGE_TYPES.map(({ type }) => {
-            const isAllTime = value === 0;
-            const diff = moment.duration(value, 'seconds').as(type);
-
-            if (diff - Math.floor(diff) === 0) {
-              return {
-                ...originalTimeRange,
-                rangeValue: diff || 0,
-                rangeType: isAllTime ? 'seconds' : type,
-                rangeAllTime: isAllTime,
-                range: value,
-              };
-            }
-
-            return null;
-          }).filter(Boolean).pop();
-
-          const _onChange = (nextValue) => onChange({ target: { name, value: nextValue } });
-
-          const _onChangeTime = (event) => {
-            const newTimeValue = moment.duration(event.target.value || 1, fromValue.rangeType).asSeconds();
-
-            _onChange(newTimeValue);
-          };
-
-          const _onChangeType = (type) => {
-            const newTimeValue = moment.duration(fromValue.rangeValue, type).asSeconds();
-
-            _onChange(newTimeValue);
-          };
-
-          const _onCheckAllTime = (event) => {
-            const notAllTime = originalTimeRange.range ?? DEFAULT_TIMERANGE.range;
-
-            _onChange(event.target.checked ? 0 : notAllTime);
-          };
-
-          return (
-            <RangeWrapper>
-              <RangeTitle>From:</RangeTitle>
-              <RangeCheck htmlFor="relative-all-time" className={limitDuration !== 0 && 'shortened'}>
-                <input type="checkbox"
-                       id="relative-all-time"
-                       value="0"
-                       className="mousetrap"
-                       checked={fromValue.rangeAllTime}
-                       onChange={_onCheckAllTime}
-                       disabled={limitDuration !== 0} />All Time
-              </RangeCheck>
-              <InputWrap>
-                <Input id="relative-timerange-from-value"
-                       name="relative-timerange-from-value"
-                       disabled={disabled || fromValue.rangeAllTime}
-                       type="number"
-                       min="1"
-                       value={fromValue.rangeValue}
-                       className="mousetrap"
-                       title="Set the range value"
-                       onChange={_onChangeTime}
-                       bsStyle={error ? 'error' : null} />
-              </InputWrap>
-              <StyledSelect id="relative-timerange-from-length"
-                            name="relative-timerange-from-length"
-                            disabled={disabled || fromValue.rangeAllTime}
-                            value={fromValue.rangeType}
-                            options={availableRangeTypes}
-                            inputProps={{ className: 'mousetrap' }}
-                            placeholder="Select a range length"
-                            onChange={_onChangeType}
-                            clearable={false} />
-
-              <Ago />
-              {error && (
-                <ErrorMessage>
-                  Admin has limited searching to {moment.duration(-limitDuration, 'seconds').humanize(true)}
-                </ErrorMessage>
-              )}
-            </RangeWrapper>
-          );
-        }}
-      </Field>
+      <RelativeTimeRangeField originalTimeRange={originalTimeRange}
+                              name="nextTimeRange.range"
+                              availableRangeTypes={availableRangeTypes}
+                              disabled={disabled}
+                              unsetRangeLabel="All Time"
+                              limitDuration={limitDuration}
+                              defaultRange={defaultRange}
+                              title="From:" />
 
       <StyledIcon name="arrow-right" />
 
-      <RangeWrapper>
-        <RangeTitle>Until:</RangeTitle>
-        <RangeCheck htmlFor="relative-offset">
-          <input type="checkbox" id="relative-offset" checked disabled />Now
-        </RangeCheck>
-
-        <InputWrap>
-          <Input id="relative-timerange-until-value"
-                 disabled
-                 type="number"
-                 value="0"
-                 min="1"
-                 title="Set the offset value"
-                 name="relative-timerange-until-value"
-                 onChange={() => {}} />
-        </InputWrap>
-
-        <StyledSelect id="relative-timerange-until-length"
-                      disabled
-                      value={RANGE_TYPES[0].type}
-                      options={availableRangeTypes}
-                      placeholder="Select an offset"
-                      name="relative-timerange-until-length"
-                      onChange={() => {}} />
-        <Ago />
-      </RangeWrapper>
+      <RelativeTimeRangeField originalTimeRange={originalTimeRange}
+                              name="nextTimeRange.offset"
+                              availableRangeTypes={availableRangeTypes}
+                              defaultRange={defaultOffset}
+                              disabled={disabled}
+                              unsetRangeLabel="Now"
+                              limitDuration={limitDuration}
+                              title="Until:" />
     </RelativeWrapper>
   );
 };

--- a/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TimeRangeLivePreview.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TimeRangeLivePreview.tsx
@@ -68,27 +68,33 @@ const MiddleIcon = styled.span(({ theme }) => css`
   padding: 0 15px;
 `);
 
+const readableTimeRange = (range: number, placeholder: string) => {
+  return !range ? placeholder : moment()
+    .subtract(range * 1000)
+    .fromNow();
+};
+
 const dateOutput = (timerange: TimeRange) => {
-  let range = EMPTY_RANGE;
+  let from = EMPTY_RANGE;
+  let until = EMPTY_RANGE;
 
   if (!timerange) {
     return EMPTY_OUTPUT;
   }
 
   if ('range' in timerange) {
-    range = !timerange.range ? 'All Time' : moment()
-      .subtract(timerange.range * 1000)
-      .fromNow();
+    from = readableTimeRange(timerange.range, 'All Time');
+    until = readableTimeRange(timerange.offset, 'Now');
 
     return {
-      from: range,
-      until: 'Now',
+      from,
+      until,
     };
   }
 
   return {
-    from: timerange.from || range,
-    until: timerange.to || range,
+    from: timerange.from || from,
+    until: timerange.to || until,
   };
 };
 

--- a/graylog2-web-interface/src/views/components/searchbar/date-time-picker/__snapshots__/AbsoluteRangeField.test.tsx.snap
+++ b/graylog2-web-interface/src/views/components/searchbar/date-time-picker/__snapshots__/AbsoluteRangeField.test.tsx.snap
@@ -381,18 +381,6 @@ fieldset[disabled] .c0.form-control:not([type="range"]) {
   padding: 0 3px;
 }
 
-.c5 {
-  padding: 0;
-  background: #f3f3f3;
-  font-weight: bold;
-}
-
-.c5:not(:first-child):not(:last-child) {
-  border-right: 0;
-  border-left: 0;
-  padding: 0 3px;
-}
-
 .c7 {
   padding: 0 6px 0 9px;
   width: 50px !important;
@@ -438,6 +426,18 @@ fieldset[disabled] .c7.form-control:not([type="range"]) {
 
 .c7:last-of-type {
   width: 60px !important;
+}
+
+.c5 {
+  padding: 0;
+  background: #f3f3f3;
+  font-weight: bold;
+}
+
+.c5:not(:first-child):not(:last-child) {
+  border-right: 0;
+  border-left: 0;
+  padding: 0 3px;
 }
 
 .c6 {
@@ -725,540 +725,546 @@ fieldset[disabled] .c7.form-control:not([type="range"]) {
   color: rgb(88,73,5);
 }
 
+.c8 {
+  color: #990606;
+  font-size: 0.79rem;
+  font-style: italic;
+  padding: 3px 3px 9px;
+  height: 1.5em;
+}
+
 <form
     action="#"
   >
-    <div>
-      <div
-        class="form-group"
-      >
-        <span>
+    <div
+      class="form-group"
+    >
+      <span>
+        <span
+          class="input-group"
+        >
+          <input
+            autocomplete="off"
+            class="c0 mousetrap form-control"
+            id="date-input-nextTimeRange[from]"
+            label=""
+            name="nextTimeRange[from]"
+            placeholder="YYYY-MM-DD HH:mm:ss"
+            type="text"
+            value="1955-05-11 06:15:00.000"
+          />
           <span
-            class="input-group"
+            class="input-group-btn"
           >
-            <input
-              autocomplete="off"
-              class="c0 form-control"
-              id="date-input-nextTimeRange[from]"
-              label=""
-              name="nextTimeRange[from]"
-              placeholder="YYYY-MM-DD HH:mm:ss"
-              type="text"
-              value="1955-05-11 06:15:00.000"
-            />
-            <span
-              class="input-group-btn"
+            <button
+              class="c1 btn btn-default"
+              title="Insert current date"
+              type="button"
             >
-              <button
-                class="c1 btn btn-default"
-                title="Insert current date"
-                type="button"
-              >
-                <svg
-                  class="svg-inline--fa fa-magic"
-                />
-              </button>
-            </span>
+              <svg
+                class="svg-inline--fa fa-magic"
+              />
+            </button>
           </span>
         </span>
-      </div>
+      </span>
+    </div>
+    <div
+      class="DayPicker c2"
+      lang="en"
+    >
       <div
-        class="DayPicker c2"
-        lang="en"
+        class="DayPicker-wrapper"
+        tabindex="0"
       >
         <div
-          class="DayPicker-wrapper"
-          tabindex="0"
+          class="DayPicker-NavBar"
+        >
+          <span
+            aria-label="Previous Month"
+            class="DayPicker-NavButton DayPicker-NavButton--prev"
+            role="button"
+            tabindex="0"
+          />
+          <span
+            aria-label="Next Month"
+            class="DayPicker-NavButton DayPicker-NavButton--next"
+            role="button"
+            tabindex="0"
+          />
+        </div>
+        <div
+          class="DayPicker-Months"
         >
           <div
-            class="DayPicker-NavBar"
-          >
-            <span
-              aria-label="Previous Month"
-              class="DayPicker-NavButton DayPicker-NavButton--prev"
-              role="button"
-              tabindex="0"
-            />
-            <span
-              aria-label="Next Month"
-              class="DayPicker-NavButton DayPicker-NavButton--next"
-              role="button"
-              tabindex="0"
-            />
-          </div>
-          <div
-            class="DayPicker-Months"
+            class="DayPicker-Month"
+            role="grid"
           >
             <div
-              class="DayPicker-Month"
-              role="grid"
+              class="DayPicker-Caption"
+              role="heading"
+            >
+              <div>
+                May 1955
+              </div>
+            </div>
+            <div
+              class="DayPicker-Weekdays"
+              role="rowgroup"
             >
               <div
-                class="DayPicker-Caption"
-                role="heading"
+                class="DayPicker-WeekdaysRow"
+                role="row"
               >
-                <div>
-                  May 1955
+                <div
+                  class="DayPicker-Weekday"
+                  role="columnheader"
+                >
+                  <abbr
+                    title="Sunday"
+                  >
+                    Su
+                  </abbr>
+                </div>
+                <div
+                  class="DayPicker-Weekday"
+                  role="columnheader"
+                >
+                  <abbr
+                    title="Monday"
+                  >
+                    Mo
+                  </abbr>
+                </div>
+                <div
+                  class="DayPicker-Weekday"
+                  role="columnheader"
+                >
+                  <abbr
+                    title="Tuesday"
+                  >
+                    Tu
+                  </abbr>
+                </div>
+                <div
+                  class="DayPicker-Weekday"
+                  role="columnheader"
+                >
+                  <abbr
+                    title="Wednesday"
+                  >
+                    We
+                  </abbr>
+                </div>
+                <div
+                  class="DayPicker-Weekday"
+                  role="columnheader"
+                >
+                  <abbr
+                    title="Thursday"
+                  >
+                    Th
+                  </abbr>
+                </div>
+                <div
+                  class="DayPicker-Weekday"
+                  role="columnheader"
+                >
+                  <abbr
+                    title="Friday"
+                  >
+                    Fr
+                  </abbr>
+                </div>
+                <div
+                  class="DayPicker-Weekday"
+                  role="columnheader"
+                >
+                  <abbr
+                    title="Saturday"
+                  >
+                    Sa
+                  </abbr>
+                </div>
+              </div>
+            </div>
+            <div
+              class="DayPicker-Body"
+              role="rowgroup"
+            >
+              <div
+                class="DayPicker-Week"
+                role="row"
+              >
+                <div
+                  aria-disabled="true"
+                  aria-label="Sun May 01 1955"
+                  aria-selected="false"
+                  class="DayPicker-Day DayPicker-Day--disabled"
+                  role="gridcell"
+                  tabindex="0"
+                >
+                  1
+                </div>
+                <div
+                  aria-disabled="true"
+                  aria-label="Mon May 02 1955"
+                  aria-selected="false"
+                  class="DayPicker-Day DayPicker-Day--disabled"
+                  role="gridcell"
+                  tabindex="-1"
+                >
+                  2
+                </div>
+                <div
+                  aria-disabled="true"
+                  aria-label="Tue May 03 1955"
+                  aria-selected="false"
+                  class="DayPicker-Day DayPicker-Day--disabled"
+                  role="gridcell"
+                  tabindex="-1"
+                >
+                  3
+                </div>
+                <div
+                  aria-disabled="true"
+                  aria-label="Wed May 04 1955"
+                  aria-selected="false"
+                  class="DayPicker-Day DayPicker-Day--disabled"
+                  role="gridcell"
+                  tabindex="-1"
+                >
+                  4
+                </div>
+                <div
+                  aria-disabled="true"
+                  aria-label="Thu May 05 1955"
+                  aria-selected="false"
+                  class="DayPicker-Day DayPicker-Day--disabled"
+                  role="gridcell"
+                  tabindex="-1"
+                >
+                  5
+                </div>
+                <div
+                  aria-disabled="true"
+                  aria-label="Fri May 06 1955"
+                  aria-selected="false"
+                  class="DayPicker-Day DayPicker-Day--disabled"
+                  role="gridcell"
+                  tabindex="-1"
+                >
+                  6
+                </div>
+                <div
+                  aria-disabled="true"
+                  aria-label="Sat May 07 1955"
+                  aria-selected="false"
+                  class="DayPicker-Day DayPicker-Day--disabled"
+                  role="gridcell"
+                  tabindex="-1"
+                >
+                  7
                 </div>
               </div>
               <div
-                class="DayPicker-Weekdays"
-                role="rowgroup"
+                class="DayPicker-Week"
+                role="row"
               >
                 <div
-                  class="DayPicker-WeekdaysRow"
-                  role="row"
+                  aria-disabled="true"
+                  aria-label="Sun May 08 1955"
+                  aria-selected="false"
+                  class="DayPicker-Day DayPicker-Day--disabled"
+                  role="gridcell"
+                  tabindex="-1"
                 >
-                  <div
-                    class="DayPicker-Weekday"
-                    role="columnheader"
-                  >
-                    <abbr
-                      title="Sunday"
-                    >
-                      Su
-                    </abbr>
-                  </div>
-                  <div
-                    class="DayPicker-Weekday"
-                    role="columnheader"
-                  >
-                    <abbr
-                      title="Monday"
-                    >
-                      Mo
-                    </abbr>
-                  </div>
-                  <div
-                    class="DayPicker-Weekday"
-                    role="columnheader"
-                  >
-                    <abbr
-                      title="Tuesday"
-                    >
-                      Tu
-                    </abbr>
-                  </div>
-                  <div
-                    class="DayPicker-Weekday"
-                    role="columnheader"
-                  >
-                    <abbr
-                      title="Wednesday"
-                    >
-                      We
-                    </abbr>
-                  </div>
-                  <div
-                    class="DayPicker-Weekday"
-                    role="columnheader"
-                  >
-                    <abbr
-                      title="Thursday"
-                    >
-                      Th
-                    </abbr>
-                  </div>
-                  <div
-                    class="DayPicker-Weekday"
-                    role="columnheader"
-                  >
-                    <abbr
-                      title="Friday"
-                    >
-                      Fr
-                    </abbr>
-                  </div>
-                  <div
-                    class="DayPicker-Weekday"
-                    role="columnheader"
-                  >
-                    <abbr
-                      title="Saturday"
-                    >
-                      Sa
-                    </abbr>
-                  </div>
+                  8
+                </div>
+                <div
+                  aria-disabled="true"
+                  aria-label="Mon May 09 1955"
+                  aria-selected="false"
+                  class="DayPicker-Day DayPicker-Day--disabled"
+                  role="gridcell"
+                  tabindex="-1"
+                >
+                  9
+                </div>
+                <div
+                  aria-disabled="true"
+                  aria-label="Tue May 10 1955"
+                  aria-selected="false"
+                  class="DayPicker-Day DayPicker-Day--disabled"
+                  role="gridcell"
+                  tabindex="-1"
+                >
+                  10
+                </div>
+                <div
+                  aria-disabled="false"
+                  aria-label="Wed May 11 1955"
+                  aria-selected="true"
+                  class="DayPicker-Day DayPicker-Day--selected"
+                  role="gridcell"
+                  tabindex="-1"
+                >
+                  11
+                </div>
+                <div
+                  aria-disabled="false"
+                  aria-label="Thu May 12 1955"
+                  aria-selected="false"
+                  class="DayPicker-Day"
+                  role="gridcell"
+                  tabindex="-1"
+                >
+                  12
+                </div>
+                <div
+                  aria-disabled="false"
+                  aria-label="Fri May 13 1955"
+                  aria-selected="false"
+                  class="DayPicker-Day"
+                  role="gridcell"
+                  tabindex="-1"
+                >
+                  13
+                </div>
+                <div
+                  aria-disabled="false"
+                  aria-label="Sat May 14 1955"
+                  aria-selected="false"
+                  class="DayPicker-Day"
+                  role="gridcell"
+                  tabindex="-1"
+                >
+                  14
                 </div>
               </div>
               <div
-                class="DayPicker-Body"
-                role="rowgroup"
+                class="DayPicker-Week"
+                role="row"
               >
                 <div
-                  class="DayPicker-Week"
-                  role="row"
+                  aria-disabled="false"
+                  aria-label="Sun May 15 1955"
+                  aria-selected="false"
+                  class="DayPicker-Day"
+                  role="gridcell"
+                  tabindex="-1"
                 >
-                  <div
-                    aria-disabled="false"
-                    aria-label="Sun May 01 1955"
-                    aria-selected="false"
-                    class="DayPicker-Day"
-                    role="gridcell"
-                    tabindex="0"
-                  >
-                    1
-                  </div>
-                  <div
-                    aria-disabled="false"
-                    aria-label="Mon May 02 1955"
-                    aria-selected="false"
-                    class="DayPicker-Day"
-                    role="gridcell"
-                    tabindex="-1"
-                  >
-                    2
-                  </div>
-                  <div
-                    aria-disabled="false"
-                    aria-label="Tue May 03 1955"
-                    aria-selected="false"
-                    class="DayPicker-Day"
-                    role="gridcell"
-                    tabindex="-1"
-                  >
-                    3
-                  </div>
-                  <div
-                    aria-disabled="false"
-                    aria-label="Wed May 04 1955"
-                    aria-selected="false"
-                    class="DayPicker-Day"
-                    role="gridcell"
-                    tabindex="-1"
-                  >
-                    4
-                  </div>
-                  <div
-                    aria-disabled="false"
-                    aria-label="Thu May 05 1955"
-                    aria-selected="false"
-                    class="DayPicker-Day"
-                    role="gridcell"
-                    tabindex="-1"
-                  >
-                    5
-                  </div>
-                  <div
-                    aria-disabled="false"
-                    aria-label="Fri May 06 1955"
-                    aria-selected="false"
-                    class="DayPicker-Day"
-                    role="gridcell"
-                    tabindex="-1"
-                  >
-                    6
-                  </div>
-                  <div
-                    aria-disabled="false"
-                    aria-label="Sat May 07 1955"
-                    aria-selected="false"
-                    class="DayPicker-Day"
-                    role="gridcell"
-                    tabindex="-1"
-                  >
-                    7
-                  </div>
+                  15
                 </div>
                 <div
-                  class="DayPicker-Week"
-                  role="row"
+                  aria-disabled="false"
+                  aria-label="Mon May 16 1955"
+                  aria-selected="false"
+                  class="DayPicker-Day"
+                  role="gridcell"
+                  tabindex="-1"
                 >
-                  <div
-                    aria-disabled="false"
-                    aria-label="Sun May 08 1955"
-                    aria-selected="false"
-                    class="DayPicker-Day"
-                    role="gridcell"
-                    tabindex="-1"
-                  >
-                    8
-                  </div>
-                  <div
-                    aria-disabled="false"
-                    aria-label="Mon May 09 1955"
-                    aria-selected="false"
-                    class="DayPicker-Day"
-                    role="gridcell"
-                    tabindex="-1"
-                  >
-                    9
-                  </div>
-                  <div
-                    aria-disabled="false"
-                    aria-label="Tue May 10 1955"
-                    aria-selected="false"
-                    class="DayPicker-Day"
-                    role="gridcell"
-                    tabindex="-1"
-                  >
-                    10
-                  </div>
-                  <div
-                    aria-disabled="false"
-                    aria-label="Wed May 11 1955"
-                    aria-selected="true"
-                    class="DayPicker-Day DayPicker-Day--selected"
-                    role="gridcell"
-                    tabindex="-1"
-                  >
-                    11
-                  </div>
-                  <div
-                    aria-disabled="false"
-                    aria-label="Thu May 12 1955"
-                    aria-selected="false"
-                    class="DayPicker-Day"
-                    role="gridcell"
-                    tabindex="-1"
-                  >
-                    12
-                  </div>
-                  <div
-                    aria-disabled="false"
-                    aria-label="Fri May 13 1955"
-                    aria-selected="false"
-                    class="DayPicker-Day"
-                    role="gridcell"
-                    tabindex="-1"
-                  >
-                    13
-                  </div>
-                  <div
-                    aria-disabled="false"
-                    aria-label="Sat May 14 1955"
-                    aria-selected="false"
-                    class="DayPicker-Day"
-                    role="gridcell"
-                    tabindex="-1"
-                  >
-                    14
-                  </div>
+                  16
                 </div>
                 <div
-                  class="DayPicker-Week"
-                  role="row"
+                  aria-disabled="false"
+                  aria-label="Tue May 17 1955"
+                  aria-selected="false"
+                  class="DayPicker-Day"
+                  role="gridcell"
+                  tabindex="-1"
                 >
-                  <div
-                    aria-disabled="false"
-                    aria-label="Sun May 15 1955"
-                    aria-selected="false"
-                    class="DayPicker-Day"
-                    role="gridcell"
-                    tabindex="-1"
-                  >
-                    15
-                  </div>
-                  <div
-                    aria-disabled="false"
-                    aria-label="Mon May 16 1955"
-                    aria-selected="false"
-                    class="DayPicker-Day"
-                    role="gridcell"
-                    tabindex="-1"
-                  >
-                    16
-                  </div>
-                  <div
-                    aria-disabled="false"
-                    aria-label="Tue May 17 1955"
-                    aria-selected="false"
-                    class="DayPicker-Day"
-                    role="gridcell"
-                    tabindex="-1"
-                  >
-                    17
-                  </div>
-                  <div
-                    aria-disabled="false"
-                    aria-label="Wed May 18 1955"
-                    aria-selected="false"
-                    class="DayPicker-Day"
-                    role="gridcell"
-                    tabindex="-1"
-                  >
-                    18
-                  </div>
-                  <div
-                    aria-disabled="false"
-                    aria-label="Thu May 19 1955"
-                    aria-selected="false"
-                    class="DayPicker-Day"
-                    role="gridcell"
-                    tabindex="-1"
-                  >
-                    19
-                  </div>
-                  <div
-                    aria-disabled="false"
-                    aria-label="Fri May 20 1955"
-                    aria-selected="false"
-                    class="DayPicker-Day"
-                    role="gridcell"
-                    tabindex="-1"
-                  >
-                    20
-                  </div>
-                  <div
-                    aria-disabled="false"
-                    aria-label="Sat May 21 1955"
-                    aria-selected="false"
-                    class="DayPicker-Day"
-                    role="gridcell"
-                    tabindex="-1"
-                  >
-                    21
-                  </div>
+                  17
                 </div>
                 <div
-                  class="DayPicker-Week"
-                  role="row"
+                  aria-disabled="false"
+                  aria-label="Wed May 18 1955"
+                  aria-selected="false"
+                  class="DayPicker-Day"
+                  role="gridcell"
+                  tabindex="-1"
                 >
-                  <div
-                    aria-disabled="false"
-                    aria-label="Sun May 22 1955"
-                    aria-selected="false"
-                    class="DayPicker-Day"
-                    role="gridcell"
-                    tabindex="-1"
-                  >
-                    22
-                  </div>
-                  <div
-                    aria-disabled="false"
-                    aria-label="Mon May 23 1955"
-                    aria-selected="false"
-                    class="DayPicker-Day"
-                    role="gridcell"
-                    tabindex="-1"
-                  >
-                    23
-                  </div>
-                  <div
-                    aria-disabled="false"
-                    aria-label="Tue May 24 1955"
-                    aria-selected="false"
-                    class="DayPicker-Day"
-                    role="gridcell"
-                    tabindex="-1"
-                  >
-                    24
-                  </div>
-                  <div
-                    aria-disabled="false"
-                    aria-label="Wed May 25 1955"
-                    aria-selected="false"
-                    class="DayPicker-Day"
-                    role="gridcell"
-                    tabindex="-1"
-                  >
-                    25
-                  </div>
-                  <div
-                    aria-disabled="false"
-                    aria-label="Thu May 26 1955"
-                    aria-selected="false"
-                    class="DayPicker-Day"
-                    role="gridcell"
-                    tabindex="-1"
-                  >
-                    26
-                  </div>
-                  <div
-                    aria-disabled="false"
-                    aria-label="Fri May 27 1955"
-                    aria-selected="false"
-                    class="DayPicker-Day"
-                    role="gridcell"
-                    tabindex="-1"
-                  >
-                    27
-                  </div>
-                  <div
-                    aria-disabled="false"
-                    aria-label="Sat May 28 1955"
-                    aria-selected="false"
-                    class="DayPicker-Day"
-                    role="gridcell"
-                    tabindex="-1"
-                  >
-                    28
-                  </div>
+                  18
                 </div>
                 <div
-                  class="DayPicker-Week"
-                  role="row"
+                  aria-disabled="false"
+                  aria-label="Thu May 19 1955"
+                  aria-selected="false"
+                  class="DayPicker-Day"
+                  role="gridcell"
+                  tabindex="-1"
                 >
-                  <div
-                    aria-disabled="false"
-                    aria-label="Sun May 29 1955"
-                    aria-selected="false"
-                    class="DayPicker-Day"
-                    role="gridcell"
-                    tabindex="-1"
-                  >
-                    29
-                  </div>
-                  <div
-                    aria-disabled="false"
-                    aria-label="Mon May 30 1955"
-                    aria-selected="false"
-                    class="DayPicker-Day"
-                    role="gridcell"
-                    tabindex="-1"
-                  >
-                    30
-                  </div>
-                  <div
-                    aria-disabled="false"
-                    aria-label="Tue May 31 1955"
-                    aria-selected="false"
-                    class="DayPicker-Day"
-                    role="gridcell"
-                    tabindex="-1"
-                  >
-                    31
-                  </div>
-                  <div
-                    aria-disabled="true"
-                    aria-label="Wed Jun 01 1955"
-                    aria-selected="false"
-                    class="DayPicker-Day DayPicker-Day--outside"
-                    role="gridcell"
-                    tabindex="-1"
-                  >
-                    1
-                  </div>
-                  <div
-                    aria-disabled="true"
-                    aria-label="Thu Jun 02 1955"
-                    aria-selected="false"
-                    class="DayPicker-Day DayPicker-Day--outside"
-                    role="gridcell"
-                    tabindex="-1"
-                  >
-                    2
-                  </div>
-                  <div
-                    aria-disabled="true"
-                    aria-label="Fri Jun 03 1955"
-                    aria-selected="false"
-                    class="DayPicker-Day DayPicker-Day--outside"
-                    role="gridcell"
-                    tabindex="-1"
-                  >
-                    3
-                  </div>
-                  <div
-                    aria-disabled="true"
-                    aria-label="Sat Jun 04 1955"
-                    aria-selected="false"
-                    class="DayPicker-Day DayPicker-Day--outside"
-                    role="gridcell"
-                    tabindex="-1"
-                  >
-                    4
-                  </div>
+                  19
+                </div>
+                <div
+                  aria-disabled="false"
+                  aria-label="Fri May 20 1955"
+                  aria-selected="false"
+                  class="DayPicker-Day"
+                  role="gridcell"
+                  tabindex="-1"
+                >
+                  20
+                </div>
+                <div
+                  aria-disabled="false"
+                  aria-label="Sat May 21 1955"
+                  aria-selected="false"
+                  class="DayPicker-Day"
+                  role="gridcell"
+                  tabindex="-1"
+                >
+                  21
+                </div>
+              </div>
+              <div
+                class="DayPicker-Week"
+                role="row"
+              >
+                <div
+                  aria-disabled="false"
+                  aria-label="Sun May 22 1955"
+                  aria-selected="false"
+                  class="DayPicker-Day"
+                  role="gridcell"
+                  tabindex="-1"
+                >
+                  22
+                </div>
+                <div
+                  aria-disabled="false"
+                  aria-label="Mon May 23 1955"
+                  aria-selected="false"
+                  class="DayPicker-Day"
+                  role="gridcell"
+                  tabindex="-1"
+                >
+                  23
+                </div>
+                <div
+                  aria-disabled="false"
+                  aria-label="Tue May 24 1955"
+                  aria-selected="false"
+                  class="DayPicker-Day"
+                  role="gridcell"
+                  tabindex="-1"
+                >
+                  24
+                </div>
+                <div
+                  aria-disabled="false"
+                  aria-label="Wed May 25 1955"
+                  aria-selected="false"
+                  class="DayPicker-Day"
+                  role="gridcell"
+                  tabindex="-1"
+                >
+                  25
+                </div>
+                <div
+                  aria-disabled="false"
+                  aria-label="Thu May 26 1955"
+                  aria-selected="false"
+                  class="DayPicker-Day"
+                  role="gridcell"
+                  tabindex="-1"
+                >
+                  26
+                </div>
+                <div
+                  aria-disabled="false"
+                  aria-label="Fri May 27 1955"
+                  aria-selected="false"
+                  class="DayPicker-Day"
+                  role="gridcell"
+                  tabindex="-1"
+                >
+                  27
+                </div>
+                <div
+                  aria-disabled="false"
+                  aria-label="Sat May 28 1955"
+                  aria-selected="false"
+                  class="DayPicker-Day"
+                  role="gridcell"
+                  tabindex="-1"
+                >
+                  28
+                </div>
+              </div>
+              <div
+                class="DayPicker-Week"
+                role="row"
+              >
+                <div
+                  aria-disabled="false"
+                  aria-label="Sun May 29 1955"
+                  aria-selected="false"
+                  class="DayPicker-Day"
+                  role="gridcell"
+                  tabindex="-1"
+                >
+                  29
+                </div>
+                <div
+                  aria-disabled="false"
+                  aria-label="Mon May 30 1955"
+                  aria-selected="false"
+                  class="DayPicker-Day"
+                  role="gridcell"
+                  tabindex="-1"
+                >
+                  30
+                </div>
+                <div
+                  aria-disabled="false"
+                  aria-label="Tue May 31 1955"
+                  aria-selected="false"
+                  class="DayPicker-Day"
+                  role="gridcell"
+                  tabindex="-1"
+                >
+                  31
+                </div>
+                <div
+                  aria-disabled="true"
+                  aria-label="Wed Jun 01 1955"
+                  aria-selected="false"
+                  class="DayPicker-Day DayPicker-Day--outside"
+                  role="gridcell"
+                  tabindex="-1"
+                >
+                  1
+                </div>
+                <div
+                  aria-disabled="true"
+                  aria-label="Thu Jun 02 1955"
+                  aria-selected="false"
+                  class="DayPicker-Day DayPicker-Day--outside"
+                  role="gridcell"
+                  tabindex="-1"
+                >
+                  2
+                </div>
+                <div
+                  aria-disabled="true"
+                  aria-label="Fri Jun 03 1955"
+                  aria-selected="false"
+                  class="DayPicker-Day DayPicker-Day--outside"
+                  role="gridcell"
+                  tabindex="-1"
+                >
+                  3
+                </div>
+                <div
+                  aria-disabled="true"
+                  aria-label="Sat Jun 04 1955"
+                  aria-selected="false"
+                  class="DayPicker-Day DayPicker-Day--outside"
+                  role="gridcell"
+                  tabindex="-1"
+                >
+                  4
                 </div>
               </div>
             </div>
@@ -1266,89 +1272,92 @@ fieldset[disabled] .c7.form-control:not([type="range"]) {
         </div>
       </div>
     </div>
-    <div>
+    <div
+      class="c3"
+    >
       <div
-        class="c3"
+        class="form-group"
       >
-        <div
-          class="form-group"
+        <span
+          class="input-group"
         >
           <span
-            class="input-group"
+            class="c4 input-group-addon c5"
           >
-            <span
-              class="c4 input-group-addon c5"
+            <button
+              class="c6 btn btn-sm btn-link"
+              title="Toggle between beginning and end of day"
+              type="button"
             >
-              <button
-                class="c6 btn btn-sm btn-link"
-                title="Toggle between beginning and end of day"
-                type="button"
-              >
-                <svg
-                  class="svg-inline--fa fa-hourglass-half"
-                />
-              </button>
-            </span>
-            <input
-              class="c7 form-control input-sm"
-              id="from-time-hours"
-              title="from hour"
-              type="number"
-              value="06"
-            />
-            <span
-              class="c4 input-group-addon c5"
-            >
-              :
-            </span>
-            <input
-              class="c7 form-control input-sm"
-              id="from-time-minutes"
-              title="from minutes"
-              type="number"
-              value="15"
-            />
-            <span
-              class="c4 input-group-addon c5"
-            >
-              :
-            </span>
-            <input
-              class="c7 form-control input-sm"
-              id="from-time-seconds"
-              title="from seconds"
-              type="number"
-              value="00"
-            />
-            <span
-              class="c4 input-group-addon c5"
-            >
-              .
-            </span>
-            <input
-              class="c7 form-control input-sm"
-              id="from-time-milliseconds"
-              title="from milliseconds"
-              type="number"
-              value="000"
-            />
-            <span
-              class="c4 input-group-addon c5"
-            >
-              <button
-                class="c6 btn btn-sm btn-link"
-                title="Set to current local time"
-                type="button"
-              >
-                <svg
-                  class="svg-inline--fa fa-magic"
-                />
-              </button>
-            </span>
+              <svg
+                class="svg-inline--fa fa-hourglass-half"
+              />
+            </button>
           </span>
-        </div>
+          <input
+            class="c7 form-control input-sm"
+            id="from-time-hours"
+            title="from hour"
+            type="number"
+            value="06"
+          />
+          <span
+            class="c4 input-group-addon c5"
+          >
+            :
+          </span>
+          <input
+            class="c7 form-control input-sm"
+            id="from-time-minutes"
+            title="from minutes"
+            type="number"
+            value="15"
+          />
+          <span
+            class="c4 input-group-addon c5"
+          >
+            :
+          </span>
+          <input
+            class="c7 form-control input-sm"
+            id="from-time-seconds"
+            title="from seconds"
+            type="number"
+            value="00"
+          />
+          <span
+            class="c4 input-group-addon c5"
+          >
+            .
+          </span>
+          <input
+            class="c7 form-control input-sm"
+            id="from-time-milliseconds"
+            title="from milliseconds"
+            type="number"
+            value="000"
+          />
+          <span
+            class="c4 input-group-addon c5"
+          >
+            <button
+              class="c6 btn btn-sm btn-link"
+              title="Set to current local time"
+              type="button"
+            >
+              <svg
+                class="svg-inline--fa fa-magic"
+              />
+            </button>
+          </span>
+        </span>
       </div>
     </div>
+    <span
+      class="c8"
+    >
+       
+    </span>
   </form>
 </DocumentFragment>
 `;

--- a/graylog2-web-interface/src/views/components/searchbar/date-time-picker/__snapshots__/AbsoluteTimeRangeSelector.test.tsx.snap
+++ b/graylog2-web-interface/src/views/components/searchbar/date-time-picker/__snapshots__/AbsoluteTimeRangeSelector.test.tsx.snap
@@ -381,18 +381,6 @@ fieldset[disabled] .c2.form-control:not([type="range"]) {
   padding: 0 3px;
 }
 
-.c7 {
-  padding: 0;
-  background: #f3f3f3;
-  font-weight: bold;
-}
-
-.c7:not(:first-child):not(:last-child) {
-  border-right: 0;
-  border-left: 0;
-  padding: 0 3px;
-}
-
 .c9 {
   padding: 0 6px 0 9px;
   width: 50px !important;
@@ -438,6 +426,18 @@ fieldset[disabled] .c9.form-control:not([type="range"]) {
 
 .c9:last-of-type {
   width: 60px !important;
+}
+
+.c7 {
+  padding: 0;
+  background: #f3f3f3;
+  font-weight: bold;
+}
+
+.c7:not(:first-child):not(:last-child) {
+  border-right: 0;
+  border-left: 0;
+  padding: 0 3px;
 }
 
 .c8 {
@@ -725,6 +725,14 @@ fieldset[disabled] .c9.form-control:not([type="range"]) {
   color: rgb(88,73,5);
 }
 
+.c10 {
+  color: #990606;
+  font-size: 0.79rem;
+  font-style: italic;
+  padding: 3px 3px 9px;
+  height: 1.5em;
+}
+
 .c0 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -762,7 +770,7 @@ fieldset[disabled] .c9.form-control:not([type="range"]) {
   padding-bottom: 0;
 }
 
-.c10 {
+.c11 {
   -webkit-flex: 0.75;
   -ms-flex: 0.75;
   flex: 0.75;
@@ -789,537 +797,535 @@ fieldset[disabled] .c9.form-control:not([type="range"]) {
       <div
         class="c1"
       >
-        <div>
-          <div
-            class="form-group"
-          >
-            <span>
+        <div
+          class="form-group"
+        >
+          <span>
+            <span
+              class="input-group"
+            >
+              <input
+                autocomplete="off"
+                class="c2 mousetrap form-control"
+                id="date-input-nextTimeRange[from]"
+                label=""
+                name="nextTimeRange[from]"
+                placeholder="YYYY-MM-DD HH:mm:ss"
+                type="text"
+                value="1955-05-11 06:15:00.000"
+              />
               <span
-                class="input-group"
+                class="input-group-btn"
               >
-                <input
-                  autocomplete="off"
-                  class="c2 form-control"
-                  id="date-input-nextTimeRange[from]"
-                  label=""
-                  name="nextTimeRange[from]"
-                  placeholder="YYYY-MM-DD HH:mm:ss"
-                  type="text"
-                  value="1955-05-11 06:15:00.000"
-                />
-                <span
-                  class="input-group-btn"
+                <button
+                  class="c3 btn btn-default"
+                  title="Insert current date"
+                  type="button"
                 >
-                  <button
-                    class="c3 btn btn-default"
-                    title="Insert current date"
-                    type="button"
-                  >
-                    <svg
-                      class="svg-inline--fa fa-magic"
-                    />
-                  </button>
-                </span>
+                  <svg
+                    class="svg-inline--fa fa-magic"
+                  />
+                </button>
               </span>
             </span>
-          </div>
+          </span>
+        </div>
+        <div
+          class="DayPicker c4"
+          lang="en"
+        >
           <div
-            class="DayPicker c4"
-            lang="en"
+            class="DayPicker-wrapper"
+            tabindex="0"
           >
             <div
-              class="DayPicker-wrapper"
-              tabindex="0"
+              class="DayPicker-NavBar"
+            >
+              <span
+                aria-label="Previous Month"
+                class="DayPicker-NavButton DayPicker-NavButton--prev"
+                role="button"
+                tabindex="0"
+              />
+              <span
+                aria-label="Next Month"
+                class="DayPicker-NavButton DayPicker-NavButton--next"
+                role="button"
+                tabindex="0"
+              />
+            </div>
+            <div
+              class="DayPicker-Months"
             >
               <div
-                class="DayPicker-NavBar"
-              >
-                <span
-                  aria-label="Previous Month"
-                  class="DayPicker-NavButton DayPicker-NavButton--prev"
-                  role="button"
-                  tabindex="0"
-                />
-                <span
-                  aria-label="Next Month"
-                  class="DayPicker-NavButton DayPicker-NavButton--next"
-                  role="button"
-                  tabindex="0"
-                />
-              </div>
-              <div
-                class="DayPicker-Months"
+                class="DayPicker-Month"
+                role="grid"
               >
                 <div
-                  class="DayPicker-Month"
-                  role="grid"
+                  class="DayPicker-Caption"
+                  role="heading"
+                >
+                  <div>
+                    May 1955
+                  </div>
+                </div>
+                <div
+                  class="DayPicker-Weekdays"
+                  role="rowgroup"
                 >
                   <div
-                    class="DayPicker-Caption"
-                    role="heading"
+                    class="DayPicker-WeekdaysRow"
+                    role="row"
                   >
-                    <div>
-                      May 1955
+                    <div
+                      class="DayPicker-Weekday"
+                      role="columnheader"
+                    >
+                      <abbr
+                        title="Sunday"
+                      >
+                        Su
+                      </abbr>
+                    </div>
+                    <div
+                      class="DayPicker-Weekday"
+                      role="columnheader"
+                    >
+                      <abbr
+                        title="Monday"
+                      >
+                        Mo
+                      </abbr>
+                    </div>
+                    <div
+                      class="DayPicker-Weekday"
+                      role="columnheader"
+                    >
+                      <abbr
+                        title="Tuesday"
+                      >
+                        Tu
+                      </abbr>
+                    </div>
+                    <div
+                      class="DayPicker-Weekday"
+                      role="columnheader"
+                    >
+                      <abbr
+                        title="Wednesday"
+                      >
+                        We
+                      </abbr>
+                    </div>
+                    <div
+                      class="DayPicker-Weekday"
+                      role="columnheader"
+                    >
+                      <abbr
+                        title="Thursday"
+                      >
+                        Th
+                      </abbr>
+                    </div>
+                    <div
+                      class="DayPicker-Weekday"
+                      role="columnheader"
+                    >
+                      <abbr
+                        title="Friday"
+                      >
+                        Fr
+                      </abbr>
+                    </div>
+                    <div
+                      class="DayPicker-Weekday"
+                      role="columnheader"
+                    >
+                      <abbr
+                        title="Saturday"
+                      >
+                        Sa
+                      </abbr>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="DayPicker-Body"
+                  role="rowgroup"
+                >
+                  <div
+                    class="DayPicker-Week"
+                    role="row"
+                  >
+                    <div
+                      aria-disabled="true"
+                      aria-label="Sun May 01 1955"
+                      aria-selected="false"
+                      class="DayPicker-Day DayPicker-Day--disabled"
+                      role="gridcell"
+                      tabindex="0"
+                    >
+                      1
+                    </div>
+                    <div
+                      aria-disabled="true"
+                      aria-label="Mon May 02 1955"
+                      aria-selected="false"
+                      class="DayPicker-Day DayPicker-Day--disabled"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      2
+                    </div>
+                    <div
+                      aria-disabled="true"
+                      aria-label="Tue May 03 1955"
+                      aria-selected="false"
+                      class="DayPicker-Day DayPicker-Day--disabled"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      3
+                    </div>
+                    <div
+                      aria-disabled="true"
+                      aria-label="Wed May 04 1955"
+                      aria-selected="false"
+                      class="DayPicker-Day DayPicker-Day--disabled"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      4
+                    </div>
+                    <div
+                      aria-disabled="true"
+                      aria-label="Thu May 05 1955"
+                      aria-selected="false"
+                      class="DayPicker-Day DayPicker-Day--disabled"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      5
+                    </div>
+                    <div
+                      aria-disabled="true"
+                      aria-label="Fri May 06 1955"
+                      aria-selected="false"
+                      class="DayPicker-Day DayPicker-Day--disabled"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      6
+                    </div>
+                    <div
+                      aria-disabled="true"
+                      aria-label="Sat May 07 1955"
+                      aria-selected="false"
+                      class="DayPicker-Day DayPicker-Day--disabled"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      7
                     </div>
                   </div>
                   <div
-                    class="DayPicker-Weekdays"
-                    role="rowgroup"
+                    class="DayPicker-Week"
+                    role="row"
                   >
                     <div
-                      class="DayPicker-WeekdaysRow"
-                      role="row"
+                      aria-disabled="true"
+                      aria-label="Sun May 08 1955"
+                      aria-selected="false"
+                      class="DayPicker-Day DayPicker-Day--disabled"
+                      role="gridcell"
+                      tabindex="-1"
                     >
-                      <div
-                        class="DayPicker-Weekday"
-                        role="columnheader"
-                      >
-                        <abbr
-                          title="Sunday"
-                        >
-                          Su
-                        </abbr>
-                      </div>
-                      <div
-                        class="DayPicker-Weekday"
-                        role="columnheader"
-                      >
-                        <abbr
-                          title="Monday"
-                        >
-                          Mo
-                        </abbr>
-                      </div>
-                      <div
-                        class="DayPicker-Weekday"
-                        role="columnheader"
-                      >
-                        <abbr
-                          title="Tuesday"
-                        >
-                          Tu
-                        </abbr>
-                      </div>
-                      <div
-                        class="DayPicker-Weekday"
-                        role="columnheader"
-                      >
-                        <abbr
-                          title="Wednesday"
-                        >
-                          We
-                        </abbr>
-                      </div>
-                      <div
-                        class="DayPicker-Weekday"
-                        role="columnheader"
-                      >
-                        <abbr
-                          title="Thursday"
-                        >
-                          Th
-                        </abbr>
-                      </div>
-                      <div
-                        class="DayPicker-Weekday"
-                        role="columnheader"
-                      >
-                        <abbr
-                          title="Friday"
-                        >
-                          Fr
-                        </abbr>
-                      </div>
-                      <div
-                        class="DayPicker-Weekday"
-                        role="columnheader"
-                      >
-                        <abbr
-                          title="Saturday"
-                        >
-                          Sa
-                        </abbr>
-                      </div>
+                      8
+                    </div>
+                    <div
+                      aria-disabled="true"
+                      aria-label="Mon May 09 1955"
+                      aria-selected="false"
+                      class="DayPicker-Day DayPicker-Day--disabled"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      9
+                    </div>
+                    <div
+                      aria-disabled="true"
+                      aria-label="Tue May 10 1955"
+                      aria-selected="false"
+                      class="DayPicker-Day DayPicker-Day--disabled"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      10
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Wed May 11 1955"
+                      aria-selected="true"
+                      class="DayPicker-Day DayPicker-Day--selected"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      11
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Thu May 12 1955"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      12
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Fri May 13 1955"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      13
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Sat May 14 1955"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      14
                     </div>
                   </div>
                   <div
-                    class="DayPicker-Body"
-                    role="rowgroup"
+                    class="DayPicker-Week"
+                    role="row"
                   >
                     <div
-                      class="DayPicker-Week"
-                      role="row"
+                      aria-disabled="false"
+                      aria-label="Sun May 15 1955"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
                     >
-                      <div
-                        aria-disabled="false"
-                        aria-label="Sun May 01 1955"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="0"
-                      >
-                        1
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Mon May 02 1955"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        2
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Tue May 03 1955"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        3
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Wed May 04 1955"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        4
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Thu May 05 1955"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        5
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Fri May 06 1955"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        6
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Sat May 07 1955"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        7
-                      </div>
+                      15
                     </div>
                     <div
-                      class="DayPicker-Week"
-                      role="row"
+                      aria-disabled="false"
+                      aria-label="Mon May 16 1955"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
                     >
-                      <div
-                        aria-disabled="false"
-                        aria-label="Sun May 08 1955"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        8
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Mon May 09 1955"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        9
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Tue May 10 1955"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        10
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Wed May 11 1955"
-                        aria-selected="true"
-                        class="DayPicker-Day DayPicker-Day--selected"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        11
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Thu May 12 1955"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        12
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Fri May 13 1955"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        13
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Sat May 14 1955"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        14
-                      </div>
+                      16
                     </div>
                     <div
-                      class="DayPicker-Week"
-                      role="row"
+                      aria-disabled="false"
+                      aria-label="Tue May 17 1955"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
                     >
-                      <div
-                        aria-disabled="false"
-                        aria-label="Sun May 15 1955"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        15
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Mon May 16 1955"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        16
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Tue May 17 1955"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        17
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Wed May 18 1955"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        18
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Thu May 19 1955"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        19
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Fri May 20 1955"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        20
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Sat May 21 1955"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        21
-                      </div>
+                      17
                     </div>
                     <div
-                      class="DayPicker-Week"
-                      role="row"
+                      aria-disabled="false"
+                      aria-label="Wed May 18 1955"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
                     >
-                      <div
-                        aria-disabled="false"
-                        aria-label="Sun May 22 1955"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        22
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Mon May 23 1955"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        23
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Tue May 24 1955"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        24
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Wed May 25 1955"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        25
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Thu May 26 1955"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        26
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Fri May 27 1955"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        27
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Sat May 28 1955"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        28
-                      </div>
+                      18
                     </div>
                     <div
-                      class="DayPicker-Week"
-                      role="row"
+                      aria-disabled="false"
+                      aria-label="Thu May 19 1955"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
                     >
-                      <div
-                        aria-disabled="false"
-                        aria-label="Sun May 29 1955"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        29
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Mon May 30 1955"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        30
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Tue May 31 1955"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        31
-                      </div>
-                      <div
-                        aria-disabled="true"
-                        aria-label="Wed Jun 01 1955"
-                        aria-selected="false"
-                        class="DayPicker-Day DayPicker-Day--outside"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        1
-                      </div>
-                      <div
-                        aria-disabled="true"
-                        aria-label="Thu Jun 02 1955"
-                        aria-selected="false"
-                        class="DayPicker-Day DayPicker-Day--outside"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        2
-                      </div>
-                      <div
-                        aria-disabled="true"
-                        aria-label="Fri Jun 03 1955"
-                        aria-selected="false"
-                        class="DayPicker-Day DayPicker-Day--outside"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        3
-                      </div>
-                      <div
-                        aria-disabled="true"
-                        aria-label="Sat Jun 04 1955"
-                        aria-selected="false"
-                        class="DayPicker-Day DayPicker-Day--outside"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        4
-                      </div>
+                      19
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Fri May 20 1955"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      20
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Sat May 21 1955"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      21
+                    </div>
+                  </div>
+                  <div
+                    class="DayPicker-Week"
+                    role="row"
+                  >
+                    <div
+                      aria-disabled="false"
+                      aria-label="Sun May 22 1955"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      22
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Mon May 23 1955"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      23
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Tue May 24 1955"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      24
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Wed May 25 1955"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      25
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Thu May 26 1955"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      26
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Fri May 27 1955"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      27
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Sat May 28 1955"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      28
+                    </div>
+                  </div>
+                  <div
+                    class="DayPicker-Week"
+                    role="row"
+                  >
+                    <div
+                      aria-disabled="false"
+                      aria-label="Sun May 29 1955"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      29
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Mon May 30 1955"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      30
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Tue May 31 1955"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      31
+                    </div>
+                    <div
+                      aria-disabled="true"
+                      aria-label="Wed Jun 01 1955"
+                      aria-selected="false"
+                      class="DayPicker-Day DayPicker-Day--outside"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      1
+                    </div>
+                    <div
+                      aria-disabled="true"
+                      aria-label="Thu Jun 02 1955"
+                      aria-selected="false"
+                      class="DayPicker-Day DayPicker-Day--outside"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      2
+                    </div>
+                    <div
+                      aria-disabled="true"
+                      aria-label="Fri Jun 03 1955"
+                      aria-selected="false"
+                      class="DayPicker-Day DayPicker-Day--outside"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      3
+                    </div>
+                    <div
+                      aria-disabled="true"
+                      aria-label="Sat Jun 04 1955"
+                      aria-selected="false"
+                      class="DayPicker-Day DayPicker-Day--outside"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      4
                     </div>
                   </div>
                 </div>
@@ -1327,92 +1333,95 @@ fieldset[disabled] .c9.form-control:not([type="range"]) {
             </div>
           </div>
         </div>
-        <div>
+        <div
+          class="c5"
+        >
           <div
-            class="c5"
+            class="form-group"
           >
-            <div
-              class="form-group"
+            <span
+              class="input-group"
             >
               <span
-                class="input-group"
+                class="c6 input-group-addon c7"
               >
-                <span
-                  class="c6 input-group-addon c7"
+                <button
+                  class="c8 btn btn-sm btn-link"
+                  title="Toggle between beginning and end of day"
+                  type="button"
                 >
-                  <button
-                    class="c8 btn btn-sm btn-link"
-                    title="Toggle between beginning and end of day"
-                    type="button"
-                  >
-                    <svg
-                      class="svg-inline--fa fa-hourglass-half"
-                    />
-                  </button>
-                </span>
-                <input
-                  class="c9 form-control input-sm"
-                  id="from-time-hours"
-                  title="from hour"
-                  type="number"
-                  value="06"
-                />
-                <span
-                  class="c6 input-group-addon c7"
-                >
-                  :
-                </span>
-                <input
-                  class="c9 form-control input-sm"
-                  id="from-time-minutes"
-                  title="from minutes"
-                  type="number"
-                  value="15"
-                />
-                <span
-                  class="c6 input-group-addon c7"
-                >
-                  :
-                </span>
-                <input
-                  class="c9 form-control input-sm"
-                  id="from-time-seconds"
-                  title="from seconds"
-                  type="number"
-                  value="00"
-                />
-                <span
-                  class="c6 input-group-addon c7"
-                >
-                  .
-                </span>
-                <input
-                  class="c9 form-control input-sm"
-                  id="from-time-milliseconds"
-                  title="from milliseconds"
-                  type="number"
-                  value="000"
-                />
-                <span
-                  class="c6 input-group-addon c7"
-                >
-                  <button
-                    class="c8 btn btn-sm btn-link"
-                    title="Set to current local time"
-                    type="button"
-                  >
-                    <svg
-                      class="svg-inline--fa fa-magic"
-                    />
-                  </button>
-                </span>
+                  <svg
+                    class="svg-inline--fa fa-hourglass-half"
+                  />
+                </button>
               </span>
-            </div>
+              <input
+                class="c9 form-control input-sm"
+                id="from-time-hours"
+                title="from hour"
+                type="number"
+                value="06"
+              />
+              <span
+                class="c6 input-group-addon c7"
+              >
+                :
+              </span>
+              <input
+                class="c9 form-control input-sm"
+                id="from-time-minutes"
+                title="from minutes"
+                type="number"
+                value="15"
+              />
+              <span
+                class="c6 input-group-addon c7"
+              >
+                :
+              </span>
+              <input
+                class="c9 form-control input-sm"
+                id="from-time-seconds"
+                title="from seconds"
+                type="number"
+                value="00"
+              />
+              <span
+                class="c6 input-group-addon c7"
+              >
+                .
+              </span>
+              <input
+                class="c9 form-control input-sm"
+                id="from-time-milliseconds"
+                title="from milliseconds"
+                type="number"
+                value="000"
+              />
+              <span
+                class="c6 input-group-addon c7"
+              >
+                <button
+                  class="c8 btn btn-sm btn-link"
+                  title="Set to current local time"
+                  type="button"
+                >
+                  <svg
+                    class="svg-inline--fa fa-magic"
+                  />
+                </button>
+              </span>
+            </span>
           </div>
         </div>
+        <span
+          class="c10"
+        >
+           
+        </span>
       </div>
       <div
-        class="c10"
+        class="c11"
       >
         <svg
           class="svg-inline--fa fa-arrow-right"
@@ -1421,537 +1430,610 @@ fieldset[disabled] .c9.form-control:not([type="range"]) {
       <div
         class="c1"
       >
-        <div>
-          <div
-            class="form-group"
-          >
-            <span>
+        <div
+          class="form-group"
+        >
+          <span>
+            <span
+              class="input-group"
+            >
+              <input
+                autocomplete="off"
+                class="c2 mousetrap form-control"
+                id="date-input-nextTimeRange[to]"
+                label=""
+                name="nextTimeRange[to]"
+                placeholder="YYYY-MM-DD HH:mm:ss"
+                type="text"
+                value="1985-25-10 08:18:00.000"
+              />
               <span
-                class="input-group"
+                class="input-group-btn"
               >
-                <input
-                  autocomplete="off"
-                  class="c2 form-control"
-                  id="date-input-nextTimeRange[to]"
-                  label=""
-                  name="nextTimeRange[to]"
-                  placeholder="YYYY-MM-DD HH:mm:ss"
-                  type="text"
-                  value="1985-25-10 08:18:00.000"
-                />
-                <span
-                  class="input-group-btn"
+                <button
+                  class="c3 btn btn-default"
+                  title="Insert current date"
+                  type="button"
                 >
-                  <button
-                    class="c3 btn btn-default"
-                    title="Insert current date"
-                    type="button"
-                  >
-                    <svg
-                      class="svg-inline--fa fa-magic"
-                    />
-                  </button>
-                </span>
+                  <svg
+                    class="svg-inline--fa fa-magic"
+                  />
+                </button>
               </span>
             </span>
-          </div>
+          </span>
+        </div>
+        <div
+          class="DayPicker c4"
+          lang="en"
+        >
           <div
-            class="DayPicker c4"
-            lang="en"
+            class="DayPicker-wrapper"
+            tabindex="0"
           >
             <div
-              class="DayPicker-wrapper"
-              tabindex="0"
+              class="DayPicker-NavBar"
+            >
+              <span
+                aria-label="Previous Month"
+                class="DayPicker-NavButton DayPicker-NavButton--prev"
+                role="button"
+                tabindex="0"
+              />
+              <span
+                aria-label="Next Month"
+                class="DayPicker-NavButton DayPicker-NavButton--next"
+                role="button"
+                tabindex="0"
+              />
+            </div>
+            <div
+              class="DayPicker-Months"
             >
               <div
-                class="DayPicker-NavBar"
-              >
-                <span
-                  aria-label="Previous Month"
-                  class="DayPicker-NavButton DayPicker-NavButton--prev"
-                  role="button"
-                  tabindex="0"
-                />
-                <span
-                  aria-label="Next Month"
-                  class="DayPicker-NavButton DayPicker-NavButton--next"
-                  role="button"
-                  tabindex="0"
-                />
-              </div>
-              <div
-                class="DayPicker-Months"
+                class="DayPicker-Month"
+                role="grid"
               >
                 <div
-                  class="DayPicker-Month"
-                  role="grid"
+                  class="DayPicker-Caption"
+                  role="heading"
+                >
+                  <div>
+                    January 2021
+                  </div>
+                </div>
+                <div
+                  class="DayPicker-Weekdays"
+                  role="rowgroup"
                 >
                   <div
-                    class="DayPicker-Caption"
-                    role="heading"
+                    class="DayPicker-WeekdaysRow"
+                    role="row"
                   >
-                    <div>
-                      December 2020
+                    <div
+                      class="DayPicker-Weekday"
+                      role="columnheader"
+                    >
+                      <abbr
+                        title="Sunday"
+                      >
+                        Su
+                      </abbr>
+                    </div>
+                    <div
+                      class="DayPicker-Weekday"
+                      role="columnheader"
+                    >
+                      <abbr
+                        title="Monday"
+                      >
+                        Mo
+                      </abbr>
+                    </div>
+                    <div
+                      class="DayPicker-Weekday"
+                      role="columnheader"
+                    >
+                      <abbr
+                        title="Tuesday"
+                      >
+                        Tu
+                      </abbr>
+                    </div>
+                    <div
+                      class="DayPicker-Weekday"
+                      role="columnheader"
+                    >
+                      <abbr
+                        title="Wednesday"
+                      >
+                        We
+                      </abbr>
+                    </div>
+                    <div
+                      class="DayPicker-Weekday"
+                      role="columnheader"
+                    >
+                      <abbr
+                        title="Thursday"
+                      >
+                        Th
+                      </abbr>
+                    </div>
+                    <div
+                      class="DayPicker-Weekday"
+                      role="columnheader"
+                    >
+                      <abbr
+                        title="Friday"
+                      >
+                        Fr
+                      </abbr>
+                    </div>
+                    <div
+                      class="DayPicker-Weekday"
+                      role="columnheader"
+                    >
+                      <abbr
+                        title="Saturday"
+                      >
+                        Sa
+                      </abbr>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="DayPicker-Body"
+                  role="rowgroup"
+                >
+                  <div
+                    class="DayPicker-Week"
+                    role="row"
+                  >
+                    <div
+                      aria-disabled="true"
+                      aria-label="Sun Dec 27 2020"
+                      aria-selected="false"
+                      class="DayPicker-Day DayPicker-Day--outside"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      27
+                    </div>
+                    <div
+                      aria-disabled="true"
+                      aria-label="Mon Dec 28 2020"
+                      aria-selected="false"
+                      class="DayPicker-Day DayPicker-Day--outside"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      28
+                    </div>
+                    <div
+                      aria-disabled="true"
+                      aria-label="Tue Dec 29 2020"
+                      aria-selected="false"
+                      class="DayPicker-Day DayPicker-Day--outside"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      29
+                    </div>
+                    <div
+                      aria-disabled="true"
+                      aria-label="Wed Dec 30 2020"
+                      aria-selected="false"
+                      class="DayPicker-Day DayPicker-Day--outside"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      30
+                    </div>
+                    <div
+                      aria-disabled="true"
+                      aria-label="Thu Dec 31 2020"
+                      aria-selected="false"
+                      class="DayPicker-Day DayPicker-Day--outside"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      31
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Fri Jan 01 2021"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="0"
+                    >
+                      1
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Sat Jan 02 2021"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      2
                     </div>
                   </div>
                   <div
-                    class="DayPicker-Weekdays"
-                    role="rowgroup"
+                    class="DayPicker-Week"
+                    role="row"
                   >
                     <div
-                      class="DayPicker-WeekdaysRow"
-                      role="row"
+                      aria-disabled="false"
+                      aria-label="Sun Jan 03 2021"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
                     >
-                      <div
-                        class="DayPicker-Weekday"
-                        role="columnheader"
-                      >
-                        <abbr
-                          title="Sunday"
-                        >
-                          Su
-                        </abbr>
-                      </div>
-                      <div
-                        class="DayPicker-Weekday"
-                        role="columnheader"
-                      >
-                        <abbr
-                          title="Monday"
-                        >
-                          Mo
-                        </abbr>
-                      </div>
-                      <div
-                        class="DayPicker-Weekday"
-                        role="columnheader"
-                      >
-                        <abbr
-                          title="Tuesday"
-                        >
-                          Tu
-                        </abbr>
-                      </div>
-                      <div
-                        class="DayPicker-Weekday"
-                        role="columnheader"
-                      >
-                        <abbr
-                          title="Wednesday"
-                        >
-                          We
-                        </abbr>
-                      </div>
-                      <div
-                        class="DayPicker-Weekday"
-                        role="columnheader"
-                      >
-                        <abbr
-                          title="Thursday"
-                        >
-                          Th
-                        </abbr>
-                      </div>
-                      <div
-                        class="DayPicker-Weekday"
-                        role="columnheader"
-                      >
-                        <abbr
-                          title="Friday"
-                        >
-                          Fr
-                        </abbr>
-                      </div>
-                      <div
-                        class="DayPicker-Weekday"
-                        role="columnheader"
-                      >
-                        <abbr
-                          title="Saturday"
-                        >
-                          Sa
-                        </abbr>
-                      </div>
+                      3
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Mon Jan 04 2021"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      4
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Tue Jan 05 2021"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      5
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Wed Jan 06 2021"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      6
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Thu Jan 07 2021"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      7
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Fri Jan 08 2021"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      8
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Sat Jan 09 2021"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      9
                     </div>
                   </div>
                   <div
-                    class="DayPicker-Body"
-                    role="rowgroup"
+                    class="DayPicker-Week"
+                    role="row"
                   >
                     <div
-                      class="DayPicker-Week"
-                      role="row"
+                      aria-disabled="false"
+                      aria-label="Sun Jan 10 2021"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
                     >
-                      <div
-                        aria-disabled="true"
-                        aria-label="Sun Nov 29 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day DayPicker-Day--outside"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        29
-                      </div>
-                      <div
-                        aria-disabled="true"
-                        aria-label="Mon Nov 30 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day DayPicker-Day--outside"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        30
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Tue Dec 01 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="0"
-                      >
-                        1
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Wed Dec 02 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        2
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Thu Dec 03 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        3
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Fri Dec 04 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        4
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Sat Dec 05 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        5
-                      </div>
+                      10
                     </div>
                     <div
-                      class="DayPicker-Week"
-                      role="row"
+                      aria-disabled="false"
+                      aria-label="Mon Jan 11 2021"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
                     >
-                      <div
-                        aria-disabled="false"
-                        aria-label="Sun Dec 06 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        6
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Mon Dec 07 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        7
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Tue Dec 08 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        8
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Wed Dec 09 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        9
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Thu Dec 10 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        10
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Fri Dec 11 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        11
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Sat Dec 12 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        12
-                      </div>
+                      11
                     </div>
                     <div
-                      class="DayPicker-Week"
-                      role="row"
+                      aria-disabled="false"
+                      aria-label="Tue Jan 12 2021"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
                     >
-                      <div
-                        aria-disabled="false"
-                        aria-label="Sun Dec 13 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        13
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Mon Dec 14 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day DayPicker-Day--today"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        14
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Tue Dec 15 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day DayPicker-Day--today"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        15
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Wed Dec 16 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        16
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Thu Dec 17 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        17
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Fri Dec 18 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        18
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Sat Dec 19 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        19
-                      </div>
+                      12
                     </div>
                     <div
-                      class="DayPicker-Week"
-                      role="row"
+                      aria-disabled="false"
+                      aria-label="Wed Jan 13 2021"
+                      aria-selected="false"
+                      class="DayPicker-Day DayPicker-Day--today"
+                      role="gridcell"
+                      tabindex="-1"
                     >
-                      <div
-                        aria-disabled="false"
-                        aria-label="Sun Dec 20 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        20
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Mon Dec 21 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        21
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Tue Dec 22 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        22
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Wed Dec 23 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        23
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Thu Dec 24 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        24
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Fri Dec 25 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        25
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Sat Dec 26 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        26
-                      </div>
+                      13
                     </div>
                     <div
-                      class="DayPicker-Week"
-                      role="row"
+                      aria-disabled="false"
+                      aria-label="Thu Jan 14 2021"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
                     >
-                      <div
-                        aria-disabled="false"
-                        aria-label="Sun Dec 27 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        27
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Mon Dec 28 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        28
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Tue Dec 29 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        29
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Wed Dec 30 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        30
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Thu Dec 31 2020"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        31
-                      </div>
-                      <div
-                        aria-disabled="true"
-                        aria-label="Fri Jan 01 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day DayPicker-Day--outside"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        1
-                      </div>
-                      <div
-                        aria-disabled="true"
-                        aria-label="Sat Jan 02 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day DayPicker-Day--outside"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        2
-                      </div>
+                      14
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Fri Jan 15 2021"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      15
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Sat Jan 16 2021"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      16
+                    </div>
+                  </div>
+                  <div
+                    class="DayPicker-Week"
+                    role="row"
+                  >
+                    <div
+                      aria-disabled="false"
+                      aria-label="Sun Jan 17 2021"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      17
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Mon Jan 18 2021"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      18
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Tue Jan 19 2021"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      19
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Wed Jan 20 2021"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      20
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Thu Jan 21 2021"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      21
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Fri Jan 22 2021"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      22
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Sat Jan 23 2021"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      23
+                    </div>
+                  </div>
+                  <div
+                    class="DayPicker-Week"
+                    role="row"
+                  >
+                    <div
+                      aria-disabled="false"
+                      aria-label="Sun Jan 24 2021"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      24
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Mon Jan 25 2021"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      25
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Tue Jan 26 2021"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      26
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Wed Jan 27 2021"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      27
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Thu Jan 28 2021"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      28
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Fri Jan 29 2021"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      29
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Sat Jan 30 2021"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      30
+                    </div>
+                  </div>
+                  <div
+                    class="DayPicker-Week"
+                    role="row"
+                  >
+                    <div
+                      aria-disabled="false"
+                      aria-label="Sun Jan 31 2021"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      31
+                    </div>
+                    <div
+                      aria-disabled="true"
+                      aria-label="Mon Feb 01 2021"
+                      aria-selected="false"
+                      class="DayPicker-Day DayPicker-Day--outside"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      1
+                    </div>
+                    <div
+                      aria-disabled="true"
+                      aria-label="Tue Feb 02 2021"
+                      aria-selected="false"
+                      class="DayPicker-Day DayPicker-Day--outside"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      2
+                    </div>
+                    <div
+                      aria-disabled="true"
+                      aria-label="Wed Feb 03 2021"
+                      aria-selected="false"
+                      class="DayPicker-Day DayPicker-Day--outside"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      3
+                    </div>
+                    <div
+                      aria-disabled="true"
+                      aria-label="Thu Feb 04 2021"
+                      aria-selected="false"
+                      class="DayPicker-Day DayPicker-Day--outside"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      4
+                    </div>
+                    <div
+                      aria-disabled="true"
+                      aria-label="Fri Feb 05 2021"
+                      aria-selected="false"
+                      class="DayPicker-Day DayPicker-Day--outside"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      5
+                    </div>
+                    <div
+                      aria-disabled="true"
+                      aria-label="Sat Feb 06 2021"
+                      aria-selected="false"
+                      class="DayPicker-Day DayPicker-Day--outside"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      6
                     </div>
                   </div>
                 </div>
@@ -1959,89 +2041,92 @@ fieldset[disabled] .c9.form-control:not([type="range"]) {
             </div>
           </div>
         </div>
-        <div>
+        <div
+          class="c5"
+        >
           <div
-            class="c5"
+            class="form-group"
           >
-            <div
-              class="form-group"
+            <span
+              class="input-group"
             >
               <span
-                class="input-group"
+                class="c6 input-group-addon c7"
               >
-                <span
-                  class="c6 input-group-addon c7"
+                <button
+                  class="c8 btn btn-sm btn-link"
+                  title="Toggle between beginning and end of day"
+                  type="button"
                 >
-                  <button
-                    class="c8 btn btn-sm btn-link"
-                    title="Toggle between beginning and end of day"
-                    type="button"
-                  >
-                    <svg
-                      class="svg-inline--fa fa-hourglass-half"
-                    />
-                  </button>
-                </span>
-                <input
-                  class="c9 form-control input-sm"
-                  id="to-time-hours"
-                  title="to hour"
-                  type="number"
-                  value="NaN"
-                />
-                <span
-                  class="c6 input-group-addon c7"
-                >
-                  :
-                </span>
-                <input
-                  class="c9 form-control input-sm"
-                  id="to-time-minutes"
-                  title="to minutes"
-                  type="number"
-                  value="NaN"
-                />
-                <span
-                  class="c6 input-group-addon c7"
-                >
-                  :
-                </span>
-                <input
-                  class="c9 form-control input-sm"
-                  id="to-time-seconds"
-                  title="to seconds"
-                  type="number"
-                  value="NaN"
-                />
-                <span
-                  class="c6 input-group-addon c7"
-                >
-                  .
-                </span>
-                <input
-                  class="c9 form-control input-sm"
-                  id="to-time-milliseconds"
-                  title="to milliseconds"
-                  type="number"
-                  value="NaN"
-                />
-                <span
-                  class="c6 input-group-addon c7"
-                >
-                  <button
-                    class="c8 btn btn-sm btn-link"
-                    title="Set to current local time"
-                    type="button"
-                  >
-                    <svg
-                      class="svg-inline--fa fa-magic"
-                    />
-                  </button>
-                </span>
+                  <svg
+                    class="svg-inline--fa fa-hourglass-half"
+                  />
+                </button>
               </span>
-            </div>
+              <input
+                class="c9 form-control input-sm"
+                id="to-time-hours"
+                title="to hour"
+                type="number"
+                value="NaN"
+              />
+              <span
+                class="c6 input-group-addon c7"
+              >
+                :
+              </span>
+              <input
+                class="c9 form-control input-sm"
+                id="to-time-minutes"
+                title="to minutes"
+                type="number"
+                value="NaN"
+              />
+              <span
+                class="c6 input-group-addon c7"
+              >
+                :
+              </span>
+              <input
+                class="c9 form-control input-sm"
+                id="to-time-seconds"
+                title="to seconds"
+                type="number"
+                value="NaN"
+              />
+              <span
+                class="c6 input-group-addon c7"
+              >
+                .
+              </span>
+              <input
+                class="c9 form-control input-sm"
+                id="to-time-milliseconds"
+                title="to milliseconds"
+                type="number"
+                value="NaN"
+              />
+              <span
+                class="c6 input-group-addon c7"
+              >
+                <button
+                  class="c8 btn btn-sm btn-link"
+                  title="Set to current local time"
+                  type="button"
+                >
+                  <svg
+                    class="svg-inline--fa fa-magic"
+                  />
+                </button>
+              </span>
+            </span>
           </div>
         </div>
+        <span
+          class="c10"
+        >
+           
+        </span>
       </div>
     </div>
   </form>

--- a/graylog2-web-interface/src/views/logic/queries/Query.ts
+++ b/graylog2-web-interface/src/views/logic/queries/Query.ts
@@ -91,6 +91,7 @@ export type TimeRangeTypes = 'relative' | 'absolute' | 'keyword';
 export type RelativeTimeRange = {
   type: 'relative',
   range: number,
+  offset: number | undefined
 };
 
 export type AbsoluteTimeRange = {

--- a/graylog2-web-interface/src/views/logic/queries/Query.ts
+++ b/graylog2-web-interface/src/views/logic/queries/Query.ts
@@ -91,7 +91,7 @@ export type TimeRangeTypes = 'relative' | 'absolute' | 'keyword';
 export type RelativeTimeRange = {
   type: 'relative',
   range: number,
-  offset: number | undefined
+  offset?: number
 };
 
 export type AbsoluteTimeRange = {


### PR DESCRIPTION
**This PR is based on https://github.com/Graylog2/graylog2-server/pull/9899 which needs to be merged first**

## Description

With this PR we are enabling the "Until" field for the relative tab in the date time picker, this allows defining e.g. the following time range:

`From: 5 minutes ago until 1 minute ago`

There is one failing test, which also fails on `feature/DateTimeRange`.



