### PR TITLE
Supporting `from` and `to` properties in relative time ranges.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/engine/QueryBackend.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/engine/QueryBackend.java
@@ -50,7 +50,7 @@ public interface QueryBackend<T extends GeneratedQueryContext> {
     T generate(SearchJob job, Query query, Set<QueryResult> predecessorResults);
 
     default boolean isAllMessages(TimeRange timeRange) {
-        return timeRange instanceof RelativeRange && ((RelativeRange)timeRange).range() == 0;
+        return timeRange instanceof RelativeRange && ((RelativeRange)timeRange).isAllMessages();
     }
 
     default AbsoluteRange effectiveTimeRangeForResult(Query query, QueryResult queryResult) {

--- a/graylog2-server/src/main/java/org/graylog2/plugin/indexer/searches/timeranges/RelativeRange.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/indexer/searches/timeranges/RelativeRange.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
 import org.graylog2.plugin.Tools;
 import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 
 import java.util.OptionalInt;
 
@@ -58,7 +59,10 @@ public abstract class RelativeRange extends TimeRange {
     public DateTime getFrom() {
         // TODO this should be computed once
         if (range().isPresent()) {
-            return Tools.nowUTC().minusSeconds(range().getAsInt());
+            final int range = range().getAsInt();
+            return range > 0
+                ? Tools.nowUTC().minusSeconds(range().getAsInt())
+                : new DateTime(0, DateTimeZone.UTC);
         }
 
         return Tools.nowUTC().minusSeconds(from().orElseThrow(() -> new IllegalStateException("Neither `range` nor `from` specified!")));

--- a/graylog2-server/src/main/java/org/graylog2/plugin/indexer/searches/timeranges/RelativeRange.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/indexer/searches/timeranges/RelativeRange.java
@@ -116,14 +116,13 @@ public abstract class RelativeRange extends TimeRange {
                 }
             }
 
-            if ((from().isPresent() && !to().isPresent()) || (to().isPresent() && !from().isPresent()) {
+            if ((from().isPresent() && !to().isPresent()) || (to().isPresent() && !from().isPresent())) {
                 throw new InvalidRangeParametersException("Both `from` and `to` must be specified!");
             }
 
             if ((from().isPresent() && to().isPresent()) && (to().getAsInt() > from().getAsInt())) {
                 throw new InvalidRangeParametersException("`from` must be greater than `to`!");
             }
-            
             return autoBuild();
         }
 

--- a/graylog2-server/src/main/java/org/graylog2/plugin/indexer/searches/timeranges/RelativeRange.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/indexer/searches/timeranges/RelativeRange.java
@@ -115,6 +115,15 @@ public abstract class RelativeRange extends TimeRange {
                     throw new InvalidRangeParametersException("Range must not be negative");
                 }
             }
+
+            if ((from().isPresent() && !to().isPresent()) || (to().isPresent() && !from().isPresent()) {
+                throw new InvalidRangeParametersException("Both `from` and `to` must be specified!");
+            }
+
+            if ((from().isPresent() && to().isPresent()) && (to().getAsInt() > from().getAsInt())) {
+                throw new InvalidRangeParametersException("`from` must be greater than `to`!");
+            }
+            
             return autoBuild();
         }
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This change is implementing functionality to support an alternative way to use relative time ranges. Instead of a `range` property that defines the length of the range in seconds going backwards from now, it allows defining `from` and `to` properties defining the endpoints of a range in relation to `now`. This allows e.g. defining a range that goes from 5 minutes ago to 1 minute ago by specifying a relative range as:

```
{
  "type": "relative",
  "from": 300,
  "to": 60
}
```

Fixes #9898.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.