### PR TITLE
Fix csv export for shared dashboards.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/MessagesResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/MessagesResource.java
@@ -65,6 +65,7 @@ public class MessagesResource extends RestResource implements PluginRestResource
     private final SearchExecutionGuard executionGuard;
     private final PermittedStreams permittedStreams;
     private final ObjectMapper objectMapper;
+    private final ViewPermissionChecks viewPermissionChecks;
 
     //allow mocking
     Function<Consumer<Consumer<SimpleMessageChunk>>, ChunkedOutput<SimpleMessageChunk>> asyncRunner = ChunkedRunner::runAsync;
@@ -78,12 +79,13 @@ public class MessagesResource extends RestResource implements PluginRestResource
             SearchExecutionGuard executionGuard,
             PermittedStreams permittedStreams,
             ObjectMapper objectMapper,
-            @SuppressWarnings("UnstableApiUsage") EventBus eventBus) {
+            ViewPermissionChecks viewPermissionChecks, @SuppressWarnings("UnstableApiUsage") EventBus eventBus) {
         this.commandFactory = commandFactory;
         this.searchDomain = searchDomain;
         this.executionGuard = executionGuard;
         this.permittedStreams = permittedStreams;
         this.objectMapper = objectMapper;
+        this.viewPermissionChecks = viewPermissionChecks;
         this.messagesExporterFactory = context -> new AuditingMessagesExporter(context, eventBus, exporter);
     }
 
@@ -182,7 +184,7 @@ public class MessagesResource extends RestResource implements PluginRestResource
     }
 
     private boolean hasViewReadPermission(ViewDTO view) {
-        return isPermitted(ViewsRestPermissions.VIEW_READ, view.id());
+        return viewPermissionChecks.allowedToSeeView(getCurrentUser(), view, this::isPermitted);
     }
 
     private ImmutableSet<String> loadAllAllowedStreamsForUser() {

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/MessagesResourceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/MessagesResourceTest.java
@@ -27,6 +27,7 @@ import org.graylog.plugins.views.search.export.CommandFactory;
 import org.graylog.plugins.views.search.export.ExportMessagesCommand;
 import org.graylog.plugins.views.search.export.MessagesExporter;
 import org.graylog.plugins.views.search.export.MessagesRequest;
+import org.graylog.plugins.views.search.export.ResultFormat;
 import org.graylog2.plugin.database.users.User;
 import org.graylog2.shared.bindings.GuiceInjectorHolder;
 import org.junit.jupiter.api.BeforeEach;
@@ -42,6 +43,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -51,6 +53,7 @@ public class MessagesResourceTest {
     private MessagesResource sut;
     private User currentUser;
     private MessagesExporter exporter;
+    private ViewPermissionChecks viewPermissionChecks;
     private PermittedStreams permittedStreams;
     private SearchExecutionGuard executionGuard;
     private CommandFactory commandFactory;
@@ -64,6 +67,7 @@ public class MessagesResourceTest {
         currentUser = mock(User.class);
         when(currentUser.getName()).thenReturn("peterchen");
         exporter = mock(MessagesExporter.class);
+        viewPermissionChecks = mock(ViewPermissionChecks.class);
         commandFactory = mock(CommandFactory.class);
         when(commandFactory.buildFromRequest(any())).thenReturn(ExportMessagesCommand.withDefaults());
         when(commandFactory.buildWithSearchOnly(any(), any())).thenReturn(ExportMessagesCommand.withDefaults());
@@ -72,7 +76,7 @@ public class MessagesResourceTest {
         when(permittedStreams.load(any())).thenReturn(ImmutableSet.of("a-default-stream"));
         executionGuard = mock(SearchExecutionGuard.class);
         searchDomain = mock(SearchDomain.class);
-        sut = new MessagesTestResource(exporter, commandFactory, searchDomain, executionGuard, permittedStreams, mock(ObjectMapper.class), eventBus);
+        sut = new MessagesTestResource(exporter, commandFactory, searchDomain, executionGuard, permittedStreams, mock(ObjectMapper.class), viewPermissionChecks, eventBus);
 
         sut.asyncRunner = c -> {
             c.accept(x -> {
@@ -82,8 +86,8 @@ public class MessagesResourceTest {
     }
 
     class MessagesTestResource extends MessagesResource {
-        public MessagesTestResource(MessagesExporter exporter, CommandFactory commandFactory, SearchDomain searchDomain, SearchExecutionGuard executionGuard, PermittedStreams permittedStreams, ObjectMapper objectMapper, EventBus eventBus) {
-            super(exporter, commandFactory, searchDomain, executionGuard, permittedStreams, objectMapper, eventBus);
+        public MessagesTestResource(MessagesExporter exporter, CommandFactory commandFactory, SearchDomain searchDomain, SearchExecutionGuard executionGuard, PermittedStreams permittedStreams, ObjectMapper objectMapper, ViewPermissionChecks viewPermissionChecks, EventBus eventBus) {
+            super(exporter, commandFactory, searchDomain, executionGuard, permittedStreams, objectMapper, viewPermissionChecks, eventBus);
         }
 
         @Nullable


### PR DESCRIPTION
## Motivation
Prior to this change, if a user had read access to a dashboard via role
or direct permission the csv export failed for this dashboard, since the
permission test was testing on 'VIEW' where the role and permission had 'DASHBOARD'.

## Description
This change will use a new funtion introduced just for this case.

## How Has This Been Tested?
- Create a dashboard containing a message table
- Assign dashboard to a role with read permission
- Assign role to a reader user
- Login as reader user and export the table as CSV

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)