### PR TITLE
Do not allow selecting same pipeline stage twice

### DIFF
--- a/graylog2-web-interface/src/components/pipelines/Pipeline.jsx
+++ b/graylog2-web-interface/src/components/pipelines/Pipeline.jsx
@@ -119,6 +119,8 @@ const Pipeline = createReactClass({
       .sort((s1, s2) => s1.stage - s2.stage)
       .map((stage) => this._formatStage(stage, maxStage));
 
+    const stageKey = pipeline.stages.map((s) => s.stage).join('-');
+
     return (
       <div>
         {this._connections_warning()}
@@ -145,7 +147,7 @@ const Pipeline = createReactClass({
         <Row className="row-sm row-margin-top">
           <Col md={12}>
             <div className="pull-right">
-              <StageForm create save={this._saveStage} />
+              <StageForm key={stageKey} create pipeline={pipeline} save={this._saveStage} />
             </div>
             <h2>Pipeline Stages</h2>
             <p className="description-margin-top">

--- a/graylog2-web-interface/src/components/pipelines/Stage.jsx
+++ b/graylog2-web-interface/src/components/pipelines/Stage.jsx
@@ -105,19 +105,19 @@ const Stage = createReactClass({
   },
 
   render() {
-    const { stage } = this.props;
+    const { onUpdate, pipeline, stage } = this.props;
 
     const suffix = `Contains ${(stage.rules.length === 1 ? '1 rule' : `${stage.rules.length} rules`)}`;
 
     const throughput = (
-      <MetricContainer name={`org.graylog.plugins.pipelineprocessor.ast.Pipeline.${this.props.pipeline.id}.stage.${stage.stage}.executed`}>
+      <MetricContainer name={`org.graylog.plugins.pipelineprocessor.ast.Pipeline.${pipeline.id}.stage.${stage.stage}.executed`}>
         <CounterRate showTotal={false} prefix="Throughput: " suffix="msg/s" />
       </MetricContainer>
     );
 
     const actions = [
       <Button key="delete-stage" bsStyle="primary" onClick={this.props.onDelete}>Delete</Button>,
-      <StageForm key="edit-stage" stage={stage} save={this.props.onUpdate} />,
+      <StageForm key={`edit-stage-${stage.stage}`} pipeline={pipeline} stage={stage} save={onUpdate} />,
     ];
 
     let description;
@@ -144,7 +144,7 @@ const Stage = createReactClass({
 
     // We check if we have the rules details before trying to render them
     if (this.state.rules) {
-      content = this._formatRules(stage, this.props.stage.rules.map((name) => this.state.rules.filter((r) => r.title === name)[0]));
+      content = this._formatRules(stage, stage.rules.map((name) => this.state.rules.filter((r) => r.title === name)[0]));
     } else {
       content = <Spinner />;
     }

--- a/graylog2-web-interface/src/components/pipelines/StageForm.jsx
+++ b/graylog2-web-interface/src/components/pipelines/StageForm.jsx
@@ -88,6 +88,13 @@ const StageForm = createReactClass({
     this.modal.close();
   },
 
+  _isOverridingStage() {
+    const { pipeline } = this.props;
+    const { initialStageNumber, stage } = this.state;
+
+    return (stage.stage !== initialStageNumber && pipeline.stages.some(({ stage: s }) => s === stage.stage));
+  },
+
   _saved() {
     this._closeModal();
   },
@@ -96,7 +103,9 @@ const StageForm = createReactClass({
     const { stage } = this.state;
     const { save } = this.props;
 
-    save(stage, this._saved);
+    if (!this._isOverridingStage()) {
+      save(stage, this._saved);
+    }
   },
 
   _getFormattedOptions(rules) {
@@ -116,8 +125,8 @@ const StageForm = createReactClass({
 
   render() {
     let triggerButtonContent;
-    const { create, pipeline } = this.props;
-    const { initialStageNumber, stage, rules } = this.state;
+    const { create } = this.props;
+    const { stage, rules } = this.state;
 
     if (create) {
       triggerButtonContent = 'Add new stage';
@@ -132,7 +141,7 @@ const StageForm = createReactClass({
       </span>
     );
 
-    const isOverridingStage = (stage.stage !== initialStageNumber && pipeline.stages.some(({ stage: s }) => s === stage.stage));
+    const isOverridingStage = this._isOverridingStage();
 
     return (
       <span>


### PR DESCRIPTION
Check if selected stage number already exists in pipeline, displaying an error in that case and not allowing to submit the form. This will prevent users of accidentally overriding one of their existing stages.

Additionally improve the initial suggestion for new stages. Before we always displayed `0` when creating a stage, now we base that value in the existing stages for the pipeline.

Fixes #6806

Backport of #9911 for 4.0