### PR TITLE
DateTimePicker: Validate Keyword

### DIFF
--- a/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TabKeywordTimeRange.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TabKeywordTimeRange.tsx
@@ -89,9 +89,8 @@ const TabKeywordTimeRange = ({ defaultValue, disabled, setValidatingKeyword }: P
       : ToolsStore.testNaturalDate(keyword)
         .then((response) => {
           if (mounted.current) _setSuccessfullPreview(response);
-        }, () => {
-          if (mounted.current) _setFailedPreview();
-        });
+        })
+        .catch(_setFailedPreview);
   };
 
   useEffect(() => {

--- a/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TabKeywordTimeRange.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TabKeywordTimeRange.tsx
@@ -57,21 +57,6 @@ type Props = {
   disabled: boolean,
 };
 
-const _validateKeyword = (
-  keyword: string,
-  _setSuccessfullPreview: (preview: { from: string, to: string }) => void,
-  _setFailedPreview: () => string,
-): Promise<string> | undefined | null => {
-  if (keyword === undefined) {
-    return undefined;
-  }
-
-  return trim(keyword) === ''
-    ? Promise.resolve('Keyword must not be empty!')
-    : ToolsStore.testNaturalDate(keyword)
-      .then(_setSuccessfullPreview, _setFailedPreview);
-};
-
 const TabKeywordTimeRange = ({ defaultValue, disabled }: Props) => {
   const [nextRangeProps, , nextRangeHelpers] = useField('nextTimeRange');
   const keywordRef = useRef();
@@ -88,8 +73,21 @@ const TabKeywordTimeRange = ({ defaultValue, disabled }: Props) => {
     return 'Unable to parse keyword.';
   }, [setKeywordPreview]);
 
+  const _validateKeyword = (keyword: string): Promise<string> | undefined | null => {
+    if (keyword === undefined) {
+      return undefined;
+    }
+
+    return trim(keyword) === ''
+      ? Promise.resolve('Keyword must not be empty!')
+      : ToolsStore.testNaturalDate(keyword)
+        .then(_setSuccessfullPreview, _setFailedPreview);
+  };
+
   const _validate = useCallback(
-    (newKeyword) => _validateKeyword(newKeyword, _setSuccessfullPreview, _setFailedPreview),
+    (newKeyword) => {
+      return _validateKeyword(newKeyword);
+    },
     [_setSuccessfullPreview, _setFailedPreview],
   );
 
@@ -97,8 +95,7 @@ const TabKeywordTimeRange = ({ defaultValue, disabled }: Props) => {
     if (keywordRef.current !== nextRangeProps?.value?.keyword) {
       keywordRef.current = nextRangeProps.value.keyword;
 
-      ToolsStore.testNaturalDate(keywordRef.current)
-        .then(_setSuccessfullPreview, _setFailedPreview);
+      _validateKeyword(keywordRef.current);
     }
   });
 

--- a/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TabKeywordTimeRange.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TabKeywordTimeRange.tsx
@@ -60,6 +60,7 @@ type Props = {
 
 const TabKeywordTimeRange = ({ defaultValue, disabled, setValidatingKeyword }: Props) => {
   const [nextRangeProps, , nextRangeHelpers] = useField('nextTimeRange');
+  const mounted = useRef(true);
   const keywordRef = useRef();
   const [keywordPreview, setKeywordPreview] = useState({ from: '', to: '' });
 
@@ -86,8 +87,18 @@ const TabKeywordTimeRange = ({ defaultValue, disabled, setValidatingKeyword }: P
     return trim(keyword) === ''
       ? Promise.resolve('Keyword must not be empty!')
       : ToolsStore.testNaturalDate(keyword)
-        .then(_setSuccessfullPreview, _setFailedPreview);
+        .then((response) => {
+          if (mounted.current) _setSuccessfullPreview(response);
+        }, () => {
+          if (mounted.current) _setFailedPreview();
+        });
   };
+
+  useEffect(() => {
+    return () => {
+      mounted.current = false;
+    };
+  }, []);
 
   useEffect(() => {
     if (keywordRef.current !== nextRangeProps?.value?.keyword) {

--- a/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TimeRangeDropdown.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TimeRangeDropdown.tsx
@@ -111,7 +111,7 @@ const DEFAULT_RANGES = {
   disabled: undefined,
 };
 
-const timeRangeTypeTabs = ({ activeTab, limitDuration }) => availableTimeRangeTypes.map(({ type, name }) => {
+const timeRangeTypeTabs = ({ activeTab, limitDuration, setValidatingKeyword }) => availableTimeRangeTypes.map(({ type, name }) => {
   const TimeRangeTypeTabs = timeRangeTypes[type];
 
   return (
@@ -120,7 +120,8 @@ const timeRangeTypeTabs = ({ activeTab, limitDuration }) => availableTimeRangeTy
          eventKey={type}>
       {type === activeTab && (
         <TimeRangeTypeTabs disabled={false}
-                           limitDuration={limitDuration} />
+                           limitDuration={limitDuration}
+                           setValidatingKeyword={type === 'keyword' ? setValidatingKeyword : undefined} />
       )}
     </Tab>
   );
@@ -181,7 +182,7 @@ export const dateTimeValidate = (values, limitDuration) => {
 
 const TimeRangeDropdown = ({ noOverride, toggleDropdownShow, currentTimeRange, setCurrentTimeRange }: Props) => {
   const { limitDuration } = useContext(DateTimeContext);
-
+  const [validatingKeyword, setValidatingKeyword] = useState(false);
   const [activeTab, setActiveTab] = useState('type' in currentTimeRange ? currentTimeRange.type : undefined);
 
   const handleNoOverride = () => {
@@ -256,6 +257,7 @@ const TimeRangeDropdown = ({ noOverride, toggleDropdownShow, currentTimeRange, s
                     {timeRangeTypeTabs({
                       activeTab,
                       limitDuration,
+                      setValidatingKeyword,
                     })}
 
                     {!activeTab && (<TabDisabledTimeRange />)}
@@ -274,7 +276,7 @@ const TimeRangeDropdown = ({ noOverride, toggleDropdownShow, currentTimeRange, s
                       <Button bsStyle="link" onClick={handleNoOverride}>No Override</Button>
                     )}
                     <CancelButton bsStyle="default" onClick={handleCancel}>Cancel</CancelButton>
-                    <Button bsStyle="success" disabled={!isValid} type="submit">Apply</Button>
+                    <Button bsStyle="success" disabled={!isValid || validatingKeyword} type="submit">Apply</Button>
                   </div>
                 </Col>
               </Row>

--- a/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TimeRangeDropdown.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TimeRangeDropdown.tsx
@@ -168,8 +168,8 @@ export const dateTimeValidate = (values, limitDuration) => {
 
   if (nextTimeRange?.type === 'keyword') {
     if (limitDuration !== 0) {
-      const durationFrom = nextTimeRange.from;
-      const durationLimit = moment().subtract(Number(limitDuration), 'seconds').format(DateTime.Formats.TIMESTAMP);
+      const durationFrom = moment(nextTimeRange.from).utc();
+      const durationLimit = moment().subtract(Number(limitDuration), 'seconds').utc().format(DateTime.Formats.TIMESTAMP);
 
       if (moment(durationFrom).isBefore(durationLimit)) {
         errors.nextTimeRange = { keyword: 'Date is outside limit duration.' };


### PR DESCRIPTION
Disable `Apply` button until keyword is fully parsed
Fix issue where blank keyword was being sent to API