### PR TITLE
Fix date format specifiers in index mapping templates. (4.0)

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/Constants.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/Constants.java
@@ -16,24 +16,6 @@
  */
 package org.graylog2.indexer;
 
-import com.google.common.collect.ImmutableMap;
-
-import static org.graylog2.plugin.Message.FIELD_GL2_MESSAGE_ID;
-
-public class EventsIndexMapping7 extends EventsIndexMapping {
-    @Override
-    protected ImmutableMap<String, Object> fieldProperties() {
-        return map()
-                .putAll(super.fieldProperties())
-                .put(FIELD_GL2_MESSAGE_ID, map()
-                        .put("type", "alias")
-                        .put("path", "id")
-                        .build())
-                .build();
-    }
-
-    @Override
-    protected String dateFormat() {
-        return ConstantsES7.ES_DATE_FORMAT;
-    }
+class Constants {
+    static final String ES_DATE_FORMAT = "yyyy-MM-dd HH:mm:ss.SSS";
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/Constants.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/Constants.java
@@ -17,5 +17,5 @@
 package org.graylog2.indexer;
 
 class Constants {
-    static final String ES_DATE_FORMAT = "yyyy-MM-dd HH:mm:ss.SSS";
+    static final String ES_DATE_FORMAT = "8yyyy-MM-dd HH:mm:ss.SSS";
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/ConstantsES7.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/ConstantsES7.java
@@ -16,24 +16,6 @@
  */
 package org.graylog2.indexer;
 
-import com.google.common.collect.ImmutableMap;
-
-import static org.graylog2.plugin.Message.FIELD_GL2_MESSAGE_ID;
-
-public class EventsIndexMapping7 extends EventsIndexMapping {
-    @Override
-    protected ImmutableMap<String, Object> fieldProperties() {
-        return map()
-                .putAll(super.fieldProperties())
-                .put(FIELD_GL2_MESSAGE_ID, map()
-                        .put("type", "alias")
-                        .put("path", "id")
-                        .build())
-                .build();
-    }
-
-    @Override
-    protected String dateFormat() {
-        return ConstantsES7.ES_DATE_FORMAT;
-    }
+class ConstantsES7 {
+    static final String ES_DATE_FORMAT = "uuuu-MM-dd HH:mm:ss.SSS";
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/EventsIndexMapping.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/EventsIndexMapping.java
@@ -19,7 +19,6 @@ package org.graylog2.indexer;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.graylog2.indexer.indexset.IndexSetConfig;
-import org.graylog2.plugin.Tools;
 
 import java.util.Map;
 
@@ -121,25 +120,25 @@ public abstract class EventsIndexMapping implements IndexMappingTemplate {
                         .put("type", "date")
                         // Use the same format we use for the "message" mapping to make sure we
                         // can use the search.
-                        .put("format", Tools.ES_DATE_FORMAT)
+                        .put("format", dateFormat())
                         .build())
                 .put("timestamp_processing", map()
                         .put("type", "date")
                         // Use the same format we use for the "message" mapping to make sure we
                         // can use the search.
-                        .put("format", Tools.ES_DATE_FORMAT)
+                        .put("format", dateFormat())
                         .build())
                 .put("timerange_start", map()
                         .put("type", "date")
                         // Use the same format we use for the "message" mapping to make sure we
                         // can use the search.
-                        .put("format", Tools.ES_DATE_FORMAT)
+                        .put("format", dateFormat())
                         .build())
                 .put("timerange_end", map()
                         .put("type", "date")
                         // Use the same format we use for the "message" mapping to make sure we
                         // can use the search.
-                        .put("format", Tools.ES_DATE_FORMAT)
+                        .put("format", dateFormat())
                         .build())
                 .put("streams", map()
                         .put("type", "keyword")
@@ -211,5 +210,9 @@ public abstract class EventsIndexMapping implements IndexMappingTemplate {
 
     protected ImmutableList.Builder<Object> list() {
         return ImmutableList.builder();
+    }
+
+    protected String dateFormat() {
+        return Constants.ES_DATE_FORMAT;
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/GIMMapping.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/GIMMapping.java
@@ -352,9 +352,7 @@ public abstract class GIMMapping extends IndexMapping {
         ));
     }
 
-    protected String dateFormats() {
-        return "yyyy-MM-dd HH:mm:ss||yyyy-MM-dd";
-    }
+    protected abstract String dateFormats();
 
     private Map<String, Object> textField() {
         return typeField("text");

--- a/graylog2-server/src/main/java/org/graylog2/indexer/GIMMapping.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/GIMMapping.java
@@ -348,8 +348,12 @@ public abstract class GIMMapping extends IndexMapping {
     private Map<String, Object> dateField() {
         return merge(typeField("date"), Collections.singletonMap(
                 "format",
-                "yyyy-MM-dd HH:mm:ss||yyyy-MM-dd||basic_date_time||basic_date_time_no_millis||epoch_second||date_time_no_millis||date_hour_minute_second_fraction||epoch_millis"
+                dateFormats() + "||basic_date_time||basic_date_time_no_millis||epoch_second||date_time_no_millis||date_hour_minute_second_fraction||epoch_millis"
         ));
+    }
+
+    protected String dateFormats() {
+        return "yyyy-MM-dd HH:mm:ss||yyyy-MM-dd";
     }
 
     private Map<String, Object> textField() {

--- a/graylog2-server/src/main/java/org/graylog2/indexer/GIMMapping6.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/GIMMapping6.java
@@ -28,4 +28,9 @@ public class GIMMapping6 extends GIMMapping {
                 "mapping", notAnalyzedString()
         );
     }
+
+    @Override
+    protected String dateFormats() {
+        return "8yyyy-MM-dd HH:mm:ss||8yyyy-MM-dd";
+    }
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/GIMMapping7.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/GIMMapping7.java
@@ -43,4 +43,9 @@ public class GIMMapping7 extends GIMMapping {
                 "mappings", mappings
         );
     }
+
+    @Override
+    protected String dateFormats() {
+        return "uuuu-MM-dd HH:mm:ss||uuuu-MM-dd";
+    }
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/GIMMapping7.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/GIMMapping7.java
@@ -48,4 +48,9 @@ public class GIMMapping7 extends GIMMapping {
     protected String dateFormats() {
         return "uuuu-MM-dd HH:mm:ss||uuuu-MM-dd";
     }
+
+    @Override
+    protected String dateFormat() {
+        return ConstantsES7.ES_DATE_FORMAT;
+    }
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/IndexMapping.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/IndexMapping.java
@@ -20,7 +20,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.graylog2.indexer.indexset.IndexSetConfig;
 import org.graylog2.plugin.Message;
-import org.graylog2.plugin.Tools;
 
 import java.util.Collections;
 import java.util.List;
@@ -121,7 +120,7 @@ public abstract class IndexMapping implements IndexMappingTemplate {
     protected Map<String, Object> typeTimeWithMillis() {
         return ImmutableMap.of(
                 "type", "date",
-                "format", Tools.ES_DATE_FORMAT);
+                "format", dateFormat());
     }
 
     protected Map<String, Object> typeLong() {
@@ -130,5 +129,9 @@ public abstract class IndexMapping implements IndexMappingTemplate {
 
     private Map<String, Boolean> enabled() {
         return ImmutableMap.of("enabled", true);
+    }
+
+    protected String dateFormat() {
+        return Constants.ES_DATE_FORMAT;
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/IndexMapping7.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/IndexMapping7.java
@@ -43,4 +43,9 @@ public class IndexMapping7 extends IndexMapping {
                 "mappings", mappings
         );
     }
+
+    @Override
+    protected String dateFormat() {
+        return ConstantsES7.ES_DATE_FORMAT;
+    }
 }

--- a/graylog2-server/src/main/java/org/graylog2/plugin/Tools.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/Tools.java
@@ -70,10 +70,11 @@ public final class Tools {
     private static final byte[] EMPTY_BYTE_ARRAY_4 = {0,0,0,0};
     private static final byte[] EMPTY_BYTE_ARRAY_16 = {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0};
 
-    public static final String ES_DATE_FORMAT = "yyyy-MM-dd HH:mm:ss.SSS";
-    public static final String ES_DATE_FORMAT_NO_MS = "yyyy-MM-dd HH:mm:ss";
+    private static final String ES_DATE_FORMAT_JODA = "yyyy-MM-dd HH:mm:ss.SSS";
+    private static final String ES_DATE_FORMAT_NO_MS = "yyyy-MM-dd HH:mm:ss";
 
-    public static final DateTimeFormatter ES_DATE_FORMAT_FORMATTER = DateTimeFormat.forPattern(Tools.ES_DATE_FORMAT).withZoneUTC();
+    public static final DateTimeFormatter ES_DATE_FORMAT_FORMATTER = DateTimeFormat.forPattern(Tools.ES_DATE_FORMAT_JODA).withZoneUTC();
+    public static final DateTimeFormatter ES_DATE_FORMAT_NO_MS_FORMATTER = DateTimeFormat.forPattern(Tools.ES_DATE_FORMAT_NO_MS).withZoneUTC();
     public static final DateTimeFormatter ISO_DATE_FORMAT_FORMATTER = ISODateTimeFormat.dateTime().withZoneUTC();
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 

--- a/graylog2-server/src/main/java/org/graylog2/plugin/utilities/date/NaturalDateParser.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/utilities/date/NaturalDateParser.java
@@ -22,7 +22,6 @@ import com.joestelmach.natty.Parser;
 import org.graylog2.plugin.Tools;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
-import org.joda.time.format.DateTimeFormat;
 
 import java.util.Collections;
 import java.util.Date;
@@ -93,7 +92,7 @@ public class NaturalDateParser {
         }
 
         private String dateFormat(final DateTime x) {
-            return x.toString(DateTimeFormat.forPattern(Tools.ES_DATE_FORMAT_NO_MS).withZoneUTC());
+            return x.toString(Tools.ES_DATE_FORMAT_NO_MS_FORMATTER.withZoneUTC());
         }
     }
 

--- a/graylog2-server/src/test/java/org/graylog2/indexer/EventsIndexMappingTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/EventsIndexMappingTest.java
@@ -79,13 +79,13 @@ public class EventsIndexMappingTest {
         at.jsonPathAsString(keyFor("properties.event_definition_id.type", version)).isEqualTo("keyword");
         at.jsonPathAsString(keyFor("properties.origin_context.type", version)).isEqualTo("keyword");
         at.jsonPathAsString(keyFor("properties.timestamp.type", version)).isEqualTo("date");
-        at.jsonPathAsString(keyFor("properties.timestamp.format", version)).isEqualTo("yyyy-MM-dd HH:mm:ss.SSS");
+        at.jsonPathAsString(keyFor("properties.timestamp.format", version)).isEqualTo(dateFormat(version));
         at.jsonPathAsString(keyFor("properties.timestamp_processing.type", version)).isEqualTo("date");
-        at.jsonPathAsString(keyFor("properties.timestamp_processing.format", version)).isEqualTo("yyyy-MM-dd HH:mm:ss.SSS");
+        at.jsonPathAsString(keyFor("properties.timestamp_processing.format", version)).isEqualTo(dateFormat(version));
         at.jsonPathAsString(keyFor("properties.timerange_start.type", version)).isEqualTo("date");
-        at.jsonPathAsString(keyFor("properties.timerange_start.format", version)).isEqualTo("yyyy-MM-dd HH:mm:ss.SSS");
+        at.jsonPathAsString(keyFor("properties.timerange_start.format", version)).isEqualTo(dateFormat(version));
         at.jsonPathAsString(keyFor("properties.timerange_end.type", version)).isEqualTo("date");
-        at.jsonPathAsString(keyFor("properties.timerange_end.format", version)).isEqualTo("yyyy-MM-dd HH:mm:ss.SSS");
+        at.jsonPathAsString(keyFor("properties.timerange_end.format", version)).isEqualTo(dateFormat(version));
         at.jsonPathAsString(keyFor("properties.streams.type", version)).isEqualTo("keyword");
         at.jsonPathAsString(keyFor("properties.source_streams.type", version)).isEqualTo("keyword");
         at.jsonPathAsString(keyFor("properties.message.type", version)).isEqualTo("text");
@@ -100,6 +100,14 @@ public class EventsIndexMappingTest {
         at.jsonPathAsString(keyFor("properties.fields.type", version)).isEqualTo("object");
         at.jsonPathAsBoolean(keyFor("properties.fields.dynamic", version)).isTrue();
         at.jsonPathAsString(keyFor("properties.triggered_jobs.type", version)).isEqualTo("keyword");
+    }
+
+    private String dateFormat(Version version) {
+        if (version.greaterThanOrEqualTo(Version.valueOf("7.0.0"))) {
+            return "uuuu-MM-dd HH:mm:ss.SSS";
+        }
+
+        return "yyyy-MM-dd HH:mm:ss.SSS";
     }
 
     private String keyFor(String keySuffix, Version version) {

--- a/graylog2-server/src/test/java/org/graylog2/indexer/EventsIndexMappingTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/EventsIndexMappingTest.java
@@ -107,7 +107,7 @@ public class EventsIndexMappingTest {
             return "uuuu-MM-dd HH:mm:ss.SSS";
         }
 
-        return "yyyy-MM-dd HH:mm:ss.SSS";
+        return "8yyyy-MM-dd HH:mm:ss.SSS";
     }
 
     private String keyFor(String keySuffix, Version version) {

--- a/graylog2-server/src/test/resources/org/graylog2/indexer/expected_gim_template6.json
+++ b/graylog2-server/src/test/resources/org/graylog2/indexer/expected_gim_template6.json
@@ -66,18 +66,18 @@
         },
         "timestamp" : {
           "type" : "date",
-          "format" : "yyyy-MM-dd HH:mm:ss.SSS"
+          "format" : "8yyyy-MM-dd HH:mm:ss.SSS"
         },
         "gl2_accounted_message_size" : {
           "type" : "long"
         },
         "gl2_receive_timestamp" : {
           "type" : "date",
-          "format" : "yyyy-MM-dd HH:mm:ss.SSS"
+          "format" : "8yyyy-MM-dd HH:mm:ss.SSS"
         },
         "gl2_processing_timestamp" : {
           "type" : "date",
-          "format" : "yyyy-MM-dd HH:mm:ss.SSS"
+          "format" : "8yyyy-MM-dd HH:mm:ss.SSS"
         },
         "source" : {
           "type" : "text",
@@ -541,7 +541,7 @@
         },
         "event_created": {
           "type": "date",
-          "format": "yyyy-MM-dd HH:mm:ss||yyyy-MM-dd||basic_date_time||basic_date_time_no_millis||epoch_second||date_time_no_millis||date_hour_minute_second_fraction||epoch_millis"
+          "format": "8yyyy-MM-dd HH:mm:ss||8yyyy-MM-dd||basic_date_time||basic_date_time_no_millis||epoch_second||date_time_no_millis||date_hour_minute_second_fraction||epoch_millis"
         },
         "event_source": {
           "type": "keyword"
@@ -554,7 +554,7 @@
         },
         "event_start": {
           "type": "date",
-          "format": "yyyy-MM-dd HH:mm:ss||yyyy-MM-dd||basic_date_time||basic_date_time_no_millis||epoch_second||date_time_no_millis||date_hour_minute_second_fraction||epoch_millis"
+          "format": "8yyyy-MM-dd HH:mm:ss||8yyyy-MM-dd||basic_date_time||basic_date_time_no_millis||epoch_second||date_time_no_millis||date_hour_minute_second_fraction||epoch_millis"
         },
         "event_code": {
           "type": "keyword"
@@ -593,7 +593,7 @@
         },
         "event_received_time": {
           "type": "date",
-          "format": "yyyy-MM-dd HH:mm:ss||yyyy-MM-dd||basic_date_time||basic_date_time_no_millis||epoch_second||date_time_no_millis||date_hour_minute_second_fraction||epoch_millis"
+          "format": "8yyyy-MM-dd HH:mm:ss||8yyyy-MM-dd||basic_date_time||basic_date_time_no_millis||epoch_second||date_time_no_millis||date_hour_minute_second_fraction||epoch_millis"
         },
         "event_repeat_count": {
           "type": "long"
@@ -615,7 +615,7 @@
         },
         "file_created_date": {
           "type": "date",
-          "format": "yyyy-MM-dd HH:mm:ss||yyyy-MM-dd||basic_date_time||basic_date_time_no_millis||epoch_second||date_time_no_millis||date_hour_minute_second_fraction||epoch_millis"
+          "format": "8yyyy-MM-dd HH:mm:ss||8yyyy-MM-dd||basic_date_time||basic_date_time_no_millis||epoch_second||date_time_no_millis||date_hour_minute_second_fraction||epoch_millis"
         },
         "file_name": {
           "type": "keyword"

--- a/graylog2-server/src/test/resources/org/graylog2/indexer/expected_gim_template7.json
+++ b/graylog2-server/src/test/resources/org/graylog2/indexer/expected_gim_template7.json
@@ -66,18 +66,18 @@
       },
       "timestamp": {
         "type": "date",
-        "format": "yyyy-MM-dd HH:mm:ss.SSS"
+        "format": "uuuu-MM-dd HH:mm:ss.SSS"
       },
       "gl2_accounted_message_size": {
         "type": "long"
       },
       "gl2_receive_timestamp": {
         "type": "date",
-        "format": "yyyy-MM-dd HH:mm:ss.SSS"
+        "format": "uuuu-MM-dd HH:mm:ss.SSS"
       },
       "gl2_processing_timestamp": {
         "type": "date",
-        "format": "yyyy-MM-dd HH:mm:ss.SSS"
+        "format": "uuuu-MM-dd HH:mm:ss.SSS"
       },
       "source": {
         "type": "text",
@@ -541,7 +541,7 @@
       },
       "event_created": {
         "type": "date",
-        "format": "yyyy-MM-dd HH:mm:ss||yyyy-MM-dd||basic_date_time||basic_date_time_no_millis||epoch_second||date_time_no_millis||date_hour_minute_second_fraction||epoch_millis"
+        "format": "uuuu-MM-dd HH:mm:ss||uuuu-MM-dd||basic_date_time||basic_date_time_no_millis||epoch_second||date_time_no_millis||date_hour_minute_second_fraction||epoch_millis"
       },
       "event_source": {
         "type": "keyword"
@@ -554,7 +554,7 @@
       },
       "event_start": {
         "type": "date",
-        "format": "yyyy-MM-dd HH:mm:ss||yyyy-MM-dd||basic_date_time||basic_date_time_no_millis||epoch_second||date_time_no_millis||date_hour_minute_second_fraction||epoch_millis"
+        "format": "uuuu-MM-dd HH:mm:ss||uuuu-MM-dd||basic_date_time||basic_date_time_no_millis||epoch_second||date_time_no_millis||date_hour_minute_second_fraction||epoch_millis"
       },
       "event_code": {
         "type": "keyword"
@@ -593,7 +593,7 @@
       },
       "event_received_time": {
         "type": "date",
-        "format": "yyyy-MM-dd HH:mm:ss||yyyy-MM-dd||basic_date_time||basic_date_time_no_millis||epoch_second||date_time_no_millis||date_hour_minute_second_fraction||epoch_millis"
+        "format": "uuuu-MM-dd HH:mm:ss||uuuu-MM-dd||basic_date_time||basic_date_time_no_millis||epoch_second||date_time_no_millis||date_hour_minute_second_fraction||epoch_millis"
       },
       "event_repeat_count": {
         "type": "long"
@@ -615,7 +615,7 @@
       },
       "file_created_date": {
         "type": "date",
-        "format": "yyyy-MM-dd HH:mm:ss||yyyy-MM-dd||basic_date_time||basic_date_time_no_millis||epoch_second||date_time_no_millis||date_hour_minute_second_fraction||epoch_millis"
+        "format": "uuuu-MM-dd HH:mm:ss||uuuu-MM-dd||basic_date_time||basic_date_time_no_millis||epoch_second||date_time_no_millis||date_hour_minute_second_fraction||epoch_millis"
       },
       "file_name": {
         "type": "keyword"

--- a/graylog2-server/src/test/resources/org/graylog2/indexer/expected_template5.json
+++ b/graylog2-server/src/test/resources/org/graylog2/indexer/expected_template5.json
@@ -26,18 +26,18 @@
         },
         "timestamp" : {
           "type" : "date",
-          "format" : "yyyy-MM-dd HH:mm:ss.SSS"
+          "format" : "8yyyy-MM-dd HH:mm:ss.SSS"
         },
         "gl2_accounted_message_size" : {
           "type" : "long"
         },
         "gl2_receive_timestamp" : {
           "type" : "date",
-          "format" : "yyyy-MM-dd HH:mm:ss.SSS"
+          "format" : "8yyyy-MM-dd HH:mm:ss.SSS"
         },
         "gl2_processing_timestamp" : {
           "type" : "date",
-          "format" : "yyyy-MM-dd HH:mm:ss.SSS"
+          "format" : "8yyyy-MM-dd HH:mm:ss.SSS"
         },
         "source" : {
           "type" : "text",

--- a/graylog2-server/src/test/resources/org/graylog2/indexer/expected_template6.json
+++ b/graylog2-server/src/test/resources/org/graylog2/indexer/expected_template6.json
@@ -26,18 +26,18 @@
         },
         "timestamp" : {
           "type" : "date",
-          "format" : "yyyy-MM-dd HH:mm:ss.SSS"
+          "format" : "8yyyy-MM-dd HH:mm:ss.SSS"
         },
         "gl2_accounted_message_size" : {
           "type" : "long"
         },
         "gl2_receive_timestamp" : {
           "type" : "date",
-          "format" : "yyyy-MM-dd HH:mm:ss.SSS"
+          "format" : "8yyyy-MM-dd HH:mm:ss.SSS"
         },
         "gl2_processing_timestamp" : {
           "type" : "date",
-          "format" : "yyyy-MM-dd HH:mm:ss.SSS"
+          "format" : "8yyyy-MM-dd HH:mm:ss.SSS"
         },
         "source" : {
           "type" : "text",

--- a/graylog2-server/src/test/resources/org/graylog2/indexer/expected_template7.json
+++ b/graylog2-server/src/test/resources/org/graylog2/indexer/expected_template7.json
@@ -25,18 +25,18 @@
       },
       "timestamp": {
         "type": "date",
-        "format": "yyyy-MM-dd HH:mm:ss.SSS"
+        "format": "uuuu-MM-dd HH:mm:ss.SSS"
       },
       "gl2_accounted_message_size": {
         "type": "long"
       },
       "gl2_receive_timestamp": {
         "type": "date",
-        "format": "yyyy-MM-dd HH:mm:ss.SSS"
+        "format": "uuuu-MM-dd HH:mm:ss.SSS"
       },
       "gl2_processing_timestamp": {
         "type": "date",
-        "format": "yyyy-MM-dd HH:mm:ss.SSS"
+        "format": "uuuu-MM-dd HH:mm:ss.SSS"
       },
       "source": {
         "type": "text",


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

**Note: This is a backport of #9873 to `4.0`**

Before this change, the pre-ES7 date format specifiers were reused for ES7 to define the format of date fields in index mapping templates.

Unfortunately, this results in warnings being returned in responses to searches operating on date fields, due to a [breaking change introduced in ES7](https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking-changes-7.0.html#_joda_based_date_formatters_are_replaced_with_java_ones).

This change is now splitting up the date format specifiers and uses joda syntax for ES6 and `java.time` syntax for ES7. In addition, the overly lax exposition of the date format specifiers from the `Tools` class was locked down to prevent them leaking into new places.

**Question:** When this change is used in existing setups, any usage of date fields in indices created before this change will still trigger a warning. Only indices created after this change will prevent the warning. This could be remedied by writing a migration that updates the index mapping templates in a subsequent PR. I am not sure if the result is worth the effort (and the risk of breaking index mapping templates in the migration), any comments?

Fixes #9690.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.