### PR TITLE
Fix waiting for recovery for red indices.

### DIFF
--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/jest/JestUtils.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/jest/JestUtils.java
@@ -46,7 +46,7 @@ public class JestUtils {
     private JestUtils() {
     }
 
-    public static <T extends JestResult> T execute(JestClient client, RequestConfig requestConfig,
+    public static <T extends JestResult> T executeUnsafe(JestClient client, RequestConfig requestConfig,
                                                    Action<T> request, Supplier<String> errorMessage) {
         final T result;
         try {
@@ -59,6 +59,12 @@ public class JestUtils {
             throw new ElasticsearchException(errorMessage.get(), e);
         }
 
+        return result;
+    }
+
+    public static <T extends JestResult> T execute(JestClient client, RequestConfig requestConfig,
+                                                   Action<T> request, Supplier<String> errorMessage) {
+        final T result = executeUnsafe(client, requestConfig, request, errorMessage);
         if (result.isSucceeded()) {
             return result;
         } else {

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/IndicesAdapterES7.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/IndicesAdapterES7.java
@@ -43,6 +43,7 @@ import org.graylog.shaded.elasticsearch7.org.elasticsearch.client.indices.Create
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.client.indices.DeleteAliasRequest;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.client.indices.PutIndexTemplateRequest;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.cluster.metadata.AliasMetadata;
+import org.graylog.shaded.elasticsearch7.org.elasticsearch.common.unit.TimeValue;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.index.query.QueryBuilders;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.index.reindex.BulkByScrollResponse;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.index.reindex.ReindexRequest;
@@ -442,7 +443,12 @@ public class IndicesAdapterES7 implements IndicesAdapter {
 
     @Override
     public HealthStatus waitForRecovery(String index) {
-        final ClusterHealthRequest clusterHealthRequest = new ClusterHealthRequest(index);
+        return waitForRecovery(index, 30);
+    }
+
+    @Override
+    public HealthStatus waitForRecovery(String index, int timeout) {
+        final ClusterHealthRequest clusterHealthRequest = new ClusterHealthRequest(index).timeout(TimeValue.timeValueSeconds(timeout));
         clusterHealthRequest.waitForGreenStatus();
 
         final ClusterHealthResponse result = client.execute((c, requestOptions) -> c.cluster().health(clusterHealthRequest, requestOptions));

--- a/graylog2-server/src/main/java/org/graylog2/indexer/MongoIndexSet.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/MongoIndexSet.java
@@ -54,6 +54,7 @@ import java.util.stream.Collectors;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.util.Objects.requireNonNull;
 import static org.graylog2.audit.AuditEventTypes.ES_WRITE_INDEX_UPDATE;
+import static org.graylog2.indexer.indices.Indices.checkIfHealthy;
 
 public class MongoIndexSet implements IndexSet {
     private static final Logger LOG = LoggerFactory.getLogger(MongoIndexSet.class);
@@ -295,7 +296,8 @@ public class MongoIndexSet implements IndexSet {
         }
 
         LOG.info("Waiting for allocation of index <{}>.", newTarget);
-        HealthStatus healthStatus = indices.waitForRecovery(newTarget);
+        final HealthStatus healthStatus = indices.waitForRecovery(newTarget);
+        checkIfHealthy(healthStatus, (status) -> new RuntimeException("New target index did not become healthy (target index: <" + newTarget + ">)"));
         LOG.debug("Health status of index <{}>: {}", newTarget, healthStatus);
 
         addDeflectorIndexRange(newTarget);

--- a/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
@@ -326,7 +326,7 @@ public class Indices {
         indicesAdapter.optimizeIndex(index, maxNumSegments, timeout);
     }
 
-    public HealthStatus waitForRecovery(String index, int timeout) {
+    HealthStatus waitForRecovery(String index, int timeout) {
         LOG.debug("Waiting until index health status of index {} is healthy", index);
         return indicesAdapter.waitForRecovery(index, timeout);
     }
@@ -334,6 +334,12 @@ public class Indices {
     public HealthStatus waitForRecovery(String index) {
         LOG.debug("Waiting until index health status of index {} is healthy", index);
         return indicesAdapter.waitForRecovery(index);
+    }
+
+    public static <E extends Exception> void checkIfHealthy(HealthStatus healthStatus, Function<HealthStatus, E> errorMessageSupplier) throws E {
+        if (healthStatus.equals(HealthStatus.Red)) {
+            throw errorMessageSupplier.apply(healthStatus);
+        }
     }
 
     public Optional<DateTime> indexCreationDate(String index) {

--- a/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
@@ -326,6 +326,11 @@ public class Indices {
         indicesAdapter.optimizeIndex(index, maxNumSegments, timeout);
     }
 
+    public HealthStatus waitForRecovery(String index, int timeout) {
+        LOG.debug("Waiting until index health status of index {} is healthy", index);
+        return indicesAdapter.waitForRecovery(index, timeout);
+    }
+
     public HealthStatus waitForRecovery(String index) {
         LOG.debug("Waiting until index health status of index {} is healthy", index);
         return indicesAdapter.waitForRecovery(index);

--- a/graylog2-server/src/main/java/org/graylog2/indexer/indices/IndicesAdapter.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indices/IndicesAdapter.java
@@ -90,6 +90,7 @@ public interface IndicesAdapter {
     IndexRangeStats indexRangeStatsOfIndex(String index);
 
     HealthStatus waitForRecovery(String index);
+    HealthStatus waitForRecovery(String index, int timeout);
 
     boolean isOpen(String index);
 

--- a/graylog2-server/src/test/java/org/graylog2/indexer/indices/IndicesIT.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/indices/IndicesIT.java
@@ -434,4 +434,11 @@ public abstract class IndicesIT extends ElasticsearchBaseTest {
         assertThat(indexSetStats.indices()).isEqualTo(2L);
         assertThat(indexSetStats.size()).isNotZero();
     }
+
+    @Test
+    public void waitForRedIndexReturnsStatus() {
+        final HealthStatus healthStatus = indices.waitForRecovery("this_index_does_not_exist", 0);
+
+        assertThat(healthStatus).isEqualTo(HealthStatus.Red);
+    }
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

When one or more ES nodes are in flood stage, cycling the deflector fails due to not being able to create a new index and toggling the deflector alias. During this step, the code waits for a new index to be created and healthy. Unfortunately, the `waitForRecovery` method used internally does not deal properly with indices being red. The response we are receiving when querying the health of a red index is set to unsuccessful, triggering our abstracted error handling mechanism which is throwing an exception instead of passing through the `red` health state.

This change is now using a different, less safe way of executing the health query request and returning the response as is. This allows waiting for recovery on red indices and timing out instead of throwing an exception.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.