### PR TITLE
Retrying bulk indexing if target alias has invalid target(s).

### DIFF
--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/MessagesAdapterES6.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/MessagesAdapterES6.java
@@ -173,7 +173,12 @@ public class MessagesAdapterES6 implements MessagesAdapter {
                 throw new ChunkedBulkIndexer.EntityTooLargeException(indexedSuccessfully, indexingErrorsFrom(failedItems, messageList));
             }
 
-            // TODO should we check result.isSucceeded()?
+            // Checking `result.isSucceeded()` is always `false` if at least one item fails. Instead, we are checking the response code to
+            // to determine if the result failed in general.
+
+            if (result.getResponseCode() >= 400) {
+                throw JestUtils.specificException(() -> "Error during bulk indexing: ", result.getJsonObject().get("error"));
+            }
 
             indexedSuccessfully += chunk.size();
 

--- a/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/testing/ClientES6.java
+++ b/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/testing/ClientES6.java
@@ -39,6 +39,7 @@ import io.searchbox.indices.IndicesExists;
 import io.searchbox.indices.Refresh;
 import io.searchbox.indices.aliases.AddAliasMapping;
 import io.searchbox.indices.aliases.ModifyAliases;
+import io.searchbox.indices.aliases.RemoveAliasMapping;
 import io.searchbox.indices.mapping.GetMapping;
 import io.searchbox.indices.template.DeleteTemplate;
 import io.searchbox.indices.template.GetTemplate;
@@ -118,6 +119,14 @@ public class ClientES6 implements Client {
         final ModifyAliases addAliasRequest = new ModifyAliases.Builder(addAliasMapping).build();
 
         executeWithExpectedSuccess(addAliasRequest, "failed to add alias " + alias + " for index " + indexName);
+    }
+
+    @Override
+    public void removeAliasMapping(String indexName, String alias) {
+        final RemoveAliasMapping removeAliasMapping = new RemoveAliasMapping.Builder(indexName, alias).build();
+        final ModifyAliases addAliasRequest = new ModifyAliases.Builder(removeAliasMapping).build();
+
+        executeWithExpectedSuccess(addAliasRequest, "failed to remove alias " + alias + " for index " + indexName);
     }
 
     private JsonNode getMapping(String... indices) {

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/ElasticsearchClient.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/ElasticsearchClient.java
@@ -25,17 +25,21 @@ import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.search.SearchR
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.client.RequestOptions;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.client.RestHighLevelClient;
 import org.graylog2.indexer.IndexNotFoundException;
-import org.graylog2.indexer.messages.InvalidWriteTargetException;
+import org.graylog2.indexer.InvalidWriteTargetException;
 
 import javax.inject.Inject;
 import javax.inject.Named;
 import java.io.IOException;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
 public class ElasticsearchClient {
+    private static final Pattern invalidWriteTarget = Pattern.compile("no write index is defined for alias \\[(?<target>[\\w_]+)\\]");
+
     private final RestHighLevelClient client;
     private final boolean compressionEnabled;
 
@@ -120,7 +124,11 @@ public class ElasticsearchClient {
                 throw IndexNotFoundException.create(errorMessage + elasticsearchException.getResourceId(), elasticsearchException.getIndex().getName());
             }
             if (isInvalidWriteTargetException(elasticsearchException)) {
-                throw new InvalidWriteTargetException("Write target for indexing is invalid.", elasticsearchException);
+                final Matcher matcher = invalidWriteTarget.matcher(elasticsearchException.getMessage());
+                if (matcher.find()) {
+                    final String target = matcher.group("target");
+                    throw InvalidWriteTargetException.create(target);
+                }
             }
         }
         return new ElasticsearchException(errorMessage, e);

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/ParsedElasticsearchException.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/ParsedElasticsearchException.java
@@ -24,7 +24,7 @@ import java.util.regex.Pattern;
 @AutoValue
 abstract class ParsedElasticsearchException {
     private static final Pattern exceptionPattern = Pattern
-            .compile("ElasticsearchException\\[Elasticsearch exception \\[type=(?<type>[\\w_]+), (?:reason=(?<reason>.+?)(\\]+;|\\]$))");
+            .compile("(ElasticsearchException\\[)?Elasticsearch exception \\[type=(?<type>[\\w_]+), (?:reason=(?<reason>.+?)(\\]+;|\\]$))");
 
     abstract String type();
     abstract String reason();

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/ParsedElasticsearchExceptionTest.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/ParsedElasticsearchExceptionTest.java
@@ -65,4 +65,18 @@ class ParsedElasticsearchExceptionTest {
                     "request: [BulkShardRequest [[graylog_0][2]] containing [125] requests]]");
         });
     }
+
+    @Test
+    void parsingInvalidWriteTargetMessage() {
+        final String exception = "Elasticsearch exception [type=illegal_argument_exception, reason=no write index is defined for alias [messages_it_deflector]. The write index may be explicitly disabled using is_write_index=false or the alias points to multiple indices without one being designated as a write index]";
+
+        final ParsedElasticsearchException parsed = ParsedElasticsearchException.from(exception);
+
+        assertThat(parsed).satisfies(p -> {
+            assertThat(p.type()).isEqualTo("illegal_argument_exception");
+            assertThat(p.reason()).isEqualTo("no write index is defined for alias [messages_it_deflector]. " +
+                    "The write index may be explicitly disabled using is_write_index=false or the alias points to " +
+                    "multiple indices without one being designated as a write index");
+        });
+    }
 }

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/testing/ClientES7.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/testing/ClientES7.java
@@ -117,6 +117,18 @@ public class ClientES7 implements Client {
     }
 
     @Override
+    public void removeAliasMapping(String indexName, String alias) {
+        final IndicesAliasesRequest indicesAliasesRequest = new IndicesAliasesRequest();
+        final AliasActions aliasAction = new AliasActions(AliasActions.Type.REMOVE)
+                .index(indexName)
+                .alias(alias);
+        indicesAliasesRequest.addAliasAction(aliasAction);
+
+        client.execute((c, requestOptions) -> c.indices().updateAliases(indicesAliasesRequest, requestOptions),
+                "failed to remove alias " + alias + " for index " + indexName);
+    }
+
+    @Override
     public String fieldType(String testIndexName, String field) {
         return getMapping(testIndexName).get(field);
     }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/ElasticsearchException.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/ElasticsearchException.java
@@ -73,6 +73,11 @@ public class ElasticsearchException extends RuntimeException {
     public String getMessage() {
         final StringBuilder sb = new StringBuilder(super.getMessage());
 
+        if(!errorDetails.isEmpty()) {
+            sb.append("\n\n");
+            errorDetails.forEach(sb::append);
+        }
+
         return sb.toString();
     }
 
@@ -81,7 +86,6 @@ public class ElasticsearchException extends RuntimeException {
         return MoreObjects.toStringHelper(this)
                 .add("message", getMessage())
                 .add("errorDetails", getErrorDetails())
-                .add("cause", getCause())
                 .toString();
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/ElasticsearchException.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/ElasticsearchException.java
@@ -18,7 +18,6 @@ package org.graylog2.indexer;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
-import joptsimple.internal.Strings;
 
 import java.util.Collections;
 import java.util.List;
@@ -74,11 +73,6 @@ public class ElasticsearchException extends RuntimeException {
     public String getMessage() {
         final StringBuilder sb = new StringBuilder(super.getMessage());
 
-        if(!errorDetails.isEmpty()) {
-            sb.append("\n\n");
-            errorDetails.forEach(sb::append);
-        }
-
         return sb.toString();
     }
 
@@ -87,6 +81,7 @@ public class ElasticsearchException extends RuntimeException {
         return MoreObjects.toStringHelper(this)
                 .add("message", getMessage())
                 .add("errorDetails", getErrorDetails())
+                .add("cause", getCause())
                 .toString();
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/IndexNotFoundException.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/IndexNotFoundException.java
@@ -31,5 +31,4 @@ public class IndexNotFoundException extends ElasticsearchException {
     public static IndexNotFoundException create(String errorMessage, String index) {
         return new IndexNotFoundException(errorMessage, Collections.singletonList("Index not found for query: " + index + ". Try recalculating your index ranges."));
     }
-
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/InvalidWriteTargetException.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/InvalidWriteTargetException.java
@@ -14,12 +14,21 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-package org.graylog2.indexer.messages;
+package org.graylog2.indexer;
 
-import org.graylog2.indexer.ElasticsearchException;
+import java.util.Collections;
 
 public class InvalidWriteTargetException extends ElasticsearchException {
-    public InvalidWriteTargetException(String errorMessage, Exception elasticsearchException) {
-        super(errorMessage, elasticsearchException);
+
+    private InvalidWriteTargetException(String target, Throwable cause) {
+        super("Write target for indexing is invalid. This can happen if the deflector points to zero or multiple targets.", Collections.singletonList("target=" + target), cause);
+    }
+
+    public static InvalidWriteTargetException create(String target, Throwable cause) {
+        return new InvalidWriteTargetException(target, cause);
+    }
+
+    public static InvalidWriteTargetException create(String target) {
+        return new InvalidWriteTargetException(target, null);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/messages/InvalidWriteTargetException.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/messages/InvalidWriteTargetException.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.indexer.messages;
+
+import org.graylog2.indexer.ElasticsearchException;
+
+public class InvalidWriteTargetException extends ElasticsearchException {
+    public InvalidWriteTargetException(String errorMessage, Exception elasticsearchException) {
+        super(errorMessage, elasticsearchException);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/indexer/messages/Messages.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/messages/Messages.java
@@ -53,6 +53,11 @@ import java.util.stream.Collectors;
 
 @Singleton
 public class Messages {
+    public interface IndexingListener {
+        void onRetry(long attemptNumber);
+        void onSuccess(long delaySinceFirstAttempt);
+    }
+
     private static final Logger LOG = LoggerFactory.getLogger(Messages.class);
 
     private static final Duration MAX_WAIT_TIME = Duration.seconds(30L);
@@ -69,7 +74,7 @@ public class Messages {
     static final WaitStrategy exponentialWaitMilliseconds = WaitStrategies.exponentialWait(MAX_WAIT_TIME.getQuantity(), MAX_WAIT_TIME.getUnit());
 
     @SuppressWarnings("UnstableApiUsage")
-    private static final Retryer<List<IndexingError>> BULK_REQUEST_RETRYER = RetryerBuilder.<List<IndexingError>>newBuilder()
+    private static final RetryerBuilder<List<IndexingError>> BULK_REQUEST_RETRYER_BUILDER = RetryerBuilder.<List<IndexingError>>newBuilder()
             .retryIfException(t -> t instanceof IOException)
             .withWaitStrategy(WaitStrategies.exponentialWait(MAX_WAIT_TIME.getQuantity(), MAX_WAIT_TIME.getUnit()))
             .withRetryListener(new RetryListener() {
@@ -81,8 +86,7 @@ public class Messages {
                         LOG.info("Bulk indexing finally successful (attempt #{}).", attempt.getAttemptNumber());
                     }
                 }
-            })
-            .build();
+            });
 
     private final LinkedBlockingQueue<List<IndexFailure>> indexFailureQueue;
     private final MessagesAdapter messagesAdapter;
@@ -110,10 +114,18 @@ public class Messages {
     }
 
     public List<String> bulkIndex(final List<Map.Entry<IndexSet, Message>> messageList) {
-        return bulkIndex(messageList, false);
+        return bulkIndex(messageList, false, null);
+    }
+
+    public List<String> bulkIndex(final List<Map.Entry<IndexSet, Message>> messageList, IndexingListener indexingListener) {
+        return bulkIndex(messageList, false, indexingListener);
     }
 
     public List<String> bulkIndex(final List<Map.Entry<IndexSet, Message>> messageList, boolean isSystemTraffic) {
+        return bulkIndex(messageList, isSystemTraffic, null);
+    }
+
+    public List<String> bulkIndex(final List<Map.Entry<IndexSet, Message>> messageList, boolean isSystemTraffic, IndexingListener indexingListener) {
         if (messageList.isEmpty()) {
             return Collections.emptyList();
         }
@@ -122,13 +134,17 @@ public class Messages {
                 .map(entry -> IndexingRequest.create(entry.getKey(), entry.getValue()))
                 .collect(Collectors.toList());
 
-        return bulkIndexRequests(indexingRequestList, isSystemTraffic);
+        return bulkIndexRequests(indexingRequestList, isSystemTraffic, indexingListener);
     }
 
     public List<String> bulkIndexRequests(List<IndexingRequest> indexingRequestList, boolean isSystemTraffic) {
-        final List<IndexingError> indexingErrors = runBulkRequest(indexingRequestList, indexingRequestList.size());
+        return bulkIndexRequests(indexingRequestList, isSystemTraffic, null);
+    }
 
-        final Set<IndexingError> remainingErrors = retryOnlyIndexBlockItemsForever(indexingRequestList, indexingErrors);
+    public List<String> bulkIndexRequests(List<IndexingRequest> indexingRequestList, boolean isSystemTraffic, IndexingListener indexingListener) {
+        final List<IndexingError> indexingErrors = runBulkRequest(indexingRequestList, indexingRequestList.size(), indexingListener);
+
+        final Set<IndexingError> remainingErrors = retryOnlyIndexBlockItemsForever(indexingRequestList, indexingErrors, indexingListener);
 
         final Set<String> failedIds = remainingErrors.stream()
                 .map(indexingError -> indexingError.message().getId())
@@ -143,7 +159,7 @@ public class Messages {
         return propagateFailure(remainingErrors);
     }
 
-    private Set<IndexingError> retryOnlyIndexBlockItemsForever(List<IndexingRequest> messages, List<IndexingError> allFailedItems) {
+    private Set<IndexingError> retryOnlyIndexBlockItemsForever(List<IndexingRequest> messages, List<IndexingError> allFailedItems, IndexingListener indexingListener) {
         Set<IndexingError> indexBlocks = indexBlocksFrom(allFailedItems);
         final Set<IndexingError> otherFailures = new HashSet<>(Sets.difference(new HashSet<>(allFailedItems), indexBlocks));
         List<IndexingRequest> blockedMessages = messagesForResultItems(messages, indexBlocks);
@@ -157,7 +173,7 @@ public class Messages {
         while (!indexBlocks.isEmpty()) {
             waitBeforeRetrying(attempt++);
 
-            final List<Messages.IndexingError> failedItems = runBulkRequest(blockedMessages, messages.size());
+            final List<Messages.IndexingError> failedItems = runBulkRequest(blockedMessages, messages.size(), indexingListener);
 
             indexBlocks = indexBlocksFrom(failedItems);
             blockedMessages = messagesForResultItems(blockedMessages, indexBlocks);
@@ -196,7 +212,11 @@ public class Messages {
         }
     }
 
-    private List<IndexingError> runBulkRequest(List<IndexingRequest> indexingRequestList, int count) {
+    private List<IndexingError> runBulkRequest(List<IndexingRequest> indexingRequestList, int count, IndexingListener indexingListener) {
+        final Retryer<List<IndexingError>> BULK_REQUEST_RETRYER = indexingListener == null
+                ? BULK_REQUEST_RETRYER_BUILDER.build()
+                : BULK_REQUEST_RETRYER_BUILDER.withRetryListener(retryListenerFor(indexingListener)).build();
+
         try {
             return BULK_REQUEST_RETRYER.call(() -> messagesAdapter.bulkIndex(indexingRequestList));
         } catch (ExecutionException | RetryException e) {
@@ -207,6 +227,19 @@ public class Messages {
             }
             throw new RuntimeException(e);
         }
+    }
+
+    private RetryListener retryListenerFor(IndexingListener indexingListener) {
+        return new RetryListener() {
+            @Override
+            public <V> void onRetry(Attempt<V> attempt) {
+                if (attempt.hasException()) {
+                    indexingListener.onRetry(attempt.getAttemptNumber());
+                } else {
+                    indexingListener.onSuccess(attempt.getDelaySinceFirstAttempt());
+                }
+            }
+        };
     }
 
     private void accountTotalMessageSizes(List<IndexingRequest> requests, boolean isSystemTraffic) {

--- a/graylog2-server/src/main/java/org/graylog2/indexer/messages/Messages.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/messages/Messages.java
@@ -75,7 +75,7 @@ public class Messages {
 
     @SuppressWarnings("UnstableApiUsage")
     private static final RetryerBuilder<List<IndexingError>> BULK_REQUEST_RETRYER_BUILDER = RetryerBuilder.<List<IndexingError>>newBuilder()
-            .retryIfException(t -> t instanceof IOException)
+            .retryIfException(t -> t instanceof IOException || t instanceof InvalidWriteTargetException)
             .withWaitStrategy(WaitStrategies.exponentialWait(MAX_WAIT_TIME.getQuantity(), MAX_WAIT_TIME.getUnit()))
             .withRetryListener(new RetryListener() {
                 @Override

--- a/graylog2-server/src/main/java/org/graylog2/indexer/messages/Messages.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/messages/Messages.java
@@ -212,6 +212,7 @@ public class Messages {
         }
     }
 
+    @SuppressWarnings("UnstableApiUsage")
     private List<IndexingError> runBulkRequest(List<IndexingRequest> indexingRequestList, int count, IndexingListener indexingListener) {
         final Retryer<List<IndexingError>> BULK_REQUEST_RETRYER = indexingListener == null
                 ? BULK_REQUEST_RETRYER_BUILDER.build()
@@ -229,6 +230,7 @@ public class Messages {
         }
     }
 
+    @SuppressWarnings("UnstableApiUsage")
     private RetryListener retryListenerFor(IndexingListener indexingListener) {
         return new RetryListener() {
             @Override

--- a/graylog2-server/src/main/java/org/graylog2/indexer/messages/Messages.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/messages/Messages.java
@@ -31,6 +31,7 @@ import com.google.common.collect.Sets;
 import org.graylog2.indexer.IndexFailure;
 import org.graylog2.indexer.IndexFailureImpl;
 import org.graylog2.indexer.IndexSet;
+import org.graylog2.indexer.InvalidWriteTargetException;
 import org.graylog2.indexer.results.ResultMessage;
 import org.graylog2.plugin.Message;
 import org.graylog2.system.processing.ProcessingStatusRecorder;

--- a/graylog2-server/src/test/java/org/graylog/testing/elasticsearch/Client.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/elasticsearch/Client.java
@@ -42,6 +42,8 @@ public interface Client {
 
     void addAliasMapping(String indexName, String alias);
 
+    void removeAliasMapping(String indexName, String alias);
+
     boolean templateExists(String templateName);
 
     void putTemplate(String templateName, Map<String, Object> source);


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Prior to this PR, if one of the write targets in a bulk indexing request is an alias with zero or multiple targets, indexing failed and messages were silently dropped. This results in an error type being returned from ES different to the ones we handled before. Before this we had:

  - requests failing completely: due to general errors (e.g. networking errors), indicated by an `IOException` being thrown and no response being returned
  - requests failing partially (one or all individual bulk items failing): due to specific errors (e.g. mapping errors), with no exception being thrown and returning a response which contains error states for individual bulk items

In this case, we have a different scenario which also differs between the ES version involved:

  - for ES6, no exception is being thrown, but the response returned does not contain failed items
  - for ES7, a generic `ElasticsearchException` thrown which is not retried

This PR is doing these things to address this:

  - parsing the result/the exception and throwing a specific `InvalidWriteTargetException` if the request fails generally and
    contains the related error message
  - make sure that the correct target index is extracted from the error
  - make the log format of the exception helpful and consistent between ES6 and ES7

and last but not least:

  - retry an `InvalidWriteTargetException` similar to an `IOException`

**Attention:** This changes the behavior of cases where a deflector points to zero or multiple targets. In these cases, indexing is retried and **blocks all further indexing until this scenario is resolved.** All messages coming in at this condition are buffered in the journal until either the situation is fixed or the journal flows over. This is similar to the behavior we have implemented for an ES node being in flood stage.

In general, this scenario most probably occurs related to one or more ES nodes having been in flood stage, while an index cycle is happening. In this condition, the deflector alias might get assigned a second target but the previous target cannot be removed due to the index it points to having an index block. When the index block is lifted, the situation is resolved automatically due to our deflector alias cleanup code. This is mostly relevant for ES6, because ES7 releases index blocks due to flood stage kicking in automatically when flood stage is over.

The behavior is undesirable in some situations, e.g. when one deflector is broken (zero or multiple targets) and cannot be repaired, while other deflectors are fine and indexing requests for both need to be processed. Requests including the broken deflector as a target for individual bulk items will be retried over and over while others (which could be processed fine) are starving. Solving this would require us to do retrying out of band (with a separate queue for it) while continuing to process the journal.

Fixes #9955, fixes #9962.
 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

To reproduce the situation where this logic is effective, we need these conditions:

  - a deflector alias pointing to two indices
  - one of the indices the deflector alias is pointing at must have an index block, so the cleanup code cannot remove its alias

The easiest way to produce this, is to switch the ES cluster to flood stage. This can be done by `PUT`ing this request to
`/_cluster/settings`:

```
{
	"transient": {
		"cluster.routing.allocation.disk.watermark.low": "1%",
		"cluster.routing.allocation.disk.watermark.high": "1%",
		"cluster.routing.allocation.disk.watermark.flood_stage": "1%"
	}
}
```

Afterwards, a manual deflector cycle should be triggered.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.