### PR TITLE
Supporting specifying implicit `to` for relative range.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/plugin/indexer/searches/timeranges/RelativeRange.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/indexer/searches/timeranges/RelativeRange.java
@@ -76,7 +76,7 @@ public abstract class RelativeRange extends TimeRange {
             return Tools.nowUTC();
         }
 
-        return Tools.nowUTC().minusSeconds(to().orElseThrow(() -> new IllegalStateException("Neither `range` nor `to` specified!")));
+        return Tools.nowUTC().minusSeconds(to().orElse(0));
     }
 
     @JsonIgnore
@@ -111,7 +111,7 @@ public abstract class RelativeRange extends TimeRange {
 
         public RelativeRange build() throws InvalidRangeParametersException {
             if (range().isPresent() && (from().isPresent() || to().isPresent())) {
-                throw new InvalidRangeParametersException("Either `range` OR `from`/`to` must be specifed, not both!");
+                throw new InvalidRangeParametersException("Either `range` OR `from`/`to` must be specified, not both!");
             }
 
             if (range().isPresent()) {
@@ -120,8 +120,8 @@ public abstract class RelativeRange extends TimeRange {
                 }
             }
 
-            if ((from().isPresent() && !to().isPresent()) || (to().isPresent() && !from().isPresent())) {
-                throw new InvalidRangeParametersException("Both `from` and `to` must be specified!");
+            if (to().isPresent() && !from().isPresent()) {
+                throw new InvalidRangeParametersException("If `to` is specified, `from` must be specified to!");
             }
 
             if ((from().isPresent() && to().isPresent()) && (to().getAsInt() > from().getAsInt())) {

--- a/graylog2-server/src/test/java/org/graylog2/plugin/indexer/searches/timeranges/RelativeRangeTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/plugin/indexer/searches/timeranges/RelativeRangeTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.plugin.indexer.searches.timeranges;
+
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class RelativeRangeTest {
+    private static final DateTime now = DateTime.parse("2021-01-26T15:59:30.428Z");
+    @BeforeEach
+    void setUp() {
+        DateTimeUtils.setCurrentMillisFixed(now.getMillis());
+    }
+
+    @AfterEach
+    void tearDown() {
+        DateTimeUtils.setCurrentMillisSystem();
+    }
+
+    @Test
+    void supportsRangeParameter() throws Exception {
+        final RelativeRange range = RelativeRange.Builder.builder().range(300).build();
+        assertThat(range.getFrom()).isEqualTo(now.minusMinutes(5));
+        assertThat(range.getTo()).isEqualTo(now);
+    }
+
+    @Test
+    void supportsFromParameter() throws Exception {
+        final RelativeRange range = RelativeRange.Builder.builder().from(300).build();
+        assertThat(range.getFrom()).isEqualTo(now.minusMinutes(5));
+        assertThat(range.getTo()).isEqualTo(now);
+    }
+
+    @Test
+    void supportsFromAndToParameter() throws Exception {
+        final RelativeRange range = RelativeRange.Builder.builder()
+                .from(300)
+                .to(60)
+                .build();
+        assertThat(range.getFrom()).isEqualTo(now.minusMinutes(5));
+        assertThat(range.getTo()).isEqualTo(now.minusMinutes(1));
+    }
+
+    @Test
+    void doesNotSupportBothRangeAndFromToParameters() throws Exception {
+        assertThatThrownBy(() -> RelativeRange.Builder.builder()
+                .range(600)
+                .from(300)
+                .to(60)
+                .build())
+                .isInstanceOf(InvalidRangeParametersException.class)
+                .hasMessage("Either `range` OR `from`/`to` must be specified, not both!");
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/plugin/indexer/searches/timeranges/RelativeRangeTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/plugin/indexer/searches/timeranges/RelativeRangeTest.java
@@ -62,7 +62,7 @@ class RelativeRangeTest {
     }
 
     @Test
-    void doesNotSupportBothRangeAndFromToParameters() throws Exception {
+    void doesNotSupportBothRangeAndFromToParameters() {
         assertThatThrownBy(() -> RelativeRange.Builder.builder()
                 .range(600)
                 .from(300)
@@ -70,5 +70,14 @@ class RelativeRangeTest {
                 .build())
                 .isInstanceOf(InvalidRangeParametersException.class)
                 .hasMessage("Either `range` OR `from`/`to` must be specified, not both!");
+    }
+
+    @Test
+    void doesNotSupportOnlyToParameter() {
+        assertThatThrownBy(() -> RelativeRange.Builder.builder()
+                .to(60)
+                .build())
+                .isInstanceOf(InvalidRangeParametersException.class)
+                .hasMessage("If `to` is specified, `from` must be specified to!");
     }
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Recently, support for specifying relative `from`/`to` values for the relative range was implemented. This PR allows to omit the `to` parameter, defaulting to an implicit value of `0` or `now`. This makes the relative range `from`-notation semantically identical to specifying `range`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.