### PR TITLE
Fixing stream rule form state update on input change (4.0).

### DIFF
--- a/graylog2-web-interface/src/components/streamrules/StreamRuleForm.jsx
+++ b/graylog2-web-interface/src/components/streamrules/StreamRuleForm.jsx
@@ -137,14 +137,15 @@ class StreamRuleForm extends React.Component<Props, State> {
 
   handleChange = (event) => {
     const { streamRule } = this.state;
+    const updatedStreamRule = { ...streamRule };
 
-    streamRule[event.target.name] = FormsUtils.getValueFromInput(event.target);
+    updatedStreamRule[event.target.name] = FormsUtils.getValueFromInput(event.target);
 
-    if (event.target.name === 'type' && String(streamRule.type) === String(this.MATCH_INPUT)) {
-      streamRule.value = String(this.PLACEHOLDER_INPUT);
+    if (event.target.name === 'type' && String(updatedStreamRule.type) === String(this.MATCH_INPUT)) {
+      updatedStreamRule.value = String(this.PLACEHOLDER_INPUT);
     }
 
-    this.setState({ streamRule });
+    this.setState({ streamRule: updatedStreamRule });
   };
 
   _formatInputOptions = (input) => (


### PR DESCRIPTION
_This is a backport of https://github.com/Graylog2/graylog2-server/pull/9968 for 4.0_

## Description
Before this change we were mutating the `StreamRuleForm` state on input changes directly which resulted in a strange behaviour.
One result was that the `StreamRuleForm` did not reset after creating a stream rule, even though the component is unmounting correctly.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)