### PR TITLE
Fix SourceCode editor combined with pipeline rules (4.0)

### DIFF
--- a/graylog2-web-interface/src/components/common/SourceCodeEditor.jsx
+++ b/graylog2-web-interface/src/components/common/SourceCodeEditor.jsx
@@ -131,7 +131,7 @@ class SourceCodeEditor extends React.Component {
     readOnly: false,
     resizable: true,
     toolbar: true,
-    value: '',
+    value: undefined,
     width: Infinity,
   };
 

--- a/graylog2-web-interface/src/components/sidecars/configuration-forms/CollectorForm.jsx
+++ b/graylog2-web-interface/src/components/sidecars/configuration-forms/CollectorForm.jsx
@@ -256,7 +256,7 @@ const CollectorForm = createReactClass({
             <FormGroup controlId="defaultTemplate">
               <ControlLabel><span>Default Template <small className="text-muted">(Optional)</small></span></ControlLabel>
               <SourceCodeEditor id="template"
-                                value={formData.default_template}
+                                value={formData.default_template || ''}
                                 onChange={this._formDataUpdate('default_template')} />
               <HelpBlock>The default Collector configuration.</HelpBlock>
             </FormGroup>

--- a/graylog2-web-interface/src/components/sidecars/configuration-forms/ConfigurationForm.jsx
+++ b/graylog2-web-interface/src/components/sidecars/configuration-forms/ConfigurationForm.jsx
@@ -337,7 +337,7 @@ const ConfigurationForm = createReactClass({
               <ControlLabel>Configuration</ControlLabel>
               <SourceCodeEditor id="template"
                                 height={400}
-                                value={formData.template}
+                                value={formData.template || ''}
                                 onChange={this._onTemplateChange} />
               <Button className="pull-right"
                       bsStyle="link"


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

**Note:** This is a backport of #9929 to `4.0`.

When editing pipeline rules, the default value of the `<SourceCodeEditor />` component overwrote the value set in the editor by the context.

This PR fixes that issue.

Fixes #9250
Fixes #9252

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.