### PR TITLE
Use aws sdk version 2 for interacting with SQS

### DIFF
--- a/graylog-project-parent/pom.xml
+++ b/graylog-project-parent/pom.xml
@@ -75,9 +75,9 @@
                 <scope>import</scope>
             </dependency>
             <dependency>
-                <groupId>com.amazonaws</groupId>
-                <artifactId>aws-java-sdk-bom</artifactId>
-                <version>${aws-java-sdk.version}</version>
+                <groupId>software.amazon.awssdk</groupId>
+                <artifactId>bom</artifactId>
+                <version>${aws-sdk.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/graylog2-server/pom.xml
+++ b/graylog2-server/pom.xml
@@ -644,6 +644,14 @@
             <artifactId>pkts-core</artifactId>
         </dependency>
         <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>sqs</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>netty-nio-client</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.glassfish.jersey.test-framework</groupId>
             <artifactId>jersey-test-framework-core</artifactId>
             <scope>test</scope>
@@ -663,10 +671,6 @@
             <artifactId>jsonassert</artifactId>
             <version>1.5.0</version>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-sqs</artifactId>
         </dependency>
     </dependencies>
 

--- a/graylog2-server/src/main/java/org/graylog2/plugin/BaseConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/BaseConfiguration.java
@@ -84,13 +84,10 @@ public abstract class BaseConfiguration extends PathConfiguration {
     private URI sqsQueueUrl;
 
     @Parameter(value = "sqs_max_inflight_outbound_batches", validators = PositiveIntegerValidator.class)
-    private int sqsMaxInflightOutboundBatches = 5;
+    private int sqsMaxInflightOutboundBatches = 50;
 
     @Parameter(value = "sqs_max_inflight_receive_batches", validators = PositiveIntegerValidator.class)
-    private int sqsMaxInflightReceiveBatches = 10;
-
-    @Parameter(value = "sqs_max_done_receive_batches", validators = PositiveIntegerValidator.class)
-    private int sqsMaxDoneReceiveBatches = 10;
+    private int sqsMaxInflightReceiveBatches = 50;
 
     @Parameter("inputbuffer_processors")
     private int inputbufferProcessors = 2;
@@ -187,10 +184,6 @@ public abstract class BaseConfiguration extends PathConfiguration {
 
     public int getSqsMaxInflightReceiveBatches() {
         return sqsMaxInflightReceiveBatches;
-    }
-
-    public int getSqsMaxDoneReceiveBatches() {
-        return sqsMaxDoneReceiveBatches;
     }
 
     public void setMessageJournalEnabled(boolean messageJournalEnabled) {

--- a/graylog2-server/src/main/java/org/graylog2/shared/messageq/sqs/BatchAggregator.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/messageq/sqs/BatchAggregator.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog2.shared.messageq.sqs;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;

--- a/graylog2-server/src/main/java/org/graylog2/shared/messageq/sqs/BatchAggregator.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/messageq/sqs/BatchAggregator.java
@@ -1,0 +1,125 @@
+package org.graylog2.shared.messageq.sqs;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+/**
+ * Ingests entries until enough of them have accumulated to form a batch of a predefined size. Flushes out the
+ * batches by calling a consumer provided on instantiation.
+ * @param <T> Type of the batch entries.
+ */
+public class BatchAggregator<T> {
+    private static final Logger log = LoggerFactory.getLogger(BatchAggregator.class);
+
+    private final Consumer<List<T>> flushAction;
+    private final int maxBatchSize;
+    private final ScheduledExecutorService scheduledExecutorService;
+
+    private List<T> currentBatch;
+    private final long flushInterval;
+    private volatile long lastFlushTime;
+    private volatile boolean isRunning = false;
+
+    /**
+     *
+     * @param flushAction Consumer which is being called with a batch when flushing
+     * @param maxBatchSize Flushing will be triggered once this much entries have accumulated.
+     * @param flushInterval To prevent non-full batches being hold back at a low ingest rate, periodical flushes will
+     * be initiated at the given interval.
+     */
+    public BatchAggregator(Consumer<List<T>> flushAction, int maxBatchSize, Duration flushInterval) {
+        this.flushAction = flushAction;
+        this.maxBatchSize = maxBatchSize;
+        this.currentBatch = new ArrayList<>(maxBatchSize);
+        this.flushInterval = flushInterval.toNanos();
+        this.scheduledExecutorService = Executors.newSingleThreadScheduledExecutor(
+                new ThreadFactoryBuilder()
+                        .setNameFormat("batch-flush-%d")
+                        .build());
+    }
+
+    /**
+     * Start the aggregator so that it is ready to accept entries. This will start the periodical flush thread.
+     */
+    public void start() {
+        if (isRunning) {
+            throw new IllegalStateException("Already running.");
+        }
+        this.scheduledExecutorService.scheduleWithFixedDelay(this::flushIfTimedOut, this.flushInterval,
+                this.flushInterval, TimeUnit.NANOSECONDS);
+        isRunning = true;
+    }
+
+    /**
+     * Stops the periodical flush thread and initiates a final flush using the current thread.
+     */
+    public void shutdown() {
+        if (! isRunning) {
+            throw new IllegalStateException("Already stopped.");
+        }
+        isRunning = false;
+        scheduledExecutorService.shutdown();
+        synchronized (this) {
+            if (!currentBatch.isEmpty()) {
+                flushAction.accept(currentBatch);
+            }
+        }
+    }
+
+    /**
+     * Feed an entry to the aggregator. If this entry triggers a batch to be flushed, the flush action will be called
+     * using the current thread.
+     * @param entry The entry to add for batching.
+     */
+    public void feed(T entry) {
+        if (!isRunning) {
+            throw new IllegalStateException("BatchFlusher is not running.");
+        }
+
+        List<T> flushBatch = null;
+        synchronized (this) {
+            currentBatch.add(entry);
+            if (currentBatch.size() >= maxBatchSize) {
+                flushBatch = currentBatch;
+                currentBatch = new ArrayList<>(maxBatchSize);
+            }
+            if (flushBatch != null) {
+                flush(flushBatch);
+            }
+        }
+    }
+
+    private void flushIfTimedOut() {
+        if (lastFlushTime != 0 && flushInterval > System.nanoTime() - lastFlushTime) {
+            return;
+        }
+
+        final List<T> flushBatch;
+        synchronized (this) {
+            if (currentBatch.isEmpty()) {
+                return;
+            }
+            flushBatch = currentBatch;
+            currentBatch = new ArrayList<>(maxBatchSize);
+        }
+        flush(flushBatch);
+    }
+
+    private void flush(List<T> batch) {
+        lastFlushTime = System.nanoTime();
+        try {
+            flushAction.accept(batch);
+        } catch (Exception e) {
+            log.error("Error while flushing batch.", e);
+        }
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/shared/messageq/sqs/SqsMessageQueueAcknowledger.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/messageq/sqs/SqsMessageQueueAcknowledger.java
@@ -36,8 +36,6 @@ public class SqsMessageQueueAcknowledger implements MessageQueueAcknowledger {
 
     @Override
     public void acknowledge(List<Object> messageIds) {
-        for (Object messageId : messageIds) {
-            sqsMessageQueueReader.commit(messageId);
-        }
+        sqsMessageQueueReader.commit(messageIds);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/shared/messageq/sqs/SqsMessageQueueAcknowledger.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/messageq/sqs/SqsMessageQueueAcknowledger.java
@@ -18,7 +18,7 @@ package org.graylog2.shared.messageq.sqs;
 
 
 import com.google.common.util.concurrent.AbstractIdleService;
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import de.huxhorn.sulky.ulid.ULID;
 import org.graylog2.plugin.BaseConfiguration;
 import org.graylog2.shared.messageq.MessageQueueAcknowledger;
 import org.slf4j.Logger;
@@ -31,39 +31,29 @@ import software.amazon.awssdk.services.sqs.model.DeleteMessageBatchRequestEntry;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.time.Duration;
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.Semaphore;
-import java.util.concurrent.TimeUnit;
 
 @Singleton
 public class SqsMessageQueueAcknowledger extends AbstractIdleService implements MessageQueueAcknowledger {
 
     private static final Logger LOG = LoggerFactory.getLogger(SqsMessageQueueAcknowledger.class);
-    private static final long BATCH_FLUSH_INTERVAL = Duration.ofSeconds(1).toNanos();
 
     private final CountDownLatch readyLatch = new CountDownLatch(1);
+    private final ULID ulid = new ULID();
     private final String queueUrl;
     private final Semaphore deleteSemaphore;
-    private final ScheduledExecutorService periodicalExecutorService;
-    private volatile long lastBatchSendTime;
+    private final BatchAggregator<DeleteMessageBatchRequestEntry> batchAggregator;
 
     private SqsAsyncClient sqsClient;
-    private List<DeleteMessageBatchRequestEntry> currentBatch = new ArrayList<>(10);
 
     @Inject
     public SqsMessageQueueAcknowledger(BaseConfiguration config) {
         this.queueUrl = config.getSqsQueueUrl().toString();
         this.deleteSemaphore = new Semaphore(config.getSqsMaxInflightOutboundBatches());
-        this.periodicalExecutorService = Executors.newSingleThreadScheduledExecutor(
-                new ThreadFactoryBuilder()
-                        .setNameFormat("sqs-delete-message-batch-flush-%d")
-                        .build());
+        this.batchAggregator = new BatchAggregator<>(this::sendBatch, 10, Duration.ofSeconds(1));
     }
 
     @Override
@@ -74,16 +64,16 @@ public class SqsMessageQueueAcknowledger extends AbstractIdleService implements 
                 .httpClientBuilder(NettyNioAsyncHttpClient.builder());
         this.sqsClient = clientBuilder.build();
 
-        // Service is ready for writing
-        readyLatch.countDown();
+        batchAggregator.start();
 
-        periodicalExecutorService.scheduleWithFixedDelay(this::flushBatch, BATCH_FLUSH_INTERVAL, BATCH_FLUSH_INTERVAL,
-                TimeUnit.NANOSECONDS);
+        // Service is ready for writing
+       readyLatch.countDown();
     }
 
     @Override
     protected void shutDown() throws Exception {
-        periodicalExecutorService.shutdown();
+        // make sure that we can flush all remaining batches out
+        batchAggregator.shutdown();
         if (sqsClient != null) {
             sqsClient.close();
         }
@@ -95,8 +85,7 @@ public class SqsMessageQueueAcknowledger extends AbstractIdleService implements 
     }
 
     @Override
-    // TODO: periodically flush batches which have been left hanging
-    public void acknowledge(List<Object> messageIds) {
+    public void acknowledge(List<Object> receiptHandles) {
         try {
             readyLatch.await();
         } catch (InterruptedException e) {
@@ -104,52 +93,25 @@ public class SqsMessageQueueAcknowledger extends AbstractIdleService implements 
             return;
         }
 
-        final Iterator<Object> iterator = messageIds.iterator();
-
-        List<List<DeleteMessageBatchRequestEntry>> batchesToSend = new ArrayList<>();
-
-        synchronized(this) {
-            while (iterator.hasNext()) {
-                Object receiptHandle = iterator.next();
-                if (!(receiptHandle instanceof String)) {
-                    LOG.error("Couldn't delete message. Expected <" + receiptHandle + "> to be a String receipt handle");
-                    continue;
-                }
-                final DeleteMessageBatchRequestEntry entry = DeleteMessageBatchRequestEntry.builder()
-                        .receiptHandle((String) receiptHandle)
-                        .id(String.valueOf(currentBatch.size() + 1))
-                        .build();
-                currentBatch.add(entry);
-
-                if (currentBatch.size() == 10) {
-                    batchesToSend.add(currentBatch);
-                    currentBatch = new ArrayList<>(10);
-                }
-            }
-        }
-
-        batchesToSend.forEach(this::deleteBatch);
+        receiptHandles.stream()
+                .filter(handle -> {
+                    if (!(handle instanceof String)) {
+                        LOG.error("Couldn't delete message. Expected <{}> to be a String receipt handle", handle);
+                        return false;
+                    }
+                    return true;
+                })
+                .map(String.class::cast)
+                .map(handle -> DeleteMessageBatchRequestEntry.builder()
+                        .receiptHandle(handle)
+                        .id(ulid.nextULID())
+                        .build())
+                .forEach(batchAggregator::feed);
     }
 
-    private void flushBatch() {
-        if (lastBatchSendTime != 0 && BATCH_FLUSH_INTERVAL > System.nanoTime() - lastBatchSendTime) {
-            return;
-        }
-
-        final List<DeleteMessageBatchRequestEntry> batchToSend;
-        synchronized(this) {
-            if (currentBatch.isEmpty()) {
-                return;
-            }
-            batchToSend = currentBatch;
-            currentBatch = new ArrayList<>(10);
-        }
-        deleteBatch(batchToSend);
-    }
-
-    private void deleteBatch(List<DeleteMessageBatchRequestEntry> entries) {
-        lastBatchSendTime = System.nanoTime();
+    private void sendBatch(List<DeleteMessageBatchRequestEntry> entries) {
         try {
+            readyLatch.await();
             deleteSemaphore.acquire();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();

--- a/graylog2-server/src/main/java/org/graylog2/shared/messageq/sqs/SqsMessageQueueAcknowledger.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/messageq/sqs/SqsMessageQueueAcknowledger.java
@@ -16,26 +16,119 @@
  */
 package org.graylog2.shared.messageq.sqs;
 
+
+import com.google.common.util.concurrent.AbstractIdleService;
+import org.graylog2.plugin.BaseConfiguration;
 import org.graylog2.shared.messageq.MessageQueueAcknowledger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient;
+import software.amazon.awssdk.services.sqs.SqsAsyncClient;
+import software.amazon.awssdk.services.sqs.SqsAsyncClientBuilder;
+import software.amazon.awssdk.services.sqs.model.DeleteMessageBatchRequestEntry;
 
 import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Semaphore;
 
-public class SqsMessageQueueAcknowledger implements MessageQueueAcknowledger {
-    private SqsMessageQueueReader sqsMessageQueueReader;
+@Singleton
+public class SqsMessageQueueAcknowledger extends AbstractIdleService implements MessageQueueAcknowledger {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SqsMessageQueueAcknowledger.class);
+    private final CountDownLatch readyLatch = new CountDownLatch(1);
+
+    private final String queueUrl;
+    private final Semaphore deleteSemaphore;
+
+    private SqsAsyncClient sqsClient;
 
     @Inject
-    public SqsMessageQueueAcknowledger(SqsMessageQueueReader sqsMessageQueueReader) {
-        this.sqsMessageQueueReader = sqsMessageQueueReader;
+    public SqsMessageQueueAcknowledger(BaseConfiguration config) {
+        this.queueUrl = config.getSqsQueueUrl().toString();
+        deleteSemaphore = new Semaphore(config.getSqsMaxInflightOutboundBatches());
     }
 
     @Override
-    public void acknowledge(Object messageId) {
-        sqsMessageQueueReader.commit(messageId);
+    protected void startUp() throws Exception {
+        LOG.info("Starting SQS message queue deletion service");
+
+        final SqsAsyncClientBuilder clientBuilder = SqsAsyncClient.builder()
+                .httpClientBuilder(NettyNioAsyncHttpClient.builder());
+        this.sqsClient = clientBuilder.build();
+
+        // Service is ready for writing
+        readyLatch.countDown();
+    }
+
+    @Override
+    protected void shutDown() throws Exception {
+        if (sqsClient != null) {
+            sqsClient.close();
+        }
+    }
+
+    // TODO: this method shouldn't be used because sending batches with only a single item is really hurting
+    //  performance. Unfortunately it's the main method used by the BenchmarkOutput so we probably need to buffer
+    //  messages manually until we have enough of them to create a batch.
+    @Override
+    public void acknowledge(Object receiptHandle) {
+        acknowledge(Collections.singletonList(receiptHandle));
     }
 
     @Override
     public void acknowledge(List<Object> messageIds) {
-        sqsMessageQueueReader.commit(messageIds);
+        try {
+            readyLatch.await();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return;
+        }
+
+        final Iterator<Object> iterator = messageIds.iterator();
+
+        List<DeleteMessageBatchRequestEntry> currentBatch = new ArrayList<>(10);
+
+        while (iterator.hasNext()) {
+            Object receiptHandle = iterator.next();
+            if (!(receiptHandle instanceof String)) {
+                LOG.error("Couldn't delete message. Expected <" + receiptHandle + "> to be a String receipt handle");
+                continue;
+            }
+            final DeleteMessageBatchRequestEntry entry = DeleteMessageBatchRequestEntry.builder()
+                    .receiptHandle((String) receiptHandle)
+                    .id(String.valueOf(currentBatch.size() + 1))
+                    .build();
+            currentBatch.add(entry);
+
+            if (currentBatch.size() == 10) {
+                deleteBatch(currentBatch);
+                currentBatch = new ArrayList<>(10);
+            }
+        }
+        if (!currentBatch.isEmpty()) {
+            deleteBatch(currentBatch);
+        }
+    }
+
+    private void deleteBatch(List<DeleteMessageBatchRequestEntry> entries) {
+        try {
+            deleteSemaphore.acquire();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return;
+        }
+        sqsClient.deleteMessageBatch(request -> request.queueUrl(queueUrl)
+                .entries(entries))
+                .whenComplete((response, error) -> {
+                    if (error != null) {
+                        LOG.error("Couldn't delete message", error);
+                    }
+                    deleteSemaphore.release();
+                });
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/shared/messageq/sqs/SqsMessageQueueEntry.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/messageq/sqs/SqsMessageQueueEntry.java
@@ -16,9 +16,9 @@
  */
 package org.graylog2.shared.messageq.sqs;
 
-import com.amazonaws.services.sqs.model.Message;
 import com.google.common.io.BaseEncoding;
 import org.graylog2.shared.messageq.MessageQueue;
+import software.amazon.awssdk.services.sqs.model.Message;
 
 import javax.annotation.Nullable;
 import java.nio.charset.StandardCharsets;
@@ -34,9 +34,9 @@ public class SqsMessageQueueEntry implements MessageQueue.Entry {
     }
 
     private SqsMessageQueueEntry(Message message) {
-        this.encodedRawMessage = BaseEncoding.base64().omitPadding().decode(message.getBody());
-        this.messageId = message.getMessageId().getBytes(StandardCharsets.UTF_8);
-        this.receiptHandle = message.getReceiptHandle();
+        this.encodedRawMessage = BaseEncoding.base64().omitPadding().decode(message.body());
+        this.messageId = message.messageId().getBytes(StandardCharsets.UTF_8);
+        this.receiptHandle = message.receiptHandle();
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/shared/messageq/sqs/SqsMessageQueueModule.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/messageq/sqs/SqsMessageQueueModule.java
@@ -27,6 +27,7 @@ import org.graylog2.shared.messageq.MessageQueueWriter;
 public class SqsMessageQueueModule extends PluginModule {
     @Override
     protected void configure() {
+        serviceBinder().addBinding().to(SqsMessageQueueAcknowledger.class).in(Scopes.SINGLETON);
         bind(MessageQueueAcknowledger.class).to(SqsMessageQueueAcknowledger.class).in(Scopes.SINGLETON);
 
         serviceBinder().addBinding().to(SqsMessageQueueReader.class).in(Scopes.SINGLETON);

--- a/graylog2-server/src/main/java/org/graylog2/shared/messageq/sqs/SqsMessageQueueReader.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/messageq/sqs/SqsMessageQueueReader.java
@@ -16,20 +16,12 @@
  */
 package org.graylog2.shared.messageq.sqs;
 
-import com.amazonaws.handlers.AsyncHandler;
-import com.amazonaws.services.sqs.AmazonSQSAsyncClientBuilder;
-import com.amazonaws.services.sqs.buffered.AmazonSQSBufferedAsyncClient;
-import com.amazonaws.services.sqs.buffered.QueueBufferConfig;
-import com.amazonaws.services.sqs.model.DeleteMessageRequest;
-import com.amazonaws.services.sqs.model.DeleteMessageResult;
-import com.amazonaws.services.sqs.model.Message;
-import com.amazonaws.services.sqs.model.ReceiveMessageRequest;
-import com.amazonaws.services.sqs.model.ReceiveMessageResult;
+
 import com.codahale.metrics.Counter;
+import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
-import com.google.common.collect.ImmutableList;
 import com.google.common.eventbus.EventBus;
 import com.google.common.util.concurrent.Uninterruptibles;
 import org.graylog2.plugin.BaseConfiguration;
@@ -37,27 +29,32 @@ import org.graylog2.plugin.journal.RawMessage;
 import org.graylog2.shared.buffers.ProcessBuffer;
 import org.graylog2.shared.messageq.AbstractMessageQueueReader;
 import org.graylog2.shared.messageq.MessageQueue;
-import org.graylog2.shared.messageq.MessageQueueException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient;
+import software.amazon.awssdk.services.sqs.SqsAsyncClient;
+import software.amazon.awssdk.services.sqs.SqsAsyncClientBuilder;
+import software.amazon.awssdk.services.sqs.model.DeleteMessageBatchRequestEntry;
+import software.amazon.awssdk.services.sqs.model.Message;
 
 import javax.inject.Inject;
 import javax.inject.Provider;
 import javax.inject.Singleton;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
-import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Semaphore;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 @Singleton
 public class SqsMessageQueueReader extends AbstractMessageQueueReader {
+
     private static final Logger LOG = LoggerFactory.getLogger(SqsMessageQueueReader.class);
 
-    private final BaseConfiguration config;
     private final String queueUrl;
 
-    private final CountDownLatch latch = new CountDownLatch(1);
     private final Meter messageMeter;
     private final Counter byteCounter;
     private final Meter byteMeter;
@@ -65,7 +62,13 @@ public class SqsMessageQueueReader extends AbstractMessageQueueReader {
 
     private final Provider<ProcessBuffer> processBufferProvider;
     private ProcessBuffer processBuffer;
-    private AmazonSQSBufferedAsyncClient sqsClient;
+
+    // TODO: check if having two distinct clients for receiving and deleting really gains us much
+    private SqsAsyncClient receiveClient;
+    private SqsAsyncClient deleteClient;
+
+    private final Semaphore receiveSemaphore;
+    private final Semaphore deleteSemaphore;
 
     @Inject
     public SqsMessageQueueReader(MetricRegistry metricRegistry, Provider<ProcessBuffer> processBufferProvider,
@@ -75,38 +78,41 @@ public class SqsMessageQueueReader extends AbstractMessageQueueReader {
         // Using a ProcessBuffer directly will lead to guice error:
         // "Please wait until after injection has completed to use this object."
         this.processBufferProvider = processBufferProvider;
-        this.config = config;
-        this.queueUrl = config.getSqsQueueUrl().toString();
+        this.queueUrl = config.getSqsQueueUrl()
+                .toString();
+
+        receiveSemaphore = new Semaphore(config.getSqsMaxInflightReceiveBatches());
+        deleteSemaphore = new Semaphore(config.getSqsMaxInflightOutboundBatches());
 
         this.messageMeter = metricRegistry.meter("system.message-queue.sqs.reader.messages");
         this.byteCounter = metricRegistry.counter("system.message-queue.sqs.reader.byte-count");
         this.byteMeter = metricRegistry.meter("system.message-queue.sqs.reader.bytes");
         this.readTimer = metricRegistry.timer("system.message-queue.sqs.reader.reads");
+        metricRegistry.register("system.message-queue.sqs.reader.in-flight-receive-batches",
+                (Gauge<Integer>) () -> config.getSqsMaxInflightReceiveBatches() - receiveSemaphore.availablePermits());
     }
 
     @Override
     protected void startUp() throws Exception {
         super.startUp();
 
-        LOG.info("Starting pulsar message queue reader service");
+        LOG.info("Starting SQS message queue reader service");
 
-        final QueueBufferConfig bufferConfig = new QueueBufferConfig()
-                .withMaxInflightReceiveBatches(config.getSqsMaxInflightReceiveBatches())
-                .withMaxInflightOutboundBatches(config.getSqsMaxInflightOutboundBatches())
-                .withMaxDoneReceiveBatches(config.getSqsMaxDoneReceiveBatches());
-
-        this.sqsClient = new AmazonSQSBufferedAsyncClient(AmazonSQSAsyncClientBuilder.defaultClient(), bufferConfig);
+        final SqsAsyncClientBuilder clientBuilder = SqsAsyncClient.builder()
+                .httpClientBuilder(NettyNioAsyncHttpClient.builder());
+        this.receiveClient = clientBuilder.build();
+        this.deleteClient = clientBuilder.build();
 
         processBuffer = processBufferProvider.get();
-
-        // Service is ready for consuming
-        latch.countDown();
     }
 
     @Override
     protected void shutDown() throws Exception {
-        if (sqsClient != null) {
-            sqsClient.shutdown();
+        if (receiveClient != null) {
+            receiveClient.close();
+        }
+        if (deleteClient != null) {
+            deleteClient.close();
         }
 
         super.shutDown();
@@ -114,89 +120,107 @@ public class SqsMessageQueueReader extends AbstractMessageQueueReader {
 
     @Override
     protected void run() throws Exception {
+
         while (isRunning()) {
             if (!shouldBeReading()) {
                 Uninterruptibles.sleepUninterruptibly(100, MILLISECONDS);
                 continue;
             }
-            final List<MessageQueue.Entry> entries = read();
-            entries.forEach(entry -> {
-                LOG.debug("Consumed message: {}", entry);
-                final RawMessage rawMessage = RawMessage.decode(entry.value(), entry.commitId());
-                processBuffer.insertBlocking(rawMessage);
-            });
+
+            receiveNextBatchAsync();
         }
     }
 
-    private List<MessageQueue.Entry> read() throws MessageQueueException {
-        if (!isRunning()) {
-            throw new MessageQueueException("Message queue service is not running");
-        }
-
-        final List<Message> messages = receiveEncodedMessages();
-        return decodeMessages(messages);
-    }
-
-    private ImmutableList<MessageQueue.Entry> decodeMessages(List<Message> messages) {
-        final ImmutableList.Builder<MessageQueue.Entry> builder = ImmutableList.builder();
-
-        messages.forEach(message -> {
-            try {
-                final MessageQueue.Entry entry = SqsMessageQueueEntry.fromMessage(message);
-                builder.add(entry);
-                messageMeter.mark();
-                byteCounter.inc(message.getBody().length());
-                byteMeter.mark(message.getBody().length());
-            } catch (Exception e) {
-                LOG.error("Unable to convert message <" + message.getMessageId() + ">. Message will be deleted from " +
-                        "message bus.", e);
-                commit(message.getReceiptHandle());
-            }
-        });
-
-        return builder.build();
-    }
-
-    private List<Message> receiveEncodedMessages() {
-        try(final Timer.Context ignored = readTimer.time()) {
-            final ReceiveMessageResult result = sqsClient.receiveMessage(
-                    new ReceiveMessageRequest(queueUrl)
-                            .withMaxNumberOfMessages(10)
-                            .withWaitTimeSeconds(20));
-            return result.getMessages();
-        } catch (Exception e) {
-            try {
-                // TODO maybe use exponential backoff
-                Thread.sleep(500);
-            } catch (InterruptedException ex) {
-                LOG.error("Interrupted sleep in error path", ex);
-            }
-            LOG.error("Error consuming messages.", e);
-        }
-        return Collections.emptyList();
-    }
-
-    public void commit(Object receiptHandle) {
-        if (!(receiptHandle instanceof String)) {
-            LOG.error("Couldn't delete message. Expected <" + receiptHandle + "> to be a String receipt handle");
+    // TODO: slow down reading if the queues are empty
+    private void receiveNextBatchAsync() throws InterruptedException {
+        receiveSemaphore.acquire();
+        if (!shouldBeReading()) {
             return;
         }
 
-        try {
-            sqsClient.deleteMessageAsync(new DeleteMessageRequest(queueUrl, (String) receiptHandle),
-                    new AsyncHandler<DeleteMessageRequest, DeleteMessageResult>() {
-                @Override
-                public void onError(Exception exception) {
-                    LOG.error("Couldn't delete message", exception);
-                }
+        final Timer.Context readTime = readTimer.time();
+        receiveClient.receiveMessage(receiveRequest -> receiveRequest.queueUrl(queueUrl)
+                .maxNumberOfMessages(10)
+                .waitTimeSeconds(20))
+                .whenComplete((response, error) -> {
+                    readTime.stop();
+                    if (error != null) {
+                        LOG.error("Receiving messages from SQS failed", error);
+                        // TODO maybe use exponential backoff
+                        Uninterruptibles.sleepUninterruptibly(500, MILLISECONDS);
+                    } else {
+                        response.messages()
+                                .forEach(this::handleMessage);
+                    }
+                    receiveSemaphore.release();
+                });
+    }
 
-                @Override
-                public void onSuccess(DeleteMessageRequest request, DeleteMessageResult deleteMessageResult) {
-                    // OK
-                }
-            });
+    private void handleMessage(Message message) {
+        messageMeter.mark();
+        byteCounter.inc(message.body()
+                .length());
+        byteMeter.mark(message.body()
+                .length());
+        try {
+            final MessageQueue.Entry entry = SqsMessageQueueEntry.fromMessage(message);
+            final RawMessage rawMessage = RawMessage.decode(entry.value(), entry.commitId());
+            processBuffer.insertBlocking(rawMessage);
         } catch (Exception e) {
-            LOG.error("Couldn't send delete request to SQS.", e);
+            LOG.error("Unable to convert message <" + message.messageId() + ">. Message will be deleted from " +
+                    "message bus.", e);
+            commit(message.receiptHandle());
         }
+    }
+
+    // TODO: this method shouldn't be used because sending batches with only a single item is really hurting
+    //  performance. Unfortunately it's the main method used by the BenchmarkOutput so we probably need to buffer
+    //  messages manually until we have enough of them to create a batch.
+    public void commit(Object receiptHandle) {
+        commit(Collections.singletonList(receiptHandle));
+    }
+
+    public void commit(List<Object> messageIds) {
+        final Iterator<Object> iterator = messageIds.iterator();
+
+        List<DeleteMessageBatchRequestEntry> currentBatch = new ArrayList<>(10);
+
+        while (iterator.hasNext()) {
+            Object receiptHandle = iterator.next();
+            if (!(receiptHandle instanceof String)) {
+                LOG.error("Couldn't delete message. Expected <" + receiptHandle + "> to be a String receipt handle");
+                continue;
+            }
+            final DeleteMessageBatchRequestEntry entry = DeleteMessageBatchRequestEntry.builder()
+                    .receiptHandle((String) receiptHandle)
+                    .id(String.valueOf(currentBatch.size() + 1))
+                    .build();
+            currentBatch.add(entry);
+
+            if (currentBatch.size() == 10) {
+                deleteBatch(currentBatch);
+                currentBatch = new ArrayList<>(10);
+            }
+        }
+        if (!currentBatch.isEmpty()) {
+            deleteBatch(currentBatch);
+        }
+    }
+
+    private void deleteBatch(List<DeleteMessageBatchRequestEntry> entries) {
+        try {
+            deleteSemaphore.acquire();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return;
+        }
+        deleteClient.deleteMessageBatch(request -> request.queueUrl(queueUrl)
+                .entries(entries))
+                .whenComplete((response, error) -> {
+                    if (error != null) {
+                        LOG.error("Couldn't delete message", error);
+                    }
+                    deleteSemaphore.release();
+                });
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/shared/messageq/sqs/BatchAggregatorTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/shared/messageq/sqs/BatchAggregatorTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog2.shared.messageq.sqs;
 
 import org.awaitility.Awaitility;

--- a/graylog2-server/src/test/java/org/graylog2/shared/messageq/sqs/BatchAggregatorTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/shared/messageq/sqs/BatchAggregatorTest.java
@@ -1,0 +1,62 @@
+package org.graylog2.shared.messageq.sqs;
+
+import org.awaitility.Awaitility;
+import org.junit.After;
+import org.junit.Test;
+import org.testcontainers.shaded.com.google.common.collect.ImmutableList;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BatchAggregatorTest {
+
+    private BatchAggregator<String> aggregator;
+
+    @After
+    public void tearDown() throws Exception {
+        if (aggregator != null) {
+            aggregator.shutdown();
+        }
+    }
+
+    @Test
+    public void testFlushWhenFull() {
+        List<List<String>> flushedBatches = new CopyOnWriteArrayList<>();
+
+        aggregator = new BatchAggregator<>(flushedBatches::add, 2, Duration.ofHours(1));
+        aggregator.start();
+
+        aggregator.feed("a");
+        assertThat(flushedBatches).isEmpty();
+        aggregator.feed("b");
+        assertThat(flushedBatches).containsExactly(ImmutableList.of("a", "b"));
+        aggregator.feed("c");
+        assertThat(flushedBatches).containsExactly(ImmutableList.of("a", "b"));
+        aggregator.feed("d");
+        assertThat(flushedBatches).containsExactly(ImmutableList.of("a", "b"), ImmutableList.of("c", "d"));
+    }
+
+    @Test
+    public void testFlushPeriodically() {
+        List<List<String>> flushedBatches = new CopyOnWriteArrayList<>();
+
+        aggregator = new BatchAggregator<>(flushedBatches::add, 2, Duration.ofMillis(10));
+        aggregator.start();
+
+        aggregator.feed("a");
+        Awaitility.await()
+                .atMost(1, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertThat(flushedBatches).containsExactly(ImmutableList.of("a")));
+
+        aggregator.feed("b");
+        Awaitility.await()
+                .atMost(1, TimeUnit.SECONDS)
+                .untilAsserted(
+                        () -> assertThat(flushedBatches).containsExactly(ImmutableList.of("a"), ImmutableList.of("b")));
+    }
+
+}

--- a/graylog2-server/src/test/java/org/graylog2/shared/messageq/sqs/SqsMessageQueueWriterTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/shared/messageq/sqs/SqsMessageQueueWriterTest.java
@@ -28,6 +28,7 @@ import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -81,7 +82,7 @@ public class SqsMessageQueueWriterTest {
 
     private RawMessageEvent createEvent(String body) {
         final RawMessageEvent rawMessageEvent = new RawMessageEvent();
-        rawMessageEvent.setEncodedRawMessage(body.getBytes());
+        rawMessageEvent.setEncodedRawMessage(body.getBytes(StandardCharsets.UTF_8));
         return rawMessageEvent;
     }
 

--- a/graylog2-server/src/test/java/org/graylog2/shared/messageq/sqs/SqsMessageQueueWriterTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/shared/messageq/sqs/SqsMessageQueueWriterTest.java
@@ -1,0 +1,72 @@
+package org.graylog2.shared.messageq.sqs;
+
+import com.codahale.metrics.MetricRegistry;
+import org.apache.commons.lang3.StringUtils;
+import org.graylog2.plugin.BaseConfiguration;
+import org.graylog2.shared.buffers.RawMessageEvent;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import java.net.URI;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.graylog2.shared.messageq.sqs.SqsMessageQueueWriter.REQUEST_SIZE_LIMIT;
+import static org.mockito.Mockito.when;
+
+public class SqsMessageQueueWriterTest {
+    @Rule
+    public MockitoRule rule = MockitoJUnit.rule();
+
+    @Mock
+    private MetricRegistry metricRegistry;
+    @Mock
+    private BaseConfiguration config;
+
+    @Before
+    public void setUp() throws Exception {
+        when(config.getSqsQueueUrl()).thenReturn(new URI("http://localhost"));
+    }
+
+    @Test
+    public void maxNumOfMessagesInBatch() {
+        final SqsMessageQueueWriter writer = new SqsMessageQueueWriter(metricRegistry, config);
+        final List<SqsMessageQueueWriter.Batch> batches = writer.createBatches(createEvents(22, "x"));
+        assertThat(batches).hasSize(3);
+        assertThat(batches.get(0).entries()).hasSize(10);
+        assertThat(batches.get(1).entries()).hasSize(10);
+        assertThat(batches.get(2).entries()).hasSize(2);
+    }
+
+    @Test
+    public void maxBytesInBatch() {
+        // make sure that only two messages will fit into one batch (after base64 encoding).
+        String payload = StringUtils.repeat("x", REQUEST_SIZE_LIMIT/3);
+
+        final SqsMessageQueueWriter writer = new SqsMessageQueueWriter(metricRegistry, config);
+        final List<SqsMessageQueueWriter.Batch> batches =
+                writer.createBatches(createEvents(4, payload));
+        assertThat(batches).hasSize(2);
+        assertThat(batches.get(0).entries()).hasSize(2);
+        assertThat(batches.get(1).entries()).hasSize(2);
+    }
+
+    private List<RawMessageEvent> createEvents(int messageCount, String body) {
+        return IntStream.range(0, messageCount)
+                .mapToObj(i -> createEvent(body))
+                .collect(Collectors.toList());
+    }
+
+    private RawMessageEvent createEvent(String body) {
+        final RawMessageEvent rawMessageEvent = new RawMessageEvent();
+        rawMessageEvent.setEncodedRawMessage(body.getBytes());
+        return rawMessageEvent;
+    }
+
+}

--- a/graylog2-server/src/test/java/org/graylog2/shared/messageq/sqs/SqsMessageQueueWriterTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/shared/messageq/sqs/SqsMessageQueueWriterTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog2.shared.messageq.sqs;
 
 import com.codahale.metrics.MetricRegistry;

--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
         <apache-directory-version>1.0.3</apache-directory-version>
         <auto-value.version>1.7.4</auto-value.version>
         <auto-value-javabean.version>2.5.2</auto-value-javabean.version>
-        <aws-java-sdk.version>1.11.939</aws-java-sdk.version>
+        <aws-sdk.version>2.15.69</aws-sdk.version>
         <bouncycastle.version>1.64</bouncycastle.version>
         <caffeine.version>2.8.1</caffeine.version>
         <cef-parser.version>0.0.1.10</cef-parser.version>


### PR DESCRIPTION
WIP

Upgrade the AWS SDK to version 2.
We can't use the `AmazonSQSBufferedAsyncClient` anymore but first experiments suggest that we can get comparable throughput with significantly lower CPU load by using the `NettyNioAsyncHttpClient`.

TODO:
- [ ] Provide internal buffering/batching for single message commit calls
- [ ] Revise error handling
- [ ] Prevent hot loops during error conditions
- [ ] Slow down reading when queue is empty
- [ ] Ensure clean shutdown sequence
- [ ] Add metrics for acknowledger