### PR TITLE
Add deployment retry.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -464,6 +464,13 @@
                             <goals>deploy</goals>
                         </configuration>
                     </plugin>
+                    <plugin>
+                      <groupId>org.apache.maven.plugins</groupId>
+                      <artifactId>maven-deploy-plugin</artifactId>
+                      <configuration>
+                        <retryFailedDeploymentCount>5</retryFailedDeploymentCount>
+                      </configuration>
+                    </plugin>
                 </plugins>
             </build>
         </profile>


### PR DESCRIPTION
Backport https://github.com/Graylog2/graylog2-server/pull/9966 to 4.0 branch.


## Description
This will configure Maven to retry deployments to oss.sonatype.org in the event of any network connectivity issues or intermittent server errors.


## Motivation and Context
Sometimes the deployment to sonatype fails when we run the release job. This offers some small degree of mitigation against this, depending on the issue.


## How Has This Been Tested?
Tested this by:

- Customizing my Maven settings.xml to override the distributionManagement tag and making it use my internal Nexus instance instead of oss.sonatype.org.
- Configuring the repositories in Nexus to be read-only, so that Maven can pull artifacts but uploads will time out.
- Mapped oss.sonatype.org in my /etc/hosts file to 127.0.0.1 (just in case).

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

