### PR TITLE
Fix export to dashboard when graylog is behind a proxy

### DIFF
--- a/graylog2-web-interface/src/views/logic/views/Actions.ts
+++ b/graylog2-web-interface/src/views/logic/views/Actions.ts
@@ -16,7 +16,6 @@
  */
 import history from 'util/History';
 import Routes from 'routing/Routes';
-import { newDashboardsPath } from 'views/Constants';
 import View from 'views/logic/views/View';
 
 export const loadNewView = () => history.push(`${Routes.SEARCH}/new`);
@@ -30,7 +29,7 @@ export const loadView = (viewId: string) => history.push(`${Routes.SEARCH}/${vie
 export const loadDashboard = (dashboardId: string) => history.push(Routes.pluginRoute('DASHBOARDS_VIEWID')(dashboardId));
 
 export const loadAsDashboard = (view: View) => history.push({
-  pathname: newDashboardsPath,
+  pathname: Routes.pluginRoute('DASHBOARDS_NEW'),
   state: {
     view,
   },


### PR DESCRIPTION
## Motivation
Prior to this change, when loading the new dashboard containing the
previous search we used a not qualified route, which did not take the
prefix in account.

## Description
This change will use `Routes` to set the new pathname for history.push.

## How Has This Been Tested?
- Setup a nginx as described in the issue #9989
- Used the graylog without frontend devserver
- `yarn build` and restarting the backend server
- going to `http://localhost/graylog` and clicking there on `Export to Dashboard`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Fixes #9989 

