### PR TITLE
Fix export to dashboard when graylog is behind a proxy

### DIFF
--- a/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchControls.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchControls.jsx
@@ -180,7 +180,7 @@ class SavedSearchControls extends React.Component<Props, State> {
     const { view } = viewStoreState;
 
     browserHistory.push({
-      pathname: Routes.pluginRoute('DASHBOARDS_NEW')
+      pathname: Routes.pluginRoute('DASHBOARDS_NEW'),
       state: {
         view: view,
       },

--- a/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchControls.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchControls.jsx
@@ -8,7 +8,6 @@ import { type ThemeInterface } from 'theme';
 import Routes from 'routing/Routes';
 import StoreProvider from 'injection/StoreProvider';
 import { isPermitted } from 'util/PermissionsMixin';
-import { newDashboardsPath } from 'views/Constants';
 import { Button, ButtonGroup, DropdownButton, MenuItem } from 'components/graylog';
 import { Icon } from 'components/common';
 import { ViewManagementActions } from 'views/stores/ViewManagementStore';
@@ -181,7 +180,7 @@ class SavedSearchControls extends React.Component<Props, State> {
     const { view } = viewStoreState;
 
     browserHistory.push({
-      pathname: newDashboardsPath,
+      pathname: Routes.pluginRoute('DASHBOARDS_NEW')
       state: {
         view: view,
       },


### PR DESCRIPTION
## Motivation
Prior to this change, when loading the new dashboard containing the
previous search we used a not qualified route, which did not take the
prefix in account.

## Description
This change will use `Routes` to set the new pathname for history.push.

## How Has This Been Tested?
- Setup a nginx as described in the issue #9989
- Used the graylog without frontend devserver
- `yarn build` and restarting the backend server
- going to `http://localhost/graylog` and clicking there on `Export to Dashboard`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Fixes #9989 

