### PR TITLE
Allow non-string options in Select component.

### DIFF
--- a/graylog2-web-interface/src/components/common/Select.test.jsx
+++ b/graylog2-web-interface/src/components/common/Select.test.jsx
@@ -15,12 +15,56 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import React from 'react';
+import { render, screen, waitFor } from 'wrappedTestingLibrary';
 import { mount } from 'wrappedEnzyme';
 import SelectComponent, { components as Components } from 'react-select';
+import selectEvent from 'react-select-event';
 
 import Select from './Select';
 
+const createOption = (x) => ({ label: x, value: x });
+
 describe('Select', () => {
+  const SimpleSelect = (props) => <Select inputProps={{ 'aria-label': 'Select value' }} {...props} />;
+
+  it('calls `onChange` upon selecting option', async () => {
+    const options = ['foo', 'bar'].map(createOption);
+
+    const onChange = jest.fn();
+
+    render((
+      <SimpleSelect options={options}
+                    onChange={onChange} />
+    ));
+
+    const select = screen.getByLabelText('Select value');
+
+    await selectEvent.openMenu(select);
+
+    await selectEvent.select(select, 'foo');
+
+    await waitFor(() => expect(onChange).toHaveBeenCalledWith('foo'));
+  });
+
+  it('works with non-string options', async () => {
+    const options = [23, 42].map(createOption);
+
+    const onChange = jest.fn();
+
+    render((
+      <SimpleSelect options={options}
+                    onChange={onChange} />
+    ));
+
+    const select = screen.getByLabelText('Select value');
+
+    await selectEvent.openMenu(select);
+
+    await selectEvent.select(select, '42');
+
+    await waitFor(() => expect(onChange).toHaveBeenCalledWith(42));
+  });
+
   describe('Upgrade to react-select v2', () => {
     const options = [{ label: 'label', value: 'value' }];
     const onChange = () => { };

--- a/graylog2-web-interface/src/components/common/Select.tsx
+++ b/graylog2-web-interface/src/components/common/Select.tsx
@@ -473,7 +473,7 @@ class Select extends React.Component<Props, State> {
     if (value && allowCreate) {
       formattedValue = this._formatInputValue(value);
     } else {
-      formattedValue = (value instanceof String
+      formattedValue = (typeof value === 'string'
         ? (value ?? '').split(delimiter)
         : [value])
         .map((v) => options.find((option) => option[valueKey || ''] === v));

--- a/graylog2-web-interface/src/components/common/Select.tsx
+++ b/graylog2-web-interface/src/components/common/Select.tsx
@@ -473,7 +473,10 @@ class Select extends React.Component<Props, State> {
     if (value && allowCreate) {
       formattedValue = this._formatInputValue(value);
     } else {
-      formattedValue = (value || '').split(delimiter).map((v) => options.find((option) => option[valueKey || ''] === v));
+      formattedValue = (value instanceof String
+        ? (value ?? '').split(delimiter)
+        : [value])
+        .map((v) => options.find((option) => option[valueKey || ''] === v));
     }
 
     const {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Prior to this change, the value part of options passed to the `Select` component must be strings. For non-numeric strings, upon selecting an option an exception was thrown due to `.split()` being called on something that does not implement it.

This PR is fixing this, by testing if the selected value is a string or not, avoiding `split` in case it is not.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.