### PR TITLE
Include all file extensions in lint runs.

### DIFF
--- a/graylog2-web-interface/packages/eslint-config-graylog/index.js
+++ b/graylog2-web-interface/packages/eslint-config-graylog/index.js
@@ -37,6 +37,9 @@ module.exports = {
         '@typescript-eslint/no-shadow': ['error'],
       },
     },
+    {
+      files: ['*.js', '*.jsx'],
+    },
   ],
   extends: [
     'eslint:recommended',


### PR DESCRIPTION
During the centralisation of the jest config module (#9548), we removed the `--ext` parameter to eslint in our yarn script definitions.  Unfortunately, this makes eslint to lint `.js`, `.ts` & `.tsx` files only, due to eslint using `js` per default and merging it with `ts`/`tsx` from the `overrides` section of the `eslint-config-graylog` module.

In order to include `jsx` files again, this PR adds an empty `overrides` section including `js` & `jsx` explicitly to the `eslint-config-graylog` module.