### PR TITLE
Add support for Highlighting for Timestamps and Booleans

### DIFF
--- a/graylog2-web-interface/src/components/common/Timestamp.jsx
+++ b/graylog2-web-interface/src/components/common/Timestamp.jsx
@@ -19,6 +19,22 @@ import React from 'react';
 
 import DateTime from 'logic/datetimes/DateTime';
 
+export const formatDateTime = (dateTime, format, tz, relative = false) => {
+  if (relative) {
+    return dateTime.toRelativeString();
+  }
+
+  switch (tz) {
+    case null:
+    case undefined:
+      return dateTime.toString(format);
+    case 'browser':
+      return dateTime.toBrowserLocalTime().toString(format);
+    default:
+      return dateTime.toTimeZone(tz).toString(format);
+  }
+}
+
 /**
  * Component that renders a `time` HTML element with a given date time. It is
  * capable of render date times in different formats, accepting ISO 8601
@@ -62,36 +78,32 @@ class Timestamp extends React.Component {
      * time zones supported by moment timezone.
      */
     tz: PropTypes.string,
+    /**
+     * Override render default function to add a decorator.
+     */
+    render: PropTypes.func,
   };
 
   static defaultProps = {
     format: DateTime.Formats.TIMESTAMP,
     relative: false,
     tz: undefined,
+    render: ({ value }) => <>{value}</>,
   };
 
   _formatDateTime = () => {
-    const dateTime = new DateTime(this.props.dateTime);
+    const { relative, dateTime: dateTime1, tz, format } = this.props;
+    const dateTime = new DateTime(dateTime1);
 
-    if (this.props.relative) {
-      return dateTime.toRelativeString();
-    }
-
-    switch (this.props.tz) {
-      case null:
-      case undefined:
-        return dateTime.toString(this.props.format);
-      case 'browser':
-        return dateTime.toBrowserLocalTime().toString(this.props.format);
-      default:
-        return dateTime.toTimeZone(this.props.tz).toString(this.props.format);
-    }
+    return formatDateTime(dateTime, format, tz, relative);
   };
 
   render() {
+    const { render: Component, dateTime } = this.props;
+
     return (
-      <time key={`time-${this.props.dateTime}`} dateTime={this.props.dateTime} title={this.props.dateTime}>
-        {this._formatDateTime()}
+      <time key={`time-${dateTime}`} dateTime={dateTime} title={dateTime}>
+        <Component value={this._formatDateTime()} />
       </time>
     );
   }

--- a/graylog2-web-interface/src/components/common/Timestamp.jsx
+++ b/graylog2-web-interface/src/components/common/Timestamp.jsx
@@ -88,7 +88,7 @@ class Timestamp extends React.Component {
     format: DateTime.Formats.TIMESTAMP,
     relative: false,
     tz: undefined,
-    render: ({ value }) => <>{value}</>,
+    render: ({ value }) => value,
   };
 
   _formatDateTime = () => {

--- a/graylog2-web-interface/src/components/common/Timestamp.jsx
+++ b/graylog2-web-interface/src/components/common/Timestamp.jsx
@@ -33,7 +33,7 @@ export const formatDateTime = (dateTime, format, tz, relative = false) => {
     default:
       return dateTime.toTimeZone(tz).toString(format);
   }
-}
+};
 
 /**
  * Component that renders a `time` HTML element with a given date time. It is

--- a/graylog2-web-interface/src/views/components/TypeSpecificValue.tsx
+++ b/graylog2-web-interface/src/views/components/TypeSpecificValue.tsx
@@ -46,6 +46,8 @@ type Props = {
 const defaultComponent = ({ value }: ValueRendererProps) => value;
 
 const TypeSpecificValue = ({ field, value, render = defaultComponent, type = FieldType.Unknown, truncate = false }: Props) => {
+  const Component = render;
+
   if (value === undefined) {
     return null;
   }
@@ -56,7 +58,7 @@ const TypeSpecificValue = ({ field, value, render = defaultComponent, type = Fie
 
   switch (type.type) {
     case 'date': return <UserTimezoneTimestamp dateTime={value} />;
-    case 'boolean': return <>{String(value)}</>;
+    case 'boolean': return <Component value={String(value)} type={type} field={field} />;
     default: return _formatValue(field, value, truncate, render, type);
   }
 };

--- a/graylog2-web-interface/src/views/components/TypeSpecificValue.tsx
+++ b/graylog2-web-interface/src/views/components/TypeSpecificValue.tsx
@@ -57,7 +57,7 @@ const TypeSpecificValue = ({ field, value, render = defaultComponent, type = Fie
   }
 
   switch (type.type) {
-    case 'date': return <UserTimezoneTimestamp dateTime={value} />;
+    case 'date': return <UserTimezoneTimestamp dateTime={value} render={render} />;
     case 'boolean': return <Component value={String(value)} type={type} field={field} />;
     default: return _formatValue(field, value, truncate, render, type);
   }

--- a/graylog2-web-interface/src/views/components/Value.test.jsx
+++ b/graylog2-web-interface/src/views/components/Value.test.jsx
@@ -20,7 +20,6 @@ import each from 'jest-each';
 import mockComponent from 'helpers/mocking/MockComponent';
 
 import FieldType from 'views/logic/fieldtypes/FieldType';
-import UserTimezoneTimestamp from 'views/components/common/UserTimezoneTimestamp';
 
 import Value from './Value';
 import EmptyValue from './EmptyValue';

--- a/graylog2-web-interface/src/views/components/Value.test.jsx
+++ b/graylog2-web-interface/src/views/components/Value.test.jsx
@@ -45,9 +45,9 @@ describe('Value', () => {
                                        queryId="someQueryId"
                                        value="2018-10-02T14:45:40Z"
                                        type={new FieldType('date', [], [])} />);
-      const valueActions = wrapper.find('ValueActions');
+      const userTimestamp = wrapper.find('UserTimezoneTimestamp');
 
-      expect(valueActions).toContainReact(<UserTimezoneTimestamp dateTime="2018-10-02T14:45:40Z" />);
+      expect(userTimestamp).toExist();
     });
 
     it('renders numeric timestamps with a custom component', () => {
@@ -55,9 +55,9 @@ describe('Value', () => {
                                        queryId="someQueryId"
                                        value={1571302317}
                                        type={new FieldType('date', [], [])} />);
-      const valueActions = wrapper.find('ValueActions');
+      const userTimeStamp = wrapper.find('UserTimezoneTimestamp');
 
-      expect(valueActions).toContainReact(<UserTimezoneTimestamp dateTime={1571302317} />);
+      expect(userTimeStamp).toExist();
     });
 
     it('renders booleans as strings', () => {

--- a/graylog2-web-interface/src/views/components/messagelist/CustomHighlighting.tsx
+++ b/graylog2-web-interface/src/views/components/messagelist/CustomHighlighting.tsx
@@ -25,6 +25,7 @@ import HighlightingRulesContext from 'views/components/contexts/HighlightingRule
 import CurrentUserContext from 'contexts/CurrentUserContext';
 import FieldTypesContext from 'views/components/contexts/FieldTypesContext';
 import { formatDateTime } from 'components/common/Timestamp';
+import FieldType from 'views/logic/fieldtypes/FieldType';
 
 import PossiblyHighlight from './PossiblyHighlight';
 import Highlight from './Highlight';
@@ -40,8 +41,13 @@ const CustomHighlighting = ({ children, field: fieldName, value: fieldValue }: P
   const highlightingRules = useContext(HighlightingRulesContext) ?? [];
   const currentUser = useContext(CurrentUserContext);
   const timezone = currentUser?.timezone ?? AppConfig.rootTimeZone();
-  const { all } = useContext(FieldTypesContext);
-  const { type } = all.find((f) => f.name === fieldName).type;
+  const fieldTypes = useContext(FieldTypesContext);
+  let type;
+
+  if (fieldTypes) {
+    const { all } = fieldTypes;
+    type = (all.find((f) => f.name === fieldName) || { type: FieldType.Unknown }).type.type;
+  }
 
   const highlightingRulesMap = highlightingRules.reduce((prev, cur) => ({ ...prev, [cur.field]: prev[cur.field] ? [...prev[cur.field], cur] : [cur] }), {});
   const rules = highlightingRulesMap[fieldName] ?? [];

--- a/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightingRule.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightingRule.tsx
@@ -88,7 +88,7 @@ const HighlightingRule = ({ rule }: Props) => {
                             triggerNode={<ColorPreview color={color} />}
                             onChange={(newColor, _, hidePopover) => updateColor(rule, newColor, hidePopover)} />
         <RuleContainer>
-          <strong>{field}</strong> {ConditionLabelMap[condition]} <i>&quot;{value}&quot;</i>.
+          <strong>{field}</strong> {ConditionLabelMap[condition]} <i>&quot;{String(value)}&quot;</i>.
         </RuleContainer>
         <ButtonContainer>
           <IconButton title="Edit this Highlighting Rule" name="edit" onClick={() => setShowForm(true)} />


### PR DESCRIPTION
## Motivation
Prior this PR we did not support highlighting for Timestamps and booleans.

## Description
- Use `render` component for booleans in Typespecific value so the highlighting will be used.
- Same for timestamps, but here we need to pass the render function to the Timestamp component
- For timestamps we need to take care of the highlighting length since the compared string is shorter then
  the rendered timestamp.

## How Has This Been Tested?
- Highlight a timestamp
- Highlight a boolean
- Ensure they are not treated as numbers

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Fixes #9835 

## Caution
#9634 needs to be merged first and then this PR needs a rebase!
