### PR TITLE
Creating common component `CopyToClipboardCapture` which allows to format content on copy

### DIFF
--- a/graylog2-web-interface/src/components/common/CopyToClipboardCapture.tsx
+++ b/graylog2-web-interface/src/components/common/CopyToClipboardCapture.tsx
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+
+type Props = {
+  children: React.ReactNode,
+  className?: string,
+  formatSelection: (originalSelection: Selection) => Selection | string
+}
+
+/**
+ * This component calls `formatSelection` every time the user copies encapsulated content (`children`) to the clipboard.
+ * `formatSelection` allows to format the selected content before it gets stored in the clipboard.
+ */
+const CopyToClipboardCapture = React.forwardRef<HTMLDivElement, Props>(({ formatSelection, children, className }: Props, ref) => {
+  const _onCopy = (event) => {
+    const selection = formatSelection(document.getSelection());
+    event.clipboardData.setData('text/plain', selection);
+    event.preventDefault();
+  };
+
+  return (
+    <div className={className} ref={ref} onCopy={_onCopy}>
+      {children}
+    </div>
+  );
+});
+
+CopyToClipboardCapture.defaultProps = {
+  className: undefined,
+};
+
+export default CopyToClipboardCapture;

--- a/graylog2-web-interface/src/components/common/index.tsx
+++ b/graylog2-web-interface/src/components/common/index.tsx
@@ -25,6 +25,7 @@ export { default as ConfirmLeaveDialog } from './ConfirmLeaveDialog';
 export { default as ContentHeadRow } from './ContentHeadRow';
 export { default as ContentPackMarker } from './ContentPackMarker';
 export { default as ControlledTableList } from './ControlledTableList';
+export { default as CopyToClipboardCapture } from './CopyToClipboardCapture';
 export { default as CountBadge } from './CountBadge';
 export { default as DataTable } from './DataTable';
 export { default as DatePicker } from './DatePicker';


### PR DESCRIPTION
## Description
This PR adds a component called `CopyToClipboardCapture` which allows to format content on copy before it gets stored in the clipboard. The component receives a function (`formatSelection`) which gets called every time the user copies encapsulated content (`children`).

## Motivation and Context
We need this functionality for the following case. When a grid is styled with `display: flex;` or `display: grid;` and a user copies a row, each cell is being separated by a line break. With this component we are able to remove the line breaks when necessary.
