### PR TITLE
Handle multiple principals in mongoDB session

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/security/MongoDbSession.java
+++ b/graylog2-server/src/main/java/org/graylog2/security/MongoDbSession.java
@@ -16,6 +16,7 @@
  */
 package org.graylog2.security;
 
+import com.google.common.collect.Iterables;
 import org.apache.shiro.subject.support.DefaultSubjectContext;
 import org.bson.types.ObjectId;
 import org.graylog2.database.CollectionName;
@@ -99,15 +100,17 @@ public class MongoDbSession extends PersistedImpl {
         if (attributes == null) {
             return Optional.empty();
         }
+
+        final Object sessionId;
+
         // A subject can have more than one principal. If that's the case, the user ID is required to be the first one.
         final Object principals = attributes.get(DefaultSubjectContext.PRINCIPALS_SESSION_KEY);
-        final String sessionId;
         if (principals instanceof Iterable) {
-            sessionId = String.valueOf(((Iterable<?>) principals).iterator().next());
+            sessionId = Iterables.getFirst((Iterable<?>) principals, null);
         } else {
-            sessionId = String.valueOf(principals);
+            sessionId = principals;
         }
-        return Optional.ofNullable(sessionId);
+        return Optional.ofNullable(sessionId).map(String::valueOf);
     }
 
     public String getHost() {

--- a/graylog2-server/src/main/java/org/graylog2/security/MongoDbSession.java
+++ b/graylog2-server/src/main/java/org/graylog2/security/MongoDbSession.java
@@ -99,7 +99,15 @@ public class MongoDbSession extends PersistedImpl {
         if (attributes == null) {
             return Optional.empty();
         }
-        return Optional.ofNullable(String.valueOf(attributes.get(DefaultSubjectContext.PRINCIPALS_SESSION_KEY)));
+        // A subject can have more than one principal. If that's the case, the user ID is required to be the first one.
+        final Object principals = attributes.get(DefaultSubjectContext.PRINCIPALS_SESSION_KEY);
+        final String sessionId;
+        if (principals instanceof Iterable) {
+            sessionId = String.valueOf(((Iterable<?>) principals).iterator().next());
+        } else {
+            sessionId = String.valueOf(principals);
+        }
+        return Optional.ofNullable(sessionId);
     }
 
     public String getHost() {

--- a/graylog2-server/src/test/java/org/graylog2/security/MongoDbSessionTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/security/MongoDbSessionTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog2.security;
 
 import com.google.common.collect.ImmutableMap;

--- a/graylog2-server/src/test/java/org/graylog2/security/MongoDbSessionTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/security/MongoDbSessionTest.java
@@ -1,0 +1,51 @@
+package org.graylog2.security;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.shaded.com.google.common.collect.ImmutableList;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.apache.shiro.subject.support.DefaultSubjectContext.PRINCIPALS_SESSION_KEY;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MongoDbSessionTest {
+
+    private Map<String, Object> fields;
+
+    @BeforeEach
+    void setUp() {
+        fields = new HashMap<>();
+        fields.put("session_id", "session-id");
+    }
+
+    @Test
+    public void noPrincipal() {
+        assertThat(new MongoDbSession(fields).getUserIdAttribute()).isEmpty();
+    }
+
+    @Test
+    public void singlePrincipal() {
+        final MongoDbSession session = new MongoDbSession(fields);
+        session.setAttributes(ImmutableMap.of(PRINCIPALS_SESSION_KEY, "a-user-id"));
+        assertThat(session.getUserIdAttribute()).contains("a-user-id");
+    }
+
+    @Test
+    public void emptyPrincipalsCollection() {
+        final MongoDbSession session = new MongoDbSession(fields);
+        session.setAttributes(ImmutableMap.of(PRINCIPALS_SESSION_KEY, Collections.emptyList()));
+        assertThat(session.getUserIdAttribute()).isEmpty();
+    }
+
+    @Test
+    public void principalsCollection() {
+        final MongoDbSession session = new MongoDbSession(fields);
+        session.setAttributes(ImmutableMap.of(PRINCIPALS_SESSION_KEY,
+                ImmutableList.of("a-user-id", "secondary-principal")));
+        assertThat(session.getUserIdAttribute()).contains("a-user-id");
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
A Shiro subject may have multiple principals, with the first principal being the "primary principal" and in our case that's the user ID.
This changes checks if we have multiple principals in a session and returns the first principal when looking up a user ID.

Once merged, we should forward-port this to the `master` branch.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The principals collection may be used to transport additional attributes of a subject from the authorization service into the session. Treating the string representation of the principals collection as the user ID is wrong in this case.

Fixes Graylog2/graylog-plugin-cloud#705

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

