### PR TITLE
Fixing linter hints related to importing `URLUtils`/`FormsUtils`.

### DIFF
--- a/graylog2-web-interface/src/components/common/Select.tsx
+++ b/graylog2-web-interface/src/components/common/Select.tsx
@@ -398,7 +398,7 @@ class Select extends React.Component<Props, State> {
 
     this.setState({ value: value });
 
-    // eslint-disable-next-line no-unused-vars, @typescript-eslint/no-empty-function,@typescript-eslint/no-unused-vars
+    // eslint-disable-next-line @typescript-eslint/no-empty-function,@typescript-eslint/no-unused-vars
     const { onChange = (v: string) => {} } = this.props;
 
     onChange(value);

--- a/graylog2-web-interface/src/components/common/TimeUnitInput.jsx
+++ b/graylog2-web-interface/src/components/common/TimeUnitInput.jsx
@@ -31,7 +31,7 @@ import {
   MenuItem,
 } from 'components/graylog';
 import { InputWrapper } from 'components/bootstrap';
-import FormsUtils from 'util/FormsUtils';
+import * as FormsUtils from 'util/FormsUtils';
 
 const unitValues = [
   'NANOSECONDS',

--- a/graylog2-web-interface/src/components/common/URLWhiteListInput.tsx
+++ b/graylog2-web-interface/src/components/common/URLWhiteListInput.tsx
@@ -20,7 +20,7 @@ import PropTypes from 'prop-types';
 import { Input } from 'components/bootstrap';
 import StoreProvider from 'injection/StoreProvider';
 import { isValidURL } from 'util/URLUtils';
-import FormsUtils from 'util/FormsUtils';
+import * as FormsUtils from 'util/FormsUtils';
 // Explicit import to fix eslint import/no-cycle
 import URLWhiteListFormModal from 'components/common/URLWhiteListFormModal';
 

--- a/graylog2-web-interface/src/components/configurationforms/BooleanField.jsx
+++ b/graylog2-web-interface/src/components/configurationforms/BooleanField.jsx
@@ -17,7 +17,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import FormsUtils from 'util/FormsUtils';
+import * as FormsUtils from 'util/FormsUtils';
 
 import FieldHelpers from './FieldHelpers';
 

--- a/graylog2-web-interface/src/components/configurationforms/NumberField.jsx
+++ b/graylog2-web-interface/src/components/configurationforms/NumberField.jsx
@@ -18,7 +18,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import createReactClass from 'create-react-class';
 
-import FormsUtils from 'util/FormsUtils';
+import * as FormsUtils from 'util/FormsUtils';
 
 import FieldHelpers from './FieldHelpers';
 

--- a/graylog2-web-interface/src/components/configurations/UrlWhiteListForm.tsx
+++ b/graylog2-web-interface/src/components/configurations/UrlWhiteListForm.tsx
@@ -71,7 +71,7 @@ const UrlWhiteListForm = ({ urls, onUpdate, disabled }: Props) => {
     let isValid = true;
 
     try {
-      // eslint-disable-next-line no-unused-vars
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const test = new URL(str);
     } catch (e) {
       isValid = false;

--- a/graylog2-web-interface/src/components/content-packs/ContentPackDownloadControl.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackDownloadControl.jsx
@@ -22,7 +22,7 @@ import ApiRoutes from 'routing/ApiRoutes';
 import { Modal, Button } from 'components/graylog';
 import { Icon } from 'components/common';
 import BootstrapModalWrapper from 'components/bootstrap/BootstrapModalWrapper';
-import URLUtils from 'util/URLUtils';
+import * as URLUtils from 'util/URLUtils';
 import StoreProvider from 'injection/StoreProvider';
 
 const SessionStore = StoreProvider.getStore('Session');

--- a/graylog2-web-interface/src/components/content-packs/ContentPackEditParameter.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackEditParameter.jsx
@@ -18,7 +18,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import { Input } from 'components/bootstrap';
-import FormsUtils from 'util/FormsUtils';
+import * as FormsUtils from 'util/FormsUtils';
 import ObjectUtils from 'util/ObjectUtils';
 
 import ContentPackUtils from './ContentPackUtils';

--- a/graylog2-web-interface/src/components/content-packs/ContentPackVersions.test.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackVersions.test.jsx
@@ -18,7 +18,7 @@ import React from 'react';
 import { mount } from 'wrappedEnzyme';
 
 import 'helpers/mocking/react-dom_mock';
-import URLUtils from 'util/URLUtils';
+import * as URLUtils from 'util/URLUtils';
 import ContentPack from 'logic/content-packs/ContentPack';
 import ContentPackRevisions from 'logic/content-packs/ContentPackRevisions';
 import ContentPackVersions from 'components/content-packs/ContentPackVersions';

--- a/graylog2-web-interface/src/components/content-packs/ContentPacksList.test.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPacksList.test.jsx
@@ -18,7 +18,7 @@ import React from 'react';
 import { mount, shallow } from 'wrappedEnzyme';
 
 import 'helpers/mocking/react-dom_mock';
-import URLUtils from 'util/URLUtils';
+import * as URLUtils from 'util/URLUtils';
 import ContentPacksList from 'components/content-packs/ContentPacksList';
 
 describe('<ContentPacksList />', () => {

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/EditQueryParameterModal.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/EditQueryParameterModal.jsx
@@ -22,7 +22,7 @@ import styled from 'styled-components';
 import { Button, Panel, ControlLabel, FormGroup, HelpBlock } from 'components/graylog';
 import { BootstrapModalForm, Input } from 'components/bootstrap';
 import { Select } from 'components/common';
-import FormsUtils from 'util/FormsUtils';
+import * as FormsUtils from 'util/FormsUtils';
 import { naturalSortIgnoreCase } from 'util/SortUtils';
 
 const StyledPanel = styled(Panel)`

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventDetailsForm.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventDetailsForm.jsx
@@ -22,7 +22,7 @@ import { Col, ControlLabel, FormGroup, HelpBlock, Row } from 'components/graylog
 import { Select } from 'components/common';
 import { Input } from 'components/bootstrap';
 import EventDefinitionPriorityEnum from 'logic/alerts/EventDefinitionPriorityEnum';
-import FormsUtils from 'util/FormsUtils';
+import * as FormsUtils from 'util/FormsUtils';
 
 import commonStyles from '../common/commonStyles.css';
 

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/FieldForm.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/FieldForm.jsx
@@ -34,7 +34,7 @@ import {
 import { Input } from 'components/bootstrap';
 import { Icon, Select } from 'components/common';
 import EventKeyHelpPopover from 'components/event-definitions/common/EventKeyHelpPopover';
-import FormsUtils from 'util/FormsUtils';
+import * as FormsUtils from 'util/FormsUtils';
 
 import commonStyles from '../common/commonStyles.css';
 

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/NotificationSettingsForm.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/NotificationSettingsForm.jsx
@@ -22,7 +22,7 @@ import moment from 'moment';
 import { ControlLabel, FormControl, FormGroup, HelpBlock, InputGroup } from 'components/graylog';
 import { TimeUnitInput } from 'components/common';
 import { extractDurationAndUnit } from 'components/common/TimeUnitInput';
-import FormsUtils from 'util/FormsUtils';
+import * as FormsUtils from 'util/FormsUtils';
 
 import commonStyles from '../common/commonStyles.css';
 

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/field-value-providers/LookupTableFieldValueProviderForm.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/field-value-providers/LookupTableFieldValueProviderForm.jsx
@@ -20,7 +20,7 @@ import lodash from 'lodash';
 
 import { Col, ControlLabel, FormGroup, HelpBlock, Row } from 'components/graylog';
 import { Select } from 'components/common';
-import FormsUtils from 'util/FormsUtils';
+import * as FormsUtils from 'util/FormsUtils';
 import { naturalSortIgnoreCase } from 'util/SortUtils';
 
 class LookupTableFieldValueProviderForm extends React.Component {

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/field-value-providers/TemplateFieldValueProviderForm.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/field-value-providers/TemplateFieldValueProviderForm.jsx
@@ -21,7 +21,7 @@ import lodash from 'lodash';
 import { Checkbox, Col, FormGroup, HelpBlock, Row } from 'components/graylog';
 import { Input } from 'components/bootstrap';
 import { ExternalLink } from 'components/common';
-import FormsUtils from 'util/FormsUtils';
+import * as FormsUtils from 'util/FormsUtils';
 
 import TemplateFieldValueProviderPreview from './TemplateFieldValueProviderPreview';
 

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/AggregationConditionExpressions/NumberExpression.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/AggregationConditionExpressions/NumberExpression.jsx
@@ -20,7 +20,7 @@ import lodash from 'lodash';
 
 import { Input } from 'components/bootstrap';
 import { Col } from 'components/graylog';
-import FormsUtils from 'util/FormsUtils';
+import * as FormsUtils from 'util/FormsUtils';
 import { numberExpressionNodePropType } from 'logic/alerts/AggregationExpressionTypes';
 
 const NumberExpression = ({ expression, onChange, renderLabel, validation }) => {

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterAggregationForm.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterAggregationForm.jsx
@@ -19,7 +19,7 @@ import PropTypes from 'prop-types';
 import lodash from 'lodash';
 
 import { Col, ControlLabel, FormGroup, Radio, Row } from 'components/graylog';
-import FormsUtils from 'util/FormsUtils';
+import * as FormsUtils from 'util/FormsUtils';
 
 import FilterForm from './FilterForm';
 import FilterPreviewContainer from './FilterPreviewContainer';

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterForm.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterForm.jsx
@@ -28,7 +28,7 @@ import { extractDurationAndUnit } from 'components/common/TimeUnitInput';
 import { MultiSelect, TimeUnitInput } from 'components/common';
 import { Input } from 'components/bootstrap';
 import { naturalSortIgnoreCase } from 'util/SortUtils';
-import FormsUtils from 'util/FormsUtils';
+import * as FormsUtils from 'util/FormsUtils';
 import CombinedProvider from 'injection/CombinedProvider';
 import { SearchMetadataActions } from 'views/stores/SearchMetadataStore';
 import PermissionsMixin from 'util/PermissionsMixin';

--- a/graylog2-web-interface/src/components/event-notifications/event-notification-form/EventNotificationForm.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-form/EventNotificationForm.jsx
@@ -22,7 +22,7 @@ import { PluginStore } from 'graylog-web-plugin/plugin';
 import { Alert, Button, ButtonToolbar, Col, ControlLabel, FormControl, FormGroup, HelpBlock, Row } from 'components/graylog';
 import { Select, Spinner } from 'components/common';
 import { Input } from 'components/bootstrap';
-import FormsUtils from 'util/FormsUtils';
+import * as FormsUtils from 'util/FormsUtils';
 
 class EventNotificationForm extends React.Component {
   static propTypes = {

--- a/graylog2-web-interface/src/components/event-notifications/event-notification-types/EmailNotificationForm.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-types/EmailNotificationForm.jsx
@@ -21,7 +21,7 @@ import lodash from 'lodash';
 import { ControlLabel, FormGroup, HelpBlock } from 'components/graylog';
 import { MultiSelect, SourceCodeEditor } from 'components/common';
 import { Input } from 'components/bootstrap';
-import FormsUtils from 'util/FormsUtils';
+import * as FormsUtils from 'util/FormsUtils';
 
 // TODO: Default body template should come from the server
 const DEFAULT_BODY_TEMPLATE = `--- [Event Definition] ---------------------------

--- a/graylog2-web-interface/src/components/event-notifications/event-notification-types/HttpNotificationForm.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-types/HttpNotificationForm.jsx
@@ -19,7 +19,7 @@ import PropTypes from 'prop-types';
 import lodash from 'lodash';
 
 import { URLWhiteListInput } from 'components/common';
-import FormsUtils from 'util/FormsUtils';
+import * as FormsUtils from 'util/FormsUtils';
 
 class HttpNotificationForm extends React.Component {
   static propTypes = {

--- a/graylog2-web-interface/src/components/events/events/EventsSearchBar.jsx
+++ b/graylog2-web-interface/src/components/events/events/EventsSearchBar.jsx
@@ -22,7 +22,7 @@ import lodash from 'lodash';
 import { ButtonGroup, ControlLabel, FormControl, FormGroup, Button } from 'components/graylog';
 import { SearchForm, TimeUnitInput, Icon } from 'components/common';
 import { extractDurationAndUnit } from 'components/common/TimeUnitInput';
-import FormsUtils from 'util/FormsUtils';
+import * as FormsUtils from 'util/FormsUtils';
 
 import styles from './EventsSearchBar.css';
 

--- a/graylog2-web-interface/src/components/lookup-tables/CacheForm.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/CacheForm.jsx
@@ -22,7 +22,7 @@ import { PluginStore } from 'graylog-web-plugin/plugin';
 import { Button, Col, Row } from 'components/graylog';
 import { Input } from 'components/bootstrap';
 import ObjectUtils from 'util/ObjectUtils';
-import FormsUtils from 'util/FormsUtils';
+import * as FormsUtils from 'util/FormsUtils';
 import CombinedProvider from 'injection/CombinedProvider';
 
 const { LookupTableCachesActions } = CombinedProvider.get('LookupTableCaches');

--- a/graylog2-web-interface/src/components/lookup-tables/DataAdapterForm.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/DataAdapterForm.jsx
@@ -22,7 +22,7 @@ import { PluginStore } from 'graylog-web-plugin/plugin';
 import { Col, Row, Button } from 'components/graylog';
 import { Input } from 'components/bootstrap';
 import ObjectUtils from 'util/ObjectUtils';
-import FormsUtils from 'util/FormsUtils';
+import * as FormsUtils from 'util/FormsUtils';
 import CombinedProvider from 'injection/CombinedProvider';
 import { TimeUnitInput } from 'components/common';
 

--- a/graylog2-web-interface/src/components/lookup-tables/LookupTable.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/LookupTable.jsx
@@ -21,7 +21,7 @@ import { LinkContainer, Link } from 'components/graylog/router';
 import { ButtonToolbar, Row, Col, Button } from 'components/graylog';
 import { Input } from 'components/bootstrap';
 import Routes from 'routing/Routes';
-import FormsUtils from 'util/FormsUtils';
+import * as FormsUtils from 'util/FormsUtils';
 import { ContentPackMarker } from 'components/common';
 import CombinedProvider from 'injection/CombinedProvider';
 

--- a/graylog2-web-interface/src/components/lookup-tables/LookupTableForm.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/LookupTableForm.jsx
@@ -21,7 +21,7 @@ import _ from 'lodash';
 import { Col, Row, Button } from 'components/graylog';
 import { Input } from 'components/bootstrap';
 import ObjectUtils from 'util/ObjectUtils';
-import FormsUtils from 'util/FormsUtils';
+import * as FormsUtils from 'util/FormsUtils';
 import { JSONValueInput } from 'components/common';
 import { CachesContainer, CachePicker, DataAdaptersContainer, DataAdapterPicker } from 'components/lookup-tables';
 import CombinedProvider from 'injection/CombinedProvider';

--- a/graylog2-web-interface/src/components/rules/RuleMetricsConfig.jsx
+++ b/graylog2-web-interface/src/components/rules/RuleMetricsConfig.jsx
@@ -21,7 +21,7 @@ import lodash from 'lodash';
 import { Alert } from 'components/graylog';
 import { BootstrapModalForm, Input } from 'components/bootstrap';
 import { Spinner } from 'components/common';
-import FormsUtils from 'util/FormsUtils';
+import * as FormsUtils from 'util/FormsUtils';
 
 export default class RuleMetricsConfig extends React.Component {
   static propTypes = {

--- a/graylog2-web-interface/src/components/search/SearchLink.ts
+++ b/graylog2-web-interface/src/components/search/SearchLink.ts
@@ -95,7 +95,7 @@ export default class SearchLink {
   }
 
   static builder() {
-    // eslint-disable-next-line no-use-before-define
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
     return new Builder();
   }
 

--- a/graylog2-web-interface/src/components/streamrules/StreamRuleForm.tsx
+++ b/graylog2-web-interface/src/components/streamrules/StreamRuleForm.tsx
@@ -26,7 +26,7 @@ import CombinedProvider from 'injection/CombinedProvider';
 import connect from 'stores/connect';
 import DocsHelper from 'util/DocsHelper';
 import Version from 'util/Version';
-import FormsUtils from 'util/FormsUtils';
+import * as FormsUtils from 'util/FormsUtils';
 import { Store } from 'stores/StoreTypes';
 
 const { InputsStore, InputsActions } = CombinedProvider.get('Inputs');

--- a/graylog2-web-interface/src/components/streams/StreamForm.jsx
+++ b/graylog2-web-interface/src/components/streams/StreamForm.jsx
@@ -21,7 +21,7 @@ import BootstrapModalForm from 'components/bootstrap/BootstrapModalForm';
 import { Input } from 'components/bootstrap';
 import { Select, Spinner } from 'components/common';
 import CombinedProvider from 'injection/CombinedProvider';
-import FormsUtils from 'util/FormsUtils';
+import * as FormsUtils from 'util/FormsUtils';
 
 const { IndexSetsActions } = CombinedProvider.get('IndexSets');
 

--- a/graylog2-web-interface/src/logic/permissions/ActiveShare.tsx
+++ b/graylog2-web-interface/src/logic/permissions/ActiveShare.tsx
@@ -44,11 +44,11 @@ export default class Grantee {
     return this._value.capability;
   }
 
-  // eslint-disable-next-line no-use-before-define
+  // eslint-disable-next-line @typescript-eslint/no-use-before-define
   toBuilder(): Builder {
     const { grant, grantee, capability } = this._value;
 
-    // eslint-disable-next-line no-use-before-define, @typescript-eslint/no-use-before-define
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
     return new Builder(Immutable.Map({ grant, grantee, capability }));
   }
 
@@ -70,7 +70,7 @@ export default class Grantee {
   }
 
   static builder(): Builder {
-    // eslint-disable-next-line no-use-before-define, @typescript-eslint/no-use-before-define
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
     return new Builder();
   }
 }

--- a/graylog2-web-interface/src/logic/permissions/Capability.tsx
+++ b/graylog2-web-interface/src/logic/permissions/Capability.tsx
@@ -39,11 +39,11 @@ export default class Capability {
     return this._value.title;
   }
 
-  // eslint-disable-next-line no-use-before-define
+  // eslint-disable-next-line @typescript-eslint/no-use-before-define
   toBuilder(): Builder {
     const { id, title } = this._value;
 
-    // eslint-disable-next-line no-use-before-define,@typescript-eslint/no-use-before-define
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
     return new Builder(Immutable.Map({ id, title }));
   }
 
@@ -63,9 +63,9 @@ export default class Capability {
       .build();
   }
 
-  // eslint-disable-next-line no-use-before-define
+  // eslint-disable-next-line @typescript-eslint/no-use-before-define
   static builder(): Builder {
-    // eslint-disable-next-line no-use-before-define,@typescript-eslint/no-use-before-define
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
     return new Builder();
   }
 }

--- a/graylog2-web-interface/src/logic/permissions/EntityShareState.tsx
+++ b/graylog2-web-interface/src/logic/permissions/EntityShareState.tsx
@@ -159,7 +159,7 @@ export default class EntityShareState {
     return _sortAndOrderGrantees<SelectedGrantee>(granteesWithCapabilities, this._value.activeShares);
   }
 
-  // eslint-disable-next-line no-use-before-define
+  // eslint-disable-next-line @typescript-eslint/no-use-before-define
   toBuilder(): Builder {
     const {
       entity,
@@ -171,7 +171,7 @@ export default class EntityShareState {
       validationResults,
     } = this._value;
 
-    // eslint-disable-next-line no-use-before-define,@typescript-eslint/no-use-before-define
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
     return new Builder(Immutable.Map({
       entity,
       availableGrantees,
@@ -235,7 +235,7 @@ export default class EntityShareState {
   }
 
   static builder(): Builder {
-    // eslint-disable-next-line no-use-before-define,@typescript-eslint/no-use-before-define
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
     return new Builder();
   }
 }

--- a/graylog2-web-interface/src/logic/permissions/Grantee.tsx
+++ b/graylog2-web-interface/src/logic/permissions/Grantee.tsx
@@ -49,7 +49,7 @@ export default class Grantee implements GranteeInterface {
   toBuilder(): Builder {
     const { id, title, type } = this._value;
 
-    // eslint-disable-next-line no-use-before-define,@typescript-eslint/no-use-before-define
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
     return new Builder(Immutable.Map({ id, title, type }));
   }
 
@@ -71,7 +71,7 @@ export default class Grantee implements GranteeInterface {
   }
 
   static builder(): Builder {
-    // eslint-disable-next-line no-use-before-define,@typescript-eslint/no-use-before-define
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
     return new Builder();
   }
 }

--- a/graylog2-web-interface/src/logic/permissions/SharedEntity.tsx
+++ b/graylog2-web-interface/src/logic/permissions/SharedEntity.tsx
@@ -59,7 +59,7 @@ export default class SharedEntity {
   toBuilder(): Builder {
     const { id, owners, title } = this._value;
 
-    // eslint-disable-next-line no-use-before-define,@typescript-eslint/no-use-before-define
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
     return new Builder(Immutable.Map({ id, owners, title }));
   }
 
@@ -83,7 +83,7 @@ export default class SharedEntity {
   }
 
   static builder(): Builder {
-    // eslint-disable-next-line no-use-before-define,@typescript-eslint/no-use-before-define
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
     return new Builder();
   }
 }

--- a/graylog2-web-interface/src/logic/permissions/ValidationResult.tsx
+++ b/graylog2-web-interface/src/logic/permissions/ValidationResult.tsx
@@ -77,7 +77,7 @@ export default class ValidationResult {
       failed,
     } = this._value;
 
-    // eslint-disable-next-line no-use-before-define,@typescript-eslint/no-use-before-define
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
     return new Builder(Immutable.Map({
       errors,
       errorContext,
@@ -133,7 +133,7 @@ export default class ValidationResult {
   }
 
   static builder() {
-    // eslint-disable-next-line no-use-before-define,@typescript-eslint/no-use-before-define
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
     return new Builder();
   }
 }

--- a/graylog2-web-interface/src/logic/roles/Role.ts
+++ b/graylog2-web-interface/src/logic/roles/Role.ts
@@ -81,7 +81,7 @@ export default class Role {
       readOnly,
     } = this._value;
 
-    // eslint-disable-next-line no-use-before-define, @typescript-eslint/no-use-before-define
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
     return new Builder(Immutable.Map({
       id,
       name,
@@ -144,7 +144,7 @@ export default class Role {
   }
 
   static builder(): Builder {
-    // eslint-disable-next-line no-use-before-define, @typescript-eslint/no-use-before-define
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
     return new Builder();
   }
 }

--- a/graylog2-web-interface/src/logic/users/User.ts
+++ b/graylog2-web-interface/src/logic/users/User.ts
@@ -213,7 +213,7 @@ export default class User {
       accountStatus,
     } = this._value;
 
-    // eslint-disable-next-line no-use-before-define
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
     return new Builder(Immutable.Map({
       id,
       username,
@@ -306,9 +306,9 @@ export default class User {
     return User.create(id, username, full_name, email, Immutable.List(permissions), timezone, preferences, Immutable.Set(roles), read_only, external, session_timeout_ms, startpage, session_active, client_address, last_activity, account_status);
   }
 
-  // eslint-disable-next-line no-use-before-define
+  // eslint-disable-next-line @typescript-eslint/no-use-before-define
   static builder(): Builder {
-    // eslint-disable-next-line no-use-before-define
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
     return new Builder();
   }
 }

--- a/graylog2-web-interface/src/logic/users/UserOverview.ts
+++ b/graylog2-web-interface/src/logic/users/UserOverview.ts
@@ -172,7 +172,7 @@ export default class UserOverview {
       accountStatus,
     } = this._value;
 
-    // eslint-disable-next-line no-use-before-define,@typescript-eslint/no-use-before-define
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
     return new Builder(Immutable.Map({
       id,
       username,
@@ -295,9 +295,9 @@ export default class UserOverview {
       accountStatus);
   }
 
-  // eslint-disable-next-line no-use-before-define
+  // eslint-disable-next-line @typescript-eslint/no-use-before-define
   static builder(): Builder {
-    // eslint-disable-next-line no-use-before-define,@typescript-eslint/no-use-before-define
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
     return new Builder();
   }
 }

--- a/graylog2-web-interface/src/pages/NodesPage.jsx
+++ b/graylog2-web-interface/src/pages/NodesPage.jsx
@@ -19,7 +19,7 @@ import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import URI from 'urijs';
 
-import URLUtils from 'util/URLUtils';
+import * as URLUtils from 'util/URLUtils';
 import StoreProvider from 'injection/StoreProvider';
 import { DocumentTitle, ExternalLinkButton, PageHeader, Spinner } from 'components/common';
 import { NodesList } from 'components/nodes';

--- a/graylog2-web-interface/src/stores/alarmcallbacks/AlarmCallbackHistoryStore.js
+++ b/graylog2-web-interface/src/stores/alarmcallbacks/AlarmCallbackHistoryStore.js
@@ -16,7 +16,7 @@
  */
 import Reflux from 'reflux';
 
-import URLUtils from 'util/URLUtils';
+import * as URLUtils from 'util/URLUtils';
 import fetch from 'logic/rest/FetchProvider';
 import UserNotification from 'util/UserNotification';
 import ApiRoutes from 'routing/ApiRoutes';

--- a/graylog2-web-interface/src/stores/alarmcallbacks/AlarmCallbacksStore.js
+++ b/graylog2-web-interface/src/stores/alarmcallbacks/AlarmCallbacksStore.js
@@ -18,7 +18,7 @@ import Reflux from 'reflux';
 
 import ActionsProvider from 'injection/ActionsProvider';
 import UserNotification from 'util/UserNotification';
-import URLUtils from 'util/URLUtils';
+import * as URLUtils from 'util/URLUtils';
 import ApiRoutes from 'routing/ApiRoutes';
 import fetch from 'logic/rest/FetchProvider';
 

--- a/graylog2-web-interface/src/stores/alertconditions/AlertConditionsStore.js
+++ b/graylog2-web-interface/src/stores/alertconditions/AlertConditionsStore.js
@@ -18,7 +18,7 @@ import Reflux from 'reflux';
 import _ from 'lodash';
 
 import UserNotification from 'util/UserNotification';
-import URLUtils from 'util/URLUtils';
+import * as URLUtils from 'util/URLUtils';
 import ApiRoutes from 'routing/ApiRoutes';
 import fetch from 'logic/rest/FetchProvider';
 import ActionsProvider from 'injection/ActionsProvider';

--- a/graylog2-web-interface/src/stores/alertnotifications/AlertNotificationsStore.js
+++ b/graylog2-web-interface/src/stores/alertnotifications/AlertNotificationsStore.js
@@ -18,7 +18,7 @@ import Reflux from 'reflux';
 
 import ActionsProvider from 'injection/ActionsProvider';
 import UserNotification from 'util/UserNotification';
-import URLUtils from 'util/URLUtils';
+import * as URLUtils from 'util/URLUtils';
 import ApiRoutes from 'routing/ApiRoutes';
 import fetch from 'logic/rest/FetchProvider';
 

--- a/graylog2-web-interface/src/stores/alerts/AlertsStore.js
+++ b/graylog2-web-interface/src/stores/alerts/AlertsStore.js
@@ -18,7 +18,7 @@ import Reflux from 'reflux';
 
 import ApiRoutes from 'routing/ApiRoutes';
 import fetch from 'logic/rest/FetchProvider';
-import URLUtils from 'util/URLUtils';
+import * as URLUtils from 'util/URLUtils';
 import UserNotification from 'util/UserNotification';
 import ActionsProvider from 'injection/ActionsProvider';
 

--- a/graylog2-web-interface/src/stores/cluster/ClusterOverviewStore.js
+++ b/graylog2-web-interface/src/stores/cluster/ClusterOverviewStore.js
@@ -16,7 +16,7 @@
  */
 import Reflux from 'reflux';
 
-import URLUtils from 'util/URLUtils';
+import * as URLUtils from 'util/URLUtils';
 import UserNotification from 'util/UserNotification';
 import fetch from 'logic/rest/FetchProvider';
 import StoreProvider from 'injection/StoreProvider';

--- a/graylog2-web-interface/src/stores/cluster/ClusterTrafficStore.js
+++ b/graylog2-web-interface/src/stores/cluster/ClusterTrafficStore.js
@@ -16,7 +16,7 @@
  */
 import Reflux from 'reflux';
 
-import URLUtils from 'util/URLUtils';
+import * as URLUtils from 'util/URLUtils';
 import fetch from 'logic/rest/FetchProvider';
 import ActionsProvider from 'injection/ActionsProvider';
 

--- a/graylog2-web-interface/src/stores/codecs/CodecTypesStore.js
+++ b/graylog2-web-interface/src/stores/codecs/CodecTypesStore.js
@@ -18,7 +18,7 @@ import Reflux from 'reflux';
 
 import ApiRoutes from 'routing/ApiRoutes';
 import fetch from 'logic/rest/FetchProvider';
-import URLUtils from 'util/URLUtils';
+import * as URLUtils from 'util/URLUtils';
 import UserNotification from 'util/UserNotification';
 import CombinedProvider from 'injection/CombinedProvider';
 

--- a/graylog2-web-interface/src/stores/content-packs/CatalogStore.jsx
+++ b/graylog2-web-interface/src/stores/content-packs/CatalogStore.jsx
@@ -17,7 +17,7 @@
 import Reflux from 'reflux';
 import lodash from 'lodash';
 
-import URLUtils from 'util/URLUtils';
+import * as URLUtils from 'util/URLUtils';
 import ApiRoutes from 'routing/ApiRoutes';
 import fetch from 'logic/rest/FetchProvider';
 import ActionsProvider from 'injection/ActionsProvider';

--- a/graylog2-web-interface/src/stores/content-packs/ContentPacksStore.jsx
+++ b/graylog2-web-interface/src/stores/content-packs/ContentPacksStore.jsx
@@ -16,7 +16,7 @@
  */
 import Reflux from 'reflux';
 
-import URLUtils from 'util/URLUtils';
+import * as URLUtils from 'util/URLUtils';
 import ApiRoutes from 'routing/ApiRoutes';
 import fetch from 'logic/rest/FetchProvider';
 import ActionsProvider from 'injection/ActionsProvider';

--- a/graylog2-web-interface/src/stores/decorators/DecoratorsStore.js
+++ b/graylog2-web-interface/src/stores/decorators/DecoratorsStore.js
@@ -16,7 +16,7 @@
  */
 import Reflux from 'reflux';
 
-import URLUtils from 'util/URLUtils';
+import * as URLUtils from 'util/URLUtils';
 import ApiRoutes from 'routing/ApiRoutes';
 import fetch from 'logic/rest/FetchProvider';
 import ActionsProvider from 'injection/ActionsProvider';

--- a/graylog2-web-interface/src/stores/event-definitions/AvailableEventDefinitionTypesStore.js
+++ b/graylog2-web-interface/src/stores/event-definitions/AvailableEventDefinitionTypesStore.js
@@ -16,7 +16,7 @@
  */
 import Reflux from 'reflux';
 
-import URLUtils from 'util/URLUtils';
+import * as URLUtils from 'util/URLUtils';
 import fetch from 'logic/rest/FetchProvider';
 import CombinedProvider from 'injection/CombinedProvider';
 

--- a/graylog2-web-interface/src/stores/event-definitions/EventDefinitionsStore.js
+++ b/graylog2-web-interface/src/stores/event-definitions/EventDefinitionsStore.js
@@ -18,7 +18,7 @@ import Reflux from 'reflux';
 import URI from 'urijs';
 import lodash from 'lodash';
 
-import URLUtils from 'util/URLUtils';
+import * as URLUtils from 'util/URLUtils';
 import UserNotification from 'util/UserNotification';
 import fetch from 'logic/rest/FetchProvider';
 import CombinedProvider from 'injection/CombinedProvider';

--- a/graylog2-web-interface/src/stores/event-definitions/FilterPreviewStore.js
+++ b/graylog2-web-interface/src/stores/event-definitions/FilterPreviewStore.js
@@ -19,7 +19,7 @@ import URI from 'urijs';
 import lodash from 'lodash';
 import Bluebird from 'bluebird';
 
-import URLUtils from 'util/URLUtils';
+import * as URLUtils from 'util/URLUtils';
 import fetch from 'logic/rest/FetchProvider';
 import UserNotification from 'util/UserNotification';
 import CombinedProvider from 'injection/CombinedProvider';

--- a/graylog2-web-interface/src/stores/event-notifications/EventNotificationsStore.js
+++ b/graylog2-web-interface/src/stores/event-notifications/EventNotificationsStore.js
@@ -18,7 +18,7 @@ import Reflux from 'reflux';
 import URI from 'urijs';
 import lodash from 'lodash';
 
-import URLUtils from 'util/URLUtils';
+import * as URLUtils from 'util/URLUtils';
 import UserNotification from 'util/UserNotification';
 import fetch from 'logic/rest/FetchProvider';
 import CombinedProvider from 'injection/CombinedProvider';

--- a/graylog2-web-interface/src/stores/events/EventsStore.js
+++ b/graylog2-web-interface/src/stores/events/EventsStore.js
@@ -18,7 +18,7 @@ import Reflux from 'reflux';
 import URI from 'urijs';
 import lodash from 'lodash';
 
-import URLUtils from 'util/URLUtils';
+import * as URLUtils from 'util/URLUtils';
 import fetch from 'logic/rest/FetchProvider';
 import CombinedProvider from 'injection/CombinedProvider';
 

--- a/graylog2-web-interface/src/stores/extractors/ExtractorsStore.js
+++ b/graylog2-web-interface/src/stores/extractors/ExtractorsStore.js
@@ -21,7 +21,7 @@ import ApiRoutes from 'routing/ApiRoutes';
 import fetch from 'logic/rest/FetchProvider';
 import ActionsProvider from 'injection/ActionsProvider';
 import ExtractorUtils from 'util/ExtractorUtils';
-import URLUtils from 'util/URLUtils';
+import * as URLUtils from 'util/URLUtils';
 import UserNotification from 'util/UserNotification';
 
 const ExtractorsActions = ActionsProvider.getActions('Extractors');

--- a/graylog2-web-interface/src/stores/gettingstarted/GettingStartedStore.js
+++ b/graylog2-web-interface/src/stores/gettingstarted/GettingStartedStore.js
@@ -19,7 +19,7 @@ import Reflux from 'reflux';
 import fetch from 'logic/rest/FetchProvider';
 import ActionsProvider from 'injection/ActionsProvider';
 import UserNotification from 'util/UserNotification';
-import URLUtils from 'util/URLUtils';
+import * as URLUtils from 'util/URLUtils';
 
 const GettingStartedActions = ActionsProvider.getActions('GettingStarted');
 

--- a/graylog2-web-interface/src/stores/indexers/IndexerClusterStore.js
+++ b/graylog2-web-interface/src/stores/indexers/IndexerClusterStore.js
@@ -16,7 +16,7 @@
  */
 import Reflux from 'reflux';
 
-import URLUtils from 'util/URLUtils';
+import * as URLUtils from 'util/URLUtils';
 import ApiRoutes from 'routing/ApiRoutes';
 import fetch from 'logic/rest/FetchProvider';
 import ActionsProvider from 'injection/ActionsProvider';

--- a/graylog2-web-interface/src/stores/indexers/IndexerFailuresStore.js
+++ b/graylog2-web-interface/src/stores/indexers/IndexerFailuresStore.js
@@ -18,7 +18,7 @@ import Reflux from 'reflux';
 import moment from 'moment';
 
 import UserNotification from 'util/UserNotification';
-import URLUtils from 'util/URLUtils';
+import * as URLUtils from 'util/URLUtils';
 import ApiRoutes from 'routing/ApiRoutes';
 import fetch from 'logic/rest/FetchProvider';
 

--- a/graylog2-web-interface/src/stores/indexers/IndexerOverviewStore.js
+++ b/graylog2-web-interface/src/stores/indexers/IndexerOverviewStore.js
@@ -16,7 +16,7 @@
  */
 import Reflux from 'reflux';
 
-import URLUtils from 'util/URLUtils';
+import * as URLUtils from 'util/URLUtils';
 import ApiRoutes from 'routing/ApiRoutes';
 import fetch from 'logic/rest/FetchProvider';
 import ActionsProvider from 'injection/ActionsProvider';

--- a/graylog2-web-interface/src/stores/indices/DeflectorStore.js
+++ b/graylog2-web-interface/src/stores/indices/DeflectorStore.js
@@ -16,7 +16,7 @@
  */
 import Reflux from 'reflux';
 
-import URLUtils from 'util/URLUtils';
+import * as URLUtils from 'util/URLUtils';
 import ApiRoutes from 'routing/ApiRoutes';
 import fetch from 'logic/rest/FetchProvider';
 import ActionsProvider from 'injection/ActionsProvider';

--- a/graylog2-web-interface/src/stores/indices/IndexRangesStore.js
+++ b/graylog2-web-interface/src/stores/indices/IndexRangesStore.js
@@ -17,7 +17,7 @@
 import Reflux from 'reflux';
 
 import UserNotification from 'util/UserNotification';
-import URLUtils from 'util/URLUtils';
+import * as URLUtils from 'util/URLUtils';
 import ApiRoutes from 'routing/ApiRoutes';
 import fetch from 'logic/rest/FetchProvider';
 import ActionsProvider from 'injection/ActionsProvider';

--- a/graylog2-web-interface/src/stores/indices/IndexSetsStore.jsx
+++ b/graylog2-web-interface/src/stores/indices/IndexSetsStore.jsx
@@ -18,7 +18,7 @@ import Reflux from 'reflux';
 
 import ApiRoutes from 'routing/ApiRoutes';
 import fetch from 'logic/rest/FetchProvider';
-import URLUtils from 'util/URLUtils';
+import * as URLUtils from 'util/URLUtils';
 import UserNotification from 'util/UserNotification';
 import ActionsProvider from 'injection/ActionsProvider';
 

--- a/graylog2-web-interface/src/stores/indices/IndicesConfigurationStore.js
+++ b/graylog2-web-interface/src/stores/indices/IndicesConfigurationStore.js
@@ -17,7 +17,7 @@
 import Reflux from 'reflux';
 
 import UserNotification from 'util/UserNotification';
-import URLUtils from 'util/URLUtils';
+import * as URLUtils from 'util/URLUtils';
 import fetch from 'logic/rest/FetchProvider';
 import ActionsProvider from 'injection/ActionsProvider';
 

--- a/graylog2-web-interface/src/stores/indices/IndicesStore.js
+++ b/graylog2-web-interface/src/stores/indices/IndicesStore.js
@@ -16,7 +16,7 @@
  */
 import Reflux from 'reflux';
 
-import URLUtils from 'util/URLUtils';
+import * as URLUtils from 'util/URLUtils';
 import ApiRoutes from 'routing/ApiRoutes';
 import fetch from 'logic/rest/FetchProvider';
 import ActionsProvider from 'injection/ActionsProvider';

--- a/graylog2-web-interface/src/stores/inputs/InputStatesStore.js
+++ b/graylog2-web-interface/src/stores/inputs/InputStatesStore.js
@@ -17,7 +17,7 @@
 import Reflux from 'reflux';
 
 import UserNotification from 'util/UserNotification';
-import URLUtils from 'util/URLUtils';
+import * as URLUtils from 'util/URLUtils';
 import ApiRoutes from 'routing/ApiRoutes';
 import fetch from 'logic/rest/FetchProvider';
 

--- a/graylog2-web-interface/src/stores/inputs/InputStaticFieldsStore.js
+++ b/graylog2-web-interface/src/stores/inputs/InputStaticFieldsStore.js
@@ -17,7 +17,7 @@
 import Reflux from 'reflux';
 
 import UserNotification from 'util/UserNotification';
-import URLUtils from 'util/URLUtils';
+import * as URLUtils from 'util/URLUtils';
 import ApiRoutes from 'routing/ApiRoutes';
 import fetch from 'logic/rest/FetchProvider';
 

--- a/graylog2-web-interface/src/stores/inputs/InputsStore.js
+++ b/graylog2-web-interface/src/stores/inputs/InputsStore.js
@@ -16,7 +16,7 @@
  */
 import Reflux from 'reflux';
 
-import URLUtils from 'util/URLUtils';
+import * as URLUtils from 'util/URLUtils';
 import fetch from 'logic/rest/FetchProvider';
 import UserNotification from 'util/UserNotification';
 import StoreProvider from 'injection/StoreProvider';

--- a/graylog2-web-interface/src/stores/journal/JournalStore.js
+++ b/graylog2-web-interface/src/stores/journal/JournalStore.js
@@ -16,7 +16,7 @@
  */
 import Reflux from 'reflux';
 
-import URLUtils from 'util/URLUtils';
+import * as URLUtils from 'util/URLUtils';
 import UserNotification from 'util/UserNotification';
 import fetch from 'logic/rest/FetchProvider';
 

--- a/graylog2-web-interface/src/stores/load-balancer/SystemLoadBalancerStore.js
+++ b/graylog2-web-interface/src/stores/load-balancer/SystemLoadBalancerStore.js
@@ -16,7 +16,7 @@
  */
 import Reflux from 'reflux';
 
-import URLUtils from 'util/URLUtils';
+import * as URLUtils from 'util/URLUtils';
 import UserNotification from 'util/UserNotification';
 import fetch from 'logic/rest/FetchProvider';
 

--- a/graylog2-web-interface/src/stores/lookup-tables/LookupTableCachesStore.js
+++ b/graylog2-web-interface/src/stores/lookup-tables/LookupTableCachesStore.js
@@ -17,7 +17,7 @@
 import Reflux from 'reflux';
 
 import UserNotification from 'util/UserNotification';
-import URLUtils from 'util/URLUtils';
+import * as URLUtils from 'util/URLUtils';
 import fetch from 'logic/rest/FetchProvider';
 import ActionsProvider from 'injection/ActionsProvider';
 

--- a/graylog2-web-interface/src/stores/lookup-tables/LookupTableDataAdaptersStore.js
+++ b/graylog2-web-interface/src/stores/lookup-tables/LookupTableDataAdaptersStore.js
@@ -17,7 +17,7 @@
 import Reflux from 'reflux';
 
 import UserNotification from 'util/UserNotification';
-import URLUtils from 'util/URLUtils';
+import * as URLUtils from 'util/URLUtils';
 import fetch from 'logic/rest/FetchProvider';
 import ActionsProvider from 'injection/ActionsProvider';
 

--- a/graylog2-web-interface/src/stores/messages/MessagesStore.js
+++ b/graylog2-web-interface/src/stores/messages/MessagesStore.js
@@ -19,7 +19,7 @@ import Reflux from 'reflux';
 import fetch from 'logic/rest/FetchProvider';
 import MessageFormatter from 'logic/message/MessageFormatter';
 import ApiRoutes from 'routing/ApiRoutes';
-import URLUtils from 'util/URLUtils';
+import * as URLUtils from 'util/URLUtils';
 import UserNotification from 'util/UserNotification';
 import StringUtils from 'util/StringUtils';
 import ActionsProvider from 'injection/ActionsProvider';

--- a/graylog2-web-interface/src/stores/metrics/MetricsStore.ts
+++ b/graylog2-web-interface/src/stores/metrics/MetricsStore.ts
@@ -16,7 +16,7 @@
  */
 import Reflux from 'reflux';
 
-import URLUtils from 'util/URLUtils';
+import * as URLUtils from 'util/URLUtils';
 import ApiRoutes from 'routing/ApiRoutes';
 import fetch, { fetchPeriodically } from 'logic/rest/FetchProvider';
 import TimeHelper from 'util/TimeHelper';

--- a/graylog2-web-interface/src/stores/nodes/SingleNodeStore.js
+++ b/graylog2-web-interface/src/stores/nodes/SingleNodeStore.js
@@ -16,7 +16,7 @@
  */
 import Reflux from 'reflux';
 
-import URLUtils from 'util/URLUtils';
+import * as URLUtils from 'util/URLUtils';
 import fetch from 'logic/rest/FetchProvider';
 import ActionsProvider from 'injection/ActionsProvider';
 

--- a/graylog2-web-interface/src/stores/notifications/NotificationsStore.js
+++ b/graylog2-web-interface/src/stores/notifications/NotificationsStore.js
@@ -16,7 +16,7 @@
  */
 import Reflux from 'reflux';
 
-import URLUtils from 'util/URLUtils';
+import * as URLUtils from 'util/URLUtils';
 import ApiRoutes from 'routing/ApiRoutes';
 import fetch, { Builder, fetchPeriodically } from 'logic/rest/FetchProvider';
 import ActionsProvider from 'injection/ActionsProvider';

--- a/graylog2-web-interface/src/stores/outputs/OutputsStore.ts
+++ b/graylog2-web-interface/src/stores/outputs/OutputsStore.ts
@@ -18,7 +18,7 @@ import Reflux from 'reflux';
 
 import fetch from 'logic/rest/FetchProvider';
 import ApiRoutes from 'routing/ApiRoutes';
-import URLUtils from 'util/URLUtils';
+import * as URLUtils from 'util/URLUtils';
 import UserNotification from 'util/UserNotification';
 
 type Output = {

--- a/graylog2-web-interface/src/stores/plugins/PluginsStore.js
+++ b/graylog2-web-interface/src/stores/plugins/PluginsStore.js
@@ -16,7 +16,7 @@
  */
 import Reflux from 'reflux';
 
-import URLUtils from 'util/URLUtils';
+import * as URLUtils from 'util/URLUtils';
 import UserNotification from 'util/UserNotification';
 import fetch from 'logic/rest/FetchProvider';
 

--- a/graylog2-web-interface/src/stores/search/UniversalSearchStore.js
+++ b/graylog2-web-interface/src/stores/search/UniversalSearchStore.js
@@ -19,7 +19,7 @@ import jQuery from 'jquery';
 import md5 from 'md5';
 
 import MessageFormatter from 'logic/message/MessageFormatter';
-import URLUtils from 'util/URLUtils';
+import * as URLUtils from 'util/URLUtils';
 import ApiRoutes from 'routing/ApiRoutes';
 import fetch from 'logic/rest/FetchProvider';
 

--- a/graylog2-web-interface/src/stores/sessions/ServerAvailabilityStore.js
+++ b/graylog2-web-interface/src/stores/sessions/ServerAvailabilityStore.js
@@ -16,7 +16,7 @@
  */
 import Reflux from 'reflux';
 
-import URLUtils from 'util/URLUtils';
+import * as URLUtils from 'util/URLUtils';
 import ApiRoutes from 'routing/ApiRoutes';
 import { Builder } from 'logic/rest/FetchProvider';
 import ActionsProvider from 'injection/ActionsProvider';

--- a/graylog2-web-interface/src/stores/sidecars/CollectorConfigurationsStore.js
+++ b/graylog2-web-interface/src/stores/sidecars/CollectorConfigurationsStore.js
@@ -18,7 +18,7 @@ import Reflux from 'reflux';
 import URI from 'urijs';
 import lodash from 'lodash';
 
-import URLUtils from 'util/URLUtils';
+import * as URLUtils from 'util/URLUtils';
 import UserNotification from 'util/UserNotification';
 import fetch from 'logic/rest/FetchProvider';
 import CombinedProvider from 'injection/CombinedProvider';

--- a/graylog2-web-interface/src/stores/sidecars/CollectorsStore.js
+++ b/graylog2-web-interface/src/stores/sidecars/CollectorsStore.js
@@ -18,7 +18,7 @@ import Reflux from 'reflux';
 import URI from 'urijs';
 import lodash from 'lodash';
 
-import URLUtils from 'util/URLUtils';
+import * as URLUtils from 'util/URLUtils';
 import fetch from 'logic/rest/FetchProvider';
 import UserNotification from 'util/UserNotification';
 import CombinedProvider from 'injection/CombinedProvider';

--- a/graylog2-web-interface/src/stores/sidecars/ConfigurationVariableStore.js
+++ b/graylog2-web-interface/src/stores/sidecars/ConfigurationVariableStore.js
@@ -17,7 +17,7 @@
 import Reflux from 'reflux';
 import lodash from 'lodash';
 
-import URLUtils from 'util/URLUtils';
+import * as URLUtils from 'util/URLUtils';
 import UserNotification from 'util/UserNotification';
 import fetch from 'logic/rest/FetchProvider';
 import CombinedProvider from 'injection/CombinedProvider';

--- a/graylog2-web-interface/src/stores/sidecars/SidecarsAdministrationStore.js
+++ b/graylog2-web-interface/src/stores/sidecars/SidecarsAdministrationStore.js
@@ -17,7 +17,7 @@
 import Reflux from 'reflux';
 import lodash from 'lodash';
 
-import URLUtils from 'util/URLUtils';
+import * as URLUtils from 'util/URLUtils';
 import UserNotification from 'util/UserNotification';
 import { fetchPeriodically } from 'logic/rest/FetchProvider';
 import CombinedProvider from 'injection/CombinedProvider';

--- a/graylog2-web-interface/src/stores/sidecars/SidecarsStore.js
+++ b/graylog2-web-interface/src/stores/sidecars/SidecarsStore.js
@@ -17,7 +17,7 @@
 import Reflux from 'reflux';
 import URI from 'urijs';
 
-import URLUtils from 'util/URLUtils';
+import * as URLUtils from 'util/URLUtils';
 import UserNotification from 'util/UserNotification';
 import fetch, { fetchPeriodically } from 'logic/rest/FetchProvider';
 import CombinedProvider from 'injection/CombinedProvider';

--- a/graylog2-web-interface/src/stores/simulator/SimulatorStore.js
+++ b/graylog2-web-interface/src/stores/simulator/SimulatorStore.js
@@ -16,7 +16,7 @@
  */
 import Reflux from 'reflux';
 
-import URLUtils from 'util/URLUtils';
+import * as URLUtils from 'util/URLUtils';
 import ApiRoutes from 'routing/ApiRoutes';
 import fetch from 'logic/rest/FetchProvider';
 import MessageFormatter from 'logic/message/MessageFormatter';

--- a/graylog2-web-interface/src/stores/streams/StreamRulesStore.ts
+++ b/graylog2-web-interface/src/stores/streams/StreamRulesStore.ts
@@ -19,7 +19,7 @@ import lodash from 'lodash';
 
 import fetch from 'logic/rest/FetchProvider';
 import ApiRoutes from 'routing/ApiRoutes';
-import URLUtils from 'util/URLUtils';
+import * as URLUtils from 'util/URLUtils';
 import UserNotification from 'util/UserNotification';
 
 type StreamRule = {

--- a/graylog2-web-interface/src/stores/system-processing/SystemProcessingStore.js
+++ b/graylog2-web-interface/src/stores/system-processing/SystemProcessingStore.js
@@ -16,7 +16,7 @@
  */
 import Reflux from 'reflux';
 
-import URLUtils from 'util/URLUtils';
+import * as URLUtils from 'util/URLUtils';
 import UserNotification from 'util/UserNotification';
 import fetch from 'logic/rest/FetchProvider';
 

--- a/graylog2-web-interface/src/stores/system-shutdown/SystemShutdownStore.js
+++ b/graylog2-web-interface/src/stores/system-shutdown/SystemShutdownStore.js
@@ -16,7 +16,7 @@
  */
 import Reflux from 'reflux';
 
-import URLUtils from 'util/URLUtils';
+import * as URLUtils from 'util/URLUtils';
 import UserNotification from 'util/UserNotification';
 import fetch from 'logic/rest/FetchProvider';
 

--- a/graylog2-web-interface/src/stores/system/LoggersStore.js
+++ b/graylog2-web-interface/src/stores/system/LoggersStore.js
@@ -16,7 +16,7 @@
  */
 import Reflux from 'reflux';
 
-import URLUtils from 'util/URLUtils';
+import * as URLUtils from 'util/URLUtils';
 import ApiRoutes from 'routing/ApiRoutes';
 import fetch from 'logic/rest/FetchProvider';
 import ActionsProvider from 'injection/ActionsProvider';

--- a/graylog2-web-interface/src/stores/system/SystemStore.js
+++ b/graylog2-web-interface/src/stores/system/SystemStore.js
@@ -17,7 +17,7 @@
 import Reflux from 'reflux';
 import Promise from 'bluebird';
 
-import URLUtils from 'util/URLUtils';
+import * as URLUtils from 'util/URLUtils';
 import ApiRoutes from 'routing/ApiRoutes';
 import fetch from 'logic/rest/FetchProvider';
 

--- a/graylog2-web-interface/src/stores/systemjobs/SystemJobsStore.js
+++ b/graylog2-web-interface/src/stores/systemjobs/SystemJobsStore.js
@@ -16,7 +16,7 @@
  */
 import Reflux from 'reflux';
 
-import URLUtils from 'util/URLUtils';
+import * as URLUtils from 'util/URLUtils';
 import ApiRoutes from 'routing/ApiRoutes';
 import fetch, { fetchPeriodically } from 'logic/rest/FetchProvider';
 import ActionsProvider from 'injection/ActionsProvider';

--- a/graylog2-web-interface/src/stores/systemmessages/SystemMessagesStore.js
+++ b/graylog2-web-interface/src/stores/systemmessages/SystemMessagesStore.js
@@ -16,7 +16,7 @@
  */
 import Reflux from 'reflux';
 
-import URLUtils from 'util/URLUtils';
+import * as URLUtils from 'util/URLUtils';
 import ApiRoutes from 'routing/ApiRoutes';
 import { fetchPeriodically } from 'logic/rest/FetchProvider';
 

--- a/graylog2-web-interface/src/views/components/DashboardSearchBar.tsx
+++ b/graylog2-web-interface/src/views/components/DashboardSearchBar.tsx
@@ -49,12 +49,13 @@ type Props = {
 };
 
 const DashboardSearchBar = ({ config, globalOverride, disableSearch = false, onExecute: performSearch }: Props) => {
+  const submitForm = useCallback(({ timerange, queryString }) => GlobalOverrideActions.set(timerange, queryString)
+    .then(() => performSearch()), [performSearch]);
+
   if (!config) {
     return <Spinner />;
   }
 
-  const submitForm = useCallback(({ timerange, queryString }) => GlobalOverrideActions.set(timerange, queryString)
-    .then(() => performSearch()), [performSearch]);
   const { timerange, query: { query_string: queryString = '' } = {} } = globalOverride || {};
 
   return (

--- a/graylog2-web-interface/src/views/components/SearchBar.tsx
+++ b/graylog2-web-interface/src/views/components/SearchBar.tsx
@@ -70,6 +70,8 @@ const defaultProps = {
 };
 
 const SearchBar = ({ availableStreams, config, currentQuery, disableSearch = defaultProps.disableSearch, queryFilters, onSubmit = defaultProps.onSubmit }: Props) => {
+  const _onSubmit = useCallback((values) => onSubmit(values, currentQuery), [onSubmit, currentQuery]);
+
   if (!currentQuery || !config) {
     return <Spinner />;
   }
@@ -78,8 +80,6 @@ const SearchBar = ({ availableStreams, config, currentQuery, disableSearch = def
   const { query_string: queryString } = query;
 
   const streams = filtersToStreamSet(queryFilters.get(id, Immutable.Map())).toJS();
-
-  const _onSubmit = useCallback((values) => onSubmit(values, currentQuery), [query, onSubmit]);
 
   return (
     <ScrollToHint value={query.query_string}>

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/AggregationControls.test.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/AggregationControls.test.tsx
@@ -46,7 +46,7 @@ jest.mock('graylog-web-plugin/plugin', () => ({
 class DummyVisualizationConfig extends VisualizationConfig {}
 
 describe('AggregationControls', () => {
-  // eslint-disable-next-line no-unused-vars, react/prop-types
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars, react/prop-types
   const DummyComponent = () => <div data-testid="dummy-component">The spice must flow.</div>;
   const children = <DummyComponent />;
   const config = AggregationWidgetConfig.builder().visualization('table').build();

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/pivottypes/AutoTimeHistogramPivot.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/pivottypes/AutoTimeHistogramPivot.tsx
@@ -18,7 +18,7 @@ import * as React from 'react';
 
 import { FormControl, HelpBlock } from 'components/graylog';
 import { Icon } from 'components/common';
-import FormsUtils from 'util/FormsUtils';
+import * as FormsUtils from 'util/FormsUtils';
 
 import type { AutoInterval, Interval } from './Interval';
 import styles from './AutoTimeHistogramPivot.css';

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/pivottypes/TermsPivotConfiguration.jsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/pivottypes/TermsPivotConfiguration.jsx
@@ -17,7 +17,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import FormsUtils from 'util/FormsUtils';
+import * as FormsUtils from 'util/FormsUtils';
 import Input from 'components/bootstrap/Input';
 
 export default class TermsPivotConfiguration extends React.Component {

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/pivottypes/TimeUnitTimeHistogramPivot.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/pivottypes/TimeUnitTimeHistogramPivot.tsx
@@ -17,7 +17,7 @@
 import * as React from 'react';
 
 import { DropdownButton, FormControl, HelpBlock, InputGroup, MenuItem } from 'components/graylog';
-import FormsUtils from 'util/FormsUtils';
+import * as FormsUtils from 'util/FormsUtils';
 import { TimeUnits } from 'views/Constants';
 
 import type { Interval, TimeUnitInterval } from './Interval';

--- a/graylog2-web-interface/src/views/components/contexts/DrilldownContextProvider.test.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/DrilldownContextProvider.test.tsx
@@ -39,7 +39,7 @@ jest.mock('views/stores/GlobalOverrideStore', () => ({
 }));
 
 describe('DrilldownContextProvider', () => {
-  // eslint-disable-next-line no-unused-vars
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const Consumer = ({ streams, timerange, query }) => null;
 
   const TestComponent = () => {

--- a/graylog2-web-interface/src/views/components/searchbar/ace-types.ts
+++ b/graylog2-web-interface/src/views/components/searchbar/ace-types.ts
@@ -37,7 +37,7 @@ export type Command = {
     win: string,
     mac: string,
   },
-  // eslint-disable-next-line no-use-before-define
+  // eslint-disable-next-line @typescript-eslint/no-use-before-define
   exec: (editor: Editor) => void,
 };
 
@@ -58,7 +58,7 @@ export type Completer = {
 export type Editor = {
   commands: Commands,
   completer: Completer,
-  // eslint-disable-next-line no-use-before-define
+  // eslint-disable-next-line @typescript-eslint/no-use-before-define
   completers: Array<AutoCompleter>,
   session: Session,
   renderer: Renderer,

--- a/graylog2-web-interface/src/views/components/searchbar/csvexport/CSVExportModal.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/csvexport/CSVExportModal.test.tsx
@@ -19,7 +19,7 @@ import { render, fireEvent, waitFor } from 'wrappedTestingLibrary';
 import * as Immutable from 'immutable';
 import asMock from 'helpers/mocking/AsMock';
 import selectEvent from 'react-select-event';
-import { $PropertyType, Optional } from 'utility-types';
+import { Optional } from 'utility-types';
 
 import { TitleType } from 'views/stores/TitleTypes';
 import { exportSearchMessages, exportSearchTypeMessages } from 'util/MessagesExportUtils';

--- a/graylog2-web-interface/src/views/components/views/MissingRequirements.tsx
+++ b/graylog2-web-interface/src/views/components/views/MissingRequirements.tsx
@@ -20,7 +20,7 @@ import * as PropTypes from 'prop-types';
 import { LinkContainer } from 'components/graylog/router';
 import type { PluginMetadata, Requirements } from 'views/logic/views/View';
 import { Col, Row, Button } from 'components/graylog';
-import URLUtils from 'util/URLUtils';
+import * as URLUtils from 'util/URLUtils';
 import fixup from 'views/pages/StyleFixups.css';
 import View from 'views/logic/views/View';
 import { viewsPath } from 'views/Constants';

--- a/graylog2-web-interface/src/views/components/views/ViewPropertiesModal.jsx
+++ b/graylog2-web-interface/src/views/components/views/ViewPropertiesModal.jsx
@@ -18,7 +18,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { isEqual } from 'lodash';
 
-import FormsUtils from 'util/FormsUtils';
+import * as FormsUtils from 'util/FormsUtils';
 import ViewTypeLabel from 'views/components/ViewTypeLabel';
 import BootstrapModalForm from 'components/bootstrap/BootstrapModalForm';
 import Input from 'components/bootstrap/Input';

--- a/graylog2-web-interface/src/views/components/visualizations/GenericPlot.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/GenericPlot.tsx
@@ -142,7 +142,7 @@ class GenericPlot extends React.Component<GenericPlotProps, State> {
   _onColorSelect = (setColor: (name: string, color: string) => Promise<unknown>, name: string, newColor: string) => setColor(name, newColor)
     .then(this._onCloseColorPopup);
 
-  // eslint-disable-next-line no-unused-vars
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   _onCloseColorPopup = () => this.setState({ legendConfig: undefined });
 
   render() {

--- a/graylog2-web-interface/src/views/components/visualizations/worldmap/WorldMapVisualization.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/worldmap/WorldMapVisualization.tsx
@@ -53,7 +53,7 @@ const _formatSeriesForMap = (rowPivots: Array<Pivot>) => {
       .map((key, idx) => ({ [rowPivots[idx].field]: key }))
       .reduce(_mergeObject, {}));
     const newX = x.map(_lastKey);
-    // eslint-disable-next-line no-unused-vars
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const values = fromPairs(zip(newX, y).filter(([_, v]) => (v !== undefined)));
 
     return { keys, name, values };

--- a/graylog2-web-interface/src/views/components/widgets/EditWidgetFrame.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/EditWidgetFrame.tsx
@@ -42,6 +42,7 @@ type DialogProps = {
   children: React.ReactNode,
 };
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const EditWidgetDialog = ({ className, children, bsClass, ...rest }: DialogProps) => (
   <Modal.Dialog {...rest} dialogClassName={styles.editWidgetDialog}>
     {children}
@@ -76,6 +77,7 @@ const EditWidgetFrame = ({ children }: Props) => {
   }, []);
 
   const widget = useContext(WidgetContext);
+  const _onSubmit = useCallback((values) => onSubmit(values, widget), [widget]);
 
   if (!widget) {
     return <Spinner text="Loading widget ..." />;
@@ -84,7 +86,6 @@ const EditWidgetFrame = ({ children }: Props) => {
   const { streams } = widget;
   const timerange = widget.timerange ?? DEFAULT_TIMERANGE;
   const { query_string: queryString } = widget.query ?? createElasticsearchQueryString('');
-  const _onSubmit = useCallback((values) => onSubmit(values, widget), [widget]);
 
   return (
     <Modal show

--- a/graylog2-web-interface/src/views/logic/aggregationbuilder/AggregationWidgetConfig.ts
+++ b/graylog2-web-interface/src/views/logic/aggregationbuilder/AggregationWidgetConfig.ts
@@ -124,7 +124,7 @@ export default class AggregationWidgetConfig extends WidgetConfig {
   }
 
   static builder() {
-    // eslint-disable-next-line no-use-before-define,@typescript-eslint/no-use-before-define
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
     return new Builder()
       .rowPivots([])
       .columnPivots([])
@@ -135,7 +135,7 @@ export default class AggregationWidgetConfig extends WidgetConfig {
   }
 
   toBuilder() {
-    // eslint-disable-next-line no-use-before-define,@typescript-eslint/no-use-before-define
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
     return new Builder(Immutable.Map(this._value));
   }
 
@@ -206,7 +206,7 @@ export default class AggregationWidgetConfig extends WidgetConfig {
       event_annotation,
     } = value;
 
-    // eslint-disable-next-line no-use-before-define,@typescript-eslint/no-use-before-define
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
     return new Builder()
       .columnPivots(column_pivots.map(Pivot.fromJSON))
       .rowPivots(row_pivots.map(Pivot.fromJSON))

--- a/graylog2-web-interface/src/views/logic/aggregationbuilder/Series.ts
+++ b/graylog2-web-interface/src/views/logic/aggregationbuilder/Series.ts
@@ -41,7 +41,7 @@ const funcNameRegex = /(\w+)\(/;
 const testSeriesRegex = /^(\w+)\((\w*)(,(\w+))*\)$/;
 
 const definitionFor = (type: string, parameters: Array<string>): Definition => {
-  // eslint-disable-next-line no-unused-vars
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [field, parameter] = parameters;
 
   if (type === 'percentile') {

--- a/graylog2-web-interface/src/views/logic/aggregationbuilder/SortConfig.ts
+++ b/graylog2-web-interface/src/views/logic/aggregationbuilder/SortConfig.ts
@@ -102,7 +102,7 @@ export default class SortConfig {
       .build();
   }
 
-  // eslint-disable-next-line no-use-before-define
+  // eslint-disable-next-line @typescript-eslint/no-use-before-define
   toBuilder(): Builder {
     const { type, field, direction } = this._value;
 

--- a/graylog2-web-interface/src/views/logic/aggregationbuilder/visualizations/AreaVisualizationConfig.ts
+++ b/graylog2-web-interface/src/views/logic/aggregationbuilder/visualizations/AreaVisualizationConfig.ts
@@ -41,7 +41,7 @@ export default class AreaVisualizationConfig extends VisualizationConfig {
   }
 
   toBuilder() {
-    // eslint-disable-next-line no-use-before-define
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
     return new Builder(Immutable.Map(this._value));
   }
 

--- a/graylog2-web-interface/src/views/logic/aggregationbuilder/visualizations/BarVisualizationConfig.ts
+++ b/graylog2-web-interface/src/views/logic/aggregationbuilder/visualizations/BarVisualizationConfig.ts
@@ -43,7 +43,7 @@ export default class BarVisualizationConfig extends VisualizationConfig {
   toBuilder() {
     const { barmode } = this._value;
 
-    // eslint-disable-next-line no-use-before-define
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
     return new Builder(Immutable.Map({ barmode }));
   }
 

--- a/graylog2-web-interface/src/views/logic/aggregationbuilder/visualizations/Viewport.ts
+++ b/graylog2-web-interface/src/views/logic/aggregationbuilder/visualizations/Viewport.ts
@@ -47,7 +47,7 @@ export default class Viewport {
   toBuilder() {
     const { center, zoom } = this._value;
 
-    // eslint-disable-next-line no-use-before-define
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
     return new Builder(Immutable.Map({ center, zoom }));
   }
 

--- a/graylog2-web-interface/src/views/logic/aggregationbuilder/visualizations/WorldMapVisualizationConfig.ts
+++ b/graylog2-web-interface/src/views/logic/aggregationbuilder/visualizations/WorldMapVisualizationConfig.ts
@@ -43,7 +43,7 @@ export default class WorldMapVisualizationConfig extends VisualizationConfig {
   toBuilder() {
     const { viewport } = this._value;
 
-    // eslint-disable-next-line no-use-before-define
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
     return new Builder(Immutable.Map({ viewport }));
   }
 
@@ -67,9 +67,9 @@ export default class WorldMapVisualizationConfig extends VisualizationConfig {
       .build();
   }
 
-  // eslint-disable-next-line no-use-before-define
+  // eslint-disable-next-line @typescript-eslint/no-use-before-define
   static builder(): Builder {
-    // eslint-disable-next-line no-use-before-define
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
     return new Builder();
   }
 }

--- a/graylog2-web-interface/src/views/logic/parameters/LookupTableParameter.ts
+++ b/graylog2-web-interface/src/views/logic/parameters/LookupTableParameter.ts
@@ -39,7 +39,7 @@ export default class LookupTableParameter extends Parameter {
 
   _value2: InternalState;
 
-  // eslint-disable-next-line no-use-before-define
+  // eslint-disable-next-line @typescript-eslint/no-use-before-define
   static Builder: typeof Builder;
 
   constructor(name: string, title: string, description: string, dataType: string, defaultValue: any, optional: boolean, lookupTable: string, key: string) {
@@ -51,12 +51,12 @@ export default class LookupTableParameter extends Parameter {
     return new LookupTableParameter(name, title, description, dataType, defaultValue, optional, lookupTable, key);
   }
 
-  // eslint-disable-next-line no-use-before-define
+  // eslint-disable-next-line @typescript-eslint/no-use-before-define
   toBuilder(): Builder {
     const { type, name, title, description, dataType, defaultValue, optional, binding } = this._value;
     const { lookupTable, key } = this._value2;
 
-    // eslint-disable-next-line no-use-before-define
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
     return new Builder(Immutable.Map({ type, name, title, description, dataType, defaultValue, optional, binding, lookupTable, key }));
   }
 
@@ -99,9 +99,9 @@ export default class LookupTableParameter extends Parameter {
     return new LookupTableParameter(name, title, description, data_type, default_value, optional, lookup_table, key);
   }
 
-  // eslint-disable-next-line no-use-before-define
+  // eslint-disable-next-line @typescript-eslint/no-use-before-define
   static builder(): Builder {
-    // eslint-disable-next-line no-use-before-define
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
     return new Builder()
       .type(LookupTableParameter.type)
       .optional(false)

--- a/graylog2-web-interface/src/views/logic/parameters/ParameterBinding.ts
+++ b/graylog2-web-interface/src/views/logic/parameters/ParameterBinding.ts
@@ -43,7 +43,7 @@ export default class ParameterBinding {
     return this._value.value;
   }
 
-  // eslint-disable-next-line no-use-before-define
+  // eslint-disable-next-line @typescript-eslint/no-use-before-define
   toBuilder(): Builder {
     const { type, value } = this._value;
 

--- a/graylog2-web-interface/src/views/logic/parameters/ValueParameter.ts
+++ b/graylog2-web-interface/src/views/logic/parameters/ValueParameter.ts
@@ -26,7 +26,7 @@ type InternalBuilderState = Immutable.Map<string, any>;
 export default class ValueParameter extends Parameter {
   static type = 'value-parameter-v1';
 
-  // eslint-disable-next-line no-use-before-define
+  // eslint-disable-next-line @typescript-eslint/no-use-before-define
   static Builder: typeof Builder;
 
   constructor(name: string, title: string, description: string, dataType: string, defaultValue: any, optional: boolean, binding?: ParameterBinding) {
@@ -37,11 +37,11 @@ export default class ValueParameter extends Parameter {
     return new ValueParameter(name, title, description, dataType, defaultValue, optional, binding);
   }
 
-  // eslint-disable-next-line no-use-before-define
+  // eslint-disable-next-line @typescript-eslint/no-use-before-define
   toBuilder(): Builder {
     const { type, name, title, description, dataType, defaultValue, optional, binding } = this._value;
 
-    // eslint-disable-next-line no-use-before-define
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
     return new Builder(Immutable.Map({ type, name, title, description, dataType, defaultValue, optional, binding }));
   }
 
@@ -66,9 +66,9 @@ export default class ValueParameter extends Parameter {
     return new ValueParameter(name, title, description, data_type, default_value, optional, ParameterBinding.fromJSON(binding));
   }
 
-  // eslint-disable-next-line no-use-before-define
+  // eslint-disable-next-line @typescript-eslint/no-use-before-define
   static builder(): Builder {
-    // eslint-disable-next-line no-use-before-define
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
     return new Builder()
       .type(ValueParameter.type)
       .optional(false)

--- a/graylog2-web-interface/src/views/logic/queries/Query.ts
+++ b/graylog2-web-interface/src/views/logic/queries/Query.ts
@@ -133,10 +133,10 @@ export default class Query {
     return this._value.searchTypes;
   }
 
-  // eslint-disable-next-line no-use-before-define
+  // eslint-disable-next-line @typescript-eslint/no-use-before-define
   toBuilder(): Builder {
     const { id, query, timerange, filter, searchTypes } = this._value;
-    // eslint-disable-next-line no-use-before-define
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
     const builder = Query.builder()
       .id(id)
       .query(query)
@@ -178,7 +178,7 @@ export default class Query {
     };
   }
 
-  // eslint-disable-next-line no-use-before-define
+  // eslint-disable-next-line @typescript-eslint/no-use-before-define
   static builder(): Builder {
     // eslint-disable-next-line @typescript-eslint/no-use-before-define
     return new Builder()

--- a/graylog2-web-interface/src/views/logic/search/GlobalOverride.ts
+++ b/graylog2-web-interface/src/views/logic/search/GlobalOverride.ts
@@ -62,11 +62,11 @@ export default class GlobalOverride {
     return this._value.searchTypes;
   }
 
-  // eslint-disable-next-line no-use-before-define
+  // eslint-disable-next-line @typescript-eslint/no-use-before-define
   toBuilder(): Builder {
     const { timerange, query, keepSearchTypes, searchTypes } = this._value;
 
-    // eslint-disable-next-line no-use-before-define
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
     return new Builder(Immutable.Map({ timerange, query, keepSearchTypes, searchTypes }));
   }
 

--- a/graylog2-web-interface/src/views/logic/search/Search.ts
+++ b/graylog2-web-interface/src/views/logic/search/Search.ts
@@ -46,7 +46,7 @@ export default class Search {
   }
 
   static create(): Search {
-    // eslint-disable-next-line no-use-before-define
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
     return new Builder()
       .newId()
       .queries([])
@@ -71,11 +71,11 @@ export default class Search {
       .filter((p) => (!p.optional && !p.defaultValue)).toSet();
   }
 
-  // eslint-disable-next-line no-use-before-define
+  // eslint-disable-next-line @typescript-eslint/no-use-before-define
   toBuilder(): Builder {
     const { id, queries, parameters } = this._value;
 
-    // eslint-disable-next-line no-use-before-define
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
     return new Builder(Immutable.Map({ id, queries, parameters }));
   }
 
@@ -97,9 +97,9 @@ export default class Search {
     return new Search(id, queries, parameters.map((p) => Parameter.fromJSON(p)));
   }
 
-  // eslint-disable-next-line no-use-before-define
+  // eslint-disable-next-line @typescript-eslint/no-use-before-define
   static builder(): Builder {
-    // eslint-disable-next-line no-use-before-define
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
     return new Builder();
   }
 }

--- a/graylog2-web-interface/src/views/logic/search/SearchExecutionState.ts
+++ b/graylog2-web-interface/src/views/logic/search/SearchExecutionState.ts
@@ -47,7 +47,7 @@ export default class SearchExecutionState {
     return this._value.globalOverride;
   }
 
-  // eslint-disable-next-line no-use-before-define
+  // eslint-disable-next-line @typescript-eslint/no-use-before-define
   toBuilder(): Builder {
     const { globalOverride, parameterBindings } = this._value;
 

--- a/graylog2-web-interface/src/views/logic/views/ViewState.ts
+++ b/graylog2-web-interface/src/views/logic/views/ViewState.ts
@@ -64,7 +64,7 @@ export default class ViewState {
   }
 
   static create(): ViewState {
-    // eslint-disable-next-line no-use-before-define
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
     return new Builder()
       .widgets(List())
       .widgetPositions(Map())
@@ -123,11 +123,11 @@ export default class ViewState {
       .build();
   }
 
-  // eslint-disable-next-line no-use-before-define
+  // eslint-disable-next-line @typescript-eslint/no-use-before-define
   toBuilder(): Builder {
     const value: {} = this._value;
 
-    // eslint-disable-next-line no-use-before-define
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
     return new Builder(Map(value));
   }
 
@@ -174,9 +174,9 @@ export default class ViewState {
       .build();
   }
 
-  // eslint-disable-next-line no-use-before-define
+  // eslint-disable-next-line @typescript-eslint/no-use-before-define
   static builder(): Builder {
-    // eslint-disable-next-line no-use-before-define
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
     return new Builder();
   }
 }

--- a/graylog2-web-interface/src/views/logic/views/ViewStateGenerator.ts
+++ b/graylog2-web-interface/src/views/logic/views/ViewStateGenerator.ts
@@ -62,7 +62,7 @@ const _defaultWidgets: DefaultWidgets = {
 
     return { titles, widgets, positions };
   },
-  // eslint-disable-next-line no-unused-vars
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   [View.Type.Dashboard]: async (streamId: string | undefined | null) => {
     const widgets = [];
     const titles = {};

--- a/graylog2-web-interface/src/views/logic/views/formatting/FormattingSettings.ts
+++ b/graylog2-web-interface/src/views/logic/views/formatting/FormattingSettings.ts
@@ -43,7 +43,7 @@ export default class FormattingSettings {
   toBuilder() {
     const { highlighting } = this._value;
 
-    // eslint-disable-next-line no-use-before-define
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
     return new Builder(Immutable.Map({ highlighting }));
   }
 
@@ -52,7 +52,7 @@ export default class FormattingSettings {
   }
 
   static empty() {
-    // eslint-disable-next-line no-use-before-define
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
     return new Builder().build();
   }
 

--- a/graylog2-web-interface/src/views/logic/views/formatting/highlighting/HighlightingRule.ts
+++ b/graylog2-web-interface/src/views/logic/views/formatting/highlighting/HighlightingRule.ts
@@ -60,7 +60,7 @@ export default class HighlightingRule {
   toBuilder() {
     const { field, value, condition, color } = this._value;
 
-    // eslint-disable-next-line no-use-before-define
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
     return new Builder(Immutable.Map({ field, value, condition, color }));
   }
 
@@ -68,9 +68,8 @@ export default class HighlightingRule {
     return new HighlightingRule(field, value, condition, color);
   }
 
-  // eslint-disable-next-line no-use-before-define
   static builder(): Builder {
-    // eslint-disable-next-line no-use-before-define
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
     return new Builder();
   }
 

--- a/graylog2-web-interface/src/views/logic/widgets/MessagesWidgetConfig.ts
+++ b/graylog2-web-interface/src/views/logic/widgets/MessagesWidgetConfig.ts
@@ -103,7 +103,7 @@ export default class MessagesWidgetConfig extends WidgetConfig {
       && isEqualForSearch(other.sort, this.sort);
   }
 
-  // eslint-disable-next-line no-use-before-define
+  // eslint-disable-next-line @typescript-eslint/no-use-before-define
   static builder(): Builder {
     // eslint-disable-next-line @typescript-eslint/no-use-before-define
     return new Builder()

--- a/graylog2-web-interface/src/views/logic/widgets/Widget.ts
+++ b/graylog2-web-interface/src/views/logic/widgets/Widget.ts
@@ -38,7 +38,7 @@ type DeserializesWidgets = {
 class Widget {
   _value: WidgetState;
 
-  // eslint-disable-next-line no-use-before-define
+  // eslint-disable-next-line @typescript-eslint/no-use-before-define
   static Builder: typeof Builder;
 
   constructor(id: string, type: string, config: any, filter?: string, timerange?: TimeRange, query?: QueryString, streams: Array<string> = []) {
@@ -77,7 +77,7 @@ class Widget {
     return this.toBuilder().id(newId).build();
   }
 
-  // eslint-disable-next-line no-use-before-define
+  // eslint-disable-next-line @typescript-eslint/no-use-before-define
   toBuilder(): Builder {
     const {
       id,

--- a/graylog2-web-interface/src/views/logic/widgets/WidgetPosition.ts
+++ b/graylog2-web-interface/src/views/logic/widgets/WidgetPosition.ts
@@ -80,12 +80,12 @@ export default class WidgetPosition {
   }
 
   toBuilder() {
-    // eslint-disable-next-line no-use-before-define
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
     return new Builder(Map(this._value));
   }
 
   static builder() {
-    // eslint-disable-next-line no-use-before-define
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
     return new Builder();
   }
 }

--- a/graylog2-web-interface/src/views/stores/AggregationFunctionsStore.js
+++ b/graylog2-web-interface/src/views/stores/AggregationFunctionsStore.js
@@ -16,7 +16,7 @@
  */
 import Reflux from 'reflux';
 
-import URLUtils from 'util/URLUtils';
+import * as URLUtils from 'util/URLUtils';
 import fetch from 'logic/rest/FetchProvider';
 import { singletonStore } from 'views/logic/singleton';
 

--- a/graylog2-web-interface/src/views/stores/SavedSearchesStore.ts
+++ b/graylog2-web-interface/src/views/stores/SavedSearchesStore.ts
@@ -16,7 +16,7 @@
  */
 import Reflux from 'reflux';
 
-import URLUtils from 'util/URLUtils';
+import * as URLUtils from 'util/URLUtils';
 import { singletonActions, singletonStore } from 'views/logic/singleton';
 import fetch from 'logic/rest/FetchProvider';
 import UserNotification from 'util/UserNotification';

--- a/graylog2-web-interface/src/views/stores/SearchJobStore.ts
+++ b/graylog2-web-interface/src/views/stores/SearchJobStore.ts
@@ -17,7 +17,7 @@
 import Reflux from 'reflux';
 
 import fetch from 'logic/rest/FetchProvider';
-import URLUtils from 'util/URLUtils';
+import * as URLUtils from 'util/URLUtils';
 import Search from 'views/logic/search/Search';
 import SearchExecutionState from 'views/logic/search/SearchExecutionState';
 import { singletonActions, singletonStore } from 'views/logic/singleton';

--- a/graylog2-web-interface/src/views/stores/SearchMetadataStore.ts
+++ b/graylog2-web-interface/src/views/stores/SearchMetadataStore.ts
@@ -17,7 +17,7 @@
 import Reflux from 'reflux';
 
 import fetch from 'logic/rest/FetchProvider';
-import URLUtils from 'util/URLUtils';
+import * as URLUtils from 'util/URLUtils';
 import SearchMetadata from 'views/logic/search/SearchMetadata';
 import { singletonActions, singletonStore } from 'views/logic/singleton';
 import type { RefluxActions, Store } from 'stores/StoreTypes';


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is fixing a number of linter hints, mostly:

  - importing `URLUtils`/`FormsUtils`, which do not have a default
    exports, by using the `import * as` notation
  - replacing `no-use-before-define` with
    `@typescript-eslint/no-use-before-define` for `.tsx?` consistently
  - replacing `no-unused-vars` with `@typescript-eslint/no-unused-vars`
    for `.tsx?` consistently

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.