### PR TITLE
Fixing gap between loading spinner icon and text

### DIFF
--- a/graylog2-web-interface/src/components/common/Spinner.tsx
+++ b/graylog2-web-interface/src/components/common/Spinner.tsx
@@ -16,9 +16,14 @@
  */
 import * as React from 'react';
 import PropTypes from 'prop-types';
+import styled from 'styled-components';
 
 import Icon from './Icon';
 import Delayed from './Delayed';
+
+const StyledIcon = styled(Icon)`
+  margin-right: 6px;
+`;
 
 type Props = {
   delay: number,
@@ -31,7 +36,7 @@ type Props = {
  */
 const Spinner = ({ name, text, delay, ...rest }: Props) => (
   <Delayed delay={delay}>
-    <Icon {...rest} name={name} spin /> {text}
+    <StyledIcon {...rest} name={name} spin />{text}
   </Delayed>
 );
 


### PR DESCRIPTION
## Description
This PR reimplements the gap between the text and icon of the loading spinner. It is now defined by a margin instead of the space character.

Before:
 the loading spinner
![image](https://user-images.githubusercontent.com/46300478/107200509-14668100-69f8-11eb-9da3-12234dd4c1e1.png)

After:
![image](https://user-images.githubusercontent.com/46300478/107200535-1b8d8f00-69f8-11eb-9b59-bb1a94e4d9f1.png)
