### PR TITLE
Import CSS modules as global to prevent rewriting classnames

### DIFF
--- a/graylog2-web-interface/webpack.config.js
+++ b/graylog2-web-interface/webpack.config.js
@@ -44,19 +44,6 @@ const BABELLOADER = { loader: 'babel-loader', options: BABELOPTIONS };
 // eslint-disable-next-line import/no-dynamic-require
 const BOOTSTRAPVARS = require(path.resolve(ROOT_PATH, 'public', 'stylesheets', 'bootstrap-config.json')).vars;
 
-const getCssLoaderOptions = () => {
-  // Development
-  if (TARGET === 'start') {
-    return {
-      modules: {
-        localIdentName: '[name]__[local]--[hash:base64:5]',
-      },
-    };
-  }
-
-  return {};
-};
-
 const chunksSortMode = (c1, c2) => {
   // Render the polyfill chunk first
   if (c1 === 'polyfill') {
@@ -153,7 +140,9 @@ const webpackConfig = {
           'style-loader',
           {
             loader: 'css-loader',
-            options: getCssLoaderOptions(),
+            options: {
+              modules: 'global',
+            },
           },
         ],
       },

--- a/graylog2-web-interface/webpack.config.js
+++ b/graylog2-web-interface/webpack.config.js
@@ -44,6 +44,24 @@ const BABELLOADER = { loader: 'babel-loader', options: BABELOPTIONS };
 // eslint-disable-next-line import/no-dynamic-require
 const BOOTSTRAPVARS = require(path.resolve(ROOT_PATH, 'public', 'stylesheets', 'bootstrap-config.json')).vars;
 
+const getCssLoaderOptions = () => {
+  // Development
+  if (TARGET === 'start') {
+    return {
+      modules: {
+        localIdentName: '[name]__[local]--[hash:base64:5]',
+        mode: 'global',
+      },
+    };
+  }
+
+  return {
+    modules: {
+      mode: 'global',
+    },
+  };
+};
+
 const chunksSortMode = (c1, c2) => {
   // Render the polyfill chunk first
   if (c1 === 'polyfill') {
@@ -140,9 +158,7 @@ const webpackConfig = {
           'style-loader',
           {
             loader: 'css-loader',
-            options: {
-              modules: 'global',
-            },
+            options: getCssLoaderOptions(),
           },
         ],
       },
@@ -152,9 +168,7 @@ const webpackConfig = {
           { loader: 'style-loader', options: { injectType: 'lazyStyleTag' } },
           {
             loader: 'css-loader',
-            options: {
-              modules: 'global',
-            },
+            options: getCssLoaderOptions(),
           },
         ],
       },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This will address the issue raised by @kyleknighted in #10023

Like before, some modules where being imported with generated classnames in develop target. I disabled it here and it solved the issue.

@dennisoelkers I am not totally sure why the options were different for develop, but maybe you know more about this and how this solution might be wrong.

Fixes #10023

## Motivation and Context

CSS modules were imported incorrectly and got generated classnames

## How Has This Been Tested?

By looking up the DatePicker and fixing the imported CSS classes.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

