### PR TITLE
Improving ESLint rule `jest/expect-expect`.

### DIFF
--- a/graylog2-web-interface/packages/eslint-config-graylog/index.js
+++ b/graylog2-web-interface/packages/eslint-config-graylog/index.js
@@ -44,6 +44,9 @@ module.exports = {
       files: ['*.test.js', '*.test.jsx', '*.test.ts', '*.test.tsx'],
       plugins: ['jest'],
       extends: ['plugin:jest/recommended'],
+      rules: {
+        'jest/expect-expect': ['error', { assertFunctionNames: ['expect*', 'findBy*'] }],
+      },
     },
   ],
   extends: [


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

While the ESLint rule `jest/expect-expect` is generally useful, it falls short in a couple of cases:

 - Using `testing-library`'s `find*` (e.g. `findByText`) functions to wait for the appearance of a qualifying element, which is an assertion in it self
 - Bundling `expect` calls in a custom `expectFoo` function

Both cases do not satisfy the rule. This is changed through this PR,which adds `expect*` as well as `findBy*` to the list of accepted function names.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.