### PR TITLE
Allow dropdown in responsive table

### DIFF
--- a/graylog2-web-interface/src/components/graylog/DropdownButton.css
+++ b/graylog2-web-interface/src/components/graylog/DropdownButton.css
@@ -1,0 +1,10 @@
+@media (max-width: 992px) {
+    .table-responsive .dropdown-menu {
+        position: static !important;
+    }
+}
+@media (min-width: 993px) {
+    .table-responsive {
+        overflow: inherit;
+    }
+}

--- a/graylog2-web-interface/src/components/graylog/DropdownButton.jsx
+++ b/graylog2-web-interface/src/components/graylog/DropdownButton.jsx
@@ -20,6 +20,8 @@ import styled, { css } from 'styled-components';
 
 import menuItemStyles from './styles/menuItem';
 
+import './DropdownButton.css';
+
 const DropdownButton = styled(BootstrapDropdownButton)(({ theme }) => css`
   ${theme.components.button}
   & ~ {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Attempts to patch the problem with https://github.com/Graylog2/graylog-plugin-cloud/issues/703

It's not the best solution, but it's a good trade off for not having to spend a long time fixing Bootstrap issues.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This solution makes it possible to use the context menu as you'd expect in full width mode.

In responsive mode it requires the user to scroll inside of the table a bit.

## How Has This Been Tested?
In Firefox and on mobile

## Screenshots (if appropriate):

Normal:
<img width="450" alt="image" src="https://user-images.githubusercontent.com/970834/107340383-febb8f00-6abd-11eb-9e13-9701d1e94fb8.png">

Responsive:
<img width="317" alt="image" src="https://user-images.githubusercontent.com/970834/107341062-d2ecd900-6abe-11eb-9a8b-60cf90edbad6.png">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

