### PR TITLE
Adding static/gradient color options to value highlighting.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/formatting/highlighting/GradientColor.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/formatting/highlighting/GradientColor.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.views.search.views.formatting.highlighting;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+
+@AutoValue
+public abstract class GradientColor implements HighlightingColor {
+    static final String TYPE = "gradient";
+
+    @Override
+    @JsonProperty
+    public String type() {
+        return TYPE;
+    }
+
+    @JsonProperty
+    public abstract String gradient();
+
+    @JsonProperty
+    public abstract Number lower();
+
+    @JsonProperty
+    public abstract Number upper();
+
+    @JsonCreator
+    public static GradientColor create(@JsonProperty("gradient") String gradient,
+                                       @JsonProperty("lower") Number lower,
+                                       @JsonProperty("upper") Number upper) {
+        return new AutoValue_GradientColor(gradient, lower, upper);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/formatting/highlighting/HighlightingColor.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/formatting/highlighting/HighlightingColor.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.views.search.views.formatting.highlighting;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+@JsonSubTypes({
+        @JsonSubTypes.Type(value = StaticColor.class, name = StaticColor.TYPE),
+        @JsonSubTypes.Type(value = GradientColor.class, name = GradientColor.TYPE)
+})
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "type")
+public interface HighlightingColor {
+    String type();
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/formatting/highlighting/HighlightingRule.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/formatting/highlighting/HighlightingRule.java
@@ -38,7 +38,7 @@ public abstract class HighlightingRule {
     public abstract String value();
 
     @JsonProperty(FIELD_COLOR)
-    public abstract String color();
+    public abstract HighlightingColor color();
 
     @JsonProperty(FIELD_CONDITION)
     public abstract Condition condition();
@@ -48,10 +48,19 @@ public abstract class HighlightingRule {
     public static abstract class Builder {
         @JsonProperty(FIELD_FIELD)
         public abstract Builder field(String field);
+
         @JsonProperty(FIELD_VALUE)
         public abstract Builder value(String value);
+
         @JsonProperty(FIELD_COLOR)
-        public abstract Builder color(String color);
+        public Builder color(String color) {
+            return this.color(StaticColor.create(color));
+        }
+
+        @JsonProperty(FIELD_COLOR)
+        @JsonDeserialize(using = LegacyColorDeserializer.class)
+        public abstract Builder color(HighlightingColor color);
+
         @JsonProperty(FIELD_CONDITION)
         public abstract Builder condition(Condition condition);
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/formatting/highlighting/HighlightingRule.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/formatting/highlighting/HighlightingRule.java
@@ -53,11 +53,6 @@ public abstract class HighlightingRule {
         public abstract Builder value(String value);
 
         @JsonProperty(FIELD_COLOR)
-        public Builder color(String color) {
-            return this.color(StaticColor.create(color));
-        }
-
-        @JsonProperty(FIELD_COLOR)
         @JsonDeserialize(using = LegacyColorDeserializer.class)
         public abstract Builder color(HighlightingColor color);
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/formatting/highlighting/LegacyColorDeserializer.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/formatting/highlighting/LegacyColorDeserializer.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.views.search.views.formatting.highlighting;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+
+import java.io.IOException;
+
+public class LegacyColorDeserializer extends JsonDeserializer<HighlightingColor> {
+    @Override
+    public HighlightingColor deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+        final JsonToken token = p.getCurrentToken();
+        if (token.isScalarValue()) {
+            return StaticColor.create(token.asString());
+        }
+
+        return p.getCodec().readValue(p, HighlightingColor.class);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/formatting/highlighting/LegacyColorDeserializer.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/formatting/highlighting/LegacyColorDeserializer.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.jsontype.TypeDeserializer;
 
 import java.io.IOException;
 
@@ -32,5 +33,16 @@ public class LegacyColorDeserializer extends JsonDeserializer<HighlightingColor>
         }
 
         return p.getCodec().readValue(p, HighlightingColor.class);
+    }
+
+    @Override
+    public Object deserializeWithType(JsonParser p, DeserializationContext ctxt, TypeDeserializer typeDeserializer) throws IOException {
+        final JsonToken token = p.getCurrentToken();
+        if (token.isScalarValue()) {
+            final String color = p.getCodec().readValue(p, String.class);
+            return StaticColor.create(color);
+        }
+
+        return super.deserializeWithType(p, ctxt, typeDeserializer);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/formatting/highlighting/StaticColor.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/formatting/highlighting/StaticColor.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.views.search.views.formatting.highlighting;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+
+@AutoValue
+public abstract class StaticColor implements HighlightingColor {
+    static final String TYPE = "static";
+
+    @JsonProperty
+    @Override
+    public String type() {
+        return TYPE;
+    }
+
+    @JsonProperty
+    public abstract String color();
+
+    @JsonCreator
+    public static StaticColor create(@JsonProperty("color") String color) {
+        return new AutoValue_StaticColor(color);
+    }
+}

--- a/graylog2-web-interface/package.json
+++ b/graylog2-web-interface/package.json
@@ -113,6 +113,7 @@
     "@babel/polyfill": "^7.8.3",
     "@babel/preset-env": "^7.8.4",
     "@babel/preset-react": "^7.8.3",
+    "@testing-library/user-event": "^12.6.3",
     "@types/lodash": "^4.14.165",
     "@types/react-plotly.js": "^2.2.4",
     "assets-webpack-plugin": "^5.1.2",

--- a/graylog2-web-interface/package.json
+++ b/graylog2-web-interface/package.json
@@ -45,6 +45,7 @@
     "@fortawesome/react-fontawesome": "^0.1.9",
     "@openfonts/roboto-mono_latin": "^1.44.1",
     "@react-bootstrap/pagination": "^1.0.0",
+    "@types/chroma-js": "^2.1.3",
     "ace-builds": "^1.4.9",
     "bluebird": "^3.4.0",
     "bootstrap": "3.4.1",

--- a/graylog2-web-interface/src/components/bootstrap/InputWrapper.jsx
+++ b/graylog2-web-interface/src/components/bootstrap/InputWrapper.jsx
@@ -17,23 +17,17 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-class InputWrapper extends React.Component {
-  static propTypes = {
-    className: PropTypes.string,
-    children: PropTypes.node.isRequired,
-  };
+const InputWrapper = ({ children, className }) => (className
+  ? <div className={className}>{children}</div>
+  : <span>{children}</span>);
 
-  static defaultProps = {
-    className: undefined,
-  };
+InputWrapper.propTypes = {
+  className: PropTypes.string,
+  children: PropTypes.node.isRequired,
+};
 
-  render() {
-    if (this.props.className) {
-      return <div className={this.props.className}>{this.props.children}</div>;
-    }
-
-    return <span>{this.props.children}</span>;
-  }
-}
+InputWrapper.defaultProps = {
+  className: undefined,
+};
 
 export default InputWrapper;

--- a/graylog2-web-interface/src/theme/utils/contrastingColor.ts
+++ b/graylog2-web-interface/src/theme/utils/contrastingColor.ts
@@ -44,9 +44,7 @@ const contrastingColor = (color: string, wcagLevel: string = 'AAA'): string => {
   let outputColor = chroma.mix(color, mixColor, mixture).css();
 
   while (mixture <= 1) {
-    const percent = mixture.toFixed(2);
-
-    outputColor = chroma.mix(color, mixColor, percent).css();
+    outputColor = chroma.mix(color, mixColor, mixture).css();
 
     if (chroma.contrast(color, outputColor) >= contrastRatios[wcagLevel]) {
       break;

--- a/graylog2-web-interface/src/views/Constants.ts
+++ b/graylog2-web-interface/src/views/Constants.ts
@@ -17,6 +17,7 @@
 import chroma from 'chroma-js';
 
 import { TimeRange, RelativeTimeRangeWithEnd } from 'views/logic/queries/Query';
+import { StaticColor } from 'views/logic/views/formatting/highlighting/HighlightingColor';
 
 export type SearchBarFormValues = {
   timerange: TimeRange,
@@ -36,7 +37,7 @@ export const DEFAULT_RELATIVE_FROM = 300;
 export const DEFAULT_RELATIVE_TO = DEFAULT_RELATIVE_FROM - 60;
 export const DEFAULT_TIMERANGE: RelativeTimeRangeWithEnd = { type: DEFAULT_RANGE_TYPE, from: DEFAULT_RELATIVE_FROM };
 
-export const DEFAULT_HIGHLIGHT_COLOR = '#ffec3d';
+export const DEFAULT_HIGHLIGHT_COLOR = StaticColor.create('#ffec3d');
 export const DEFAULT_CUSTOM_HIGHLIGHT_RANGE = chroma.scale(['lightyellow', 'lightgreen', 'lightblue', 'red'])
   .mode('lch')
   .colors(40);

--- a/graylog2-web-interface/src/views/components/contexts/HighlightingRulesProvider.test.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/HighlightingRulesProvider.test.tsx
@@ -20,6 +20,7 @@ import asMock from 'helpers/mocking/AsMock';
 
 import HighlightingRule from 'views/logic/views/formatting/highlighting/HighlightingRule';
 import { HighlightingRulesStore } from 'views/stores/HighlightingRulesStore';
+import { StaticColor } from 'views/logic/views/formatting/highlighting/HighlightingColor';
 
 import HighlightingRulesContext from './HighlightingRulesContext';
 import HighlightingRulesProvider from './HighlightingRulesProvider';
@@ -56,7 +57,7 @@ describe('HighlightingRulesProvider', () => {
     const rule = HighlightingRule.builder()
       .field('field-name')
       .value(String(42))
-      .color('#bc98fd')
+      .color(StaticColor.create('#bc98fd'))
       .build();
 
     asMock(HighlightingRulesStore.getInitialState).mockReturnValue([rule]);

--- a/graylog2-web-interface/src/views/components/messagelist/CustomHighlighting.test.tsx
+++ b/graylog2-web-interface/src/views/components/messagelist/CustomHighlighting.test.tsx
@@ -21,6 +21,7 @@ import HighlightingRulesContext from 'views/components/contexts/HighlightingRule
 import HighlightingRule from 'views/logic/views/formatting/highlighting/HighlightingRule';
 import DecoratorContext from 'views/components/messagelist/decoration/DecoratorContext';
 import FieldType from 'views/logic/fieldtypes/FieldType';
+import { StaticColor } from 'views/logic/views/formatting/highlighting/HighlightingColor';
 
 import CustomHighlighting from './CustomHighlighting';
 
@@ -68,7 +69,7 @@ describe('CustomHighlighting', () => {
     const rule = HighlightingRule.builder()
       .field('bar')
       .value(String(value))
-      .color('#bc98fd')
+      .color(StaticColor.create('#bc98fd'))
       .build();
     const { findByText } = render(<CustomHighlightingWithContext highlightingRules={[rule]} />);
 
@@ -81,7 +82,7 @@ describe('CustomHighlighting', () => {
     const rule = HighlightingRule.builder()
       .field(field)
       .value(String(value))
-      .color('#bc98fd')
+      .color(StaticColor.create('#bc98fd'))
       .build();
     const { findByText } = render(<CustomHighlightingWithContext highlightingRules={[rule]} />);
 
@@ -94,7 +95,7 @@ describe('CustomHighlighting', () => {
     const rule = HighlightingRule.builder()
       .field(field)
       .value('2')
-      .color('#bc98fd')
+      .color(StaticColor.create('#bc98fd'))
       .build();
     const { findByText } = render(<CustomHighlightingWithContext highlightingRules={[rule]} />);
 
@@ -107,7 +108,7 @@ describe('CustomHighlighting', () => {
     const rule = HighlightingRule.builder()
       .field(field)
       .value('23')
-      .color('#bc98fd')
+      .color(StaticColor.create('#bc98fd'))
       .build();
     const { findByText } = render(<CustomHighlightingWithContext highlightingRules={[rule]} />);
 

--- a/graylog2-web-interface/src/views/components/messagelist/Highlight.tsx
+++ b/graylog2-web-interface/src/views/components/messagelist/Highlight.tsx
@@ -20,7 +20,6 @@ import { get } from 'lodash';
 
 import { AdditionalContext } from 'views/logic/ActionContext';
 import { DEFAULT_HIGHLIGHT_COLOR } from 'views/Constants';
-import { StaticColor } from 'views/logic/views/formatting/highlighting/HighlightingColor';
 
 import PossiblyHighlight from './PossiblyHighlight';
 
@@ -29,13 +28,11 @@ type Props = {
   value: any,
 };
 
-const defaultHighlightColor = StaticColor.create(DEFAULT_HIGHLIGHT_COLOR);
-
 const Highlight = ({ field, value }: Props) => (
   <AdditionalContext.Consumer>
     {({ message }) => (
       <PossiblyHighlight field={field}
-                         color={defaultHighlightColor}
+                         color={DEFAULT_HIGHLIGHT_COLOR}
                          value={value}
                          highlightRanges={get(message, 'highlight_ranges')} />
     )}

--- a/graylog2-web-interface/src/views/components/messagelist/Highlight.tsx
+++ b/graylog2-web-interface/src/views/components/messagelist/Highlight.tsx
@@ -20,6 +20,7 @@ import { get } from 'lodash';
 
 import { AdditionalContext } from 'views/logic/ActionContext';
 import { DEFAULT_HIGHLIGHT_COLOR } from 'views/Constants';
+import { StaticColor } from 'views/logic/views/formatting/highlighting/HighlightingColor';
 
 import PossiblyHighlight from './PossiblyHighlight';
 
@@ -28,11 +29,13 @@ type Props = {
   value: any,
 };
 
+const defaultHighlightColor = StaticColor.create(DEFAULT_HIGHLIGHT_COLOR);
+
 const Highlight = ({ field, value }: Props) => (
   <AdditionalContext.Consumer>
     {({ message }) => (
       <PossiblyHighlight field={field}
-                         color={DEFAULT_HIGHLIGHT_COLOR}
+                         color={defaultHighlightColor}
                          value={value}
                          highlightRanges={get(message, 'highlight_ranges')} />
     )}

--- a/graylog2-web-interface/src/views/components/messagelist/PossiblyHighlight.tsx
+++ b/graylog2-web-interface/src/views/components/messagelist/PossiblyHighlight.tsx
@@ -22,10 +22,7 @@ import { withTheme, DefaultTheme } from 'styled-components';
 import StringUtils from 'util/StringUtils';
 import { DEFAULT_HIGHLIGHT_COLOR } from 'views/Constants';
 import { isFunction } from 'views/logic/aggregationbuilder/Series';
-import HighlightingColor, {
-  GradientColor,
-  StaticColor,
-} from 'views/logic/views/formatting/highlighting/HighlightingColor';
+import HighlightingColor from 'views/logic/views/formatting/highlighting/HighlightingColor';
 
 import formatNumber from './FormatNumber';
 import isNumeric from './IsNumeric';
@@ -60,9 +57,7 @@ function highlightCompleteValue(ranges: Array<HighlightRange>, value) {
 
 const shouldBeFormatted = (field, value) => isFunction(field) && isNumeric(value);
 
-const defaultHighlightColor = StaticColor.create(DEFAULT_HIGHLIGHT_COLOR);
-
-const PossiblyHighlight = ({ color = defaultHighlightColor, field, value, highlightRanges = {}, theme }: Props) => {
+const PossiblyHighlight = ({ color = DEFAULT_HIGHLIGHT_COLOR, field, value, highlightRanges = {}, theme }: Props) => {
   if (value === undefined || value === null) {
     return '';
   }
@@ -115,7 +110,7 @@ const PossiblyHighlight = ({ color = defaultHighlightColor, field, value, highli
 };
 
 PossiblyHighlight.propTypes = {
-  color: PropTypes.string,
+  color: PropTypes.object,
   field: PropTypes.string.isRequired,
   value: PropTypes.any,
   highlightRanges: PropTypes.object,

--- a/graylog2-web-interface/src/views/components/messagelist/PossiblyHighlight.tsx
+++ b/graylog2-web-interface/src/views/components/messagelist/PossiblyHighlight.tsx
@@ -22,6 +22,10 @@ import { withTheme, DefaultTheme } from 'styled-components';
 import StringUtils from 'util/StringUtils';
 import { DEFAULT_HIGHLIGHT_COLOR } from 'views/Constants';
 import { isFunction } from 'views/logic/aggregationbuilder/Series';
+import HighlightingColor, {
+  GradientColor,
+  StaticColor,
+} from 'views/logic/views/formatting/highlighting/HighlightingColor';
 
 import formatNumber from './FormatNumber';
 import isNumeric from './IsNumeric';
@@ -36,7 +40,7 @@ type Ranges = { [key: string]: Array<HighlightRange> };
 const highlight = (value: any, idx: number, style = {}) => <span key={`highlight-${idx}`} style={style}>{value}</span>;
 
 type Props = {
-  color: string,
+  color: HighlightingColor,
   field: string,
   value?: any,
   highlightRanges: Ranges,
@@ -56,7 +60,9 @@ function highlightCompleteValue(ranges: Array<HighlightRange>, value) {
 
 const shouldBeFormatted = (field, value) => isFunction(field) && isNumeric(value);
 
-const PossiblyHighlight = ({ color = DEFAULT_HIGHLIGHT_COLOR, field, value, highlightRanges = {}, theme }: Props) => {
+const defaultHighlightColor = StaticColor.create(DEFAULT_HIGHLIGHT_COLOR);
+
+const PossiblyHighlight = ({ color = defaultHighlightColor, field, value, highlightRanges = {}, theme }: Props) => {
   if (value === undefined || value === null) {
     return '';
   }
@@ -67,9 +73,11 @@ const PossiblyHighlight = ({ color = DEFAULT_HIGHLIGHT_COLOR, field, value, high
       : value;
   }
 
+  const backgroundColor = color.colorFor(value);
+
   const style = {
-    backgroundColor: color,
-    color: theme.utils.contrastingColor(color),
+    backgroundColor: backgroundColor,
+    color: theme.utils.contrastingColor(backgroundColor),
     padding: '0 1px',
   };
 

--- a/graylog2-web-interface/src/views/components/sidebar/highlighting/ColorPreview.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/highlighting/ColorPreview.tsx
@@ -17,10 +17,9 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
-import chroma from 'chroma-js';
-import { scales } from 'plotly.js/src/components/colorscale';
 
 import HighlightingColor, { GradientColor, StaticColor } from 'views/logic/views/formatting/highlighting/HighlightingColor';
+import { scaleForGradient } from 'views/components/sidebar/highlighting/Scale';
 
 const ColorPreviewBase = styled.div`
   height: 2rem;
@@ -34,29 +33,6 @@ const ColorPreviewBase = styled.div`
 const StaticColorPreview = styled(ColorPreviewBase)(({ color }) => css`
   background-color: ${color};
 `);
-
-const plotlyScaleToChroma = (plotlyScale: Array<[domain: number, color: string]>) => {
-  const domains = plotlyScale.map(([domain]) => domain);
-  const colors = plotlyScale.map(([, color]) => color);
-
-  return chroma.scale(colors).domain(domains);
-};
-
-const scaleForGradient = (gradient: string): chroma.Scale => {
-  switch (gradient) {
-    case 'Blackbody':
-    case 'Bluered':
-    case 'Cividis':
-    case 'Earth':
-    case 'Electric':
-    case 'Hot':
-    case 'Jet':
-    case 'Picnic':
-    case 'Portland':
-    case 'Rainbow': return plotlyScaleToChroma(scales[gradient]);
-    default: return chroma.scale(gradient);
-  }
-};
 
 const colorsForGradient = (gradient: string, count = 5): Array<string> => scaleForGradient(gradient).colors(count);
 

--- a/graylog2-web-interface/src/views/components/sidebar/highlighting/ColorPreview.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/highlighting/ColorPreview.tsx
@@ -15,6 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
+import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
 import chroma from 'chroma-js';
 
@@ -50,7 +51,7 @@ type ColorPreviewProps = {
   onClick?: () => void,
 };
 
-const ColorPreview = React.forwardRef(({ color, onClick = () => {} }: ColorPreviewProps, ref) => {
+const ColorPreview = React.forwardRef<HTMLDivElement, ColorPreviewProps>(({ color, onClick = () => {} }, ref) => {
   if (color.isStatic()) {
     return <StaticColorPreview ref={ref} onClick={onClick} color={(color as StaticColor).color} />;
   }
@@ -61,5 +62,14 @@ const ColorPreview = React.forwardRef(({ color, onClick = () => {} }: ColorPrevi
 
   throw new Error(`Invalid highlighting color type: ${color}`);
 });
+
+ColorPreview.propTypes = {
+  color: PropTypes.any.isRequired,
+  onClick: PropTypes.func,
+};
+
+ColorPreview.defaultProps = {
+  onClick: () => {},
+};
 
 export default ColorPreview;

--- a/graylog2-web-interface/src/views/components/sidebar/highlighting/ColorPreview.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/highlighting/ColorPreview.tsx
@@ -32,7 +32,7 @@ const ColorPreviewBase = styled.div`
 `;
 
 const StaticColorPreview = styled(ColorPreviewBase)(({ color }) => css`
-  background-color: ${color}
+  background-color: ${color};
 `);
 
 const plotlyScaleToChroma = (plotlyScale: Array<[domain: number, color: string]>) => {

--- a/graylog2-web-interface/src/views/components/sidebar/highlighting/ColorPreview.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/highlighting/ColorPreview.tsx
@@ -14,16 +14,43 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
+import * as React from 'react';
 import styled, { css } from 'styled-components';
+import chroma from 'chroma-js';
 
-const ColorPreview = styled.div<{ color: string }>(({ color }) => css`
+import HighlightingColor, { GradientColor, StaticColor } from 'views/logic/views/formatting/highlighting/HighlightingColor';
+
+const ColorPreviewBase = styled.div`
   height: 2rem;
   width: 2rem;
   margin-right: 0.4rem;
 
-  background-color: ${color};
   border-radius: 4px;
   border: 1px solid rgba(0, 126, 255, 0.24);
+`;
+
+const StaticColorPreview = styled(ColorPreviewBase)(({ color }) => css`
+  background-color: ${color}
 `);
+
+export const GradientColorPreview = styled(ColorPreviewBase)(({ gradient }: { gradient: string }) => {
+  try {
+    const colors = chroma.scale(gradient).colors(5);
+
+    return css`
+    background: linear-gradient(0deg, ${colors.map((color, idx) => `${color} ${idx * (100 / colors.length)}%`).join(', ')});
+  `;
+  } catch (e) {
+    console.log(`Error for ${gradient}: ${e}`);
+  }
+});
+
+const ColorPreview = ({ color }: { color: HighlightingColor }) => {
+  switch (color.type) {
+    case 'static': return <StaticColorPreview color={(color as StaticColor).color} />;
+    case 'gradient': return <GradientColorPreview gradient={(color as GradientColor).gradient} />;
+    default: throw new Error(`Invalid highlighting color type: ${color.type}`);
+  }
+};
 
 export default ColorPreview;

--- a/graylog2-web-interface/src/views/components/sidebar/highlighting/ColorPreview.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/highlighting/ColorPreview.tsx
@@ -18,6 +18,7 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
 import chroma from 'chroma-js';
+import { scales } from 'plotly.js/src/components/colorscale';
 
 import HighlightingColor, { GradientColor, StaticColor } from 'views/logic/views/formatting/highlighting/HighlightingColor';
 
@@ -34,16 +35,38 @@ const StaticColorPreview = styled(ColorPreviewBase)(({ color }) => css`
   background-color: ${color}
 `);
 
-export const GradientColorPreview = styled(ColorPreviewBase)(({ gradient }: { gradient: string }) => {
-  try {
-    const colors = chroma.scale(gradient).colors(5);
+const plotlyScaleToChroma = (plotlyScale: Array<[domain: number, color: string]>) => {
+  const domains = plotlyScale.map(([domain]) => domain);
+  const colors = plotlyScale.map(([, color]) => color);
 
-    return css`
-    background: linear-gradient(0deg, ${colors.map((color, idx) => `${color} ${idx * (100 / colors.length)}%`).join(', ')});
-  `;
-  } catch (e) {
-    console.log(`Error for ${gradient}: ${e}`);
+  return chroma.scale(colors).domain(domains);
+};
+
+const scaleForGradient = (gradient: string): chroma.Scale => {
+  switch (gradient) {
+    case 'Blackbody':
+    case 'Bluered':
+    case 'Cividis':
+    case 'Earth':
+    case 'Electric':
+    case 'Hot':
+    case 'Jet':
+    case 'Picnic':
+    case 'Portland':
+    case 'Rainbow': return plotlyScaleToChroma(scales[gradient]);
+    default: return chroma.scale(gradient);
   }
+};
+
+const colorsForGradient = (gradient: string, count = 5): Array<string> => scaleForGradient(gradient).colors(count);
+
+export const GradientColorPreview = styled(ColorPreviewBase)(({ gradient }: { gradient: string }) => {
+  const colors = colorsForGradient(gradient);
+
+  return css`
+      border: none;
+      background: linear-gradient(0deg, ${colors.map((color, idx) => `${color} ${idx * (100 / colors.length)}%`).join(', ')});
+    `;
 });
 
 type ColorPreviewProps = {

--- a/graylog2-web-interface/src/views/components/sidebar/highlighting/ColorPreview.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/highlighting/ColorPreview.tsx
@@ -50,12 +50,16 @@ type ColorPreviewProps = {
   onClick?: () => void,
 };
 
-const ColorPreview = ({ color, onClick = () => {} }: ColorPreviewProps) => {
-  switch (color.type) {
-    case 'static': return <StaticColorPreview onClick={onClick} color={(color as StaticColor).color} />;
-    case 'gradient': return <GradientColorPreview onClick={onClick} gradient={(color as GradientColor).gradient} />;
-    default: throw new Error(`Invalid highlighting color type: ${color.type}`);
+const ColorPreview = React.forwardRef(({ color, onClick = () => {} }: ColorPreviewProps, ref) => {
+  if (color.isStatic()) {
+    return <StaticColorPreview ref={ref} onClick={onClick} color={(color as StaticColor).color} />;
   }
-};
 
-export default React.forwardRef(ColorPreview);
+  if (color.isGradient()) {
+    return <GradientColorPreview ref={ref} onClick={onClick} gradient={(color as GradientColor).gradient} />;
+  }
+
+  throw new Error(`Invalid highlighting color type: ${color}`);
+});
+
+export default ColorPreview;

--- a/graylog2-web-interface/src/views/components/sidebar/highlighting/ColorPreview.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/highlighting/ColorPreview.tsx
@@ -45,12 +45,17 @@ export const GradientColorPreview = styled(ColorPreviewBase)(({ gradient }: { gr
   }
 });
 
-const ColorPreview = ({ color }: { color: HighlightingColor }) => {
+type ColorPreviewProps = {
+  color: HighlightingColor,
+  onClick?: () => void,
+};
+
+const ColorPreview = ({ color, onClick = () => {} }: ColorPreviewProps) => {
   switch (color.type) {
-    case 'static': return <StaticColorPreview color={(color as StaticColor).color} />;
-    case 'gradient': return <GradientColorPreview gradient={(color as GradientColor).gradient} />;
+    case 'static': return <StaticColorPreview onClick={onClick} color={(color as StaticColor).color} />;
+    case 'gradient': return <GradientColorPreview onClick={onClick} gradient={(color as GradientColor).gradient} />;
     default: throw new Error(`Invalid highlighting color type: ${color.type}`);
   }
 };
 
-export default ColorPreview;
+export default React.forwardRef(ColorPreview);

--- a/graylog2-web-interface/src/views/components/sidebar/highlighting/ColorPreview.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/highlighting/ColorPreview.tsx
@@ -75,11 +75,11 @@ type ColorPreviewProps = {
 };
 
 const ColorPreview = React.forwardRef<HTMLDivElement, ColorPreviewProps>(({ color, onClick = () => {} }, ref) => {
-  if (color.isStatic()) {
+  if (color.type === 'static') {
     return <StaticColorPreview ref={ref} onClick={onClick} color={(color as StaticColor).color} />;
   }
 
-  if (color.isGradient()) {
+  if (color.type === 'gradient') {
     return <GradientColorPreview ref={ref} onClick={onClick} gradient={(color as GradientColor).gradient} />;
   }
 

--- a/graylog2-web-interface/src/views/components/sidebar/highlighting/ColorPreview.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/highlighting/ColorPreview.tsx
@@ -19,7 +19,7 @@ import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
 
 import HighlightingColor, { GradientColor, StaticColor } from 'views/logic/views/formatting/highlighting/HighlightingColor';
-import { scaleForGradient } from 'views/components/sidebar/highlighting/Scale';
+import scaleForGradient from 'views/components/sidebar/highlighting/Scale';
 
 const ColorPreviewBase = styled.div`
   height: 2rem;

--- a/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightForm.test.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightForm.test.tsx
@@ -20,6 +20,7 @@ import { render, fireEvent, waitFor } from 'wrappedTestingLibrary';
 import HighlightForm from 'views/components/sidebar/highlighting/HighlightForm';
 import HighlightingRule from 'views/logic/views/formatting/highlighting/HighlightingRule';
 import { HighlightingRulesActions } from 'views/stores/HighlightingRulesStore';
+import { StaticColor } from 'views/logic/views/formatting/highlighting/HighlightingColor';
 
 jest.mock('views/stores/HighlightingRulesStore', () => ({
   HighlightingRulesActions: {
@@ -30,7 +31,7 @@ jest.mock('views/stores/HighlightingRulesStore', () => ({
 }));
 
 const rule = HighlightingRule.builder()
-  .color('#333333')
+  .color(StaticColor.create('#333333'))
   .condition('not_equal')
   .field('foob')
   .value('noob')

--- a/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightForm.test.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightForm.test.tsx
@@ -15,12 +15,17 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import React from 'react';
-import { render, fireEvent, waitFor } from 'wrappedTestingLibrary';
+import { render, fireEvent, waitFor, screen } from 'wrappedTestingLibrary';
+import userEvent from '@testing-library/user-event';
+import * as Immutable from 'immutable';
 
 import HighlightForm from 'views/components/sidebar/highlighting/HighlightForm';
 import HighlightingRule from 'views/logic/views/formatting/highlighting/HighlightingRule';
 import { HighlightingRulesActions } from 'views/stores/HighlightingRulesStore';
 import { StaticColor } from 'views/logic/views/formatting/highlighting/HighlightingColor';
+import FieldTypesContext, { FieldTypes } from 'views/components/contexts/FieldTypesContext';
+import FieldTypeMapping from 'views/logic/fieldtypes/FieldTypeMapping';
+import FieldType, { Properties } from 'views/logic/fieldtypes/FieldType';
 
 jest.mock('views/stores/HighlightingRulesStore', () => ({
   HighlightingRulesActions: {
@@ -38,8 +43,18 @@ const rule = HighlightingRule.builder()
   .build();
 
 describe('HighlightForm', () => {
+  const fieldTypes: FieldTypes = {
+    all: Immutable.List([FieldTypeMapping.create('foob', FieldType.create('long', [Properties.Numeric]))]),
+    queryFields: Immutable.Map(),
+  };
+  const HighlightFormWithContext = (props) => (
+    <FieldTypesContext.Provider value={fieldTypes}>
+      <HighlightForm {...props} />
+    </FieldTypesContext.Provider>
+  );
+
   it('should render for edit', async () => {
-    const { findByText, findByDisplayValue } = render(<HighlightForm onClose={() => {}} rule={rule} />);
+    const { findByText, findByDisplayValue } = render(<HighlightFormWithContext onClose={() => {}} rule={rule} />);
 
     const form = await findByText('Edit Highlighting Rule');
     const value = await findByDisplayValue(rule.value);
@@ -49,7 +64,7 @@ describe('HighlightForm', () => {
   });
 
   it('should render for new', async () => {
-    const { findByText } = render(<HighlightForm onClose={() => {}} />);
+    const { findByText } = render(<HighlightFormWithContext onClose={() => {}} />);
 
     const form = await findByText('New Highlighting Rule');
 
@@ -58,7 +73,7 @@ describe('HighlightForm', () => {
 
   it('should fire onClose on cancel', async () => {
     const onClose = jest.fn();
-    const { findByText } = render(<HighlightForm onClose={onClose} />);
+    const { findByText } = render(<HighlightFormWithContext onClose={onClose} />);
 
     const elem = await findByText('Cancel');
 
@@ -68,7 +83,7 @@ describe('HighlightForm', () => {
   });
 
   it('should fire remove action when saving a existing rule', async () => {
-    const { findByText } = render(<HighlightForm onClose={() => {}} rule={rule} />);
+    const { findByText } = render(<HighlightFormWithContext onClose={() => {}} rule={rule} />);
 
     const elem = await findByText('Save');
 
@@ -76,5 +91,35 @@ describe('HighlightForm', () => {
 
     await waitFor(() => expect(HighlightingRulesActions.update)
       .toBeCalledWith(rule, { field: rule.field, value: rule.value, condition: rule.condition, color: rule.color }));
+  });
+
+  it('assigns a new static color when type is selected', async () => {
+    render(<HighlightFormWithContext onClose={() => {}} rule={rule} />);
+
+    userEvent.click(screen.getByLabelText('Static Color'));
+
+    userEvent.click(screen.getByText('Save'));
+
+    await waitFor(() => expect(HighlightingRulesActions.update)
+      .toBeCalledWith(rule, expect.objectContaining({
+        color: expect.objectContaining({ type: 'static', color: expect.any(String) }),
+      })));
+  });
+
+  it('creates a new gradient when type is selected', async () => {
+    render(<HighlightFormWithContext onClose={() => {}} rule={rule} />);
+
+    userEvent.click(screen.getByLabelText('Gradient'));
+
+    const highestValue = await screen.findByLabelText('Specify highest value');
+    userEvent.clear(highestValue);
+    userEvent.type(highestValue, '100');
+
+    userEvent.click(screen.getByText('Save'));
+
+    await waitFor(() => expect(HighlightingRulesActions.update)
+      .toBeCalledWith(rule, expect.objectContaining({
+        color: expect.objectContaining({ gradient: 'Viridis' }),
+      })));
   });
 });

--- a/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightForm.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightForm.tsx
@@ -26,15 +26,13 @@ import { Button, Modal } from 'components/graylog';
 import FieldTypesContext from 'views/components/contexts/FieldTypesContext';
 import FieldTypeMapping from 'views/logic/fieldtypes/FieldTypeMapping';
 import Select from 'components/common/Select';
-import { ColorPickerPopover } from 'components/common';
-import { DEFAULT_CUSTOM_HIGHLIGHT_RANGE } from 'views/Constants';
-import ColorPreview from 'views/components/sidebar/highlighting/ColorPreview';
 import { HighlightingRulesActions } from 'views/stores/HighlightingRulesStore';
 import HighlightingRule, {
   ConditionLabelMap,
   randomColor,
   StringConditionLabelMap,
 } from 'views/logic/views/formatting/highlighting/HighlightingRule';
+import HighlightingColorForm from 'views/components/sidebar/highlighting/HighlightingColorForm';
 
 type Props = {
   onClose: () => void,
@@ -133,18 +131,7 @@ const HighlightForm = ({ onClose, rule }: Props) => {
               </Field>
               <Field name="color">
                 {({ field: { name, value, onChange } }) => (
-                  <Input id={name}
-                         label="Color">
-                    <ColorPickerPopover id="formatting-rule-color"
-                                        placement="right"
-                                        color={value}
-                                        colors={DEFAULT_CUSTOM_HIGHLIGHT_RANGE.map((c) => [c])}
-                                        triggerNode={<ColorPreview color={value} />}
-                                        onChange={(newColor, _, hidePopover) => {
-                                          hidePopover();
-                                          onChange({ target: { name, value: newColor } });
-                                        }} />
-                  </Input>
+                  <HighlightingColorForm name={name} value={value} onChange={onChange} />
                 )}
               </Field>
             </Modal.Body>

--- a/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightForm.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightForm.tsx
@@ -34,7 +34,6 @@ import HighlightingRule, {
 } from 'views/logic/views/formatting/highlighting/HighlightingRule';
 import HighlightingColorForm from 'views/components/sidebar/highlighting/HighlightingColorForm';
 import { FieldTypeMappingsList } from 'views/stores/FieldTypesStore';
-import { StaticColor } from 'views/logic/views/formatting/highlighting/HighlightingColor';
 import Series, { isFunction } from 'views/logic/aggregationbuilder/Series';
 import inferTypeForSeries from 'views/logic/fieldtypes/InferTypeForSeries';
 
@@ -82,10 +81,10 @@ const HighlightForm = ({ onClose, rule }: Props) => {
   return (
     <Formik onSubmit={onSubmit}
             initialValues={{
-              field: rule?.field ?? undefined,
-              value: rule?.value ?? '',
+              field: rule?.field,
+              value: rule?.value,
               condition: rule?.condition ?? 'equal',
-              color: rule?.color ?? randomColor(),
+              color: rule?.color,
             }}>
       {() => (
         <BootstrapModalWrapper showModal

--- a/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightForm.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightForm.tsx
@@ -35,6 +35,9 @@ import HighlightingRule, {
 import HighlightingColorForm from 'views/components/sidebar/highlighting/HighlightingColorForm';
 import { FieldTypeMappingsList } from 'views/stores/FieldTypesStore';
 import { StaticColor } from 'views/logic/views/formatting/highlighting/HighlightingColor';
+import Series, { isFunction } from 'views/logic/aggregationbuilder/Series';
+import FieldType, { Properties } from 'views/logic/fieldtypes/FieldType';
+import inferTypeForSeries from 'views/logic/fieldtypes/InferTypeForSeries';
 
 type Props = {
   onClose: () => void,
@@ -52,7 +55,9 @@ const _isRequired = (field) => (value) => {
 const numberConditionOptions = Object.entries(ConditionLabelMap).map(([value, label]) => ({ value, label }));
 const otherConditionOptions = Object.entries(StringConditionLabelMap).map(([value, label]) => ({ value, label }));
 
-const fieldTypeFor = (fields: FieldTypeMappingsList, selectedField: string) => fields.find((field) => field.name === selectedField);
+const fieldTypeFor = (fields: FieldTypeMappingsList, selectedField: string) => (isFunction(selectedField)
+  ? inferTypeForSeries(Series.forFunction(selectedField), fields)
+  : fields.find((field) => field.name === selectedField));
 
 const HighlightForm = ({ onClose, rule }: Props) => {
   const fieldTypes = useContext(FieldTypesContext);

--- a/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightForm.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightForm.tsx
@@ -29,7 +29,6 @@ import Select from 'components/common/Select';
 import { HighlightingRulesActions } from 'views/stores/HighlightingRulesStore';
 import HighlightingRule, {
   ConditionLabelMap,
-  randomColor,
   StringConditionLabelMap,
 } from 'views/logic/views/formatting/highlighting/HighlightingRule';
 import HighlightingColorForm from 'views/components/sidebar/highlighting/HighlightingColorForm';

--- a/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightForm.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightForm.tsx
@@ -49,6 +49,8 @@ const _isRequired = (field) => (value) => {
   return undefined;
 };
 
+const _validateColor = (value) => (!value ? 'Color is required' : undefined);
+
 const numberConditionOptions = Object.entries(ConditionLabelMap).map(([value, label]) => ({ value, label }));
 const otherConditionOptions = Object.entries(StringConditionLabelMap).map(([value, label]) => ({ value, label }));
 
@@ -135,12 +137,12 @@ const HighlightForm = ({ onClose, rule }: Props) => {
                          label="Value" />
                 )}
               </Field>
-              <Field name="color">
-                {({ field: { name, value, onChange }, form: { values: { field: selectedField } } }) => {
+              <Field name="color" validate={_validateColor}>
+                {({ field: { name, value, onChange }, form: { values: { field: selectedField } }, meta }) => {
                   const selectedFieldType = fieldTypeFor(fields, selectedField);
 
                   return (
-                    <HighlightingColorForm name={name} field={selectedFieldType} value={value} onChange={onChange} />
+                    <HighlightingColorForm name={name} field={selectedFieldType} value={value} onChange={onChange} error={meta?.error} />
                   );
                 } }
               </Field>

--- a/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightForm.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightForm.tsx
@@ -73,11 +73,7 @@ type GradientColorObject = {
 };
 
 const colorToObject = (color: HighlightingColor | undefined): StaticColorObject | GradientColorObject => {
-  if (color === undefined) {
-    return undefined;
-  }
-
-  if (color.type === 'static') {
+  if (color?.type === 'static') {
     const { type, color: staticColor } = color as StaticColor;
 
     return {
@@ -86,7 +82,7 @@ const colorToObject = (color: HighlightingColor | undefined): StaticColorObject 
     };
   }
 
-  if (color.type === 'gradient') {
+  if (color?.type === 'gradient') {
     const { type, gradient, upper, lower } = color as GradientColor;
 
     return {
@@ -96,22 +92,22 @@ const colorToObject = (color: HighlightingColor | undefined): StaticColorObject 
       lower,
     };
   }
+
+  return undefined;
 };
 
 const colorFromObject = (color: StaticColorObject | GradientColorObject) => {
-  if (color === undefined) {
-    return undefined;
-  }
-
-  if (color.type === 'static') {
+  if (color?.type === 'static') {
     return StaticColor.create(color.color);
   }
 
-  if (color.type === 'gradient') {
+  if (color?.type === 'gradient') {
     const { gradient, lower, upper } = color;
 
     return GradientColor.create(gradient, lower, upper);
   }
+
+  return undefined;
 };
 
 const HighlightForm = ({ onClose, rule }: Props) => {

--- a/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightForm.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightForm.tsx
@@ -36,7 +36,6 @@ import HighlightingColorForm from 'views/components/sidebar/highlighting/Highlig
 import { FieldTypeMappingsList } from 'views/stores/FieldTypesStore';
 import { StaticColor } from 'views/logic/views/formatting/highlighting/HighlightingColor';
 import Series, { isFunction } from 'views/logic/aggregationbuilder/Series';
-import FieldType, { Properties } from 'views/logic/fieldtypes/FieldType';
 import inferTypeForSeries from 'views/logic/fieldtypes/InferTypeForSeries';
 
 type Props = {

--- a/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightingColorForm.test.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightingColorForm.test.tsx
@@ -18,19 +18,28 @@ import * as React from 'react';
 import { render, screen } from 'wrappedTestingLibrary';
 
 import HighlightingColorForm from 'views/components/sidebar/highlighting/HighlightingColorForm';
-import { StaticColor } from 'views/logic/views/formatting/highlighting/HighlightingColor';
+import { GradientColor, StaticColor } from 'views/logic/views/formatting/highlighting/HighlightingColor';
 import FieldTypeMapping from 'views/logic/fieldtypes/FieldTypeMapping';
 import FieldType, { Properties } from 'views/logic/fieldtypes/FieldType';
 
 describe('HighlightingColorForm', () => {
   const field = FieldTypeMapping.create('foo', FieldType.create('number', [Properties.Numeric]));
 
-  it('shows color picker for static color', async () => {
-    const color = StaticColor.create('#666666');
-    render(<HighlightingColorForm name="color" field={field} value={color} onChange={jest.fn()} />);
+  it('selects correct type for static color', async () => {
+    const staticColor = StaticColor.create('#666666');
+    render(<HighlightingColorForm name="color" field={field} value={staticColor} onChange={jest.fn()} />);
 
-    const typeInput = await screen.findByLabelText('Static Color');
+    const staticOption = await screen.findByLabelText('Static Color');
 
-    expect(typeInput).toBeChecked();
+    expect(staticOption).toBeChecked();
+  });
+
+  it('selects correct type for gradient', async () => {
+    const gradientColor = GradientColor.create('Viridis', 0, 100);
+    render(<HighlightingColorForm name="color" field={field} value={gradientColor} onChange={jest.fn()} />);
+
+    const gradientOption = await screen.findByLabelText('Gradient');
+
+    expect(gradientOption).toBeChecked();
   });
 });

--- a/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightingColorForm.test.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightingColorForm.test.tsx
@@ -14,26 +14,19 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import PropTypes from 'prop-types';
-import React from 'react';
+import * as React from 'react';
+import { render, screen } from 'wrappedTestingLibrary';
 
-class InputWrapper extends React.Component {
-  static propTypes = {
-    className: PropTypes.string,
-    children: PropTypes.node.isRequired,
-  };
+import HighlightingColorForm from 'views/components/sidebar/highlighting/HighlightingColorForm';
+import { StaticColor } from 'views/logic/views/formatting/highlighting/HighlightingColor';
 
-  static defaultProps = {
-    className: undefined,
-  };
+describe('HighlightingColorForm', () => {
+  it('shows color picker for static color', async () => {
+    const color = StaticColor.create('#666666');
+    render(<HighlightingColorForm name="color" value={color} onChange={jest.fn()} />);
 
-  render() {
-    if (this.props.className) {
-      return <div className={this.props.className}>{this.props.children}</div>;
-    }
+    const typeInput = await screen.findByLabelText('Static Color');
 
-    return <span>{this.props.children}</span>;
-  }
-}
-
-export default InputWrapper;
+    expect(typeInput).toBeChecked();
+  });
+});

--- a/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightingColorForm.test.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightingColorForm.test.tsx
@@ -16,7 +16,7 @@
  */
 import * as React from 'react';
 import { render, screen, waitFor } from 'wrappedTestingLibrary';
-import userEvent from '@testing-library/user-event';
+import { Formik } from 'formik';
 
 import HighlightingColorForm from 'views/components/sidebar/highlighting/HighlightingColorForm';
 import { GradientColor, StaticColor } from 'views/logic/views/formatting/highlighting/HighlightingColor';
@@ -26,9 +26,16 @@ import FieldType, { Properties } from 'views/logic/fieldtypes/FieldType';
 describe('HighlightingColorForm', () => {
   const field = FieldTypeMapping.create('foo', FieldType.create('number', [Properties.Numeric]));
 
+  // eslint-disable-next-line react/prop-types
+  const SimpleForm = ({ value = undefined, ...rest }) => (
+    <Formik initialValues={{ color: value }} onSubmit={() => {}}>
+      <HighlightingColorForm field={field} {...rest} />
+    </Formik>
+  );
+
   it('selects correct type for static color', async () => {
     const staticColor = StaticColor.create('#666666');
-    render(<HighlightingColorForm name="color" field={field} value={staticColor} onChange={jest.fn()} />);
+    render(<SimpleForm value={staticColor} />);
 
     const staticOption = await screen.findByLabelText('Static Color');
 
@@ -37,7 +44,7 @@ describe('HighlightingColorForm', () => {
 
   it('selects correct type for gradient', async () => {
     const gradientColor = GradientColor.create('Viridis', 0, 100);
-    render(<HighlightingColorForm name="color" field={field} value={gradientColor} onChange={jest.fn()} />);
+    render(<SimpleForm value={gradientColor} />);
 
     const gradientOption = await screen.findByLabelText('Gradient');
 
@@ -47,7 +54,7 @@ describe('HighlightingColorForm', () => {
   });
 
   it('should not select a type if none is present', async () => {
-    render(<HighlightingColorForm name="color" field={field} value={undefined} onChange={jest.fn()} />);
+    render(<SimpleForm />);
     const staticOption = await screen.findByLabelText('Static Color');
 
     expect(staticOption).not.toBeChecked();
@@ -60,7 +67,7 @@ describe('HighlightingColorForm', () => {
   it('disables gradient option for non-numeric types', async () => {
     const nonNumericField = FieldTypeMapping.create('foo', FieldType.create('string', []));
 
-    render(<HighlightingColorForm name="color" field={nonNumericField} value={undefined} onChange={jest.fn()} />);
+    render(<SimpleForm field={nonNumericField} />);
     const staticOption = await screen.findByLabelText('Static Color');
 
     expect(staticOption).not.toBeDisabled();
@@ -68,31 +75,5 @@ describe('HighlightingColorForm', () => {
     const gradientOption = await screen.findByLabelText('Gradient');
 
     expect(gradientOption).toBeDisabled();
-  });
-
-  it('assigns a new static color when type is selected', async () => {
-    const onChange = jest.fn();
-    render(<HighlightingColorForm name="color" field={field} value={undefined} onChange={onChange} />);
-    userEvent.click(screen.getByLabelText('Static Color'));
-
-    await waitFor(() => expect(onChange).toHaveBeenCalledWith(expect.objectContaining({
-      target: expect.objectContaining({
-        name: 'color',
-        value: expect.objectContaining({ color: expect.any(String) }),
-      }),
-    })));
-  });
-
-  it('creates a new gradient when type is selected', async () => {
-    const onChange = jest.fn();
-    render(<HighlightingColorForm name="color" field={field} value={undefined} onChange={onChange} />);
-    userEvent.click(screen.getByLabelText('Gradient'));
-
-    await waitFor(() => expect(onChange).toHaveBeenCalledWith(expect.objectContaining({
-      target: expect.objectContaining({
-        name: 'color',
-        value: expect.objectContaining({ gradient: 'Viridis' }),
-      }),
-    })));
   });
 });

--- a/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightingColorForm.test.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightingColorForm.test.tsx
@@ -19,11 +19,15 @@ import { render, screen } from 'wrappedTestingLibrary';
 
 import HighlightingColorForm from 'views/components/sidebar/highlighting/HighlightingColorForm';
 import { StaticColor } from 'views/logic/views/formatting/highlighting/HighlightingColor';
+import FieldTypeMapping from 'views/logic/fieldtypes/FieldTypeMapping';
+import FieldType, { Properties } from 'views/logic/fieldtypes/FieldType';
 
 describe('HighlightingColorForm', () => {
+  const field = FieldTypeMapping.create('foo', FieldType.create('number', [Properties.Numeric]));
+
   it('shows color picker for static color', async () => {
     const color = StaticColor.create('#666666');
-    render(<HighlightingColorForm name="color" value={color} onChange={jest.fn()} />);
+    render(<HighlightingColorForm name="color" field={field} value={color} onChange={jest.fn()} />);
 
     const typeInput = await screen.findByLabelText('Static Color');
 

--- a/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightingColorForm.test.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightingColorForm.test.tsx
@@ -15,7 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { render, screen, waitFor } from 'wrappedTestingLibrary';
+import { render, screen } from 'wrappedTestingLibrary';
 import { Formik } from 'formik';
 
 import HighlightingColorForm from 'views/components/sidebar/highlighting/HighlightingColorForm';

--- a/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightingColorForm.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightingColorForm.tsx
@@ -43,7 +43,7 @@ type Props = {
   field: FieldTypeMapping,
   value: HighlightingColor,
   onChange: (e: ChangeEvent) => void,
-  error: string | undefined,
+  error?: string,
 };
 
 const StaticColorPicker = ({ name, value, onChange }: { name: string, value: StaticColor, onChange: (newColor: HighlightingColor) => void}) => (
@@ -154,6 +154,10 @@ const HighlightingColorForm = ({ name, field, value, onChange, error }: Props) =
       {value && <ColorForm color={value} onChange={_onChange} name={name} />}
     </>
   );
+};
+
+HighlightingColorForm.defaultProps = {
+  error: undefined,
 };
 
 export default HighlightingColorForm;

--- a/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightingColorForm.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightingColorForm.tsx
@@ -112,6 +112,10 @@ const ColorForm = ({ color, name, onChange }: { color: HighlightingColor, name: 
   }
 };
 
+const Container = styled.div`
+  margin-left: 10px;
+`;
+
 const HighlightingColorForm = ({ name, value, onChange }: Props) => {
   const onChangeType = useCallback(({ target: { value: newValue } }) => onChange({ target: { name, value: createNewColor(newValue) } }), [name, onChange]);
   const _onChange = useCallback((newColor: HighlightingColor) => onChange({ target: { name, value: newColor } }), [name, onChange]);
@@ -120,20 +124,22 @@ const HighlightingColorForm = ({ name, value, onChange }: Props) => {
     <>
       <Input id={name}
              label="Color">
-        <Input checked={value?.type === 'static'}
-               formGroupClassName=""
-               id={name}
-               label="Static Color"
-               onChange={onChangeType}
-               type="radio"
-               value="static" />
-        <Input checked={value?.type === 'gradient'}
-               formGroupClassName=""
-               id={name}
-               label="Gradient"
-               onChange={onChangeType}
-               type="radio"
-               value="gradient" />
+        <Container>
+          <Input checked={value?.type === 'static'}
+                 formGroupClassName=""
+                 id={name}
+                 label="Static Color"
+                 onChange={onChangeType}
+                 type="radio"
+                 value="static" />
+          <Input checked={value?.type === 'gradient'}
+                 formGroupClassName=""
+                 id={name}
+                 label="Gradient"
+                 onChange={onChangeType}
+                 type="radio"
+                 value="gradient" />
+        </Container>
       </Input>
       <ColorForm color={value} onChange={_onChange} name={name} />
     </>

--- a/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightingColorForm.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightingColorForm.tsx
@@ -28,6 +28,7 @@ import HighlightingColor, {
 } from 'views/logic/views/formatting/highlighting/HighlightingColor';
 import { COLORSCALES } from 'views/logic/aggregationbuilder/visualizations/HeatmapVisualizationConfig';
 import { defaultCompare } from 'views/logic/DefaultCompare';
+import FieldTypeMapping from 'views/logic/fieldtypes/FieldTypeMapping';
 
 type ChangeEvent = {
   target: {
@@ -38,6 +39,7 @@ type ChangeEvent = {
 
 type Props = {
   name: string,
+  field: FieldTypeMapping,
   value: HighlightingColor,
   onChange: (e: ChangeEvent) => void,
 };
@@ -116,9 +118,12 @@ const Container = styled.div`
   margin-left: 10px;
 `;
 
-const HighlightingColorForm = ({ name, value, onChange }: Props) => {
+const HighlightingColorForm = ({ name, field, value, onChange }: Props) => {
   const onChangeType = useCallback(({ target: { value: newValue } }) => onChange({ target: { name, value: createNewColor(newValue) } }), [name, onChange]);
   const _onChange = useCallback((newColor: HighlightingColor) => onChange({ target: { name, value: newColor } }), [name, onChange]);
+
+  const isNumeric = field?.type?.isNumeric() ?? false;
+  const isDisabled = field === undefined;
 
   return (
     <>
@@ -128,6 +133,7 @@ const HighlightingColorForm = ({ name, value, onChange }: Props) => {
           <Input checked={value?.type === 'static'}
                  formGroupClassName=""
                  id={name}
+                 disabled={isDisabled}
                  label="Static Color"
                  onChange={onChangeType}
                  type="radio"
@@ -135,6 +141,7 @@ const HighlightingColorForm = ({ name, value, onChange }: Props) => {
           <Input checked={value?.type === 'gradient'}
                  formGroupClassName=""
                  id={name}
+                 disabled={isDisabled || !isNumeric}
                  label="Gradient"
                  onChange={onChangeType}
                  type="radio"

--- a/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightingColorForm.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightingColorForm.tsx
@@ -75,21 +75,21 @@ const GradientColorPicker = ({ name, value, onChange }: { name: string, value: G
 
   return (
     <>
-      <Input id={name}
+      <Input id={`${name}-name`}
              label="Gradient Name">
         <Select options={GRADIENTS}
                 inputProps={{ 'aria-label': 'Select gradient colors' }}
                 value={value.gradient}
                 onChange={_onChangeGradient} />
       </Input>
-      <Input id={name}
+      <Input id={`${name}-lowest`}
              label="Lowest Value"
              type="number"
              value={value.lower}
              onChange={_onChangeLower}
              help="The lowest value expected in the field/series."
              required />
-      <Input id={name}
+      <Input id={`${name}-highest`}
              label="Highest Value"
              type="number"
              value={value.upper}
@@ -129,13 +129,13 @@ const HighlightingColorForm = ({ name, field, value, onChange, error }: Props) =
 
   return (
     <>
-      <Input id={name}
+      <Input id={`${name}-coloring`}
              label="Coloring"
              error={error}>
         <Container>
           <Input checked={value?.type === 'static'}
                  formGroupClassName=""
-                 id={name}
+                 id={`${name}-static`}
                  disabled={isDisabled}
                  label="Static Color"
                  onChange={onChangeType}
@@ -143,7 +143,7 @@ const HighlightingColorForm = ({ name, field, value, onChange, error }: Props) =
                  value="static" />
           <Input checked={value?.type === 'gradient'}
                  formGroupClassName=""
-                 id={name}
+                 id={`${name}-gradient`}
                  disabled={isDisabled || !isNumeric}
                  label="Gradient"
                  onChange={onChangeType}

--- a/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightingColorForm.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightingColorForm.tsx
@@ -61,7 +61,7 @@ const StaticColorPicker = ({ name, value, onChange }: { name: string, value: Sta
 );
 
 const OptionContainer = styled.div`
-  display: flex
+  display: flex;
 `;
 const createOption = (name) => ({ label: <OptionContainer><GradientColorPreview gradient={name} />{name}</OptionContainer>, value: name });
 

--- a/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightingColorForm.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightingColorForm.tsx
@@ -75,7 +75,7 @@ const GradientColorPicker = ({ name, value, onChange }: { name: string, value: G
   return (
     <>
       <Input id={name}
-             label="Gradient">
+             label="Gradient Name">
         <Select options={GRADIENTS}
                 value={value.gradient}
                 onChange={_onChangeGradient} />

--- a/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightingColorForm.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightingColorForm.tsx
@@ -43,6 +43,7 @@ type Props = {
   field: FieldTypeMapping,
   value: HighlightingColor,
   onChange: (e: ChangeEvent) => void,
+  error?: string,
 };
 
 const StaticColorPicker = ({ name, value, onChange }: { name: string, value: StaticColor, onChange: (newColor: HighlightingColor) => void}) => (
@@ -119,7 +120,7 @@ const Container = styled.div`
   margin-left: 10px;
 `;
 
-const HighlightingColorForm = ({ name, field, value, onChange }: Props) => {
+const HighlightingColorForm = ({ name, field, value, onChange, error }: Props) => {
   const onChangeType = useCallback(({ target: { value: newValue } }) => onChange({ target: { name, value: createNewColor(newValue) } }), [name, onChange]);
   const _onChange = useCallback((newColor: HighlightingColor) => onChange({ target: { name, value: newColor } }), [name, onChange]);
 
@@ -129,7 +130,8 @@ const HighlightingColorForm = ({ name, field, value, onChange }: Props) => {
   return (
     <>
       <Input id={name}
-             label="Color">
+             label="Coloring"
+             error={error}>
         <Container>
           <Input checked={value?.type === 'static'}
                  formGroupClassName=""

--- a/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightingColorForm.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightingColorForm.tsx
@@ -43,7 +43,7 @@ type Props = {
   field: FieldTypeMapping,
   value: HighlightingColor,
   onChange: (e: ChangeEvent) => void,
-  error?: string,
+  error: string | undefined,
 };
 
 const StaticColorPicker = ({ name, value, onChange }: { name: string, value: StaticColor, onChange: (newColor: HighlightingColor) => void}) => (

--- a/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightingColorForm.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightingColorForm.tsx
@@ -77,6 +77,7 @@ const GradientColorPicker = ({ name, value, onChange }: { name: string, value: G
       <Input id={name}
              label="Gradient Name">
         <Select options={GRADIENTS}
+                inputProps={{ 'aria-label': 'Select gradient colors' }}
                 value={value.gradient}
                 onChange={_onChangeGradient} />
       </Input>

--- a/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightingColorForm.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightingColorForm.tsx
@@ -29,6 +29,7 @@ import HighlightingColor, {
 import { COLORSCALES } from 'views/logic/aggregationbuilder/visualizations/HeatmapVisualizationConfig';
 import { defaultCompare } from 'views/logic/DefaultCompare';
 import FieldTypeMapping from 'views/logic/fieldtypes/FieldTypeMapping';
+import { randomColor } from 'views/logic/views/formatting/highlighting/HighlightingRule';
 
 type ChangeEvent = {
   target: {
@@ -100,9 +101,8 @@ const GradientColorPicker = ({ name, value, onChange }: { name: string, value: G
 const createNewColor = (type: 'static' | 'gradient') => {
   switch (type) {
     case 'gradient': return GradientColor.create('Viridis', 0, 0);
-    case 'static':
-    default:
-      return StaticColor.create('#dddddd');
+    case 'static': return randomColor();
+    default: throw new Error(`Invalid color type: ${type}`);
   }
 };
 
@@ -148,7 +148,7 @@ const HighlightingColorForm = ({ name, field, value, onChange }: Props) => {
                  value="gradient" />
         </Container>
       </Input>
-      <ColorForm color={value} onChange={_onChange} name={name} />
+      {value && <ColorForm color={value} onChange={_onChange} name={name} />}
     </>
   );
 };

--- a/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightingColorForm.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightingColorForm.tsx
@@ -17,48 +17,44 @@
 import * as React from 'react';
 import { useCallback } from 'react';
 import styled from 'styled-components';
+import { trim } from 'lodash';
+import { Field, useFormikContext } from 'formik';
 
 import { Input } from 'components/bootstrap';
 import { ColorPickerPopover, Select } from 'components/common';
 import { DEFAULT_CUSTOM_HIGHLIGHT_RANGE } from 'views/Constants';
 import ColorPreview, { GradientColorPreview } from 'views/components/sidebar/highlighting/ColorPreview';
-import HighlightingColor, {
-  GradientColor,
-  StaticColor,
-} from 'views/logic/views/formatting/highlighting/HighlightingColor';
+import { StaticColor } from 'views/logic/views/formatting/highlighting/HighlightingColor';
 import { COLORSCALES } from 'views/logic/aggregationbuilder/visualizations/HeatmapVisualizationConfig';
 import { defaultCompare } from 'views/logic/DefaultCompare';
 import FieldTypeMapping from 'views/logic/fieldtypes/FieldTypeMapping';
-import { randomColor } from 'views/logic/views/formatting/highlighting/HighlightingRule';
-
-type ChangeEvent = {
-  target: {
-    name: string,
-    value: HighlightingColor,
-  },
-};
 
 type Props = {
-  name: string,
   field: FieldTypeMapping,
-  value: HighlightingColor,
-  onChange: (e: ChangeEvent) => void,
-  error?: string,
 };
 
-const StaticColorPicker = ({ name, value, onChange }: { name: string, value: StaticColor, onChange: (newColor: HighlightingColor) => void}) => (
-  <Input id={name}
-         label="Color">
-    <ColorPickerPopover id="formatting-rule-color"
-                        placement="right"
-                        color={value.color}
-                        colors={DEFAULT_CUSTOM_HIGHLIGHT_RANGE.map((c) => [c])}
-                        triggerNode={<ColorPreview color={value} />}
-                        onChange={(newColor, _, hidePopover) => {
-                          hidePopover();
-                          onChange(StaticColor.create(newColor));
-                        }} />
-  </Input>
+type ColorPickerProps = {
+  type: string,
+};
+
+const StaticColorPicker = () => (
+  <Field name="color.color">
+    {({ field: { name, value, onChange }, meta }) => (
+      <Input id={name}
+             error={meta?.error}
+             label="Color">
+        <ColorPickerPopover id="formatting-rule-color"
+                            placement="right"
+                            color={value}
+                            colors={DEFAULT_CUSTOM_HIGHLIGHT_RANGE.map((c) => [c])}
+                            triggerNode={<ColorPreview color={StaticColor.create(value)} />}
+                            onChange={(newColor, _, hidePopover) => {
+                              hidePopover();
+                              onChange({ target: { name, value: newColor } });
+                            }} />
+      </Input>
+    )}
+  </Field>
 );
 
 const OptionContainer = styled.div`
@@ -68,50 +64,91 @@ const createOption = (name) => ({ label: <OptionContainer><GradientColorPreview 
 
 const GRADIENTS = COLORSCALES.sort(defaultCompare).map(createOption);
 
-const GradientColorPicker = ({ name, value, onChange }: { name: string, value: GradientColor, onChange: (newColor: GradientColor) => void}) => {
-  const _onChangeGradient = useCallback((newGradient) => onChange(value.withGradient(newGradient)), [onChange, value]);
-  const _onChangeLower = useCallback(({ target: { value: newLower } }) => onChange(value.withLower(newLower)), [onChange, value]);
-  const _onChangeUpper = useCallback(({ target: { value: newUpper } }) => onChange(value.withUpper(newUpper)), [onChange, value]);
+type ColorErrors = Record<string, string>;
 
+const numericRegex = /^-?[0-9]+$/;
+
+const validateColor = (values) => {
+  const errors: ColorErrors = {};
+
+  if (values?.type === 'gradient') {
+    if (trim(values?.gradient) === '') {
+      errors.gradient = 'Must be selected.';
+    }
+
+    if (trim(values?.lower) === '') {
+      errors.lower = 'Must be present.';
+    } else if (!numericRegex.test(values?.lower)) {
+      errors.lower = 'Must be a number.';
+    }
+
+    if (trim(values?.upper) === '') {
+      errors.upper = 'Must be present.';
+    } else if (!numericRegex.test(values?.upper)) {
+      errors.upper = 'Must be a number.';
+    }
+
+    if (values?.upper <= values?.lower) {
+      errors.upper = 'Must be higher than lowest value.';
+    }
+  }
+
+  return Object.keys(errors).length > 0 ? errors : undefined;
+};
+
+const GradientColorPicker = () => {
   return (
-    <>
-      <Input id={`${name}-name`}
-             label="Gradient Name">
-        <Select options={GRADIENTS}
-                inputProps={{ 'aria-label': 'Select gradient colors' }}
-                value={value.gradient}
-                onChange={_onChangeGradient} />
-      </Input>
-      <Input id={`${name}-lowest`}
-             label="Lowest Value"
-             type="number"
-             value={value.lower}
-             onChange={_onChangeLower}
-             help="The lowest value expected in the field/series."
-             required />
-      <Input id={`${name}-highest`}
-             label="Highest Value"
-             type="number"
-             value={value.upper}
-             onChange={_onChangeUpper}
-             help="The highest value expected in the field/series."
-             required />
-    </>
+    <Field name="color" validate={validateColor}>
+      {() => (
+        <>
+          <Field name="color.gradient">
+            {({ field: { name, value, onChange }, meta }) => (
+              <Input id={`${name}-name`}
+                     error={meta?.error}
+                     label="Gradient Name">
+                <Select options={GRADIENTS}
+                        inputProps={{ 'aria-label': 'Select gradient colors' }}
+                        value={value}
+                        onChange={(newGradient) => onChange({ target: { name, value: newGradient } })} />
+              </Input>
+            )}
+          </Field>
+          <Field name="color.lower">
+            {({ field: { name, value, onChange }, meta }) => (
+              <Input id={name}
+                     aria-label="Specify lowest value"
+                     label="Lowest Value"
+                     type="number"
+                     value={value}
+                     error={meta?.error}
+                     onChange={onChange}
+                     help="The lowest value expected in the field/series."
+                     required />
+            )}
+          </Field>
+          <Field name="color.upper">
+            {({ field: { name, value, onChange }, meta }) => (
+              <Input id={name}
+                     aria-label="Specify highest value"
+                     label="Highest Value"
+                     type="number"
+                     value={value}
+                     error={meta?.error}
+                     onChange={onChange}
+                     help="The highest value expected in the field/series."
+                     required />
+            )}
+          </Field>
+        </>
+      )}
+    </Field>
   );
 };
 
-const createNewColor = (type: 'static' | 'gradient') => {
+const ColorForm = ({ type }: ColorPickerProps) => {
   switch (type) {
-    case 'gradient': return GradientColor.create('Viridis', 0, 0);
-    case 'static': return randomColor();
-    default: throw new Error(`Invalid color type: ${type}`);
-  }
-};
-
-const ColorForm = ({ color, name, onChange }: { color: HighlightingColor, name: string, onChange: (newColor: HighlightingColor) => void }) => {
-  switch (color.type) {
-    case 'static': return <StaticColorPicker value={color as StaticColor} name={name} onChange={onChange} />;
-    case 'gradient': return <GradientColorPicker value={color as GradientColor} name={name} onChange={onChange} />;
+    case 'static': return <StaticColorPicker />;
+    case 'gradient': return <GradientColorPicker />;
     default: return null;
   }
 };
@@ -120,44 +157,74 @@ const Container = styled.div`
   margin-left: 10px;
 `;
 
-const HighlightingColorForm = ({ name, field, value, onChange, error }: Props) => {
-  const onChangeType = useCallback(({ target: { value: newValue } }) => onChange({ target: { name, value: createNewColor(newValue) } }), [name, onChange]);
-  const _onChange = useCallback((newColor: HighlightingColor) => onChange({ target: { name, value: newColor } }), [name, onChange]);
+const _typeIsRequired = () => {};
 
+const randomColor = () => DEFAULT_CUSTOM_HIGHLIGHT_RANGE[
+  Math.floor(Math.random() * DEFAULT_CUSTOM_HIGHLIGHT_RANGE.length)
+];
+
+const createNewColor = (newType: string) => {
+  if (newType === 'static') {
+    return {
+      type: 'static',
+      color: randomColor(),
+    };
+  }
+
+  if (newType === 'gradient') {
+    return {
+      type: 'gradient',
+      gradient: 'Viridis',
+      upper: 0,
+      lower: 0,
+    };
+  }
+
+  throw new Error(`Invalid color type: ${newType}`);
+};
+
+const HighlightingColorForm = ({ field }: Props) => {
   const isNumeric = field?.type?.isNumeric() ?? false;
   const isDisabled = field === undefined;
 
-  return (
-    <>
-      <Input id={`${name}-coloring`}
-             label="Coloring"
-             error={error}>
-        <Container>
-          <Input checked={value?.type === 'static'}
-                 formGroupClassName=""
-                 id={`${name}-static`}
-                 disabled={isDisabled}
-                 label="Static Color"
-                 onChange={onChangeType}
-                 type="radio"
-                 value="static" />
-          <Input checked={value?.type === 'gradient'}
-                 formGroupClassName=""
-                 id={`${name}-gradient`}
-                 disabled={isDisabled || !isNumeric}
-                 label="Gradient"
-                 onChange={onChangeType}
-                 type="radio"
-                 value="gradient" />
-        </Container>
-      </Input>
-      {value && <ColorForm color={value} onChange={_onChange} name={name} />}
-    </>
-  );
-};
+  const { setFieldValue } = useFormikContext();
 
-HighlightingColorForm.defaultProps = {
-  error: undefined,
+  const onChangeType = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const { target: { value: newType } } = e;
+    setFieldValue('color', createNewColor(newType));
+  }, [setFieldValue]);
+
+  return (
+    <Field name="color.type" validate={_typeIsRequired}>
+      {({ field: { name, value } }, meta) => (
+        <>
+          <Input id={`${name}-coloring`}
+                 label="Coloring"
+                 error={meta?.error}>
+            <Container>
+              <Input checked={value === 'static'}
+                     formGroupClassName=""
+                     id={name}
+                     disabled={isDisabled}
+                     label="Static Color"
+                     onChange={onChangeType}
+                     type="radio"
+                     value="static" />
+              <Input checked={value === 'gradient'}
+                     formGroupClassName=""
+                     id={name}
+                     disabled={isDisabled || !isNumeric}
+                     label="Gradient"
+                     onChange={onChangeType}
+                     type="radio"
+                     value="gradient" />
+            </Container>
+          </Input>
+          {value && <ColorForm type={value} />}
+        </>
+      )}
+    </Field>
+  );
 };
 
 export default HighlightingColorForm;

--- a/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightingColorForm.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightingColorForm.tsx
@@ -1,0 +1,143 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import { useCallback } from 'react';
+import styled from 'styled-components';
+
+import { Input } from 'components/bootstrap';
+import { ColorPickerPopover, Select } from 'components/common';
+import { DEFAULT_CUSTOM_HIGHLIGHT_RANGE } from 'views/Constants';
+import ColorPreview, { GradientColorPreview } from 'views/components/sidebar/highlighting/ColorPreview';
+import HighlightingColor, {
+  GradientColor,
+  StaticColor,
+} from 'views/logic/views/formatting/highlighting/HighlightingColor';
+import { COLORSCALES } from 'views/logic/aggregationbuilder/visualizations/HeatmapVisualizationConfig';
+import { defaultCompare } from 'views/logic/DefaultCompare';
+
+type ChangeEvent = {
+  target: {
+    name: string,
+    value: HighlightingColor,
+  },
+};
+
+type Props = {
+  name: string,
+  value: HighlightingColor,
+  onChange: (e: ChangeEvent) => void,
+};
+
+const StaticColorPicker = ({ name, value, onChange }: { name: string, value: StaticColor, onChange: (newColor: HighlightingColor) => void}) => (
+  <Input id={name}
+         label="Color">
+    <ColorPickerPopover id="formatting-rule-color"
+                        placement="right"
+                        color={value.color}
+                        colors={DEFAULT_CUSTOM_HIGHLIGHT_RANGE.map((c) => [c])}
+                        triggerNode={<ColorPreview color={value} />}
+                        onChange={(newColor, _, hidePopover) => {
+                          hidePopover();
+                          onChange(StaticColor.create(newColor));
+                        }} />
+  </Input>
+);
+
+const OptionContainer = styled.div`
+  display: flex
+`;
+const createOption = (name) => ({ label: <OptionContainer><GradientColorPreview gradient={name} />{name}</OptionContainer>, value: name });
+
+const GRADIENTS = COLORSCALES.sort(defaultCompare).map(createOption);
+
+const GradientColorPicker = ({ name, value, onChange }: { name: string, value: GradientColor, onChange: (newColor: GradientColor) => void}) => {
+  const _onChangeGradient = useCallback((newGradient) => onChange(value.withGradient(newGradient)), [onChange, value]);
+  const _onChangeLower = useCallback(({ target: { value: newLower } }) => onChange(value.withLower(newLower)), [onChange, value]);
+  const _onChangeUpper = useCallback(({ target: { value: newUpper } }) => onChange(value.withUpper(newUpper)), [onChange, value]);
+
+  return (
+    <>
+      <Input id={name}
+             label="Gradient">
+        <Select options={GRADIENTS}
+                value={value.gradient}
+                onChange={_onChangeGradient} />
+      </Input>
+      <Input id={name}
+             label="Lowest Value"
+             type="number"
+             value={value.lower}
+             onChange={_onChangeLower}
+             help="The lowest value expected in the field/series."
+             required />
+      <Input id={name}
+             label="Highest Value"
+             type="number"
+             value={value.upper}
+             onChange={_onChangeUpper}
+             help="The highest value expected in the field/series."
+             required />
+    </>
+  );
+};
+
+const createNewColor = (type: 'static' | 'gradient') => {
+  switch (type) {
+    case 'gradient': return GradientColor.create('Viridis', 0, 0);
+    case 'static':
+    default:
+      return StaticColor.create('#dddddd');
+  }
+};
+
+const ColorForm = ({ color, name, onChange }: { color: HighlightingColor, name: string, onChange: (newColor: HighlightingColor) => void }) => {
+  switch (color.type) {
+    case 'static': return <StaticColorPicker value={color as StaticColor} name={name} onChange={onChange} />;
+    case 'gradient': return <GradientColorPicker value={color as GradientColor} name={name} onChange={onChange} />;
+    default: return null;
+  }
+};
+
+const HighlightingColorForm = ({ name, value, onChange }: Props) => {
+  const onChangeType = useCallback(({ target: { value: newValue } }) => onChange({ target: { name, value: createNewColor(newValue) } }), [name, onChange]);
+  const _onChange = useCallback((newColor: HighlightingColor) => onChange({ target: { name, value: newColor } }), [name, onChange]);
+
+  return (
+    <>
+      <Input id={name}
+             label="Color">
+        <Input checked={value?.type === 'static'}
+               formGroupClassName=""
+               id={name}
+               label="Static Color"
+               onChange={onChangeType}
+               type="radio"
+               value="static" />
+        <Input checked={value?.type === 'gradient'}
+               formGroupClassName=""
+               id={name}
+               label="Gradient"
+               onChange={onChangeType}
+               type="radio"
+               value="gradient" />
+      </Input>
+      <ColorForm color={value} onChange={_onChange} name={name} />
+    </>
+  );
+};
+
+export default HighlightingColorForm;

--- a/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightingRule.test.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightingRule.test.tsx
@@ -55,7 +55,7 @@ describe('HighlightingRule', () => {
           .field('response_time')
           .value('250')
           .color(StaticColor.create('#f44242'))
-          .build(), { color: '#416af4' });
+          .build(), { color: StaticColor.create('#416af4') });
     });
   });
 

--- a/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightingRule.test.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightingRule.test.tsx
@@ -21,6 +21,7 @@ import mockAction from 'helpers/mocking/MockAction';
 
 import Rule from 'views/logic/views/formatting/highlighting/HighlightingRule';
 import { HighlightingRulesActions } from 'views/stores/HighlightingRulesStore';
+import { StaticColor } from 'views/logic/views/formatting/highlighting/HighlightingColor';
 
 import HighlightingRule from './HighlightingRule';
 
@@ -32,7 +33,7 @@ type ColorPickerProps = HTMLAttributes & {
 };
 
 describe('HighlightingRule', () => {
-  const rule = Rule.create('response_time', '250', undefined, '#f44242');
+  const rule = Rule.create('response_time', '250', undefined, StaticColor.create('#f44242'));
 
   it('should display field and value of rule', () => {
     const wrapper = mount(<HighlightingRule rule={rule} />);
@@ -53,7 +54,7 @@ describe('HighlightingRule', () => {
         .toHaveBeenCalledWith(Rule.builder()
           .field('response_time')
           .value('250')
-          .color('#f44242')
+          .color(StaticColor.create('#f44242'))
           .build(), { color: '#416af4' });
     });
   });

--- a/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightingRule.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightingRule.tsx
@@ -15,15 +15,16 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
 import { HighlightingRulesActions } from 'views/stores/HighlightingRulesStore';
 import { DEFAULT_CUSTOM_HIGHLIGHT_RANGE } from 'views/Constants';
 import Rule, { ConditionLabelMap } from 'views/logic/views/formatting/highlighting/HighlightingRule';
-import { ColorPickerPopover, IconButton } from 'components/common';
+import { ColorPicker, ColorPickerPopover, IconButton } from 'components/common';
 import HighlightForm from 'views/components/sidebar/highlighting/HighlightForm';
+import HighlightingColor, { StaticColor } from 'views/logic/views/formatting/highlighting/HighlightingColor';
 
 import ColorPreview from './ColorPreview';
 
@@ -63,7 +64,7 @@ type Props = {
   rule: Rule,
 };
 
-const updateColor = (rule, newColor, hidePopover) => {
+const updateColor = (rule: Rule, newColor: HighlightingColor, hidePopover: () => void) => {
   return HighlightingRulesActions.update(rule, { color: newColor }).then(hidePopover);
 };
 
@@ -74,25 +75,48 @@ const onDelete = (rule) => {
   }
 };
 
+type RuleColorPreviewProps = {
+  color: HighlightingColor,
+  onChange: (newColor: HighlightingColor, hidePopover: () => void) => void,
+};
+
+const RuleColorPreview = ({ color, onChange }: RuleColorPreviewProps) => {
+  const _onChange = useCallback((newColor, ignored, hidePopover) => onChange(StaticColor.create(newColor), hidePopover), [onChange]);
+
+  if (color.isStatic()) {
+    return (
+      <ColorPickerPopover id="formatting-rule-color"
+                          placement="right"
+                          color={color.color}
+                          colors={DEFAULT_CUSTOM_HIGHLIGHT_RANGE.map((c) => [c])}
+                          triggerNode={<ColorPreview color={color} />}
+                          onChange={_onChange} />
+    );
+  }
+
+  if (color.isGradient()) {
+    return <ColorPreview color={color} />;
+  }
+
+  throw new Error(`Invalid highlighting color: ${color}`);
+};
+
 const HighlightingRule = ({ rule }: Props) => {
   const { field, value, color, condition } = rule;
   const [showForm, setShowForm] = useState(false);
 
+  const _onChange = useCallback((newColor: HighlightingColor, hidePopover: () => void) => updateColor(rule, newColor, hidePopover), [rule]);
+
   return (
     <>
       <HighlightingRuleGrid>
-        <ColorPickerPopover id="formatting-rule-color"
-                            placement="right"
-                            color={color}
-                            colors={DEFAULT_CUSTOM_HIGHLIGHT_RANGE.map((c) => [c])}
-                            triggerNode={<ColorPreview color={color} />}
-                            onChange={(newColor, _, hidePopover) => updateColor(rule, newColor, hidePopover)} />
+        <RuleColorPreview color={color} onChange={_onChange} />
         <RuleContainer>
           <strong>{field}</strong> {ConditionLabelMap[condition]} <i>&quot;{String(value)}&quot;</i>.
         </RuleContainer>
         <ButtonContainer>
           <IconButton title="Edit this Highlighting Rule" name="edit" onClick={() => setShowForm(true)} />
-          <IconButton title="Remove this Highlighting Rule" name="trash" onClick={() => onDelete(rule)} />
+          <IconButton title="Remove this Highlighting Rule" name="trash-alt" onClick={() => onDelete(rule)} />
         </ButtonContainer>
       </HighlightingRuleGrid>
       { showForm && <HighlightForm onClose={() => setShowForm(false)} rule={rule} />}

--- a/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightingRule.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightingRule.tsx
@@ -22,7 +22,7 @@ import styled from 'styled-components';
 import { HighlightingRulesActions } from 'views/stores/HighlightingRulesStore';
 import { DEFAULT_CUSTOM_HIGHLIGHT_RANGE } from 'views/Constants';
 import Rule, { ConditionLabelMap } from 'views/logic/views/formatting/highlighting/HighlightingRule';
-import { ColorPicker, ColorPickerPopover, IconButton } from 'components/common';
+import { ColorPickerPopover, IconButton } from 'components/common';
 import HighlightForm from 'views/components/sidebar/highlighting/HighlightForm';
 import HighlightingColor, { StaticColor } from 'views/logic/views/formatting/highlighting/HighlightingColor';
 

--- a/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightingRules.test.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightingRules.test.tsx
@@ -19,6 +19,7 @@ import { mount } from 'wrappedEnzyme';
 
 import HighlightingRuleContext from 'views/components/contexts/HighlightingRulesContext';
 import HighlightingRule from 'views/logic/views/formatting/highlighting/HighlightingRule';
+import { StaticColor } from 'views/logic/views/formatting/highlighting/HighlightingColor';
 
 import HighlightingRules from './HighlightingRules';
 
@@ -43,8 +44,8 @@ describe('HighlightingRules', () => {
 
   it('renders element for each HighlightingRule', () => {
     const rules = [
-      HighlightingRule.create('foo', 'bar', undefined, '#f4f141'),
-      HighlightingRule.create('response_time', '250', undefined, '#f44242'),
+      HighlightingRule.create('foo', 'bar', undefined, StaticColor.create('#f4f141')),
+      HighlightingRule.create('response_time', '250', undefined, StaticColor.create('#f44242')),
     ];
     const wrapper = mount(
       <HighlightingRuleContext.Provider value={rules}>

--- a/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightingRules.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightingRules.tsx
@@ -20,7 +20,6 @@ import { useContext, useState } from 'react';
 import { DEFAULT_HIGHLIGHT_COLOR } from 'views/Constants';
 import HighlightingRulesContext from 'views/components/contexts/HighlightingRulesContext';
 import IconButton from 'components/common/IconButton';
-import { StaticColor } from 'views/logic/views/formatting/highlighting/HighlightingColor';
 
 import HighlightingRule, { HighlightingRuleGrid, RuleContainer } from './HighlightingRule';
 import ColorPreview from './ColorPreview';
@@ -28,8 +27,6 @@ import HighlightForm from './HighlightForm';
 
 import SectionInfo from '../SectionInfo';
 import SectionSubheadline from '../SectionSubheadline';
-
-const defaultHighlightingColor = StaticColor.create(DEFAULT_HIGHLIGHT_COLOR);
 
 const HighlightingRules = () => {
   const [showForm, setShowForm] = useState(false);
@@ -45,7 +42,7 @@ const HighlightingRules = () => {
       <SectionSubheadline>Active highlights <IconButton className="pull-right" name="plus" onClick={() => setShowForm(!showForm)} /> </SectionSubheadline>
       { showForm && <HighlightForm onClose={() => setShowForm(false)} />}
       <HighlightingRuleGrid>
-        <ColorPreview color={defaultHighlightingColor} />
+        <ColorPreview color={DEFAULT_HIGHLIGHT_COLOR} />
         <RuleContainer>Search terms</RuleContainer>
       </HighlightingRuleGrid>
       {rules.map((rule) => <HighlightingRule key={`${rule.field}-${rule.value}-${rule.color}-${rule.condition}`} rule={rule} />)}

--- a/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightingRules.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightingRules.tsx
@@ -20,6 +20,7 @@ import { useContext, useState } from 'react';
 import { DEFAULT_HIGHLIGHT_COLOR } from 'views/Constants';
 import HighlightingRulesContext from 'views/components/contexts/HighlightingRulesContext';
 import IconButton from 'components/common/IconButton';
+import { StaticColor } from 'views/logic/views/formatting/highlighting/HighlightingColor';
 
 import HighlightingRule, { HighlightingRuleGrid, RuleContainer } from './HighlightingRule';
 import ColorPreview from './ColorPreview';
@@ -27,6 +28,8 @@ import HighlightForm from './HighlightForm';
 
 import SectionInfo from '../SectionInfo';
 import SectionSubheadline from '../SectionSubheadline';
+
+const defaultHighlightingColor = StaticColor.create(DEFAULT_HIGHLIGHT_COLOR);
 
 const HighlightingRules = () => {
   const [showForm, setShowForm] = useState(false);
@@ -42,7 +45,7 @@ const HighlightingRules = () => {
       <SectionSubheadline>Active highlights <IconButton className="pull-right" name="plus" onClick={() => setShowForm(!showForm)} /> </SectionSubheadline>
       { showForm && <HighlightForm onClose={() => setShowForm(false)} />}
       <HighlightingRuleGrid>
-        <ColorPreview color={DEFAULT_HIGHLIGHT_COLOR} />
+        <ColorPreview color={defaultHighlightingColor} />
         <RuleContainer>Search terms</RuleContainer>
       </HighlightingRuleGrid>
       {rules.map((rule) => <HighlightingRule key={`${rule.field}-${rule.value}-${rule.color}-${rule.condition}`} rule={rule} />)}

--- a/graylog2-web-interface/src/views/components/sidebar/highlighting/Scale.ts
+++ b/graylog2-web-interface/src/views/components/sidebar/highlighting/Scale.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import { scales } from 'plotly.js/src/components/colorscale';
+import * as chroma from 'chroma-js';
+
+const plotlyScaleToChroma = (plotlyScale: Array<[domain: number, color: string]>) => {
+  const domains = plotlyScale.map(([domain]) => domain);
+  const colors = plotlyScale.map(([, color]) => color);
+
+  return chroma.scale(colors).domain(domains);
+};
+
+export const scaleForGradient = (gradient: string): chroma.Scale => {
+  switch (gradient) {
+    case 'Blackbody':
+    case 'Bluered':
+    case 'Cividis':
+    case 'Earth':
+    case 'Electric':
+    case 'Hot':
+    case 'Jet':
+    case 'Picnic':
+    case 'Portland':
+    case 'Rainbow': return plotlyScaleToChroma(scales[gradient]);
+    default: return chroma.scale(gradient);
+  }
+};

--- a/graylog2-web-interface/src/views/components/sidebar/highlighting/Scale.ts
+++ b/graylog2-web-interface/src/views/components/sidebar/highlighting/Scale.ts
@@ -24,7 +24,7 @@ const plotlyScaleToChroma = (plotlyScale: Array<[domain: number, color: string]>
   return chroma.scale(colors).domain(domains);
 };
 
-export const scaleForGradient = (gradient: string): chroma.Scale => {
+const scaleForGradient = (gradient: string): chroma.Scale => {
   switch (gradient) {
     case 'Blackbody':
     case 'Bluered':
@@ -39,3 +39,5 @@ export const scaleForGradient = (gradient: string): chroma.Scale => {
     default: return chroma.scale(gradient);
   }
 };
+
+export default scaleForGradient;

--- a/graylog2-web-interface/src/views/logic/aggregationbuilder/WidgetFormattingSettings.ts
+++ b/graylog2-web-interface/src/views/logic/aggregationbuilder/WidgetFormattingSettings.ts
@@ -17,8 +17,7 @@
 import * as Immutable from 'immutable';
 import { $PropertyType } from 'utility-types';
 
-import type { Color } from 'views/logic/views/formatting/highlighting/HighlightingRule';
-
+type Color = string;
 type ChartColors = { [key: string]: Color };
 
 type InternalState = {

--- a/graylog2-web-interface/src/views/logic/views/formatting/highlighting/HighlightingColor.ts
+++ b/graylog2-web-interface/src/views/logic/views/formatting/highlighting/HighlightingColor.ts
@@ -16,6 +16,8 @@
  */
 import * as chroma from 'chroma-js';
 
+import { scaleForGradient } from 'views/components/sidebar/highlighting/Scale';
+
 export type HighlightingColorJson = StaticColorJson | GradientColorJson;
 
 abstract class HighlightingColor {
@@ -122,7 +124,7 @@ export class GradientColor extends HighlightingColor {
     this._upper = upper;
     this._gradient = gradient;
 
-    this._scale = chroma.scale(gradient);
+    this._scale = scaleForGradient(gradient);
   }
 
   // eslint-disable-next-line class-methods-use-this
@@ -140,6 +142,10 @@ export class GradientColor extends HighlightingColor {
 
   get upper(): number {
     return this._upper;
+  }
+
+  get scale(): chroma.Scale {
+    return this._scale;
   }
 
   colorFor(value: any) {

--- a/graylog2-web-interface/src/views/logic/views/formatting/highlighting/HighlightingColor.ts
+++ b/graylog2-web-interface/src/views/logic/views/formatting/highlighting/HighlightingColor.ts
@@ -1,0 +1,178 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as chroma from 'chroma-js';
+
+export type HighlightingColorJson = StaticColorJson | GradientColorJson;
+
+abstract class HighlightingColor {
+  abstract get type(): 'static' | 'gradient';
+
+  static fromJSON(json: HighlightingColorJson) {
+    switch (json.type) {
+      // eslint-disable-next-line @typescript-eslint/no-use-before-define
+      case 'gradient': return GradientColor.fromJSON(json);
+      // eslint-disable-next-line @typescript-eslint/no-use-before-define
+      case 'static': return StaticColor.fromJSON(json);
+      default: // @ts-ignore
+        throw new Error(`Invalid highlighting color type: ${json.type}`);
+    }
+  }
+
+  abstract colorFor(value: any);
+}
+
+type StaticColorJson = {
+  type: 'static',
+  color: string,
+};
+
+export class StaticColor extends HighlightingColor {
+  private readonly _color: string;
+
+  private constructor(color: string) {
+    super();
+    this._color = color;
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  get type() {
+    return 'static' as const;
+  }
+
+  get color(): string {
+    return this._color;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  colorFor(value: any) {
+    return this.color;
+  }
+
+  static fromJSON({ color }: StaticColorJson) {
+    return new StaticColor(color);
+  }
+
+  static create(color: string) {
+    return new StaticColor(color);
+  }
+
+  toJSON() {
+    const { color } = this;
+
+    return {
+      type: 'static',
+      color,
+    };
+  }
+}
+
+type GradientColorJson = {
+  type: 'gradient',
+  gradient: string,
+  lower: number,
+  upper: number,
+}
+
+const parseValue = (value: any, defaultValue: number = 0): number => {
+  if (typeof value === 'number') {
+    return value as number;
+  }
+
+  try {
+    return Number.parseFloat(value);
+  } catch (ignored) {
+    return defaultValue;
+  }
+};
+
+export class GradientColor extends HighlightingColor {
+  private readonly _gradient: string;
+
+  private readonly _lower: number;
+
+  private readonly _upper: number;
+
+  private readonly _scale: chroma.Scale;
+
+  private constructor(gradient: string, lower: number, upper: number) {
+    super();
+    this._lower = lower;
+    this._upper = upper;
+    this._gradient = gradient;
+
+    this._scale = chroma.scale(gradient);
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  get type() {
+    return 'gradient' as const;
+  }
+
+  get gradient(): string {
+    return this._gradient;
+  }
+
+  get lower(): number {
+    return this._lower;
+  }
+
+  get upper(): number {
+    return this._upper;
+  }
+
+  colorFor(value: any) {
+    const parsedValue = parseValue(value, this.lower);
+
+    const spread = this.upper - this.lower;
+    const normalizedValue = Math.max(this.lower, Math.min(this.upper, parsedValue));
+
+    return this._scale((normalizedValue - this.lower) / spread);
+  }
+
+  static fromJSON({ gradient, lower, upper }: GradientColorJson) {
+    return new GradientColor(gradient, lower, upper);
+  }
+
+  static create(gradient: string, lower: number, upper: number) {
+    return new GradientColor(gradient, lower, upper);
+  }
+
+  withGradient(gradient: string) {
+    return GradientColor.create(gradient, this.lower, this.upper);
+  }
+
+  withLower(lower: number) {
+    return GradientColor.create(this.gradient, lower, this.upper);
+  }
+
+  withUpper(upper: number) {
+    return GradientColor.create(this.gradient, this.lower, upper);
+  }
+
+  toJSON() {
+    const { gradient, lower, upper } = this;
+
+    return {
+      type: 'gradient',
+      gradient,
+      lower,
+      upper,
+    };
+  }
+}
+
+export default HighlightingColor;

--- a/graylog2-web-interface/src/views/logic/views/formatting/highlighting/HighlightingColor.ts
+++ b/graylog2-web-interface/src/views/logic/views/formatting/highlighting/HighlightingColor.ts
@@ -16,7 +16,7 @@
  */
 import * as chroma from 'chroma-js';
 
-import { scaleForGradient } from 'views/components/sidebar/highlighting/Scale';
+import scaleForGradient from 'views/components/sidebar/highlighting/Scale';
 
 export type HighlightingColorJson = StaticColorJson | GradientColorJson;
 

--- a/graylog2-web-interface/src/views/logic/views/formatting/highlighting/HighlightingColor.ts
+++ b/graylog2-web-interface/src/views/logic/views/formatting/highlighting/HighlightingColor.ts
@@ -33,6 +33,14 @@ abstract class HighlightingColor {
   }
 
   abstract colorFor(value: any);
+
+  isStatic(): this is StaticColor {
+    return this.type === 'static';
+  }
+
+  isGradient(): this is GradientColor {
+    return this.type === 'gradient';
+  }
 }
 
 type StaticColorJson = {

--- a/graylog2-web-interface/src/views/logic/views/formatting/highlighting/HighlightingRule.ts
+++ b/graylog2-web-interface/src/views/logic/views/formatting/highlighting/HighlightingRule.ts
@@ -17,7 +17,10 @@
 import * as Immutable from 'immutable';
 
 import highlightConditionFunctions from 'views/logic/views/formatting/highlighting/highlightConditionFunctions';
-import HighlightingColor, { HighlightingColorJson } from 'views/logic/views/formatting/highlighting/HighlightingColor';
+import HighlightingColor, {
+  HighlightingColorJson,
+  StaticColor,
+} from 'views/logic/views/formatting/highlighting/HighlightingColor';
 import { DEFAULT_CUSTOM_HIGHLIGHT_RANGE } from 'views/Constants';
 
 export const StringConditionLabelMap = {
@@ -51,9 +54,11 @@ type InternalState = {
   color: Color,
 };
 
-export const randomColor = () => DEFAULT_CUSTOM_HIGHLIGHT_RANGE[
-  Math.floor(Math.random() * DEFAULT_CUSTOM_HIGHLIGHT_RANGE.length)
-];
+export const randomColor = () => StaticColor.create(
+  DEFAULT_CUSTOM_HIGHLIGHT_RANGE[
+    Math.floor(Math.random() * DEFAULT_CUSTOM_HIGHLIGHT_RANGE.length)
+  ],
+);
 
 export default class HighlightingRule {
   _value: InternalState;

--- a/graylog2-web-interface/src/views/logic/views/formatting/highlighting/HighlightingRule.ts
+++ b/graylog2-web-interface/src/views/logic/views/formatting/highlighting/HighlightingRule.ts
@@ -17,6 +17,7 @@
 import * as Immutable from 'immutable';
 
 import highlightConditionFunctions from 'views/logic/views/formatting/highlighting/highlightConditionFunctions';
+import HighlightingColor, { HighlightingColorJson } from 'views/logic/views/formatting/highlighting/HighlightingColor';
 import { DEFAULT_CUSTOM_HIGHLIGHT_RANGE } from 'views/Constants';
 
 export const StringConditionLabelMap = {
@@ -33,14 +34,14 @@ export const ConditionLabelMap = {
 };
 
 export type Value = string;
-export type Color = string;
+export type Color = HighlightingColor;
 export type Condition = keyof typeof ConditionLabelMap;
 
 export type HighlightingRuleJSON = {
   field: string,
   value: Value,
   condition: Condition,
-  color: Color,
+  color: HighlightingColorJson,
 };
 
 type InternalState = {
@@ -111,7 +112,7 @@ export default class HighlightingRule {
   static fromJSON(json: HighlightingRuleJSON) {
     const { field, value, condition, color } = json;
 
-    return HighlightingRule.create(field, value, condition, color);
+    return HighlightingRule.create(field, value, condition, HighlightingColor.fromJSON(color));
   }
 }
 

--- a/graylog2-web-interface/src/views/stores/HighlightingRulesStore.ts
+++ b/graylog2-web-interface/src/views/stores/HighlightingRulesStore.ts
@@ -24,6 +24,7 @@ import FormattingSettings from 'views/logic/views/formatting/FormattingSettings'
 import HighlightingRule, { Condition } from 'views/logic/views/formatting/highlighting/HighlightingRule';
 import type { Value } from 'views/logic/views/formatting/highlighting/HighlightingRule';
 import { singletonActions, singletonStore } from 'views/logic/singleton';
+import HighlightingColor from 'views/logic/views/formatting/highlighting/HighlightingColor';
 
 import { CurrentViewStateActions, CurrentViewStateStore } from './CurrentViewStateStore';
 
@@ -53,7 +54,7 @@ class Key extends Immutable.Record({ field: null, value: undefined, condition: u
 
 const makeKey = (field: string, value: Value, condition: Condition) => new Key({ field, value, condition });
 
-type StateType = Immutable.OrderedMap<Key, string>;
+type StateType = Immutable.OrderedMap<Key, HighlightingColor>;
 
 const HighlightingRulesStore: Store<Array<HighlightingRule>> = singletonStore(
   'views.HighlightingRules',
@@ -73,7 +74,7 @@ const HighlightingRulesStore: Store<Array<HighlightingRule>> = singletonStore(
       const { highlighting } = formatting;
       const rules = highlighting.reduce(
         (prev: StateType, rule: HighlightingRule) => prev.set(makeKey(rule.field, rule.value, rule.condition), rule.color),
-        Immutable.OrderedMap<Key, string>(),
+        Immutable.OrderedMap<Key, HighlightingColor>(),
       );
 
       if (!isEqual(rules, this.state)) {

--- a/graylog2-web-interface/src/views/stores/HighlightingRulesStore.ts
+++ b/graylog2-web-interface/src/views/stores/HighlightingRulesStore.ts
@@ -32,7 +32,7 @@ type UpdatePayload = {
   field?: string,
   value?: string,
   condition?: Condition,
-  color: string,
+  color: HighlightingColor,
 };
 
 type HighlightingRulesActionsType = RefluxActions<{

--- a/graylog2-web-interface/src/views/stores/HighlightingRulesStore.ts
+++ b/graylog2-web-interface/src/views/stores/HighlightingRulesStore.ts
@@ -124,9 +124,10 @@ const HighlightingRulesStore: Store<Array<HighlightingRule>> = singletonStore(
     update(rule: HighlightingRule, payload): Promise<Array<HighlightingRule>> {
       const { field = rule.field, value = rule.value, condition = rule.condition, color = rule.color } = payload;
       const oldKey = makeKey(rule.field, rule.value, rule.condition);
-      this.state.delete(oldKey);
       const newKey = makeKey(field, value, condition);
-      const promise = this._propagateAndTrigger(this.state.set(newKey, color));
+      const newState = this.state.delete(oldKey)
+        .set(newKey, color);
+      const promise = this._propagateAndTrigger(newState);
 
       HighlightingRulesActions.update.promise(promise);
 

--- a/graylog2-web-interface/yarn.lock
+++ b/graylog2-web-interface/yarn.lock
@@ -2183,6 +2183,13 @@
     "@babel/runtime" "^7.12.5"
     "@testing-library/dom" "^7.28.1"
 
+"@testing-library/user-event@^12.6.3":
+  version "12.6.3"
+  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-12.6.3.tgz#4a77c56a48823cf8adebd0f57670e4a89c24d058"
+  integrity sha512-PCmbUKofE4SXA7l8jphZAbvv5H3c4ix34xPZ/GNe99fASX//msJRgiMbHIBP+GwRfgVG9c7zmkODSPu2X2vNRw==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+
 "@turf/area@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/@turf/area/-/area-6.0.1.tgz#50ed63c70ef2bdb72952384f1594319d94f3b051"

--- a/graylog2-web-interface/yarn.lock
+++ b/graylog2-web-interface/yarn.lock
@@ -2269,6 +2269,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/chroma-js@^2.1.3":
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/@types/chroma-js/-/chroma-js-2.1.3.tgz#0b03d737ff28fad10eb884e0c6cedd5ffdc4ba0a"
+  integrity sha512-1xGPhoSGY1CPmXLCBcjVZSQinFjL26vlR8ZqprsBWiFyED4JacJJ9zHhh5aaUXqbY9B37mKQ73nlydVAXmr1+g==
+
 "@types/classnames@^2.2.9":
   version "2.2.9"
   resolved "https://registry.yarnpkg.com/@types/classnames/-/classnames-2.2.9.tgz#d868b6febb02666330410fe7f58f3c4b8258be7b"


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This change is making the color for a value highlighting configurable.  It allows the user to choose between a static color (for all field types) or a gradient (for numeric fields). If the gradient option is selected, it requires the user to select a gradient and defined upper/lower bounds for the field values (as we cannot infer them at this point). It offers the same gradients we do offer for the heatmap visualization.

The change does not require a migration for existing highlights. If a highlight color contains a string, it will be converted into a `StaticColor` silently.

**Notes:**

  - This PR includes previously missing types for `chroma-js` and fixes one related error
  - This PR includes `@testing-library/user-event` to make testing easier

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

![gradient-highlighting-pr](https://user-images.githubusercontent.com/41929/107355747-34697380-6ad0-11eb-9c8a-efec01aff275.gif)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.