### PR TITLE
Adjustments for enterprise widget

### DIFF
--- a/graylog2-web-interface/src/components/common/IconButton.tsx
+++ b/graylog2-web-interface/src/components/common/IconButton.tsx
@@ -16,11 +16,11 @@
  */
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import styled, { css } from 'styled-components';
+import styled, { css, DefaultTheme } from 'styled-components';
 
 import Icon from 'components/common/Icon';
 
-const Wrapper = styled.button(({ theme, disabled }: {theme: any, disabled: boolean}) => css`
+const Wrapper = styled.button(({ theme, disabled }: {theme: DefaultTheme, disabled: boolean}) => css`
   display: inline-flex;
   justify-content: center;
   align-items: center;

--- a/graylog2-web-interface/src/components/common/IconButton.tsx
+++ b/graylog2-web-interface/src/components/common/IconButton.tsx
@@ -20,7 +20,7 @@ import styled, { css } from 'styled-components';
 
 import Icon from 'components/common/Icon';
 
-const Wrapper = styled.button(({ theme }) => css`
+const Wrapper = styled.button(({ theme, disabled }: {theme: any, disabled: boolean}) => css`
   display: inline-flex;
   justify-content: center;
   align-items: center;
@@ -29,15 +29,15 @@ const Wrapper = styled.button(({ theme }) => css`
   border: 0;
   background-color: transparent;
   cursor: pointer;
-  color: ${theme.colors.gray[70]};
+  color: ${disabled ? theme.colors.gray[90] : theme.colors.gray[60]};
   font-size: ${theme.fonts.size.large};
 
   :hover {
-    background-color: ${theme.colors.gray[90]};
+    background-color: ${theme.colors.gray[80]};
   }
 
   :active {
-    background-color: ${theme.colors.gray[80]};
+    background-color: ${theme.colors.gray[70]};
   }
 `);
 
@@ -47,6 +47,7 @@ type Props = {
   onClick?: () => void,
   className?: string,
   name: string,
+  disabled?: boolean,
 };
 
 const handleClick = (onClick) => {
@@ -55,8 +56,8 @@ const handleClick = (onClick) => {
   }
 };
 
-const IconButton = ({ title, onClick, focusable, className, ...rest }: Props) => (
-  <Wrapper tabIndex={focusable ? 0 : -1} title={title} onClick={() => handleClick(onClick)} className={className} type="button">
+const IconButton = ({ title, onClick, focusable, className, disabled, ...rest }: Props) => (
+  <Wrapper tabIndex={focusable ? 0 : -1} title={title} onClick={() => handleClick(onClick)} className={className} type="button" disabled={disabled}>
     <Icon {...rest} />
   </Wrapper>
 );
@@ -74,6 +75,7 @@ IconButton.defaultProps = {
   onClick: undefined,
   title: undefined,
   name: undefined,
+  disabled: false,
 };
 
 export default IconButton;

--- a/graylog2-web-interface/src/views/components/sidebar/ContentColumn.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/ContentColumn.tsx
@@ -44,7 +44,7 @@ export const Container = styled.div<{ sidebarIsPinned: boolean }>(({ theme, side
   border-right: ${sidebarIsPinned ? 'none' : `1px solid ${theme.colors.variant.light.default}`};
   box-shadow: ${sidebarIsPinned ? `3px 3px 3px ${theme.colors.global.navigationBoxShadow}` : 'none'};
 
-  z-index: ${sidebarIsPinned ? 1030 : 3};
+  z-index: ${sidebarIsPinned ? 1030 : 4};
 
   ${sidebarIsPinned && css`
     ::before {
@@ -57,7 +57,7 @@ export const Container = styled.div<{ sidebarIsPinned: boolean }>(({ theme, side
       border-top-left-radius: 50%;
       background: transparent;
       box-shadow: -6px -6px 0 3px ${theme.colors.global.contentBackground};
-      z-index: 4; /* to render over Sidebar ContentColumn */
+      z-index: 5; /* to render over Sidebar ContentColumn */
     }
   `}
 `);

--- a/graylog2-web-interface/src/views/components/sidebar/Sidebar.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/Sidebar.tsx
@@ -53,7 +53,7 @@ const ContentOverlay = styled.div(({ theme }) => css`
   left: 50px;
   right: 0;
   background: ${chroma(theme.colors.brand.tertiary).alpha(0.25).css()};
-  z-index: 2;
+  z-index: 3;
 `);
 
 const _toggleSidebar = (initialSectionKey: string, activeSectionKey: string | undefined | null, setActiveSectionKey) => {

--- a/graylog2-web-interface/src/views/components/widgets/__snapshots__/Widget.test.tsx.snap
+++ b/graylog2-web-interface/src/views/components/widgets/__snapshots__/Widget.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports['<Widget /> should render with empty props 1'] = `
+exports[`<Widget /> should render with empty props 1`] = `
 .c2 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -19,16 +19,16 @@ exports['<Widget /> should render with empty props 1'] = `
   border: 0;
   background-color: transparent;
   cursor: pointer;
-  color: #b4b4b4;
+  color: #9b9b9b;
   font-size: 1.125rem;
 }
 
 .c2:hover {
-  background-color: #e6e6e6;
+  background-color: #cdcdcd;
 }
 
 .c2:active {
-  background-color: #cdcdcd;
+  background-color: #b4b4b4;
 }
 
 .c0 {


### PR DESCRIPTION
## Motivation
Prior to this change, we handled the z-index for the sidebar in way that
it was hard to add new z-index for widgets.
Also we could not disable a icon button.

## Description
This change raise the z-index for the sidebar so widget have a little
space for their own z-index without jumping out of the overlay.
Add IconButton disable prop.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [x] Breaking change (fix or feature that would cause existing functionality to change)


