### PR TITLE
Add link focus state color

### DIFF
--- a/graylog2-web-interface/src/theme/GlobalThemeStyles.jsx
+++ b/graylog2-web-interface/src/theme/GlobalThemeStyles.jsx
@@ -88,7 +88,8 @@ const GlobalThemeStyles = createGlobalStyle(({ theme }) => css`
     color: ${theme.colors.global.link};
   }
 
-  a:hover {
+  a:hover,
+  a:focus {
     color: ${theme.colors.global.linkHover};
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
These Changes add `:focus `color to` <a>` tag.
Okta widget form has a help link with `:focus` state with color not handled by our global style. Because of that browser style is applied instead resulting in an unreadable purple color.
## Screenshots (if appropriate):
Before :

![](https://user-images.githubusercontent.com/3423655/107344459-c66a7f80-6ac2-11eb-9f5d-57397bd43cc7.png)

After
<img width="217" alt="image" src="https://user-images.githubusercontent.com/1381455/107475157-f756bd00-6b73-11eb-8727-76268e07290d.png">

/jenkins-pr-deps Graylog2/graylog-plugin-cloud#721
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

