### PR TITLE
ESLint: Support `screen.findBy*` as expectation in tests.

### DIFF
--- a/graylog2-web-interface/packages/eslint-config-graylog/index.js
+++ b/graylog2-web-interface/packages/eslint-config-graylog/index.js
@@ -45,7 +45,15 @@ module.exports = {
       plugins: ['jest'],
       extends: ['plugin:jest/recommended'],
       rules: {
-        'jest/expect-expect': ['error', { assertFunctionNames: ['expect*', 'findBy*', 'screen.findBy*'] }],
+        'jest/expect-expect': ['error', {
+          assertFunctionNames: [
+            'expect*',
+            'findBy*',
+            'findAllBy*',
+            'screen.findBy*',
+            'screen.findAllBy*',
+          ],
+        }],
       },
     },
   ],

--- a/graylog2-web-interface/packages/eslint-config-graylog/index.js
+++ b/graylog2-web-interface/packages/eslint-config-graylog/index.js
@@ -45,7 +45,7 @@ module.exports = {
       plugins: ['jest'],
       extends: ['plugin:jest/recommended'],
       rules: {
-        'jest/expect-expect': ['error', { assertFunctionNames: ['expect*', 'findBy*'] }],
+        'jest/expect-expect': ['error', { assertFunctionNames: ['expect*', 'findBy*', 'screen.findBy*'] }],
       },
     },
   ],

--- a/graylog2-web-interface/packages/eslint-config-graylog/index.js
+++ b/graylog2-web-interface/packages/eslint-config-graylog/index.js
@@ -45,15 +45,7 @@ module.exports = {
       plugins: ['jest'],
       extends: ['plugin:jest/recommended'],
       rules: {
-        'jest/expect-expect': ['error', {
-          assertFunctionNames: [
-            'expect*',
-            'findBy*',
-            'findAllBy*',
-            'screen.findBy*',
-            'screen.findAllBy*',
-          ],
-        }],
+        'jest/expect-expect': ['error', { assertFunctionNames: ['expect*', '(screen.)?find(All)?By*'] }],
       },
     },
   ],


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Before this change, jest plugin for ESLint accepted only stand-alone calls to `findBy*` as expectations. This change makes it accept calls to `screen.findBy*` and `(screen.)findAllBy*` as well, therefore not raising the `expect-expect` hint.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.