### PR TITLE
Remove development grants migration

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/security/DBGrantService.java
+++ b/graylog2-server/src/main/java/org/graylog/security/DBGrantService.java
@@ -20,10 +20,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.mongodb.BasicDBObject;
-import com.mongodb.client.MongoCollection;
-import com.mongodb.client.model.Filters;
-import com.mongodb.client.model.Updates;
-import org.bson.Document;
 import org.graylog.grn.GRN;
 import org.graylog.grn.GRNRegistry;
 import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
@@ -71,21 +67,6 @@ public class DBGrantService extends PaginatedDbService<GrantDTO> {
                         .append(GrantDTO.FIELD_TARGET, 1),
                 new BasicDBObject("unique", true));
         // TODO: Add more indices
-
-        // TODO: Inline migration for development. Must be removed before shipping 4.0 GA!
-        final MongoCollection<Document> collection = mongoConnection.getMongoDatabase().getCollection(COLLECTION_NAME);
-        collection.updateMany(
-                Filters.eq(GrantDTO.FIELD_CAPABILITY, "grn::::capability:54e3deadbeefdeadbeef0000"),
-                Updates.set(GrantDTO.FIELD_CAPABILITY, Capability.VIEW.toId())
-        );
-        collection.updateMany(
-                Filters.eq(GrantDTO.FIELD_CAPABILITY, "grn::::capability:54e3deadbeefdeadbeef0001"),
-                Updates.set(GrantDTO.FIELD_CAPABILITY, Capability.MANAGE.toId())
-        );
-        collection.updateMany(
-                Filters.eq(GrantDTO.FIELD_CAPABILITY, "grn::::capability:54e3deadbeefdeadbeef0002"),
-                Updates.set(GrantDTO.FIELD_CAPABILITY, Capability.OWN.toId())
-        );
     }
 
     public ImmutableSet<GrantDTO> getForGranteesOrGlobal(Set<GRN> grantees) {


### PR DESCRIPTION
This shouldn't have been released and can cause a
high load on MongoDB.

Fixes #10043

