### PR TITLE
Defining generic type definition for `GlobalOverride` search type options.

### DIFF
--- a/graylog2-web-interface/src/views/actions/SearchActions.ts
+++ b/graylog2-web-interface/src/views/actions/SearchActions.ts
@@ -27,6 +27,7 @@ import { singletonActions } from 'views/logic/singleton';
 import type { RefluxActions } from 'stores/StoreTypes';
 import type { TimeRange } from 'views/logic/queries/Query';
 import type { WidgetMapping } from 'views/logic/views/types';
+import type { SearchTypeOptions } from 'views/logic/search/GlobalOverride';
 
 export type CreateSearchResponse = {
   search: Search,
@@ -43,7 +44,7 @@ type SearchActionsType = RefluxActions<{
   create: (search: Search) => Promise<CreateSearchResponse>,
   execute: (state: SearchExecutionState) => Promise<SearchExecutionResult>,
   reexecuteSearchTypes: (
-    searchTypes: {[searchTypeId: string]: { limit: number, offset: number }},
+    searchTypes: SearchTypeOptions,
     effectiveTimeRange?: TimeRange,
   ) => Promise<SearchExecutionResult>,
   executeWithCurrentState: () => Promise<SearchExecutionResult>,

--- a/graylog2-web-interface/src/views/components/widgets/MessageList.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageList.tsx
@@ -30,6 +30,7 @@ import MessagesWidgetConfig from 'views/logic/widgets/MessagesWidgetConfig';
 import type { TimeRange } from 'views/logic/queries/Query';
 import type { FieldTypeMappingsList } from 'views/stores/FieldTypesStore';
 import type { ViewStoreState } from 'views/stores/ViewStore';
+import type { PaginatedListOptions } from 'views/logic/search/GlobalOverride';
 import { PaginatedList } from 'components/common';
 import MessageTable from 'views/components/widgets/MessageTable';
 import ErrorWidget from 'views/components/widgets/ErrorWidget';
@@ -117,7 +118,8 @@ class MessageList extends React.Component<Props, State> {
     // execute search with new offset
     const { pageSize, searchTypes, data: { id: searchTypeId }, setLoadingState } = this.props;
     const { effectiveTimerange } = searchTypes[searchTypeId];
-    const searchTypePayload = { [searchTypeId]: { limit: pageSize, offset: pageSize * (pageNo - 1) } };
+    const messageListOptions: PaginatedListOptions = { limit: pageSize, offset: pageSize * (pageNo - 1) };
+    const searchTypePayload = { [searchTypeId]: messageListOptions };
 
     RefreshActions.disable();
     setLoadingState(true);

--- a/graylog2-web-interface/src/views/components/widgets/MessageList.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageList.tsx
@@ -30,7 +30,7 @@ import MessagesWidgetConfig from 'views/logic/widgets/MessagesWidgetConfig';
 import type { TimeRange } from 'views/logic/queries/Query';
 import type { FieldTypeMappingsList } from 'views/stores/FieldTypesStore';
 import type { ViewStoreState } from 'views/stores/ViewStore';
-import type { PaginatedListOptions } from 'views/logic/search/GlobalOverride';
+import type { SearchTypeOptions } from 'views/logic/search/GlobalOverride';
 import { PaginatedList } from 'components/common';
 import MessageTable from 'views/components/widgets/MessageTable';
 import ErrorWidget from 'views/components/widgets/ErrorWidget';
@@ -118,8 +118,15 @@ class MessageList extends React.Component<Props, State> {
     // execute search with new offset
     const { pageSize, searchTypes, data: { id: searchTypeId }, setLoadingState } = this.props;
     const { effectiveTimerange } = searchTypes[searchTypeId];
-    const messageListOptions: PaginatedListOptions = { limit: pageSize, offset: pageSize * (pageNo - 1) };
-    const searchTypePayload = { [searchTypeId]: messageListOptions };
+    const searchTypePayload: SearchTypeOptions<{
+      limit: number,
+      offset: number,
+    }> = {
+      [searchTypeId]: {
+        limit: pageSize,
+        offset: pageSize * (pageNo - 1),
+      },
+    };
 
     RefreshActions.disable();
     setLoadingState(true);

--- a/graylog2-web-interface/src/views/logic/search/GlobalOverride.ts
+++ b/graylog2-web-interface/src/views/logic/search/GlobalOverride.ts
@@ -18,31 +18,37 @@ import * as Immutable from 'immutable';
 
 import type { QueryString, TimeRange } from '../queries/Query';
 
-export type MessageListOptions = {
-  [searchTypeId: string]: {
-    limit: number;
-    offset: number;
-  };
+export type PaginatedListOptions = {
+  limit: number,
+  offset: number,
+};
+
+export type ScrollListOptions = {
+  after: Array<any>,
+}
+
+export type SearchTypeOptions = {
+  [searchTypeId: string]: ScrollListOptions | PaginatedListOptions
 };
 
 type InternalState = {
   timerange?: TimeRange,
   query?: QueryString,
   keepSearchTypes?: string[],
-  searchTypes?: MessageListOptions,
+  searchTypes?: SearchTypeOptions,
 };
 
 type JsonRepresentation = {
   timerange?: TimeRange,
   query?: QueryString,
   keep_search_types?: string[],
-  search_types?: MessageListOptions,
+  search_types?: SearchTypeOptions,
 };
 
 export default class GlobalOverride {
   _value: InternalState;
 
-  constructor(timerange?: TimeRange, query?: QueryString, keepSearchTypes?: string[], searchTypes?: MessageListOptions) {
+  constructor(timerange?: TimeRange, query?: QueryString, keepSearchTypes?: string[], searchTypes?: SearchTypeOptions) {
     this._value = { timerange, query, keepSearchTypes, searchTypes };
   }
 
@@ -58,7 +64,7 @@ export default class GlobalOverride {
     return this._value.keepSearchTypes;
   }
 
-  get searchTypes(): MessageListOptions | undefined | null {
+  get searchTypes(): SearchTypeOptions | undefined | null {
     return this._value.searchTypes;
   }
 
@@ -70,7 +76,7 @@ export default class GlobalOverride {
     return new Builder(Immutable.Map({ timerange, query, keepSearchTypes, searchTypes }));
   }
 
-  static create(timerange?: TimeRange, query?: QueryString, keepSearchTypes?: string[], searchTypes?: MessageListOptions): GlobalOverride {
+  static create(timerange?: TimeRange, query?: QueryString, keepSearchTypes?: string[], searchTypes?: SearchTypeOptions): GlobalOverride {
     return new GlobalOverride(timerange, query, keepSearchTypes, searchTypes);
   }
 
@@ -117,7 +123,7 @@ class Builder {
     return new Builder(this.value.set('keepSearchTypes', keepSearchTypes));
   }
 
-  searchTypes(searchTypes: MessageListOptions): Builder {
+  searchTypes(searchTypes: SearchTypeOptions): Builder {
     return new Builder(this.value.set('searchTypes', searchTypes));
   }
 

--- a/graylog2-web-interface/src/views/logic/search/GlobalOverride.ts
+++ b/graylog2-web-interface/src/views/logic/search/GlobalOverride.ts
@@ -18,17 +18,8 @@ import * as Immutable from 'immutable';
 
 import type { QueryString, TimeRange } from '../queries/Query';
 
-export type PaginatedListOptions = {
-  limit: number,
-  offset: number,
-};
-
-export type ScrollListOptions = {
-  after: Array<any>,
-}
-
-export type SearchTypeOptions = {
-  [searchTypeId: string]: ScrollListOptions | PaginatedListOptions
+export type SearchTypeOptions<T = any> = {
+  [searchTypeId: string]: T
 };
 
 type InternalState = {

--- a/graylog2-web-interface/src/views/stores/SearchStore.ts
+++ b/graylog2-web-interface/src/views/stores/SearchStore.ts
@@ -30,7 +30,7 @@ import SearchActions from 'views/actions/SearchActions';
 import Search from 'views/logic/search/Search';
 import type { CreateSearchResponse, SearchId, SearchExecutionResult } from 'views/actions/SearchActions';
 import GlobalOverride from 'views/logic/search/GlobalOverride';
-import type { MessageListOptions } from 'views/logic/search/GlobalOverride';
+import type { SearchTypeOptions } from 'views/logic/search/GlobalOverride';
 import SearchExecutionState from 'views/logic/search/SearchExecutionState';
 import View from 'views/logic/views/View';
 import Parameter from 'views/logic/parameters/Parameter';
@@ -143,7 +143,7 @@ export const SearchStore: Store<SearchStoreState> = singletonStore(
       return this._executePromise(executionState, startActionPromise, handleSearchResult);
     },
 
-    reexecuteSearchTypes(searchTypes: MessageListOptions, effectiveTimerange?: TimeRange): Promise<SearchExecutionResult> {
+    reexecuteSearchTypes(searchTypes: SearchTypeOptions, effectiveTimerange?: TimeRange): Promise<SearchExecutionResult> {
       const { parameterBindings, globalOverride } = this.executionState;
       const searchTypeIds = Object.keys(searchTypes);
       const globalQuery = globalOverride && globalOverride.query ? globalOverride.query : undefined;


### PR DESCRIPTION
## Description
The type definition for the search type options in `GlobalOverride` currently only consider properties for a paginated list.
`{ limit: number, offset: number }`

This PR is adds a type definition for a scroll parameter.
`{ after: [any] }`

## Motivation and Context
We need this new type definition for a search type which uses a scroll position instead of pagination to receive the messages for a specific position in a list.
