### PR TITLE
Don't execute a search when focusing or unfocusing a widget

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/filter/StreamFilter.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/filter/StreamFilter.java
@@ -17,6 +17,7 @@
 package org.graylog.plugins.views.search.filter;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -42,6 +43,7 @@ public abstract class StreamFilter implements Filter {
     @Override
     @Nullable
     @JsonProperty
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public abstract Set<Filter> filters();
 
     @Nullable
@@ -50,6 +52,7 @@ public abstract class StreamFilter implements Filter {
 
     @Nullable
     @JsonProperty("title")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public abstract String streamTitle();
 
     public static Builder builder() {

--- a/graylog2-web-interface/src/views/hooks/BindSearchParamsFromQuery.test.ts
+++ b/graylog2-web-interface/src/views/hooks/BindSearchParamsFromQuery.test.ts
@@ -151,11 +151,11 @@ describe('BindSearchParamsFromQuery should', () => {
 
     const expectedFilter = Immutable.Map({
       type: 'or',
-      filters: [
+      filters: Immutable.List([
         Immutable.Map({ type: 'stream', id: 'stream1' }),
         Immutable.Map({ type: 'stream', id: 'stream2' }),
         Immutable.Map({ type: 'stream', id: 'stream3' }),
-      ],
+      ]),
     });
 
     expect(QueriesActions.update)

--- a/graylog2-web-interface/src/views/logic/queries/Query.ts
+++ b/graylog2-web-interface/src/views/logic/queries/Query.ts
@@ -51,8 +51,8 @@ export type ElasticsearchQueryString = {
 
 export const createElasticsearchQueryString = (query = ''): ElasticsearchQueryString => ({ type: 'elasticsearch', query_string: query });
 
-const _streamFilters = (selectedStreams: Array<string>): Array<Immutable.Map<string, string>> => {
-  return selectedStreams.map((stream) => Immutable.Map({ type: 'stream', id: stream }));
+const _streamFilters = (selectedStreams: Array<string>) => {
+  return Immutable.List(selectedStreams.map((stream) => Immutable.Map({ type: 'stream', id: stream })));
 };
 
 export const filtersForQuery = (streams: Array<string> | null | undefined): FilterType | null | undefined => {


### PR DESCRIPTION
## Motivation
Prior to this change,  if the user focused or unfocused a widget a
search was executed, since the code assumed the streams filters changed.

## Description
This change will cleanup the filters we get from the backend (it
included title and other filters which where set to null).
Also to compare the new streams filter and the old one the need to be
from the same object type. So we enusre that the new streams filter is
also containing immutable list and not an array.


## How Has This Been Tested?
- Focus and unfocus a widget
- ensure no search gets executed

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Also
Fixes #9467
Fixes #8421
