### PR TITLE
Allow passing timeout multiplier for frontend tests.

### DIFF
--- a/graylog2-web-interface/package.json
+++ b/graylog2-web-interface/package.json
@@ -31,6 +31,10 @@
     "preset": "jest-preset-graylog",
     "setupFiles": [
       "<rootDir>/test/setup-jest.js"
+    ],
+    "setupFilesAfterEnv": [
+      "jest-enzyme",
+      "<rootDir>/test/configure-testing-library.js"
     ]
   },
   "dependencies": {

--- a/graylog2-web-interface/packages/jest-preset-graylog/jest-preset.js
+++ b/graylog2-web-interface/packages/jest-preset-graylog/jest-preset.js
@@ -14,6 +14,9 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
+
+const TIMEOUT_MULTIPLIER = Number.parseFloat(process.env.TIMEOUT_MULTIPLIER);
+
 module.exports = {
   rootDir: '../../',
   collectCoverageFrom: [
@@ -49,4 +52,5 @@ module.exports = {
   testPathIgnorePatterns: [
     '.fixtures.[jt]s$',
   ],
+  testTimeout: (Number.isFinite(TIMEOUT_MULTIPLIER) ? TIMEOUT_MULTIPLIER : 1.0) * 5000,
 };

--- a/graylog2-web-interface/test/configure-testing-library.js
+++ b/graylog2-web-interface/test/configure-testing-library.js
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import { configure } from '@testing-library/react';
+
+const TIMEOUT_MULTIPLIER = Number.parseFloat(process.env.TIMEOUT_MULTIPLIER);
+
+if (Number.isFinite(TIMEOUT_MULTIPLIER)) {
+  configure((existingConfig) => ({ ...existingConfig, asyncUtilTimeout: TIMEOUT_MULTIPLIER * existingConfig.asyncUtilTimeout }));
+}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Before this change, we were using default timeouts for frontend tests. These are:

  - 5s for each jest test
  - 1s for async wait utils in testing-library

On lower-end machines (e.g. github actions), these timeouts are sometimes too aggressive. Instead of raising timeouts in general, we want to raise timeouts only for specific environments.

Therefore, this PR allows passing a `TIMEOUT_MULTIPLIER` environment variable to the `yarn test` run. It is being parsed as a number (either int or float) and applied to the defaults.

E.g. `TIMEOUT_MULTIPLIER=2 yarn test` results in:

  - 10s for each jest test
  - 2s for async wait utils in testing-library

It also works the other way, `TIMEOUT_MULTIPLIER=0.5 yarn test` results in:

  - 2.5s for each jest test
  - 0.5s for async wait utils in testing-library

Unfortunately, it was not possible to contain this change completely in `jest-preset-graylog`, because:

  - testing-library needs to be configured in each module that uses it, therefore requiring to run a script from `graylog2-web-interface`'s `setupFilesAfterEnv`
  - if `setupFilesAfterEnv` is specified in the parent module, the section from the preset will be ignored, therefore requiring to add `jest-enzyme` to the `setupFilesAfterEnv` section in `graylog2-web-interface` again

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.