### PR TITLE
Updates to include dynamic plugin UI settings in generated config.js at startup

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/bindings/ServerBindings.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/ServerBindings.java
@@ -121,6 +121,7 @@ public class ServerBindings extends Graylog2Module {
 
     private void bindProviders() {
         bind(ClusterEventBus.class).toProvider(ClusterEventBusProvider.class).asEagerSingleton();
+        pluginUISettingsProviderBinder();
     }
 
     private void bindFactoryModules() {

--- a/graylog2-server/src/main/java/org/graylog2/bindings/ServerBindings.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/ServerBindings.java
@@ -121,7 +121,6 @@ public class ServerBindings extends Graylog2Module {
 
     private void bindProviders() {
         bind(ClusterEventBus.class).toProvider(ClusterEventBusProvider.class).asEagerSingleton();
-        pluginUISettingsProviderBinder();
     }
 
     private void bindFactoryModules() {

--- a/graylog2-server/src/main/java/org/graylog2/plugin/PluginModule.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/PluginModule.java
@@ -58,6 +58,7 @@ import org.graylog2.plugin.periodical.Periodical;
 import org.graylog2.plugin.rest.PluginRestResource;
 import org.graylog2.plugin.security.PasswordAlgorithm;
 import org.graylog2.plugin.security.PluginPermissions;
+import org.graylog2.web.PluginUISettingsProvider;
 
 import javax.ws.rs.ext.ExceptionMapper;
 import java.util.Collections;
@@ -322,5 +323,14 @@ public abstract class PluginModule extends Graylog2Module {
         install(new FactoryModuleBuilder().implement(AuthServiceBackend.class, backendClass).build(factoryClass));
         authServiceBackendBinder().addBinding(name).to(factoryClass);
         registerJacksonSubtype(configClass, name);
+    }
+
+    protected MapBinder<String, PluginUISettingsProvider> pluginUISettingsProviderBinder() {
+        return MapBinder.newMapBinder(binder(), String.class, PluginUISettingsProvider.class);
+    }
+
+    protected void addPluginUISettingsProvider(String providerKey,
+                                               Class<? extends PluginUISettingsProvider> uiSettingsProviderClass) {
+        pluginUISettingsProviderBinder().addBinding(providerKey).to(uiSettingsProviderClass);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/plugin/inject/Graylog2Module.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/inject/Graylog2Module.java
@@ -52,6 +52,7 @@ import org.graylog2.plugin.lookup.LookupDataAdapterConfiguration;
 import org.graylog2.plugin.outputs.MessageOutput;
 import org.graylog2.plugin.security.PasswordAlgorithm;
 import org.graylog2.plugin.security.PluginPermissions;
+import org.graylog2.web.PluginUISettingsProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -463,6 +464,14 @@ public abstract class Graylog2Module extends AbstractModule {
 
     protected Multibinder<ConstraintChecker> constraintCheckerBinder() {
         return Multibinder.newSetBinder(binder(), ConstraintChecker.class);
+    }
+
+    protected Multibinder<PluginUISettingsProvider> pluginUISettingsProviderBinder() {
+        return Multibinder.newSetBinder(binder(), PluginUISettingsProvider.class);
+    }
+
+    protected void addPluginUISettingsProvider(Class<? extends PluginUISettingsProvider> uiSettingsProviderClass) {
+        pluginUISettingsProviderBinder().addBinding().to(uiSettingsProviderClass);
     }
 
     private static class DynamicFeatureType extends TypeLiteral<Class<? extends DynamicFeature>> {}

--- a/graylog2-server/src/main/java/org/graylog2/plugin/inject/Graylog2Module.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/inject/Graylog2Module.java
@@ -466,14 +466,6 @@ public abstract class Graylog2Module extends AbstractModule {
         return Multibinder.newSetBinder(binder(), ConstraintChecker.class);
     }
 
-    protected Multibinder<PluginUISettingsProvider> pluginUISettingsProviderBinder() {
-        return Multibinder.newSetBinder(binder(), PluginUISettingsProvider.class);
-    }
-
-    protected void addPluginUISettingsProvider(Class<? extends PluginUISettingsProvider> uiSettingsProviderClass) {
-        pluginUISettingsProviderBinder().addBinding().to(uiSettingsProviderClass);
-    }
-
     private static class DynamicFeatureType extends TypeLiteral<Class<? extends DynamicFeature>> {}
 
     private static class ContainerResponseFilterType extends TypeLiteral<Class<? extends ContainerResponseFilter>> {}

--- a/graylog2-server/src/main/java/org/graylog2/web/PluginUISettingsProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/web/PluginUISettingsProvider.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.web;
+
+/**
+ * Some plugins may have dynamic data that needs to be made available to the UI at server startup.  This interface
+ * provides a mechanism for providing that data via the generated config.js file's pluginUISettings map.  When an
+ * instance of this interface is registered via the Graylog2Module.addPluginUISettingsProvider() method, an entry will
+ * be added to the pluginUISettings map using the key and JSON data the instance provides.
+ */
+public interface PluginUISettingsProvider {
+
+    /**
+     * @return The key used to store the plugin's UI settings in the pluginUISettings map in config.js
+     */
+    String pluginSettingsKey();
+
+    /**
+     * @return The JSON data to be stored in the pluginUISettings map in config.js
+     */
+    String pluginSettingsJson();
+}

--- a/graylog2-server/src/main/java/org/graylog2/web/PluginUISettingsProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/web/PluginUISettingsProvider.java
@@ -16,6 +16,8 @@
  */
 package org.graylog2.web;
 
+import java.util.Map;
+
 /**
  * Some plugins may have dynamic data that needs to be made available to the UI at server startup.  This interface
  * provides a mechanism for providing that data via the generated config.js file's pluginUISettings map.  When an
@@ -25,12 +27,7 @@ package org.graylog2.web;
 public interface PluginUISettingsProvider {
 
     /**
-     * @return The key used to store the plugin's UI settings in the pluginUISettings map in config.js
-     */
-    String pluginSettingsKey();
-
-    /**
      * @return The JSON data to be stored in the pluginUISettings map in config.js
      */
-    String pluginSettingsJson();
+    Map<String,Object> pluginSettings();
 }

--- a/graylog2-server/src/main/java/org/graylog2/web/PluginUISettingsProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/web/PluginUISettingsProvider.java
@@ -21,13 +21,20 @@ import java.util.Map;
 /**
  * Some plugins may have dynamic data that needs to be made available to the UI at server startup.  This interface
  * provides a mechanism for providing that data via the generated config.js file's pluginUISettings map.  When an
- * instance of this interface is registered via the Graylog2Module.addPluginUISettingsProvider() method, an entry will
+ * instance of this interface is registered via the PluginModule.addPluginUISettingsProvider() method, an entry will
  * be added to the pluginUISettings map using the key and JSON data the instance provides.
+ *
+ * When registering a new PluginUISettingsProvider via addPluginUISettingsProvider(), you must register with a unique
+ * providerKey value.  To help guarantee uniqueness, we recommend following Java package naming standards.  As an
+ * example, a new Graylog plugin might use the key: "org.graylog.newuiplugin".
  */
 public interface PluginUISettingsProvider {
 
     /**
-     * @return The JSON data to be stored in the pluginUISettings map in config.js
+     * This method returns the UI settings data for your plugin as a Map which will be converted to JSON and
+     * surfaced via the generated config.js file at server startup.
+     *
+     * @return The settings data to be included in config.js
      */
     Map<String,Object> pluginSettings();
 }

--- a/graylog2-server/src/main/java/org/graylog2/web/resources/AppConfigResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/web/resources/AppConfigResource.java
@@ -16,6 +16,8 @@
  */
 package org.graylog2.web.resources;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.floreysoft.jmte.Engine;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Resources;
@@ -23,6 +25,7 @@ import org.graylog2.Configuration;
 import org.graylog2.configuration.HttpConfiguration;
 import org.graylog2.rest.MoreMediaTypes;
 import org.graylog2.rest.RestTools;
+import org.graylog2.web.PluginUISettingsProvider;
 
 import javax.inject.Inject;
 import javax.ws.rs.GET;
@@ -35,6 +38,8 @@ import java.net.URI;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static java.util.Objects.requireNonNull;
 
@@ -43,14 +48,21 @@ public class AppConfigResource {
     private final Configuration configuration;
     private final HttpConfiguration httpConfiguration;
     private final Engine templateEngine;
+    private final Map<String, String> pluginUISettings;
+    private final ObjectMapper objectMapper;
 
     @Inject
     public AppConfigResource(Configuration configuration,
                              HttpConfiguration httpConfiguration,
-                             Engine templateEngine) {
+                             Engine templateEngine,
+                             Set<PluginUISettingsProvider> settingsProviders,
+                             ObjectMapper objectMapper) {
         this.configuration = requireNonNull(configuration, "configuration");
         this.httpConfiguration = requireNonNull(httpConfiguration, "httpConfiguration");
         this.templateEngine = requireNonNull(templateEngine, "templateEngine");
+        this.pluginUISettings = requireNonNull(settingsProviders, "settingsProviders").stream()
+                .collect(Collectors.toMap(PluginUISettingsProvider::pluginSettingsKey, PluginUISettingsProvider::pluginSettingsJson));
+        this.objectMapper = objectMapper;
     }
 
     @GET
@@ -68,7 +80,16 @@ public class AppConfigResource {
         final Map<String, Object> model = ImmutableMap.of(
             "rootTimeZone", configuration.getRootTimeZone(),
             "serverUri", baseUri.resolve(HttpConfiguration.PATH_API),
-            "appPathPrefix", baseUri.getPath());
+            "appPathPrefix", baseUri.getPath(),
+            "pluginUISettings", buildPluginUISettings());
         return templateEngine.transform(template, model);
+    }
+
+    private String buildPluginUISettings() {
+        try {
+            return objectMapper.writeValueAsString(pluginUISettings);
+        } catch (JsonProcessingException ex) {
+            return "{}";
+        }
     }
 }

--- a/graylog2-server/src/main/resources/web-interface/config.js.template
+++ b/graylog2-server/src/main/resources/web-interface/config.js.template
@@ -2,4 +2,5 @@ window.appConfig = {
   gl2ServerUrl: '${serverUri}',
   gl2AppPathPrefix: '${appPathPrefix}',
   rootTimeZone: '${rootTimeZone}',
+  pluginUISettings: ${pluginUISettings},
 };


### PR DESCRIPTION
## Description
Some plugins have dynamic UI settings data that needs to be provided to the UI at startup time via inclusion in the generated config.js file.  This change adds a new `PluginUISettingsProvider` interface and a method for binding instances of that interface such that the data they provide will be included when the config.js file is generated at server startup.

## How Has This Been Tested?
This change has been tested locally using an in-development Enterprise plugin.

## Screenshots (if appropriate):
![Screen Shot 2021-02-16 at 4 26 54 PM](https://user-images.githubusercontent.com/6466251/108123453-df030880-7073-11eb-9da2-b44a0469c5c0.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

