### PR TITLE
Provide a timeout for request when optimizing index in ES7.

### DIFF
--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/ElasticsearchClient.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/ElasticsearchClient.java
@@ -16,6 +16,7 @@
  */
 package org.graylog.storage.elasticsearch7;
 
+import com.github.joschi.jadconfig.util.Duration;
 import com.google.common.collect.Streams;
 import org.graylog.shaded.elasticsearch7.org.apache.http.client.config.RequestConfig;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.ElasticsearchException;
@@ -31,7 +32,6 @@ import org.graylog2.indexer.InvalidWriteTargetException;
 import javax.inject.Inject;
 import javax.inject.Named;
 import java.io.IOException;
-import java.time.Duration;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -149,11 +149,11 @@ public class ElasticsearchClient {
         return e.getMessage().contains("index_not_found_exception");
     }
 
-    public static RequestOptions withTimeout(RequestOptions requestOptions, com.github.joschi.jadconfig.util.Duration timeout) {
+    public static RequestOptions withTimeout(RequestOptions requestOptions, Duration timeout) {
         final RequestConfig requestConfigWithTimeout = RequestConfig.copy(requestOptions.getRequestConfig())
                 .setSocketTimeout(Math.toIntExact(timeout.toMilliseconds()))
                 .build();
-        final RequestOptions requestOptionsWithTimeout = requestOptions.toBuilder()
+        return requestOptions.toBuilder()
                 .setRequestConfig(requestConfigWithTimeout)
                 .build();
 

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/ElasticsearchClient.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/ElasticsearchClient.java
@@ -17,6 +17,7 @@
 package org.graylog.storage.elasticsearch7;
 
 import com.google.common.collect.Streams;
+import org.graylog.shaded.elasticsearch7.org.apache.http.client.config.RequestConfig;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.ElasticsearchException;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.search.MultiSearchRequest;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.search.MultiSearchResponse;
@@ -30,6 +31,7 @@ import org.graylog2.indexer.InvalidWriteTargetException;
 import javax.inject.Inject;
 import javax.inject.Named;
 import java.io.IOException;
+import java.time.Duration;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -145,5 +147,15 @@ public class ElasticsearchClient {
 
     private boolean isIndexNotFoundException(ElasticsearchException e) {
         return e.getMessage().contains("index_not_found_exception");
+    }
+
+    public static RequestOptions withTimeout(RequestOptions requestOptions, com.github.joschi.jadconfig.util.Duration timeout) {
+        final RequestConfig requestConfigWithTimeout = RequestConfig.copy(requestOptions.getRequestConfig())
+                .setSocketTimeout(Math.toIntExact(timeout.toMilliseconds()))
+                .build();
+        final RequestOptions requestOptionsWithTimeout = requestOptions.toBuilder()
+                .setRequestConfig(requestConfigWithTimeout)
+                .build();
+
     }
 }

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/IndicesAdapterES7.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/IndicesAdapterES7.java
@@ -87,6 +87,7 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import static java.util.stream.Collectors.toList;
+import static org.graylog.storage.elasticsearch7.ElasticsearchClient.withTimeout;
 
 public class IndicesAdapterES7 implements IndicesAdapter {
     private static final Logger LOG = LoggerFactory.getLogger(IndicesAdapterES7.class);
@@ -392,7 +393,7 @@ public class IndicesAdapterES7 implements IndicesAdapter {
                 .maxNumSegments(maxNumSegments)
                 .flush(true);
 
-        client.execute((c, requestOptions) -> c.indices().forcemerge(request, requestOptions));
+        client.execute((c, requestOptions) -> c.indices().forcemerge(request, withTimeout(requestOptions, timeout)));
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/configuration/DurationCastedToIntegerValidator.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/DurationCastedToIntegerValidator.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.configuration;
+
+import com.github.joschi.jadconfig.ValidationException;
+import com.github.joschi.jadconfig.Validator;
+import com.github.joschi.jadconfig.util.Duration;
+
+public class DurationCastedToIntegerValidator implements Validator<Duration> {
+    /**
+     * Validates if the value {@literal value} of the provided configuration parameter {@literal name} is a positive
+     * {@link Duration}, that is not higher than 24 days. This constraint is related to the duration (in milliseconds)
+     * being casted to integer at some point. {@link Integer#MAX_VALUE} / (24 * 60 * 60 * 1000) roughly equals to 24 days.
+     *
+     * @param name  The name of the configuration parameter
+     * @param value The value of the configuration validator
+     * @throws ValidationException If the value {@literal value} configuration parameter {@literal name} can't be parsed
+     *                             as a {@link Duration}, is negative or higher than 24 days.
+     */
+    @Override
+    public void validate(String name, Duration value) throws ValidationException {
+        if (value != null && (value.getQuantity() < 0L || value.toMilliseconds() > Integer.MAX_VALUE)) {
+            throw new ValidationException("Parameter " + name + " should be positive and not higher than 24 days (found " + value + ")");
+        }
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/configuration/DurationCastedToIntegerValidator.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/DurationCastedToIntegerValidator.java
@@ -21,6 +21,8 @@ import com.github.joschi.jadconfig.Validator;
 import com.github.joschi.jadconfig.util.Duration;
 
 public class DurationCastedToIntegerValidator implements Validator<Duration> {
+    private static final Duration maximumValue = Duration.days(24);
+
     /**
      * Validates if the value {@literal value} of the provided configuration parameter {@literal name} is a positive
      * {@link Duration}, that is not higher than 24 days. This constraint is related to the duration (in milliseconds)
@@ -33,7 +35,7 @@ public class DurationCastedToIntegerValidator implements Validator<Duration> {
      */
     @Override
     public void validate(String name, Duration value) throws ValidationException {
-        if (value != null && (value.getQuantity() < 0L || value.toMilliseconds() > Integer.MAX_VALUE)) {
+        if (value != null && (value.getQuantity() < 0L || value.toMilliseconds() > maximumValue.toMilliseconds())) {
             throw new ValidationException("Parameter " + name + " should be positive and not higher than 24 days (found " + value + ")");
         }
     }

--- a/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchConfiguration.java
@@ -88,7 +88,7 @@ public class ElasticsearchConfiguration {
     @Parameter(value = "index_optimization_max_num_segments", validator = PositiveIntegerValidator.class)
     private int indexOptimizationMaxNumSegments = 1;
 
-    @Parameter(value = "elasticsearch_index_optimization_timeout", validator = PositiveDurationValidator.class)
+    @Parameter(value = "elasticsearch_index_optimization_timeout", validator = DurationCastedToIntegerValidator.class)
     private Duration indexOptimizationTimeout = Duration.hours(1L);
 
     @Parameter(value = "elasticsearch_index_optimization_jobs", validator = PositiveIntegerValidator.class)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

**Note:** This PR requires a backport to `4.0`.

Prior to this change, the force merge request which is used during the index optimization job did not supply a timeout for ES7. This leads to the default timeout (60s) being used, which is too short in most cases.

While this might not result in the force merge request being cancelled ([details](https://github.com/Graylog2/graylog2-server/issues/10054#issuecomment-778460239)), it leads to unnecessarily logging of misleading errors.

This PR is supplying the configured timeout to the request.

Fixes #10054.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.