### PR TITLE
Fix race condition pipeline

### DIFF
--- a/graylog2-web-interface/src/components/rules/RuleContext.jsx
+++ b/graylog2-web-interface/src/components/rules/RuleContext.jsx
@@ -14,7 +14,7 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import React, { createContext, useEffect, useRef, useCallback } from 'react';
+import React, { createContext, useEffect, useRef, useCallback, useState } from 'react';
 import PropTypes from 'prop-types';
 
 import CombinedProvider from 'injection/CombinedProvider';
@@ -27,6 +27,9 @@ export const PipelineRulesContext = createContext();
 export const PipelineRulesProvider = ({ children, usedInPipelines, rule }) => {
   const descriptionRef = useRef();
   const ruleSourceRef = useRef();
+  const [, setAceLoaded] = useState(false);
+
+  const onAceLoaded = () => setAceLoaded(true);
 
   const createAnnotations = (nextErrors) => {
     const nextErrorAnnotations = nextErrors.map((e) => {
@@ -113,6 +116,7 @@ export const PipelineRulesProvider = ({ children, usedInPipelines, rule }) => {
       handleSavePipelineRule,
       ruleSourceRef,
       usedInPipelines,
+      onAceLoaded,
     }}>
       {children}
     </PipelineRulesContext.Provider>

--- a/graylog2-web-interface/src/components/rules/RuleForm.jsx
+++ b/graylog2-web-interface/src/components/rules/RuleForm.jsx
@@ -32,6 +32,7 @@ const RuleForm = ({ create }) => {
     handleDescription,
     handleSavePipelineRule,
     ruleSourceRef,
+    onAceLoaded,
   } = useContext(PipelineRulesContext);
 
   const handleSubmit = (event) => {
@@ -73,6 +74,7 @@ const RuleForm = ({ create }) => {
         <Input id="rule-source-editor" label="Rule source" help="Rule source, see quick reference for more information.">
           <SourceCodeEditor id={`source${create ? '-create' : '-edit'}`}
                             mode="pipeline"
+                            onLoad={onAceLoaded}
                             innerRef={ruleSourceRef} />
         </Input>
       </fieldset>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR fixes #9341

## Motivation and Context
The pipeline rule context and source code editor didn't play well together. In some instances the source code of pipeline rules was not loaded into the source code editor.

Because of the nature of how the context and source code editor were implemented it sometimes didn't work correctly.

It problem lies in the way the rule values are set on the source code editor. After debugging I came to the conclusion that the source code editor was not loaded, but the rule source had and thus wanted to update a non-existing source code editor.

This fix will trigger the context to apply the rule source on the source code editor should it load after the rule has been loaded.

I am using `useState` to get the desired effect. It's a bit weird, but it retriggers the effects inside the Context correctly. If we were to fix the way source code editor and the context work we'd have to refactor them to be controlled inputs instead of uncontrolled.

## How Has This Been Tested?
Was tested using the reproduction steps of #9341

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

