### PR TITLE
Set right input IDs and references

### DIFF
--- a/graylog2-web-interface/src/components/configurationforms/BooleanField.jsx
+++ b/graylog2-web-interface/src/components/configurationforms/BooleanField.jsx
@@ -32,15 +32,14 @@ class BooleanField extends React.Component {
   };
 
   render() {
-    const { field } = this.props;
-    const { typeName } = this.props;
-    const { title } = this.props;
+    const { field, title, typeName } = this.props;
+    const fieldId = `${typeName}-${title}`;
 
     return (
       <div className="form-group">
         <div className="checkbox">
           <label>
-            <input id={`${typeName}-${title}`}
+            <input id={fieldId}
                    type="checkbox"
                    checked={this.props.value}
                    name={`configuration[${title}]`}

--- a/graylog2-web-interface/src/components/configurationforms/DropdownField.jsx
+++ b/graylog2-web-interface/src/components/configurationforms/DropdownField.jsx
@@ -60,24 +60,24 @@ class DropdownField extends React.Component {
   };
 
   render() {
-    const { field } = this.state;
+    const { field, title, typeName } = this.state;
+    const fieldId = `${typeName}-${title}`;
+
     const options = $.map(field.additional_info.values, this._formatOption);
 
     if (this.props.addPlaceholder) {
       options.unshift(this._formatOption(`Select ${field.human_name || this.state.title}`, '', true));
     }
 
-    const { typeName } = this.state;
-
     return (
       <div className="form-group">
-        <label htmlFor={`${typeName}-${field.title}`}>
+        <label htmlFor={fieldId}>
           {field.human_name}
 
           {FieldHelpers.optionalMarker(field)}
         </label>
 
-        <select id={field.title}
+        <select id={fieldId}
                 value={this.state.value}
                 className="input-xlarge form-control"
                 onChange={this.handleChange}

--- a/graylog2-web-interface/src/components/configurationforms/ListField.jsx
+++ b/graylog2-web-interface/src/components/configurationforms/ListField.jsx
@@ -63,6 +63,8 @@ class ListField extends React.Component {
     const { field } = this.state;
     const { typeName } = this.state;
     const { value } = this.state;
+    const fieldId = `${typeName}-${field.title}`;
+
     const isRequired = !field.is_optional;
     const allowCreate = field.attributes.includes('allow_create');
     const options = (field.additional_info && field.additional_info.values ? field.additional_info.values : {});
@@ -70,13 +72,13 @@ class ListField extends React.Component {
 
     return (
       <div className="form-group">
-        <label htmlFor={`${typeName}-${field.title}`}>
+        <label htmlFor={fieldId}>
           {field.human_name}
 
           {FieldHelpers.optionalMarker(field)}
         </label>
 
-        <MultiSelect id={field.title}
+        <MultiSelect id={fieldId}
                      required={isRequired}
                      autoFocus={this.props.autoFocus}
                      options={formattedOptions}

--- a/graylog2-web-interface/src/components/configurationforms/NumberField.jsx
+++ b/graylog2-web-interface/src/components/configurationforms/NumberField.jsx
@@ -69,20 +69,20 @@ const NumberField = createReactClass({
   },
 
   render() {
-    const { typeName } = this.props;
-    const { field } = this.props;
+    const { field, title, typeName } = this.state;
     const isRequired = !field.is_optional;
     const validationSpecs = this.validationSpec(field);
+    const fieldId = `${typeName}-${title}`;
 
     // TODO: replace with bootstrap input component
     return (
       <div className="form-group">
-        <label htmlFor={`${typeName}-${field.title}`}>
+        <label htmlFor={fieldId}>
           {field.human_name}
           {FieldHelpers.optionalMarker(field)}
         </label>
 
-        <input id={field.title}
+        <input id={fieldId}
                type="number"
                required={isRequired}
                onChange={this.handleChange}

--- a/graylog2-web-interface/src/components/configurationforms/NumberField.jsx
+++ b/graylog2-web-interface/src/components/configurationforms/NumberField.jsx
@@ -69,7 +69,7 @@ const NumberField = createReactClass({
   },
 
   render() {
-    const { field, title, typeName } = this.state;
+    const { field, title, typeName } = this.props;
     const isRequired = !field.is_optional;
     const validationSpecs = this.validationSpec(field);
     const fieldId = `${typeName}-${title}`;

--- a/graylog2-web-interface/src/components/configurationforms/TextField.jsx
+++ b/graylog2-web-interface/src/components/configurationforms/TextField.jsx
@@ -47,9 +47,8 @@ class TextField extends React.Component {
   };
 
   render() {
-    const { field } = this.state;
-    const { title } = this.state;
-    const { typeName } = this.state;
+    const { field, title, typeName } = this.state;
+    const fieldId = `${typeName}-${title}`;
 
     let inputField;
     const isRequired = !field.is_optional;
@@ -57,7 +56,7 @@ class TextField extends React.Component {
 
     if (FieldHelpers.hasAttribute(field.attributes, 'textarea')) {
       inputField = (
-        <textarea id={title}
+        <textarea id={fieldId}
                   className="form-control"
                   rows={10}
                   name={`configuration[${title}]`}
@@ -68,7 +67,7 @@ class TextField extends React.Component {
       );
     } else {
       inputField = (
-        <input id={title}
+        <input id={fieldId}
                type={fieldType}
                className="form-control"
                name={`configuration[${title}]`}
@@ -82,7 +81,7 @@ class TextField extends React.Component {
     // TODO: replace with bootstrap input component
     return (
       <div className="form-group">
-        <label htmlFor={`${typeName}-${title})`}>
+        <label htmlFor={fieldId}>
           {field.human_name}
           {FieldHelpers.optionalMarker(field)}
         </label>


### PR DESCRIPTION
Before this change, components for auto-generated configuration forms did not associate their labels and inputs correctly, setting different values for the label's `for` attribute and the input's `id`. This represents a usability issue, and also throw errors when testing these components with `react-testing-library`'s `getByLabelText` method.

This PR ensures all auto-generated labels and inputs are connected through the same id values.

Refs Graylog2/graylog-plugin-cloud#741

