### PR TITLE
Support pluggable widget actions.

### DIFF
--- a/graylog2-web-interface/src/views/components/contexts/WidgetFocusContext.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/WidgetFocusContext.tsx
@@ -18,7 +18,7 @@ import * as React from 'react';
 
 import { singleton } from 'views/logic/singleton';
 
-type WidgetFocusContextType = {
+export type WidgetFocusContextType = {
   focusedWidget: string | undefined | null,
   setFocusedWidget: (focusedWidget: string | undefined | null) => void,
 };

--- a/graylog2-web-interface/src/views/components/widgets/ExtraWidgetActions.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/ExtraWidgetActions.test.tsx
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import { render, screen, waitFor } from 'wrappedTestingLibrary';
+import asMock from 'helpers/mocking/AsMock';
+import userEvent from '@testing-library/user-event';
+
+import ExtraWidgetActions from 'views/components/widgets/ExtraWidgetActions';
+import Widget from 'views/logic/widgets/Widget';
+import usePluginEntities from 'views/logic/usePluginEntities';
+
+jest.mock('views/logic/usePluginEntities', () => jest.fn(() => []));
+
+describe('ExtraWidgetActions', () => {
+  const widget = Widget.empty();
+  const dummyActionWithoutIsHidden = {
+    type: 'dummy-action',
+    title: () => 'Dummy Action',
+    action: jest.fn(),
+  };
+  const dummyActionWhichIsHidden = {
+    ...dummyActionWithoutIsHidden,
+    isHidden: jest.fn(() => true),
+  };
+  const dummyActionWhichIsNotHidden = {
+    ...dummyActionWithoutIsHidden,
+    isHidden: jest.fn(() => false),
+  };
+
+  it('returns `null` if no action is configured', () => {
+    const { container } = render(<ExtraWidgetActions widget={widget} />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('returns `null` if no action is not hidden', () => {
+    asMock(usePluginEntities).mockReturnValue([dummyActionWhichIsHidden]);
+
+    const { container } = render(<ExtraWidgetActions widget={widget} />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders action which has no `isHidden`', async () => {
+    asMock(usePluginEntities).mockReturnValue([dummyActionWithoutIsHidden]);
+
+    render(<ExtraWidgetActions widget={widget} />);
+
+    await screen.findByText('Dummy Action');
+  });
+
+  it('renders action where `isHidden` returns `false`', async () => {
+    asMock(usePluginEntities).mockReturnValue([dummyActionWhichIsNotHidden]);
+
+    render(<ExtraWidgetActions widget={widget} />);
+
+    await screen.findByText('Dummy Action');
+  });
+
+  it('clicking menu item triggers action', async () => {
+    asMock(usePluginEntities).mockReturnValue([dummyActionWhichIsNotHidden]);
+
+    render(<ExtraWidgetActions widget={widget} />);
+
+    const menuItem = await screen.findByText('Dummy Action');
+
+    await userEvent.click(menuItem);
+
+    await waitFor(() => expect(dummyActionWhichIsNotHidden.action).toHaveBeenCalledWith(widget));
+  });
+
+  it('renders divider if at least one action is present', async () => {
+    asMock(usePluginEntities).mockReturnValue([dummyActionWithoutIsHidden]);
+
+    render(<ExtraWidgetActions widget={widget} />);
+
+    await screen.findByRole('separator');
+  });
+});

--- a/graylog2-web-interface/src/views/components/widgets/ExtraWidgetActions.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/ExtraWidgetActions.test.tsx
@@ -42,7 +42,7 @@ describe('ExtraWidgetActions', () => {
   };
 
   it('returns `null` if no action is configured', () => {
-    const { container } = render(<ExtraWidgetActions widget={widget} />);
+    const { container } = render(<ExtraWidgetActions onSelect={() => {}} widget={widget} />);
 
     expect(container).toBeEmptyDOMElement();
   });
@@ -50,7 +50,7 @@ describe('ExtraWidgetActions', () => {
   it('returns `null` if no action is not hidden', () => {
     asMock(usePluginEntities).mockReturnValue([dummyActionWhichIsHidden]);
 
-    const { container } = render(<ExtraWidgetActions widget={widget} />);
+    const { container } = render(<ExtraWidgetActions onSelect={() => {}} widget={widget} />);
 
     expect(container).toBeEmptyDOMElement();
   });
@@ -58,7 +58,7 @@ describe('ExtraWidgetActions', () => {
   it('renders action which has no `isHidden`', async () => {
     asMock(usePluginEntities).mockReturnValue([dummyActionWithoutIsHidden]);
 
-    render(<ExtraWidgetActions widget={widget} />);
+    render(<ExtraWidgetActions onSelect={() => {}} widget={widget} />);
 
     await screen.findByText('Dummy Action');
   });
@@ -66,7 +66,7 @@ describe('ExtraWidgetActions', () => {
   it('renders action where `isHidden` returns `false`', async () => {
     asMock(usePluginEntities).mockReturnValue([dummyActionWhichIsNotHidden]);
 
-    render(<ExtraWidgetActions widget={widget} />);
+    render(<ExtraWidgetActions onSelect={() => {}} widget={widget} />);
 
     await screen.findByText('Dummy Action');
   });
@@ -74,7 +74,7 @@ describe('ExtraWidgetActions', () => {
   it('clicking menu item triggers action', async () => {
     asMock(usePluginEntities).mockReturnValue([dummyActionWhichIsNotHidden]);
 
-    render(<ExtraWidgetActions widget={widget} />);
+    render(<ExtraWidgetActions onSelect={() => {}} widget={widget} />);
 
     const menuItem = await screen.findByText('Dummy Action');
 
@@ -83,10 +83,23 @@ describe('ExtraWidgetActions', () => {
     await waitFor(() => expect(dummyActionWhichIsNotHidden.action).toHaveBeenCalledWith(widget));
   });
 
+  it('clicking menu item triggers `onSelect` to close menu', async () => {
+    asMock(usePluginEntities).mockReturnValue([dummyActionWhichIsNotHidden]);
+    const onSelect = jest.fn();
+
+    render(<ExtraWidgetActions onSelect={onSelect} widget={widget} />);
+
+    const menuItem = await screen.findByText('Dummy Action');
+
+    await userEvent.click(menuItem);
+
+    await waitFor(() => expect(onSelect).toHaveBeenCalled());
+  });
+
   it('renders divider if at least one action is present', async () => {
     asMock(usePluginEntities).mockReturnValue([dummyActionWithoutIsHidden]);
 
-    render(<ExtraWidgetActions widget={widget} />);
+    render(<ExtraWidgetActions onSelect={() => {}} widget={widget} />);
 
     await screen.findByRole('separator');
   });

--- a/graylog2-web-interface/src/views/components/widgets/ExtraWidgetActions.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/ExtraWidgetActions.test.tsx
@@ -80,7 +80,13 @@ describe('ExtraWidgetActions', () => {
 
     await userEvent.click(menuItem);
 
-    await waitFor(() => expect(dummyActionWhichIsNotHidden.action).toHaveBeenCalledWith(widget));
+    await waitFor(() => expect(dummyActionWhichIsNotHidden.action)
+      .toHaveBeenCalledWith(widget, expect.objectContaining({
+        widgetFocusContext: expect.objectContaining({
+          focusedWidget: undefined,
+          setFocusedWidget: expect.any(Function),
+        }),
+      })));
   });
 
   it('clicking menu item triggers `onSelect` to close menu', async () => {

--- a/graylog2-web-interface/src/views/components/widgets/ExtraWidgetActions.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/ExtraWidgetActions.tsx
@@ -41,7 +41,7 @@ const ExtraWidgetActions = ({ onSelect, widget }: Props) => {
       };
 
       return (<MenuItem key={`${type}-${widget.id}`} onSelect={_onSelect}>{title(widget)}</MenuItem>);
-    }), [onSelect, pluginWidgetActions, widget]);
+    }), [onSelect, pluginWidgetActions, widget, widgetFocusContext]);
 
   return extraWidgetActions.length > 0
     ? (

--- a/graylog2-web-interface/src/views/components/widgets/ExtraWidgetActions.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/ExtraWidgetActions.tsx
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import { useMemo } from 'react';
+
+import Widget from 'views/logic/widgets/Widget';
+import usePluginEntities from 'views/logic/usePluginEntities';
+import { MenuItem } from 'components/graylog';
+
+type Props = {
+  widget: Widget,
+};
+
+type WidgetAction = {
+  type: string,
+  title: (w: Widget) => string,
+  isHidden?: (w: Widget) => boolean,
+  action: (w: Widget) => unknown,
+};
+
+const ExtraWidgetActions = ({ widget }: Props) => {
+  const pluginWidgetActions = usePluginEntities<WidgetAction>('views.widgets.actions');
+  const extraWidgetActions = useMemo(() => pluginWidgetActions
+    .filter(({ isHidden = () => false }) => !isHidden(widget))
+    .map(({ title, action, type }) => <MenuItem key={`${type}-${widget.id}`} onSelect={() => action(widget)}>{title(widget)}</MenuItem>), [pluginWidgetActions, widget]);
+
+  return extraWidgetActions.length > 0
+    ? (
+      <>
+        <MenuItem divider />
+        {extraWidgetActions}
+      </>
+    )
+    : null;
+};
+
+export default ExtraWidgetActions;

--- a/graylog2-web-interface/src/views/components/widgets/ExtraWidgetActions.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/ExtraWidgetActions.tsx
@@ -22,6 +22,7 @@ import usePluginEntities from 'views/logic/usePluginEntities';
 import { MenuItem } from 'components/graylog';
 
 type Props = {
+  onSelect: (eventKey: string, e: MouseEvent) => void,
   widget: Widget,
 };
 
@@ -32,11 +33,18 @@ type WidgetAction = {
   action: (w: Widget) => unknown,
 };
 
-const ExtraWidgetActions = ({ widget }: Props) => {
+const ExtraWidgetActions = ({ onSelect, widget }: Props) => {
   const pluginWidgetActions = usePluginEntities<WidgetAction>('views.widgets.actions');
   const extraWidgetActions = useMemo(() => pluginWidgetActions
     .filter(({ isHidden = () => false }) => !isHidden(widget))
-    .map(({ title, action, type }) => <MenuItem key={`${type}-${widget.id}`} onSelect={() => action(widget)}>{title(widget)}</MenuItem>), [pluginWidgetActions, widget]);
+    .map(({ title, action, type }) => {
+      const _onSelect = (eventKey: string, e: MouseEvent) => {
+        action(widget);
+        onSelect(eventKey, e);
+      };
+
+      return (<MenuItem key={`${type}-${widget.id}`} onSelect={_onSelect}>{title(widget)}</MenuItem>);
+    }), [onSelect, pluginWidgetActions, widget]);
 
   return extraWidgetActions.length > 0
     ? (

--- a/graylog2-web-interface/src/views/components/widgets/ExtraWidgetActions.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/ExtraWidgetActions.tsx
@@ -15,31 +15,37 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { useMemo } from 'react';
+import { useContext, useMemo } from 'react';
 
 import Widget from 'views/logic/widgets/Widget';
 import usePluginEntities from 'views/logic/usePluginEntities';
 import { MenuItem } from 'components/graylog';
+import WidgetFocusContext, { WidgetFocusContextType } from 'views/components/contexts/WidgetFocusContext';
 
 type Props = {
   onSelect: (eventKey: string, e: MouseEvent) => void,
   widget: Widget,
 };
 
+type Contexts = {
+  widgetFocusContext: WidgetFocusContextType,
+};
+
 type WidgetAction = {
   type: string,
   title: (w: Widget) => string,
   isHidden?: (w: Widget) => boolean,
-  action: (w: Widget) => unknown,
+  action: (w: Widget, contexts: Contexts) => unknown,
 };
 
 const ExtraWidgetActions = ({ onSelect, widget }: Props) => {
+  const widgetFocusContext = useContext(WidgetFocusContext);
   const pluginWidgetActions = usePluginEntities<WidgetAction>('views.widgets.actions');
   const extraWidgetActions = useMemo(() => pluginWidgetActions
     .filter(({ isHidden = () => false }) => !isHidden(widget))
     .map(({ title, action, type }) => {
       const _onSelect = (eventKey: string, e: MouseEvent) => {
-        action(widget);
+        action(widget, { widgetFocusContext });
         onSelect(eventKey, e);
       };
 

--- a/graylog2-web-interface/src/views/components/widgets/ExtraWidgetActions.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/ExtraWidgetActions.tsx
@@ -20,27 +20,18 @@ import { useContext, useMemo } from 'react';
 import Widget from 'views/logic/widgets/Widget';
 import usePluginEntities from 'views/logic/usePluginEntities';
 import { MenuItem } from 'components/graylog';
-import WidgetFocusContext, { WidgetFocusContextType } from 'views/components/contexts/WidgetFocusContext';
+import WidgetFocusContext from 'views/components/contexts/WidgetFocusContext';
+
+import { WidgetActionType } from './Types';
 
 type Props = {
   onSelect: (eventKey: string, e: MouseEvent) => void,
   widget: Widget,
 };
 
-type Contexts = {
-  widgetFocusContext: WidgetFocusContextType,
-};
-
-type WidgetAction = {
-  type: string,
-  title: (w: Widget) => string,
-  isHidden?: (w: Widget) => boolean,
-  action: (w: Widget, contexts: Contexts) => unknown,
-};
-
 const ExtraWidgetActions = ({ onSelect, widget }: Props) => {
   const widgetFocusContext = useContext(WidgetFocusContext);
-  const pluginWidgetActions = usePluginEntities<WidgetAction>('views.widgets.actions');
+  const pluginWidgetActions = usePluginEntities<WidgetActionType>('views.widgets.actions');
   const extraWidgetActions = useMemo(() => pluginWidgetActions
     .filter(({ isHidden = () => false }) => !isHidden(widget))
     .map(({ title, action, type }) => {

--- a/graylog2-web-interface/src/views/components/widgets/Types.ts
+++ b/graylog2-web-interface/src/views/components/widgets/Types.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import { WidgetFocusContextType } from 'views/components/contexts/WidgetFocusContext';
+import Widget from 'views/logic/widgets/Widget';
+
+export type Contexts = {
+  widgetFocusContext: WidgetFocusContextType,
+};
+
+export type WidgetAction = (w: Widget, contexts: Contexts) => unknown;
+
+export type WidgetActionType = {
+  type: string,
+  title: (w: Widget) => string,
+  isHidden?: (w: Widget) => boolean,
+  action: WidgetAction,
+};

--- a/graylog2-web-interface/src/views/components/widgets/Types.ts
+++ b/graylog2-web-interface/src/views/components/widgets/Types.ts
@@ -14,6 +14,8 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
+import * as React from 'react';
+
 import { WidgetFocusContextType } from 'views/components/contexts/WidgetFocusContext';
 import Widget from 'views/logic/widgets/Widget';
 
@@ -25,7 +27,7 @@ export type WidgetAction = (w: Widget, contexts: Contexts) => unknown;
 
 export type WidgetActionType = {
   type: string,
-  title: (w: Widget) => string,
+  title: (w: Widget) => React.ReactNode,
   isHidden?: (w: Widget) => boolean,
   action: WidgetAction,
 };

--- a/graylog2-web-interface/src/views/components/widgets/Widget.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/Widget.tsx
@@ -404,7 +404,7 @@ class Widget extends React.Component<Props, State> {
                       <IfDashboard>
                         <MenuItem onSelect={this._onToggleMoveWidgetToTab}>Move to Page</MenuItem>
                       </IfDashboard>
-                      <ExtraWidgetActions widget={widget} />
+                      <ExtraWidgetActions widget={widget} onSelect={() => {}} />
                       <MenuItem divider />
                       <MenuItem onSelect={() => this._onDelete(widget)}>Delete</MenuItem>
                     </WidgetActionDropdown>

--- a/graylog2-web-interface/src/views/components/widgets/Widget.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/Widget.tsx
@@ -62,6 +62,7 @@ import CopyToDashboard from './CopyToDashboardForm';
 import MoveWidgetToTabModal from './MoveWidgetToTabModal';
 import WidgetErrorBoundary from './WidgetErrorBoundary';
 import ReplaySearchButton from './ReplaySearchButton';
+import ExtraWidgetActions from './ExtraWidgetActions';
 
 import CustomPropTypes from '../CustomPropTypes';
 import IfDashboard from '../dashboard/IfDashboard';
@@ -403,6 +404,7 @@ class Widget extends React.Component<Props, State> {
                       <IfDashboard>
                         <MenuItem onSelect={this._onToggleMoveWidgetToTab}>Move to Page</MenuItem>
                       </IfDashboard>
+                      <ExtraWidgetActions widget={widget} />
                       <MenuItem divider />
                       <MenuItem onSelect={() => this._onDelete(widget)}>Delete</MenuItem>
                     </WidgetActionDropdown>


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR adds functionality to support pluggable widget actions. These can be added conditionally to the action dropdown present for each widget. The key used to register widget actions is `views.widgets.actions`, the type for the actions looks like this:

```javascript
type WidgetAction = {
  type: string, // arbitrary string, just used to differentiate actions (e.g. `dummy-action`)
  title: (w: Widget) => string, // Generates the title
  isHidden?: (w: Widget) => boolean, // Determines if the action is hidden or not (optional, defaults to `false`)
  action: (w: Widget, contexts: Contexts) => unknown, // The action which is triggered upon click
};

type Contexts = {
  widgetFocusContext: WidgetFocusContextType,
};
```

The actual action is called with the current widget and an extendable object containing contexts. Currently the `WidgetFocusContext` is added, other contexts can be added in the future if needed.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.