### PR TITLE
Update testcontainers to 1.15.2.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -174,7 +174,7 @@
         <nosqlunit.version>1.0.0-rc.5</nosqlunit.version>
         <restassured.version>4.3.1</restassured.version>
         <system-rules.version>1.19.0</system-rules.version>
-        <testcontainers.version>1.15.1</testcontainers.version>
+        <testcontainers.version>1.15.2</testcontainers.version>
 
         <!-- Nodejs dependencies -->
         <nodejs.version>v14.15.4</nodejs.version>


### PR DESCRIPTION
This release of testcontainers has a fix for an issue where the Ryuk container hangs forever. It could possibly help with our CI hangs. 

https://github.com/testcontainers/testcontainers-java/releases/tag/1.15.2



