### PR TITLE
Update styling of OverlayTrigger to not break lines

### DIFF
--- a/graylog2-web-interface/src/components/graylog/OverlayTrigger.tsx
+++ b/graylog2-web-interface/src/components/graylog/OverlayTrigger.tsx
@@ -34,16 +34,8 @@ type State = {
   show: boolean,
 }
 
-const TriggerWrap = styled.button`
+const TriggerWrap = styled.span`
   display: inline-block;
-  background: transparent;
-  padding: 0;
-  border: none;
-
-  &::-moz-focus-inner {
-    border: 0;
-    padding: 0;
-  }
 `;
 
 const Container = styled.div`
@@ -103,7 +95,7 @@ class OverlayTrigger extends React.Component<Props, State> {
 
     return (
       <Container ref={() => this.containerRef}>
-        <TriggerWrap ref={this.targetRef} className={children.props.className}>
+        <TriggerWrap ref={this.targetRef} className={children.props.className} role="button">
           {React.cloneElement(children, { ...triggerables, className: '' })}
         </TriggerWrap>
 

--- a/graylog2-web-interface/src/components/graylog/OverlayTrigger.tsx
+++ b/graylog2-web-interface/src/components/graylog/OverlayTrigger.tsx
@@ -103,8 +103,8 @@ class OverlayTrigger extends React.Component<Props, State> {
 
     return (
       <Container ref={() => this.containerRef}>
-        <TriggerWrap ref={this.targetRef}>
-          {React.cloneElement(children, { ...triggerables })}
+        <TriggerWrap ref={this.targetRef} className={children.props.className}>
+          {React.cloneElement(children, { ...triggerables, className: '' })}
         </TriggerWrap>
 
         {show && (

--- a/graylog2-web-interface/src/components/graylog/OverlayTrigger.tsx
+++ b/graylog2-web-interface/src/components/graylog/OverlayTrigger.tsx
@@ -18,7 +18,6 @@ import * as React from 'react';
 import { createRef } from 'react';
 import { Overlay, Transition } from 'react-overlays';
 import styled from 'styled-components';
-import assign from 'lodash/assign';
 
 type Triggers = 'click' | 'focus' | 'hover';
 
@@ -71,6 +70,7 @@ class OverlayTrigger extends React.Component<Props, State> {
   }
 
   render() {
+    let triggerables;
     const { children, container, placement, overlay, rootClose, trigger, ...overlayProps } = this.props;
     const { show } = this.state;
 
@@ -91,14 +91,14 @@ class OverlayTrigger extends React.Component<Props, State> {
       },
     };
 
-    let triggerables = _onTrigger[trigger];
-
     if (Array.isArray(trigger)) {
       const multipleTriggers = {};
 
       trigger.forEach((triggerType) => {
-        triggerables = assign(multipleTriggers, _onTrigger[triggerType]);
+        triggerables = Object.assign(multipleTriggers, _onTrigger[triggerType]);
       });
+    } else {
+      triggerables = _onTrigger[trigger];
     }
 
     return (

--- a/graylog2-web-interface/src/components/graylog/OverlayTrigger.tsx
+++ b/graylog2-web-interface/src/components/graylog/OverlayTrigger.tsx
@@ -31,12 +31,24 @@ type State = {
   show: boolean,
 }
 
-const TriggerWrap = styled.span`
+const TriggerWrap = styled.button`
+  display: inline-block;
+  background: transparent;
+  padding: 0;
+  border: none;
+
+  &::-moz-focus-inner {
+    border: 0;
+    padding: 0;
+  }
+`;
+
+const Container = styled.div`
   display: inline-block;
 `;
 
 class OverlayTrigger extends React.Component<Props, State> {
-  targetRef = createRef<HTMLElement>();
+  targetRef = createRef<HTMLButtonElement>();
 
   containerRef = createRef<HTMLElement>();
 
@@ -61,7 +73,7 @@ class OverlayTrigger extends React.Component<Props, State> {
     const toggleShow = () => this.setState({ show: !show });
 
     return (
-      <div ref={() => this.containerRef}>
+      <Container ref={() => this.containerRef}>
         <TriggerWrap ref={this.targetRef}>
           {React.cloneElement(children, { onClick: toggleShow })}
         </TriggerWrap>
@@ -80,7 +92,7 @@ class OverlayTrigger extends React.Component<Props, State> {
             {overlay}
           </Overlay>
         )}
-      </div>
+      </Container>
     );
   }
 }

--- a/graylog2-web-interface/src/views/components/searchbar/saved-search/__snapshots__/SavedSearchControls.test.tsx.snap
+++ b/graylog2-web-interface/src/views/components/searchbar/saved-search/__snapshots__/SavedSearchControls.test.tsx.snap
@@ -281,6 +281,10 @@ exports[`SavedSearchControls Button handling has "Share" option which should be 
   color: rgb(88,73,5);
 }
 
+.c3 {
+  display: inline-block;
+}
+
 .c2 {
   display: inline-block;
 }
@@ -347,35 +351,49 @@ exports[`SavedSearchControls Button handling has "Share" option which should be 
             ]
           }
         >
-          <div>
-            <OverlayTrigger__TriggerWrap>
-              <span
-                className="c2"
+          <OverlayTrigger__Container>
+            <div
+              className="c2"
+            >
+              <OverlayTrigger__TriggerWrap
+                className="c1 "
+                role="button"
               >
-                <Icon
-                  className="c1 "
-                  name="question-circle"
-                  onClick={[Function]}
-                  type="solid"
+                <span
+                  className="c3 c1 "
+                  role="button"
                 >
-                  <FontAwesomeIcon
-                    className="c1 "
-                    icon={
-                      Object {
-                        "iconName": "question-circle",
-                        "prefix": "fas",
-                      }
-                    }
-                    onClick={[Function]}
+                  <Icon
+                    className=""
+                    name="question-circle"
+                    onBlur={[Function]}
+                    onFocus={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                    type="solid"
                   >
-                    <svg
-                      className="svg-inline--fa fa-question-circle"
-                    />
-                  </FontAwesomeIcon>
-                </Icon>
-              </span>
-            </OverlayTrigger__TriggerWrap>
-          </div>
+                    <FontAwesomeIcon
+                      className=""
+                      icon={
+                        Object {
+                          "iconName": "question-circle",
+                          "prefix": "fas",
+                        }
+                      }
+                      onBlur={[Function]}
+                      onFocus={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      <svg
+                        className="svg-inline--fa fa-question-circle"
+                      />
+                    </FontAwesomeIcon>
+                  </Icon>
+                </span>
+              </OverlayTrigger__TriggerWrap>
+            </div>
+          </OverlayTrigger__Container>
         </OverlayTrigger>
       </HoverForHelp>
     </SharingDisabledPopover__StyledHoverForHelp>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Updated styles within OverlayTrigger to stop line break regression.
Added ability for `trigger` prop to function

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Updated version of OverlayTrigger would cause line breaks where there should not be one.
`trigger` prop was not used other than defaultProps, so functionality was added.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/122591/108266138-59449300-712f-11eb-9009-1f92a446640e.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

