### PR TITLE
Fixing counting of messages in index for ES7.

### DIFF
--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/IndicesAdapterES7.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/IndicesAdapterES7.java
@@ -246,7 +246,11 @@ public class IndicesAdapterES7 implements IndicesAdapter {
     @Override
     public long numberOfMessages(String index) {
         final JsonNode result = statsApi.indexStats(index);
-        return result.path("primaries").path("docs").path("count").asLong();
+        final JsonNode count = result.path("_all").path("primaries").path("docs").path("count");
+        if (count.isMissingNode()) {
+            throw new RuntimeException("Unable to extract count from response.");
+        }
+        return count.asLong();
     }
 
     private GetSettingsResponse settingsFor(String indexOrAlias) {

--- a/graylog2-server/src/test/java/org/graylog2/indexer/indices/IndicesIT.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/indices/IndicesIT.java
@@ -441,4 +441,11 @@ public abstract class IndicesIT extends ElasticsearchBaseTest {
 
         assertThat(healthStatus).isEqualTo(HealthStatus.Red);
     }
+
+    @Test
+    public void numberOfMessagesReturnsCorrectSize() {
+        importFixture("org/graylog2/indexer/indices/IndicesIT.json");
+
+        assertThat(indices.numberOfMessages("graylog_0")).isEqualTo(10);
+    }
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

**Note:** This PR should be backported to `4.0`.

Prior to this change, the `Indices#numberOfMessages` implementation for ES7 was using the same JSON path as in ES6, although the structure of the response has changed. This, in combination with an overly relaxed parsing of the response lead to the method always returning 0.

The consequence of this is that any configured count-based rotation policy was never triggered, due to the threshold never being crossed.

This PR is adding a test for the method, fixes the JSON path and makes sure that if the node is not found, it will raise an exception instead of returning 0.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.