### PR TITLE
Providing active query id for each widget on search page.

### DIFF
--- a/graylog2-web-interface/src/views/components/widgets/Widget.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/Widget.tsx
@@ -307,7 +307,7 @@ class Widget extends React.Component<Props, State> {
 
     if (data) {
       const { editing } = this.state;
-      const { id, widget, height, width, fields } = this.props;
+      const { id, widget, height, width, fields, view: { activeQuery: queryId } } = this.props;
       const { config, filter } = widget;
       const VisComponent = _visualizationForType(widget.type);
 
@@ -318,6 +318,7 @@ class Widget extends React.Component<Props, State> {
                       fields={fields}
                       filter={filter}
                       height={height}
+                      queryId={queryId}
                       onConfigChange={(newWidgetConfig) => this._onWidgetConfigChange(id, newWidgetConfig)}
                       setLoadingState={this._setLoadingState}
                       title={title}


### PR DESCRIPTION
## Description
With this PR we are providing the id of the active query for each widget as a component prop.

## Motivation and Context
We need to know this id for a specific widget type.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

