### PR TITLE
Toggling date time picker when clicking on date time in search bar.

### DIFF
--- a/graylog2-web-interface/src/views/components/DashboardSearchBar.test.tsx
+++ b/graylog2-web-interface/src/views/components/DashboardSearchBar.test.tsx
@@ -50,7 +50,7 @@ describe('DashboardSearchBar', () => {
     render(<DashboardSearchBar onExecute={onExecute} config={config} />);
 
     const timeRangeButton = screen.getByLabelText('Open Time Range Selector');
-    const timeRangeDisplay = screen.getByLabelText('Search Time Range');
+    const timeRangeDisplay = screen.getByLabelText('Search Time Range, Opens Time Range Selector On Click');
     const liveUpdate = screen.getByLabelText('Refresh Search Controls');
     const searchButton = screen.getByTitle('Perform search');
 

--- a/graylog2-web-interface/src/views/components/DashboardSearchBar.tsx
+++ b/graylog2-web-interface/src/views/components/DashboardSearchBar.tsx
@@ -38,7 +38,6 @@ import { SearchesConfig } from 'components/search/SearchConfig';
 
 import DashboardSearchForm from './DashboardSearchBarForm';
 import TimeRangeTypeSelector from './searchbar/TimeRangeTypeSelector';
-import TimeRangeDisplay from './searchbar/TimeRangeDisplay';
 
 const FlexCol = styled(Col)`
   display: flex;
@@ -83,7 +82,6 @@ const DashboardSearchBar = ({ config, globalOverride, disableSearch = false, onE
                                            currentTimeRange={values?.timerange}
                                            hasErrorOnMount={!isValid}
                                            noOverride />
-                    <TimeRangeDisplay timerange={values?.timerange} />
                   </FlexCol>
                   <Col lg={4} md={3} xs={2}>
                     <RefreshControls />

--- a/graylog2-web-interface/src/views/components/SearchBar.test.tsx
+++ b/graylog2-web-interface/src/views/components/SearchBar.test.tsx
@@ -66,7 +66,7 @@ describe('SearchBar', () => {
     render(<SearchBar config={config} />);
 
     const timeRangeButton = screen.getByLabelText('Open Time Range Selector');
-    const timeRangeDisplay = screen.getByLabelText('Search Time Range');
+    const timeRangeDisplay = screen.getByLabelText('Search Time Range, Opens Time Range Selector On Click');
     const streamsFilter = screen.getByTestId('streams-filter');
     const liveUpdate = screen.getByLabelText('Refresh Search Controls');
     const searchButton = screen.getByTitle('Perform search');

--- a/graylog2-web-interface/src/views/components/SearchBar.tsx
+++ b/graylog2-web-interface/src/views/components/SearchBar.tsx
@@ -45,7 +45,6 @@ import type { SearchesConfig } from 'components/search/SearchConfig';
 import type { SearchBarFormValues } from 'views/Constants';
 
 import SearchBarForm from './searchbar/SearchBarForm';
-import TimeRangeDisplay from './searchbar/TimeRangeDisplay';
 
 type Props = {
   availableStreams: Array<{ key: string, value: string }>,
@@ -120,7 +119,6 @@ const SearchBar = ({
                                            setCurrentTimeRange={(nextTimeRange) => setFieldValue('timerange', nextTimeRange)}
                                            currentTimeRange={values?.timerange}
                                            hasErrorOnMount={!isValid} />
-                    <TimeRangeDisplay timerange={values?.timerange} />
                   </FlexCol>
 
                   <Col mdHidden lgHidden>

--- a/graylog2-web-interface/src/views/components/WidgetQueryControls.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetQueryControls.tsx
@@ -35,7 +35,6 @@ import TimeRangeTypeSelector from './searchbar/TimeRangeTypeSelector';
 import StreamsFilter from './searchbar/StreamsFilter';
 import SearchButton from './searchbar/SearchButton';
 import QueryInput from './searchbar/AsyncQueryInput';
-import TimeRangeDisplay from './searchbar/TimeRangeDisplay';
 
 type Props = {
   availableStreams: Array<any>,
@@ -100,7 +99,6 @@ const WidgetQueryControls = ({ availableStreams, globalOverride }: Props) => {
                                      setCurrentTimeRange={(nextTimeRange) => setFieldValue('timerange', nextTimeRange)}
                                      currentTimeRange={values?.timerange}
                                      hasErrorOnMount={!isValid} />
-              <TimeRangeDisplay timerange={values?.timerange} />
             </FlexCol>
 
             <Col md={8}>

--- a/graylog2-web-interface/src/views/components/searchbar/TimeRangeDisplay.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/TimeRangeDisplay.test.tsx
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import { fireEvent, render, screen } from 'wrappedTestingLibrary';
+import * as React from 'react';
+
+import TimeRangeDisplay from './TimeRangeDisplay';
+
+describe('TimeRangeDisplay', () => {
+  it('opens the date time range picker on click', () => {
+    const toggleShow = jest.fn();
+    render(<TimeRangeDisplay toggleDropdownShow={toggleShow} timerange={{ type: 'relative', from: 300 }} />);
+
+    const timeRangeDisplay = screen.getByRole('button', { name: 'Search Time Range, Opens Time Range Selector On Click' });
+
+    fireEvent.click(timeRangeDisplay);
+
+    expect(toggleShow).toHaveBeenCalled();
+  });
+});

--- a/graylog2-web-interface/src/views/components/searchbar/TimeRangeDisplay.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/TimeRangeDisplay.tsx
@@ -120,7 +120,7 @@ const TimeRangeDisplay = ({ timerange, toggleDropdownShow }: Props) => {
   }, [dateTested, timerange]);
 
   return (
-    <TimeRangeWrapper aria-label="Search Time Range" onClick={toggleDropdownShow}>
+    <TimeRangeWrapper aria-label="Search Time Range, Opens Time Range Selector On Click" role="button" onClick={toggleDropdownShow}>
       {!(timerange && 'type' in timerange)
         ? <span><code>No Override</code></span>
         : (

--- a/graylog2-web-interface/src/views/components/searchbar/TimeRangeDisplay.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/TimeRangeDisplay.tsx
@@ -42,7 +42,6 @@ const TimeRangeWrapper = styled.p(({ theme }) => css`
   background-color: ${theme.colors.variant.lightest.primary};
   align-items: center;
   border-radius: 4px;
-  cursor: pointer;
 
   > span {
     flex: 1;

--- a/graylog2-web-interface/src/views/components/searchbar/TimeRangeDisplay.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/TimeRangeDisplay.tsx
@@ -25,6 +25,7 @@ import { isTypeKeyword, isTypeRelativeWithStartOnly, isTypeRelativeWithEnd } fro
 
 type Props = {
   timerange: TimeRange | NoTimeRangeOverride | null | undefined,
+  toggleDropdownShow: () => void,
 };
 
 export const EMPTY_RANGE = '----/--/-- --:--:--.---';
@@ -41,6 +42,7 @@ const TimeRangeWrapper = styled.p(({ theme }) => css`
   background-color: ${theme.colors.variant.lightest.primary};
   align-items: center;
   border-radius: 4px;
+  cursor: pointer;
 
   > span {
     flex: 1;
@@ -93,7 +95,7 @@ const dateOutput = (timerange: TimeRange) => {
   }
 };
 
-const TimeRangeDisplay = ({ timerange }: Props) => {
+const TimeRangeDisplay = ({ timerange, toggleDropdownShow }: Props) => {
   const [{ from, until }, setTimeOutput] = useState(EMPTY_OUTPUT);
   const dateTested = useRef(false);
 
@@ -118,7 +120,7 @@ const TimeRangeDisplay = ({ timerange }: Props) => {
   }, [dateTested, timerange]);
 
   return (
-    <TimeRangeWrapper aria-label="Search Time Range">
+    <TimeRangeWrapper aria-label="Search Time Range" onClick={toggleDropdownShow}>
       {!(timerange && 'type' in timerange)
         ? <span><code>No Override</code></span>
         : (

--- a/graylog2-web-interface/src/views/components/searchbar/TimeRangeTypeSelector.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/TimeRangeTypeSelector.tsx
@@ -22,6 +22,7 @@ import { TimeRange, NoTimeRangeOverride } from 'views/logic/queries/Query';
 
 import TimeRangeDropdownButton from './TimeRangeDropdownButton';
 import TimeRangeDropdown from './date-time-picker/TimeRangeDropdown';
+import TimeRangeDisplay from './TimeRangeDisplay';
 
 type Props = {
   currentTimeRange: TimeRange | NoTimeRangeOverride,
@@ -37,15 +38,18 @@ const TimeRangeTypeSelector = ({ disabled, hasErrorOnMount, noOverride, currentT
   const toggleShow = () => setShow(!show);
 
   return (
-    <TimeRangeDropdownButton disabled={disabled}
-                             show={show}
-                             toggleShow={toggleShow}
-                             hasErrorOnMount={hasErrorOnMount}>
-      <TimeRangeDropdown currentTimeRange={currentTimeRange}
-                         noOverride={noOverride}
-                         setCurrentTimeRange={setCurrentTimeRange}
-                         toggleDropdownShow={toggleShow} />
-    </TimeRangeDropdownButton>
+    <>
+      <TimeRangeDropdownButton disabled={disabled}
+                               show={show}
+                               toggleShow={toggleShow}
+                               hasErrorOnMount={hasErrorOnMount}>
+        <TimeRangeDropdown currentTimeRange={currentTimeRange}
+                           noOverride={noOverride}
+                           setCurrentTimeRange={setCurrentTimeRange}
+                           toggleDropdownShow={toggleShow} />
+      </TimeRangeDropdownButton>
+      <TimeRangeDisplay timerange={currentTimeRange} toggleDropdownShow={toggleShow} />
+    </>
   );
 };
 


### PR DESCRIPTION
## Description
We improved the search date time picker recently. Currently a user needs to click on the blue button to open the date time picker. With this change clicking on the selected date time range (in this case "From: 5 minutes ago - Until: now") will also toggle the date time picker.

![image](https://user-images.githubusercontent.com/46300478/108487337-70a28e00-729f-11eb-8c2b-2bd3eaaa01f1.png)


## Motivation and Context
This change will make it slightly easier to open the date time picker which speeds up the process.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

