### PR TITLE
Reducing height of message table header.

### DIFF
--- a/graylog2-web-interface/src/views/components/widgets/MessageTable.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageTable.tsx
@@ -147,8 +147,10 @@ const TableHead = styled.thead(({ theme }) => css`
   background-color: ${theme.colors.gray[90]};
   color: ${theme.utils.readableColor(theme.colors.gray[90])};
 
-  th {
+  && > tr > th {
     min-width: 50px;
+    min-height: 28px;
+    padding: 0 5px;
     border: 0;
     font-size: ${theme.fonts.size.small};
     font-weight: normal;


### PR DESCRIPTION
## Description
The message table now has a height of 28px, which is the minimum due to the height of the sort icon buttons.

## Motivation and Context
Reducing the header height provides more space for the message table rows.