### PR TITLE
Add missing GRN type for outputs (#10089)

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/grn/GRNTypes.java
+++ b/graylog2-server/src/main/java/org/graylog/grn/GRNTypes.java
@@ -25,6 +25,7 @@ public class GRNTypes {
     public static final GRNType EVENT_DEFINITION = GRNType.create("event_definition", "eventdefinitions:");
     public static final GRNType EVENT_NOTIFICATION = GRNType.create("notification", "eventnotifications:");
     public static final GRNType GRANT = GRNType.create("grant", "grants:");
+    public static final GRNType OUTPUT = GRNType.create("output", "outputs:");
     public static final GRNType ROLE = GRNType.create("role", "roles:");
     public static final GRNType SEARCH = GRNType.create("search", "view:");
     public static final GRNType STREAM = GRNType.create("stream", "streams:");
@@ -40,6 +41,7 @@ public class GRNTypes {
             .add(EVENT_DEFINITION)
             .add(EVENT_NOTIFICATION)
             .add(GRANT)
+            .add(OUTPUT)
             .add(ROLE)
             .add(SEARCH)
             .add(STREAM)

--- a/graylog2-server/src/main/java/org/graylog/security/BuiltinCapabilities.java
+++ b/graylog2-server/src/main/java/org/graylog/security/BuiltinCapabilities.java
@@ -37,10 +37,12 @@ public class BuiltinCapabilities {
                         "Viewer",
                         ImmutableSet.of(
                                 RestPermissions.STREAMS_READ,
+                                RestPermissions.STREAM_OUTPUTS_READ,
                                 RestPermissions.DASHBOARDS_READ,
                                 ViewsRestPermissions.VIEW_READ,
                                 RestPermissions.EVENT_DEFINITIONS_READ,
-                                RestPermissions.EVENT_NOTIFICATIONS_READ
+                                RestPermissions.EVENT_NOTIFICATIONS_READ,
+                                RestPermissions.OUTPUTS_READ
                         )
                 ))
                 .put(Capability.MANAGE, CapabilityDescriptor.create(
@@ -50,6 +52,8 @@ public class BuiltinCapabilities {
                                 RestPermissions.STREAMS_READ,
                                 RestPermissions.STREAMS_EDIT,
                                 RestPermissions.STREAMS_CHANGESTATE,
+                                RestPermissions.STREAM_OUTPUTS_READ,
+                                RestPermissions.STREAM_OUTPUTS_CREATE,
                                 RestPermissions.DASHBOARDS_READ,
                                 RestPermissions.DASHBOARDS_EDIT,
                                 ViewsRestPermissions.VIEW_READ,
@@ -57,7 +61,9 @@ public class BuiltinCapabilities {
                                 RestPermissions.EVENT_DEFINITIONS_READ,
                                 RestPermissions.EVENT_DEFINITIONS_EDIT,
                                 RestPermissions.EVENT_NOTIFICATIONS_READ,
-                                RestPermissions.EVENT_NOTIFICATIONS_EDIT
+                                RestPermissions.EVENT_NOTIFICATIONS_EDIT,
+                                RestPermissions.OUTPUTS_READ,
+                                RestPermissions.OUTPUTS_EDIT
                         )
                 ))
                 .put(Capability.OWN, CapabilityDescriptor.create(
@@ -68,6 +74,9 @@ public class BuiltinCapabilities {
                                 RestPermissions.STREAMS_READ,
                                 RestPermissions.STREAMS_EDIT,
                                 RestPermissions.STREAMS_CHANGESTATE,
+                                RestPermissions.STREAM_OUTPUTS_READ,
+                                RestPermissions.STREAM_OUTPUTS_CREATE,
+                                RestPermissions.STREAM_OUTPUTS_DELETE,
                                 RestPermissions.DASHBOARDS_READ,
                                 RestPermissions.DASHBOARDS_EDIT,
                                 ViewsRestPermissions.VIEW_READ,
@@ -78,7 +87,10 @@ public class BuiltinCapabilities {
                                 RestPermissions.EVENT_DEFINITIONS_DELETE,
                                 RestPermissions.EVENT_NOTIFICATIONS_READ,
                                 RestPermissions.EVENT_NOTIFICATIONS_EDIT,
-                                RestPermissions.EVENT_NOTIFICATIONS_DELETE
+                                RestPermissions.EVENT_NOTIFICATIONS_DELETE,
+                                RestPermissions.OUTPUTS_READ,
+                                RestPermissions.OUTPUTS_EDIT,
+                                RestPermissions.OUTPUTS_TERMINATE
                         )
                 ))
                 .build();

--- a/graylog2-server/src/main/java/org/graylog/security/entities/EntityDependencyPermissionChecker.java
+++ b/graylog2-server/src/main/java/org/graylog/security/entities/EntityDependencyPermissionChecker.java
@@ -80,6 +80,7 @@ public class EntityDependencyPermissionChecker {
     private boolean cannotView(GranteeAuthorizer authorizer, EntityDescriptor dependency) {
         final Optional<CapabilityDescriptor> capabilityDescriptor = builtinCapabilities.get(Capability.VIEW);
 
+        // TODO: This only looks at grants permissions, but should also check for permissions through roles
         return capabilityDescriptor.map(CapabilityDescriptor::permissions)
                 .orElse(Collections.emptySet())
                 .stream()


### PR DESCRIPTION
* Add missing GRN type for outputs

Fixes #10088

* Add output permissions to the capabilities

Without this, the dependency check doesn't run properly
because it filters out any permission that isn't handled via grants.
That's another bug we should be fixing..

* Add TODO comment

* Hide some dependencies that are not relevant for sharing entities

* Use Set instead of List for ignored dependcies lookup

(cherry picked from commit 8eec5db77ce28e8819f6ace3f8d92b28bd937883)
