### PR TITLE
Fix rendering of trend color in report generation

### DIFF
--- a/graylog2-web-interface/src/views/components/visualizations/PlotLegend.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/PlotLegend.tsx
@@ -31,8 +31,8 @@ import { colors as defaultColors } from 'views/components/visualizations/Colors'
 
 const ColorHint = styled.div(({ color }) => `
   cursor: pointer;
-  background-color: ${color} !important;
-  -webkit-print-color-adjust: exact !important;
+  background-color: ${color} !important; /* Needed for report generation */
+  -webkit-print-color-adjust: exact !important; /* Needed for report generation */
   width: 12px;
   height: 12px;
 `);

--- a/graylog2-web-interface/src/views/components/visualizations/number/Trend.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/number/Trend.tsx
@@ -40,7 +40,8 @@ const Background = styled.div<{ trend: string | undefined | null }>(({ theme, tr
     ${trend && css`
       background-color: ${bgColor} !important; /* Needed for report generation */
       color: ${theme.utils.contrastingColor(bgColor)} !important /* Needed for report generation */;
-      /* eslint-disable-next-line property-no-vendor-prefix */
+
+      /* stylelint-disable-next-line property-no-vendor-prefix */
       -webkit-print-color-adjust: exact !important; /* Needed for report generation */
     `}
   `;
@@ -53,8 +54,9 @@ const TextContainer = styled.div<{ trend: string | undefined | null, ref }>(({ t
   return css`
       margin: 5px;
       color: ${theme.utils.contrastingColor(bgColor)} !important /* Needed for report generation */;
-      /* eslint-disable-next-line property-no-vendor-prefix */
       font-family: ${theme.fonts.family.body};
+
+      /* stylelint-disable-next-line property-no-vendor-prefix */
       -webkit-print-color-adjust: exact !important; /* Needed for report generation */`;
 });
 
@@ -64,7 +66,7 @@ const StyledIcon = styled(Icon)<{ trend: string | undefined | null }>(({ theme, 
 
   return css`
     path {
-        fill: ${theme.utils.contrastingColor(bgColor)};
+      fill: ${theme.utils.contrastingColor(bgColor)};
     }`;
 });
 

--- a/graylog2-web-interface/src/views/components/visualizations/number/Trend.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/number/Trend.tsx
@@ -38,8 +38,9 @@ const Background = styled.div<{ trend: string | undefined | null }>(({ theme, tr
   return css`
     text-align: right;
     ${trend && css`
-      background-color: ${bgColor};
+      background-color: ${bgColor} !important; /* Needed for report generation */
       color: ${theme.utils.contrastingColor(bgColor)};
+      -webkit-print-color-adjust: exact !important; /* Needed for report generation */
     `}
   `;
 });

--- a/graylog2-web-interface/src/views/components/visualizations/number/Trend.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/number/Trend.tsx
@@ -39,15 +39,34 @@ const Background = styled.div<{ trend: string | undefined | null }>(({ theme, tr
     text-align: right;
     ${trend && css`
       background-color: ${bgColor} !important; /* Needed for report generation */
-      color: ${theme.utils.contrastingColor(bgColor)};
+      color: ${theme.utils.contrastingColor(bgColor)} !important /* Needed for report generation */;
+      /* eslint-disable-next-line property-no-vendor-prefix */
       -webkit-print-color-adjust: exact !important; /* Needed for report generation */
     `}
   `;
 });
 
-const TextContainer = styled.span`
-  margin: 5px;
-`;
+const TextContainer = styled.div<{ trend: string | undefined | null, ref }>(({ theme, trend }) => {
+  const { variant } = theme.colors;
+  const bgColor = trend && trend === TREND_GOOD ? variant.success : variant.primary;
+
+  return css`
+      margin: 5px;
+      color: ${theme.utils.contrastingColor(bgColor)} !important /* Needed for report generation */;
+      /* eslint-disable-next-line property-no-vendor-prefix */
+      font-family: ${theme.fonts.family.body};
+      -webkit-print-color-adjust: exact !important; /* Needed for report generation */`;
+});
+
+const StyledIcon = styled(Icon)<{ trend: string | undefined | null }>(({ theme, trend }) => {
+  const { variant } = theme.colors;
+  const bgColor = trend && trend === TREND_GOOD ? variant.success : variant.primary;
+
+  return css`
+    path {
+        fill: ${theme.utils.contrastingColor(bgColor)};
+    }`;
+});
 
 const _background = (delta, trendPreference: TrendPreference) => {
   switch (trendPreference) {
@@ -63,10 +82,10 @@ const _background = (delta, trendPreference: TrendPreference) => {
 
 const _trendIcon = (delta) => {
   if (delta === 0) {
-    return <Icon name="arrow-circle-right" />;
+    return <StyledIcon name="arrow-circle-right" />;
   }
 
-  return <Icon name={delta > 0 ? 'arrow-circle-up' : 'arrow-circle-down'} />;
+  return <StyledIcon name={delta > 0 ? 'arrow-circle-up' : 'arrow-circle-down'} />;
 };
 
 const Trend = React.forwardRef<HTMLSpanElement, Props>(({ current, previous, trendPreference }: Props, ref) => {
@@ -78,7 +97,7 @@ const Trend = React.forwardRef<HTMLSpanElement, Props>(({ current, previous, tre
 
   return (
     <Background trend={backgroundTrend} data-test-id="trend-background">
-      <TextContainer ref={ref}>
+      <TextContainer trend={backgroundTrend} ref={ref}>
         {trendIcon} {numeral(difference).format('+0,0[.]0[000]')} / {numeral(differencePercent).format('+0[.]0[0]%')}
       </TextContainer>
     </Background>


### PR DESCRIPTION
## Motivation
The report generation is using the chrome print to pdf functionallity
which will turn all backgrounds in css to white.

## Description
We add an !important to the css rule (and explain why) and add the
magical webkit rule which tells chrome to keep the background as it is.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Fixes https://github.com/Graylog2/graylog-plugin-enterprise/issues/1997

