### PR TITLE
Use default remove icon for `react-select`

### DIFF
--- a/graylog2-web-interface/src/components/common/Select.tsx
+++ b/graylog2-web-interface/src/components/common/Select.tsx
@@ -27,9 +27,7 @@ import Icon from './Icon';
 type Option = { [key: string]: any };
 
 const MultiValueRemove = (props) => (
-  <Components.MultiValueRemove {...props}>
-    &times;
-  </Components.MultiValueRemove>
+  <Components.MultiValueRemove {...props} />
 );
 
 const IndicatorSeparator = () => null;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes #7166

<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Right now the remove button is a custom one which overwrites the one `react-select` uses. This PR will revert to using `react-select` remove button, but keeping our CSS changes.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
By measuring the distance of the icon and spacing.

## Screenshots (if appropriate):

<img width="305" alt="image" src="https://user-images.githubusercontent.com/970834/108723035-17975c00-7524-11eb-806e-cac7e524d35a.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

