### PR TITLE
Prevent NPE in index optimization job. (4.0)

### DIFF
--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/ElasticsearchClient.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/ElasticsearchClient.java
@@ -150,13 +150,16 @@ public class ElasticsearchClient {
     }
 
     public static RequestOptions withTimeout(RequestOptions requestOptions, Duration timeout) {
-        final RequestConfig.Builder requestConfigBuilder = requestOptions.getRequestConfig() == null
+        final RequestConfig.Builder requestConfigBuilder = (requestOptions == null || requestOptions.getRequestConfig() == null)
                 ? RequestConfig.custom()
                 : RequestConfig.copy(requestOptions.getRequestConfig());
         final RequestConfig requestConfigWithTimeout = requestConfigBuilder
                 .setSocketTimeout(Math.toIntExact(timeout.toMilliseconds()))
                 .build();
-        return requestOptions.toBuilder()
+        final RequestOptions.Builder requestOptionsBuilder = requestOptions == null
+                ? RequestOptions.DEFAULT.toBuilder()
+                : requestOptions.toBuilder();
+        return requestOptionsBuilder
                 .setRequestConfig(requestConfigWithTimeout)
                 .build();
 

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/ElasticsearchClient.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/ElasticsearchClient.java
@@ -150,7 +150,10 @@ public class ElasticsearchClient {
     }
 
     public static RequestOptions withTimeout(RequestOptions requestOptions, Duration timeout) {
-        final RequestConfig requestConfigWithTimeout = RequestConfig.copy(requestOptions.getRequestConfig())
+        final RequestConfig.Builder requestConfigBuilder = requestOptions.getRequestConfig() == null
+                ? RequestConfig.custom()
+                : RequestConfig.copy(requestOptions.getRequestConfig());
+        final RequestConfig requestConfigWithTimeout = requestConfigBuilder
                 .setSocketTimeout(Math.toIntExact(timeout.toMilliseconds()))
                 .build();
         return requestOptions.toBuilder()

--- a/graylog2-server/src/test/java/org/graylog2/indexer/indices/IndicesIT.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/indices/IndicesIT.java
@@ -16,6 +16,7 @@
  */
 package org.graylog2.indexer.indices;
 
+import com.github.joschi.jadconfig.util.Duration;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.eventbus.EventBus;
@@ -440,5 +441,12 @@ public abstract class IndicesIT extends ElasticsearchBaseTest {
         importFixture("org/graylog2/indexer/indices/IndicesIT.json");
 
         assertThat(indices.numberOfMessages("graylog_0")).isEqualTo(10);
+    }
+
+    @Test
+    public void optimizeIndexJobDoesNotThrowException() {
+        importFixture("org/graylog2/indexer/indices/IndicesIT.json");
+
+        indices.optimizeIndex("graylog_0", 1, Duration.minutes(1));
     }
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

**Note:** This is a backport of #10118 to `4.0`.

In #10065, an attempt was made to introduce timeout handling for ES7 for the force merge request performed by the index optimization job. This made things much worse, by trying to copy a `RequestConfig` instance that is `null` in this situation. This results in an NPE and is aborting the index optimization job before it can perform any action.

This change is now checking if the `RequestConfig` instance is `null` and instantiates a new one in this case instead of trying to copy it.

Fixes #10117.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.