### PR TITLE
Replace `loadable-components` with `React.lazy`.

### DIFF
--- a/graylog2-web-interface/package.json
+++ b/graylog2-web-interface/package.json
@@ -61,7 +61,6 @@
     "javascript-natural-sort": "^0.7.1",
     "jquery-ui": "1.12.x",
     "leaflet": "^1.5.1",
-    "loadable-components": "^2.2.3",
     "lodash": "^4.17.4",
     "marked": "^2.0.0",
     "md5": "^2.2.1",

--- a/graylog2-web-interface/src/routing/loadAsync.tsx
+++ b/graylog2-web-interface/src/routing/loadAsync.tsx
@@ -60,7 +60,7 @@ class AsyncLoaderErrorBoundary extends React.Component<{ errorComponent: React.C
   }
 }
 
-export default <T, >(f: () => Promise<{ default: React.ComponentType<T> }>) => (props: T) => {
+export default <T extends React.ComponentType<any>>(f: () => Promise<{ default: T }>) => (props: React.ComponentPropsWithRef<T>) => {
   const LazyComponent = React.lazy(f);
 
   return (

--- a/graylog2-web-interface/src/views/components/SearchBar.test.tsx
+++ b/graylog2-web-interface/src/views/components/SearchBar.test.tsx
@@ -38,7 +38,7 @@ jest.mock('stores/streams/StreamsStore', () => MockStore(
   'availableStreams',
 ));
 
-jest.mock('views/components/searchbar/QueryInput', () => 'query-input');
+jest.mock('views/components/searchbar/AsyncQueryInput', () => 'query-input');
 jest.mock('views/components/searchbar/saved-search/SavedSearchControls', () => 'saved-search-controls');
 
 jest.mock('views/stores/CurrentQueryStore', () => ({


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is a minor optimization to remove the need for an external dependency like `loadable-components` and using stock React functionality instead.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

The web app was build and tested in the browser while looking at the network tab to ensure that code splitting is still working.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.