### PR TITLE
Mocking `OverlayTrigger` in `UsersOverview.test` to reduce duration of test execution.

### DIFF
--- a/graylog2-web-interface/src/components/users/UsersOverview/UsersOverview.test.tsx
+++ b/graylog2-web-interface/src/components/users/UsersOverview/UsersOverview.test.tsx
@@ -27,6 +27,9 @@ import { UsersActions } from 'stores/users/UsersStore';
 
 import UsersOverview from './UsersOverview';
 
+// The usage of OverlayTrigger in the StatusCell of the users overview
+// often results in a timeout when executing the 'should search users' test.
+// We need to mock OverlayTrigger until we fix the root problem.
 jest.mock('components/graylog/OverlayTrigger', () => 'overlay-trigger');
 
 const mockLoadUsersPaginatedPromise = Promise.resolve(paginatedUsers);

--- a/graylog2-web-interface/src/components/users/UsersOverview/UsersOverview.test.tsx
+++ b/graylog2-web-interface/src/components/users/UsersOverview/UsersOverview.test.tsx
@@ -27,6 +27,8 @@ import { UsersActions } from 'stores/users/UsersStore';
 
 import UsersOverview from './UsersOverview';
 
+jest.mock('components/graylog/OverlayTrigger', () => 'overlay-trigger');
+
 const mockLoadUsersPaginatedPromise = Promise.resolve(paginatedUsers);
 
 jest.mock('stores/users/UsersStore', () => ({


### PR DESCRIPTION
## Description
The `UsersOverview.test` is currently failing often because of a timeout. One reason are `OverlayTrigger` changes we merged recently. We will improve the `OverlayTrigger` in another iteration, mocking the component in the `UsersOverview.test` should help us with the tests in the short term.