### PR TITLE
Fix rendering of trend color in report generation

### DIFF
--- a/graylog2-web-interface/src/views/components/visualizations/number/Trend.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/number/Trend.jsx
@@ -34,7 +34,7 @@ const Background: StyledComponent<{trend: ?string}, ThemeInterface, HTMLDivEleme
   `;
 });
 
-const TextContainer = styled.div<{ trend: string | undefined | null, ref }>(({ theme, trend }) => {
+const TextContainer = styled.div<{trend: ?string}, ThemeInterface, HTMLDivElement>(({ theme, trend }) => {
   const { variant } = theme.colors;
   const bgColor = trend && trend === TREND_GOOD ? variant.success : variant.primary;
 
@@ -47,7 +47,7 @@ const TextContainer = styled.div<{ trend: string | undefined | null, ref }>(({ t
       -webkit-print-color-adjust: exact !important; /* Needed for report generation */`;
 });
 
-const StyledIcon = styled(Icon)<{ trend: string | undefined | null }>(({ theme, trend }) => {
+const StyledIcon = styled(Icon)<{ trend: ?string}, ThemeInterface, HTMLDivElement>(({ theme, trend }) => {
   const { variant } = theme.colors;
   const bgColor = trend && trend === TREND_GOOD ? variant.success : variant.primary;
 

--- a/graylog2-web-interface/src/views/components/visualizations/number/Trend.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/number/Trend.jsx
@@ -27,7 +27,8 @@ const Background: StyledComponent<{trend: ?string}, ThemeInterface, HTMLDivEleme
     ${trend && css`
       background-color: ${bgColor} !important; /* Needed for report generation */
       color: ${util.contrastingColor(bgColor)} !important /* Needed for report generation */;
-      /* eslint-disable-next-line property-no-vendor-prefix */
+
+      /* stylelint-disable-next-line property-no-vendor-prefix */
       -webkit-print-color-adjust: exact !important; /* Needed for report generation */
     `}
   `;
@@ -40,8 +41,9 @@ const TextContainer = styled.div<{ trend: string | undefined | null, ref }>(({ t
   return css`
       margin: 5px;
       color: ${theme.utils.contrastingColor(bgColor)} !important /* Needed for report generation */;
-      /* eslint-disable-next-line property-no-vendor-prefix */
       font-family: ${theme.fonts.family.body};
+
+      /* stylelint-disable-next-line property-no-vendor-prefix */
       -webkit-print-color-adjust: exact !important; /* Needed for report generation */`;
 });
 
@@ -51,7 +53,7 @@ const StyledIcon = styled(Icon)<{ trend: string | undefined | null }>(({ theme, 
 
   return css`
     path {
-        fill: ${theme.utils.contrastingColor(bgColor)};
+      fill: ${theme.utils.contrastingColor(bgColor)};
     }`;
 });
 

--- a/graylog2-web-interface/src/views/components/visualizations/number/Trend.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/number/Trend.jsx
@@ -35,25 +35,24 @@ const Background: StyledComponent<{trend: ?string}, ThemeInterface, HTMLDivEleme
 });
 
 const TextContainer: StyledComponent<{trend: ?string}, ThemeInterface, HTMLDivElement> = styled.div(({ theme, trend }) => {
-  const { variant } = theme.colors;
+  const { variant } = theme.color;
   const bgColor = trend && trend === TREND_GOOD ? variant.success : variant.primary;
 
   return css`
       margin: 5px;
-      color: ${theme.utils.contrastingColor(bgColor)} !important /* Needed for report generation */;
-      font-family: ${theme.fonts.family.body};
+      color: ${util.contrastingColor(bgColor)} !important /* Needed for report generation */;
 
       /* stylelint-disable-next-line property-no-vendor-prefix */
       -webkit-print-color-adjust: exact !important; /* Needed for report generation */`;
 });
 
 const StyledIcon: StyledComponent<{trend: ?string}, ThemeInterface, typeof Icon> = styled(Icon)(({ theme, trend }) => {
-  const { variant } = theme.colors;
+  const { variant } = theme.color;
   const bgColor = trend && trend === TREND_GOOD ? variant.success : variant.primary;
 
   return css`
     path {
-      fill: ${theme.utils.contrastingColor(bgColor)};
+      fill: ${util.contrastingColor(bgColor)};
     }`;
 });
 

--- a/graylog2-web-interface/src/views/components/visualizations/number/Trend.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/number/Trend.jsx
@@ -25,8 +25,9 @@ const Background: StyledComponent<{trend: ?string}, ThemeInterface, HTMLDivEleme
   return css`
     text-align: right;
     ${trend && css`
-      background-color: ${bgColor};
+      background-color: ${bgColor} !important; /* Needed for report generation */
       color: ${util.contrastingColor(bgColor)};
+      -webkit-print-color-adjust: exact !important; /* Needed for report generation */
     `}
   `;
 });

--- a/graylog2-web-interface/src/views/components/visualizations/number/Trend.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/number/Trend.jsx
@@ -26,15 +26,34 @@ const Background: StyledComponent<{trend: ?string}, ThemeInterface, HTMLDivEleme
     text-align: right;
     ${trend && css`
       background-color: ${bgColor} !important; /* Needed for report generation */
-      color: ${util.contrastingColor(bgColor)};
+      color: ${util.contrastingColor(bgColor)} !important /* Needed for report generation */;
+      /* eslint-disable-next-line property-no-vendor-prefix */
       -webkit-print-color-adjust: exact !important; /* Needed for report generation */
     `}
   `;
 });
 
-const TextContainer = styled.span`
-  margin: 5px;
-`;
+const TextContainer = styled.div<{ trend: string | undefined | null, ref }>(({ theme, trend }) => {
+  const { variant } = theme.colors;
+  const bgColor = trend && trend === TREND_GOOD ? variant.success : variant.primary;
+
+  return css`
+      margin: 5px;
+      color: ${theme.utils.contrastingColor(bgColor)} !important /* Needed for report generation */;
+      /* eslint-disable-next-line property-no-vendor-prefix */
+      font-family: ${theme.fonts.family.body};
+      -webkit-print-color-adjust: exact !important; /* Needed for report generation */`;
+});
+
+const StyledIcon = styled(Icon)<{ trend: string | undefined | null }>(({ theme, trend }) => {
+  const { variant } = theme.colors;
+  const bgColor = trend && trend === TREND_GOOD ? variant.success : variant.primary;
+
+  return css`
+    path {
+        fill: ${theme.utils.contrastingColor(bgColor)};
+    }`;
+});
 
 const _background = (delta, trendPreference: TrendPreference) => {
   switch (trendPreference) {
@@ -50,10 +69,10 @@ const _background = (delta, trendPreference: TrendPreference) => {
 
 const _trendIcon = (delta) => {
   if (delta === 0) {
-    return <Icon name="arrow-circle-right" />;
+    return <StyledIcon name="arrow-circle-right" />;
   }
 
-  return <Icon name={delta > 0 ? 'arrow-circle-up' : 'arrow-circle-down'} />;
+  return <StyledIcon name={delta > 0 ? 'arrow-circle-up' : 'arrow-circle-down'} />;
 };
 
 const Trend = React.forwardRef<Props, any>(({ current, previous, trendPreference }: Props, ref) => {
@@ -65,7 +84,7 @@ const Trend = React.forwardRef<Props, any>(({ current, previous, trendPreference
 
   return (
     <Background trend={backgroundTrend} data-test-id="trend-background">
-      <TextContainer ref={ref}>
+      <TextContainer trend={backgroundTrend} ref={ref}>
         {trendIcon} {numeral(difference).format('+0,0[.]0[000]')} / {numeral(differencePercent).format('+0[.]0[0]%')}
       </TextContainer>
     </Background>

--- a/graylog2-web-interface/src/views/components/visualizations/number/Trend.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/number/Trend.jsx
@@ -34,7 +34,7 @@ const Background: StyledComponent<{trend: ?string}, ThemeInterface, HTMLDivEleme
   `;
 });
 
-const TextContainer = styled.div<{trend: ?string}, ThemeInterface, HTMLDivElement>(({ theme, trend }) => {
+const TextContainer: StyledComponent<{trend: ?string}, ThemeInterface, HTMLDivElement> = styled.div(({ theme, trend }) => {
   const { variant } = theme.colors;
   const bgColor = trend && trend === TREND_GOOD ? variant.success : variant.primary;
 
@@ -47,7 +47,7 @@ const TextContainer = styled.div<{trend: ?string}, ThemeInterface, HTMLDivElemen
       -webkit-print-color-adjust: exact !important; /* Needed for report generation */`;
 });
 
-const StyledIcon = styled(Icon)<{ trend: ?string}, ThemeInterface, HTMLDivElement>(({ theme, trend }) => {
+const StyledIcon: StyledComponent<{trend: ?string}, ThemeInterface, typeof Icon> = styled(Icon)(({ theme, trend }) => {
   const { variant } = theme.colors;
   const bgColor = trend && trend === TREND_GOOD ? variant.success : variant.primary;
 
@@ -69,12 +69,12 @@ const _background = (delta, trendPreference: TrendPreference) => {
   }
 };
 
-const _trendIcon = (delta) => {
+const _trendIcon = (delta, trend) => {
   if (delta === 0) {
-    return <StyledIcon name="arrow-circle-right" />;
+    return <StyledIcon trend={trend} name="arrow-circle-right" />;
   }
 
-  return <StyledIcon name={delta > 0 ? 'arrow-circle-up' : 'arrow-circle-down'} />;
+  return <StyledIcon trend={trend} name={delta > 0 ? 'arrow-circle-up' : 'arrow-circle-down'} />;
 };
 
 const Trend = React.forwardRef<Props, any>(({ current, previous, trendPreference }: Props, ref) => {
@@ -82,7 +82,7 @@ const Trend = React.forwardRef<Props, any>(({ current, previous, trendPreference
   const differencePercent = previous ? difference / previous : NaN;
 
   const backgroundTrend = _background(difference, trendPreference);
-  const trendIcon = _trendIcon(difference);
+  const trendIcon = _trendIcon(difference, backgroundTrend);
 
   return (
     <Background trend={backgroundTrend} data-test-id="trend-background">


### PR DESCRIPTION
## Motivation
The report generation is using the chrome print to pdf functionallity
which will turn all backgrounds in css to white.

## Description
We add an !important to the css rule (and explain why) and add the
magical webkit rule which tells chrome to keep the background as it is.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Fixes https://github.com/Graylog2/graylog-plugin-enterprise/issues/1997