### PR TITLE
Add report styling for a widget

### DIFF
--- a/graylog2-web-interface/src/views/bindings.tsx
+++ b/graylog2-web-interface/src/views/bindings.tsx
@@ -135,6 +135,7 @@ export default {
       type: 'MESSAGES',
       displayName: 'Message List',
       defaultHeight: 5,
+      reportStyle: () => ({ width: 800 }),
       defaultWidth: 6,
       visualizationComponent: MessageList,
       editComponent: EditMessageList,
@@ -148,6 +149,7 @@ export default {
       displayName: 'Results',
       defaultHeight: 4,
       defaultWidth: 4,
+      reportStyle: () => ({ width: 600 }),
       visualizationComponent: AggregationBuilder,
       editComponent: AggregationControls,
       needsControlledHeight: (widget: Widget) => {


### PR DESCRIPTION
## Motivation
Prior to this change, all widgets had the same width in a report.

## Description
This change will give message list a broader width so it has more space
to show big messages.


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

