### PR TITLE
Fixing initial height of widget container in edit mode by removing lazy loaded css.

### DIFF
--- a/graylog2-web-interface/src/components/graylog/Modal.jsx
+++ b/graylog2-web-interface/src/components/graylog/Modal.jsx
@@ -24,6 +24,7 @@ const Dialog = css`
   .modal-content {
     background-color: ${({ theme }) => theme.colors.global.contentBackground};
     border-color: ${({ theme }) => theme.colors.variant.light.default};
+    height: 100%;
   }
 `;
 

--- a/graylog2-web-interface/src/views/components/widgets/EditWidgetFrame.global.lazy.css
+++ b/graylog2-web-interface/src/views/components/widgets/EditWidgetFrame.global.lazy.css
@@ -1,5 +1,0 @@
-.modal-content {
-    padding: 10px 15px 10px 15px;
-    border-radius: unset;
-    height: 100%;
-}

--- a/graylog2-web-interface/src/views/components/widgets/EditWidgetFrame.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/EditWidgetFrame.tsx
@@ -15,7 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { useContext, useEffect } from 'react';
+import { useContext } from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment';
 
@@ -31,7 +31,6 @@ import { DEFAULT_TIMERANGE } from 'views/Constants';
 import { SearchConfigStore } from 'views/stores/SearchConfigStore';
 
 import styles from './EditWidgetFrame.css';
-import globalStyles from './EditWidgetFrame.global.lazy.css';
 
 import WidgetQueryControls from '../WidgetQueryControls';
 import IfDashboard from '../dashboard/IfDashboard';
@@ -73,12 +72,6 @@ const onSubmit = (values, widget: Widget) => {
 
 const EditWidgetFrame = ({ children }: Props) => {
   const config = useStore(SearchConfigStore, ({ searchesClusterConfig }) => searchesClusterConfig);
-
-  useEffect(() => {
-    globalStyles.use();
-
-    return globalStyles.unuse;
-  }, []);
 
   const widget = useContext(WidgetContext);
 


### PR DESCRIPTION
## Description

Before this change the initial widget container `clientHeight` equaled the `scrollHeight` because the lazy loaded css defined `height: 100%` for the modal container, which is necessary for the correct `clientHeight`.

We can remove this css file because we defined `height: 100%` for the modal content by default, the styling is not required and we will adjust / restyle the related components soon.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)