### PR TITLE
Update Netty to the latest version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -136,7 +136,7 @@
         <mongojack.version>2.10.1</mongojack.version>
         <natty.version>0.13</natty.version>
         <netty.version>4.1.59.Final</netty.version>
-        <netty-tcnative-boringssl-static.version>2.0.34.Final</netty-tcnative-boringssl-static.version>
+        <netty-tcnative-boringssl-static.version>2.0.36.Final</netty-tcnative-boringssl-static.version>
         <okhttp.version>3.14.6</okhttp.version>
         <okta-sdk.version>3.0.1</okta-sdk.version>
         <opencsv.version>2.3</opencsv.version>

--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,7 @@
         <mongodb-driver.version>3.12.1</mongodb-driver.version>
         <mongojack.version>2.10.1</mongojack.version>
         <natty.version>0.13</natty.version>
-        <netty.version>4.1.59.Final</netty.version>
+        <netty.version>4.1.60.Final</netty.version>
         <netty-tcnative-boringssl-static.version>2.0.36.Final</netty-tcnative-boringssl-static.version>
         <okhttp.version>3.14.6</okhttp.version>
         <okta-sdk.version>3.0.1</okta-sdk.version>

--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,7 @@
         <mongodb-driver.version>3.12.1</mongodb-driver.version>
         <mongojack.version>2.10.1</mongojack.version>
         <natty.version>0.13</natty.version>
-        <netty.version>4.1.52.Final</netty.version>
+        <netty.version>4.1.59.Final</netty.version>
         <netty-tcnative-boringssl-static.version>2.0.34.Final</netty-tcnative-boringssl-static.version>
         <okhttp.version>3.14.6</okhttp.version>
         <okta-sdk.version>3.0.1</okta-sdk.version>


### PR DESCRIPTION
Update Netty dependency to the latest version. 

This was recently done in https://github.com/Graylog2/gelfclient/pull/52, so the same update is being done in the graylog2-server core while we're looking at this. 