### PR TITLE
Copy widget title when copying widget to dashboard

### DIFF
--- a/graylog2-web-interface/src/views/logic/views/CopyWidgetToDashboard.Search-View.fixture.json
+++ b/graylog2-web-interface/src/views/logic/views/CopyWidgetToDashboard.Search-View.fixture.json
@@ -6,7 +6,8 @@
       "titles": {
         "widget": {
           "9f194c3a-3db8-4d9a-8b93-8f356477d976": "Message Count",
-          "6a8eebc7-53f3-447e-8f81-f997d42a376a": "All Messages"
+          "6a8eebc7-53f3-447e-8f81-f997d42a376a": "All Messages",
+          "4d73ccaa-aabf-451a-b36e-309f55798e04": "Widget Title"
         }
       },
       "widgets": [

--- a/graylog2-web-interface/src/views/logic/views/CopyWidgetToDashboard.ts
+++ b/graylog2-web-interface/src/views/logic/views/CopyWidgetToDashboard.ts
@@ -21,7 +21,7 @@ import View from 'views/logic/views/View';
 import Query from 'views/logic/queries/Query';
 import GenerateNextPosition from 'views/logic/views/GenerateNextPosition';
 import WidgetPosition from 'views/logic/widgets/WidgetPosition';
-import TitleTypes, { TitleType } from 'views/stores/TitleTypes';
+import TitleTypes from 'views/stores/TitleTypes';
 
 import UpdateSearchForWidgets from './UpdateSearchForWidgets';
 import FindWidgetAndQueryIdInView from './FindWidgetAndQueryIdInView';

--- a/graylog2-web-interface/src/views/logic/views/CopyWidgetToDashboard.ts
+++ b/graylog2-web-interface/src/views/logic/views/CopyWidgetToDashboard.ts
@@ -21,7 +21,7 @@ import View from 'views/logic/views/View';
 import Query from 'views/logic/queries/Query';
 import GenerateNextPosition from 'views/logic/views/GenerateNextPosition';
 import WidgetPosition from 'views/logic/widgets/WidgetPosition';
-import TitleTypes from 'views/stores/TitleTypes';
+import TitleTypes, { TitleType } from 'views/stores/TitleTypes';
 
 import UpdateSearchForWidgets from './UpdateSearchForWidgets';
 import FindWidgetAndQueryIdInView from './FindWidgetAndQueryIdInView';
@@ -42,7 +42,7 @@ const _newTitlesMap = (titlesMap, widget, title) => {
     return titlesMap;
   }
 
-  const widgetTitles = titlesMap.get(TitleTypes.Widget);
+  const widgetTitles = titlesMap.get(TitleTypes.Widget, Map());
   const newWidgetTitles = widgetTitles.set(widget.id, title);
 
   return titlesMap.set(TitleTypes.Widget, newWidgetTitles);

--- a/graylog2-web-interface/src/views/logic/views/CopyWidgetToDashboard.ts
+++ b/graylog2-web-interface/src/views/logic/views/CopyWidgetToDashboard.ts
@@ -21,24 +21,47 @@ import View from 'views/logic/views/View';
 import Query from 'views/logic/queries/Query';
 import GenerateNextPosition from 'views/logic/views/GenerateNextPosition';
 import WidgetPosition from 'views/logic/widgets/WidgetPosition';
+import TitleTypes from 'views/stores/TitleTypes';
 
 import UpdateSearchForWidgets from './UpdateSearchForWidgets';
 import FindWidgetAndQueryIdInView from './FindWidgetAndQueryIdInView';
 
 type QueryId = string;
 
-const _addWidgetToDashboard = (widget: Widget, dashboard: View, oldPosition: WidgetPosition): View => {
-  const dashboardQueryId = dashboard.state.keySeq().first();
-  const viewState = dashboard.state.get(dashboardQueryId);
-  const widgets = viewState.widgets.push(widget);
-  const { widgetPositions } = viewState;
+const _newPositionsMap = (oldPosition, widgetPositions, widget, widgets) => {
   const widgetPositionsMap = oldPosition ? {
     ...widgetPositions,
     [widget.id]: oldPosition.toBuilder().row(0).col(0).build(),
   } : widgetPositions;
-  const newWidgetPositions = GenerateNextPosition(Map(widgetPositionsMap), widgets.toArray());
+
+  return GenerateNextPosition(Map(widgetPositionsMap), widgets.toArray());
+};
+
+const _newTitlesMap = (titlesMap, widget, title) => {
+  if (!title) {
+    return titlesMap;
+  }
+
+  const widgetTitles = titlesMap.get(TitleTypes.Widget);
+  const newWidgetTitles = widgetTitles.set(widget.id, title);
+
+  return titlesMap.set(TitleTypes.Widget, newWidgetTitles);
+};
+
+const _addWidgetToDashboard = (widget: Widget, dashboard: View, oldPosition: WidgetPosition, title: string | undefined | null): View => {
+  const dashboardQueryId = dashboard.state.keySeq().first();
+  const viewState = dashboard.state.get(dashboardQueryId);
+  const widgets = viewState.widgets.push(widget);
+
+  const { widgetPositions } = viewState;
+  const newWidgetPositions = _newPositionsMap(oldPosition, widgetPositions, widget, widgets);
+
+  const titlesMap = viewState.titles;
+  const newTitlesMap = _newTitlesMap(titlesMap, widget, title);
+
   const newViewState = viewState.toBuilder()
     .widgets(widgets)
+    .titles(newTitlesMap)
     .widgetPositions(newWidgetPositions)
     .build();
 
@@ -60,6 +83,7 @@ const CopyWidgetToDashboard = (widgetId: string, search: View, dashboard: View):
     const { timerange, query, filter = Map() } = queryMap.get(queryId);
     const { widgetPositions } = search.state.get(queryId);
     const oldPositions = widgetPositions[widgetId];
+    const title = search.state.get(queryId).titles.get(TitleTypes.Widget).get(widgetId);
 
     const streams = (filter ? filter.get('filters', List.of()) : List.of())
       .filter((value) => Map.isMap(value) && value.get('type') === 'stream')
@@ -74,7 +98,7 @@ const CopyWidgetToDashboard = (widgetId: string, search: View, dashboard: View):
       .streams(streams)
       .build();
 
-    return UpdateSearchForWidgets(_addWidgetToDashboard(dashboardWidget, dashboard, oldPositions));
+    return UpdateSearchForWidgets(_addWidgetToDashboard(dashboardWidget, dashboard, oldPositions, title));
   }
 
   return undefined;

--- a/graylog2-web-interface/src/views/logic/views/ViewState.ts
+++ b/graylog2-web-interface/src/views/logic/views/ViewState.ts
@@ -20,7 +20,7 @@ import isDeepEqual from 'stores/isDeepEqual';
 import Widget from 'views/logic/widgets/Widget';
 import WidgetPosition from 'views/logic/widgets/WidgetPosition';
 import TitleTypes from 'views/stores/TitleTypes';
-import type { TitlesMap, TitleType } from 'views/stores/TitleTypes';
+import type { TitlesMap } from 'views/stores/TitleTypes';
 import type { WidgetPositionJSON } from 'views/logic/widgets/WidgetPosition';
 
 import type { FormattingSettingsJSON } from './formatting/FormattingSettings';

--- a/graylog2-web-interface/src/views/logic/views/__snapshots__/CopyWidgetToDashboard.test.js.snap
+++ b/graylog2-web-interface/src/views/logic/views/__snapshots__/CopyWidgetToDashboard.test.js.snap
@@ -36,6 +36,7 @@ Object {
           "8532ff94-2881-42b4-b26d-080d09305e95": "Message Count",
           "32889f0b-fe5a-4f18-baa0-773869d49af3": "All Messages",
           "a8058a41-34ea-4846-83d0-1acc2fbc1d7f": "Aggregating stddev(files_changed) by author (copy)",
+          "dead-beef": "Widget Title",
         },
       },
       "widget_mapping": Immutable.Map {


### PR DESCRIPTION
## Motivation
Prior to this change, the function which copys the widget from the
search to the dashboard was missing to copy the title if a title exists.

## Description
This change will add a function which will add a possible new title of
the new widget to the dashboard.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Fixes #10003 