### PR TITLE
Fix type inference for functions with a dash as a parameter

### DIFF
--- a/graylog2-web-interface/src/views/logic/aggregationbuilder/Series.test.ts
+++ b/graylog2-web-interface/src/views/logic/aggregationbuilder/Series.test.ts
@@ -1,0 +1,35 @@
+import { parseSeries } from './Series';
+
+describe('parseSeries', () => {
+  it('should parse count() without a parameter', () => {
+    const definition = parseSeries('count()');
+
+    expect(definition.type).toBe('count');
+    expect(definition.field).toBeUndefined();
+    expect(definition.percentile).toBeUndefined();
+  });
+
+  it('should parse count() with a parameter', () => {
+    const definition = parseSeries('count(bytes)');
+
+    expect(definition.type).toBe('count');
+    expect(definition.field).toBe('bytes');
+    expect(definition.percentile).toBeUndefined();
+  });
+
+  it('should parse count() with a parameter containing a dash', () => {
+    const definition = parseSeries('count(incoming-bytes)');
+
+    expect(definition.type).toBe('count');
+    expect(definition.field).toBe('incoming-bytes');
+    expect(definition.percentile).toBeUndefined();
+  });
+
+  it('should parse percentiles() with a parameter', () => {
+    const definition = parseSeries('percentile(bytes,90)');
+
+    expect(definition.type).toBe('percentile');
+    expect(definition.field).toBe('bytes');
+    expect(definition.percentile).toBe('90');
+  });
+});

--- a/graylog2-web-interface/src/views/logic/aggregationbuilder/Series.test.ts
+++ b/graylog2-web-interface/src/views/logic/aggregationbuilder/Series.test.ts
@@ -1,35 +1,57 @@
-import { parseSeries } from './Series';
+import each from 'jest-each';
 
-describe('parseSeries', () => {
-  it('should parse count() without a parameter', () => {
-    const definition = parseSeries('count()');
+import { parseSeries, isFunction } from './Series';
 
-    expect(definition.type).toBe('count');
-    expect(definition.field).toBeUndefined();
-    expect(definition.percentile).toBeUndefined();
+describe('Series.ts', () => {
+  describe('parseSeries', () => {
+    it('should parse count() without a parameter', () => {
+      const definition = parseSeries('count()');
+
+      expect(definition.type).toBe('count');
+      expect(definition.field).toBeUndefined();
+      expect(definition.percentile).toBeUndefined();
+    });
+
+    it('should parse count() with a parameter', () => {
+      const definition = parseSeries('count(bytes)');
+
+      expect(definition.type).toBe('count');
+      expect(definition.field).toBe('bytes');
+      expect(definition.percentile).toBeUndefined();
+    });
+
+    it('should parse count() with a parameter containing a dash', () => {
+      const definition = parseSeries('count(incoming-bytes)');
+
+      expect(definition.type).toBe('count');
+      expect(definition.field).toBe('incoming-bytes');
+      expect(definition.percentile).toBeUndefined();
+    });
+
+    it('should parse percentiles() with a parameter', () => {
+      const definition = parseSeries('percentile(bytes,90)');
+
+      expect(definition.type).toBe('percentile');
+      expect(definition.field).toBe('bytes');
+      expect(definition.percentile).toBe('90');
+    });
   });
 
-  it('should parse count() with a parameter', () => {
-    const definition = parseSeries('count(bytes)');
-
-    expect(definition.type).toBe('count');
-    expect(definition.field).toBe('bytes');
-    expect(definition.percentile).toBeUndefined();
+  describe('isFunction', () => {
+    each`
+    func                    | result
+    ${'count()'}            | ${true}
+    ${'count(foo)'}         | ${true}
+    ${'sum(send-q)'}        | ${true}
+    ${'sum(send q)'}        | ${true}
+    ${'percentile(send,99)'}| ${true}
+    ${'foob(,)'}            | ${true}
+    ${'count-foo'}          | ${false}
+    ${'foob('}              | ${false}
+    ${'foob)'}              | ${false}
+    ${'(foob)'}             | ${false}
+  `.test('returns type of field for "$func(field)"', ({ func, result }) => {
+    expect(isFunction(func)).toBe(result);
   });
-
-  it('should parse count() with a parameter containing a dash', () => {
-    const definition = parseSeries('count(incoming-bytes)');
-
-    expect(definition.type).toBe('count');
-    expect(definition.field).toBe('incoming-bytes');
-    expect(definition.percentile).toBeUndefined();
-  });
-
-  it('should parse percentiles() with a parameter', () => {
-    const definition = parseSeries('percentile(bytes,90)');
-
-    expect(definition.type).toBe('percentile');
-    expect(definition.field).toBe('bytes');
-    expect(definition.percentile).toBe('90');
   });
 });

--- a/graylog2-web-interface/src/views/logic/aggregationbuilder/Series.ts
+++ b/graylog2-web-interface/src/views/logic/aggregationbuilder/Series.ts
@@ -38,7 +38,7 @@ export type Definition = {
 
 const parametersRegex = /\((.+)\)/;
 const funcNameRegex = /(\w+)\(/;
-const testSeriesRegex = /^(\w+)\((\w*)(,(\w+))*\)$/;
+const testSeriesRegex = /^(\w+)\((.*)(,(\w+))*\)$/;
 
 const definitionFor = (type: string, parameters: Array<string>): Definition => {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/graylog2-web-interface/src/views/logic/fieldtypes/FieldTypeFor.test.ts
+++ b/graylog2-web-interface/src/views/logic/fieldtypes/FieldTypeFor.test.ts
@@ -41,6 +41,9 @@ describe('FieldTypeFor', () => {
 
     expect(fieldTypeFor('card(foo)', [FieldTypeMapping.create('foo', FieldTypes.STRING())]))
       .toEqual(FieldTypes.LONG());
+
+    expect(fieldTypeFor('sum(foo-bar)', [FieldTypeMapping.create('foo-bar', FieldTypes.LONG())]))
+      .toEqual(FieldTypes.FLOAT());
   });
 
   it('returns inferred type (long) for `count()`', () => {

--- a/graylog2-web-interface/src/views/logic/fieldtypes/FieldTypeFor.test.ts
+++ b/graylog2-web-interface/src/views/logic/fieldtypes/FieldTypeFor.test.ts
@@ -41,13 +41,13 @@ describe('FieldTypeFor', () => {
 
     expect(fieldTypeFor('card(foo)', [FieldTypeMapping.create('foo', FieldTypes.STRING())]))
       .toEqual(FieldTypes.LONG());
+  });
+
+  it('returns inferred type (long) for `count() and sum()`', () => {
+    expect(fieldTypeFor('count()', []))
+      .toEqual(FieldTypes.LONG());
 
     expect(fieldTypeFor('sum(foo-bar)', [FieldTypeMapping.create('foo-bar', FieldTypes.LONG())]))
       .toEqual(FieldTypes.FLOAT());
-  });
-
-  it('returns inferred type (long) for `count()`', () => {
-    expect(fieldTypeFor('count()', []))
-      .toEqual(FieldTypes.LONG());
   });
 });

--- a/graylog2-web-interface/src/views/logic/fieldtypes/InferTypeForSeries.test.ts
+++ b/graylog2-web-interface/src/views/logic/fieldtypes/InferTypeForSeries.test.ts
@@ -24,14 +24,15 @@ import Series from '../aggregationbuilder/Series';
 
 describe('InferTypeForSeries', () => {
   each`
-    func              | expectedType
-    ${'card'}         | ${FieldTypes.LONG()}
-    ${'count'}        | ${FieldTypes.LONG()}
-    ${'stddev'}       | ${FieldTypes.FLOAT()}
-    ${'sum'}          | ${FieldTypes.FLOAT()}
-    ${'sumofsquares'} | ${FieldTypes.FLOAT()}
-  `.test('returns expected type for constant type function "$func(field)"', ({ func, expectedType }) => {
-    const functionName = `${func}(foo)`;
+    func              | expectedType          | field
+    ${'card'}         | ${FieldTypes.LONG()}  | ${'foo'}
+    ${'count'}        | ${FieldTypes.LONG()}  | ${'foo'} 
+    ${'stddev'}       | ${FieldTypes.FLOAT()} | ${'foo'} 
+    ${'sum'}          | ${FieldTypes.FLOAT()} | ${'foo'} 
+    ${'sum'}          | ${FieldTypes.FLOAT()} | ${'foo-bar'} 
+    ${'sumofsquares'} | ${FieldTypes.FLOAT()} | ${'foo'} 
+  `.test('returns expected type for constant type function "$func($field)"', ({ func, expectedType, field }) => {
+    const functionName = `${func}(${field})`;
 
     expect(inferTypeForSeries(Series.forFunction(functionName), []))
       .toEqual(FieldTypeMapping.create(functionName, expectedType));


### PR DESCRIPTION
## Motivation and Context
When using a data table with big numbers and the series function contained a field with a dash `-` the type of the value was not correctly recognized which lead to the problem that no digit grouping was applied.

## Description
The `isFunction` function from Series.ts was a regex which would test for `\w` (word characters `[A-Z,a-z,_]`) which is not including the `-`. This PR changes the function to also include any character to the next `,` or `)` for the group.

## How Has This Been Tested?
- add a field containing a `-`
- use the `sum` function on that field
- check that the type is now `long` instead of `unknown`.

## Also
This PR will also add tests which were written during debugging the problem

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)