### PR TITLE
Preventing widget unmount on widget focus.

### DIFF
--- a/graylog2-web-interface/src/components/common/ReactGridContainer.jsx
+++ b/graylog2-web-interface/src/components/common/ReactGridContainer.jsx
@@ -189,7 +189,7 @@ class ReactGridContainer extends React.Component {
   };
 
   static defaultProps = {
-    animate: true,
+    animate: false,
     className: undefined,
     columns: COLUMNS,
     isResizable: true,

--- a/graylog2-web-interface/src/components/common/ReactGridContainer.jsx
+++ b/graylog2-web-interface/src/components/common/ReactGridContainer.jsx
@@ -77,16 +77,18 @@ const BREAKPOINTS = {
   xs: COLUMN_WIDTH * COLUMNS.xs,
 };
 
-const _gridClass = (locked, isResizable, useDragHandle) => {
+const _gridClass = (locked, isResizable, useDragHandle, propsClassName) => {
+  const className = `${propsClassName}`;
+
   if (locked || !isResizable) {
-    return 'locked';
+    return `${className} locked`;
   }
 
   if (useDragHandle) {
-    return '';
+    return className;
   }
 
-  return 'unlocked';
+  return `${className} unlocked`;
 };
 
 /**
@@ -118,6 +120,10 @@ class ReactGridContainer extends React.Component {
      * right value, the positioning will be wrong.
      */
     children: PropTypes.node.isRequired,
+    /**
+     * The className prop is necessary to style the component with styled-components `styled()` function.
+     */
+    className: PropTypes.string,
     /**
      * Function that will be called when positions change. The function
      * receives the new positions in the format:
@@ -183,13 +189,14 @@ class ReactGridContainer extends React.Component {
   };
 
   static defaultProps = {
-    locked: false,
-    isResizable: true,
-    rowHeight: ROW_HEIGHT,
-    columns: COLUMNS,
     animate: true,
-    useDragHandle: undefined,
+    className: undefined,
+    columns: COLUMNS,
+    isResizable: true,
+    locked: false,
     measureBeforeMount: false,
+    rowHeight: ROW_HEIGHT,
+    useDragHandle: undefined,
     width: undefined,
   };
 
@@ -251,13 +258,13 @@ class ReactGridContainer extends React.Component {
   };
 
   render() {
-    const { children, width, locked, isResizable, rowHeight, columns, animate, useDragHandle, measureBeforeMount } = this.props;
+    const { children, width, locked, isResizable, rowHeight, columns, animate, useDragHandle, measureBeforeMount, className } = this.props;
     const { layout } = this.state;
 
     // We need to use a className and draggableHandle to avoid re-rendering all graphs on lock/unlock. See:
     // https://github.com/STRML/react-grid-layout/issues/371
     return (
-      <StyledWidthProvidedGridLayout className={_gridClass(locked, isResizable, useDragHandle)}
+      <StyledWidthProvidedGridLayout className={_gridClass(locked, isResizable, useDragHandle, className)}
                                      width={width}
                                      layouts={{ xxl: layout, xl: layout, lg: layout, md: layout, sm: layout, xs: layout }}
                                      breakpoints={BREAKPOINTS}

--- a/graylog2-web-interface/src/components/common/ReactGridContainer.jsx
+++ b/graylog2-web-interface/src/components/common/ReactGridContainer.jsx
@@ -272,6 +272,7 @@ class ReactGridContainer extends React.Component {
                                      rowHeight={rowHeight}
                                      containerPadding={[0, 0]}
                                      margin={[10, 10]}
+                                     isResizable={isResizable}
                                      measureBeforeMount={measureBeforeMount}
         // Do not allow dragging from elements inside a `.actions` css class. This is
         // meant to avoid calling `onDragStop` callbacks when clicking on an action button.

--- a/graylog2-web-interface/src/views/components/Query.tsx
+++ b/graylog2-web-interface/src/views/components/Query.tsx
@@ -15,7 +15,6 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { useContext } from 'react';
 import PropTypes from 'prop-types';
 import Immutable from 'immutable';
 import styled, { css } from 'styled-components';
@@ -30,7 +29,6 @@ import IfDashboard from 'views/components/dashboard/IfDashboard';
 import IfSearch from 'views/components/search/IfSearch';
 import WidgetGrid from 'views/components/WidgetGrid';
 import WidgetPosition from 'views/logic/widgets/WidgetPosition';
-import WidgetFocusContext from 'views/components/contexts/WidgetFocusContext';
 
 import { PositionsMap, ImmutableWidgetsMap } from './widgets/WidgetPropTypes';
 import InteractiveContext from './contexts/InteractiveContext';
@@ -142,16 +140,12 @@ const EmptyDashboardInfo = () => (
 );
 
 const Query = ({ allFields, fields, results, positions, widgetMapping, widgets, queryId }) => {
-  const { focusedWidget } = useContext(WidgetFocusContext);
-
   if (!widgets || widgets.isEmpty()) {
     return <EmptyDashboardInfo />;
   }
 
-  const visibleWidgets = focusedWidget ? widgets.filter((widget) => widget.id === focusedWidget) : widgets;
-
   if (results) {
-    const widgetGrid = _renderWidgetGrid(visibleWidgets, widgetMapping.toJS(), results, positions, queryId, fields, allFields);
+    const widgetGrid = _renderWidgetGrid(widgets, widgetMapping.toJS(), results, positions, queryId, fields, allFields);
 
     return (<>{widgetGrid}</>);
   }

--- a/graylog2-web-interface/src/views/components/WidgetComponent.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetComponent.tsx
@@ -24,34 +24,39 @@ import WidgetClass from 'views/logic/widgets/Widget';
 import WidgetPosition from 'views/logic/widgets/WidgetPosition';
 import TFieldTypeMapping from 'views/logic/fieldtypes/FieldTypeMapping';
 
+import WidgetContainer from './WidgetContainer';
 import { WidgetDataMap, WidgetErrorsMap } from './widgets/WidgetPropTypes';
 import Widget from './widgets/Widget';
 import DrilldownContextProvider from './contexts/DrilldownContextProvider';
 
 type Props = {
-  widget: WidgetClass & { data: string };
-  widgetId: string,
   data: WidgetDataMap,
   errors: WidgetErrorsMap,
-  widgetDimension: { height: number | null | undefined, width: number | null | undefined },
-  title: string,
-  position: WidgetPosition,
-  onPositionsChange: (position?: WidgetPosition) => void,
   fields: Immutable.List<TFieldTypeMapping>,
+  isFocused: boolean,
+  onPositionsChange: (position?: WidgetPosition) => void,
   onWidgetSizeChange: (widgetId?: string, dimensions?: { height: number, width: number }) => void,
+  position: WidgetPosition,
+  style?: React.CSSProperties,
+  title: string,
+  widget: WidgetClass & { data: string };
+  widgetDimension: { height: number | null | undefined, width: number | null | undefined },
+  widgetId: string,
 };
 
 const WidgetComponent = ({
-  widget,
-  widgetId,
   data,
   errors,
-  widgetDimension: { height, width },
-  position,
-  onPositionsChange = () => undefined,
-  title,
   fields,
+  isFocused,
+  onPositionsChange = () => undefined,
   onWidgetSizeChange = () => {},
+  position,
+  style,
+  title,
+  widget,
+  widgetDimension: { height, width },
+  widgetId,
 }: Props) => {
   const dataKey = widget.data || widget.id;
   const widgetData = data[dataKey];
@@ -61,18 +66,20 @@ const WidgetComponent = ({
     <DrilldownContextProvider widget={widget}>
       <WidgetContext.Provider value={widget}>
         <AdditionalContext.Provider value={{ widget }}>
-          <Widget key={widgetId}
-                  id={widgetId}
-                  widget={widget}
-                  data={widgetData}
-                  errors={widgetErrors}
-                  height={height}
-                  position={position}
-                  width={width}
-                  fields={fields}
-                  onPositionsChange={onPositionsChange}
-                  onSizeChange={onWidgetSizeChange}
-                  title={title} />
+          <WidgetContainer key={widgetId} isFocused={isFocused} style={style}>
+            <Widget key={widgetId}
+                    id={widgetId}
+                    widget={widget}
+                    data={widgetData}
+                    errors={widgetErrors}
+                    height={height}
+                    position={position}
+                    width={width}
+                    fields={fields}
+                    onPositionsChange={onPositionsChange}
+                    onSizeChange={onWidgetSizeChange}
+                    title={title} />
+          </WidgetContainer>
         </AdditionalContext.Provider>
       </WidgetContext.Provider>
     </DrilldownContextProvider>
@@ -95,6 +102,7 @@ WidgetComponent.propTypes = {
 WidgetComponent.defaultProps = {
   onPositionsChange: () => {},
   onWidgetSizeChange: () => {},
+  style: {},
 };
 
 export default WidgetComponent;

--- a/graylog2-web-interface/src/views/components/WidgetComponent.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetComponent.tsx
@@ -24,7 +24,6 @@ import WidgetClass from 'views/logic/widgets/Widget';
 import WidgetPosition from 'views/logic/widgets/WidgetPosition';
 import TFieldTypeMapping from 'views/logic/fieldtypes/FieldTypeMapping';
 
-import WidgetContainer from './WidgetContainer';
 import { WidgetDataMap, WidgetErrorsMap } from './widgets/WidgetPropTypes';
 import Widget from './widgets/Widget';
 import DrilldownContextProvider from './contexts/DrilldownContextProvider';
@@ -33,30 +32,24 @@ type Props = {
   data: WidgetDataMap,
   errors: WidgetErrorsMap,
   fields: Immutable.List<TFieldTypeMapping>,
-  isFocused: boolean,
   onPositionsChange: (position?: WidgetPosition) => void,
   onWidgetSizeChange: (widgetId?: string, dimensions?: { height: number, width: number }) => void,
   position: WidgetPosition,
-  style?: React.CSSProperties,
   title: string,
   widget: WidgetClass & { data: string };
   widgetDimension: { height: number | null | undefined, width: number | null | undefined },
-  widgetId: string,
 };
 
 const WidgetComponent = ({
   data,
   errors,
   fields,
-  isFocused,
   onPositionsChange = () => undefined,
   onWidgetSizeChange = () => {},
   position,
-  style,
   title,
   widget,
   widgetDimension: { height, width },
-  widgetId,
 }: Props) => {
   const dataKey = widget.data || widget.id;
   const widgetData = data[dataKey];
@@ -66,20 +59,17 @@ const WidgetComponent = ({
     <DrilldownContextProvider widget={widget}>
       <WidgetContext.Provider value={widget}>
         <AdditionalContext.Provider value={{ widget }}>
-          <WidgetContainer key={widgetId} isFocused={isFocused} style={style}>
-            <Widget key={widgetId}
-                    id={widgetId}
-                    widget={widget}
-                    data={widgetData}
-                    errors={widgetErrors}
-                    height={height}
-                    position={position}
-                    width={width}
-                    fields={fields}
-                    onPositionsChange={onPositionsChange}
-                    onSizeChange={onWidgetSizeChange}
-                    title={title} />
-          </WidgetContainer>
+          <Widget id={widget.id}
+                  widget={widget}
+                  data={widgetData}
+                  errors={widgetErrors}
+                  height={height}
+                  position={position}
+                  width={width}
+                  fields={fields}
+                  onPositionsChange={onPositionsChange}
+                  onSizeChange={onWidgetSizeChange}
+                  title={title} />
         </AdditionalContext.Provider>
       </WidgetContext.Provider>
     </DrilldownContextProvider>
@@ -88,7 +78,6 @@ const WidgetComponent = ({
 
 WidgetComponent.propTypes = {
   widget: PropTypes.object.isRequired,
-  widgetId: PropTypes.string.isRequired,
   data: PropTypes.object.isRequired,
   errors: PropTypes.object.isRequired,
   widgetDimension: PropTypes.object.isRequired,
@@ -102,7 +91,6 @@ WidgetComponent.propTypes = {
 WidgetComponent.defaultProps = {
   onPositionsChange: () => {},
   onWidgetSizeChange: () => {},
-  style: {},
 };
 
 export default WidgetComponent;

--- a/graylog2-web-interface/src/views/components/WidgetContainer.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetContainer.tsx
@@ -33,13 +33,19 @@ type Props = {
 }
 
 const WidgetContainer = ({ children, className, isFocused, style, ...rest }: Props) => {
-  let containerStyle = { ...style };
+  let containerStyle = {
+    ...style,
+    transition: 'none',
+  };
 
   if (isFocused) {
     containerStyle = {
       ...containerStyle,
       height: '100%',
       width: '100%',
+      zIndex: 5,
+      top: 0,
+      left: 0,
     };
   }
 

--- a/graylog2-web-interface/src/views/components/WidgetContainer.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetContainer.tsx
@@ -32,16 +32,20 @@ type Props = {
   style?: React.CSSProperties,
 }
 
-const WidgetContainer = ({ children, className, isFocused, style }: Props) => {
-  const containerStyle = {
-    ...style,
-    height: isFocused ? '100%' : (style.height ?? 'auto'),
-    width: isFocused ? '100%' : (style.width ?? 'auto'),
-    transition: 'none',
-  };
+const WidgetContainer = ({ children, className, isFocused, style, ...rest }: Props) => {
+  let containerStyle = { ...style };
+
+  if (isFocused) {
+    containerStyle = {
+      ...containerStyle,
+      height: '100%',
+      width: '100%',
+      transition: 'none',
+    };
+  }
 
   return (
-    <Container className={className} style={containerStyle}>
+    <Container className={className} style={containerStyle} {...rest}>
       {children}
     </Container>
   );

--- a/graylog2-web-interface/src/views/components/WidgetContainer.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetContainer.tsx
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import styled from 'styled-components';
+
+import { RowContentStyles } from 'components/graylog/Row';
+
+const Container = styled.div`
+  z-index: auto;
+  ${RowContentStyles}
+  margin-bottom: 0;
+`;
+
+type Props = {
+  isFocused: boolean,
+  children: React.ReactNode,
+  className?: string,
+  style?: React.CSSProperties,
+}
+
+const WidgetContainer = ({ children, className, isFocused, style }: Props) => {
+  const containerStyle = {
+    ...style,
+    height: isFocused ? '100%' : (style.height ?? 'auto'),
+    width: isFocused ? '100%' : (style.width ?? 'auto'),
+    transition: 'none',
+  };
+
+  return (
+    <Container className={className} style={containerStyle}>
+      {children}
+    </Container>
+  );
+};
+
+WidgetContainer.defaultProps = {
+  className: undefined,
+  style: {},
+};
+
+export default WidgetContainer;

--- a/graylog2-web-interface/src/views/components/WidgetContainer.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetContainer.tsx
@@ -40,7 +40,6 @@ const WidgetContainer = ({ children, className, isFocused, style, ...rest }: Pro
       ...containerStyle,
       height: '100%',
       width: '100%',
-      transition: 'none',
     };
   }
 

--- a/graylog2-web-interface/src/views/components/WidgetGrid.jsx
+++ b/graylog2-web-interface/src/views/components/WidgetGrid.jsx
@@ -15,7 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { useState, useContext } from 'react';
+import { useState, useContext, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import * as Immutable from 'immutable';
 import ImmutablePropTypes from 'react-immutable-proptypes';
@@ -130,7 +130,7 @@ const WidgetGrid = ({
   const { focusedWidget } = useContext(WidgetFocusContext);
   const [widgetDimensions, setWidgetDimensions] = useState({});
 
-  const { widgets, positions } = _renderWidgets({
+  const { widgets, positions } = useMemo(() => _renderWidgets({
     allFields,
     data,
     errors,
@@ -142,7 +142,19 @@ const WidgetGrid = ({
     titles,
     widgetDimensions,
     focusedWidget,
-  });
+  }), [
+    allFields,
+    data,
+    errors,
+    fields,
+    onPositionsChange,
+    propsPositions,
+    propsWidgets,
+    setWidgetDimensions,
+    titles,
+    widgetDimensions,
+    focusedWidget,
+  ]);
 
   const grid = widgets && widgets.length > 0 ? (
     <StyledReactGridContainer animate

--- a/graylog2-web-interface/src/views/components/WidgetGrid.jsx
+++ b/graylog2-web-interface/src/views/components/WidgetGrid.jsx
@@ -157,7 +157,7 @@ const WidgetGrid = ({
   ]);
 
   const grid = widgets && widgets.length > 0 ? (
-    <StyledReactGridContainer animate
+    <StyledReactGridContainer focusedWidget={focusedWidget}
                               columns={{
                                 xxl: 12,
                                 xl: 12,
@@ -166,7 +166,6 @@ const WidgetGrid = ({
                                 sm: 12,
                                 xs: 12,
                               }}
-                              focusedWidget={focusedWidget}
                               isResizable={!focusedWidget}
                               locked={locked}
                               measureBeforeMount

--- a/graylog2-web-interface/src/views/components/WidgetGrid.jsx
+++ b/graylog2-web-interface/src/views/components/WidgetGrid.jsx
@@ -94,14 +94,14 @@ const _renderWidgets = ({
     const widget = widgets[widgetId];
     returnedWidgets.positions[widgetId] = positions[widgetId] || _defaultDimensions(widget.type);
     const widgetTitle = titles.getIn([TitleTypes.Widget, widget.id], defaultTitle(widget));
+    const isFocused = focusedWidget === widgetId;
 
     returnedWidgets.widgets.push(
-      <WidgetContainer isFocused={focusedWidget === widgetId} key={widget.id}>
+      <WidgetContainer isFocused={isFocused} key={widget.id}>
         <WidgetComponent allFields={allFields}
                          data={data}
                          errors={errors}
                          fields={fields}
-                         isFocused={focusedWidget === widgetId}
                          onPositionsChange={_onPositionsChange}
                          onWidgetSizeChange={_onWidgetSizeChange(widgetDimensions, setWidgetDimensions)}
                          position={returnedWidgets.positions[widgetId]}
@@ -158,7 +158,6 @@ const WidgetGrid = ({
 
   const grid = widgets && widgets.length > 0 ? (
     <StyledReactGridContainer animate
-                              locked={locked}
                               columns={{
                                 xxl: 12,
                                 xl: 12,
@@ -167,8 +166,10 @@ const WidgetGrid = ({
                                 sm: 12,
                                 xs: 12,
                               }}
-                              measureBeforeMount
                               focusedWidget={focusedWidget}
+                              isResizable={!focusedWidget}
+                              locked={locked}
+                              measureBeforeMount
                               onPositionsChange={onPositionsChange}
                               positions={positions}
                               useDragHandle=".widget-drag-handle">

--- a/graylog2-web-interface/src/views/components/WidgetGrid.jsx
+++ b/graylog2-web-interface/src/views/components/WidgetGrid.jsx
@@ -46,6 +46,7 @@ const DashboardWrap = styled.div(({ theme }) => css`
 const StyledReactGridContainer = styled(ReactGridContainer)(({ focusedWidget }) => `
   height: ${focusedWidget ? '100% !important' : '100%'};
   max-height: ${focusedWidget ? '100%' : 'auto'};
+  overflow: ${focusedWidget ? 'hidden' : 'visible'};
   transition: none;
 `);
 

--- a/graylog2-web-interface/src/views/components/sidebar/ContentColumn.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/ContentColumn.tsx
@@ -44,7 +44,7 @@ export const Container = styled.div<{ sidebarIsPinned: boolean }>(({ theme, side
   border-right: ${sidebarIsPinned ? 'none' : `1px solid ${theme.colors.variant.light.default}`};
   box-shadow: ${sidebarIsPinned ? `3px 3px 3px ${theme.colors.global.navigationBoxShadow}` : 'none'};
 
-  z-index: ${sidebarIsPinned ? 1030 : 4};
+  z-index: ${sidebarIsPinned ? 1030 : 6};
 
   ${sidebarIsPinned && css`
     ::before {

--- a/graylog2-web-interface/src/views/components/sidebar/Sidebar.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/Sidebar.tsx
@@ -53,7 +53,7 @@ const ContentOverlay = styled.div(({ theme }) => css`
   left: 50px;
   right: 0;
   background: ${chroma(theme.colors.brand.tertiary).alpha(0.25).css()};
-  z-index: 3;
+  z-index: 5;
 `);
 
 const _toggleSidebar = (initialSectionKey: string, activeSectionKey: string | undefined | null, setActiveSectionKey) => {


### PR DESCRIPTION
## Description
Previously on widget focus we replaced the `WidgetGrid` with the selected widget. This way the widget got unmounted and lost its state. As described in https://github.com/Graylog2/graylog2-server/issues/10099 this was a problem for e.g. the message table, which stores information like the current page in its state.

With this PR we are only changing the widget and widget grid style on widget focus. This way not only the selected widgets keeps its focus, but also all other widgets. They also do no loose e.g. their scroll position.

While working on these changes I tried out different approaches. E.g. I tried to change the widget position and the react grid layout row height, when a widget is being focused. But all these approaches were more complex and had more side effects than the current solution.

Fixes: https://github.com/Graylog2/graylog2-server/issues/10099

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

