### PR TITLE
Update guice to 5.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
         <grpc.version>1.29.0</grpc.version>
         <guava-retrying.version>2.0.0</guava-retrying.version>
         <guava.version>28.2-jre</guava.version>
-        <guice.version>4.2.2</guice.version>
+        <guice.version>5.0.1</guice.version>
         <HdrHistogram.version>2.1.12</HdrHistogram.version>
         <hibernate-validator.version>6.1.2.Final</hibernate-validator.version>
         <hk2.version>2.6.1</hk2.version> <!-- The HK2 version should match the version being used by Jersey -->


### PR DESCRIPTION
Finally fixed 'illegal reflective access' warnings with Java 9 or later.
 https://github.com/google/guice/issues/1133

Full changelog:
https://github.com/google/guice/wiki/Guice501

