### PR TITLE
Style DataTableEntries for numeric values

### DIFF
--- a/graylog2-web-interface/src/views/components/datatable/DataTableEntry.tsx
+++ b/graylog2-web-interface/src/views/components/datatable/DataTableEntry.tsx
@@ -17,6 +17,7 @@
 import React from 'react';
 import * as Immutable from 'immutable';
 import { flatten, get } from 'lodash';
+import styled, { css, DefaultTheme } from 'styled-components';
 
 import Value from 'views/components/Value';
 import FieldType from 'views/logic/fieldtypes/FieldType';
@@ -29,6 +30,11 @@ import fieldTypeFor from 'views/logic/fieldtypes/FieldTypeFor';
 import type { CurrentViewType } from '../CustomPropTypes';
 import CustomHighlighting from '../messagelist/CustomHighlighting';
 import DecoratedValue from '../messagelist/decoration/DecoratedValue';
+
+const StyledTd = styled.td(({ isNumeric, theme }: { isNumeric: boolean, theme: DefaultTheme }) => css`
+  ${isNumeric ? `font-family: ${theme.fonts.family.monospace};` : ''}
+  ${isNumeric ? 'text-align: right' : ''}
+`);
 
 type Field = {
   field: string,
@@ -48,13 +54,13 @@ type Props = {
 const _c = (field, value, path, source) => ({ field, value, path, source });
 
 const _column = (field: string, value: any, selectedQuery: string, idx: number, type: FieldType, valuePath: ValuePath, source: string | undefined | null) => (
-  <td key={`${selectedQuery}-${field}=${value}-${idx}`}>
+  <StyledTd isNumeric={type.isNumeric()} key={`${selectedQuery}-${field}=${value}-${idx}`}>
     <AdditionalContext.Provider value={{ valuePath }}>
       <CustomHighlighting field={source ?? field} value={value}>
         {value !== null && value !== undefined ? <Value field={source ?? field} type={type} value={value} queryId={selectedQuery} render={DecoratedValue} /> : null}
       </CustomHighlighting>
     </AdditionalContext.Provider>
-  </td>
+  </StyledTd>
 );
 
 const fullValuePathForField = (fieldName, valuePath) => {

--- a/graylog2-web-interface/src/views/components/datatable/Headers.tsx
+++ b/graylog2-web-interface/src/views/components/datatable/Headers.tsx
@@ -48,6 +48,7 @@ const _headerFieldForValue = (activeQuery: string, field, value, span = 1, prefi
   </th>
 );
 
+// eslint-disable-next-line jsx-a11y/control-has-associated-label
 const _spacer = (idx, span = 1) => <th colSpan={span} key={`spacer-${idx}`} className={styles.leftAligned} />;
 
 const columnPivotFieldsHeaders = (activeQuery: string, columnPivots: string[], actualColumnPivotValues: any[], series: Series[], offset = 1) => {

--- a/graylog2-web-interface/src/views/components/datatable/Headers.tsx
+++ b/graylog2-web-interface/src/views/components/datatable/Headers.tsx
@@ -16,6 +16,7 @@
  */
 import React from 'react';
 import { flatten, get, isEqual, last } from 'lodash';
+import styled, { css } from 'styled-components';
 
 import Field from 'views/components/Field';
 import FieldType from 'views/logic/fieldtypes/FieldType';
@@ -27,11 +28,19 @@ import fieldTypeFor from 'views/logic/fieldtypes/FieldTypeFor';
 
 import styles from './DataTable.css';
 
-const _headerField = (activeQuery: string, fields, field: string, prefix: (string | number) = '', span: number = 1, title: string = field) => (
-  <th key={`${prefix}${field}`} colSpan={span} className={styles.leftAligned}>
-    <Field name={field} queryId={activeQuery} type={fieldTypeFor(field, fields)}>{title}</Field>
-  </th>
-);
+const StyledTh = styled.th(({ isNumeric }: { isNumeric: boolean }) => css`
+  ${isNumeric ? 'text-align: right' : ''}
+`);
+
+const _headerField = (activeQuery: string, fields, field: string, prefix: (string | number) = '', span: number = 1, title: string = field) => {
+  const type = fieldTypeFor(field, fields);
+
+  return (
+    <StyledTh isNumeric={type.isNumeric()} key={`${prefix}${field}`} colSpan={span} className={styles.leftAligned}>
+      <Field name={field} queryId={activeQuery} type={type}>{title}</Field>
+    </StyledTh>
+  );
+};
 
 const _headerFieldForValue = (activeQuery: string, field, value, span = 1, prefix = '') => (
   <th key={`${prefix}${field}-${value}`} colSpan={span} className={styles.leftAligned}>


### PR DESCRIPTION
## Motivation
Prior to this change, numeric values where render just like the rest of
field types. But this makes it increasingly hard to read the values,
especially if the numbers are getting bigger. In a first step
@dennisoelkers introduced digig grouping.

## Description
This change will use monospace font for numeric values and align the
text on the right side so bigger numbers are easier to read.

## How Has This Been Tested?
- Add a aggregation with big numbers
- hava look on the numbers

## Screenshots (if appropriate):
![Graylog (38)](https://user-images.githubusercontent.com/448763/109953364-3e9e1c80-7ce0-11eb-955e-032c70c92919.png)

Refs #7831 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)