### PR TITLE
Make webpack /api proxy host and port configurable

### DIFF
--- a/graylog2-web-interface/devServer.js
+++ b/graylog2-web-interface/devServer.js
@@ -28,6 +28,8 @@ const webpackConfig = require('./webpack.bundled');
 
 const DEFAULT_HOST = '127.0.0.1';
 const DEFAULT_PORT = 8080;
+const DEFAULT_API_HOST = '127.0.0.1';
+const DEFAULT_API_PORT = 9000;
 
 const app = express();
 const vendorConfig = webpackConfig[0];
@@ -37,8 +39,15 @@ const appConfig = webpackConfig[1];
 const vendorCompiler = webpack(vendorConfig);
 const appCompiler = webpack(appConfig);
 
+const { argv } = yargs;
+const host = argv.host || DEFAULT_HOST;
+const port = argv.port || DEFAULT_PORT;
+const apiHost = argv.apiHost || DEFAULT_API_HOST;
+const apiPort = argv.apiPort || DEFAULT_API_PORT;
+
 // Proxy all "/api" requests to the server backend API.
-app.use('/api', proxy('localhost:9000', {
+console.log(`Graylog web interface forwarding /api requests to http://${apiHost}:${apiPort}`);
+app.use('/api', proxy(`${apiHost}:${apiPort}`, {
   proxyReqPathResolver(req) {
     // The proxy middleware removes the prefix from the path but we need it
     // to make sure we hit the "/api" resources on the server.
@@ -64,10 +73,6 @@ app.use(webpackDevMiddleware(appCompiler, {
 app.use(webpackHotMiddleware(appCompiler));
 
 const server = http.createServer(app);
-
-const { argv } = yargs;
-const host = argv.host || DEFAULT_HOST;
-const port = argv.port || DEFAULT_PORT;
 
 server
   .listen(port, host, () => {

--- a/graylog2-web-interface/devServer.js
+++ b/graylog2-web-interface/devServer.js
@@ -41,7 +41,9 @@ const appCompiler = webpack(appConfig);
 const { argv } = yargs;
 const host = argv.host || DEFAULT_HOST;
 const port = argv.port || DEFAULT_PORT;
-const apiUrl = argv.apiUrl || DEFAULT_API_URL;
+// Adhere to the URI environment variable that some folks use as well
+// (see https://github.com/Graylog2/graylog2-server/pull/5276)
+const apiUrl = argv.apiUrl || process.env.GRAYLOG_HTTP_PUBLISH_URI || DEFAULT_API_URL;
 
 // Proxy all "/api" requests to the server backend API.
 console.log(`Graylog web interface forwarding /api requests to ${apiUrl}`);

--- a/graylog2-web-interface/devServer.js
+++ b/graylog2-web-interface/devServer.js
@@ -44,6 +44,7 @@ const port = argv.port || DEFAULT_PORT;
 const apiUrl = argv.apiUrl || process.env.GRAYLOG_API_URL || DEFAULT_API_URL;
 
 // Proxy all "/api" requests to the server backend API.
+// eslint-disable-next-line no-console
 console.log(`Graylog web interface forwarding /api requests to ${apiUrl}`);
 app.use('/api', proxy(apiUrl, {
   proxyReqPathResolver(req) {

--- a/graylog2-web-interface/devServer.js
+++ b/graylog2-web-interface/devServer.js
@@ -41,9 +41,7 @@ const appCompiler = webpack(appConfig);
 const { argv } = yargs;
 const host = argv.host || DEFAULT_HOST;
 const port = argv.port || DEFAULT_PORT;
-// Adhere to the URI environment variable that some folks use as well
-// (see https://github.com/Graylog2/graylog2-server/pull/5276)
-const apiUrl = argv.apiUrl || process.env.GRAYLOG_HTTP_PUBLISH_URI || DEFAULT_API_URL;
+const apiUrl = argv.apiUrl || process.env.GRAYLOG_API_URL || DEFAULT_API_URL;
 
 // Proxy all "/api" requests to the server backend API.
 console.log(`Graylog web interface forwarding /api requests to ${apiUrl}`);

--- a/graylog2-web-interface/devServer.js
+++ b/graylog2-web-interface/devServer.js
@@ -46,6 +46,7 @@ const apiUrl = argv.apiUrl || process.env.GRAYLOG_API_URL || DEFAULT_API_URL;
 // Proxy all "/api" requests to the server backend API.
 // eslint-disable-next-line no-console
 console.log(`Graylog web interface forwarding /api requests to ${apiUrl}`);
+
 app.use('/api', proxy(apiUrl, {
   proxyReqPathResolver(req) {
     // The proxy middleware removes the prefix from the path but we need it

--- a/graylog2-web-interface/devServer.js
+++ b/graylog2-web-interface/devServer.js
@@ -28,8 +28,7 @@ const webpackConfig = require('./webpack.bundled');
 
 const DEFAULT_HOST = '127.0.0.1';
 const DEFAULT_PORT = 8080;
-const DEFAULT_API_HOST = '127.0.0.1';
-const DEFAULT_API_PORT = 9000;
+const DEFAULT_API_URL = 'http://127.0.0.1:9000';
 
 const app = express();
 const vendorConfig = webpackConfig[0];
@@ -42,12 +41,11 @@ const appCompiler = webpack(appConfig);
 const { argv } = yargs;
 const host = argv.host || DEFAULT_HOST;
 const port = argv.port || DEFAULT_PORT;
-const apiHost = argv.apiHost || DEFAULT_API_HOST;
-const apiPort = argv.apiPort || DEFAULT_API_PORT;
+const apiUrl = argv.apiUrl || DEFAULT_API_URL;
 
 // Proxy all "/api" requests to the server backend API.
-console.log(`Graylog web interface forwarding /api requests to http://${apiHost}:${apiPort}`);
-app.use('/api', proxy(`${apiHost}:${apiPort}`, {
+console.log(`Graylog web interface forwarding /api requests to ${apiUrl}`);
+app.use('/api', proxy(apiUrl, {
   proxyReqPathResolver(req) {
     // The proxy middleware removes the prefix from the path but we need it
     // to make sure we hit the "/api" resources on the server.

--- a/graylog2-web-interface/src/util/AppConfig.js
+++ b/graylog2-web-interface/src/util/AppConfig.js
@@ -16,10 +16,10 @@
  */
 const AppConfig = {
   gl2ServerUrl() {
-    if (typeof (GRAYLOG_HTTP_PUBLISH_URI) !== 'undefined') {
-      // The GRAYLOG_HTTP_PUBLISH_URI variable will be set by webpack via the DefinePlugin.
+    if (typeof (GRAYLOG_API_URL) !== 'undefined') {
+      // The GRAYLOG_API_URL variable will be set by webpack via the DefinePlugin.
       // eslint-disable-next-line no-undef
-      return GRAYLOG_HTTP_PUBLISH_URI;
+      return GRAYLOG_API_URL;
     }
 
     return this.appConfig().gl2ServerUrl;

--- a/graylog2-web-interface/webpack.config.js
+++ b/graylog2-web-interface/webpack.config.js
@@ -228,7 +228,8 @@ if (TARGET === 'start') {
     plugins: [
       new webpack.DefinePlugin({
         DEVELOPMENT: true,
-        GRAYLOG_HTTP_PUBLISH_URI: JSON.stringify(process.env.GRAYLOG_HTTP_PUBLISH_URI),
+        // Keep old env to avoid breaking developer setups
+        GRAYLOG_API_URL: JSON.stringify(process.env.GRAYLOG_API_URL || process.env.GRAYLOG_HTTP_PUBLISH_URI),
       }),
       new CopyWebpackPlugin({ patterns: [{ from: 'config.js' }] }),
       new webpack.HotModuleReplacementPlugin(),


### PR DESCRIPTION
This makes is possible to let the DEV web interface talk to a different backend server.