### PR TITLE
Support custom settings in CSV export dialog.

### DIFF
--- a/graylog2-web-interface/src/views/components/ExportSettingsContext.tsx
+++ b/graylog2-web-interface/src/views/components/ExportSettingsContext.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react';
+
+import { singleton } from 'views/logic/singleton';
+
+type ExportSettingsContextType = {
+  settings: ExportSettings;
+  setSettings: (settings: ExportSettings) => void;
+}
+
+export interface ExportSettings {}
+
+const ExportSettingsContext = React.createContext<ExportSettingsContextType>({ settings: {}, setSettings: () => {} });
+
+export default singleton('contexts.ExportSettingsContext', () => ExportSettingsContext);

--- a/graylog2-web-interface/src/views/components/ExportSettingsContext.tsx
+++ b/graylog2-web-interface/src/views/components/ExportSettingsContext.tsx
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 import * as React from 'react';
 
 import { singleton } from 'views/logic/singleton';

--- a/graylog2-web-interface/src/views/components/ExportSettingsContextProvider.tsx
+++ b/graylog2-web-interface/src/views/components/ExportSettingsContextProvider.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react';
+import { useState } from 'react';
+
+import ExportSettingsContext, { ExportSettings } from 'views/components/ExportSettingsContext';
+
+type Props = {
+  children: React.ReactNode,
+};
+
+const ExportSettingsContextProvider = ({ children }: Props) => {
+  const [exportSettings, setExportSettings] = useState<ExportSettings>();
+
+  return (
+    <ExportSettingsContext.Provider value={{ settings: exportSettings, setSettings: setExportSettings }}>
+      {children}
+    </ExportSettingsContext.Provider>
+  );
+};
+
+export default ExportSettingsContextProvider;

--- a/graylog2-web-interface/src/views/components/ExportSettingsContextProvider.tsx
+++ b/graylog2-web-interface/src/views/components/ExportSettingsContextProvider.tsx
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 import * as React from 'react';
 import { useState } from 'react';
 

--- a/graylog2-web-interface/src/views/components/WidgetComponent.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetComponent.tsx
@@ -23,6 +23,7 @@ import WidgetContext from 'views/components/contexts/WidgetContext';
 import WidgetClass from 'views/logic/widgets/Widget';
 import WidgetPosition from 'views/logic/widgets/WidgetPosition';
 import TFieldTypeMapping from 'views/logic/fieldtypes/FieldTypeMapping';
+import ExportSettingsContextProvider from 'views/components/ExportSettingsContextProvider';
 
 import { WidgetDataMap, WidgetErrorsMap } from './widgets/WidgetPropTypes';
 import Widget from './widgets/Widget';
@@ -59,17 +60,20 @@ const WidgetComponent = ({
     <DrilldownContextProvider widget={widget}>
       <WidgetContext.Provider value={widget}>
         <AdditionalContext.Provider value={{ widget }}>
-          <Widget id={widget.id}
-                  widget={widget}
-                  data={widgetData}
-                  errors={widgetErrors}
-                  height={height}
-                  position={position}
-                  width={width}
-                  fields={fields}
-                  onPositionsChange={onPositionsChange}
-                  onSizeChange={onWidgetSizeChange}
-                  title={title} />
+          <ExportSettingsContextProvider>
+            <Widget
+                    id={widget.id}
+                    widget={widget}
+                    data={widgetData}
+                    errors={widgetErrors}
+                    height={height}
+                    position={position}
+                    width={width}
+                    fields={fields}
+                    onPositionsChange={onPositionsChange}
+                    onSizeChange={onWidgetSizeChange}
+                    title={title} />
+          </ExportSettingsContextProvider>
         </AdditionalContext.Provider>
       </WidgetContext.Provider>
     </DrilldownContextProvider>

--- a/graylog2-web-interface/src/views/components/WidgetComponent.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetComponent.tsx
@@ -61,8 +61,7 @@ const WidgetComponent = ({
       <WidgetContext.Provider value={widget}>
         <AdditionalContext.Provider value={{ widget }}>
           <ExportSettingsContextProvider>
-            <Widget
-                    id={widget.id}
+            <Widget id={widget.id}
                     widget={widget}
                     data={widgetData}
                     errors={widgetErrors}

--- a/graylog2-web-interface/src/views/components/searchbar/csvexport/CSVExportModal.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/csvexport/CSVExportModal.tsx
@@ -35,6 +35,7 @@ import CSVExportSettings from 'views/components/searchbar/csvexport/CSVExportSet
 import CSVExportWidgetSelection from 'views/components/searchbar/csvexport/CSVExportWidgetSelection';
 import CustomPropTypes from 'views/components/CustomPropTypes';
 import { MESSAGE_FIELD, SOURCE_FIELD, TIMESTAMP_FIELD } from 'views/Constants';
+import { ExportSettings } from 'views/components/ExportSettingsContext';
 
 import ExportStrategy from './ExportStrategy';
 import startDownload from './startDownload';
@@ -72,6 +73,7 @@ type FormState = {
   selectedWidget: Widget | undefined,
   limit: number,
   selectedFields: Array<{ field: string }>,
+  customSettings: ExportSettings,
 };
 
 const CSVExportModal = ({ closeModal, fields, view, directExportWidgetId, executionState }: Props) => {
@@ -85,14 +87,19 @@ const CSVExportModal = ({ closeModal, fields, view, directExportWidgetId, execut
 
   const singleWidgetDownload = !!directExportWidgetId;
 
-  const _startDownload = (values: FormState) => {
-    return _onStartDownload(downloadFile, view, executionState, values.selectedWidget, values.selectedFields, values.limit, setLoading, closeModal);
+  const _startDownload = ({ selectedWidget, selectedFields, limit, customSettings }: FormState) => {
+    setLoading(true);
+
+    return startDownload(downloadFile, view, executionState, selectedWidget, selectedFields, limit, customSettings)
+      .then(closeModal)
+      .finally(() => setLoading(false));
   };
 
   const initialValues: FormState = {
     selectedWidget: initialSelectedWidget,
     selectedFields: initialSelectedFields,
     limit: undefined,
+    customSettings: {},
   };
 
   return (

--- a/graylog2-web-interface/src/views/components/searchbar/csvexport/CSVExportModal.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/csvexport/CSVExportModal.tsx
@@ -14,7 +14,8 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import React, { useState } from 'react';
+import * as React from 'react';
+import { useState } from 'react';
 import { List, Set } from 'immutable';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
@@ -65,11 +66,6 @@ const _getInitialFields = (selectedWidget) => {
   const initialFields = selectedWidget ? _getInitialWidgetFields(selectedWidget) : DEFAULT_FIELDS;
 
   return initialFields.map((field) => ({ field })).toArray();
-};
-
-const _onStartDownload = (downloadFile, view, executionState, selectedWidget, selectedFields, limit, setLoading, closeModal) => {
-  setLoading(true);
-  startDownload(downloadFile, view, executionState, selectedWidget, selectedFields, limit).then(closeModal);
 };
 
 type FormState = {

--- a/graylog2-web-interface/src/views/components/searchbar/csvexport/CSVExportSettings.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/csvexport/CSVExportSettings.test.tsx
@@ -1,0 +1,67 @@
+import * as React from 'react';
+import { Formik } from 'formik';
+import * as Immutable from 'immutable';
+import { render } from 'wrappedTestingLibrary';
+import { PluginStore } from 'graylog-web-plugin/plugin';
+
+import Widget from 'views/logic/widgets/Widget';
+import View from 'views/logic/views/View';
+import CSVExportSettings from 'views/components/searchbar/csvexport/CSVExportSettings';
+import MessagesWidget from 'views/logic/widgets/MessagesWidget';
+import FieldTypeMapping from 'views/logic/fieldtypes/FieldTypeMapping';
+import FieldType from 'views/logic/fieldtypes/FieldType';
+
+import { viewWithoutWidget, stateWithOneWidget } from './Fixtures';
+
+const CustomExportComponent = () => <>This is a custom export component</>;
+
+const pluginExports = {
+  exports: {
+    enterpriseWidgets: [
+      {
+        type: 'messages',
+        displayName: 'Message List',
+        titleGenerator: () => MessagesWidget.defaultTitle,
+      },
+      {
+        type: 'custom',
+        displayName: 'Widget with Custom Export Settings',
+        titleGenerator: () => 'Default Title',
+        exportComponent: CustomExportComponent,
+      },
+    ],
+  },
+};
+
+const fields = Immutable.List([FieldTypeMapping.create('foo', FieldType.create('long'))]);
+
+const SimpleExportSettings = (props: Omit<React.ComponentProps<typeof CSVExportSettings>, 'fields'>) => (
+  <Formik initialValues={{ selectedFields: [] }} onSubmit={() => {}}>
+    {() => (
+      <CSVExportSettings fields={fields} {...props} />
+    )}
+  </Formik>
+);
+const customWidget = Widget.builder()
+  .id('widget-id-1')
+  .type('custom')
+  .build();
+const view = viewWithoutWidget(View.Type.Search).toBuilder()
+  .state(Immutable.Map({ 'query-id-1': stateWithOneWidget(customWidget) }))
+  .build();
+
+describe('CSVExportSettings', () => {
+  beforeAll(() => {
+    PluginStore.register(pluginExports);
+  });
+
+  afterAll(() => {
+    PluginStore.unregister(pluginExports);
+  });
+
+  it('renders custom export settings component', async () => {
+    const { findByText } = render(<SimpleExportSettings view={view} selectedWidget={customWidget} />);
+
+    await findByText('This is a custom export component');
+  });
+});

--- a/graylog2-web-interface/src/views/components/searchbar/csvexport/CSVExportSettings.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/csvexport/CSVExportSettings.test.tsx
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 import * as React from 'react';
 import { Formik } from 'formik';
 import * as Immutable from 'immutable';

--- a/graylog2-web-interface/src/views/components/searchbar/csvexport/CSVExportSettings.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/csvexport/CSVExportSettings.tsx
@@ -27,6 +27,8 @@ import FieldSelect from 'views/components/widgets/FieldSelect';
 import IfDashboard from 'views/components/dashboard/IfDashboard';
 import IfSearch from 'views/components/search/IfSearch';
 
+import CustomExportSettings from './CustomExportSettings';
+
 type CSVExportSettingsType = {
   fields: List<FieldTypeMapping>,
   selectedWidget: Widget | undefined | null,
@@ -108,6 +110,8 @@ const CSVExportSettings = ({
           )}
         </Field>
       </Row>
+
+      <CustomExportSettings widget={selectedWidget} />
     </>
   );
 };

--- a/graylog2-web-interface/src/views/components/searchbar/csvexport/CustomExportSettings.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/csvexport/CustomExportSettings.tsx
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 import * as React from 'react';
 import { useMemo } from 'react';
 

--- a/graylog2-web-interface/src/views/components/searchbar/csvexport/CustomExportSettings.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/csvexport/CustomExportSettings.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react';
+import { useMemo } from 'react';
+
+import Widget from 'views/logic/widgets/Widget';
+import { widgetDefinition } from 'views/logic/Widgets';
+
+type Props = {
+  widget: Widget,
+}
+
+const CustomExportSettings = ({ widget }: Props) => {
+  const { exportComponent: ExportComponent = () => null } = useMemo(() => (widget?.type && widgetDefinition(widget.type)) ?? {}, [widget]);
+
+  return <ExportComponent widget={widget} />;
+};
+
+export default CustomExportSettings;

--- a/graylog2-web-interface/src/views/components/searchbar/csvexport/Fixtures.ts
+++ b/graylog2-web-interface/src/views/components/searchbar/csvexport/Fixtures.ts
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 import * as Immutable from 'immutable';
 
 import Query from 'views/logic/queries/Query';

--- a/graylog2-web-interface/src/views/components/searchbar/csvexport/Fixtures.ts
+++ b/graylog2-web-interface/src/views/components/searchbar/csvexport/Fixtures.ts
@@ -1,0 +1,69 @@
+import * as Immutable from 'immutable';
+
+import Query from 'views/logic/queries/Query';
+import SortConfig from 'views/logic/aggregationbuilder/SortConfig';
+import Direction from 'views/logic/aggregationbuilder/Direction';
+import MessagesWidgetConfig from 'views/logic/widgets/MessagesWidgetConfig';
+import MessagesWidget from 'views/logic/widgets/MessagesWidget';
+import View, { ViewStateMap, ViewType } from 'views/logic/views/View';
+import ViewState from 'views/logic/views/ViewState';
+import Search from 'views/logic/search/Search';
+import { TitleType } from 'views/stores/TitleTypes';
+
+const searchType = {
+  id: 'search-type-id-1',
+  type: 'messages',
+  streams: [],
+  sort: [],
+  filter: '',
+  name: null,
+  query: null,
+  timerange: null,
+  limit: 150,
+  decorators: [],
+  offset: 0,
+};
+const queries = [
+  Query.builder().id('query-id-1').searchTypes([searchType]).build(),
+];
+const currentSort = new SortConfig(SortConfig.PIVOT_TYPE, 'level', Direction.Descending);
+const config = new MessagesWidgetConfig(['level', 'http_method'], true, [], [currentSort]);
+
+export const messagesWidget = (id: string = 'widget-id-1') => MessagesWidget.builder()
+  .id(id)
+  .config(config)
+  .build();
+const states: ViewStateMap = Immutable.Map({
+  'query-id-1': ViewState.create(),
+});
+const searchWithQueries = Search.builder()
+  .id('search-id')
+  .queries(queries)
+  .build();
+export const viewWithoutWidget = (viewType: ViewType) => View.create()
+  .toBuilder()
+  .id('deadbeef')
+  .type(viewType)
+  .search(searchWithQueries)
+  .state(states)
+  .build();
+// Prepare view with one widget
+export const stateWithOneWidget = (widget) => ViewState.builder()
+  .widgets(Immutable.List([widget]))
+  .widgetMapping(Immutable.Map({ 'widget-id-1': Immutable.Set(['search-type-id-1']) }))
+  .titles(Immutable.Map<TitleType, Immutable.Map<string, string>>({ widget: Immutable.Map<string, string>({ 'widget-id-1': 'Widget 1' }) }))
+  .build();
+export const viewWithOneWidget = (viewType) => viewWithoutWidget(viewType)
+  .toBuilder()
+  .state(Immutable.Map({ 'query-id-1': stateWithOneWidget(messagesWidget()) }))
+  .build();
+// Prepare view with multiple widgets
+const stateWithMultipleWidgets: ViewState = ViewState.builder()
+  .widgets(Immutable.List([messagesWidget('widget-id-1'), messagesWidget('widget-id-2')]))
+  .widgetMapping(Immutable.Map({ 'widget-id-1': Immutable.Set(['search-type-id-1']) }))
+  .titles(Immutable.Map<TitleType, Immutable.Map<string, string>>({ widget: Immutable.Map({ 'widget-id-1': 'Widget 1', 'widget-id-2': 'Widget 2' }) }))
+  .build();
+export const viewWithMultipleWidgets = (viewType) => viewWithoutWidget(viewType)
+  .toBuilder()
+  .state(Immutable.Map({ 'query-id-1': stateWithMultipleWidgets }))
+  .build();

--- a/graylog2-web-interface/src/views/components/searchbar/csvexport/startDownload.ts
+++ b/graylog2-web-interface/src/views/components/searchbar/csvexport/startDownload.ts
@@ -24,6 +24,7 @@ import Widget from 'views/logic/widgets/Widget';
 import ViewTypeLabel from 'views/components/ViewTypeLabel';
 import SearchExecutionState from 'views/logic/search/SearchExecutionState';
 import type { SearchType } from 'views/logic/queries/SearchType';
+import { ExportSettings } from 'views/components/ExportSettingsContext';
 
 const getFilename = (view, selectedWidget) => {
   let filename = 'search-result';
@@ -48,11 +49,13 @@ const startDownload = (
   selectedWidget: Widget | undefined | null,
   selectedFields: { field: string }[],
   limit: number | undefined | null,
+  customSettings: ExportSettings,
 ) => {
   const payload: ExportPayload = {
     execution_state: executionState,
     fields_in_order: selectedFields.map((field) => field.field),
     limit,
+    ...customSettings,
   };
   const searchType: SearchType | undefined | null = selectedWidget ? view.getSearchTypeByWidgetId(selectedWidget.id) : undefined;
   const filename = getFilename(view, selectedWidget);


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is adding functionality to support custom settings for the CSV export provided by widget-specific components, by:
  - Allowing to define an `exportComponent` in a widget definition. This component is rendered in the export dialog if a widget of this definition's type is exported.
  - Providing an `ExportSettingsContext` per widget which allows tracking custom export settings derived from the current widget's state. This can be used to communicate between a widget component (and/or its visualization) and the custom export settings components which are part of the export dialog.
  - When the export dialog is submitted, the `customSettings` key of the form's state is merged into the export request. This allows custom export components to override parts of the export dialog.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.