### PR TITLE
Disable no-standalone-expect for each.test blocks

### DIFF
--- a/graylog2-web-interface/packages/eslint-config-graylog/index.js
+++ b/graylog2-web-interface/packages/eslint-config-graylog/index.js
@@ -53,7 +53,9 @@ module.exports = {
       ],
       rules: {
         'jest/expect-expect': ['error', { assertFunctionNames: ['expect*', '(screen.)?find(All)?By*'] }],
+        'jest/no-standalone-expect': ['error', { additionalTestBlockFunctions: ['each.test'] }],
         'testing-library/no-debug': 'warn',
+	"jest/no-standalone-expect": [ "error", { "additionalTestBlockFunctions": ["each.test"] } ]
       },
     },
   ],


### PR DESCRIPTION
## Motivation
With the new jest-linter we get linting errors when using test blocks
like:

```
each([
  [1, 1, 2],
  [1, 2, 3],
  [2, 1, 3],
]).test('returns the result of adding %d to %d', (a, b, expected) => {
  expect(a + b).toBe(expected);
});
```

## Description
This PR will disable warnings for such tests.

