### PR TITLE
Adding optional timerange parameter to export request.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/export/CommandFactory.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/export/CommandFactory.java
@@ -57,7 +57,7 @@ public class CommandFactory {
         Query query = queryFrom(search);
 
         return builderFrom(resultFormat)
-                .timeRange(toAbsolute(query.timerange()))
+                .timeRange(resultFormat.timerange().orElse(toAbsolute(query.timerange())))
                 .queryString(queryStringFrom(search, query))
                 .streams(query.usedStreamIds())
                 .build();
@@ -79,7 +79,7 @@ public class CommandFactory {
         final List<Decorator> decorators = searchType instanceof MessageList ? ((MessageList) searchType).decorators() : Collections.emptyList();
 
         ExportMessagesCommand.Builder commandBuilder = builderFrom(resultFormat)
-                .timeRange(toAbsolute(timeRangeFrom(query, searchType)))
+                .timeRange(resultFormat.timerange().orElse(toAbsolute(timeRangeFrom(query, searchType))))
                 .queryString(queryStringFrom(search, query, searchType))
                 .streams(streamsFrom(query, searchType))
                 .decorators(decorators);

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/export/MessagesRequest.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/export/MessagesRequest.java
@@ -100,11 +100,7 @@ public abstract class MessagesRequest {
         @JsonProperty
         public abstract Builder limit(Integer limit);
 
-        abstract MessagesRequest autoBuild();
-
-        public MessagesRequest build() {
-            return autoBuild();
-        }
+        public abstract MessagesRequest build();
 
         @JsonCreator
         public static Builder create() {

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/export/ResultFormat.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/export/ResultFormat.java
@@ -21,12 +21,15 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
+import org.graylog2.plugin.indexer.searches.timeranges.AbsoluteRange;
 
+import javax.annotation.Nullable;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.Positive;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.Optional;
 import java.util.OptionalInt;
 
 import static org.graylog.plugins.views.search.export.ExportMessagesCommand.DEFAULT_FIELDS;
@@ -41,6 +44,9 @@ public abstract class ResultFormat {
     @JsonProperty(FIELD_FIELDS)
     @NotEmpty
     public abstract LinkedHashSet<String> fieldsInOrder();
+
+    @JsonProperty
+    public abstract Optional<AbsoluteRange> timerange();
 
     @JsonProperty
     @Positive
@@ -72,11 +78,10 @@ public abstract class ResultFormat {
         @JsonProperty
         public abstract Builder executionState(Map<String, Object> executionState);
 
-        abstract ResultFormat autoBuild();
+        @JsonProperty
+        public abstract Builder timerange(@Nullable AbsoluteRange timeRange);
 
-        public ResultFormat build() {
-            return autoBuild();
-        }
+        public abstract ResultFormat build();
 
         @JsonCreator
         public static ResultFormat.Builder create() {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is adding an optional `timerange` parameter to the request used to export a single widget's searchtype. If it is not present, the export will still use the widget's timerange (or the one from its query, if it's absent).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.