### PR TITLE
Remove trailing parenthesis for IPInfo database types

### DIFF
--- a/graylog2-web-interface/src/components/maps/adapter/MaxmindAdapterFieldSet.jsx
+++ b/graylog2-web-interface/src/components/maps/adapter/MaxmindAdapterFieldSet.jsx
@@ -55,8 +55,8 @@ class MaxmindAdapterFieldSet extends React.Component {
       { label: 'ASN database', value: 'MAXMIND_ASN' },
       { label: 'City database', value: 'MAXMIND_CITY' },
       { label: 'Country database', value: 'MAXMIND_COUNTRY' },
-      { label: 'IPinfo location database)', value: 'IPINFO_STANDARD_LOCATION' },
-      { label: 'IPinfo ASN database)', value: 'IPINFO_ASN' },
+      { label: 'IPinfo location database', value: 'IPINFO_STANDARD_LOCATION' },
+      { label: 'IPinfo ASN database', value: 'IPINFO_ASN' },
     ];
 
     return (


### PR DESCRIPTION
Remove the trailing parenthesis for IPInfo database types.

![image](https://user-images.githubusercontent.com/3423655/110324205-f7809600-8015-11eb-9aef-b3d52c466535.png)
