### PR TITLE
Fixing name of `TimeRangeInput` test.

### DIFF
--- a/graylog2-web-interface/src/views/components/searchbar/TimeRangeInput.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/TimeRangeInput.test.tsx
@@ -19,7 +19,7 @@ import { fireEvent, render, screen, waitFor, within } from 'wrappedTestingLibrar
 
 import TimeRangeInput from 'views/components/searchbar/TimeRangeInput';
 
-describe('LogViewExportSettings', () => {
+describe('TimeRangeInput', () => {
   const defaultTimeRange = { type: 'relative', range: 300 };
 
   it('opens date picker dropdown when clicking button', async () => {


### PR DESCRIPTION
## Description

This PR is just fixing the name of the `TimeRangeInput` test.