### PR TITLE
Search not executing when form state is clean

### DIFF
--- a/graylog2-web-interface/src/views/components/DashboardSearchBar.test.tsx
+++ b/graylog2-web-interface/src/views/components/DashboardSearchBar.test.tsx
@@ -18,11 +18,17 @@ import * as React from 'react';
 import { render, screen, fireEvent, waitFor } from 'wrappedTestingLibrary';
 import { StoreMock as MockStore } from 'helpers/mocking';
 
-import { GlobalOverrideActions } from 'views/stores/GlobalOverrideStore';
+import { SearchActions } from 'views/stores/SearchStore';
 
 import DashboardSearchBar from './DashboardSearchBar';
 
 jest.mock('views/components/ViewActionsMenu', () => () => <span>View Actions</span>);
+
+jest.mock('views/stores/SearchStore', () => ({
+  SearchActions: {
+    refresh: jest.fn(),
+  },
+}));
 
 jest.mock('views/stores/GlobalOverrideStore', () => ({
   GlobalOverrideActions: {
@@ -73,8 +79,6 @@ describe('DashboardSearchBar', () => {
 
     fireEvent.click(searchButton);
 
-    await waitFor(() => expect(onExecute).toHaveBeenCalledTimes(1));
-
-    expect(GlobalOverrideActions.set).toHaveBeenCalledWith(undefined, '');
+    await waitFor(() => expect(SearchActions.refresh).toHaveBeenCalledTimes(1));
   });
 });

--- a/graylog2-web-interface/src/views/components/DashboardSearchBar.test.tsx
+++ b/graylog2-web-interface/src/views/components/DashboardSearchBar.test.tsx
@@ -39,6 +39,8 @@ jest.mock('views/stores/SearchStore', () => ({
   },
 }));
 
+jest.mock('views/components/searchbar/AsyncQueryInput', () => () => null);
+
 const config = {
   analysis_disabled_fields: ['full_message', 'message'],
   query_time_range_limit: 'PT0S',

--- a/graylog2-web-interface/src/views/components/DashboardSearchBar.test.tsx
+++ b/graylog2-web-interface/src/views/components/DashboardSearchBar.test.tsx
@@ -16,7 +16,6 @@
  */
 import * as React from 'react';
 import { render, screen, fireEvent, waitFor } from 'wrappedTestingLibrary';
-import { StoreMock as MockStore } from 'helpers/mocking';
 
 import { SearchActions } from 'views/stores/SearchStore';
 
@@ -28,13 +27,6 @@ jest.mock('views/stores/SearchStore', () => ({
   SearchActions: {
     refresh: jest.fn(),
   },
-}));
-
-jest.mock('views/stores/GlobalOverrideStore', () => ({
-  GlobalOverrideActions: {
-    set: jest.fn(() => Promise.resolve()),
-  },
-  GlobalOverrideStore: MockStore(),
 }));
 
 const config = {

--- a/graylog2-web-interface/src/views/components/SearchBar.test.tsx
+++ b/graylog2-web-interface/src/views/components/SearchBar.test.tsx
@@ -19,7 +19,7 @@ import { fireEvent, render, screen, waitFor } from 'wrappedTestingLibrary';
 import { StoreMock as MockStore } from 'helpers/mocking';
 import mockAction from 'helpers/mocking/MockAction';
 
-import { QueriesActions } from 'views/stores/QueriesStore';
+import { SearchActions } from 'views/stores/SearchStore';
 // eslint-disable-next-line import/no-named-default
 import { default as MockQuery } from 'views/logic/queries/Query';
 
@@ -59,7 +59,7 @@ describe('SearchBar', () => {
   };
 
   beforeEach(() => {
-    QueriesActions.update = mockAction(jest.fn());
+    SearchActions.refresh = mockAction(jest.fn());
   });
 
   it('should render the SearchBar', () => {
@@ -87,9 +87,7 @@ describe('SearchBar', () => {
 
     fireEvent.click(searchButton);
 
-    const queryId = '34efae1e-e78e-48ab-ab3f-e83c8611a683';
-
-    await waitFor(() => expect(QueriesActions.update).toHaveBeenCalledWith(queryId, expect.objectContaining({ id: queryId })));
+    await waitFor(() => expect(SearchActions.refresh).toHaveBeenCalledTimes(1));
   });
 
   it('date exceeding limitDuration should render with error Icon & search button disabled', async () => {

--- a/graylog2-web-interface/src/views/components/searchbar/SearchButton.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/SearchButton.test.tsx
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import { render, screen, fireEvent } from 'wrappedTestingLibrary';
+
+import { SearchActions } from 'views/stores/SearchStore';
+import SearchButton from 'views/components/searchbar/SearchButton';
+
+jest.mock('views/stores/SearchStore', () => ({
+  SearchActions: {
+    refresh: jest.fn(),
+  },
+}));
+
+describe('SearchButton', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should perform refresh when not dirty', () => {
+    render(<SearchButton />);
+
+    const button = screen.getByTitle('Perform search');
+
+    fireEvent.click(button);
+
+    expect(SearchActions.refresh).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not perform refresh when not dirty and disabled', () => {
+    render(<SearchButton disabled />);
+
+    const button = screen.getByTitle('Perform search');
+
+    fireEvent.click(button);
+
+    expect(SearchActions.refresh).not.toHaveBeenCalled();
+  });
+});

--- a/graylog2-web-interface/src/views/components/searchbar/SearchButton.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/SearchButton.tsx
@@ -20,6 +20,7 @@ import styled, { css } from 'styled-components';
 
 import { Button } from 'components/graylog';
 import { Icon } from 'components/common';
+import { SearchActions } from 'views/stores/SearchStore';
 
 const StyledButton = styled(Button)`
   margin-right: 7px;
@@ -46,20 +47,27 @@ type Props = {
   dirty: boolean,
 };
 
-const SearchButton = ({ disabled, glyph, dirty }: Props) => {
-  const ButtonComponent = dirty ? DirtyButton : StyledButton;
-  const title = dirty ? 'Perform search (changes were made after last search execution)' : 'Perform search';
+const DirtySearchButton = ({ disabled, glyph }: { disabled: boolean, glyph: string }) => (
+  <DirtyButton type="submit"
+               bsStyle="success"
+               disabled={disabled}
+               title="Perform search (changes were made after last search execution)"
+               className="pull-left">
+    <Icon name={glyph} />
+  </DirtyButton>
+);
 
-  return (
-    <ButtonComponent type="submit"
-                     bsStyle="success"
-                     disabled={disabled}
-                     title={title}
-                     className="pull-left">
-      <Icon name={glyph} />
-    </ButtonComponent>
-  );
-};
+const CleanSearchButton = ({ disabled, glyph }: { disabled: boolean, glyph: string }) => (
+  <StyledButton bsStyle="success"
+                onClick={() => SearchActions.refresh()}
+                disabled={disabled}
+                title="Perform search"
+                className="pull-left">
+    <Icon name={glyph} />
+  </StyledButton>
+);
+
+const SearchButton = ({ dirty, ...rest }: Props) => (dirty ? <DirtySearchButton {...rest} /> : <CleanSearchButton {...rest} />);
 
 SearchButton.defaultProps = {
   disabled: false,

--- a/graylog2-web-interface/src/views/components/widgets/EditWidgetFrame.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/EditWidgetFrame.test.tsx
@@ -20,6 +20,7 @@ import selectEvent from 'react-select-event';
 import MockStore from 'helpers/mocking/StoreMock';
 
 import { WidgetActions } from 'views/stores/WidgetStore';
+import { SearchActions } from 'views/stores/SearchStore';
 import Widget from 'views/logic/widgets/Widget';
 
 import EditWidgetFrame from './EditWidgetFrame';
@@ -30,6 +31,12 @@ import WidgetContext from '../contexts/WidgetContext';
 jest.mock('views/stores/WidgetStore', () => ({
   WidgetActions: {
     update: jest.fn(),
+  },
+}));
+
+jest.mock('views/stores/SearchStore', () => ({
+  SearchActions: {
+    refresh: jest.fn(),
   },
 }));
 
@@ -75,15 +82,13 @@ describe('EditWidgetFrame', () => {
       </ViewTypeContext.Provider>
     ));
 
-    it('parses timerange when time range input is used', async () => {
+    it('performs search when clicking on search button', async () => {
       renderSUT();
       const searchButton = screen.getByTitle(/Perform search/);
 
       fireEvent.click(searchButton);
 
-      await waitFor(() => expect(WidgetActions.update).toHaveBeenCalledWith('deadbeef', expect.objectContaining({
-        timerange: { from: 300, type: 'relative' },
-      })));
+      await waitFor(() => expect(SearchActions.refresh).toHaveBeenCalledTimes(1));
     });
 
     it('changes the widget\'s streams when using stream filter', async () => {


### PR DESCRIPTION
## Motivation and Context
When the search configuration did not change clicking on the search button did not trigger a new search execution.

## Description
When the state of the search is not dirty the search was not executed since no change on the search was found.
Now in stead of submitting a new search we call `SearchActions.refresh` when the state of the form is not dirty.

## How Has This Been Tested?
- Perfoming searches with dirty and clean state
- On dashboard and search

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
