### PR TITLE
Revert "Replace `loadable-components` with `React.lazy`. (#10138)"

### DIFF
--- a/graylog2-web-interface/package.json
+++ b/graylog2-web-interface/package.json
@@ -61,6 +61,7 @@
     "javascript-natural-sort": "^0.7.1",
     "jquery-ui": "1.12.x",
     "leaflet": "^1.5.1",
+    "loadable-components": "^2.2.3",
     "lodash": "^4.17.4",
     "marked": "^2.0.0",
     "md5": "^2.2.1",

--- a/graylog2-web-interface/src/routing/loadAsync.tsx
+++ b/graylog2-web-interface/src/routing/loadAsync.tsx
@@ -14,21 +14,17 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import * as React from 'react';
-import { Suspense } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
-
-import Spinner from 'components/common/Spinner';
-
-type Error = {
-  message: string;
-};
+import loadable from 'loadable-components';
 
 type Props = {
-  error: Error;
+  error: {
+    message: string;
+  };
 };
 
-const ErrorComponent: React.ComponentType<Props> = ({ error }: Props) => <div>Loading component failed: {error.message}</div>;
+const ErrorComponent: React.FC<Props> = ({ error }: Props) => <div>Loading component failed: {error.message}</div>;
 
 ErrorComponent.propTypes = {
   error: PropTypes.exact({
@@ -36,38 +32,4 @@ ErrorComponent.propTypes = {
   }).isRequired,
 };
 
-class AsyncLoaderErrorBoundary extends React.Component<{ errorComponent: React.ComponentType<Props> }, { error?: Error }> {
-  constructor(props: Readonly<{ errorComponent: React.ComponentType<Props> }>) {
-    super(props);
-    this.state = {};
-  }
-
-  componentDidCatch(error) {
-    this.setState({ error });
-  }
-
-  render() {
-    const { error } = this.state;
-    const { children } = this.props;
-
-    if (error) {
-      const { errorComponent: CustomErrorComponent } = this.props;
-
-      return <CustomErrorComponent error={error} />;
-    }
-
-    return children;
-  }
-}
-
-export default <T extends React.ComponentType<any>>(f: () => Promise<{ default: T }>) => (props: React.ComponentPropsWithRef<T>) => {
-  const LazyComponent = React.lazy(f);
-
-  return (
-    <AsyncLoaderErrorBoundary errorComponent={ErrorComponent}>
-      <Suspense fallback={<Spinner />}>
-        <LazyComponent {...props} />
-      </Suspense>
-    </AsyncLoaderErrorBoundary>
-  );
-};
+export default <T, >(f: () => Promise<{ default: loadable.DefaultComponent<T> }>) => loadable<T>(() => f().then((c) => c.default), { ErrorComponent });

--- a/graylog2-web-interface/src/views/components/SearchBar.test.tsx
+++ b/graylog2-web-interface/src/views/components/SearchBar.test.tsx
@@ -38,7 +38,7 @@ jest.mock('stores/streams/StreamsStore', () => MockStore(
   'availableStreams',
 ));
 
-jest.mock('views/components/searchbar/AsyncQueryInput', () => 'query-input');
+jest.mock('views/components/searchbar/QueryInput', () => 'query-input');
 jest.mock('views/components/searchbar/saved-search/SavedSearchControls', () => 'saved-search-controls');
 
 jest.mock('views/stores/CurrentQueryStore', () => ({


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This reverts commit f8a32f0f31b95a432c621a9cff9b8e001950882a.

The previous change introduced some issues with component structure
mounting, leading to route changes unmounting and remounting the
complete component tree.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.