### PR TITLE
Allow filtering valid time range types in time range picker.

### DIFF
--- a/graylog2-web-interface/src/views/Constants.ts
+++ b/graylog2-web-interface/src/views/Constants.ts
@@ -92,7 +92,7 @@ export const showDashboardsPath = `${dashboardsPath}/:viewId`;
 export const extendedSearchPath = '/extendedsearch';
 
 export const availableTimeRangeTypes = [
-  { type: 'relative', name: 'Relative' },
-  { type: 'absolute', name: 'Absolute' },
-  { type: 'keyword', name: 'Keyword' },
+  { type: 'relative' as const, name: 'Relative' },
+  { type: 'absolute' as const, name: 'Absolute' },
+  { type: 'keyword' as const, name: 'Keyword' },
 ];

--- a/graylog2-web-interface/src/views/components/searchbar/TimeRangeInput.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/TimeRangeInput.test.tsx
@@ -79,4 +79,25 @@ describe('LogViewExportSettings', () => {
 
     await screen.findByText('No Override');
   });
+
+  it('shows all tabs if no `validTypes` prop is passed', async () => {
+    render(<TimeRangeInput onChange={() => {}} value={defaultTimeRange} />);
+
+    fireEvent.click(await screen.findByText(/5 minutes ago/));
+
+    await screen.findByRole('tab', { name: 'Absolute' });
+    await screen.findByRole('tab', { name: 'Keyword' });
+    await screen.findByRole('tab', { name: 'Relative' });
+  });
+
+  it('shows only valid tabs if `validTypes` prop is passed', async () => {
+    render(<TimeRangeInput onChange={() => {}} value={defaultTimeRange} validTypes={['relative']} />);
+
+    fireEvent.click(await screen.findByText(/5 minutes ago/));
+
+    await screen.findByRole('tab', { name: 'Relative' });
+
+    expect(screen.queryByRole('tab', { name: 'Keyword' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('tab', { name: 'Absolute' })).not.toBeInTheDocument();
+  });
 });

--- a/graylog2-web-interface/src/views/components/searchbar/TimeRangeInput.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/TimeRangeInput.tsx
@@ -43,7 +43,7 @@ const FlexContainer = styled.span`
 const TimeRangeInput = ({ disabled, hasErrorOnMount, noOverride, value = {}, onChange, validTypes }: Props) => {
   const [show, setShow] = useState(false);
 
-  if (validTypes && value?.type && !validTypes.includes(value?.type)) {
+  if (validTypes && value && 'type' in value && !validTypes.includes(value?.type)) {
     throw new Error(`Value is of type ${value.type}, but only these types are valid: ${validTypes}`);
   }
 

--- a/graylog2-web-interface/src/views/components/searchbar/TimeRangeInput.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/TimeRangeInput.tsx
@@ -22,7 +22,7 @@ import styled from 'styled-components';
 import { TimeRange, NoTimeRangeOverride } from 'views/logic/queries/Query';
 
 import TimeRangeDropdownButton from './TimeRangeDropdownButton';
-import TimeRangeDropdown from './date-time-picker/TimeRangeDropdown';
+import TimeRangeDropdown, { TimeRangeType } from './date-time-picker/TimeRangeDropdown';
 import TimeRangeDisplay from './TimeRangeDisplay';
 
 type Props = {
@@ -31,6 +31,7 @@ type Props = {
   noOverride?: boolean,
   hasErrorOnMount?: boolean,
   onChange: (nextTimeRange: TimeRange | NoTimeRangeOverride) => void,
+  validTypes?: Array<TimeRangeType>,
 };
 
 const FlexContainer = styled.span`
@@ -39,8 +40,12 @@ const FlexContainer = styled.span`
   justify-content: space-between;
 `;
 
-const TimeRangeInput = ({ disabled, hasErrorOnMount, noOverride, value = {}, onChange }: Props) => {
+const TimeRangeInput = ({ disabled, hasErrorOnMount, noOverride, value = {}, onChange, validTypes }: Props) => {
   const [show, setShow] = useState(false);
+
+  if (validTypes && value?.type && !validTypes.includes(value?.type)) {
+    throw new Error(`Value is of type ${value.type}, but only these types are valid: ${validTypes}`);
+  }
 
   const toggleShow = () => setShow(!show);
 
@@ -53,7 +58,8 @@ const TimeRangeInput = ({ disabled, hasErrorOnMount, noOverride, value = {}, onC
         <TimeRangeDropdown currentTimeRange={value}
                            noOverride={noOverride}
                            setCurrentTimeRange={onChange}
-                           toggleDropdownShow={toggleShow} />
+                           toggleDropdownShow={toggleShow}
+                           validTypes={validTypes} />
       </TimeRangeDropdownButton>
       <TimeRangeDisplay timerange={value} toggleDropdownShow={toggleShow} />
     </FlexContainer>
@@ -64,12 +70,14 @@ TimeRangeInput.propTypes = {
   disabled: PropTypes.bool,
   hasErrorOnMount: PropTypes.bool,
   noOverride: PropTypes.bool,
+  validTypes: PropTypes.arrayOf(PropTypes.string),
 };
 
 TimeRangeInput.defaultProps = {
   disabled: false,
   hasErrorOnMount: false,
   noOverride: false,
+  validTypes: undefined,
 };
 
 export default TimeRangeInput;

--- a/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TimeRangeDropdown.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TimeRangeDropdown.tsx
@@ -46,11 +46,14 @@ const timeRangeTypes = {
   keyword: TabKeywordTimeRange,
 };
 
+const allTimeRangeTypes = Object.keys(timeRangeTypes) as Array<TimeRangeType>;
+
 type Props = {
   noOverride?: boolean,
   currentTimeRange: SearchBarFormValues['timerange'] | NoTimeRangeOverride,
   setCurrentTimeRange: (nextTimeRange: SearchBarFormValues['timerange'] | NoTimeRangeOverride) => void,
   toggleDropdownShow: () => void,
+  validTypes?: Array<TimeRangeType>,
 };
 
 const StyledPopover = styled(Popover)(({ theme }) => css`
@@ -112,21 +115,32 @@ const DEFAULT_RANGES = {
   disabled: undefined,
 };
 
-const timeRangeTypeTabs = ({ activeTab, limitDuration, setValidatingKeyword }) => availableTimeRangeTypes.map(({ type, name }) => {
-  const TimeRangeTypeTabs = timeRangeTypes[type];
+export type TimeRangeType = keyof typeof timeRangeTypes;
 
-  return (
-    <Tab title={name}
-         key={`time-range-type-selector-${type}`}
-         eventKey={type}>
-      {type === activeTab && (
-        <TimeRangeTypeTabs disabled={false}
-                           limitDuration={limitDuration}
-                           setValidatingKeyword={type === 'keyword' ? setValidatingKeyword : undefined} />
-      )}
-    </Tab>
-  );
-});
+type TimeRangeTabsArguments = {
+  activeTab: TimeRangeType,
+  limitDuration: number,
+  setValidatingKeyword: (status: boolean) => void,
+  tabs: Array<TimeRangeType>,
+}
+
+const timeRangeTypeTabs = ({ activeTab, limitDuration, setValidatingKeyword, tabs }: TimeRangeTabsArguments) => availableTimeRangeTypes
+  .filter(({ type }) => tabs.includes(type))
+  .map(({ type, name }) => {
+    const TimeRangeTypeTab = timeRangeTypes[type];
+
+    return (
+      <Tab title={name}
+           key={`time-range-type-selector-${type}`}
+           eventKey={type}>
+        {type === activeTab && (
+        <TimeRangeTypeTab disabled={false}
+                          limitDuration={limitDuration}
+                          setValidatingKeyword={type === 'keyword' ? setValidatingKeyword : undefined} />
+        )}
+      </Tab>
+    );
+  });
 
 const exceedsDuration = (timerange, limitDuration) => {
   if (limitDuration === 0) {
@@ -225,7 +239,7 @@ const onSettingCurrentTimeRange = (nextTimeRange: TimeRangeDropDownFormValues['n
   return (nextTimeRange as SearchBarFormValues['timerange']);
 };
 
-const TimeRangeDropdown = ({ noOverride, toggleDropdownShow, currentTimeRange, setCurrentTimeRange }: Props) => {
+const TimeRangeDropdown = ({ noOverride, toggleDropdownShow, currentTimeRange, setCurrentTimeRange, validTypes = allTimeRangeTypes }: Props) => {
   const { limitDuration } = useContext(DateTimeContext);
   const [validatingKeyword, setValidatingKeyword] = useState(false);
   const [activeTab, setActiveTab] = useState('type' in currentTimeRange ? currentTimeRange.type : undefined);
@@ -294,6 +308,7 @@ const TimeRangeDropdown = ({ noOverride, toggleDropdownShow, currentTimeRange, s
                         activeTab,
                         limitDuration,
                         setValidatingKeyword,
+                        tabs: validTypes,
                       })}
 
                       {!activeTab && (<TabDisabledTimeRange />)}
@@ -327,6 +342,7 @@ const TimeRangeDropdown = ({ noOverride, toggleDropdownShow, currentTimeRange, s
 
 TimeRangeDropdown.defaultProps = {
   noOverride: false,
+  validTypes: allTimeRangeTypes,
 };
 
 export default TimeRangeDropdown;


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This change is introducing an optional `validTypes` prop for the `TimeRangeInput` component, which allows filtering which time range type tabs are shown. If it is not present, all tabs are shown per default.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.