### PR TITLE
Fixing theme usage in style guide.

### DIFF
--- a/graylog2-web-interface/docs/StyleGuideWrapper.tsx
+++ b/graylog2-web-interface/docs/StyleGuideWrapper.tsx
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import React from 'react';
+
+import GraylogThemeProvider from '../src/theme/GraylogThemeProvider';
+
+type Props = {
+  children: React.Component,
+}
+
+const StyleGuideWrapper = ({ children }: Props) => (
+  <GraylogThemeProvider initialThemeModeOverride="teint">
+    {children}
+  </GraylogThemeProvider>
+);
+
+export default StyleGuideWrapper;

--- a/graylog2-web-interface/src/theme/GraylogThemeProvider.tsx
+++ b/graylog2-web-interface/src/theme/GraylogThemeProvider.tsx
@@ -24,9 +24,10 @@ import buttonStyles from 'components/graylog/styles/buttonStyles';
 import aceEditorStyles from 'components/graylog/styles/aceEditorStyles';
 
 import useCurrentThemeMode from './UseCurrentThemeMode';
+import { THEME_MODES } from './constants';
 
-const GraylogThemeProvider = ({ children }) => {
-  const [mode, changeMode] = useCurrentThemeMode();
+const GraylogThemeProvider = ({ children, initialThemeModeOverride }) => {
+  const [mode, changeMode] = useCurrentThemeMode(initialThemeModeOverride);
   const themeColors = colors[mode];
 
   const theme = useCallback((): DefaultTheme => {
@@ -59,6 +60,11 @@ const GraylogThemeProvider = ({ children }) => {
 
 GraylogThemeProvider.propTypes = {
   children: PropTypes.any.isRequired,
+  initialThemeModeOverride: PropTypes.oneOf(THEME_MODES),
+};
+
+GraylogThemeProvider.defaultProps = {
+  initialThemeModeOverride: undefined,
 };
 
 export default GraylogThemeProvider;

--- a/graylog2-web-interface/src/theme/UseCurrentThemeMode.tsx
+++ b/graylog2-web-interface/src/theme/UseCurrentThemeMode.tsx
@@ -20,7 +20,7 @@ import { useStore } from 'stores/connect';
 import CombinedProvider from 'injection/CombinedProvider';
 import Store from 'logic/local-storage/Store';
 
-import { PREFERENCES_THEME_MODE, DEFAULT_THEME_MODE } from './constants';
+import { PREFERENCES_THEME_MODE, DEFAULT_THEME_MODE, ThemeMode } from './constants';
 
 import UserPreferencesContext from '../contexts/UserPreferencesContext';
 import usePrefersColorScheme from '../hooks/usePrefersColorScheme';
@@ -35,7 +35,17 @@ type CurrentUser = {
   };
 };
 
-const useCurrentThemeMode = (): [string, (newThemeMode: string) => void] => {
+const _getInitialThemeMode = (userPreferences, browserThemePreference, initialThemeModeOverride) => {
+  if (initialThemeModeOverride) {
+    return initialThemeModeOverride;
+  }
+
+  const userThemePreference = userPreferences[PREFERENCES_THEME_MODE] ?? Store.get(PREFERENCES_THEME_MODE);
+
+  return userThemePreference ?? browserThemePreference ?? DEFAULT_THEME_MODE;
+};
+
+const useCurrentThemeMode = (initialThemeModeOverride: ThemeMode): [string, (newThemeMode: string) => void] => {
   const browserThemePreference = usePrefersColorScheme();
 
   const { userIsReadOnly, username } = useStore(CurrentUserStore, (userStore) => ({
@@ -44,8 +54,7 @@ const useCurrentThemeMode = (): [string, (newThemeMode: string) => void] => {
   }));
 
   const userPreferences = useContext(UserPreferencesContext);
-  const userThemePreference = userPreferences[PREFERENCES_THEME_MODE] ?? Store.get(PREFERENCES_THEME_MODE);
-  const initialThemeMode = userThemePreference ?? browserThemePreference ?? DEFAULT_THEME_MODE;
+  const initialThemeMode = _getInitialThemeMode(userPreferences, browserThemePreference, initialThemeModeOverride);
   const [currentThemeMode, setCurrentThemeMode] = useState<string>(initialThemeMode);
 
   const changeCurrentThemeMode = useCallback((newThemeMode: string) => {

--- a/graylog2-web-interface/src/theme/constants.ts
+++ b/graylog2-web-interface/src/theme/constants.ts
@@ -23,10 +23,12 @@ const PREFERENCES_THEME_MODE: PreferencesThemeMode = 'themeMode';
 const THEME_MODE_LIGHT = 'teint';
 const THEME_MODE_DARK = 'noir';
 const DEFAULT_THEME_MODE: ThemeMode = prefersDarkMode ? THEME_MODE_DARK : THEME_MODE_LIGHT;
+const THEME_MODES: Array<ThemeMode> = [THEME_MODE_LIGHT, THEME_MODE_DARK];
 
 export {
   DEFAULT_THEME_MODE,
   PREFERENCES_THEME_MODE,
   THEME_MODE_LIGHT,
   THEME_MODE_DARK,
+  THEME_MODES,
 };

--- a/graylog2-web-interface/src/theme/docs/Colors.md
+++ b/graylog2-web-interface/src/theme/docs/Colors.md
@@ -4,17 +4,18 @@ _Click any color block below to copy the color path._
 
 ```jsx noeditor
 import React, { useEffect } from 'react';
-import styled from 'styled-components';
+import styled, { useTheme } from 'styled-components';
 import chroma from 'chroma-js';
 
-import { colors } from 'theme';
 import ColorSwatch, { Swatch } from './Colors';
 
-const ModeTitle = styled.h3`
+const { colors } = useTheme();
+
+const CategoryTitle = styled.h3`
   margin: 0 0 6px;
 `;
 
-const Section = styled.h4`
+const SubcategoryName = styled.h4`
   margin: 0 0 6px;
 `;
 
@@ -25,8 +26,8 @@ const Swatches = styled.div`
 `;
 
 const StyledColorSwatch = styled(ColorSwatch)`
-  flex-basis: ${(props) => props.section === 'global' ? '100px' : '1px'};
-  max-width: ${(props) => props.section === 'global' ? '200px' : 'auto'};
+  flex-basis: ${(props) => props.categoryName === 'global' ? '100px' : '1px'};
+  max-width: ${(props) => props.categoryName === 'global' ? '200px' : 'auto'};
 
   ${Swatch} {
     margin-right: 6px;
@@ -42,63 +43,56 @@ const getValues = (data = {}, callback = () => {}) => {
   return Object.keys(data).map((key) => callback(key));
 }
 
-const SectionWrap = (mode, section) => {
-  return (
-    <>
-      <Swatches>
-        {getValues(mode, (name) => {
-          if (typeof mode[name] === 'string' && chroma.valid(mode[name])) {
-            const copyTextName = section === 'gray' ? `${section}[${name}]` : `${section}.${name}`;
+const CategoryWrap = (categoryName, categoryColors) => (
+  <>
+    <Swatches>
+      {getValues(categoryColors, (name) => {
+        if (typeof categoryColors[name] === 'string' && chroma.valid(categoryColors[name])) {
+          const copyTextName = categoryName === 'gray' ? `${categoryName}[${name}]` : `${categoryName}.${name}`;
 
-            return (
-              <StyledColorSwatch name={name}
-                                 section={section}
-                                 color={mode[name]}
-                                 copyText={`theme.colors.${copyTextName}`} />
-            )
-          }
-        })}
-      </Swatches>
-
-      <div>
-        {getValues(mode, (name) =>
-          typeof mode[name] === 'object' && (
-            <>
-              <Section>{section} &mdash; {name}</Section>
-
-              <Swatches>
-                {getValues(mode[name], (subname) => (
-                  <StyledColorSwatch name={subname}
-                                     section={section}
-                                     color={mode[name][subname]}
-                                     copyText={`theme.colors.${section}.${name}.${subname}`} />
-                ))}
-              </Swatches>
-            </>
+          return (
+            <StyledColorSwatch name={name}
+                               section={categoryName}
+                               color={categoryColors[name]}
+                               copyText={`theme.colors.${copyTextName}`}
+                               key={`${categoryName}-${name}`} />
           )
-        )}
-      </div>
-    </>
-  );
-};
+        }
+      })}
+    </Swatches>
 
-const Colors = () => {
-  return (
-    <>
-      {getValues(colors, (themeMode) => (
-<>
-        <ModeTitle key={`title-${themeMode}`}>{themeMode}</ModeTitle>
-        {getValues(colors[themeMode], (section) => (
-          <>
-            <Section key={`section-${section}`}>{section}</Section>
-            {SectionWrap(colors[themeMode][section], section)}
-          </>
-        ))}
-</>
-      ))}
-    </>
-  );
-};
+    <div>
+      {getValues(categoryColors, (name) =>
+        typeof categoryColors[name] === 'object' && (
+          <div key={`${categoryName}-${name}`}>
+            <SubcategoryName>{categoryName} &mdash; {name}</SubcategoryName>
+
+            <Swatches>
+              {getValues(categoryColors[name], (subname) => (
+                <StyledColorSwatch name={subname}
+                                   categoryName={categoryName}
+                                   color={categoryColors[name][subname]}
+                                   copyText={`theme.colors.${categoryName}.${name}.${subname}`}
+                                   key={`${categoryName}-${name}-${categoryColors[name][subname]}`} />
+              ))}
+            </Swatches>
+          </div>
+        )
+      )}
+    </div>
+  </>
+);
+
+const Colors = () => (
+  <>
+    {getValues(colors, (categoryName) => (
+      <div key={categoryName}>
+          <CategoryTitle key={`title-${categoryName}`}>{categoryName}</CategoryTitle>
+          {CategoryWrap(categoryName, colors[categoryName])}
+      </div>
+    ))}
+  </>
+);
 
 <Colors />
 ```

--- a/graylog2-web-interface/src/theme/docs/Utilities.md
+++ b/graylog2-web-interface/src/theme/docs/Utilities.md
@@ -1,7 +1,8 @@
 Color utilities can be found at
 
 ```js static
-import { util } from 'theme';
+import { useTheme } from 'styled-components';
+const { utils } = useTheme();
 ```
 
 ## colorLevel
@@ -17,8 +18,10 @@ Recreating [`color-level`](https://github.com/twbs/bootstrap/blob/08ba61e276a639
 Negative numbers render a lighter color, positive numbers get darker. Check out the follow example to see some samples of this in action.
 
 ```jsx
-import { colors, utils } from 'theme';
+import { useTheme } from 'styled-components';
 import ColorSwatch from './Colors';
+
+const { colors, utils } = useTheme();
 
 const { info, primary } = colors.variant;
 
@@ -48,8 +51,10 @@ Accepts a color and [WCAG](https://www.w3.org/TR/WCAG21/#distinguishable) level,
   - defaults: "AAA" -Based on the [contrast calculations recommended by W3](https://www.w3.org/WAI/WCAG21/Understanding/contrast-enhanced.html). (available levels: "AA", "AALarge", "AAA", "AAALarge")
 
 ```jsx
-import { colors, utils } from 'theme';
+import { useTheme } from 'styled-components';
 import ColorSwatch from './Colors';
+
+const { colors, utils } = useTheme();
 
 const { info, primary } = colors.variant;
 const { textDefault } = colors.global;
@@ -88,8 +93,10 @@ Generating a readable color following [W3C specs for readability](https://www.w3
   - defaults: Currently `color.global.textAlt`
 
 ```jsx
-import { colors, utils } from 'theme';
+import { useTheme } from 'styled-components';
 import ColorSwatch from './Colors';
+
+const { colors, utils } = useTheme();
 
 const { info, primary } = colors.variant;
 const { textDefault } = colors.global;

--- a/graylog2-web-interface/styleguide.config.js
+++ b/graylog2-web-interface/styleguide.config.js
@@ -80,7 +80,10 @@ module.exports = {
           name: 'Fonts',
           content: 'src/theme/docs/Fonts.md',
         },
-        // TODO: add src/theme/docs/Colors.md color swatches
+        {
+          name: 'Colors',
+          content: 'src/theme/docs/Colors.md',
+        },
         {
           name: 'Color Utilities',
           content: 'src/theme/docs/Utilities.md',

--- a/graylog2-web-interface/styleguide.config.js
+++ b/graylog2-web-interface/styleguide.config.js
@@ -90,7 +90,7 @@ module.exports = {
   ],
   usageMode: 'collapse',
   styleguideComponents: {
-    Wrapper: path.join(__dirname, 'src/theme/GraylogThemeProvider'),
+    Wrapper: path.join(__dirname, 'docs/StyleGuideWrapper'),
   },
   styleguideDir: 'docs/styleguide',
   title: 'Graylog UI documentation',


### PR DESCRIPTION
## Description
Before this change the `GraylogThemeProvider` implementation of the style guide always used the browser setting for the theme mode. Since the style guide components expect / are configured for the `teint` theme mode, we need to override this theme provider setting.

Beside fixing the initial theme setting for the style guide, this PR is also:
- fixing the theme usage in `Utilities.md`
- updating and reimplementing `Colors.md`

![image](https://user-images.githubusercontent.com/46300478/110508457-4d7e3800-8101-11eb-9505-3775fb844999.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
