### PR TITLE
Fix content-pack auto installation

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/periodical/ContentPackLoaderPeriodical.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/ContentPackLoaderPeriodical.java
@@ -19,13 +19,13 @@ package org.graylog2.periodical;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import org.graylog2.Configuration;
 import org.graylog2.contentpacks.ContentPackInstallationPersistenceService;
 import org.graylog2.contentpacks.ContentPackPersistenceService;
 import org.graylog2.contentpacks.ContentPackService;
 import org.graylog2.contentpacks.model.ContentPack;
 import org.graylog2.contentpacks.model.ContentPackV1;
 import org.graylog2.plugin.periodical.Periodical;
-import org.graylog2.shared.users.UserService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -50,6 +50,7 @@ public class ContentPackLoaderPeriodical extends Periodical {
     private final ContentPackService contentPackService;
     private final ContentPackPersistenceService contentPackPersistenceService;
     private final ContentPackInstallationPersistenceService contentPackInstallationPersistenceService;
+    private final Configuration configuration;
     private final boolean contentPacksLoaderEnabled;
     private final Path contentPacksDir;
     private final Set<String> contentPacksAutoInstall;
@@ -59,6 +60,7 @@ public class ContentPackLoaderPeriodical extends Periodical {
                                        ContentPackService contentPackService,
                                        ContentPackPersistenceService contentPackPersistenceService,
                                        ContentPackInstallationPersistenceService contentPackInstallationPersistenceService,
+                                       Configuration configuration,
                                        @Named("content_packs_loader_enabled") boolean contentPacksLoaderEnabled,
                                        @Named("content_packs_dir") Path contentPacksDir,
                                        @Named("content_packs_auto_install") Set<String> contentPacksAutoInstall) {
@@ -66,6 +68,7 @@ public class ContentPackLoaderPeriodical extends Periodical {
         this.contentPackInstallationPersistenceService = contentPackInstallationPersistenceService;
         this.contentPackService = contentPackService;
         this.contentPackPersistenceService = contentPackPersistenceService;
+        this.configuration = configuration;
         this.contentPacksLoaderEnabled = contentPacksLoaderEnabled;
         this.contentPacksDir = contentPacksDir;
         this.contentPacksAutoInstall = ImmutableSet.copyOf(contentPacksAutoInstall);
@@ -180,7 +183,7 @@ public class ContentPackLoaderPeriodical extends Periodical {
                 }
 
                 contentPackService.installContentPack(contentPack, Collections.emptyMap(),
-                        "Installed by auto loader", "local:admin");
+                        "Installed by auto loader", configuration.getRootUsername());
             }
 
         }


### PR DESCRIPTION
This fixes the automatic content pack installation when using the
"content_packs_auto_install" config option.

The ContentPackService#installContentPack expects a username as third
argument, not a user ID. We've been using "local:admin" which is the
local admin's pseudo user ID. UserService#load has a special case for the
local admin user but is expecting Configuration#getRootUsername to be
used and not "local:admin".
So the user service tried to find a user with name "local:admin" in the
database instead of returning the special admin user object.

That fails with:
  `Caused by: java.lang.IllegalStateException: Cannot load user <local:admin> from db`

The ContentPackLoaderPeriodical is now using
Configuration#getRootUsername instead of hard coding "local:admin".

Fixes Graylog2/graylog-docker#153