### PR TITLE
Forbid usage of `jest-each` module.

### DIFF
--- a/graylog2-web-interface/packages/eslint-config-graylog/index.js
+++ b/graylog2-web-interface/packages/eslint-config-graylog/index.js
@@ -94,6 +94,9 @@ module.exports = {
       }, {
         name: 'create-react-class',
         message: 'Please use an ES6 or functional component instead.',
+      }, {
+        name: 'jest-each',
+        message: 'Please use `it.each` instead.',
       }],
     }],
     'no-underscore-dangle': 'off',

--- a/graylog2-web-interface/src/views/components/Value.test.jsx
+++ b/graylog2-web-interface/src/views/components/Value.test.jsx
@@ -16,7 +16,6 @@
  */
 import React from 'react';
 import { mount } from 'wrappedEnzyme';
-import each from 'jest-each';
 import mockComponent from 'helpers/mocking/MockComponent';
 
 import FieldType from 'views/logic/fieldtypes/FieldType';
@@ -107,59 +106,31 @@ describe('Value', () => {
     });
   });
 
-  each([true, false]).describe('setting interactive context to `%p`', (interactive) => {
+  it.each`
+     interactive | value                     | type                                
+     ${true}     | ${42}                     | ${undefined}                        
+     ${true}     | ${'2018-10-02T14:45:40Z'} | ${new FieldType('date', [], [])}    
+     ${true}     | ${false}                  | ${new FieldType('boolean', [], [])} 
+     ${true}     | ${[23, 'foo']}            | ${FieldType.Unknown}                
+     ${true}     | ${{ foo: 23 }}            | ${FieldType.Unknown}                
+     ${false}    | ${42}                     | ${undefined}                        
+     ${false}    | ${'2018-10-02T14:45:40Z'} | ${new FieldType('date', [], [])}    
+     ${false}    | ${false}                  | ${new FieldType('boolean', [], [])} 
+     ${false}    | ${[23, 'foo']}            | ${FieldType.Unknown}                
+     ${false}    | ${{ foo: 23 }}            | ${FieldType.Unknown}                
+  `('verifying that value $value is rendered correctly when interactive=$interactive', ({ interactive, value, type }) => {
     const Component = (props) => (
       <InteractiveContext.Provider value={interactive}>
         <Value {...props} />
       </InteractiveContext.Provider>
     );
+    const wrapper = mount(<Component field="foo"
+                                     queryId="someQueryId"
+                                     value={value}
+                                     type={type} />);
+    const typeSpecificValue = wrapper.find('TypeSpecificValue');
 
-    it('renders without type information but no children', () => {
-      const wrapper = mount(<Component field="foo" queryId="someQueryId" value={42} />);
-      const typeSpecificValue = wrapper.find('TypeSpecificValue');
-
-      expect(typeSpecificValue).toHaveValue(42);
-    });
-
-    it('renders timestamps with a custom component', () => {
-      const wrapper = mount(<Component field="foo"
-                                       queryId="someQueryId"
-                                       value="2018-10-02T14:45:40Z"
-                                       type={new FieldType('date', [], [])} />);
-      const typeSpecificValue = wrapper.find('TypeSpecificValue');
-
-      expect(typeSpecificValue).toHaveValue('2018-10-02T14:45:40Z');
-    });
-
-    it('renders booleans', () => {
-      const wrapper = mount(<Component field="foo"
-                                       queryId="someQueryId"
-                                       value={false}
-                                       type={new FieldType('boolean', [], [])} />);
-      const typeSpecificValue = wrapper.find('TypeSpecificValue');
-
-      expect(typeSpecificValue).toHaveValue(false);
-    });
-
-    it('renders arrays', () => {
-      const wrapper = mount(<Component field="foo"
-                                       queryId="someQueryId"
-                                       value={[23, 'foo']}
-                                       type={FieldType.Unknown} />);
-      const typeSpecificValue = wrapper.find('TypeSpecificValue');
-
-      expect(typeSpecificValue).toHaveProp('value', [23, 'foo']);
-    });
-
-    it('renders objects', () => {
-      const wrapper = mount(<Component field="foo"
-                                       queryId="someQueryId"
-                                       value={{ foo: 23 }}
-                                       type={FieldType.Unknown} />);
-      const typeSpecificValue = wrapper.find('TypeSpecificValue');
-
-      expect(typeSpecificValue).toHaveProp('value', { foo: 23 });
-    });
+    expect(typeSpecificValue).toHaveValue(value);
   });
 
   describe('handles value action menu depending on interactive context', () => {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Previously, `jest-each` was the go to way to create parameterized tests. Starting with Jest 23, it has been integrated into the jest core.  In order to have proper typing, linting and less dependencies, `it.each` should be used instead of `each` from `jest-each`. This PR is removing one last usage of `jest-each` and adds an ESLint rule that forbids importing `jest-each`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.