### PR TITLE
Drain input buffer when shutting down server

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/buffers/Buffers.java
+++ b/graylog2-server/src/main/java/org/graylog2/buffers/Buffers.java
@@ -67,15 +67,18 @@ public class Buffers {
      */
     @Deprecated
     public void waitForEmptyBuffers() {
-        waitForEmptyBuffers(DEFAULT_MAX_WAIT, TimeUnit.SECONDS);
-    }
-
-    public void waitForEmptyBuffers(EnumSet<Type> bufferTypes) {
-        waitForEmptyBuffers(EnumSet.of(PROCESS, OUTPUT), DEFAULT_MAX_WAIT, TimeUnit.SECONDS);
+        waitForEmptyBuffers(EnumSet.of(PROCESS, OUTPUT));
     }
 
     /**
-     * @deprecated Usse {@link #waitForEmptyBuffers(EnumSet, long, TimeUnit)} instead
+     * Wait until the buffers of the given types have been drained or abort after 30 seconds
+     */
+    public void waitForEmptyBuffers(EnumSet<Type> bufferTypes) {
+        waitForEmptyBuffers(bufferTypes, DEFAULT_MAX_WAIT, TimeUnit.SECONDS);
+    }
+
+    /**
+     * @deprecated Use {@link #waitForEmptyBuffers(EnumSet, long, TimeUnit)} instead
      */
     @Deprecated
     public void waitForEmptyBuffers(final long maxWait, final TimeUnit timeUnit) {

--- a/graylog2-server/src/main/java/org/graylog2/buffers/Buffers.java
+++ b/graylog2-server/src/main/java/org/graylog2/buffers/Buffers.java
@@ -22,47 +22,76 @@ import com.github.rholder.retry.RetryerBuilder;
 import com.github.rholder.retry.StopStrategies;
 import com.github.rholder.retry.WaitStrategies;
 import com.google.common.base.Predicates;
+import org.graylog2.plugin.buffers.EventBuffer;
+import org.graylog2.plugin.buffers.InputBuffer;
 import org.graylog2.shared.buffers.ProcessBuffer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
+import java.util.EnumSet;
+import java.util.LinkedHashMap;
 import java.util.Locale;
-import java.util.concurrent.Callable;
+import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static org.graylog2.buffers.Buffers.Type.INPUT;
+import static org.graylog2.buffers.Buffers.Type.OUTPUT;
+import static org.graylog2.buffers.Buffers.Type.PROCESS;
 
 public class Buffers {
+    public enum Type {
+        INPUT,
+        PROCESS,
+        OUTPUT,
+    }
+
     private static final Logger LOG = LoggerFactory.getLogger(Buffers.class);
     private static final long DEFAULT_MAX_WAIT = 30L;
 
+    private final InputBuffer inputBuffer;
     private final ProcessBuffer processBuffer;
     private final OutputBuffer outputBuffer;
 
     @Inject
-    public Buffers(final ProcessBuffer processBuffer, final OutputBuffer outputBuffer) {
+    public Buffers(InputBuffer inputBuffer, final ProcessBuffer processBuffer, final OutputBuffer outputBuffer) {
+        this.inputBuffer = inputBuffer;
         this.processBuffer = processBuffer;
         this.outputBuffer = outputBuffer;
     }
 
+    /**
+     * @deprecated Use {@link #waitForEmptyBuffers(EnumSet)} instead
+     */
+    @Deprecated
     public void waitForEmptyBuffers() {
         waitForEmptyBuffers(DEFAULT_MAX_WAIT, TimeUnit.SECONDS);
     }
 
-    public void waitForEmptyBuffers(final long maxWait, final TimeUnit timeUnit) {
-        LOG.info("Waiting until all buffers are empty.");
-        final Callable<Boolean> checkForEmptyBuffers = new Callable<Boolean>() {
-            @Override
-            public Boolean call() throws Exception {
-                if (processBuffer.isEmpty() && outputBuffer.isEmpty()) {
-                    return true;
-                } else {
-                    LOG.info("Waiting for buffers to drain. ({}p/{}o)", processBuffer.getUsage(), outputBuffer.getUsage());
-                }
+    public void waitForEmptyBuffers(EnumSet<Type> bufferTypes) {
+        waitForEmptyBuffers(EnumSet.of(PROCESS, OUTPUT), DEFAULT_MAX_WAIT, TimeUnit.SECONDS);
+    }
 
-                return false;
-            }
-        };
+    /**
+     * @deprecated Usse {@link #waitForEmptyBuffers(EnumSet, long, TimeUnit)} instead
+     */
+    @Deprecated
+    public void waitForEmptyBuffers(final long maxWait, final TimeUnit timeUnit) {
+        waitForEmptyBuffers(EnumSet.of(PROCESS, OUTPUT), maxWait, timeUnit);
+    }
+
+    /**
+     * Wait until the buffers of the given types have been drained or abort after a given maximum waiting time
+     */
+    public void waitForEmptyBuffers(EnumSet<Type> bufferTypes, final long maxWait, final TimeUnit timeUnit) {
+        if (bufferTypes.isEmpty()) {
+            return;
+        }
+        LOG.info("Waiting until {} buffers are empty.", bufferTypes);
+
+        final Map<Type, EventBuffer> buffersByTypes = buffersByTypes(bufferTypes);
 
         final Retryer<Boolean> retryer = RetryerBuilder.<Boolean>newBuilder()
                 .retryIfResult(Predicates.not(Predicates.equalTo(Boolean.TRUE)))
@@ -71,7 +100,14 @@ public class Buffers {
                 .build();
 
         try {
-            retryer.call(checkForEmptyBuffers);
+            retryer.call(() -> {
+                if (buffersByTypes.values().stream().allMatch(EventBuffer::isEmpty)) {
+                    return true;
+                } else {
+                    LOG.info("Waiting for buffers to drain. ({})", getUsageStats(buffersByTypes));
+                }
+                return false;
+            });
         } catch (RetryException e) {
             LOG.info("Buffers not empty after {} {}. Giving up.", maxWait, timeUnit.name().toLowerCase(Locale.ENGLISH));
             return;
@@ -81,5 +117,26 @@ public class Buffers {
         }
 
         LOG.info("All buffers are empty. Continuing.");
+    }
+
+    // e.g. 123i/432p/545o
+    private String getUsageStats(Map<Type, EventBuffer> buffersByTypes) {
+        return buffersByTypes.entrySet().stream()
+                .map(e -> e.getValue().getUsage() + e.getKey().name().substring(0, 1).toLowerCase())
+                .collect(Collectors.joining("/"));
+    }
+
+    private Map<Type, EventBuffer> buffersByTypes(EnumSet<Type> bufferTypes) {
+        Map<Type, EventBuffer> bufferMap = new LinkedHashMap<>();
+        if (bufferTypes.contains(INPUT)) {
+            bufferMap.put(INPUT, inputBuffer);
+        }
+        if (bufferTypes.contains(PROCESS)) {
+            bufferMap.put(PROCESS, processBuffer);
+        }
+        if (bufferTypes.contains(OUTPUT)) {
+            bufferMap.put(OUTPUT, outputBuffer);
+        }
+        return bufferMap;
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/buffers/Buffers.java
+++ b/graylog2-server/src/main/java/org/graylog2/buffers/Buffers.java
@@ -122,7 +122,7 @@ public class Buffers {
     // e.g. 123i/432p/545o
     private String getUsageStats(Map<Type, EventBuffer> buffersByTypes) {
         return buffersByTypes.entrySet().stream()
-                .map(e -> e.getValue().getUsage() + e.getKey().name().substring(0, 1).toLowerCase())
+                .map(e -> e.getValue().getUsage() + e.getKey().name().substring(0, 1).toLowerCase(Locale.ENGLISH))
                 .collect(Collectors.joining("/"));
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/indexer/healing/FixDeflectorByDeleteJob.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/healing/FixDeflectorByDeleteJob.java
@@ -30,6 +30,11 @@ import org.graylog2.system.jobs.SystemJob;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.EnumSet;
+
+import static org.graylog2.buffers.Buffers.Type.OUTPUT;
+import static org.graylog2.buffers.Buffers.Type.PROCESS;
+
 /**
  * @author Lennart Koopmann <lennart@torch.sh>
  */
@@ -92,7 +97,7 @@ public class FixDeflectorByDeleteJob extends SystemJob {
         serverStatus.pauseMessageProcessing();
         progress = 10;
 
-        bufferSynchronizer.waitForEmptyBuffers();
+        bufferSynchronizer.waitForEmptyBuffers(EnumSet.of(PROCESS, OUTPUT));
         progress = 25;
 
         // Delete deflector index.

--- a/graylog2-server/src/main/java/org/graylog2/indexer/healing/FixDeflectorByMoveJob.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/healing/FixDeflectorByMoveJob.java
@@ -30,6 +30,11 @@ import org.graylog2.system.jobs.SystemJob;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.EnumSet;
+
+import static org.graylog2.buffers.Buffers.Type.OUTPUT;
+import static org.graylog2.buffers.Buffers.Type.PROCESS;
+
 public class FixDeflectorByMoveJob extends SystemJob {
     public interface Factory {
         FixDeflectorByMoveJob create();
@@ -88,7 +93,7 @@ public class FixDeflectorByMoveJob extends SystemJob {
             serverStatus.pauseMessageProcessing();
             progress = 5;
 
-            bufferSynchronizer.waitForEmptyBuffers();
+            bufferSynchronizer.waitForEmptyBuffers(EnumSet.of(PROCESS, OUTPUT));
             progress = 10;
 
             // Copy messages to new index.

--- a/graylog2-server/src/main/java/org/graylog2/plugin/buffers/Buffer.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/buffers/Buffer.java
@@ -27,15 +27,15 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- *
  * @author Lennart Koopmann <lennart@socketfeed.com>
  */
-public abstract class Buffer {
+public abstract class Buffer implements EventBuffer {
     private static final Logger log = LoggerFactory.getLogger(Buffer.class);
 
     protected RingBuffer<MessageEvent> ringBuffer;
     protected int ringBufferSize;
 
+    @Override
     public boolean isEmpty() {
         return getUsage() == 0;
     }
@@ -48,6 +48,7 @@ public abstract class Buffer {
         return ringBufferSize;
     }
 
+    @Override
     public long getUsage() {
         if (ringBuffer == null) {
             return 0;

--- a/graylog2-server/src/main/java/org/graylog2/plugin/buffers/EventBuffer.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/buffers/EventBuffer.java
@@ -16,8 +16,10 @@
  */
 package org.graylog2.plugin.buffers;
 
-import org.graylog2.plugin.journal.RawMessage;
+public interface EventBuffer {
+    long getUsage();
 
-public interface InputBuffer extends EventBuffer {
-    void insert(RawMessage message);
+    default boolean isEmpty() {
+        return getUsage() == 0;
+    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When the server shuts down, it drains the process buffer and the output buffer and only then continues with the shutdown sequence.

This change adds the input buffer to the list of buffers to be drained and waited upon during server shutdown.

When elasticsearch is down, we skip buffer draining, because we don't want to wait for the process and output buffers to be empty (which wouldn't happen). This made a small refactoring of the buffer synchronizer necessary so that we can still wait for the input buffer to be drained in that case.

Must only be merged after Graylog2/graylog-plugin-cloud#793 is merged.

Should be forward-ported to `master`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Draining the input buffer is usually a really fast operation. Once no more events are added to the buffer, it will be empty pretty much instantly because flushing out the remaining events to the on-disk journal doesn't take much time.

By moving towards enabling alternative journal implementations, the situation might be a bit different though.

If a journal implementation experiences slowness, e.g. due to network issues, draining the input buffer might take longer than usual. If the server shutdown sequence completes faster than it takes the input buffer to be drained, the messages in the input buffer will be lost. Waiting for the buffer to be drained should reduce the chance of losing messages significantly.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually tested by shutting down after artificially slowing down journal write operations and/or stopping elasticsearch.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

