### PR TITLE
Remove the Collector and AWS plugins from the list of expected Cloud plugins

### DIFF
--- a/full-backend-tests/src/test/java/org/graylog/testing/fullbackend/BackendStartupIT.java
+++ b/full-backend-tests/src/test/java/org/graylog/testing/fullbackend/BackendStartupIT.java
@@ -65,8 +65,6 @@ class BackendStartupIT {
 
         assertThat(pluginNames).containsExactlyInAnyOrder(
                 "Threat Intelligence Plugin",
-                "Collector",
-                "AWS plugins",
                 "Elasticsearch 6 Support",
                 "Elasticsearch 7 Support");
     }


### PR DESCRIPTION
Remove the Collector and AWS plugins from the list of expected Cloud plugins. They were removed from the manifests in https://github.com/Graylog2/graylog-project-internal/pull/58

Fixes this failing integration test:
```
[2021-03-16T10:58:59.494Z] [ERROR]   BackendStartupIT.loadsDefaultPlugins:66 
[2021-03-16T10:58:59.494Z] Expecting:
[2021-03-16T10:58:59.494Z]   <["Elasticsearch 7 Support",
[2021-03-16T10:58:59.494Z]     "Threat Intelligence Plugin",
[2021-03-16T10:58:59.494Z]     "Elasticsearch 6 Support"]>
[2021-03-16T10:58:59.494Z] to contain exactly in any order:
[2021-03-16T10:58:59.494Z]   <["Threat Intelligence Plugin",
[2021-03-16T10:58:59.494Z]     "Collector",
[2021-03-16T10:58:59.494Z]     "AWS plugins",
[2021-03-16T10:58:59.494Z]     "Elasticsearch 6 Support",
[2021-03-16T10:58:59.494Z]     "Elasticsearch 7 Support"]>
[2021-03-16T10:58:59.494Z] but could not find the following elements:
[2021-03-16T10:58:59.494Z]   <["Collector", "AWS plugins"]>
```