### PR TITLE
Fix test after removing plugins in cloud manifest

### DIFF
--- a/full-backend-tests/src/test/java/org/graylog/testing/fullbackend/BackendStartupIT.java
+++ b/full-backend-tests/src/test/java/org/graylog/testing/fullbackend/BackendStartupIT.java
@@ -65,8 +65,6 @@ class BackendStartupIT {
 
         assertThat(pluginNames).containsExactlyInAnyOrder(
                 "Threat Intelligence Plugin",
-                "Collector",
-                "AWS plugins",
                 "Elasticsearch 6 Support",
                 "Elasticsearch 7 Support");
     }


### PR DESCRIPTION
After https://github.com/Graylog2/graylog-project-internal/pull/58, cloud tests are failing, since some plugins are no longer available. This PR removes them from the test, so builds are green again.
