### PR TITLE
Remove workaround for apache commons vulnerability

### DIFF
--- a/graylog2-server/pom.xml
+++ b/graylog2-server/pom.xml
@@ -736,13 +736,6 @@
                     <shadedArtifactAttached>true</shadedArtifactAttached>
                     <minimizeJar>false</minimizeJar>
                     <filters>
-                        <!-- http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/ -->
-                        <filter>
-                            <artifact>commons-collections:commons-collections</artifact>
-                            <excludes>
-                                <exclude>org/apache/commons/collections/functors/InvokerTransformer.class</exclude>
-                            </excludes>
-                        </filter>
                         <!-- Bouncycastle's JARs are signed. When building a shaded JAR, either remove the signatures, or
                              add dependency to the main JAR's manifest. Otherwise running the application will fail. -->
                         <filter>


### PR DESCRIPTION
This has been resolved with version 3.2.2

https://commons.apache.org/proper/commons-collections/javadocs/api-3.2.2/org/apache/commons/collections/functors/InvokerTransformer.html

WARNING: from v3.2.2 onwards this class will throw an
UnsupportedOperationException when trying to serialize or de-serialize
an instance to prevent potential remote code execution exploits.

