### PR TITLE
Fixes small resolution MessageTable scroll

### DIFF
--- a/graylog2-web-interface/src/views/components/widgets/MessageTable.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageTable.tsx
@@ -36,13 +36,6 @@ import { SOURCE_FIELD } from 'views/Constants';
 import HighlightMessageContext from '../contexts/HighlightMessageContext';
 import InteractiveContext from '../contexts/InteractiveContext';
 
-const TableWrapper = styled.div`
-  grid-row: 1;
-  -ms-grid-row: 1;
-  grid-column: 1;
-  -ms-grid-column: 1;
-`;
-
 const Table = styled.table(({ theme }) => css`
   position: relative;
   font-size: ${theme.fonts.size.small};
@@ -140,6 +133,19 @@ const Table = styled.table(({ theme }) => css`
       left: 0;
       padding: 5px;
       position: static;
+    }
+  }
+`);
+
+const TableWrapper = styled.div(({ theme }) => css`
+  grid-row: 1;
+  -ms-grid-row: 1;
+  grid-column: 1;
+  -ms-grid-column: 1;
+
+  @media screen and (max-width: ${theme.breakpoints.max.md}) {
+    &.table-responsive {
+      overflow-y: auto;
     }
   }
 `);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Reverted `overflow-y: hidden` that was defaulted in Bootstrap styles

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
While we don't fully support mobile views, we should not intentionally break them either.
Resolves #8920

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

