### PR TITLE
Move dependabot schedule to less active time.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,15 +4,16 @@ updates:
   directory: "/"
   schedule:
     interval: daily
-    time: "11:00"
+    time: "01:00"
+    timezone: "Europe/Berlin"
   open-pull-requests-limit: 10
   labels:
   - dependencies
 - package-ecosystem: npm
   directory: "/graylog2-web-interface/packages/graylog-web-plugin"
   schedule:
-    interval: daily
-    time: "11:00"
+    time: "01:00"
+    timezone: "Europe/Berlin"
   open-pull-requests-limit: 10
   labels:
   - dependencies
@@ -24,8 +25,8 @@ updates:
 - package-ecosystem: npm
   directory: "/graylog2-web-interface"
   schedule:
-    interval: daily
-    time: "11:00"
+    time: "01:00"
+    timezone: "Europe/Berlin"
   open-pull-requests-limit: 10
   labels:
   - dependencies
@@ -37,16 +38,16 @@ updates:
 - package-ecosystem: npm
   directory: "/graylog2-web-interface/packages/eslint-config-graylog"
   schedule:
-    interval: daily
-    time: "11:00"
+    time: "01:00"
+    timezone: "Europe/Berlin"
   open-pull-requests-limit: 10
   labels:
   - dependencies
 - package-ecosystem: npm
   directory: "/graylog2-web-interface/packages/jest-preset-graylog"
   schedule:
-    interval: daily
-    time: "11:00"
+    time: "01:00"
+    timezone: "Europe/Berlin"
   open-pull-requests-limit: 10
   labels:
   - dependencies

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,7 @@ updates:
 - package-ecosystem: npm
   directory: "/graylog2-web-interface/packages/graylog-web-plugin"
   schedule:
+    interval: daily
     time: "02:00"
     timezone: "Europe/Berlin"
   open-pull-requests-limit: 10
@@ -25,6 +26,7 @@ updates:
 - package-ecosystem: npm
   directory: "/graylog2-web-interface"
   schedule:
+    interval: daily
     time: "02:00"
     timezone: "Europe/Berlin"
   open-pull-requests-limit: 10
@@ -38,6 +40,7 @@ updates:
 - package-ecosystem: npm
   directory: "/graylog2-web-interface/packages/eslint-config-graylog"
   schedule:
+    interval: daily
     time: "02:00"
     timezone: "Europe/Berlin"
   open-pull-requests-limit: 10
@@ -46,6 +49,7 @@ updates:
 - package-ecosystem: npm
   directory: "/graylog2-web-interface/packages/jest-preset-graylog"
   schedule:
+    interval: daily
     time: "02:00"
     timezone: "Europe/Berlin"
   open-pull-requests-limit: 10

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
   directory: "/"
   schedule:
     interval: daily
-    time: "01:00"
+    time: "02:00"
     timezone: "Europe/Berlin"
   open-pull-requests-limit: 10
   labels:
@@ -12,7 +12,7 @@ updates:
 - package-ecosystem: npm
   directory: "/graylog2-web-interface/packages/graylog-web-plugin"
   schedule:
-    time: "01:00"
+    time: "02:00"
     timezone: "Europe/Berlin"
   open-pull-requests-limit: 10
   labels:
@@ -25,7 +25,7 @@ updates:
 - package-ecosystem: npm
   directory: "/graylog2-web-interface"
   schedule:
-    time: "01:00"
+    time: "02:00"
     timezone: "Europe/Berlin"
   open-pull-requests-limit: 10
   labels:
@@ -38,7 +38,7 @@ updates:
 - package-ecosystem: npm
   directory: "/graylog2-web-interface/packages/eslint-config-graylog"
   schedule:
-    time: "01:00"
+    time: "02:00"
     timezone: "Europe/Berlin"
   open-pull-requests-limit: 10
   labels:
@@ -46,7 +46,7 @@ updates:
 - package-ecosystem: npm
   directory: "/graylog2-web-interface/packages/jest-preset-graylog"
   schedule:
-    time: "01:00"
+    time: "02:00"
     timezone: "Europe/Berlin"
   open-pull-requests-limit: 10
   labels:


### PR DESCRIPTION
I propose that we change Dependabot to run at a less active time. 

## Description
This makes Dependabot check for updates at 2am CET (8pm CST/6pm PST).

Reference:
https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates#scheduletime

## Motivation and Context
The Dependabot PRs are starting to back up the CI system a bit. Rescheduling it to 2am CET would let the jobs run without impacting developers. 


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

