### PR TITLE
Reduce label size in MessageDetailsTitle

### DIFF
--- a/graylog2-web-interface/src/components/search/MessageDetailsTitle.jsx
+++ b/graylog2-web-interface/src/components/search/MessageDetailsTitle.jsx
@@ -25,7 +25,7 @@ const Title = styled.h3(({ theme }) => css`
   }
 
   .label {
-    font-size: calc(${theme.fonts.size.h3} - 40%);
+    font-size: ${theme.fonts.size.tiny};
     line-height: 200%;
     margin-left: 5px;
     vertical-align: bottom;

--- a/graylog2-web-interface/src/components/search/MessageDetailsTitle.jsx
+++ b/graylog2-web-interface/src/components/search/MessageDetailsTitle.jsx
@@ -25,7 +25,7 @@ const Title = styled.h3(({ theme }) => css`
   }
 
   .label {
-    font-size: calc(${theme.fonts.size.small} + 50%);
+    font-size: calc(${theme.fonts.size.h3} - 40%);
     line-height: 200%;
     margin-left: 5px;
     vertical-align: bottom;


### PR DESCRIPTION
This change needs to be backported to 4.0/cloud-4.0.

Fixes #10200 

## Screenshots:

<img width="825" alt="Screenshot 2021-03-18 at 15 25 30" src="https://user-images.githubusercontent.com/716185/111657620-e7359b80-880b-11eb-90a2-24d8d3da93db.png">
