### PR TITLE
Support for displaying cloud version number

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/plugin/Version.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/Version.java
@@ -164,6 +164,21 @@ public class Version implements Comparable<Version> {
     }
 
     /**
+     * Try to read the version from the {@literal graylog-plugin.properties} file included in a plugin
+     * and {@literal git.properties} ({@code git.commit.id} property) from the classpath..
+     *
+     * @param pluginClass     Class where the class loader should be obtained from.
+     * @param path            Path of the properties file on the classpath which contains the version information.
+     * @param propertyName    The name of the property to read as project version ("major.minor.patch-preReleaseVersion").
+     * @param gitPath         Path of the properties file on the classpath which contains the SCM information.
+     * @param gitPropertyName The name of the property to read as git commit SHA.
+     * @param defaultVersion  The {@link Version} to return if reading the information from the properties files failed.
+     */
+    public static Version fromPluginProperties(Class<?> pluginClass, String path, String propertyName, String gitPath, String gitPropertyName, Version defaultVersion) {
+        return fromClasspathProperties(pluginClass, path, propertyName, gitPath, gitPropertyName, defaultVersion);
+    }
+
+    /**
      * Try to read the version from {@literal version.properties} ({@code project.version} property)
      * and {@literal git.properties} ({@code git.commit.id} property) from the classpath.
      *

--- a/graylog2-web-interface/src/components/layout/Footer.jsx
+++ b/graylog2-web-interface/src/components/layout/Footer.jsx
@@ -15,23 +15,13 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 // @flow strict
-import React, { useEffect, useState } from 'react';
-import PropTypes from 'prop-types';
+import React from 'react';
 import styled, { type StyledComponent, css } from 'styled-components';
+import { PluginStore } from 'graylog-web-plugin/plugin';
 
 import type { ThemeInterface } from 'theme';
-import Version from 'util/Version';
-import connect from 'stores/connect';
-import StoreProvider from 'injection/StoreProvider';
 
-const SystemStore = StoreProvider.getStore('System');
-
-type Props = {
-  system?: {
-    version: string,
-    hostname: string,
-  },
-};
+import StandardFooter from './StandardFooter';
 
 const StyledFooter: StyledComponent<{}, ThemeInterface, HTMLElement> = styled.footer(({ theme }) => css`
   text-align: center;
@@ -45,47 +35,26 @@ const StyledFooter: StyledComponent<{}, ThemeInterface, HTMLElement> = styled.fo
   }
 `);
 
-const Footer = ({ system }: Props) => {
-  const [jvm, setJvm] = useState();
+const Footer = () => {
+  const customFooter = PluginStore.exports('pageFooter');
 
-  useEffect(() => {
-    let mounted = true;
+  if (customFooter.length === 1) {
+    const CustomFooter = customFooter[0].component;
 
-    SystemStore.jvm().then((jvmInfo) => {
-      if (mounted) {
-        setJvm(jvmInfo);
-      }
-    });
-
-    return () => {
-      mounted = false;
-    };
-  }, []);
-
-  if (!(system && jvm)) {
     return (
       <StyledFooter>
-        Graylog {Version.getFullVersion()}
+        <CustomFooter />
       </StyledFooter>
     );
   }
 
   return (
     <StyledFooter>
-      Graylog {system.version} on {system.hostname} ({jvm.info})
+      <StandardFooter />
     </StyledFooter>
   );
 };
 
-Footer.propTypes = {
-  system: PropTypes.shape({
-    version: PropTypes.string,
-    hostname: PropTypes.string,
-  }),
-};
+Footer.propTypes = {};
 
-Footer.defaultProps = {
-  system: undefined,
-};
-
-export default connect(Footer, { system: SystemStore }, ({ system: { system } = {} }) => ({ system }));
+export default Footer;

--- a/graylog2-web-interface/src/components/layout/Footer.test.jsx
+++ b/graylog2-web-interface/src/components/layout/Footer.test.jsx
@@ -17,6 +17,8 @@
 // @flow strict
 import * as React from 'react';
 import { render } from 'wrappedTestingLibrary';
+import { asMock } from 'helpers/mocking';
+import { PluginStore } from 'graylog-web-plugin/plugin';
 
 import Footer from './Footer';
 
@@ -28,6 +30,10 @@ jest.mock('injection/StoreProvider', () => ({
     jvm: jest.fn(() => Promise.resolve({ info: 'SomeJDK v12.0.0' })),
     listen: jest.fn(() => () => {}),
   }),
+}));
+
+jest.mock('graylog-web-plugin/plugin', () => ({
+  PluginStore: { exports: jest.fn(() => []) },
 }));
 
 describe('Footer', () => {
@@ -47,5 +53,17 @@ describe('Footer', () => {
     const { findByText } = render(<Footer />);
 
     await findByText('SomeJDK v12.0.0', { exact: false });
+  });
+
+  it('can be customized with a plugin', async () => {
+    asMock(PluginStore.exports).mockImplementation((type) => ({
+      pageFooter: [{
+        component: () => <>&copy;My custom Footer</>,
+      }],
+    }[type]));
+
+    const { findByText } = render(<Footer />);
+
+    await findByText(/my custom footer/i);
   });
 });

--- a/graylog2-web-interface/src/components/layout/StandardFooter.jsx
+++ b/graylog2-web-interface/src/components/layout/StandardFooter.jsx
@@ -18,7 +18,7 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 
-import Version from 'util/Version';
+import { getFullVersion } from 'util/Version';
 import connect from 'stores/connect';
 import StoreProvider from 'injection/StoreProvider';
 
@@ -50,7 +50,7 @@ const StandardFooter = ({ system }: Props) => {
 
   if (!(system && jvm)) {
     return (
-      <>Graylog {Version.getFullVersion()}</>
+      <>Graylog {getFullVersion()}</>
     );
   }
 

--- a/graylog2-web-interface/src/components/layout/StandardFooter.jsx
+++ b/graylog2-web-interface/src/components/layout/StandardFooter.jsx
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+// @flow strict
+import React, { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+
+import Version from 'util/Version';
+import connect from 'stores/connect';
+import StoreProvider from 'injection/StoreProvider';
+
+const SystemStore = StoreProvider.getStore('System');
+
+type Props = {
+  system?: {
+    version: string,
+    hostname: string,
+  },
+};
+
+const StandardFooter = ({ system }: Props) => {
+  const [jvm, setJvm] = useState();
+
+  useEffect(() => {
+    let mounted = true;
+
+    SystemStore.jvm().then((jvmInfo) => {
+      if (mounted) {
+        setJvm(jvmInfo);
+      }
+    });
+
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  if (!(system && jvm)) {
+    return (
+      <>Graylog {Version.getFullVersion()}</>
+    );
+  }
+
+  return (
+    <>
+      Graylog {system.version} on {system.hostname} ({jvm.info})
+    </>
+  );
+};
+
+StandardFooter.propTypes = {
+  system: PropTypes.shape({
+    version: PropTypes.string,
+    hostname: PropTypes.string,
+  }),
+};
+
+StandardFooter.defaultProps = {
+  system: undefined,
+};
+
+export default connect(StandardFooter, { system: SystemStore }, ({ system: { system } = {} }) => ({ system }));

--- a/graylog2-web-interface/src/util/Version.js
+++ b/graylog2-web-interface/src/util/Version.js
@@ -33,6 +33,7 @@ export const parseVersion = (version?: string = defaultVersion): Version | void 
   const result = versionRegex.exec(version);
 
   if (!result || !result.groups) {
+    // eslint-disable-next-line no-console
     console.error('Failed to parse version', version);
 
     return undefined;

--- a/graylog2-web-interface/src/util/Version.js
+++ b/graylog2-web-interface/src/util/Version.js
@@ -15,6 +15,7 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
+// $FlowFixMe: Import fail in enterprise plugin
 import pjson from '../../package.json';
 
 const versionRegex = /(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)(-(?<preRelease>[\w.\d]+))?(\+(?<buildMetadata>\w+))?/;

--- a/graylog2-web-interface/src/util/Version.js
+++ b/graylog2-web-interface/src/util/Version.js
@@ -1,3 +1,4 @@
+// @flow strict
 /*
  * Copyright (C) 2020 Graylog, Inc.
  *
@@ -16,23 +17,55 @@
  */
 import pjson from '../../package.json';
 
-class Version {
-  constructor() {
-    this.full = pjson.version;
-    const splitVersion = this.full.split('.');
+const versionRegex = /(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)(-(?<preRelease>[\w.\d]+))?(\+(?<buildMetadata>\w+))?/;
+const defaultVersion = pjson.version;
 
-    this.major = splitVersion[0];
-    this.minor = splitVersion[1];
+export type Version = {
+  major: string,
+  minor: string,
+  patch: string,
+  preRelease?: string,
+  buildMetadata?: string,
+};
+
+export const parseVersion = (version?: string = defaultVersion): Version | void => {
+  const result = versionRegex.exec(version);
+
+  if (!result || !result.groups) {
+    console.error('Failed to parse version', version);
+
+    return undefined;
   }
 
-  getMajorAndMinorVersion() {
-    return `${this.major}.${this.minor}`;
+  const versionGroups = (result.groups: Version);
+
+  return {
+    major: versionGroups.major,
+    minor: versionGroups.minor,
+    patch: versionGroups.patch,
+    preRelease: versionGroups.preRelease,
+    buildMetadata: versionGroups.buildMetadata,
+  };
+};
+
+export const getFullVersion = (): string => {
+  return defaultVersion;
+};
+
+export const getMajorAndMinorVersion = (): string => {
+  const result = parseVersion();
+
+  if (!result) {
+    return getFullVersion();
   }
 
-  getFullVersion() {
-    return this.full;
-  }
-}
+  const { major, minor } = result;
 
-const version = new Version();
-export default version;
+  return `${major}.${minor}`;
+};
+
+export default {
+  parseVersion,
+  getMajorAndMinorVersion,
+  getFullVersion,
+};

--- a/graylog2-web-interface/src/util/Version.test.jsx
+++ b/graylog2-web-interface/src/util/Version.test.jsx
@@ -15,6 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 
+// eslint-disable-next-line import/no-named-as-default
 import Version, { getFullVersion, getMajorAndMinorVersion, parseVersion } from './Version';
 
 jest.unmock('util/Version');
@@ -24,11 +25,13 @@ describe('<Version>', () => {
   it('returns the full version from package information', () => {
     const version = '4.0.6-SNAPSHOT';
 
+    // eslint-disable-next-line import/no-named-as-default-member
     expect(Version.getFullVersion()).toBe(version);
     expect(getFullVersion()).toBe(version);
   });
 
   it('returns the major and minor version from package information', () => {
+    // eslint-disable-next-line import/no-named-as-default-member
     expect(Version.getMajorAndMinorVersion()).toBe('4.0');
     expect(getMajorAndMinorVersion()).toBe('4.0');
   });

--- a/graylog2-web-interface/src/util/Version.test.jsx
+++ b/graylog2-web-interface/src/util/Version.test.jsx
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+
+import Version, { getFullVersion, getMajorAndMinorVersion, parseVersion } from './Version';
+
+jest.unmock('util/Version');
+jest.mock('../../package.json', () => ({ version: '4.0.6-SNAPSHOT' }));
+
+describe('<Version>', () => {
+  it('returns the full version from package information', () => {
+    const version = '4.0.6-SNAPSHOT';
+
+    expect(Version.getFullVersion()).toBe(version);
+    expect(getFullVersion()).toBe(version);
+  });
+
+  it('returns the major and minor version from package information', () => {
+    expect(Version.getMajorAndMinorVersion()).toBe('4.0');
+    expect(getMajorAndMinorVersion()).toBe('4.0');
+  });
+
+  it('parses version and returns an object with its components', () => {
+    const versions = {
+      final: {
+        version: '4.0.6',
+        expected: {
+          major: '4',
+          minor: '0',
+          patch: '6',
+        },
+      },
+      finalWithBuild: {
+        version: '4.0.6+35bdc1',
+        expected: {
+          major: '4',
+          minor: '0',
+          patch: '6',
+          buildMetadata: '35bdc1',
+        },
+      },
+      snapshotVersion: {
+        version: '4.0.6-SNAPSHOT',
+        expected: {
+          major: '4',
+          minor: '0',
+          patch: '6',
+          preRelease: 'SNAPSHOT',
+        },
+      },
+      snapshotWithBuildVersion: {
+        version: '4.0.6-SNAPSHOT+35bdc1',
+        expected: {
+          major: '4',
+          minor: '0',
+          patch: '6',
+          preRelease: 'SNAPSHOT',
+          buildMetadata: '35bdc1',
+        },
+      },
+      betaVersion: {
+        version: '4.0.6-beta.1',
+        expected: {
+          major: '4',
+          minor: '0',
+          patch: '6',
+          preRelease: 'beta.1',
+        },
+      },
+      betaWithBuildVersion: {
+        version: '4.0.6-beta.1+35bdc1',
+        expected: {
+          major: '4',
+          minor: '0',
+          patch: '6',
+          preRelease: 'beta.1',
+          buildMetadata: '35bdc1',
+        },
+      },
+    };
+
+    Object.keys(versions).forEach((versionType) => {
+      const { version, expected } = versions[versionType];
+
+      expect(parseVersion(version)).toEqual(expected);
+    });
+  });
+});


### PR DESCRIPTION
This PR adds some features to support https://github.com/Graylog2/graylog-plugin-cloud/issues/295:

- Plugins can now set a git commit ID in their versions by providing a `properties` file
- Allow plugins to customize the page footer
- Add more flexibility to `Version.js`, so consumers can decide which parts of the version use