### PR TITLE
NaturalDateParser, add alignment to start/end of day

### DIFF
--- a/UPGRADING.rst
+++ b/UPGRADING.rst
@@ -1,41 +1,33 @@
 **************************
-Upgrading to Graylog 4.1.x
+Upgrading to Graylog 4.2.x
 **************************
 
-.. _upgrade-from-40-to-41:
+.. _upgrade-from-41-to-42:
 
 .. contents:: Overview
    :depth: 3
    :backlinks: top
 
-.. warning:: Please make sure to create a MongoDB database backup before starting the upgrade to Graylog 4.1!
+.. warning:: Please make sure to create a MongoDB database backup before starting the upgrade to Graylog 4.2!
 
 Breaking Changes
 ================
 
-The limit parameter in the legacy search api (``/search/universal/(absolute|keyword|relative)``) semantics has changed
-to fix an inconsistency introduced in ``4.0``: prior to ``4.0``, ``0`` meant "no limit", with ``4.0`` this changed to ``-1``
-and ``0`` for "empty result". With 4.1 this has been fixed to work again like in the past but the underlying
-``Searches#scroll`` method has been tagged as ``@deprecated`` now, too.
+Search From/To by Keyword
+-------------------------
+Prior to this version, if the time was inferred from the keyword string (e.g. "last week" or "last monday"),
+the interval did not make much sense, because the hour/minute/sec part of the interval was taken from the moment
+in time, the query was submitted. So, the intervals were not aligned to something that made sense.
+This has been changed so that. e.g. "last monday" is indeed aligned to start at 00:00:00 and ends on the next day at 00:00:00.
+Also, ending on the next day at 00:00:00 is a breaking change. This was chosen so that millis/nanos etc. until the very end
+of the interval are included in the search (and not because of different messages with handling of millis, nanos etc. some messages
+get omitted).
 
 Changes to the Elasticsearch Support
 ------------------------------------
 
-When you have version-probing for the used Elasticsearch version enabled, and Graylog starts up but can not
-connect to ES, the startup stopped immediately with v4.0 and prior. Starting from 4.1 the default behaviour is,
-that Graylog retries connecting with a delay until it can connect to Elasticsearch. See the Elasticsearch
-configuration_ for details.
-
-.. _configuration: https://docs.graylog.org/en/4.1/pages/configuration/elasticsearch.html
-
-Configuration options: ``elasticsearch_version_probe_attempts`` and ``elasticsearch_version_probe_delay``.
-
 Configuration file changes
 --------------------------
-
-The system stats collector has been reimplemented using OSHI instead of SIGAR.
-The configuration option `disable_sigar` has been renamed to `disable_native_system_stats_collector`.
-
 
 Change of API endpoint for user retrieval and modification
 ----------------------------------------------------------
@@ -50,10 +42,10 @@ Change of API endpoint for user retrieval and modification
 API Endpoint Deprecations
 =========================
 
-The following API endpoints are deprecated beginning with 4.1.
+The following API endpoints are deprecated beginning with 4.2.
 
 API Endpoint Removals
 =====================
 
-The following API endpoints have been removed in 4.1.
+The following API endpoints have been removed in 4.2.
 

--- a/graylog2-server/src/main/java/org/graylog2/plugin/utilities/date/NaturalDateParser.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/utilities/date/NaturalDateParser.java
@@ -23,6 +23,7 @@ import org.graylog2.plugin.Tools;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 
+import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
@@ -32,6 +33,7 @@ import java.util.TimeZone;
 
 public class NaturalDateParser {
     private final TimeZone timeZone;
+    private final ZoneId zoneId;
     private final DateTimeZone dateTimeZone;
 
     public NaturalDateParser() {
@@ -43,11 +45,20 @@ public class NaturalDateParser {
             throw new IllegalArgumentException("Invalid timeZone: " + timeZone);
 
         this.timeZone = TimeZone.getTimeZone(timeZone);
+        this.zoneId = ZoneId.of(timeZone);
         this.dateTimeZone = DateTimeZone.forTimeZone(this.timeZone);
     }
 
     boolean isValidTimeZone(final String timeZone) {
         return Arrays.stream(TimeZone.getAvailableIDs()).anyMatch(id -> id.equals(timeZone));
+    }
+
+    Date alignToStartOfDay(Date dateToConvert) {
+        return java.util.Date.from(dateToConvert.toInstant().atZone(zoneId).toLocalDate().atStartOfDay().atZone(zoneId).toInstant());
+    }
+
+    Date alignToEndOfDay(Date dateToConvert) {
+        return java.util.Date.from(dateToConvert.toInstant().atZone(zoneId).plusDays(1).toLocalDate().atStartOfDay().atZone(zoneId).toInstant());
     }
 
     public Result parse(final String string) throws DateNotParsableException {
@@ -61,15 +72,21 @@ public class NaturalDateParser {
         final Parser parser = new Parser(this.timeZone);
         final List<DateGroup> groups = parser.parse(string, referenceDate);
         if (!groups.isEmpty()) {
-            final List<Date> dates = groups.get(0).getDates();
+            // only working on with the first DateGroup
+            final DateGroup group = groups.get(0);
+            final boolean timeIsInferred = group.isTimeInferred();
+
+            final List<Date> dates = group.getDates();
             Collections.sort(dates);
 
             if (dates.size() >= 1) {
-                from = dates.get(0);
+                from = timeIsInferred ? alignToStartOfDay(dates.get(0)) : dates.get(0);
             }
 
             if (dates.size() >= 2) {
-                to = dates.get(1);
+                to = timeIsInferred ? alignToEndOfDay(dates.get(1)) : dates.get(1);
+            } else {
+                to = timeIsInferred ? alignToEndOfDay(dates.get(0)) : null;
             }
         } else {
             throw new DateNotParsableException("Unparsable date: " + string);

--- a/graylog2-server/src/test/java/org/graylog2/plugin/utilities/date/NaturalDateParserTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/plugin/utilities/date/NaturalDateParserTest.java
@@ -24,6 +24,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
+import java.util.Locale;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.jodatime.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -57,7 +59,7 @@ public class NaturalDateParserTest {
 
     final String[] testsThatAlignToStartOfDay = {
             "yesterday", "the day before yesterday", "today",
-            "monday", "monday to friday", "last week"
+            "monday", "monday to friday", "last week", "last month"
     };
 
     final String[][] singleDaytestsThatAlignToAGivenTime = {
@@ -284,14 +286,65 @@ public class NaturalDateParserTest {
     }
 
     @Test
-    public void testParseLastWeek() throws Exception {
+    public void testParseMondayLastWeek() throws Exception {
+        DateTime reference = DateTimeFormat.forPattern("dd.MM.yyyy HH:mm:ss").withZoneUTC().parseDateTime("12.06.2021 09:45:23");
+        NaturalDateParser.Result result = naturalDateParser.parse("monday last week", reference.toDate());
+
+        DateTime lastMondayStart = DateTimeFormat.forPattern("dd.MM.yyyy HH:mm:ss").withZoneUTC().parseDateTime("31.05.2021 00:00:00");
+        DateTime lastMondayEnd = DateTimeFormat.forPattern("dd.MM.yyyy HH:mm:ss").withZoneUTC().parseDateTime("01.06.2021 00:00:00");
+
+        assertThat(result.getFrom()).as("should be equal to").isEqualTo(lastMondayStart);
+        assertThat(result.getTo()).as("should be equal to").isEqualTo(lastMondayEnd);
+    }
+
+    @Test
+    public void testParseLastWeekGermany() throws Exception {
+        final NaturalDateParser naturalDateParser = new NaturalDateParser(Locale.GERMANY);
         DateTime reference = DateTimeFormat.forPattern("dd.MM.yyyy HH:mm:ss").withZoneUTC().parseDateTime("12.06.2021 09:45:23");
         NaturalDateParser.Result result = naturalDateParser.parse("last week", reference.toDate());
 
-        DateTime lastMonday = DateTimeFormat.forPattern("dd.MM.yyyy HH:mm:ss").withZoneUTC().parseDateTime("05.06.2021 00:00:00");
+        DateTime lastMonday = DateTimeFormat.forPattern("dd.MM.yyyy HH:mm:ss").withZoneUTC().parseDateTime("31.05.2021 00:00:00");
+        DateTime nextMonday = DateTimeFormat.forPattern("dd.MM.yyyy HH:mm:ss").withZoneUTC().parseDateTime("07.06.2021 00:00:00");
 
         assertThat(result.getFrom()).as("should be equal to").isEqualTo(lastMonday);
-        assertThat(result.getTo()).as("should differ from").isNotEqualTo(lastMonday);
+        assertThat(result.getTo()).as("should be equal to").isEqualTo(nextMonday);
+    }
+
+    @Test
+    public void testParseLastWeekUS() throws Exception {
+        final NaturalDateParser naturalDateParser = new NaturalDateParser(Locale.US);
+        DateTime reference = DateTimeFormat.forPattern("dd.MM.yyyy HH:mm:ss").withZoneUTC().parseDateTime("12.06.2021 09:45:23");
+        NaturalDateParser.Result result = naturalDateParser.parse("last week", reference.toDate());
+
+        DateTime lastMonday = DateTimeFormat.forPattern("dd.MM.yyyy HH:mm:ss").withZoneUTC().parseDateTime("30.05.2021 00:00:00");
+        DateTime nextMonday = DateTimeFormat.forPattern("dd.MM.yyyy HH:mm:ss").withZoneUTC().parseDateTime("06.06.2021 00:00:00");
+
+        assertThat(result.getFrom()).as("should be equal to").isEqualTo(lastMonday);
+        assertThat(result.getTo()).as("should be equal to").isEqualTo(nextMonday);
+    }
+
+    @Test
+    public void testParseLastMonth() throws Exception {
+        DateTime reference = DateTimeFormat.forPattern("dd.MM.yyyy HH:mm:ss").withZoneUTC().parseDateTime("12.06.2021 09:45:23");
+        NaturalDateParser.Result result = naturalDateParser.parse("last month", reference.toDate());
+
+        DateTime lastMonthStart = DateTimeFormat.forPattern("dd.MM.yyyy HH:mm:ss").withZoneUTC().parseDateTime("01.05.2021 00:00:00");
+        DateTime lastMonthEnd = DateTimeFormat.forPattern("dd.MM.yyyy HH:mm:ss").withZoneUTC().parseDateTime("01.06.2021 00:00:00");
+
+        assertThat(result.getFrom()).as("should be equal to").isEqualTo(lastMonthStart);
+        assertThat(result.getTo()).as("should be equal to").isEqualTo(lastMonthEnd);
+    }
+
+    @Test
+    public void testParseLastYear() throws Exception {
+        DateTime reference = DateTimeFormat.forPattern("dd.MM.yyyy HH:mm:ss").withZoneUTC().parseDateTime("12.06.2021 09:45:23");
+        NaturalDateParser.Result result = naturalDateParser.parse("last year", reference.toDate());
+
+        DateTime lastYearStart = DateTimeFormat.forPattern("dd.MM.yyyy HH:mm:ss").withZoneUTC().parseDateTime("01.01.2020 00:00:00");
+        DateTime lastYearEnd = DateTimeFormat.forPattern("dd.MM.yyyy HH:mm:ss").withZoneUTC().parseDateTime("01.01.2021 00:00:00");
+
+        assertThat(result.getFrom()).as("should be equal to").isEqualTo(lastYearStart);
+        assertThat(result.getTo()).as("should be equal to").isEqualTo(lastYearEnd);
     }
 
     @Test

--- a/graylog2-server/src/test/java/org/graylog2/plugin/utilities/date/NaturalDateParserTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/plugin/utilities/date/NaturalDateParserTest.java
@@ -19,6 +19,7 @@ package org.graylog2.plugin.utilities.date;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -53,6 +54,24 @@ public class NaturalDateParserTest {
     private NaturalDateParser naturalDateParser;
     private NaturalDateParser naturalDateParserAntarctica;
     private NaturalDateParser naturalDateParserUtc;
+
+    final String[] testsThatAlignToStartOfDay = {
+            "yesterday", "the day before yesterday", "today",
+            "monday", "monday to friday", "last week"
+    };
+
+    final String[][] singleDaytestsThatAlignToAGivenTime = {
+            {"yesterday at noon", "12:00:00"},
+            {"the day before yesterday at 10", "10:00:00"},
+            {"today at 5", "05:00:00"},
+            {"monday at 7", "07:00:00"}
+    };
+
+    final String[][] multipleDaytestsThatAlignToAGivenTime =  {
+            {"monday to friday at 7", "07:00:00"},
+            {"monday to friday at 7:59", "07:59:00"},
+            {"monday to friday at 7:59:59", "07:59:59"}
+    };
 
     @BeforeEach
     public void setUp() {
@@ -129,20 +148,21 @@ public class NaturalDateParserTest {
     @Test
     public void issue1226() throws Exception {
         NaturalDateParser.Result result99days = naturalDateParser.parse("last 99 days");
-        assertThat(result99days.getFrom()).isEqualToIgnoringMillis(result99days.getTo().minusDays(99));
+        assertThat(result99days.getFrom()).isEqualToIgnoringMillis(result99days.getTo().minusDays(100));
 
         NaturalDateParser.Result result100days = naturalDateParser.parse("last 100 days");
-        assertThat(result100days.getFrom()).isEqualToIgnoringMillis(result100days.getTo().minusDays(100));
+        assertThat(result100days.getFrom()).isEqualToIgnoringMillis(result100days.getTo().minusDays(101));
 
         NaturalDateParser.Result result101days = naturalDateParser.parse("last 101 days");
-        assertThat(result101days.getFrom()).isEqualToIgnoringMillis(result101days.getTo().minusDays(101));
+        assertThat(result101days.getFrom()).isEqualToIgnoringMillis(result101days.getTo().minusDays(102));
     }
 
     @Test
     public void testThisMonth() throws Exception {
         DateTime reference = DateTimeFormat.forPattern("dd.MM.yyyy HH:mm:ss").withZoneUTC().parseDateTime("12.06.2021 09:45:23");
+        DateTime startOfDay = DateTimeFormat.forPattern("dd.MM.yyyy HH:mm:ss").withZoneUTC().parseDateTime("12.06.2021 00:00:00");
         NaturalDateParser.Result result = naturalDateParser.parse("this month", reference.toDate());
-        assertThat(result.getFrom()).as("is the same as the reference date").isEqualTo(reference);
+        assertThat(result.getFrom()).as("is the same as the start of the day of the reference date").isEqualTo(startOfDay);
 
 //        DateTime first = DateTimeFormat.forPattern("dd.MM.yyyy HH:mm:ss").withZoneUTC().parseDateTime("01.06.2021 09:45:23");
 //        DateTime firstNextMonth = DateTimeFormat.forPattern("dd.MM.yyyy HH:mm:ss").withZoneUTC().parseDateTime("01.07.2021 09:45:23");
@@ -153,36 +173,36 @@ public class NaturalDateParserTest {
     @Test
     public void testMondayToFriday() throws Exception {
         DateTime reference = DateTimeFormat.forPattern("dd.MM.yyyy HH:mm:ss").withZoneUTC().parseDateTime("12.06.2021 09:45:23");
-        DateTime monday = DateTimeFormat.forPattern("dd.MM.yyyy HH:mm:ss").withZoneUTC().parseDateTime("14.06.2021 09:45:23");
-        DateTime friday = DateTimeFormat.forPattern("dd.MM.yyyy HH:mm:ss").withZoneUTC().parseDateTime("18.06.2021 09:45:23");
+        DateTime startOfMonday = DateTimeFormat.forPattern("dd.MM.yyyy HH:mm:ss").withZoneUTC().parseDateTime("14.06.2021 00:00:00");
+        DateTime endOfFriday = DateTimeFormat.forPattern("dd.MM.yyyy HH:mm:ss").withZoneUTC().parseDateTime("19.06.2021 00:00:00");
 
         NaturalDateParser.Result result = naturalDateParser.parse("monday to friday", reference.toDate());
-        assertThat(result.getFrom()).as("should be Monday, 14.").isEqualTo(monday);
-        assertThat(result.getTo()).as("should be Friday, 18.").isEqualTo(friday);
+        assertThat(result.getFrom()).as("should be Monday, 14.").isEqualTo(startOfMonday);
+        assertThat(result.getTo()).as("should be Friday, 18.").isEqualTo(endOfFriday);
 
         /* fails with current Natty implementation
-        DateTime lastMonday = DateTimeFormat.forPattern("dd.MM.yyyy HH:mm:ss").withZoneUTC().parseDateTime("06.06.2021 09:45:23");
-        DateTime lastFriday = DateTimeFormat.forPattern("dd.MM.yyyy HH:mm:ss").withZoneUTC().parseDateTime("11.06.2021 09:45:23");
+        DateTime startOfLastMonday = DateTimeFormat.forPattern("dd.MM.yyyy HH:mm:ss").withZoneUTC().parseDateTime("06.06.2021 00:00:00");
+        DateTime endOfLastFriday = DateTimeFormat.forPattern("dd.MM.yyyy HH:mm:ss").withZoneUTC().parseDateTime("12.06.2021 00:00:00");
 
         result = naturalDateParser.parse("last monday to friday", reference.toDate());
-        assertThat(result.getFrom()).as("should be Monday, 06.").isEqualTo(lastMonday);
-        assertThat(result.getTo()).as("should be Friday, 11.").isEqualTo(lastFriday);
+        assertThat(result.getFrom()).as("should be Monday, 06.").isEqualTo(startOfLastMonday);
+        assertThat(result.getTo()).as("should be Friday, 11.").isEqualTo(endOfLastFriday);
         */
 
         result = naturalDateParser.parse("next monday to friday", reference.toDate());
-        assertThat(result.getFrom()).as("should be Monday, 14.").isEqualTo(monday);
-        assertThat(result.getTo()).as("should be Friday, 18.").isEqualTo(friday);
+        assertThat(result.getFrom()).as("should be Monday, 14.").isEqualTo(startOfMonday);
+        assertThat(result.getTo()).as("should be Friday, 18.").isEqualTo(endOfFriday);
 
         reference = DateTimeFormat.forPattern("dd.MM.yyyy HH:mm:ss").withZoneUTC().parseDateTime("08.06.2021 09:45:23");
         result = naturalDateParser.parse("next monday to friday", reference.toDate());
-        assertThat(result.getFrom()).as("should be Monday, 14.").isEqualTo(monday);
-        assertThat(result.getTo()).as("should be Friday, 18.").isEqualTo(friday);
+        assertThat(result.getFrom()).as("should be Monday, 14.").isEqualTo(startOfMonday);
+        assertThat(result.getTo()).as("should be Friday, 18.").isEqualTo(endOfFriday);
 
         /* fails with current Natty implementaiton
         reference = DateTimeFormat.forPattern("dd.MM.yyyy HH:mm:ss").withZoneUTC().parseDateTime("14.06.2021 09:45:23");
         result = naturalDateParser.parse("monday to friday", reference.toDate());
-        assertThat(result.getFrom()).as("should be Monday, 14.").isEqualTo(monday);
-        assertThat(result.getTo()).as("should be Friday, 18.").isEqualTo(friday);
+        assertThat(result.getFrom()).as("should be Monday, 14.").isEqualTo(startOfMonday);
+        assertThat(result.getTo()).as("should be Friday, 18.").isEqualTo(endOfFriday);
          */
     }
 
@@ -245,12 +265,11 @@ public class NaturalDateParserTest {
     @Test
     public void testParseToday() throws Exception {
         DateTime reference = DateTimeFormat.forPattern("dd.MM.yyyy HH:mm:ss").withZoneUTC().parseDateTime("12.06.2021 09:45:23");
+        DateTime startOfToday = DateTimeFormat.forPattern("dd.MM.yyyy HH:mm:ss").withZoneUTC().parseDateTime("12.06.2021 00:00:00");
         NaturalDateParser.Result result = naturalDateParser.parse("today", reference.toDate());
 
-        // TODO: in the future, this should compare to "12.06.2021 00:00:00"
-        assertThat(result.getFrom()).as("should be equal to").isEqualTo(reference);
-        // TODO: in the future, this should compare to "13.06.2021 00:00:00"
-        assertThat(result.getTo()).as("should differ from").isNotEqualTo(reference);
+        assertThat(result.getFrom()).as("should be equal to").isEqualTo(startOfToday);
+        assertThat(result.getTo()).as("should differ from").isNotEqualTo(startOfToday);
      }
 
     @Test
@@ -258,7 +277,7 @@ public class NaturalDateParserTest {
         DateTime reference = DateTimeFormat.forPattern("dd.MM.yyyy HH:mm:ss").withZoneUTC().parseDateTime("12.06.2021 09:45:23");
         NaturalDateParser.Result result = naturalDateParser.parse("last monday", reference.toDate());
 
-        DateTime lastMonday = DateTimeFormat.forPattern("dd.MM.yyyy HH:mm:ss").withZoneUTC().parseDateTime("31.05.2021 09:45:23");
+        DateTime lastMonday = DateTimeFormat.forPattern("dd.MM.yyyy HH:mm:ss").withZoneUTC().parseDateTime("31.05.2021 00:00:00");
 
         assertThat(result.getFrom()).as("should be equal to").isEqualTo(lastMonday);
         assertThat(result.getTo()).as("should differ from").isNotEqualTo(lastMonday);
@@ -269,7 +288,7 @@ public class NaturalDateParserTest {
         DateTime reference = DateTimeFormat.forPattern("dd.MM.yyyy HH:mm:ss").withZoneUTC().parseDateTime("12.06.2021 09:45:23");
         NaturalDateParser.Result result = naturalDateParser.parse("last week", reference.toDate());
 
-        DateTime lastMonday = DateTimeFormat.forPattern("dd.MM.yyyy HH:mm:ss").withZoneUTC().parseDateTime("05.06.2021 09:45:23");
+        DateTime lastMonday = DateTimeFormat.forPattern("dd.MM.yyyy HH:mm:ss").withZoneUTC().parseDateTime("05.06.2021 00:00:00");
 
         assertThat(result.getFrom()).as("should be equal to").isEqualTo(lastMonday);
         assertThat(result.getTo()).as("should differ from").isNotEqualTo(lastMonday);
@@ -280,10 +299,71 @@ public class NaturalDateParserTest {
         DateTime reference = DateTimeFormat.forPattern("dd.MM.yyyy HH:mm:ss").withZoneUTC().parseDateTime("12.06.2021 09:45:23");
         NaturalDateParser.Result result = naturalDateParser.parse("monday to friday", reference.toDate());
 
-        DateTime monday = DateTimeFormat.forPattern("dd.MM.yyyy HH:mm:ss").withZoneUTC().parseDateTime("14.06.2021 09:45:23");
-        DateTime friday = DateTimeFormat.forPattern("dd.MM.yyyy HH:mm:ss").withZoneUTC().parseDateTime("18.06.2021 09:45:23");
+        DateTime startOfMonday = DateTimeFormat.forPattern("dd.MM.yyyy HH:mm:ss").withZoneUTC().parseDateTime("14.06.2021 00:00:00");
+        DateTime endOfFriday = DateTimeFormat.forPattern("dd.MM.yyyy HH:mm:ss").withZoneUTC().parseDateTime("19.06.2021 00:00:00");
 
-        assertThat(result.getFrom()).as("should be equal to").isEqualTo(monday);
-        assertThat(result.getTo()).as("should be equal to").isEqualTo(friday);
+        assertThat(result.getFrom()).as("should be equal to").isEqualTo(startOfMonday);
+        assertThat(result.getTo()).as("should be equal to").isEqualTo(endOfFriday);
+    }
+
+    @Test
+    public void testParseAlignToStartOfDay() throws Exception {
+        final DateTimeFormatter df = DateTimeFormat.forPattern("HH:mm:ss");
+
+        for(String test: testsThatAlignToStartOfDay) {
+            NaturalDateParser.Result result = naturalDateParser.parse(test);
+            assertNotNull(result.getFrom());
+            assertNotNull(result.getTo());
+
+            assertThat(df.print(result.getFrom())).as("time part of date should equal 00:00:00 in").isEqualTo("00:00:00");
+            assertThat(df.print(result.getTo())).as("time part of date should equal 00:00:00 in").isEqualTo("00:00:00");
+        }
+    }
+
+    @Test
+    @Disabled
+    /**
+     * This test should be ignored for now. The problem is, that the to-date has the hour subtracted by 1 - which is not reasonable
+     * at all in this context but without further digging into Natty not solvable. And that effort would be too much by now.
+     */
+    public void multipleDaytestParseAlignToAGivenTime() throws Exception {
+        final DateTimeFormatter df = DateTimeFormat.forPattern("HH:mm:ss");
+
+        for(String[] test: multipleDaytestsThatAlignToAGivenTime) {
+            NaturalDateParser.Result result = naturalDateParser.parse(test[0]);
+            assertNotNull(result.getFrom());
+            assertNotNull(result.getTo());
+
+            assertThat(df.print(result.getFrom())).as("time part of date should equal " + test[1] + " in").isEqualTo(test[1]);
+            assertThat(df.print(result.getTo())).as("time part of date should equal " + test[1] + " in").isEqualTo(test[1]);
+        }
+    }
+
+    @Test
+    public void singleDaytestParseAlignToAGivenTime() throws Exception {
+        final DateTimeFormatter df = DateTimeFormat.forPattern("HH:mm:ss");
+
+        for(String[] test: singleDaytestsThatAlignToAGivenTime) {
+            NaturalDateParser.Result result = naturalDateParser.parse(test[0]);
+            assertNotNull(result.getFrom());
+            assertNotNull(result.getTo());
+
+            assertThat(df.print(result.getFrom())).as("time part of date should equal "+ test[1] + " in").isEqualTo(test[1]);
+        }
+    }
+
+    @Test
+    public void testParseAlignToStartOfDayEuropeBerlin() throws Exception {
+        final NaturalDateParser naturalDateParser = new NaturalDateParser("Antarctica/Palmer");
+        final DateTimeFormatter df = DateTimeFormat.forPattern("HH:mm:ss");
+
+        for(String test: testsThatAlignToStartOfDay) {
+            NaturalDateParser.Result result = naturalDateParser.parse(test);
+            assertNotNull(result.getFrom());
+            assertNotNull(result.getTo());
+
+            assertThat(df.print(result.getFrom())).as("time part of date should equal 00:00:00 in").isEqualTo("00:00:00");
+            assertThat(df.print(result.getTo())).as("time part of date should equal 00:00:00 in").isEqualTo("00:00:00");
+        }
     }
 }


### PR DESCRIPTION
## Description
When Natty does not parse any times, only dates, the start of day/end of day should be aligned to the given day(s).

## Motivation and Context
e.g. "yesterday" is currently parsed exactly into the same times as "last 24 hours" - which is not what the user expects.

## How Has This Been Tested?
Manual tests in the GUI.
Added more tests to the existing NaturalDateParserTest Unit-tests

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

