### PR TITLE
Initialize ES7 client and sniffer lazily. (4.0)

### DIFF
--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/RestHighLevelClientProvider.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/RestHighLevelClientProvider.java
@@ -59,7 +59,6 @@ public class RestHighLevelClientProvider implements Provider<RestHighLevelClient
             @Named("elasticsearch_discovery_frequency") Duration discoveryFrequency,
             @Named("elasticsearch_discovery_default_scheme") String defaultSchemeForDiscoveredNodes,
             @Named("elasticsearch_use_expect_continue") boolean useExpectContinue,
-            @Named("elasticsearch_mute_deprecation_warnings") boolean muteElasticsearchDeprecationWarnings,
             CredentialsProvider credentialsProvider) {
         clientSupplier = Suppliers.memoize(() -> {
             final RestHighLevelClient client = buildClient(hosts,
@@ -68,7 +67,6 @@ public class RestHighLevelClientProvider implements Provider<RestHighLevelClient
                     maxTotalConnections,
                     maxTotalConnectionsPerRoute,
                     useExpectContinue,
-                    muteElasticsearchDeprecationWarnings,
                 credentialsProvider);
 
             if (discoveryEnabled) {
@@ -113,7 +111,6 @@ public class RestHighLevelClientProvider implements Provider<RestHighLevelClient
             int maxTotalConnections,
             int maxTotalConnectionsPerRoute,
             boolean useExpectContinue,
-            boolean muteElasticsearchDeprecationWarnings,
             CredentialsProvider credentialsProvider) {
         final HttpHost[] esHosts = hosts.stream().map(uri -> new HttpHost(uri.getHost(), uri.getPort(), uri.getScheme())).toArray(HttpHost[]::new);
 
@@ -129,10 +126,6 @@ public class RestHighLevelClientProvider implements Provider<RestHighLevelClient
                         .setMaxConnPerRoute(maxTotalConnectionsPerRoute)
                         .setDefaultCredentialsProvider(credentialsProvider)
                 );
-
-        if(muteElasticsearchDeprecationWarnings) {
-            restClientBuilder.setHttpClientConfigCallback(httpClientBuilder -> httpClientBuilder.addInterceptorFirst(new ElasticsearchFilterDeprecationWarningsInterceptor()));
-        }
 
         return new RestHighLevelClient(restClientBuilder);
     }

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/RestHighLevelClientProvider.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/RestHighLevelClientProvider.java
@@ -17,6 +17,7 @@
 package org.graylog.storage.elasticsearch7;
 
 import com.github.joschi.jadconfig.util.Duration;
+import com.google.common.base.Suppliers;
 import org.graylog.shaded.elasticsearch7.org.apache.http.HttpHost;
 import org.graylog.shaded.elasticsearch7.org.apache.http.client.CredentialsProvider;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.client.RestClient;
@@ -26,8 +27,6 @@ import org.graylog.shaded.elasticsearch7.org.elasticsearch.client.sniff.Elastics
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.client.sniff.NodesSniffer;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.client.sniff.Sniffer;
 import org.graylog2.system.shutdown.GracefulShutdownService;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 import javax.inject.Inject;
@@ -38,14 +37,11 @@ import java.net.URI;
 import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 
 @Singleton
 public class RestHighLevelClientProvider implements Provider<RestHighLevelClient> {
-
-    private static final Logger LOG = LoggerFactory.getLogger(RestHighLevelClientProvider.class);
-
-    private final RestHighLevelClient client;
-    private final Sniffer sniffer;
+    private final Supplier<RestHighLevelClient> clientSupplier;
 
     @SuppressWarnings("unused")
     @Inject
@@ -63,23 +59,25 @@ public class RestHighLevelClientProvider implements Provider<RestHighLevelClient
             @Named("elasticsearch_discovery_frequency") Duration discoveryFrequency,
             @Named("elasticsearch_discovery_default_scheme") String defaultSchemeForDiscoveredNodes,
             @Named("elasticsearch_use_expect_continue") boolean useExpectContinue,
+            @Named("elasticsearch_mute_deprecation_warnings") boolean muteElasticsearchDeprecationWarnings,
             CredentialsProvider credentialsProvider) {
-        client = buildClient(
-                hosts,
-                connectTimeout,
-                socketTimeout,
-                maxTotalConnections,
-                maxTotalConnectionsPerRoute,
-                useExpectContinue,
+        clientSupplier = Suppliers.memoize(() -> {
+            final RestHighLevelClient client = buildClient(hosts,
+                    connectTimeout,
+                    socketTimeout,
+                    maxTotalConnections,
+                    maxTotalConnectionsPerRoute,
+                    useExpectContinue,
+                    muteElasticsearchDeprecationWarnings,
                 credentialsProvider);
 
-        sniffer = discoveryEnabled
-                ? createNodeDiscoverySniffer(client.getLowLevelClient(), discoveryFrequency, defaultSchemeForDiscoveredNodes, discoveryFilter)
-                : null;
+            if (discoveryEnabled) {
+                final Sniffer sniffer = createNodeDiscoverySniffer(client.getLowLevelClient(), discoveryFrequency, defaultSchemeForDiscoveredNodes, discoveryFilter);
+                shutdownService.register(sniffer::close);
+            }
 
-        if (discoveryEnabled) {
-            registerSnifferShutdownHook(shutdownService);
-        }
+            return client;
+        });
     }
 
     private Sniffer createNodeDiscoverySniffer(RestClient restClient, Duration discoveryFrequency, String defaultSchemeForDiscoveredNodes, String discoveryFilter) {
@@ -105,7 +103,7 @@ public class RestHighLevelClientProvider implements Provider<RestHighLevelClient
 
     @Override
     public RestHighLevelClient get() {
-        return client;
+        return this.clientSupplier.get();
     }
 
     private RestHighLevelClient buildClient(
@@ -115,6 +113,7 @@ public class RestHighLevelClientProvider implements Provider<RestHighLevelClient
             int maxTotalConnections,
             int maxTotalConnectionsPerRoute,
             boolean useExpectContinue,
+            boolean muteElasticsearchDeprecationWarnings,
             CredentialsProvider credentialsProvider) {
         final HttpHost[] esHosts = hosts.stream().map(uri -> new HttpHost(uri.getHost(), uri.getPort(), uri.getScheme())).toArray(HttpHost[]::new);
 
@@ -131,10 +130,10 @@ public class RestHighLevelClientProvider implements Provider<RestHighLevelClient
                         .setDefaultCredentialsProvider(credentialsProvider)
                 );
 
-        return new RestHighLevelClient(restClientBuilder);
-    }
+        if(muteElasticsearchDeprecationWarnings) {
+            restClientBuilder.setHttpClientConfigCallback(httpClientBuilder -> httpClientBuilder.addInterceptorFirst(new ElasticsearchFilterDeprecationWarningsInterceptor()));
+        }
 
-    private void registerSnifferShutdownHook(GracefulShutdownService shutdownService) {
-        shutdownService.register(sniffer::close);
+        return new RestHighLevelClient(restClientBuilder);
     }
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

**Note:** This is a backport of #10264 to `4.0`.

This change is avoiding eager initialization of the ES7 client (and sniffer) in its provider class. Instead, it is initializing a memoized supplier, which returns the same instance upon repeated invocation.

This avoids initializing the client and the sniffer unnecessarily when the ES7 module is not in use.

In a future improvement, we could safeguard against this by determining the ES version earlier and include the ES6/ES7/... guice module only if the module is active. This is beyond the scope of this bugfix PR.

## How Has This Been Tested?
The backport has been tested manually (startup of 4.0, creation of the changed class)

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.