### PR TITLE
Support configuration of group by / row & column pivots in new aggregation controls.

### DIFF
--- a/graylog2-web-interface/src/views/components/MigrateFieldCharts.tsx
+++ b/graylog2-web-interface/src/views/components/MigrateFieldCharts.tsx
@@ -26,7 +26,7 @@ import Store from 'logic/local-storage/Store';
 import { widgetDefinition } from 'views/logic/Widgets';
 import AggregationWidget from 'views/logic/aggregationbuilder/AggregationWidget';
 import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
-import Pivot from 'views/logic/aggregationbuilder/Pivot';
+import Pivot, { PivotConfigType } from 'views/logic/aggregationbuilder/Pivot';
 import Series from 'views/logic/aggregationbuilder/Series';
 import WidgetPosition from 'views/logic/widgets/WidgetPosition';
 import LineVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/LineVisualizationConfig';
@@ -150,7 +150,7 @@ const _migrateWidgets = (legacyCharts) => {
       const series = new Series(mapSeries(chart.valuetype, field));
       // Because all field charts show the results for the defined timerange,
       // the new row pivot always contains the timestamp field.
-      const rowPivotConfig = { interval: { type: 'timeunit', ...mapTime(chart.interval) } };
+      const rowPivotConfig = { interval: { type: 'timeunit', ...mapTime(chart.interval) } } as PivotConfigType;
       const rowPivot = new Pivot(TIMESTAMP_FIELD, 'time', rowPivotConfig);
       const visualization = mapVisualization(chart.renderer);
       const visualizationConfig = createVisualizationConfig(chart.interpolation, visualization);

--- a/graylog2-web-interface/src/views/components/aggregationwizard/AggregationWizard.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/AggregationWizard.tsx
@@ -69,7 +69,7 @@ const _onElementCreate = (
 ) => {
   const aggregationElement = aggregationElementsByKey[elementKey];
 
-  if ('addEmptyElement' in aggregationElement) {
+  if (aggregationElement?.addEmptyElement) {
     setValues(aggregationElement.addEmptyElement(values));
   } else {
     setValues({

--- a/graylog2-web-interface/src/views/components/aggregationwizard/AggregationWizard.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/AggregationWizard.tsx
@@ -67,11 +67,14 @@ const _onElementCreate = (
   values: WidgetConfigFormValues,
   setValues: (formValues: WidgetConfigFormValues) => void,
 ) => {
+  const aggregationElement = aggregationElementsByKey[elementKey];
+  const newElement = 'createEmpty' in aggregationElement ? aggregationElement.createEmpty() : {};
+
   setValues({
     ...values,
     [elementKey]: [
       ...(values[elementKey] ?? []),
-      {},
+      newElement ?? {},
     ],
   });
 };

--- a/graylog2-web-interface/src/views/components/aggregationwizard/AggregationWizard.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/AggregationWizard.tsx
@@ -68,15 +68,18 @@ const _onElementCreate = (
   setValues: (formValues: WidgetConfigFormValues) => void,
 ) => {
   const aggregationElement = aggregationElementsByKey[elementKey];
-  const newElement = 'createEmpty' in aggregationElement ? aggregationElement.createEmpty() : {};
 
-  setValues({
-    ...values,
-    [elementKey]: [
-      ...(values[elementKey] ?? []),
-      newElement ?? {},
-    ],
-  });
+  if ('addEmptyElement' in aggregationElement) {
+    setValues(aggregationElement.addEmptyElement(values));
+  } else {
+    setValues({
+      ...values,
+      [elementKey]: [
+        ...(values[elementKey] ?? []),
+        {},
+      ],
+    });
+  }
 };
 
 const _onSubmit = (formValues: WidgetConfigFormValues, onConfigChange: (newConfig: AggregationWidgetConfig) => void) => {

--- a/graylog2-web-interface/src/views/components/aggregationwizard/WidgetConfigForm.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/WidgetConfigForm.tsx
@@ -28,7 +28,7 @@ export type GroupingDirection = 'row' | 'column';
 
 export type DateGrouping = {
   direction: GroupingDirection,
-  field: string,
+  field: string | undefined,
   interval: {
     type: 'auto',
     scaling: number,
@@ -42,7 +42,7 @@ export type DateGrouping = {
 
 export type ValuesGrouping = {
   direction: GroupingDirection,
-  field: string,
+  field: string | undefined,
   limit: number,
 };
 

--- a/graylog2-web-interface/src/views/components/aggregationwizard/WidgetConfigForm.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/WidgetConfigForm.tsx
@@ -53,7 +53,10 @@ export type VisualizationFormValues = {};
 export type SortFormValues = {}
 export interface WidgetConfigFormValues {
   metrics?: Array<MetricFormValues>,
-  groupBy?: Array<GroupByFormValues>,
+  groupBy?: {
+    columnRollup: boolean,
+    groupings: Array<GroupByFormValues>,
+  },
   visualization?: VisualizationFormValues,
   sort?: SortFormValues,
 }

--- a/graylog2-web-interface/src/views/components/aggregationwizard/WidgetConfigForm.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/WidgetConfigForm.tsx
@@ -24,7 +24,29 @@ export type MetricFormValues = {
   percentile?: number | undefined,
 };
 
-export type GroupByFormValues = {};
+export type GroupingDirection = 'row' | 'column';
+
+export type DateGrouping = {
+  direction: GroupingDirection,
+  field: string,
+  interval: {
+    type: 'auto',
+    scaling: number,
+  } | {
+    type: 'timeunit',
+    value: number,
+    unit: string,
+  }
+
+}
+
+export type ValuesGrouping = {
+  direction: GroupingDirection,
+  field: string,
+  limit: number,
+};
+
+export type GroupByFormValues = DateGrouping | ValuesGrouping;
 
 export type VisualizationFormValues = {};
 

--- a/graylog2-web-interface/src/views/components/aggregationwizard/WidgetConfigForm.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/WidgetConfigForm.tsx
@@ -24,11 +24,16 @@ export type MetricFormValues = {
   percentile?: number | undefined,
 };
 
+type GroupingField<T extends 'values' | 'time'> = {
+  field: string | undefined
+  type: T;
+}
+
 export type GroupingDirection = 'row' | 'column';
 
 export type DateGrouping = {
   direction: GroupingDirection,
-  field: string | undefined,
+  field: GroupingField<'time'>,
   interval: {
     type: 'auto',
     scaling: number,
@@ -39,10 +44,9 @@ export type DateGrouping = {
   }
 
 }
-
 export type ValuesGrouping = {
   direction: GroupingDirection,
-  field: string | undefined,
+  field: GroupingField<'values'>,
   limit: number,
 };
 

--- a/graylog2-web-interface/src/views/components/aggregationwizard/WidgetConfigForm.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/WidgetConfigForm.tsx
@@ -17,7 +17,7 @@
 import * as React from 'react';
 import { Form, Formik, FormikProps } from 'formik';
 
-import { TimeUnits } from 'views/Constants';
+import { AutoTimeConfig, TimeUnitConfig } from 'views/logic/aggregationbuilder/Pivot';
 
 export type MetricFormValues = {
   function: string,
@@ -36,15 +36,7 @@ export type GroupingDirection = 'row' | 'column';
 export type DateGrouping = {
   direction: GroupingDirection,
   field: GroupingField<'time'>,
-  interval: {
-    type: 'auto',
-    scaling: number,
-  } | {
-    type: 'timeunit',
-    value: number,
-    unit: keyof typeof TimeUnits,
-  }
-
+  interval: AutoTimeConfig | TimeUnitConfig,
 }
 export type ValuesGrouping = {
   direction: GroupingDirection,

--- a/graylog2-web-interface/src/views/components/aggregationwizard/WidgetConfigForm.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/WidgetConfigForm.tsx
@@ -17,6 +17,8 @@
 import * as React from 'react';
 import { Form, Formik, FormikProps } from 'formik';
 
+import { TimeUnits } from 'views/Constants';
+
 export type MetricFormValues = {
   function: string,
   field: string | undefined,
@@ -40,7 +42,7 @@ export type DateGrouping = {
   } | {
     type: 'timeunit',
     value: number,
-    unit: string,
+    unit: keyof typeof TimeUnits,
   }
 
 }

--- a/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.groupBy.test.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.groupBy.test.tsx
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 import React from 'react';
 import * as Immutable from 'immutable';
 import { act, fireEvent, render, screen, waitFor } from 'wrappedTestingLibrary';

--- a/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.groupBy.test.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.groupBy.test.tsx
@@ -1,0 +1,161 @@
+import React from 'react';
+import * as Immutable from 'immutable';
+import { act, fireEvent, render, screen, waitFor } from 'wrappedTestingLibrary';
+import selectEvent from 'react-select-event';
+import userEvent from '@testing-library/user-event';
+
+import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
+import DataTable from 'views/components/datatable/DataTable';
+import FieldType, { FieldTypes } from 'views/logic/fieldtypes/FieldType';
+import FieldTypeMapping from 'views/logic/fieldtypes/FieldTypeMapping';
+import FieldTypesContext from 'views/components/contexts/FieldTypesContext';
+import Pivot from 'views/logic/aggregationbuilder/Pivot';
+
+import AggregationWizard from '../AggregationWizard';
+
+const widgetConfig = AggregationWidgetConfig
+  .builder()
+  .visualization(DataTable.type)
+  .build();
+
+const fieldType = new FieldType('field_type', ['numeric'], []);
+const fieldTypeMapping1 = new FieldTypeMapping('took_ms', fieldType);
+const fieldTypeMapping2 = new FieldTypeMapping('http_method', fieldType);
+const fieldTypeMapping3 = new FieldTypeMapping('timestamp', FieldTypes.DATE());
+const fields = Immutable.List([fieldTypeMapping1, fieldTypeMapping2, fieldTypeMapping3]);
+const fieldTypes = { all: fields, queryFields: Immutable.Map({ queryId: fields }) };
+
+describe('AggregationWizard', () => {
+  const renderSUT = (props = {}) => render(
+    <FieldTypesContext.Provider value={fieldTypes}>
+      <AggregationWizard config={widgetConfig}
+                         editing
+                         id="widget-id"
+                         type="AGGREGATION"
+                         fields={Immutable.List([])}
+                         onChange={() => {}}
+                         {...props}>
+        The Visualization
+      </AggregationWizard>,
+    </FieldTypesContext.Provider>,
+  );
+
+  it('should require group by function when adding a group by element', async () => {
+    renderSUT();
+
+    const aggregationElementSelect = screen.getByLabelText('Select an element to add ...');
+
+    await selectEvent.openMenu(aggregationElementSelect);
+    await selectEvent.select(aggregationElementSelect, 'Group By');
+
+    await waitFor(() => expect(screen.getByText('Field is required.')).toBeInTheDocument());
+  });
+
+  it('should change the config when applied', async () => {
+    const onChange = jest.fn();
+    renderSUT({ onChange });
+
+    const aggregationElementSelect = screen.getByLabelText('Select an element to add ...');
+
+    await selectEvent.openMenu(aggregationElementSelect);
+    await selectEvent.select(aggregationElementSelect, 'Group By');
+
+    const fieldSelection = await screen.findByLabelText('Field');
+
+    await act(async () => {
+      await selectEvent.openMenu(fieldSelection);
+      await selectEvent.select(fieldSelection, 'took_ms');
+    });
+
+    const applyButton = await screen.findByRole('button', { name: 'Apply Changes' });
+    fireEvent.click(applyButton);
+
+    const pivot = Pivot.create('took_ms', 'values', { limit: 15 });
+    const updatedConfig = AggregationWidgetConfig
+      .builder()
+      .rowPivots([pivot])
+      .build();
+
+    await waitFor(() => expect(onChange).toHaveBeenCalledTimes(1));
+
+    expect(onChange).toHaveBeenCalledWith(updatedConfig);
+  });
+
+  it('should handle timestamp field types', async () => {
+    renderSUT();
+
+    const aggregationElementSelect = screen.getByLabelText('Select an element to add ...');
+
+    await selectEvent.openMenu(aggregationElementSelect);
+    await selectEvent.select(aggregationElementSelect, 'Group By');
+
+    const fieldSelection = await screen.findByLabelText('Field');
+
+    await act(async () => {
+      await selectEvent.openMenu(fieldSelection);
+      await selectEvent.select(fieldSelection, 'timestamp');
+    });
+
+    const autoCheckbox = await screen.findByRole('checkbox', { name: 'Auto' });
+    await screen.findByText(/A smaller granularity leads to/);
+
+    await userEvent.click(autoCheckbox);
+
+    await screen.findByText('The size of the buckets for this timestamp type.');
+  });
+
+  it('should create group by with multiple groupings', async () => {
+    const onChange = jest.fn();
+    renderSUT({ onChange });
+
+    const aggregationElementSelect = screen.getByLabelText('Select an element to add ...');
+
+    await selectEvent.openMenu(aggregationElementSelect);
+    await selectEvent.select(aggregationElementSelect, 'Group By');
+
+    const fieldSelection = await screen.findByLabelText('Field');
+
+    await act(async () => {
+      await selectEvent.openMenu(fieldSelection);
+      await selectEvent.select(fieldSelection, 'timestamp');
+    });
+
+    await selectEvent.openMenu(aggregationElementSelect);
+    await selectEvent.select(aggregationElementSelect, 'Group By');
+
+    const fieldSelections = await screen.findAllByLabelText('Field');
+
+    await act(async () => {
+      await selectEvent.openMenu(fieldSelections[1]);
+      await selectEvent.select(fieldSelections[1], 'took_ms');
+    });
+
+    const applyButton = await screen.findByRole('button', { name: 'Apply Changes' });
+    fireEvent.click(applyButton);
+
+    const pivot0 = Pivot.create('timestamp', 'time', { interval: { type: 'auto', scaling: 1 } });
+    const pivot1 = Pivot.create('took_ms', 'values', { limit: 15 });
+    const updatedConfig = AggregationWidgetConfig
+      .builder()
+      .rowPivots([pivot0, pivot1])
+      .build();
+
+    await waitFor(() => expect(onChange).toHaveBeenCalledTimes(1));
+
+    expect(onChange).toHaveBeenCalledWith(updatedConfig);
+  });
+
+  it('should display group by with values from config', async () => {
+    const pivot0 = Pivot.create('timestamp', 'time', { interval: { type: 'auto', scaling: 1 } });
+    const pivot1 = Pivot.create('took_ms', 'values', { limit: 15 });
+    const config = AggregationWidgetConfig
+      .builder()
+      .rowPivots([pivot0, pivot1])
+      .build();
+
+    renderSUT({ config });
+
+    await screen.findByText('took_ms');
+    await screen.findByText('timestamp');
+  });
+});

--- a/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/AggregationElementType.ts
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/AggregationElementType.ts
@@ -23,6 +23,7 @@ export type AggregationElement = {
   key: string,
   allowCreate: (formValues: WidgetConfigFormValues) => boolean,
   order: number,
+  createEmpty?: () => Object,
   toConfig?: (formValues: WidgetConfigFormValues, currentConfig: AggregationWidgetConfig) => AggregationWidgetConfig,
   fromConfig?: (config: AggregationWidgetConfig) => Partial<WidgetConfigFormValues>,
   onCreate?: () => void,

--- a/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/AggregationElementType.ts
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/AggregationElementType.ts
@@ -32,5 +32,5 @@ export type AggregationElement = {
     config: AggregationWidgetConfig,
     onConfigChange: (newConfig: AggregationWidgetConfig) => void
   }>,
-  validate?: (formValues: WidgetConfigFormValues) => { [key: string]: string },
+  validate?: (formValues: WidgetConfigFormValues) => { [key: string]: any },
 }

--- a/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/AggregationElementType.ts
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/AggregationElementType.ts
@@ -23,7 +23,7 @@ export type AggregationElement = {
   key: string,
   allowCreate: (formValues: WidgetConfigFormValues) => boolean,
   order: number,
-  createEmpty?: () => Object,
+  addEmptyElement?: (formValues: WidgetConfigFormValues) => WidgetConfigFormValues,
   toConfig?: (formValues: WidgetConfigFormValues, currentConfig: AggregationWidgetConfig) => AggregationWidgetConfig,
   fromConfig?: (config: AggregationWidgetConfig) => Partial<WidgetConfigFormValues>,
   onCreate?: () => void,

--- a/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/GroupByElement.test.ts
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/GroupByElement.test.ts
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 import { GroupByFormValues, WidgetConfigFormValues } from 'views/components/aggregationwizard/WidgetConfigForm';
 
 import GroupByElement from './GroupByElement';

--- a/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/GroupByElement.test.ts
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/GroupByElement.test.ts
@@ -1,0 +1,94 @@
+import { GroupByFormValues, WidgetConfigFormValues } from 'views/components/aggregationwizard/WidgetConfigForm';
+
+import GroupByElement from './GroupByElement';
+
+describe('GroupByElement', () => {
+  describe('Validation', () => {
+    const { validate } = GroupByElement;
+    const values = { groupBy: { columnRollup: true, groupings: [] } } as WidgetConfigFormValues;
+
+    describe('Values', () => {
+      it('should add an error if field absence', () => {
+        const grouping = { direction: 'row', field: { field: undefined }, limit: 10 } as GroupByFormValues;
+        values.groupBy.groupings = [grouping];
+        const result = validate(values);
+
+        expect(result.groupBy.groupings[0].field).toBe('Field is required.');
+      });
+
+      it('should not add an error if everything is fine', () => {
+        const grouping = { direction: 'row', field: { field: 'action' }, limit: 10 } as GroupByFormValues;
+        values.groupBy.groupings = [grouping];
+        const result = validate(values);
+
+        expect(result.groupBy).toBeUndefined();
+      });
+
+      it('should add an error if limit is undefined', () => {
+        const grouping = { direction: 'row', field: { field: 'action' }, limit: undefined } as GroupByFormValues;
+        values.groupBy.groupings = [grouping];
+        const result = validate(values);
+
+        expect(result.groupBy.groupings[0].limit).toBe('Limit is required.');
+      });
+
+      it('should add an error if limit is smaller than 0', () => {
+        const grouping = { direction: 'row', field: { field: 'action' }, limit: -1 } as GroupByFormValues;
+        values.groupBy.groupings = [grouping];
+        const result = validate(values);
+
+        expect(result.groupBy.groupings[0].limit).toBe('Must be greater than 0.');
+      });
+    });
+
+    describe('Dates', () => {
+      it('should add an error if field absence', () => {
+        const grouping = { direction: 'row', field: { field: undefined }, interval: { type: 'auto', scaling: 1 } } as GroupByFormValues;
+        values.groupBy.groupings = [grouping];
+        const result = validate(values);
+
+        expect(result.groupBy.groupings[0].field).toBe('Field is required.');
+      });
+
+      it('should not add an error if everything is fine', () => {
+        const grouping = { direction: 'row', field: { field: 'action' }, interval: { type: 'auto', scaling: 1 } } as GroupByFormValues;
+        values.groupBy.groupings = [grouping];
+        const result = validate(values);
+
+        expect(result.groupBy).toBeUndefined();
+      });
+
+      it('should add an error if scaling absence', () => {
+        const grouping = { direction: 'row', field: { field: undefined }, interval: { type: 'auto', scaling: undefined } } as GroupByFormValues;
+        values.groupBy.groupings = [grouping];
+        const result = validate(values);
+
+        expect(result.groupBy.groupings[0].interval).toBe('Scaling is required.');
+      });
+
+      it('should add an error if scaling out of range', () => {
+        const grouping = { direction: 'row', field: { field: undefined }, interval: { type: 'auto', scaling: -1 } } as GroupByFormValues;
+        values.groupBy.groupings = [grouping];
+        const result = validate(values);
+
+        expect(result.groupBy.groupings[0].interval).toBe('Must be greater than 0 and smaller or equals 10.');
+      });
+
+      it('should add an error if value is out of range', () => {
+        const grouping = { direction: 'row', field: { field: undefined }, interval: { type: 'timeunit', value: -1, unit: 'second' } } as GroupByFormValues;
+        values.groupBy.groupings = [grouping];
+        const result = validate(values);
+
+        expect(result.groupBy.groupings[0].interval).toBe('Must be greater than 0.');
+      });
+
+      it('should add an error if value is absent', () => {
+        const grouping = { direction: 'row', field: { field: undefined }, interval: { type: 'timeunit', value: undefined, unit: 'second' } } as GroupByFormValues;
+        values.groupBy.groupings = [grouping];
+        const result = validate(values);
+
+        expect(result.groupBy.groupings[0].interval).toBe('Value is required.');
+      });
+    });
+  });
+});

--- a/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/GroupByElement.test.ts
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/GroupByElement.test.ts
@@ -75,7 +75,7 @@ describe('GroupByElement', () => {
       });
 
       it('should add an error if value is out of range', () => {
-        const grouping = { direction: 'row', field: { field: undefined }, interval: { type: 'timeunit', value: -1, unit: 'second' } } as GroupByFormValues;
+        const grouping = { direction: 'row', field: { field: undefined }, interval: { type: 'timeunit', value: -1, unit: 'seconds' } } as GroupByFormValues;
         values.groupBy.groupings = [grouping];
         const result = validate(values);
 
@@ -83,7 +83,7 @@ describe('GroupByElement', () => {
       });
 
       it('should add an error if value is absent', () => {
-        const grouping = { direction: 'row', field: { field: undefined }, interval: { type: 'timeunit', value: undefined, unit: 'second' } } as GroupByFormValues;
+        const grouping = { direction: 'row', field: { field: undefined }, interval: { type: 'timeunit', value: undefined, unit: 'seconds' } } as GroupByFormValues;
         values.groupBy.groupings = [grouping];
         const result = validate(values);
 

--- a/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/GroupByElement.ts
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/GroupByElement.ts
@@ -70,11 +70,16 @@ const groupByToPivot = (groupBy: GroupByFormValues) => {
   return new Pivot(groupBy.field, 'interval' in groupBy ? 'time' : 'values', pivotConfig);
 };
 
-const groupByToConfigWithPivots = (groupByEntires: Array<GroupByFormValues>, config: AggregationWidgetConfig) => {
-  const rowPivots = groupByEntires.filter((groupBy) => groupBy.direction === 'row').map(groupByToPivot);
-  const columnPivots = groupByEntires.filter((groupBy) => groupBy.direction === 'column').map(groupByToPivot);
+const groupByToConfig = (groupBy: WidgetConfigFormValues['groupBy'], config: AggregationWidgetConfig) => {
+  const rowPivots = groupBy.groupings.filter((grouping) => grouping.direction === 'row').map(groupByToPivot);
+  const columnPivots = groupBy.groupings.filter((grouping) => grouping.direction === 'column').map(groupByToPivot);
+  const { columnRollup } = groupBy;
 
-  return config.toBuilder().rowPivots(rowPivots).columnPivots(columnPivots).build();
+  return config.toBuilder()
+    .rowPivots(rowPivots)
+    .columnPivots(columnPivots)
+    .rollup(columnRollup)
+    .build();
 };
 
 const GroupByElement: AggregationElement = {
@@ -88,9 +93,12 @@ const GroupByElement: AggregationElement = {
     limit: 15,
   }),
   fromConfig: (config: AggregationWidgetConfig) => ({
-    groupBy: pivotsToGroupBy(config),
+    groupBy: {
+      columnRollup: config.rollup,
+      groupings: pivotsToGroupBy(config),
+    },
   }),
-  toConfig: (formValues: WidgetConfigFormValues, config: AggregationWidgetConfig) => groupByToConfigWithPivots(formValues.groupBy, config),
+  toConfig: (formValues: WidgetConfigFormValues, config: AggregationWidgetConfig) => groupByToConfig(formValues.groupBy, config),
   component: GroupByConfiguration,
 };
 

--- a/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/GroupByElement.ts
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/GroupByElement.ts
@@ -16,12 +16,26 @@
  */
 import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
 import Pivot from 'views/logic/aggregationbuilder/Pivot';
-import type { DatePivotConfig, ValuesPivotConfig } from 'views/logic/aggregationbuilder/Pivot';
 
 import type { AggregationElement } from './AggregationElementType';
 
 import type { GroupingDirection, DateGrouping, ValuesGrouping, GroupByFormValues, WidgetConfigFormValues } from '../WidgetConfigForm';
 import GroupByConfiguration from '../elementConfiguration/GroupByConfiguration';
+
+export type DatePivotConfig = {
+  interval: {
+    type: 'auto',
+    scaling: number
+  } | {
+    type: 'timeunit',
+    value: number,
+    unit: string
+  }
+}
+
+export type ValuesPivotConfig = {
+  limit: number
+}
 
 const datePivotToGrouping = (pivot: Pivot, direction: GroupingDirection): DateGrouping => {
   const { field, config } = pivot;

--- a/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/GroupByElement.ts
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/GroupByElement.ts
@@ -19,7 +19,13 @@ import Pivot, { TimeConfigType, ValuesConfigType } from 'views/logic/aggregation
 
 import type { AggregationElement } from './AggregationElementType';
 
-import type { GroupingDirection, DateGrouping, ValuesGrouping, GroupByFormValues, WidgetConfigFormValues } from '../WidgetConfigForm';
+import type {
+  DateGrouping,
+  GroupByFormValues,
+  GroupingDirection,
+  ValuesGrouping,
+  WidgetConfigFormValues,
+} from '../WidgetConfigForm';
 import GroupByConfiguration from '../elementConfiguration/GroupByConfiguration';
 
 type GroupByError = {
@@ -59,7 +65,7 @@ const validateDateGrouping = (grouping: DateGrouping): GroupByError => {
 };
 
 const validateValuesGrouping = (grouping: ValuesGrouping): GroupByError => {
-  const groupByError = {} as GroupByError;
+  const groupByError: GroupByError = {};
 
   if (!grouping.field?.field) {
     groupByError.field = 'Field is required.';
@@ -82,14 +88,10 @@ const hasErrors = <T extends {}>(errors: Array<T>): boolean => {
 
 const validateGrouping = (grouping: GroupByFormValues): GroupByError => {
   if ('interval' in grouping) {
-    const dateGrouping = grouping as DateGrouping;
-
-    return validateDateGrouping(dateGrouping);
+    return validateDateGrouping(grouping);
   }
 
-  const valuesGrouping = grouping as ValuesGrouping;
-
-  return validateValuesGrouping(valuesGrouping);
+  return validateValuesGrouping(grouping);
 };
 
 const validateGroupBy = (values: WidgetConfigFormValues) => {

--- a/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/GroupByElement.ts
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/GroupByElement.ts
@@ -82,6 +82,11 @@ const GroupByElement: AggregationElement = {
   key: 'groupBy',
   order: 1,
   allowCreate: () => true,
+  createEmpty: (): GroupByFormValues => ({
+    direction: 'row',
+    field: undefined,
+    limit: 15,
+  }),
   fromConfig: (config: AggregationWidgetConfig) => ({
     groupBy: pivotsToGroupBy(config),
   }),

--- a/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/GroupByElement.ts
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/GroupByElement.ts
@@ -40,36 +40,33 @@ export type ValuesPivotConfig = {
 type GroupByError = {
   field?: string,
   limit?: string,
-  interval?: {
-    scaling?: string,
-    value?: string,
-  },
+  interval?: string,
 };
 
 const validateDateGrouping = (grouping: DateGrouping): GroupByError => {
   const groupByError = {} as GroupByError;
 
   if (!grouping.field?.field) {
-    groupByError.field = 'Field is required';
+    groupByError.field = 'Field is required.';
   }
 
   if (grouping.interval.type === 'auto') {
     if (!grouping.interval.scaling) {
-      groupByError.interval.scaling = 'Scaling is required.';
+      groupByError.interval = 'Scaling is required.';
     }
 
     if (grouping.interval.scaling && (grouping.interval.scaling <= 0 || grouping.interval.scaling >= 10)) {
-      groupByError.interval.scaling = 'Scaling is out of range.';
+      groupByError.interval = 'Must be greater than 0 and smaller or equals 10.';
     }
   }
 
   if (grouping.interval.type === 'timeunit') {
     if (!grouping.interval.value) {
-      groupByError.interval.value = 'Value is required.';
+      groupByError.interval = 'Value is required.';
     }
 
     if (grouping.interval.value && grouping.interval.value <= 0) {
-      groupByError.interval.value = 'Value must be greater than 0.';
+      groupByError.interval = 'Must be greater than 0.';
     }
   }
 

--- a/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/GroupByElement.ts
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/GroupByElement.ts
@@ -15,28 +15,12 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
-import { TimeUnits } from 'views/Constants';
-import Pivot from 'views/logic/aggregationbuilder/Pivot';
+import Pivot, { TimeConfigType, ValuesConfigType } from 'views/logic/aggregationbuilder/Pivot';
 
 import type { AggregationElement } from './AggregationElementType';
 
 import type { GroupingDirection, DateGrouping, ValuesGrouping, GroupByFormValues, WidgetConfigFormValues } from '../WidgetConfigForm';
 import GroupByConfiguration from '../elementConfiguration/GroupByConfiguration';
-
-export type DatePivotConfig = {
-  interval: {
-    type: 'auto',
-    scaling: number
-  } | {
-    type: 'timeunit',
-    value: number,
-    unit: keyof typeof TimeUnits,
-  }
-}
-
-export type ValuesPivotConfig = {
-  limit: number
-}
 
 type GroupByError = {
   field?: string,
@@ -124,7 +108,7 @@ const validateGroupBy = (values: WidgetConfigFormValues) => {
 const datePivotToGrouping = (pivot: Pivot, direction: GroupingDirection): DateGrouping => {
   const { field, config } = pivot;
 
-  const { interval } = config as DatePivotConfig;
+  const { interval } = config as TimeConfigType;
 
   return ({
     direction,
@@ -135,7 +119,7 @@ const datePivotToGrouping = (pivot: Pivot, direction: GroupingDirection): DateGr
 
 const valuesPivotToGrouping = (pivot: Pivot, direction: GroupingDirection): ValuesGrouping => {
   const { field, config } = pivot;
-  const { limit } = config as ValuesPivotConfig;
+  const { limit } = config as ValuesConfigType;
 
   return ({
     direction,

--- a/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/GroupByElement.ts
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/GroupByElement.ts
@@ -111,9 +111,15 @@ const GroupByElement: AggregationElement = {
   key: 'groupBy',
   order: 1,
   allowCreate: () => true,
-  createEmpty: (): WidgetConfigFormValues['groupBy'] => ({
-    columnRollup: true,
-    groupings: [emptyGrouping],
+  addEmptyElement: (formValues: WidgetConfigFormValues): WidgetConfigFormValues => ({
+    ...formValues,
+    groupBy: {
+      columnRollup: 'columnRollup' in formValues.groupBy ? formValues.groupBy.columnRollup : true,
+      groupings: [
+        ...formValues.groupBy.groupings,
+        emptyGrouping,
+      ],
+    },
   }),
   fromConfig: (config: AggregationWidgetConfig) => ({
     groupBy: {

--- a/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/GroupByElement.ts
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/GroupByElement.ts
@@ -14,15 +14,91 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
+import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
+import Pivot from 'views/logic/aggregationbuilder/Pivot';
+import type { DatePivotConfig, ValuesPivotConfig } from 'views/logic/aggregationbuilder/Pivot';
+
 import type { AggregationElement } from './AggregationElementType';
 
 import GroupByConfiguration from '../elementConfiguration/GroupByConfiguration';
+
+type Direction = 'row' | 'column';
+
+type DateGroupBy = {
+  direction: Direction,
+  field: string,
+  type: 'time',
+  interval: {
+    type: 'auto',
+    scaling: number,
+  } | {
+    type: 'timeunit',
+    value: number,
+    unit: string,
+  }
+
+}
+
+type ValuesGroupBy = {
+  direction: Direction,
+  field: string,
+  type: 'values',
+  limit: number,
+}
+
+type GroupByEntry = DateGroupBy | ValuesGroupBy;
+
+const datePivotToGroupBy = (pivot: Pivot, direction: Direction): DateGroupBy => {
+  const { field, config } = pivot;
+  const { interval } = config as DatePivotConfig;
+
+  return ({
+    type: 'time',
+    field,
+    direction,
+    interval,
+  });
+};
+
+const valuesPivotToGroupBy = (pivot: Pivot, direction: Direction): ValuesGroupBy => {
+  const { field, config } = pivot;
+  const { limit } = config as ValuesPivotConfig;
+
+  return ({
+    type: 'values',
+    field,
+    direction,
+    limit,
+  });
+};
+
+const pivotToGroupBy = (pivot: Pivot, direction: Direction): GroupByEntry => {
+  if (pivot.type === 'time') {
+    return datePivotToGroupBy(pivot, direction);
+  }
+
+  if (pivot.type === 'values') {
+    return valuesPivotToGroupBy(pivot, direction);
+  }
+
+  throw new Error(`Widget has not supported pivot type "${pivot.type}"`);
+};
+
+const pivotsToGroupBy = (config: AggregationWidgetConfig) => {
+  const transformedRowPivots = config.rowPivots.map((pivot) => pivotToGroupBy(pivot, 'row'));
+  const transformedColumnPivots = config.columnPivots.map((pivot) => pivotToGroupBy(pivot, 'column'));
+
+  return [...transformedRowPivots, ...transformedColumnPivots];
+};
 
 const GroupByElement: AggregationElement = {
   title: 'Group By',
   key: 'groupBy',
   order: 1,
   allowCreate: () => true,
+  fromConfig: (config: AggregationWidgetConfig) => ({
+    groupBy: pivotsToGroupBy(config),
+  }),
   component: GroupByConfiguration,
 };
 

--- a/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/GroupByElement.ts
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/GroupByElement.ts
@@ -15,6 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
+import { TimeUnits } from 'views/Constants';
 import Pivot from 'views/logic/aggregationbuilder/Pivot';
 
 import type { AggregationElement } from './AggregationElementType';
@@ -29,7 +30,7 @@ export type DatePivotConfig = {
   } | {
     type: 'timeunit',
     value: number,
-    unit: string
+    unit: keyof typeof TimeUnits,
   }
 }
 

--- a/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/MetricElement.ts
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/MetricElement.ts
@@ -95,10 +95,10 @@ const MetricElement: AggregationElement = {
   key: 'metrics',
   order: 2,
   allowCreate: () => true,
-  fromConfig: (providedConfig: AggregationWidgetConfig) => ({
-    metrics: seriesToMetrics(providedConfig.series),
+  fromConfig: (config: AggregationWidgetConfig) => ({
+    metrics: seriesToMetrics(config.series),
   }),
-  toConfig: (formValues: WidgetConfigFormValues, currentConfig: AggregationWidgetConfig) => currentConfig
+  toConfig: (formValues: WidgetConfigFormValues, config: AggregationWidgetConfig) => config
     .toBuilder()
     .series(metricsToSeries(formValues.metrics))
     .build(),

--- a/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/FieldSelect.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/FieldSelect.tsx
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import { useContext } from 'react';
+
+import { defaultCompare } from 'views/logic/DefaultCompare';
+import FieldTypesContext from 'views/components/contexts/FieldTypesContext';
+import { Input } from 'components/bootstrap';
+import Select from 'components/common/Select';
+
+type Props = {
+  ariaLabel?: string,
+  clearable?: boolean,
+  error?: string,
+  id: string,
+  label: string,
+  name: string,
+  onChange: (changeEvent: { target: { name: string, value: string } }) => void,
+  value: string | undefined,
+}
+
+const sortByLabel = ({ label: label1 }: { label: string }, { label: label2 }: { label: string }) => defaultCompare(label1, label2);
+
+const FieldSelect = ({ name, id, error, clearable, value, onChange, label, ariaLabel }: Props) => {
+  const fieldTypes = useContext(FieldTypesContext);
+  const fieldTypeOptions = fieldTypes.all.map((fieldType) => ({ label: fieldType.name, value: fieldType.name })).toArray().sort(sortByLabel);
+
+  return (
+    <Input id={id}
+           label={label}
+           error={error}
+           labelClassName="col-sm-3"
+           wrapperClassName="col-sm-9">
+      <Select options={fieldTypeOptions}
+              clearable={clearable}
+              name={name}
+              value={value}
+              aria-label={ariaLabel}
+              onChange={(newValue) => onChange({ target: { name, value: newValue } })} />
+    </Input>
+
+  );
+};
+
+FieldSelect.defaultProps = {
+  clearable: false,
+  error: undefined,
+  ariaLabel: undefined,
+};
+
+export default FieldSelect;

--- a/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/GroupBy.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/GroupBy.tsx
@@ -1,0 +1,193 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import { useMemo, useContext } from 'react';
+import styled from 'styled-components';
+import { Field, useFormikContext } from 'formik';
+
+import { TimeUnits } from 'views/Constants';
+import { Icon, FormikFormGroup } from 'components/common';
+import { FormControl, Checkbox, DropdownButton, HelpBlock, MenuItem, InputGroup } from 'components/graylog';
+import { WidgetConfigFormValues } from 'views/components/aggregationwizard/WidgetConfigForm';
+import { Input } from 'components/bootstrap';
+import FieldTypesContext from 'views/components/contexts/FieldTypesContext';
+
+import FieldSelect from './FieldSelect';
+
+const Wrapper = styled.div``;
+
+const RangeSelect = styled.div`
+  display: flex;
+  align-items: center;
+`;
+
+const DirectionOptions = styled.div`
+  display: flex;
+
+  div:first-child {
+    margin-right: 5px;
+  }
+`;
+
+const CurrentScale = styled.div`
+  min-width: 30px;
+  margin-left: 5px;
+  text-align: right;
+`;
+
+const TypeCheckboxWrapper = styled.div`
+  margin-bottom: 5px;
+`;
+
+type Props = {
+  index: number,
+}
+
+const GroupBy = ({ index }: Props) => {
+  const { values: { groupBy } } = useFormikContext<WidgetConfigFormValues>();
+  const selectedFieldName = groupBy[index].field;
+  const fieldTypes = useContext(FieldTypesContext);
+
+  const selectedField = useMemo(() => fieldTypes.all.find((field) => field.value.name === selectedFieldName), [selectedFieldName, fieldTypes.all]);
+
+  const isDateField = selectedField.type.type === 'date';
+
+  const toggleIntervalType = (name, currentType, onChange) => {
+    if (currentType === 'auto') {
+      onChange({ target: { name, value: { type: 'timeunit', value: 1, unit: 'minutes' } } });
+    } else {
+      onChange({ target: { name, value: { type: 'auto', scaling: 1.0 } } });
+    }
+  };
+
+  return (
+    <Wrapper>
+      <Field name={`groupBy.${index}.direction`}>
+        {({ field: { name, value, onChange, onBlur }, meta: { error } }) => (
+          <Input id="group-by-direction"
+                 label="Direction"
+                 error={error}
+                 labelClassName="col-sm-3"
+                 wrapperClassName="col-sm-9">
+            <DirectionOptions>
+              <Input defaultChecked={value === 'row'}
+                     formGroupClassName=""
+                     id={name}
+                     label="Row"
+                     onBlur={onBlur}
+                     onChange={onChange}
+                     type="radio"
+                     value="row" />
+              <Input defaultChecked={value === 'column'}
+                     formGroupClassName=""
+                     id={name}
+                     label="Column"
+                     onBlur={onBlur}
+                     onChange={onChange}
+                     type="radio"
+                     value="column" />
+            </DirectionOptions>
+          </Input>
+        )}
+      </Field>
+
+      <Field name={`groupBy.${index}.field`}>
+        {({ field: { name, value, onChange }, meta: { error } }) => (
+          <FieldSelect id="group-by-field-select"
+                       label="Field"
+                       onChange={onChange}
+                       error={error}
+                       clearable={false}
+                       name={name}
+                       value={value}
+                       aria-label="Select a field" />
+        )}
+      </Field>
+
+      {isDateField && (
+        <Field name={`groupBy.${index}.interval`}>
+          {({ field: { name, value, onChange }, meta: { error } }) => {
+            console.log({ value });
+
+            return (
+              <Input id="group-by-interval"
+                     label="Interval"
+                     error={error}
+                     labelClassName="col-sm-3"
+                     wrapperClassName="col-sm-9">
+                <TypeCheckboxWrapper>
+                  <Checkbox onChange={() => toggleIntervalType(name, value.type, onChange)}
+                            checked={value.type === 'auto'}>
+                    Auto
+                  </Checkbox>
+                </TypeCheckboxWrapper>
+
+                {value.type === 'auto' && (
+                  <>
+                    <RangeSelect>
+                      <Icon name="search-minus" size="lg" style={{ paddingRight: '0.5rem' }} />
+                      <FormControl type="range"
+                                   style={{ padding: 0, border: 0 }}
+                                   min={0.5}
+                                   max={10}
+                                   step={0.5}
+                                   value={value.scaling ? (1 / value.scaling) : 1.0}
+                                   onChange={(e) => { console.log(e.target.value, value); onChange({ target: { name, value: { ...value, scaling: 1 / parseFloat(e.target.value) } } }); }} />
+                      <Icon name="search-plus" size="lg" style={{ paddingLeft: '0.5rem' }} />
+                      <CurrentScale>
+                        {value.scaling ? (1 / value.scaling) : 1.0}x
+                      </CurrentScale>
+                    </RangeSelect>
+                    <HelpBlock className="no-bm">
+                      A smaller granularity leads to <strong>less</strong>, a bigger to <strong>more</strong> values.
+                    </HelpBlock>
+                  </>
+                )}
+                {value.type !== 'auto' && (
+                  <>
+                    <InputGroup>
+                      <FormControl type="number"
+                                   value={value.value}
+                                   step="1"
+                                   min="1"
+                                   onChange={(e) => onChange({ target: { name, value: { ...value, value: e.target.value } } })} />
+                      <InputGroup.Button>
+                        <DropdownButton id="input-dropdown-addon"
+                                        title={TimeUnits[value.unit] || ''}>
+                          {Object.keys(TimeUnits).map((unit) => <MenuItem key={unit} onSelect={() => onChange({ target: { name, value: { ...value, unit } } })}>{TimeUnits[unit]}</MenuItem>)}
+                        </DropdownButton>
+                      </InputGroup.Button>
+                    </InputGroup>
+                    <HelpBlock className="no-bm">
+                      The size of the buckets for this timestamp type.
+                    </HelpBlock>
+                  </>
+                )}
+              </Input>
+            );
+          }}
+        </Field>
+      )}
+
+      {!isDateField && (
+        <FormikFormGroup label="Limit" name={`groupBy.${index}.limit`} type="number" />
+      )}
+    </Wrapper>
+  );
+};
+
+export default GroupBy;

--- a/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/GroupBy.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/GroupBy.tsx
@@ -137,6 +137,7 @@ const GroupBy = ({ index }: Props) => {
                        onChange={(e) => onChangeField(e, name, onChange)}
                        error={error}
                        clearable={false}
+                       ariaLabel="Field"
                        name={name}
                        value={value.field}
                        aria-label="Select a field" />

--- a/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/GroupBy.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/GroupBy.tsx
@@ -59,7 +59,7 @@ type Props = {
 
 const GroupBy = ({ index }: Props) => {
   const { values: { groupBy } } = useFormikContext<WidgetConfigFormValues>();
-  const selectedFieldName = groupBy[index].field;
+  const selectedFieldName = groupBy.groupings[index].field;
   const fieldTypes = useContext(FieldTypesContext);
 
   const selectedField = useMemo(() => fieldTypes.all.find((field) => field.value.name === selectedFieldName), [selectedFieldName, fieldTypes.all]);
@@ -76,7 +76,7 @@ const GroupBy = ({ index }: Props) => {
 
   return (
     <Wrapper>
-      <Field name={`groupBy.${index}.direction`}>
+      <Field name={`groupBy.groupings.${index}.direction`}>
         {({ field: { name, value, onChange, onBlur }, meta: { error } }) => (
           <Input id="group-by-direction"
                  label="Direction"
@@ -105,7 +105,7 @@ const GroupBy = ({ index }: Props) => {
         )}
       </Field>
 
-      <Field name={`groupBy.${index}.field`}>
+      <Field name={`groupBy.groupings.${index}.field`}>
         {({ field: { name, value, onChange }, meta: { error } }) => (
           <FieldSelect id="group-by-field-select"
                        label="Field"
@@ -119,72 +119,68 @@ const GroupBy = ({ index }: Props) => {
       </Field>
 
       {isDateField && (
-        <Field name={`groupBy.${index}.interval`}>
-          {({ field: { name, value, onChange }, meta: { error } }) => {
-            console.log({ value });
+        <Field name={`groupBy.groupings.${index}.interval`}>
+          {({ field: { name, value, onChange }, meta: { error } }) => (
+            <Input id="group-by-interval"
+                   label="Interval"
+                   error={error}
+                   labelClassName="col-sm-3"
+                   wrapperClassName="col-sm-9">
+              <TypeCheckboxWrapper>
+                <Checkbox onChange={() => toggleIntervalType(name, value.type, onChange)}
+                          checked={value.type === 'auto'}>
+                  Auto
+                </Checkbox>
+              </TypeCheckboxWrapper>
 
-            return (
-              <Input id="group-by-interval"
-                     label="Interval"
-                     error={error}
-                     labelClassName="col-sm-3"
-                     wrapperClassName="col-sm-9">
-                <TypeCheckboxWrapper>
-                  <Checkbox onChange={() => toggleIntervalType(name, value.type, onChange)}
-                            checked={value.type === 'auto'}>
-                    Auto
-                  </Checkbox>
-                </TypeCheckboxWrapper>
-
-                {value.type === 'auto' && (
-                  <>
-                    <RangeSelect>
-                      <Icon name="search-minus" size="lg" style={{ paddingRight: '0.5rem' }} />
-                      <FormControl type="range"
-                                   style={{ padding: 0, border: 0 }}
-                                   min={0.5}
-                                   max={10}
-                                   step={0.5}
-                                   value={value.scaling ? (1 / value.scaling) : 1.0}
-                                   onChange={(e) => onChange({ target: { name, value: { ...value, scaling: 1 / parseFloat(e.target.value) } } })} />
-                      <Icon name="search-plus" size="lg" style={{ paddingLeft: '0.5rem' }} />
-                      <CurrentScale>
-                        {value.scaling ? (1 / value.scaling) : 1.0}x
-                      </CurrentScale>
-                    </RangeSelect>
-                    <HelpBlock className="no-bm">
-                      A smaller granularity leads to <strong>less</strong>, a bigger to <strong>more</strong> values.
-                    </HelpBlock>
-                  </>
-                )}
-                {value.type !== 'auto' && (
-                  <>
-                    <InputGroup>
-                      <FormControl type="number"
-                                   value={value.value}
-                                   step="1"
-                                   min="1"
-                                   onChange={(e) => onChange({ target: { name, value: { ...value, value: e.target.value } } })} />
-                      <InputGroup.Button>
-                        <DropdownButton id="input-dropdown-addon"
-                                        title={TimeUnits[value.unit] || ''}>
-                          {Object.keys(TimeUnits).map((unit) => <MenuItem key={unit} onSelect={() => onChange({ target: { name, value: { ...value, unit } } })}>{TimeUnits[unit]}</MenuItem>)}
-                        </DropdownButton>
-                      </InputGroup.Button>
-                    </InputGroup>
-                    <HelpBlock className="no-bm">
-                      The size of the buckets for this timestamp type.
-                    </HelpBlock>
-                  </>
-                )}
-              </Input>
-            );
-          }}
+              {value.type === 'auto' && (
+                <>
+                  <RangeSelect>
+                    <Icon name="search-minus" size="lg" style={{ paddingRight: '0.5rem' }} />
+                    <FormControl type="range"
+                                 style={{ padding: 0, border: 0 }}
+                                 min={0.5}
+                                 max={10}
+                                 step={0.5}
+                                 value={value.scaling ? (1 / value.scaling) : 1.0}
+                                 onChange={(e) => onChange({ target: { name, value: { ...value, scaling: 1 / parseFloat(e.target.value) } } })} />
+                    <Icon name="search-plus" size="lg" style={{ paddingLeft: '0.5rem' }} />
+                    <CurrentScale>
+                      {value.scaling ? (1 / value.scaling) : 1.0}x
+                    </CurrentScale>
+                  </RangeSelect>
+                  <HelpBlock className="no-bm">
+                    A smaller granularity leads to <strong>less</strong>, a bigger to <strong>more</strong> values.
+                  </HelpBlock>
+                </>
+              )}
+              {value.type !== 'auto' && (
+                <>
+                  <InputGroup>
+                    <FormControl type="number"
+                                 value={value.value}
+                                 step="1"
+                                 min="1"
+                                 onChange={(e) => onChange({ target: { name, value: { ...value, value: e.target.value } } })} />
+                    <InputGroup.Button>
+                      <DropdownButton id="input-dropdown-addon"
+                                      title={TimeUnits[value.unit] || ''}>
+                        {Object.keys(TimeUnits).map((unit) => <MenuItem key={unit} onSelect={() => onChange({ target: { name, value: { ...value, unit } } })}>{TimeUnits[unit]}</MenuItem>)}
+                      </DropdownButton>
+                    </InputGroup.Button>
+                  </InputGroup>
+                  <HelpBlock className="no-bm">
+                    The size of the buckets for this timestamp type.
+                  </HelpBlock>
+                </>
+              )}
+            </Input>
+          )}
         </Field>
       )}
 
       {!isDateField && (
-        <FormikFormGroup label="Limit" name={`groupBy.${index}.limit`} type="number" />
+        <FormikFormGroup label="Limit" name={`groupBy.groupings.${index}.limit`} type="number" />
       )}
     </Wrapper>
   );

--- a/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/GroupBy.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/GroupBy.tsx
@@ -15,196 +15,31 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { useContext } from 'react';
 import styled from 'styled-components';
-import { Field, useFormikContext } from 'formik';
+import { useFormikContext } from 'formik';
 
-import { TimeUnits } from 'views/Constants';
-import { Icon, FormikFormGroup } from 'components/common';
-import { FormControl, Checkbox, DropdownButton, HelpBlock, MenuItem, InputGroup } from 'components/graylog';
+import { FormikFormGroup } from 'components/common';
 import { WidgetConfigFormValues } from 'views/components/aggregationwizard/WidgetConfigForm';
-import { Input } from 'components/bootstrap';
-import FieldTypesContext from 'views/components/contexts/FieldTypesContext';
 
-import FieldSelect from './FieldSelect';
+import Direction from './GroupBy/Direction';
+import FieldComponent from './GroupBy/FieldComponent';
+import Time from './GroupBy/Time';
 
 const Wrapper = styled.div``;
-
-const RangeSelect = styled.div`
-  display: flex;
-  align-items: center;
-`;
-
-const DirectionOptions = styled.div`
-  display: flex;
-
-  div:first-child {
-    margin-right: 5px;
-  }
-`;
-
-const CurrentScale = styled.div`
-  min-width: 30px;
-  margin-left: 5px;
-  text-align: right;
-`;
-
-const TypeCheckboxWrapper = styled.div`
-  margin-bottom: 5px;
-`;
 
 type Props = {
   index: number,
 }
 
 const GroupBy = ({ index }: Props) => {
-  const { values: { groupBy }, setFieldValue } = useFormikContext<WidgetConfigFormValues>();
+  const { values: { groupBy } } = useFormikContext<WidgetConfigFormValues>();
   const fieldType = groupBy.groupings[index].field.type;
-  const fieldTypes = useContext(FieldTypesContext);
-
-  const toggleIntervalType = (name, currentType, onChange) => {
-    if (currentType === 'auto') {
-      onChange({ target: { name, value: { type: 'timeunit', value: 1, unit: 'minutes' } } });
-    } else {
-      onChange({ target: { name, value: { type: 'auto', scaling: 1.0 } } });
-    }
-  };
-
-  const onChangeField = (e, name, onChange) => {
-    const fieldName = e.target.value;
-    const newField = fieldTypes.all.find((field) => field.name === fieldName);
-    const newFieldType = newField?.type.type === 'date' ? 'time' : 'values';
-
-    if (fieldType !== newFieldType) {
-      if (newFieldType === 'time') {
-        setFieldValue(`groupBy.groupings.${index}.interval`, {
-          type: 'auto',
-          scaling: 1.0,
-        });
-      }
-
-      if (newFieldType === 'values') {
-        setFieldValue(`groupBy.groupings.${index}.limit`, 15);
-      }
-    }
-
-    onChange({
-      target: {
-        name,
-        value: {
-          field: newField.name,
-          type: newFieldType,
-        },
-      },
-    });
-  };
 
   return (
     <Wrapper>
-      <Field name={`groupBy.groupings.${index}.direction`}>
-        {({ field: { name, value, onChange, onBlur }, meta: { error } }) => (
-          <Input id="group-by-direction"
-                 label="Direction"
-                 error={error}
-                 labelClassName="col-sm-3"
-                 wrapperClassName="col-sm-9">
-            <DirectionOptions>
-              <Input defaultChecked={value === 'row'}
-                     formGroupClassName=""
-                     id={name}
-                     label="Row"
-                     onBlur={onBlur}
-                     onChange={onChange}
-                     type="radio"
-                     value="row" />
-              <Input defaultChecked={value === 'column'}
-                     formGroupClassName=""
-                     id={name}
-                     label="Column"
-                     onBlur={onBlur}
-                     onChange={onChange}
-                     type="radio"
-                     value="column" />
-            </DirectionOptions>
-          </Input>
-        )}
-      </Field>
-
-      <Field name={`groupBy.groupings.${index}.field`}>
-        {({ field: { name, value, onChange }, meta: { error } }) => (
-          <FieldSelect id="group-by-field-select"
-                       label="Field"
-                       onChange={(e) => onChangeField(e, name, onChange)}
-                       error={error}
-                       clearable={false}
-                       ariaLabel="Field"
-                       name={name}
-                       value={value.field}
-                       aria-label="Select a field" />
-        )}
-      </Field>
-
-      {fieldType === 'time' && (
-        <Field name={`groupBy.groupings.${index}.interval`}>
-          {({ field: { name, value, onChange }, meta: { error } }) => (
-            <Input id="group-by-interval"
-                   label="Interval"
-                   error={error}
-                   labelClassName="col-sm-3"
-                   wrapperClassName="col-sm-9">
-              <TypeCheckboxWrapper>
-                <Checkbox onChange={() => toggleIntervalType(name, value.type, onChange)}
-                          checked={value.type === 'auto'}>
-                  Auto
-                </Checkbox>
-              </TypeCheckboxWrapper>
-
-              {value.type === 'auto' && (
-                <>
-                  <RangeSelect>
-                    <Icon name="search-minus" size="lg" style={{ paddingRight: '0.5rem' }} />
-                    <FormControl type="range"
-                                 style={{ padding: 0, border: 0 }}
-                                 min={0.5}
-                                 max={10}
-                                 step={0.5}
-                                 value={value.scaling ? (1 / value.scaling) : 1.0}
-                                 onChange={(e) => onChange({ target: { name, value: { ...value, scaling: 1 / parseFloat(e.target.value) } } })} />
-                    <Icon name="search-plus" size="lg" style={{ paddingLeft: '0.5rem' }} />
-                    <CurrentScale>
-                      {value.scaling ? (1 / value.scaling) : 1.0}x
-                    </CurrentScale>
-                  </RangeSelect>
-                  <HelpBlock className="no-bm">
-                    A smaller granularity leads to <strong>less</strong>, a bigger to <strong>more</strong> values.
-                  </HelpBlock>
-                </>
-              )}
-              {value.type !== 'auto' && (
-                <>
-                  <InputGroup>
-                    <FormControl type="number"
-                                 value={value.value}
-                                 step="1"
-                                 min="1"
-                                 onChange={(e) => onChange({ target: { name, value: { ...value, value: e.target.value } } })} />
-                    <InputGroup.Button>
-                      <DropdownButton id="input-dropdown-addon"
-                                      title={TimeUnits[value.unit] || ''}>
-                        {Object.keys(TimeUnits).map((unit) => <MenuItem key={unit} onSelect={() => onChange({ target: { name, value: { ...value, unit } } })}>{TimeUnits[unit]}</MenuItem>)}
-                      </DropdownButton>
-                    </InputGroup.Button>
-                  </InputGroup>
-                  <HelpBlock className="no-bm">
-                    The size of the buckets for this timestamp type.
-                  </HelpBlock>
-                </>
-              )}
-            </Input>
-          )}
-        </Field>
-      )}
-
+      <Direction index={index} />
+      <FieldComponent index={index} fieldType={fieldType} />
+      {fieldType === 'time' && (<Time index={index} />)}
       {fieldType === 'values' && (
         <FormikFormGroup label="Limit" name={`groupBy.groupings.${index}.limit`} type="number" />
       )}

--- a/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/GroupBy.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/GroupBy.tsx
@@ -79,6 +79,7 @@ const GroupBy = ({ index }: Props) => {
       if (newFieldType === 'time') {
         setFieldValue(`groupBy.groupings.${index}.interval`, {
           type: 'auto',
+          scaling: 1.0,
         });
       }
 

--- a/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/GroupBy.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/GroupBy.tsx
@@ -64,7 +64,7 @@ const GroupBy = ({ index }: Props) => {
 
   const selectedField = useMemo(() => fieldTypes.all.find((field) => field.value.name === selectedFieldName), [selectedFieldName, fieldTypes.all]);
 
-  const isDateField = selectedField.type.type === 'date';
+  const isDateField = selectedField?.type.type === 'date';
 
   const toggleIntervalType = (name, currentType, onChange) => {
     if (currentType === 'auto') {
@@ -146,7 +146,7 @@ const GroupBy = ({ index }: Props) => {
                                    max={10}
                                    step={0.5}
                                    value={value.scaling ? (1 / value.scaling) : 1.0}
-                                   onChange={(e) => { console.log(e.target.value, value); onChange({ target: { name, value: { ...value, scaling: 1 / parseFloat(e.target.value) } } }); }} />
+                                   onChange={(e) => onChange({ target: { name, value: { ...value, scaling: 1 / parseFloat(e.target.value) } } })} />
                       <Icon name="search-plus" size="lg" style={{ paddingLeft: '0.5rem' }} />
                       <CurrentScale>
                         {value.scaling ? (1 / value.scaling) : 1.0}x

--- a/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/GroupBy/Direction.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/GroupBy/Direction.tsx
@@ -21,11 +21,11 @@ import { Field } from 'formik';
 import { Input } from 'components/bootstrap';
 
 const DirectionOptions = styled.div`
-  display: flex;
+display: flex;
 
-  div:first-child {
-    margin-right: 5px;
-  }
+div:first-child {
+  margin-right: 5px;
+}
 `;
 
 type Props = {

--- a/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/GroupBy/Direction.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/GroupBy/Direction.tsx
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import styled from 'styled-components';
+import { Field } from 'formik';
+
+import { Input } from 'components/bootstrap';
+
+const DirectionOptions = styled.div`
+  display: flex;
+
+  div:first-child {
+    margin-right: 5px;
+  }
+`;
+
+type Props = {
+  index: number,
+};
+
+const Direction = ({ index }: Props) => (
+  <Field name={`groupBy.groupings.${index}.direction`}>
+    {({ field: { name, value, onChange, onBlur }, meta: { error } }) => (
+      <Input id="group-by-direction"
+             label="Direction"
+             error={error}
+             labelClassName="col-sm-3"
+             wrapperClassName="col-sm-9">
+        <DirectionOptions>
+          <Input defaultChecked={value === 'row'}
+                 formGroupClassName=""
+                 id={name}
+                 label="Row"
+                 onBlur={onBlur}
+                 onChange={onChange}
+                 type="radio"
+                 value="row" />
+          <Input defaultChecked={value === 'column'}
+                 formGroupClassName=""
+                 id={name}
+                 label="Column"
+                 onBlur={onBlur}
+                 onChange={onChange}
+                 type="radio"
+                 value="column" />
+        </DirectionOptions>
+      </Input>
+    )}
+  </Field>
+);
+
+export default Direction;

--- a/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/GroupBy/FieldComponent.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/GroupBy/FieldComponent.tsx
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import { Field, useFormikContext } from 'formik';
+import { useContext } from 'react';
+
+import FieldSelect from 'views/components/aggregationwizard/elementConfiguration/FieldSelect';
+import FieldTypesContext from 'views/components/contexts/FieldTypesContext';
+import { WidgetConfigFormValues } from 'views/components/aggregationwizard/WidgetConfigForm';
+
+type Props = {
+  index: number,
+  fieldType: string,
+};
+
+const FieldComponent = ({ index, fieldType }: Props) => {
+  const fieldTypes = useContext(FieldTypesContext);
+  const { setFieldValue } = useFormikContext<WidgetConfigFormValues>();
+
+  const onChangeField = (e, name, onChange) => {
+    const fieldName = e.target.value;
+    const newField = fieldTypes.all.find((field) => field.name === fieldName);
+    const newFieldType = newField?.type.type === 'date' ? 'time' : 'values';
+
+    if (fieldType !== newFieldType) {
+      if (newFieldType === 'time') {
+        setFieldValue(`groupBy.groupings.${index}.interval`, {
+          type: 'auto',
+          scaling: 1.0,
+        });
+      }
+
+      if (newFieldType === 'values') {
+        setFieldValue(`groupBy.groupings.${index}.limit`, 15);
+      }
+    }
+
+    onChange({
+      target: {
+        name,
+        value: {
+          field: newField.name,
+          type: newFieldType,
+        },
+      },
+    });
+  };
+
+  return (
+    <Field name={`groupBy.groupings.${index}.field`}>
+      {({ field: { name, value, onChange }, meta: { error } }) => (
+        <FieldSelect id="group-by-field-select"
+                     label="Field"
+                     onChange={(e) => onChangeField(e, name, onChange)}
+                     error={error}
+                     clearable={false}
+                     ariaLabel="Field"
+                     name={name}
+                     value={value.field}
+                     aria-label="Select a field" />
+      )}
+    </Field>
+  );
+};
+
+export default FieldComponent;

--- a/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/GroupBy/Time.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/GroupBy/Time.tsx
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import styled from 'styled-components';
+import { Field } from 'formik';
+
+import { Icon } from 'components/common';
+import { TimeUnits } from 'views/Constants';
+import { FormControl, Checkbox, DropdownButton, HelpBlock, MenuItem, InputGroup } from 'components/graylog';
+import { Input } from 'components/bootstrap';
+
+const RangeSelect = styled.div`
+  display: flex;
+  align-items: center;
+`;
+
+const CurrentScale = styled.div`
+  min-width: 30px;
+  margin-left: 5px;
+  text-align: right;
+`;
+
+const TypeCheckboxWrapper = styled.div`
+  margin-bottom: 5px;
+`;
+
+type Props = {
+  index: number
+};
+
+const Time = ({ index }: Props) => {
+  const toggleIntervalType = (name, currentType, onChange) => {
+    if (currentType === 'auto') {
+      onChange({ target: { name, value: { type: 'timeunit', value: 1, unit: 'minutes' } } });
+    } else {
+      onChange({ target: { name, value: { type: 'auto', scaling: 1.0 } } });
+    }
+  };
+
+  return (
+    <Field name={`groupBy.groupings.${index}.interval`}>
+      {({ field: { name, value, onChange }, meta: { error } }) => (
+        <Input id="group-by-interval"
+               label="Interval"
+               error={error}
+               labelClassName="col-sm-3"
+               wrapperClassName="col-sm-9">
+          <TypeCheckboxWrapper>
+            <Checkbox onChange={() => toggleIntervalType(name, value.type, onChange)}
+                      checked={value.type === 'auto'}>
+              Auto
+            </Checkbox>
+          </TypeCheckboxWrapper>
+
+          {value.type === 'auto' && (
+            <>
+              <RangeSelect>
+                <Icon name="search-minus" size="lg" style={{ paddingRight: '0.5rem' }} />
+                <FormControl type="range"
+                             style={{ padding: 0, border: 0 }}
+                             min={0.5}
+                             max={10}
+                             step={0.5}
+                             value={value.scaling ? (1 / value.scaling) : 1.0}
+                             onChange={(e) => onChange({ target: { name, value: { ...value, scaling: 1 / parseFloat(e.target.value) } } })} />
+                <Icon name="search-plus" size="lg" style={{ paddingLeft: '0.5rem' }} />
+                <CurrentScale>
+                  {value.scaling ? (1 / value.scaling) : 1.0}x
+                </CurrentScale>
+              </RangeSelect>
+              <HelpBlock className="no-bm">
+                A smaller granularity leads to <strong>less</strong>, a bigger to <strong>more</strong> values.
+              </HelpBlock>
+            </>
+          )}
+          {value.type !== 'auto' && (
+            <>
+              <InputGroup>
+                <FormControl type="number"
+                             value={value.value}
+                             step="1"
+                             min="1"
+                             onChange={(e) => onChange({ target: { name, value: { ...value, value: e.target.value } } })} />
+                <InputGroup.Button>
+                  <DropdownButton id="input-dropdown-addon"
+                                  title={TimeUnits[value.unit] || ''}>
+                    {Object.keys(TimeUnits).map((unit) => <MenuItem key={unit} onSelect={() => onChange({ target: { name, value: { ...value, unit } } })}>{TimeUnits[unit]}</MenuItem>)}
+                  </DropdownButton>
+                </InputGroup.Button>
+              </InputGroup>
+              <HelpBlock className="no-bm">
+                The size of the buckets for this timestamp type.
+              </HelpBlock>
+            </>
+          )}
+        </Input>
+      )}
+    </Field>
+  );
+};
+
+export default Time;

--- a/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/GroupByConfiguration.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/GroupByConfiguration.tsx
@@ -48,7 +48,7 @@ const GroupByConfiguration = () => {
 
   return (
     <>
-      <FieldArray name="groupBy"
+      <FieldArray name="groupBy.groupings"
                   render={(arrayHelpers) => (
                     <>
                       <div>

--- a/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/GroupByConfiguration.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/GroupByConfiguration.tsx
@@ -24,7 +24,7 @@ import { Button, ButtonToolbar, Checkbox } from 'components/graylog';
 import ElementConfigurationSection from './ElementConfigurationSection';
 import GroupBy from './GroupBy';
 
-import GroupByElement from '../aggregationElements/GroupByElement';
+import { emptyGrouping } from '../aggregationElements/GroupByElement';
 import { WidgetConfigFormValues } from '../WidgetConfigForm';
 
 const ActionsBar = styled.div`
@@ -44,7 +44,6 @@ const RollupHoverForHelp = styled(HoverForHelp)`
 
 const GroupByConfiguration = () => {
   const { values: { groupBy } } = useFormikContext<WidgetConfigFormValues>();
-  console.log({ groupBy });
   const disableColumnRollup = !groupBy.groupings.find(({ direction }) => direction === 'column');
 
   return (
@@ -78,7 +77,7 @@ const GroupByConfiguration = () => {
                           )}
                         </Field>
                         <ButtonToolbar>
-                          <Button className="pull-right" bsSize="small" type="button" onClick={() => arrayHelpers.push(GroupByElement.createEmpty())}>
+                          <Button className="pull-right" bsSize="small" type="button" onClick={() => arrayHelpers.push(emptyGrouping)}>
                             Add Grouping
                           </Button>
                         </ButtonToolbar>

--- a/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/GroupByConfiguration.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/GroupByConfiguration.tsx
@@ -24,6 +24,7 @@ import { Button, ButtonToolbar, Checkbox } from 'components/graylog';
 import ElementConfigurationSection from './ElementConfigurationSection';
 import GroupBy from './GroupBy';
 
+import GroupByElement from '../aggregationElements/GroupByElement';
 import { WidgetConfigFormValues } from '../WidgetConfigForm';
 
 const ActionsBar = styled.div`
@@ -73,7 +74,7 @@ const GroupByConfiguration = () => {
                           </RollupColumnsLabel>
                         </Checkbox>
                         <ButtonToolbar>
-                          <Button className="pull-right" bsSize="small" type="button" onClick={() => arrayHelpers.push(defaultValues)}>
+                          <Button className="pull-right" bsSize="small" type="button" onClick={() => arrayHelpers.push(GroupByElement.createEmpty())}>
                             Add an Entry
                           </Button>
                         </ButtonToolbar>

--- a/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/GroupByConfiguration.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/GroupByConfiguration.tsx
@@ -16,17 +16,35 @@
  */
 import * as React from 'react';
 import { useFormikContext, FieldArray } from 'formik';
+import styled from 'styled-components';
 
-import { Button, ButtonToolbar } from 'components/graylog';
+import { HoverForHelp } from 'components/common';
+import { Button, ButtonToolbar, Checkbox } from 'components/graylog';
 
 import ElementConfigurationSection from './ElementConfigurationSection';
 import GroupBy from './GroupBy';
 
 import { WidgetConfigFormValues } from '../WidgetConfigForm';
 
+const ActionsBar = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+const RollupColumnsLabel = styled.div`
+  display: flex;
+  align-items: center;
+`;
+
+const RollupHoverForHelp = styled(HoverForHelp)`
+  margin-left: 5px;
+`;
+
 const GroupByConfiguration = () => {
   const { values: { groupBy } } = useFormikContext<WidgetConfigFormValues>();
   const defaultValues = { direction: 'row' };
+  const disableColumnRollup = !groupBy.find(({ direction }) => direction === 'column');
 
   return (
     <>
@@ -43,11 +61,23 @@ const GroupByConfiguration = () => {
                           );
                         })}
                       </div>
-                      <ButtonToolbar>
-                        <Button className="pull-right" bsSize="small" type="button" onClick={() => arrayHelpers.push(defaultValues)}>
-                          Add an Entry
-                        </Button>
-                      </ButtonToolbar>
+                      <ActionsBar>
+                        <Checkbox onChange={() => {}}
+                                  disabled={disableColumnRollup}
+                                  checked={false}>
+                          <RollupColumnsLabel>
+                            Rollup Columns
+                            <RollupHoverForHelp title="Rollup Columns">
+                              When rollup is enabled, an additional trace totalling individual subtraces will be included.
+                            </RollupHoverForHelp>
+                          </RollupColumnsLabel>
+                        </Checkbox>
+                        <ButtonToolbar>
+                          <Button className="pull-right" bsSize="small" type="button" onClick={() => arrayHelpers.push(defaultValues)}>
+                            Add an Entry
+                          </Button>
+                        </ButtonToolbar>
+                      </ActionsBar>
                     </>
                   )} />
     </>

--- a/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/GroupByConfiguration.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/GroupByConfiguration.tsx
@@ -15,7 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { useFormikContext, FieldArray } from 'formik';
+import { useFormikContext, FieldArray, Field } from 'formik';
 import styled from 'styled-components';
 
 import { HoverForHelp } from 'components/common';
@@ -44,8 +44,8 @@ const RollupHoverForHelp = styled(HoverForHelp)`
 
 const GroupByConfiguration = () => {
   const { values: { groupBy } } = useFormikContext<WidgetConfigFormValues>();
-  const defaultValues = { direction: 'row' };
-  const disableColumnRollup = !groupBy.find(({ direction }) => direction === 'column');
+  console.log({ groupBy });
+  const disableColumnRollup = !groupBy.groupings.find(({ direction }) => direction === 'column');
 
   return (
     <>
@@ -53,29 +53,33 @@ const GroupByConfiguration = () => {
                   render={(arrayHelpers) => (
                     <>
                       <div>
-                        {groupBy.map((groupByEntity, index) => {
+                        {groupBy.groupings.map((grouping, index) => {
                           return (
-                          // eslint-disable-next-line react/no-array-index-key
-                            <ElementConfigurationSection key={`metrics-${index}`}>
+                            // eslint-disable-next-line react/no-array-index-key
+                            <ElementConfigurationSection key={`grouping-${index}`}>
                               <GroupBy index={index} />
                             </ElementConfigurationSection>
                           );
                         })}
                       </div>
                       <ActionsBar>
-                        <Checkbox onChange={() => {}}
-                                  disabled={disableColumnRollup}
-                                  checked={false}>
-                          <RollupColumnsLabel>
-                            Rollup Columns
-                            <RollupHoverForHelp title="Rollup Columns">
-                              When rollup is enabled, an additional trace totalling individual subtraces will be included.
-                            </RollupHoverForHelp>
-                          </RollupColumnsLabel>
-                        </Checkbox>
+                        <Field name="groupBy.columnRollup">
+                          {({ field: { name, onChange, value } }) => (
+                            <Checkbox onChange={() => onChange({ target: { name, value: !groupBy.columnRollup } })}
+                                      checked={value}
+                                      disabled={disableColumnRollup}>
+                              <RollupColumnsLabel>
+                                Rollup Columns
+                                <RollupHoverForHelp title="Rollup Columns">
+                                  When rollup is enabled, an additional trace totalling individual subtraces will be included.
+                                </RollupHoverForHelp>
+                              </RollupColumnsLabel>
+                            </Checkbox>
+                          )}
+                        </Field>
                         <ButtonToolbar>
                           <Button className="pull-right" bsSize="small" type="button" onClick={() => arrayHelpers.push(GroupByElement.createEmpty())}>
-                            Add an Entry
+                            Add Grouping
                           </Button>
                         </ButtonToolbar>
                       </ActionsBar>

--- a/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/GroupByConfiguration.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/GroupByConfiguration.tsx
@@ -15,19 +15,41 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
+import { useFormikContext, FieldArray } from 'formik';
 
-import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
+import { Button, ButtonToolbar } from 'components/graylog';
 
-type Props = {
-  config: AggregationWidgetConfig,
-  onConfigChange: (newConfig: AggregationWidgetConfig) => void
-}
+import ElementConfigurationSection from './ElementConfigurationSection';
+import GroupBy from './GroupBy';
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const GroupByConfiguration = ({ config, onConfigChange }: Props) => {
+import { WidgetConfigFormValues } from '../WidgetConfigForm';
+
+const GroupByConfiguration = () => {
+  const { values: { groupBy } } = useFormikContext<WidgetConfigFormValues>();
+  const defaultValues = { direction: 'row' };
+
   return (
     <>
-      Configuration Elements
+      <FieldArray name="groupBy"
+                  render={(arrayHelpers) => (
+                    <>
+                      <div>
+                        {groupBy.map((groupByEntity, index) => {
+                          return (
+                          // eslint-disable-next-line react/no-array-index-key
+                            <ElementConfigurationSection key={`metrics-${index}`}>
+                              <GroupBy index={index} />
+                            </ElementConfigurationSection>
+                          );
+                        })}
+                      </div>
+                      <ButtonToolbar>
+                        <Button className="pull-right" bsSize="small" type="button" onClick={() => arrayHelpers.push(defaultValues)}>
+                          Add an Entry
+                        </Button>
+                      </ButtonToolbar>
+                    </>
+                  )} />
     </>
   );
 };

--- a/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/Metric.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/Metric.tsx
@@ -15,17 +15,17 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { useContext } from 'react';
 import { Field, useFormikContext } from 'formik';
 
 import { defaultCompare } from 'views/logic/DefaultCompare';
-import FieldTypesContext from 'views/components/contexts/FieldTypesContext';
 import { Input } from 'components/bootstrap';
 import Select from 'components/common/Select';
 import { useStore } from 'stores/connect';
 import AggregationFunctionsStore from 'views/stores/AggregationFunctionsStore';
 import { WidgetConfigFormValues } from 'views/components/aggregationwizard/WidgetConfigForm';
 import FormikInput from 'components/common/FormikInput';
+
+import FieldSelect from './FieldSelect';
 
 type Props = {
   index: number,
@@ -37,12 +37,10 @@ const percentileOptions = [25.0, 50.0, 75.0, 90.0, 95.0, 99.0].map((value) => ({
 
 const Metric = ({ index }: Props) => {
   const functions = useStore(AggregationFunctionsStore);
-  const fieldTypes = useContext(FieldTypesContext);
-  const fieldTypeOptions = fieldTypes.all.map((fieldType) => ({ label: fieldType.name, value: fieldType.name })).toArray().sort(sortByLabel);
   const functionOptions = Object.values(functions).map(({ type }) => ({ label: type, value: type })).sort(sortByLabel);
 
-  const { values } = useFormikContext<WidgetConfigFormValues>();
-  const currentFunction = values.metrics[index].function;
+  const { values: { metrics } } = useFormikContext<WidgetConfigFormValues>();
+  const currentFunction = metrics[index].function;
 
   const isFieldRequired = currentFunction !== 'count';
 
@@ -59,7 +57,7 @@ const Metric = ({ index }: Props) => {
 
       <Field name={`metrics.${index}.function`}>
         {({ field: { name, value, onChange }, meta: { error } }) => (
-          <Input id="function-select"
+          <Input id="metric-function-select"
                  label="Function"
                  error={error}
                  labelClassName="col-sm-3"
@@ -75,27 +73,22 @@ const Metric = ({ index }: Props) => {
           </Input>
         )}
       </Field>
-
       <Field name={`metrics.${index}.field`}>
         {({ field: { name, value, onChange }, meta: { error } }) => (
-          <Input id="field-select"
-                 label="Field"
-                 error={error}
-                 labelClassName="col-sm-3"
-                 wrapperClassName="col-sm-9">
-            <Select options={fieldTypeOptions}
-                    clearable={!isFieldRequired}
-                    name={name}
-                    value={value}
-                    aria-label="Select a field"
-                    onChange={(newValue) => onChange({ target: { name, value: newValue } })} />
-          </Input>
+          <FieldSelect id="metric-field-select"
+                       label="Field"
+                       onChange={onChange}
+                       error={error}
+                       clearable={!isFieldRequired}
+                       name={name}
+                       value={value}
+                       aria-label="Select a field" />
         )}
       </Field>
       {isPercentile && (
         <Field name={`metrics.${index}.percentile`}>
           {({ field: { name, value, onChange }, meta: { error } }) => (
-            <Input id="percentile-select"
+            <Input id="metric-percentile-select"
                    label="Percentile"
                    error={error}
                    labelClassName="col-sm-3"

--- a/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/Metric.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/Metric.tsx
@@ -82,7 +82,7 @@ const Metric = ({ index }: Props) => {
                        clearable={!isFieldRequired}
                        name={name}
                        value={value}
-                       aria-label="Select a field" />
+                       ariaLabel="Select a field" />
         )}
       </Field>
       {isPercentile && (

--- a/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/MetricsConfiguration.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/MetricsConfiguration.tsx
@@ -25,8 +25,7 @@ import Metric from './Metric';
 import { WidgetConfigFormValues } from '../WidgetConfigForm';
 
 const MetricsConfiguration = () => {
-  const { values } = useFormikContext<WidgetConfigFormValues>();
-  const { metrics } = values;
+  const { values: { metrics } } = useFormikContext<WidgetConfigFormValues>();
 
   return (
     <>

--- a/graylog2-web-interface/src/views/components/datatable/DataTable.test.tsx
+++ b/graylog2-web-interface/src/views/components/datatable/DataTable.test.tsx
@@ -51,7 +51,7 @@ describe('DataTable', () => {
   };
 
   const columnPivot = new Pivot('source', 'values', { limit: 15 });
-  const rowPivot = new Pivot('timestamp', 'time', { interval: 'auto' });
+  const rowPivot = new Pivot('timestamp', 'time', { interval: { type: 'auto', scaling: 1.0 } });
   const series = new Series('count()');
 
   const SimplifiedDataTable = (props) => (

--- a/graylog2-web-interface/src/views/components/visualizations/__tests__/XYPlot.test.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/__tests__/XYPlot.test.tsx
@@ -62,7 +62,7 @@ jest.mock('views/stores/QueriesStore');
 
 describe('XYPlot', () => {
   const currentQuery = Query.fromJSON({ id: 'dummyquery', query: {}, timerange: {}, search_types: {} });
-  const timestampPivot = new Pivot('timestamp', 'time', {});
+  const timestampPivot = new Pivot('timestamp', 'time', { interval: { type: 'auto', scaling: 1.0 } });
   const config = AggregationWidgetConfig.builder().rowPivots([timestampPivot]).build();
   const getChartColor = () => undefined;
   const setChartColor = () => ({});

--- a/graylog2-web-interface/src/views/components/visualizations/area/__tests__/AreaVisualization.test.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/area/__tests__/AreaVisualization.test.tsx
@@ -46,7 +46,7 @@ describe('AreaVisualization', () => {
     const config = AggregationWidgetConfig.builder()
       .visualization('area')
       .columnPivots([])
-      .rowPivots([Pivot.create('timestamp', 'time', { interval: { type: 'timeunit', unit: 'minutes' } })])
+      .rowPivots([Pivot.create('timestamp', 'time', { interval: { type: 'timeunit', unit: 'minutes', value: 10 } })])
       .series([Series.forFunction('avg(nf_bytes)'), Series.forFunction('sum(nf_pkts)')])
       .build();
 

--- a/graylog2-web-interface/src/views/logic/aggregationbuilder/Pivot.ts
+++ b/graylog2-web-interface/src/views/logic/aggregationbuilder/Pivot.ts
@@ -14,8 +14,28 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
+import { TimeUnits } from 'views/Constants';
 
-type ConfigType = { [key: string]: unknown };
+export type AutoTimeConfig = {
+  type: 'auto',
+  scaling: number,
+};
+
+export type TimeUnitConfig = {
+  type: 'timeunit',
+  value: number,
+  unit: keyof typeof TimeUnits,
+};
+
+export type TimeConfigType = {
+  interval: AutoTimeConfig | TimeUnitConfig,
+};
+
+export type ValuesConfigType = {
+  limit: number,
+}
+
+export type PivotConfigType = TimeConfigType | ValuesConfigType;
 
 export const DateType = 'time';
 export const ValuesType = 'values';
@@ -23,19 +43,19 @@ export const ValuesType = 'values';
 export type PivotJson = {
   field: string,
   type: string,
-  config: ConfigType,
+  config: PivotConfigType,
 };
 
 type InternalState = {
   field: string,
   type: string,
-  config: ConfigType,
+  config: PivotConfigType,
 };
 
 export default class Pivot {
   _value: InternalState;
 
-  constructor(field: string, type: string, config: ConfigType = {}) {
+  constructor(field: string, type: string, config: PivotConfigType = { limit: 15 }) {
     this._value = { field, type, config };
   }
 
@@ -51,12 +71,12 @@ export default class Pivot {
     return this._value.config;
   }
 
-  static create(field: string, type: string, config: ConfigType = {}) {
+  static create(field: string, type: string, config: PivotConfigType = { limit: 15 }) {
     return new Pivot(field, type, config);
   }
 
   static fromJSON(value: PivotJson) {
-    const { field, type, config = {} } = value;
+    const { field, type, config = { limit: 15 } } = value;
 
     return new Pivot(field, type, config);
   }

--- a/graylog2-web-interface/src/views/logic/aggregationbuilder/Pivot.ts
+++ b/graylog2-web-interface/src/views/logic/aggregationbuilder/Pivot.ts
@@ -15,22 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 
-export type DatePivotConfig = {
-  interval: {
-    type: 'auto',
-    scaling: number
-  } | {
-    type: 'timeunit',
-    value: number,
-    unit: string
-  }
-}
-
-export type ValuesPivotConfig = {
-  limit: number
-}
-
-type ConfigType = DatePivotConfig | ValuesPivotConfig;
+type ConfigType = { [key: string]: unknown };
 
 export const DateType = 'time';
 export const ValuesType = 'values';

--- a/graylog2-web-interface/src/views/logic/aggregationbuilder/Pivot.ts
+++ b/graylog2-web-interface/src/views/logic/aggregationbuilder/Pivot.ts
@@ -15,7 +15,22 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 
-type ConfigType = { [key: string]: unknown };
+export type DatePivotConfig = {
+  interval: {
+    type: 'auto',
+    scaling: number
+  } | {
+    type: 'timeunit',
+    value: number,
+    unit: string
+  }
+}
+
+export type ValuesPivotConfig = {
+  limit: number
+}
+
+type ConfigType = DatePivotConfig | ValuesPivotConfig;
 
 export const DateType = 'time';
 export const ValuesType = 'values';

--- a/graylog2-web-interface/src/views/logic/searchtypes/aggregation/PivotConfigGenerator.ts
+++ b/graylog2-web-interface/src/views/logic/searchtypes/aggregation/PivotConfigGenerator.ts
@@ -20,11 +20,11 @@ import { $Shape } from 'utility-types';
 
 import { parseSeries } from 'views/logic/aggregationbuilder/Series';
 import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
-import Pivot from 'views/logic/aggregationbuilder/Pivot';
+import Pivot, { TimeConfigType, TimeUnitConfig } from 'views/logic/aggregationbuilder/Pivot';
 import type { Definition } from 'views/logic/aggregationbuilder/Series';
 import NumberVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/NumberVisualizationConfig';
+import type { TimeUnit } from 'views/Constants';
 
-import type { TimeUnit } from '../../../Constants';
 import SortConfig from '../../aggregationbuilder/SortConfig';
 
 const mapTimeunit = (unit: TimeUnit) => {
@@ -39,39 +39,29 @@ const mapTimeunit = (unit: TimeUnit) => {
   }
 };
 
+type FormattedInterval = {
+  timeunit: string,
+  type: string,
+}
+
 type FormattedPivot = {
   type: string,
   field: string,
-  interval: {
-    timeunit: string,
-    type: string,
-  },
-};
-
-type TimeConfig = {
-  interval: 'timeunit',
-  unit: TimeUnit,
-  value: number,
-};
-
-type TimePivotConfig = {
-  interval: {
-    type: string;
-  };
+  interval: FormattedInterval,
 };
 
 const formatPivot = (pivot: Pivot): FormattedPivot => {
   const { type, field, config } = pivot;
-  const newConfig = { ...config };
+  const newConfig = { ...config } as unknown;
 
   switch (type) {
     // eslint-disable-next-line no-case-declarations
     case 'time':
-      if ((newConfig as TimePivotConfig).interval.type === 'timeunit') {
-        const { interval } = newConfig;
-        const { unit, value } = interval as TimeConfig;
+      if ((config as TimeConfigType).interval.type === 'timeunit') {
+        const { interval } = config as TimeConfigType;
 
-        newConfig.interval = { type: 'timeunit', timeunit: `${value}${mapTimeunit(unit)}` };
+        const { unit, value } = (interval as TimeUnitConfig);
+        (newConfig as { interval: FormattedInterval }).interval = { type: 'timeunit', timeunit: `${value}${mapTimeunit(unit)}` };
       }
 
       break;
@@ -81,7 +71,7 @@ const formatPivot = (pivot: Pivot): FormattedPivot => {
   return {
     type,
     field,
-    ...newConfig,
+    ...(newConfig as { interval: FormattedInterval }),
   } as FormattedPivot;
 };
 

--- a/graylog2-web-interface/src/views/logic/searchtypes/aggregation/PivotGenerator.test.ts
+++ b/graylog2-web-interface/src/views/logic/searchtypes/aggregation/PivotGenerator.test.ts
@@ -23,7 +23,7 @@ describe('PivotGenerator', () => {
   it('generates time pivot for date fields', () => {
     const result = PivotGenerator('foo', new FieldType('date', [], []));
 
-    expect(result).toEqual(new Pivot('foo', 'time', { interval: { type: 'auto' } }));
+    expect(result).toEqual(new Pivot('foo', 'time', { interval: { type: 'auto', scaling: 1.0 } }));
   });
 
   it('generates values pivot for other fields', () => {

--- a/graylog2-web-interface/src/views/logic/searchtypes/aggregation/PivotGenerator.ts
+++ b/graylog2-web-interface/src/views/logic/searchtypes/aggregation/PivotGenerator.ts
@@ -20,7 +20,7 @@ import FieldType from 'views/logic/fieldtypes/FieldType';
 export default (fieldName: string, type: FieldType) => {
   switch (type.type) {
     case 'date':
-      return new Pivot(fieldName, 'time', { interval: { type: 'auto' } });
+      return new Pivot(fieldName, 'time', { interval: { type: 'auto', scaling: 1.0 } });
     default:
       return new Pivot(fieldName, 'values', { limit: 15 });
   }

--- a/graylog2-web-interface/src/views/logic/searchtypes/aggregation/__snapshots__/PivotConfigGenerator.test.ts.snap
+++ b/graylog2-web-interface/src/views/logic/searchtypes/aggregation/__snapshots__/PivotConfigGenerator.test.ts.snap
@@ -9,6 +9,7 @@ Object {
     "row_groups": Array [
       Object {
         "field": "field",
+        "limit": 15,
         "type": "type",
       },
     ],
@@ -41,6 +42,7 @@ Object {
   "row_groups": Array [
     Object {
       "field": "field",
+      "limit": 15,
       "type": "type",
     },
   ],
@@ -62,6 +64,7 @@ Object {
     "row_groups": Array [
       Object {
         "field": "field",
+        "limit": 15,
         "type": "type",
       },
     ],
@@ -87,6 +90,7 @@ Object {
     "row_groups": Array [
       Object {
         "field": "field",
+        "limit": 15,
         "type": "type",
       },
     ],


### PR DESCRIPTION
## Description
This PR extends the new aggregation controls by:
- Implementing the components to configure the different group by options.
- When editing an existing widget, transforming the configured row & column pivots and the column rollup option for the group by form elements.
- Updating the widget config row & column pivots and column rollup option after submitting the group by settings.

Overview of the different configuration options:
![image](https://user-images.githubusercontent.com/46300478/111802167-faa93b00-88cd-11eb-8c3c-b53393eb8aff.png)

To finish this implementation we need to:
- [x] Validate the configuration options.
- [x] Test if the widget configuration is always being updated properly.
- [x] Polish the exiting group by components (mainly by splitting up `elementsConfiguration/GroupBy` in multiple components).
- [x] Find the best place for `DatePivotConfig` and `ValuesPivotConfig` in `GroupByElements`. In the past I've added and used them in `Pivot.ts` but this would require many changes in other files.
- [x] Write tests for the new functionality, similar to `__tests__/AggregationWizard.metric.test`
- [x] Check if we can centralize the default values for new grouping. Relevant for the `AggregationElementSelect` / `Add grouping` button and `GroupBy` -> `onChangeField` function.