### PR TITLE
Fix NPE in MongoProbe if MongoDB doesn't run with MMAPv1

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/system/stats/mongo/MongoProbe.java
+++ b/graylog2-server/src/main/java/org/graylog2/system/stats/mongo/MongoProbe.java
@@ -209,7 +209,7 @@ public class MongoProbe {
                     memoryMap.getInt("resident"),
                     memoryMap.getInt("virtual"),
                     memoryMap.getBoolean("supported"),
-                    memoryMap.getInt("mapped"),
+                    memoryMap.getInt("mapped", -1),
                     memoryMap.getInt("mappedWithJournal", -1)
             );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
clone of #8274 for branch 3.3

## Description
The MongoProbe data collector expects the mem.mapped field to be present in the MongoDB serverStatus output.

As it turns out, this value is only available if the MMAPv1 storage engine is being used. This storage engine is deprecated since MongoDB 4.0.

Refs:
* https://docs.mongodb.com/v4.0/reference/command/serverStatus/#serverstatus.mem.mapped
* https://docs.mongodb.com/v4.0/core/storage-engines/ 

## Motivation and Context
Fix #8273

## How Has This Been Tested?
I am not a Java developer. So I dont know how to build or test these source files.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.