### PR TITLE
Enable in-development aggregation wizard using feature flag.

### DIFF
--- a/graylog2-web-interface/src/views/bindings.routes.test.tsx
+++ b/graylog2-web-interface/src/views/bindings.routes.test.tsx
@@ -21,6 +21,7 @@ import bindings from './bindings';
 jest.mock('util/AppConfig', () => ({
   gl2ServerUrl: () => 'localhost:9000/api/',
   gl2AppPathPrefix: jest.fn(() => '/gl2/'),
+  isFeatureEnabled: () => false,
 }));
 
 describe('bindings.routes', () => {

--- a/graylog2-web-interface/src/views/bindings.tsx
+++ b/graylog2-web-interface/src/views/bindings.tsx
@@ -20,6 +20,7 @@ import { PluginExports } from 'graylog-web-plugin/plugin';
 
 import Routes from 'routing/Routes';
 import App from 'routing/App';
+import AppConfig from 'util/AppConfig';
 import * as Permissions from 'views/Permissions';
 import { MessageListHandler } from 'views/logic/searchtypes/messages';
 import { MessageList } from 'views/components/widgets';
@@ -82,6 +83,7 @@ import ShowDashboardInBigDisplayMode from 'views/pages/ShowDashboardInBigDisplay
 import LookupTableParameter from 'views/logic/parameters/LookupTableParameter';
 import HeatmapVisualizationConfiguration from 'views/components/aggregationbuilder/HeatmapVisualizationConfiguration';
 import HeatmapVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/HeatmapVisualizationConfig';
+import AggregationWizard from 'views/components/aggregationwizard/AggregationWizard';
 
 import type { ActionHandlerArguments } from './components/actions/ActionHandler';
 import NumberVisualizationConfig from './logic/aggregationbuilder/visualizations/NumberVisualizationConfig';
@@ -152,7 +154,9 @@ const exports: PluginExports = {
       defaultWidth: 4,
       reportStyle: () => ({ width: 600 }),
       visualizationComponent: AggregationBuilder,
-      editComponent: AggregationControls,
+      editComponent: AppConfig.isFeatureEnabled('aggregation-wizard')
+        ? AggregationWizard
+        : AggregationControls,
       needsControlledHeight: (widget: Widget) => {
         const widgetVisualization = get(widget, 'config.visualization');
         const flexibleHeightWidgets = [


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

<!--- If it fixes an open issue, please link to the issue here. -->

This change allows enabling the new aggregation builder UI which is currently in development using a feature flag. It is enabled by running the dev server like this:

```
FEATURES=aggregation-wizard yarn start
```

If not `FEATURES` environment variable is specified, the current UI will be used.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Previously, a manual change to the bindings file was required to enable the new UI. This leads to having to stash and pop the changes all the time when switching branches.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.