### PR TITLE
Restore ability to use the CSV File adapter in Cloud

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/configuration/PathConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/PathConfiguration.java
@@ -17,11 +17,17 @@
 package org.graylog2.configuration;
 
 import com.github.joschi.jadconfig.Parameter;
+import org.graylog2.configuration.converters.SortedPathSetConverter;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.Set;
+import java.util.SortedSet;
 
-public abstract class PathConfiguration {
+public class PathConfiguration {
+    public static final String ALLOWED_AUXILIARY_PATHS = "allowed_auxiliary_paths";
+
     protected static final Path DEFAULT_BIN_DIR = Paths.get("bin");
     protected static final Path DEFAULT_DATA_DIR = Paths.get("data");
     protected static final Path DEFAULT_PLUGIN_DIR = Paths.get("plugin");
@@ -34,6 +40,19 @@ public abstract class PathConfiguration {
 
     @Parameter(value = "plugin_dir", required = true)
     private Path pluginDir = DEFAULT_PLUGIN_DIR;
+
+    /**
+     * Optional allowed paths for Graylog data files.
+     *
+     * If provided, certain operations in Graylog will only be permitted if the data file(s) are located in the
+     * specified paths. All subdirectories of indicated paths are allowed by default.
+     *
+     * This provides an additional layer of security, and allows administrators to control where in the file system
+     * Graylog users can select files from. It protects against the potential inspection of arbitrary files in the
+     * file system from the Graylog user interface.
+     */
+    @Parameter(value = ALLOWED_AUXILIARY_PATHS, converter = SortedPathSetConverter.class)
+    private SortedSet<Path> allowedAuxiliaryPaths = Collections.emptySortedSet();
 
     public Path getBinDir() {
         return binDir;
@@ -50,4 +69,7 @@ public abstract class PathConfiguration {
         return pluginDir;
     }
 
+    public Set<Path> getAllowedAuxiliaryPaths() {
+        return allowedAuxiliaryPaths;
+    }
 }

--- a/graylog2-server/src/main/java/org/graylog2/configuration/converters/SortedPathSetConverter.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/converters/SortedPathSetConverter.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.configuration.converters;
+
+import com.github.joschi.jadconfig.Converter;
+import com.github.joschi.jadconfig.ParameterException;
+import org.apache.commons.lang3.StringUtils;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.Objects;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+public class SortedPathSetConverter implements Converter<SortedSet<Path>> {
+    protected static final String SEPARATOR = ",";
+
+    @Override
+    public SortedSet<Path> convertFrom(String value) {
+        if (value == null) {
+            throw new ParameterException("Path list must not be null.");
+        }
+
+        return Arrays.stream(value.split(SEPARATOR))
+                     .map(StringUtils::trimToNull)
+                     .filter(Objects::nonNull)
+                     .map(Paths::get)
+                     .collect(Collectors.toCollection(sortedPathSupplier()));
+    }
+
+    @Override
+    public String convertTo(SortedSet<Path> value) {
+        if (value == null) {
+            throw new ParameterException("String list of Paths must not be null.");
+        }
+
+        return value.stream().map(Path::toString).collect(Collectors.joining(","));
+    }
+
+    /**
+     * @return {@link Supplier<TreeSet>} which sorts based on {@literal path.toString()}.
+     *         Sorting is intentionally performed on a case-sensitive basis, since paths
+     *         are also case-sensitive.
+     */
+    private Supplier<TreeSet<Path>> sortedPathSupplier() {
+        return () -> new TreeSet<>(Comparator.comparing(Path::toString));
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/lookup/AllowedAuxiliaryPathChecker.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/AllowedAuxiliaryPathChecker.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.lookup;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.SortedSet;
+
+@Singleton
+public class AllowedAuxiliaryPathChecker {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AllowedAuxiliaryPathChecker.class);
+
+    private final SortedSet<Path> allowedPaths;
+
+    @Inject
+    public AllowedAuxiliaryPathChecker(@Named("allowed_auxiliary_paths") SortedSet<Path> allowedPaths) {
+        this.allowedPaths = allowedPaths;
+    }
+
+    public boolean fileIsInAllowedPath(Path path) {
+        if (allowedPaths.isEmpty()) {
+            return true;
+        }
+
+        final Path realFilePath = resolveRealPath(path);
+        if (realFilePath == null) {
+            return false;
+        }
+        for (Path allowedPath : allowedPaths) {
+            final Path realAllowedPath = resolveRealPath(allowedPath);
+            if (realAllowedPath != null && realFilePath.startsWith(realAllowedPath)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public static Path resolveRealPath(Path path) {
+        try {
+            // Get the real path by resolving all relative paths and symbolic links.
+            return path.toRealPath();
+        } catch (IOException e) {
+            LOG.error("Could not resolve real location of path [{}].", path, e);
+        }
+        return null;
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/lookup/LookupModule.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/LookupModule.java
@@ -53,12 +53,10 @@ public class LookupModule extends Graylog2Module {
                 CaffeineLookupCache.Factory.class,
                 CaffeineLookupCache.Config.class);
 
-        if (!configuration.isCloud()) {
-            installLookupDataAdapter(CSVFileDataAdapter.NAME,
-                    CSVFileDataAdapter.class,
-                    CSVFileDataAdapter.Factory.class,
-                    CSVFileDataAdapter.Config.class);
-        }
+        installLookupDataAdapter(CSVFileDataAdapter.NAME,
+                CSVFileDataAdapter.class,
+                CSVFileDataAdapter.Factory.class,
+                CSVFileDataAdapter.Config.class);
 
         installLookupDataAdapter2(DnsLookupDataAdapter.NAME,
                 DnsLookupDataAdapter.class,

--- a/graylog2-server/src/main/java/org/graylog2/lookup/LookupModule.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/LookupModule.java
@@ -39,6 +39,7 @@ public class LookupModule extends Graylog2Module {
     protected void configure() {
         serviceBinder().addBinding().to(UrlWhitelistService.class).in(Scopes.SINGLETON);
         binder().bind(UrlWhitelistNotificationService.class).in(Scopes.SINGLETON);
+        binder().bind(AllowedAuxiliaryPathChecker.class).in(Scopes.SINGLETON);
 
         serviceBinder().addBinding().to(LookupTableService.class).asEagerSingleton();
 

--- a/graylog2-server/src/test/java/org/graylog2/configuration/PathConfigurationTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/configuration/PathConfigurationTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.configuration;
+
+import com.github.joschi.jadconfig.JadConfig;
+import com.github.joschi.jadconfig.RepositoryException;
+import com.github.joschi.jadconfig.ValidationException;
+import com.github.joschi.jadconfig.repositories.InMemoryRepository;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.TemporaryFolder;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class PathConfigurationTest {
+    public static final String BIN_PATH = "bin";
+    public static final String DATA_PATH = "data";
+    public static final String PLUGINS_PATH = "plugins";
+    @Rule
+    public final ExpectedException expectedException = ExpectedException.none();
+
+    @Rule
+    public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    private Map<String, String> validProperties;
+
+    @Before
+    public void setUp() throws Exception {
+        validProperties = new HashMap<>();
+
+        // Required properties
+        validProperties.put("bin_dir", BIN_PATH);
+        validProperties.put("data_dir", DATA_PATH);
+        validProperties.put("plugin_dir", PLUGINS_PATH);
+    }
+
+    @Test
+    public void testBaseConfiguration() throws ValidationException, RepositoryException {
+        PathConfiguration configuration = new PathConfiguration();
+        final JadConfig jadConfig = new JadConfig(new InMemoryRepository(validProperties), configuration);
+        jadConfig.process();
+        assertEquals(BIN_PATH, configuration.getBinDir().toString());
+        assertEquals(DATA_PATH, configuration.getDataDir().toString());
+        assertEquals(PLUGINS_PATH, configuration.getPluginDir().toString());
+        assertTrue(configuration.getAllowedAuxiliaryPaths().isEmpty());
+    }
+
+    @Test
+    public void testAllowedAuxiliaryPaths() throws ValidationException, RepositoryException {
+        validProperties.put("allowed_auxiliary_paths", "/permitted-dir,/another-valid-dir");
+        PathConfiguration configuration = new PathConfiguration();
+        final JadConfig jadConfig = new JadConfig(new InMemoryRepository(validProperties), configuration);
+        jadConfig.process();
+        assertEquals(2,configuration.getAllowedAuxiliaryPaths().size());
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/configuration/converters/SortedPathSetConverterTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/configuration/converters/SortedPathSetConverterTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.configuration.converters;
+
+import com.github.joschi.jadconfig.ParameterException;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Comparator;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+
+public class SortedPathSetConverterTest {
+    private SortedPathSetConverter converter;
+
+    @Before
+    public void setUp() {
+        converter = new SortedPathSetConverter();
+    }
+
+    @Test
+    public void testConvertFrom() {
+        // Verify path set sizes.
+        assertEquals(0, converter.convertFrom("").size());
+        assertEquals(0, converter.convertFrom(",").size());
+        assertEquals(0, converter.convertFrom(",,,").size());
+        assertEquals(1, converter.convertFrom("/another-dir").size());
+        assertEquals(1, converter.convertFrom("/another-dir;/some-dir;/finally-dir").size());
+        assertEquals(3, converter.convertFrom("/another-dir, /some-dir, /finally-dir").size());
+
+        // Verify path sorting.
+        final String unsortedPaths = "/some-dir,/Z-dir,/z-dir,/another-dir/sub,/another-dir";
+        final SortedSet<Path> result = converter.convertFrom(unsortedPaths);
+        assertEquals(5, result.size());
+        assertEquals("Paths were not sorted as expected",
+                     "/Z-dir,/another-dir,/another-dir/sub,/some-dir,/z-dir",
+                     result.stream().map(Path::toString).collect(Collectors.joining(",")));
+    }
+
+    @Test
+    public void testConvertTo() {
+        TreeSet<Path> sortedSet = new TreeSet<>(Comparator.comparing(Path::toString));
+        sortedSet.add(Paths.get("/some-dir"));
+        sortedSet.add(Paths.get("/Z-dir"));
+        sortedSet.add(Paths.get("/z-dir"));
+        sortedSet.add(Paths.get("/another-dir/sub"));
+        sortedSet.add(Paths.get("/another-dir"));
+        assertEquals("/Z-dir,/another-dir,/another-dir/sub,/some-dir,/z-dir", converter.convertTo(sortedSet));
+    }
+
+    @Test
+    public void testConvertFromEmpty() {
+        assertEquals(new TreeSet<>(), converter.convertFrom(""));
+    }
+
+    @Test
+    public void testConvertToEmpty() {
+        assertEquals("", converter.convertTo(new TreeSet<>()));
+    }
+
+    @Test(expected = ParameterException.class)
+    public void testConvertFromNull() {
+        converter.convertFrom(null);
+    }
+
+    @Test(expected = ParameterException.class)
+    public void testConvertToNull() {
+        converter.convertTo(null);
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/lookup/AllowedAuxiliaryPathCheckerTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/lookup/AllowedAuxiliaryPathCheckerTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.lookup;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.TreeSet;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class AllowedAuxiliaryPathCheckerTest {
+
+    public static final String FILE = "file";
+
+    @Rule
+    public TemporaryFolder permittedTempDir = new TemporaryFolder();
+
+    @Rule
+    public TemporaryFolder forbiddenTempDir = new TemporaryFolder();
+
+    AllowedAuxiliaryPathChecker pathChecker;
+
+    @Test
+    public void inAllowedPath() throws IOException {
+        final Path permittedPath = permittedTempDir.getRoot().toPath();
+        final Path filePath = permittedTempDir.newFile(FILE).toPath();
+        pathChecker = new AllowedAuxiliaryPathChecker(new TreeSet<>(Collections.singleton(permittedPath)));
+        assertTrue(pathChecker.fileIsInAllowedPath(filePath));
+    }
+
+    @Test
+    public void outsideOfAllowedPath() throws IOException {
+        final Path permittedPath = permittedTempDir.getRoot().toPath();
+        final Path filePath = forbiddenTempDir.newFile(FILE).toPath();
+        pathChecker = new AllowedAuxiliaryPathChecker(new TreeSet<>(Collections.singleton(permittedPath)));
+        assertFalse(pathChecker.fileIsInAllowedPath(filePath));
+    }
+
+    @Test
+    public void noPathsFileLocationOkNoChecksRequired() throws IOException {
+        pathChecker = new AllowedAuxiliaryPathChecker(new TreeSet<>(Collections.emptySet()));
+        assertTrue(pathChecker.fileIsInAllowedPath(permittedTempDir.newFile(FILE).toPath()));
+    }
+
+    @Test
+    public void fileDoesNotExist() {
+        final Path filePath = Paths.get("non-existent-file");
+        pathChecker = new AllowedAuxiliaryPathChecker(
+                new TreeSet<>(Collections.singleton(permittedTempDir.getRoot().toPath())));
+        assertFalse(pathChecker.fileIsInAllowedPath(filePath));
+    }
+
+    @Test
+    public void permittedPathDoesNotExist() throws IOException {
+        final Path permittedPath = Paths.get("non-existent-file-path");
+        final Path filePath = permittedTempDir.newFile(FILE).toPath();
+
+        pathChecker = new AllowedAuxiliaryPathChecker(new TreeSet<>(Collections.singleton(permittedPath)));
+        assertFalse(pathChecker.fileIsInAllowedPath(filePath));
+    }
+
+    @Test
+    public void realPathNullWhenDoesNotExist() {
+        final Path path = Paths.get("non-existent-file-path");
+        assertNull(AllowedAuxiliaryPathChecker.resolveRealPath(path));
+    }
+
+    /**
+     * Verifies that the {@literal path.toRealPath()} method is called in the process of checking the file path.
+     * This is essential, because this is the operative part that resolves relative paths and symbolic links
+     * before verifying that a file is in the appropriate path.
+     */
+    @Test
+    public void verifyToRealPathCalled() throws IOException {
+        final Path permittedPath = mock(Path.class);
+        final Path filePath = mock(Path.class);
+
+        pathChecker = new AllowedAuxiliaryPathChecker(new TreeSet<>(Collections.singleton(permittedPath)));
+        when(filePath.toRealPath()).thenReturn(filePath);
+        pathChecker.fileIsInAllowedPath(filePath);
+        verify(permittedPath, times(1)).toRealPath();
+        verify(filePath, times(1)).toRealPath();
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/lookup/adapters/CSVFileDataAdapterTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/lookup/adapters/CSVFileDataAdapterTest.java
@@ -18,37 +18,53 @@ package org.graylog2.lookup.adapters;
 
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.io.Resources;
+import org.graylog2.lookup.AllowedAuxiliaryPathChecker;
+import org.graylog2.plugin.lookup.LookupCachePurge;
 import org.graylog2.plugin.lookup.LookupResult;
+import org.junit.Rule;
 import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 
 import java.net.URL;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.graylog2.lookup.adapters.CSVFileDataAdapter.Config;
+import static org.graylog2.lookup.adapters.CSVFileDataAdapter.NAME;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 public class CSVFileDataAdapterTest {
+    @Rule
+    public MockitoRule rule = MockitoJUnit.rule();
+
     private final Path csvFile;
     private CSVFileDataAdapter csvFileDataAdapter;
 
+    @Mock
+    AllowedAuxiliaryPathChecker pathChecker;
+
+    @Mock
+    LookupCachePurge cachePurge;
+
     public CSVFileDataAdapterTest() throws Exception {
         final URL resource = Resources.getResource("org/graylog2/lookup/adapters/CSVFileDataAdapterTest.csv");
-        this.csvFile = Paths.get(resource.toURI());
+        final Path csvFilePath = Paths.get(resource.toURI());
+        this.csvFile = csvFilePath;
     }
 
     @Test
     public void doGet_successfully_returns_values() throws Exception {
-        final CSVFileDataAdapter.Config config = CSVFileDataAdapter.Config.builder()
-                .type(org.graylog2.lookup.adapters.CSVFileDataAdapter.NAME)
-                .path(csvFile.toString())
-                .separator(",")
-                .quotechar("\"")
-                .keyColumn("key")
-                .valueColumn("value")
-                .checkInterval(60)
-                .caseInsensitiveLookup(false)
-                .build();
-        csvFileDataAdapter = new CSVFileDataAdapter("id", "name", config, new MetricRegistry());
+        final Config config = baseConfig();
+        csvFileDataAdapter = spy(new CSVFileDataAdapter("id", "name", config, new MetricRegistry(), pathChecker));
+        when(pathChecker.fileIsInAllowedPath(isA(Path.class))).thenReturn(true);
         csvFileDataAdapter.doStart();
 
         assertThat(csvFileDataAdapter.doGet("foo")).isEqualTo(LookupResult.single("23"));
@@ -58,21 +74,65 @@ public class CSVFileDataAdapterTest {
 
     @Test
     public void doGet_successfully_returns_values_with_key_and_value_column_identical() throws Exception {
-        final CSVFileDataAdapter.Config config = CSVFileDataAdapter.Config.builder()
-                .type(org.graylog2.lookup.adapters.CSVFileDataAdapter.NAME)
-                .path(csvFile.toString())
-                .separator(",")
-                .quotechar("\"")
-                .keyColumn("key")
-                .valueColumn("key")
-                .checkInterval(60)
-                .caseInsensitiveLookup(false)
-                .build();
-        csvFileDataAdapter = new CSVFileDataAdapter("id", "name", config, new MetricRegistry());
+        final Config config = Config.builder()
+                                    .type(NAME)
+                                    .path(csvFile.toString())
+                                    .separator(",")
+                                    .quotechar("\"")
+                                    .keyColumn("key")
+                                    .valueColumn("key")
+                                    .checkInterval(60)
+                                    .caseInsensitiveLookup(false)
+                                    .build();
+        csvFileDataAdapter = spy(new CSVFileDataAdapter("id", "name", config, new MetricRegistry(), pathChecker));
+        when(pathChecker.fileIsInAllowedPath((isA(Path.class)))).thenReturn(true);
         csvFileDataAdapter.doStart();
 
         assertThat(csvFileDataAdapter.doGet("foo")).isEqualTo(LookupResult.single("foo"));
         assertThat(csvFileDataAdapter.doGet("bar")).isEqualTo(LookupResult.single("bar"));
         assertThat(csvFileDataAdapter.doGet("quux")).isEqualTo(LookupResult.empty());
+    }
+
+    @Test
+    public void doGet_failure_filePathInvalid() throws Exception {
+        final Config config = baseConfig();
+        when(pathChecker.fileIsInAllowedPath((isA(Path.class)))).thenReturn(false);
+        csvFileDataAdapter = new CSVFileDataAdapter("id", "name", config, new MetricRegistry(), pathChecker);
+        assertThatThrownBy(() -> csvFileDataAdapter.doStart())
+                .isExactlyInstanceOf(IllegalStateException.class)
+                .hasMessageStartingWith("The specified CSV file is not in an allowed path.");
+    }
+
+    @Test
+    public void refresh_success() throws Exception {
+        final Config config = baseConfig();
+        csvFileDataAdapter = spy(new CSVFileDataAdapter("id", "name", config, new MetricRegistry(), pathChecker));
+        when(pathChecker.fileIsInAllowedPath(isA(Path.class))).thenReturn(true).thenReturn(true);
+        csvFileDataAdapter.doStart();
+        csvFileDataAdapter.doRefresh(cachePurge);
+        assertFalse(csvFileDataAdapter.getError().isPresent());
+    }
+
+    @Test
+    public void refresh_failure_disallowedFileLocation() throws Exception {
+        final Config config = baseConfig();
+        csvFileDataAdapter = spy(new CSVFileDataAdapter("id", "name", config, new MetricRegistry(), pathChecker));
+        when(pathChecker.fileIsInAllowedPath(isA(Path.class))).thenReturn(true).thenReturn(false);
+        csvFileDataAdapter.doStart();
+        csvFileDataAdapter.doRefresh(cachePurge);
+        assertTrue(csvFileDataAdapter.getError().isPresent());
+    }
+
+    private Config baseConfig() {
+        return Config.builder()
+                     .type(NAME)
+                     .path(csvFile.toString())
+                     .separator(",")
+                     .quotechar("\"")
+                     .keyColumn("key")
+                     .valueColumn("value")
+                     .checkInterval(60)
+                     .caseInsensitiveLookup(false)
+                     .build();
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Restores the ability to use the CSV File lookup adapter in Cloud with added protections for where files can be lookup up from (porting #10244 to `cloud-4.0`).

Closes https://github.com/Graylog2/graylog-plugin-cloud/issues/790

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The CSV File adapter is needed for content packs (specifically Illuminate). Adding it back to Cloud allows the content packs to be installed and used.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Started the app, and verified that the CSV File adapter can be used. Also, smoke-tested to verify that the patch checking from #10244 is working. 