### PR TITLE
Respect User TimeZone in Keyword Search

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/KeywordRangeEntity.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/KeywordRangeEntity.java
@@ -21,7 +21,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
 import org.graylog2.contentpacks.model.entities.references.ValueReference;
-import org.graylog2.plugin.indexer.searches.timeranges.AbsoluteRange;
 import org.graylog2.plugin.indexer.searches.timeranges.InvalidRangeParametersException;
 import org.graylog2.plugin.indexer.searches.timeranges.KeywordRange;
 import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
@@ -34,14 +33,20 @@ import java.util.Map;
 public abstract class KeywordRangeEntity extends TimeRangeEntity {
     static final String TYPE = "keyword";
     private static final String FIELD_KEYWORD = "keyword";
+    private static final String FIELD_TIMEZONE = "timezone";
 
     @JsonProperty(FIELD_KEYWORD)
     public abstract ValueReference keyword();
 
+    @JsonProperty(FIELD_TIMEZONE)
+    public abstract ValueReference timezone();
+
     public static KeywordRangeEntity of(KeywordRange keywordRange) {
         final String keyword = keywordRange.keyword();
+        final String timezone = keywordRange.timezone();
         return builder()
                 .keyword(ValueReference.of(keyword))
+                .timezone(ValueReference.of(timezone))
                 .build();
     }
 
@@ -52,8 +57,9 @@ public abstract class KeywordRangeEntity extends TimeRangeEntity {
     @Override
     public final TimeRange convert(Map<String, ValueReference> parameters) {
         final String keyword = keyword().asString(parameters);
+        final String timezone = timezone().asString(parameters);
         try {
-            return KeywordRange.create(keyword);
+            return KeywordRange.create(keyword, timezone);
         } catch (InvalidRangeParametersException e) {
             throw new RuntimeException("Invalid timerange.", e);
         }
@@ -63,6 +69,9 @@ public abstract class KeywordRangeEntity extends TimeRangeEntity {
     abstract static class Builder implements TimeRangeBuilder<Builder> {
         @JsonProperty(FIELD_KEYWORD)
         abstract Builder keyword(ValueReference keyword);
+
+        @JsonProperty(FIELD_TIMEZONE)
+        abstract Builder timezone(ValueReference timezone);
 
         abstract KeywordRangeEntity autoBuild();
 

--- a/graylog2-server/src/main/java/org/graylog2/plugin/utilities/date/NaturalDateParser.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/utilities/date/NaturalDateParser.java
@@ -194,6 +194,7 @@ public class NaturalDateParser {
 
             result.put("from", dateFormat(getFrom()));
             result.put("to", dateFormat(getTo()));
+            result.put("timezone", getDateTimeZone().getID());
 
             return result;
         }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/tools/NaturalDateTesterResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/tools/NaturalDateTesterResource.java
@@ -40,11 +40,11 @@ public class NaturalDateTesterResource extends RestResource {
     @GET
     @Timed
     @Produces(MediaType.APPLICATION_JSON)
-    public Map<String, String> naturalDateTester(@QueryParam("string") @NotEmpty String string) {
+    public Map<String, String> naturalDateTester(@QueryParam("string") @NotEmpty final String string, @QueryParam("timezone") @NotEmpty final String timezone) {
         try {
-            return new NaturalDateParser().parse(string).asMap();
+            return new NaturalDateParser(timezone).parse(string).asMap();
         } catch (NaturalDateParser.DateNotParsableException e) {
-            LOG.debug("Could not parse from natural date: " + string, e);
+            LOG.debug("Could not parse from natural date: " + string + " and TimeZone: " + timezone, e);
             throw new WebApplicationException(e, 422);
         }
     }

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/timeranges/DerivedTimeRangeTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/timeranges/DerivedTimeRangeTest.java
@@ -48,7 +48,7 @@ public class DerivedTimeRangeTest {
 
     @Test
     public void returnsInitialRangeForKeywordRange() throws Exception {
-        final KeywordRange range = KeywordRange.create("yesterday");
+        final KeywordRange range = KeywordRange.create("yesterday", "Etc/UTC");
         final DerivedTimeRange derivedTimeRange = DerivedTimeRange.of(range);
 
         assertThat(derivedTimeRange.effectiveTimeRange(emptyRootQuery, null)).isEqualTo(range);

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/ViewFacadeTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/ViewFacadeTest.java
@@ -288,7 +288,7 @@ public class ViewFacadeTest {
     private EntityV1 createViewEntity() throws Exception {
         final QueryEntity query = QueryEntity.builder()
                 .id("dead-beef")
-                .timerange(KeywordRange.create("last 5 minutes"))
+                .timerange(KeywordRange.create("last 5 minutes", "Etc/UTC"))
                 .filter(OrFilter.or(StreamFilter.ofId(newStreamId)))
                 .query(ElasticsearchQueryString.builder().queryString("author: Mara Jade").build())
                 .build();

--- a/graylog2-server/src/test/java/org/graylog2/indexer/searches/SearchesIT.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/searches/SearchesIT.java
@@ -290,7 +290,7 @@ public abstract class SearchesIT extends ElasticsearchBaseTest {
         when(indexRangeService.find(any(DateTime.class), any(DateTime.class))).thenReturn(indices);
 
         final TimeRange absoluteRange = AbsoluteRange.create(now.minusDays(1), now.plusDays(1));
-        final TimeRange keywordRange = KeywordRange.create("1 day ago");
+        final TimeRange keywordRange = KeywordRange.create("1 day ago", "Etc/UTC");
         final TimeRange relativeRange = RelativeRange.create(3600);
 
         assertThat(searches.determineAffectedIndicesWithRanges(absoluteRange, null))
@@ -314,7 +314,7 @@ public abstract class SearchesIT extends ElasticsearchBaseTest {
         when(indexRangeService.find(any(DateTime.class), any(DateTime.class))).thenReturn(indices);
 
         final TimeRange absoluteRange = AbsoluteRange.create(now.minusDays(1), now.plusDays(1));
-        final TimeRange keywordRange = KeywordRange.create("1 day ago");
+        final TimeRange keywordRange = KeywordRange.create("1 day ago", "Etc/UTC");
         final TimeRange relativeRange = RelativeRange.create(3600);
 
         assertThat(searches.determineAffectedIndicesWithRanges(absoluteRange, null))
@@ -366,7 +366,7 @@ public abstract class SearchesIT extends ElasticsearchBaseTest {
         when(indexRangeService.find(any(DateTime.class), any(DateTime.class))).thenReturn(indices);
 
         final TimeRange absoluteRange = AbsoluteRange.create(now.minusDays(1), now.plusDays(1));
-        final TimeRange keywordRange = KeywordRange.create("1 day ago");
+        final TimeRange keywordRange = KeywordRange.create("1 day ago", "Etc/UTC");
         final TimeRange relativeRange = RelativeRange.create(3600);
 
         assertThat(searches.determineAffectedIndices(absoluteRange, null))
@@ -390,7 +390,7 @@ public abstract class SearchesIT extends ElasticsearchBaseTest {
         when(indexRangeService.find(any(DateTime.class), any(DateTime.class))).thenReturn(indices);
 
         final TimeRange absoluteRange = AbsoluteRange.create(now.minusDays(1), now.plusDays(1));
-        final TimeRange keywordRange = KeywordRange.create("1 day ago");
+        final TimeRange keywordRange = KeywordRange.create("1 day ago", "Etc/UTC");
         final TimeRange relativeRange = RelativeRange.create(3600);
 
         assertThat(searches.determineAffectedIndices(absoluteRange, null))

--- a/graylog2-server/src/test/java/org/graylog2/indexer/searches/timeranges/TimeRangesTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/searches/timeranges/TimeRangesTest.java
@@ -71,6 +71,6 @@ public class TimeRangesTest {
 
         assertThat(TimeRanges.toSeconds(AbsoluteRange.create(from, to))).isEqualTo(300);
         assertThat(TimeRanges.toSeconds(RelativeRange.create(300))).isEqualTo(300);
-        assertThat(TimeRanges.toSeconds(KeywordRange.create("last 5 minutes"))).isEqualTo(300);
+        assertThat(TimeRanges.toSeconds(KeywordRange.create("last 5 minutes", "Etc/UTC"))).isEqualTo(300);
     }
 }

--- a/graylog2-web-interface/src/logic/datetimes/DateTime.ts
+++ b/graylog2-web-interface/src/logic/datetimes/DateTime.ts
@@ -47,7 +47,7 @@ class DateTime {
   }
 
   static fromDateTimeAndTZ(dateTime, timezone) {
-    return new DateTime(moment(dateTime).tz(timezone));
+    return new DateTime(moment.utc(dateTime).tz(timezone));
   }
 
   static _cleanDateTimeString(dateTimeString) {

--- a/graylog2-web-interface/src/logic/datetimes/DateTime.ts
+++ b/graylog2-web-interface/src/logic/datetimes/DateTime.ts
@@ -46,6 +46,10 @@ class DateTime {
     return new DateTime(moment.utc(dateTime));
   }
 
+  static fromDateTimeAndTZ(dateTime, timezone) {
+    return new DateTime(moment(dateTime).tz(timezone));
+  }
+
   static _cleanDateTimeString(dateTimeString) {
     if (dateTimeString instanceof String) {
       return dateTimeString.trim();

--- a/graylog2-web-interface/src/routing/ApiRoutes.ts
+++ b/graylog2-web-interface/src/routing/ApiRoutes.ts
@@ -285,7 +285,7 @@ const ApiRoutes = {
   ToolsApiController: {
     grokTest: () => { return { url: '/tools/grok_tester' }; },
     jsonTest: () => { return { url: '/tools/json_tester' }; },
-    naturalDateTest: (text: string) => { return { url: `/tools/natural_date_tester?string=${text}` }; },
+    naturalDateTest: (string, timezone) => { return { url: `/tools/natural_date_tester?string=${string}&timezone=${timezone}` }; },
     regexTest: () => { return { url: '/tools/regex_tester' }; },
     regexValidate: (regex: string) => { return { url: `/tools/regex_tester/validate?regex=${regex}` }; },
     regexReplaceTest: () => { return { url: '/tools/regex_replace_tester' }; },

--- a/graylog2-web-interface/src/stores/tools/ToolsStore.ts
+++ b/graylog2-web-interface/src/stores/tools/ToolsStore.ts
@@ -21,10 +21,12 @@ import fetch from 'logic/rest/FetchProvider';
 import ApiRoutes from 'routing/ApiRoutes';
 import { qualifyUrl } from 'util/URLUtils';
 import UserNotification from 'util/UserNotification';
+import DateTime from 'logic/datetimes/DateTime';
 
 const ToolsStore = Reflux.createStore({
-  testNaturalDate(text: string): Promise<string[]> {
-    const { url } = ApiRoutes.ToolsApiController.naturalDateTest(encodeURIComponent(text));
+  testNaturalDate(keyword: string): Promise<string[]> {
+    const timezone = DateTime.getUserTimezone();
+    const { url } = ApiRoutes.ToolsApiController.naturalDateTest(encodeURIComponent(keyword), encodeURIComponent(timezone));
     const promise = fetch('GET', qualifyUrl(url));
 
     promise.catch((errorThrown) => {

--- a/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TabKeywordTimeRange.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TabKeywordTimeRange.test.tsx
@@ -36,13 +36,18 @@ const TabKeywordTimeRange = ({ defaultValue, ...props }: { defaultValue: string 
   </Formik>
 );
 
-jest.mock('logic/datetimes/DateTime', () => ({ fromUTCDateTime: (date) => date }));
+jest.mock('logic/datetimes/DateTime', () => ({
+  fromUTCDateTime: (date) => date,
+  getUserTimezone: () => 'Europe/Berlin',
+  fromDateTimeAndTZ: (date) => date,
+}));
 
 describe('TabKeywordTimeRange', () => {
   beforeEach(() => {
     ToolsStore.testNaturalDate = jest.fn(() => Promise.resolve({
       from: '2018-11-14 13:52:38',
       to: '2018-11-14 13:57:38',
+      timezone: 'Europe/Berlin',
     }));
   });
 

--- a/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TabKeywordTimeRange.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TabKeywordTimeRange.tsx
@@ -46,10 +46,11 @@ const ErrorMessage = styled.span(({ theme }) => css`
 `);
 
 const _parseKeywordPreview = (data) => {
-  const from = DateTime.fromUTCDateTime(data.from).toString();
-  const to = DateTime.fromUTCDateTime(data.to).toString();
+  const { timezone } = data;
+  const from = DateTime.fromDateTimeAndTZ(data.from, timezone).toString();
+  const to = DateTime.fromDateTimeAndTZ(data.to, timezone).toString();
 
-  return { from, to };
+  return { from, to, timezone };
 };
 
 type Props = {
@@ -62,9 +63,9 @@ const TabKeywordTimeRange = ({ defaultValue, disabled, setValidatingKeyword }: P
   const [nextRangeProps, , nextRangeHelpers] = useField('nextTimeRange');
   const mounted = useRef(true);
   const keywordRef = useRef();
-  const [keywordPreview, setKeywordPreview] = useState({ from: '', to: '' });
+  const [keywordPreview, setKeywordPreview] = useState({ from: '', to: '', timezone: '' });
 
-  const _setSuccessfullPreview = useCallback((response: { from: string, to: string }) => {
+  const _setSuccessfullPreview = useCallback((response: { from: string, to: string, timezone: string }) => {
     setValidatingKeyword(false);
 
     return setKeywordPreview(_parseKeywordPreview(response));
@@ -72,7 +73,7 @@ const TabKeywordTimeRange = ({ defaultValue, disabled, setValidatingKeyword }: P
   [setValidatingKeyword]);
 
   const _setFailedPreview = useCallback(() => {
-    setKeywordPreview({ from: EMPTY_RANGE, to: EMPTY_RANGE });
+    setKeywordPreview({ from: EMPTY_RANGE, to: EMPTY_RANGE, timezone: DateTime.getUserTimezone() });
 
     return 'Unable to parse keyword.';
   }, [setKeywordPreview]);

--- a/graylog2-web-interface/src/views/hooks/BindSearchParamsFromQuery.ts
+++ b/graylog2-web-interface/src/views/hooks/BindSearchParamsFromQuery.ts
@@ -39,6 +39,7 @@ type RawAbsoluteRange = {
 type RawKeywordRange = {
   rangetype: 'keyword';
   keyword?: string;
+  timezone?: string;
 };
 
 const _getRange = (query): RawAbsoluteRange | RawRelativeRange | RawKeywordRange => {
@@ -84,7 +85,7 @@ const _getTimerange = (query = {}) => {
         } as AbsoluteTimeRange
         : undefined;
     case 'keyword':
-      return range.keyword ? { type: range.rangetype, keyword: range.keyword } as KeywordTimeRange : undefined;
+      return range.keyword ? { type: range.rangetype, keyword: range.keyword, timezone: range.timezone } as KeywordTimeRange : undefined;
     default:
       // @ts-ignore
       throw new Error(`Unsupported range type ${range.rangetype}`);

--- a/graylog2-web-interface/src/views/logic/queries/Query.ts
+++ b/graylog2-web-interface/src/views/logic/queries/Query.ts
@@ -112,6 +112,7 @@ export type KeywordTimeRange = {
   keyword: string,
   from?: string,
   to?: string,
+  timezone?: string,
 };
 
 export type TimeRange = RelativeTimeRange | AbsoluteTimeRange | KeywordTimeRange;


### PR DESCRIPTION
## Motivation and Context
Added the timezone as a parameter to the keyword-search.
Added the timezone as a parameter to the NaturalDateParser

Fixes: #7796

## How Has This Been Tested?
Manual tests

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

