### PR TITLE
Unset old group by form values when changing the type of the field

### DIFF
--- a/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.groupBy.test.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.groupBy.test.tsx
@@ -174,4 +174,37 @@ describe('AggregationWizard', () => {
     await screen.findByText('took_ms');
     await screen.findByText('timestamp');
   });
+
+  it('should correctly change config', async () => {
+    const pivot0 = Pivot.create('timestamp', 'time', { interval: { type: 'auto', scaling: 1 } });
+    const pivot1 = Pivot.create('took_ms', 'values', { limit: 15 });
+    const config = AggregationWidgetConfig
+      .builder()
+      .rowPivots([pivot0])
+      .build();
+
+    const onChange = jest.fn();
+    renderSUT({ onChange, config });
+
+    await screen.findByText('timestamp');
+
+    const fieldSelection = await screen.findByLabelText('Field');
+
+    await act(async () => {
+      await selectEvent.openMenu(fieldSelection);
+      await selectEvent.select(fieldSelection, 'took_ms');
+    });
+
+    const applyButton = await screen.findByRole('button', { name: 'Apply Changes' });
+    fireEvent.click(applyButton);
+
+    const updatedConfig = AggregationWidgetConfig
+      .builder()
+      .rowPivots([pivot1])
+      .build();
+
+    await waitFor(() => expect(onChange).toHaveBeenCalledTimes(1));
+
+    expect(onChange).toHaveBeenCalledWith(updatedConfig);
+  });
 });

--- a/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/GroupBy/FieldComponent.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/GroupBy/FieldComponent.tsx
@@ -38,6 +38,8 @@ const FieldComponent = ({ index, fieldType }: Props) => {
 
     if (fieldType !== newFieldType) {
       if (newFieldType === 'time') {
+        setFieldValue(`groupBy.groupings.${index}.limit`, undefined, false);
+
         setFieldValue(`groupBy.groupings.${index}.interval`, {
           type: 'auto',
           scaling: 1.0,
@@ -45,6 +47,7 @@ const FieldComponent = ({ index, fieldType }: Props) => {
       }
 
       if (newFieldType === 'values') {
+        setFieldValue(`groupBy.groupings.${index}.interval`, undefined, false);
         setFieldValue(`groupBy.groupings.${index}.limit`, 15);
       }
     }


### PR DESCRIPTION
## Motivation
Prior to this change, the frontend included the old form values in the
request to the backend when applying a new config. For example if the
field type changed from time to value, we do not need the interval
values anymore but only the limit form value.

## Description
This change will set the old values to undefined before setting the new
default values.

## How Has This Been Tested?
- Edit a histogram widget
- Change the GroupBy from `timestamp` to a value fieldtype like `action`
- Apply those changes

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
