### PR TITLE
Include view type in `ViewMetadataStore`.

### DIFF
--- a/graylog2-web-interface/src/views/components/QueryBar.tsx
+++ b/graylog2-web-interface/src/views/components/QueryBar.tsx
@@ -26,7 +26,7 @@ import NewQueryActionHandler from 'views/logic/NewQueryActionHandler';
 import { QueriesActions } from 'views/stores/QueriesStore';
 import { QueryIdsStore } from 'views/stores/QueryIdsStore';
 import { QueryTitlesStore } from 'views/stores/QueryTitlesStore';
-import { ViewMetaData, ViewMetadataStore } from 'views/stores/ViewMetadataStore';
+import { ViewMetadataStore } from 'views/stores/ViewMetadataStore';
 import { ViewStatesActions } from 'views/stores/ViewStatesStore';
 
 import QueryTabs from './QueryTabs';
@@ -59,7 +59,9 @@ type Props = {
   children?: React.ReactElement,
   queries: string[],
   queryTitles: Immutable.Map<string, string>,
-  viewMetadata: ViewMetaData,
+  viewMetadata: {
+    activeQuery: string,
+  },
 };
 
 const QueryBar = ({ children, queries, queryTitles, viewMetadata }: Props) => {
@@ -84,10 +86,6 @@ QueryBar.propTypes = {
   queries: ImmutablePropTypes.listOf(PropTypes.string).isRequired,
   queryTitles: ImmutablePropTypes.mapOf(PropTypes.string, PropTypes.string).isRequired,
   viewMetadata: PropTypes.exact({
-    id: PropTypes.string,
-    title: PropTypes.string,
-    description: PropTypes.string,
-    summary: PropTypes.string,
     activeQuery: PropTypes.string.isRequired,
   }).isRequired,
 };

--- a/graylog2-web-interface/src/views/stores/ViewMetadataStore.ts
+++ b/graylog2-web-interface/src/views/stores/ViewMetadataStore.ts
@@ -19,6 +19,7 @@ import { isEqual } from 'lodash';
 
 import type { Store } from 'stores/StoreTypes';
 import { singletonStore } from 'views/logic/singleton';
+import { ViewType } from 'views/logic/views/View';
 
 import { ViewStore } from './ViewStore';
 
@@ -28,6 +29,7 @@ export type ViewMetaData = {
   id: string,
   summary: string,
   title: string,
+  type: ViewType,
 };
 
 export type ViewMetadataStoreType = Store<ViewMetaData>;
@@ -47,9 +49,9 @@ export const ViewMetadataStore: ViewMetadataStoreType = singletonStore(
       let newState;
 
       if (view) {
-        const { id, title, description, summary } = view;
+        const { id, title, description, summary, type } = view;
 
-        newState = { id, title, description, summary, activeQuery };
+        newState = { id, title, description, summary, activeQuery, type };
       } else {
         newState = {};
       }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is a small change to include the `type` field of a view in the
`ViewMetadataStore`, so components interested in the metadata of a view
only can still consume its type without having to fetch the full view.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.