### PR TITLE
Remove Unnecessary Elasticsearch Version Props from Integration Tests

### DIFF
--- a/graylog-storage-elasticsearch6/pom.xml
+++ b/graylog-storage-elasticsearch6/pom.xml
@@ -35,7 +35,6 @@
     <description>Graylog Storage Module for Elasticsearch 6</description>
 
     <properties>
-        <it.es.version>6.8.0</it.es.version>
         <elasticsearch.version>5.6.16-2</elasticsearch.version>
         <jest.version>2.4.15+jackson</jest.version>
         <maven.deploy.skip>true</maven.deploy.skip>

--- a/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/testing/ElasticsearchInstanceES6.java
+++ b/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/testing/ElasticsearchInstanceES6.java
@@ -20,11 +20,10 @@ import com.github.joschi.jadconfig.util.Duration;
 import com.github.zafarkhaja.semver.Version;
 import com.google.common.collect.ImmutableList;
 import io.searchbox.client.JestClient;
-import org.graylog.testing.PropertyLoader;
+import org.graylog.storage.elasticsearch6.jest.JestClientProvider;
 import org.graylog.testing.elasticsearch.Client;
 import org.graylog.testing.elasticsearch.ElasticsearchInstance;
 import org.graylog.testing.elasticsearch.FixtureImporter;
-import org.graylog.storage.elasticsearch6.jest.JestClientProvider;
 import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,8 +34,7 @@ import java.net.URI;
 
 public class ElasticsearchInstanceES6 extends ElasticsearchInstance {
     private static final Logger LOG = LoggerFactory.getLogger(ElasticsearchInstance.class);
-    private static final String DEFAULT_VERSION = "6.8.4";
-    private static final String PROPERTIES_RESOURCE_NAME = "elasticsearch.properties";
+    private static final String ES_VERSION = "6.8.4";
 
     private final Client client;
     private final JestClient jestClient;
@@ -68,11 +66,7 @@ public class ElasticsearchInstanceES6 extends ElasticsearchInstance {
     }
 
     public static ElasticsearchInstance create(Network network) {
-        String version = PropertyLoader
-                .loadProperties(PROPERTIES_RESOURCE_NAME)
-                .getProperty("version", DEFAULT_VERSION);
-
-        return create(version, network);
+        return create(ES_VERSION, network);
     }
 
     public static ElasticsearchInstance create(String versionString, Network network) {

--- a/graylog-storage-elasticsearch6/src/test/resources/elasticsearch.properties
+++ b/graylog-storage-elasticsearch6/src/test/resources/elasticsearch.properties
@@ -1,1 +1,0 @@
-version=${it.es.version}

--- a/graylog-storage-elasticsearch7/pom.xml
+++ b/graylog-storage-elasticsearch7/pom.xml
@@ -35,7 +35,6 @@
     <description>Graylog Storage Module for Elasticsearch 7</description>
 
     <properties>
-        <it.es.version>7.6.2</it.es.version>
         <elasticsearch.version>7.9.1-0</elasticsearch.version>
         <maven.deploy.skip>true</maven.deploy.skip>
     </properties>

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/testing/ElasticsearchInstanceES7.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/testing/ElasticsearchInstanceES7.java
@@ -35,7 +35,7 @@ import java.net.URI;
 
 public class ElasticsearchInstanceES7 extends ElasticsearchInstance {
     private static final Logger LOG = LoggerFactory.getLogger(ElasticsearchInstanceES7.class);
-    private static final String DEFAULT_VERSION = "7.8.0";
+    private static final String ES_VERSION = "7.8.0";
 
     private final RestHighLevelClient restHighLevelClient;
     private final ElasticsearchClient elasticsearchClient;
@@ -75,7 +75,7 @@ public class ElasticsearchInstanceES7 extends ElasticsearchInstance {
     }
 
     public static ElasticsearchInstanceES7 create(Network network) {
-        return create(DEFAULT_VERSION, network);
+        return create(ES_VERSION, network);
     }
 
     public static ElasticsearchInstanceES7 create(String versionString, Network network) {


### PR DESCRIPTION
## Description
renamed DEFAULT_VERSION to ES_VERSION so it's not misleading (you can't set it to sth. different)
removed properties from pom
removed property file and loading

Fixes #8283

## Motivation and Context
There should only be one version in the src. 

## How Has This Been Tested?
I ran the IT-tests

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

