### PR TITLE
Fixing loading lifecycle for exported dashboards with failing load hooks.

### DIFF
--- a/graylog2-web-interface/src/views/logic/views/UseLoadView.ts
+++ b/graylog2-web-interface/src/views/logic/views/UseLoadView.ts
@@ -34,7 +34,10 @@ const useLoadView = (view: Promise<View>, query: { [key: string]: any }) => {
       loadingViewHooks,
       executingViewHooks,
       query,
-      () => setLoaded(true),
+      () => {
+        setLoaded(true);
+        setHookComponent(undefined);
+      },
     ).catch((e) => {
       if (e instanceof Error) {
         throw e;

--- a/graylog2-web-interface/src/views/pages/NewDashboardPage.tsx
+++ b/graylog2-web-interface/src/views/pages/NewDashboardPage.tsx
@@ -47,6 +47,8 @@ const NewDashboardPage = ({ location }: Props) => {
     }
 
     return ViewActions.create(View.Type.Dashboard).then(({ view }) => view);
+    // This should be run only once upon mount on purpose.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const [loaded, HookComponent] = useLoadView(loadedView, location.query);

--- a/graylog2-web-interface/src/views/pages/NewDashboardPage.tsx
+++ b/graylog2-web-interface/src/views/pages/NewDashboardPage.tsx
@@ -47,7 +47,7 @@ const NewDashboardPage = ({ location }: Props) => {
     }
 
     return ViewActions.create(View.Type.Dashboard).then(({ view }) => view);
-  }, [searchView]);
+  }, []);
 
   const [loaded, HookComponent] = useLoadView(loadedView, location.query);
 

--- a/graylog2-web-interface/src/views/stores/SearchExecutionStateStore.ts
+++ b/graylog2-web-interface/src/views/stores/SearchExecutionStateStore.ts
@@ -66,7 +66,7 @@ export const SearchExecutionStateStore: Store<SearchExecutionState> = singletonS
 
     clear(): SearchExecutionState {
       this.executionState = defaultExecutionState;
-      this.trigger(this.executionState);
+      this._trigger();
       SearchExecutionStateActions.clear.promise(Promise.resolve(this.executionState));
 
       return this.executionState;
@@ -76,7 +76,7 @@ export const SearchExecutionStateStore: Store<SearchExecutionState> = singletonS
       this.executionState = executionState;
 
       if (trigger) {
-        this.trigger(this.executionState);
+        this._trigger();
       }
 
       SearchExecutionStateActions.replace.promise(Promise.resolve(executionState));
@@ -92,7 +92,7 @@ export const SearchExecutionStateStore: Store<SearchExecutionState> = singletonS
       });
 
       this.executionState = this.executionState.toBuilder().parameterBindings(parameterBindings).build();
-      this.trigger(this.executionState);
+      this._trigger();
       SearchExecutionStateActions.setParameterValues.promise(Promise.resolve(this.executionState));
 
       return this.executionState;
@@ -103,7 +103,7 @@ export const SearchExecutionStateStore: Store<SearchExecutionState> = singletonS
         .parameterBindings(this.executionState.parameterBindings.set(parameterName, ParameterBinding.forValue(value)))
         .build();
 
-      this.trigger(this.executionState);
+      this._trigger();
       SearchExecutionStateActions.bindParameterValue.promise(Promise.resolve(this.executionState));
 
       return this.executionState;
@@ -114,10 +114,14 @@ export const SearchExecutionStateStore: Store<SearchExecutionState> = singletonS
         .globalOverride(newGlobalOverride)
         .build();
 
-      this.trigger(this.executionState);
+      this._trigger();
       SearchExecutionStateActions.globalOverride.promise(Promise.resolve(this.executionState));
 
       return this.executionState;
+    },
+
+    _trigger() {
+      this.trigger(this.executionState);
     },
   }),
 );


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This change is making sure that a dashboard which has been exported from
a search loads properly if one of the (load/execute) hooks fails. There
were two issues which are fixed in this change:

  1. The view was immediately recreated in the `NewDashboardPage` after
     taken from state, due to a rerendering of the `NewDashboardPage`
  2. The `HookComponent` returned by `useLoadView` was not cleared after
     a successful retry.

This change is fixing these issues, ensuring that a search exported to a
dashboard loads fine, e.g. if containing parameters.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.