### PR TITLE
Replace superagent with native fetch API.

### DIFF
--- a/graylog2-web-interface/package.json
+++ b/graylog2-web-interface/package.json
@@ -72,6 +72,7 @@
     "numeral": "^2.0.6",
     "opensans-npm-webfont": "1.0.0",
     "plotly.js": "^1.58.4",
+    "promise-polyfill": "^8.2.0",
     "qs": "^6.3.0",
     "react-ace": "9.2.1",
     "react-color": "^2.14.0",
@@ -101,7 +102,8 @@
     "ua-parser-js": "^0.7.12",
     "urijs": "^1.19.1",
     "utility-types": "^3.10.0",
-    "uuid": "^3.2.1"
+    "uuid": "^3.2.1",
+    "whatwg-fetch": "^3.6.2"
   },
   "devDependencies": {
     "@babel/core": "7.13.10",

--- a/graylog2-web-interface/package.json
+++ b/graylog2-web-interface/package.json
@@ -142,6 +142,7 @@
     "json-loader": "^0.5.3",
     "less": "^3.0.1",
     "less-loader": "^7.0.0",
+    "node-fetch": "^2.6.1",
     "puppeteer": "^2.1.1",
     "react-styleguidist": "^11.0.8",
     "style-loader": "2.0.0",

--- a/graylog2-web-interface/package.json
+++ b/graylog2-web-interface/package.json
@@ -94,8 +94,6 @@
     "react-ultimate-pagination": "^1.2.0",
     "react-window": "^1.8.2",
     "sockjs-client": "^1.4.0",
-    "superagent": "^6.1.0",
-    "superagent-bluebird-promise": "^4.1.0",
     "terser-webpack-plugin": "^4.0.0",
     "toastr": "^2.1.2",
     "twix": "^1.1.4",

--- a/graylog2-web-interface/src/polyfill.js
+++ b/graylog2-web-interface/src/polyfill.js
@@ -16,3 +16,7 @@
  */
 import 'core-js';
 import 'regenerator-runtime/runtime';
+
+// To support IE11 (remove if support is dropped)
+import 'promise-polyfill/src/polyfill';
+import 'whatwg-fetch';

--- a/graylog2-web-interface/src/views/stores/SearchStore.test.ts
+++ b/graylog2-web-interface/src/views/stores/SearchStore.test.ts
@@ -14,11 +14,12 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
+import asMock from 'helpers/mocking/AsMock';
+
 import fetch from 'logic/rest/FetchProvider';
 import Search from 'views/logic/search/Search';
 
 import { SearchActions } from './SearchStore';
-import asMock from 'helpers/mocking/AsMock';
 
 jest.mock('logic/rest/FetchProvider', () => jest.fn());
 

--- a/graylog2-web-interface/src/views/stores/SearchStore.test.ts
+++ b/graylog2-web-interface/src/views/stores/SearchStore.test.ts
@@ -18,12 +18,13 @@ import fetch from 'logic/rest/FetchProvider';
 import Search from 'views/logic/search/Search';
 
 import { SearchActions } from './SearchStore';
+import asMock from 'helpers/mocking/AsMock';
 
 jest.mock('logic/rest/FetchProvider', () => jest.fn());
 
 describe('SearchStore', () => {
   it('assigns a new search id when creating a search', () => {
-    fetch.mockImplementation((method, url, body) => Promise.resolve(body && JSON.parse(body)));
+    asMock(fetch).mockImplementation((method: string, url: string, body: any) => Promise.resolve(body && JSON.parse(body)));
     const newSearch = Search.create();
 
     return SearchActions.create(newSearch).then(({ search }) => {

--- a/graylog2-web-interface/test/integration-environment.js
+++ b/graylog2-web-interface/test/integration-environment.js
@@ -35,6 +35,7 @@ class IntegrationEnvironment extends JSDomEnvironment {
       version: '3.0.0',
       tagline: 'Manage your logs in the dark and have lasers going and make it look like you\'re from space!',
     }));
+
     api.post(`${prefix}cluster/metrics/multiple`, (req, res) => res.json({}));
     api.get(`${prefix}dashboards`, (req, res) => res.json([]));
     api.get(`${prefix}search/decorators/available`, (req, res) => res.json({}));
@@ -47,10 +48,12 @@ class IntegrationEnvironment extends JSDomEnvironment {
     api.get(`${prefix}system/sessions`, (req, res) => res.json({ session_id: null, username: null, is_valid: false }));
     api.get(`${prefix}system/notifications`, (req, res) => res.json([]));
     api.get(`${prefix}system/cluster/nodes`, (req, res) => res.json({ nodes: [], total: 0 }));
+
     api.get(`${prefix}system/cluster_config/org.graylog2.indexer.searches.SearchesClusterConfig`, (req, res) => res.json({
       relative_timerange_options: {},
       query_time_range_limit: 'P5M',
     }));
+
     api.get(`${prefix}views`, (req, res) => res.json({
       total: 0,
       page: 1,
@@ -58,17 +61,22 @@ class IntegrationEnvironment extends JSDomEnvironment {
       count: 0,
       views: [],
     }));
+
     api.get(`${prefix}views/fields`, (req, res) => res.json([]));
     api.get(`${prefix}views/functions`, (req, res) => res.json([]));
+
     api.post(`${prefix}views/search`, (req, res) => {
       const search = req.body;
       searches[search.id] = search;
+
       return res.json(search);
     });
+
     api.post(`${prefix}views/search/metadata`, (req, res) => res.json({
       query_metadata: {},
       declared_parameters: {},
     }));
+
     api.post(/views\/search\/(\w+)\/execute$/, (req, res) => {
       const search = searches[req.params[0]];
       const results = search.queries.map(({ id }) => [id, {
@@ -84,6 +92,7 @@ class IntegrationEnvironment extends JSDomEnvironment {
         state: 'COMPLETED',
       }])
         .reduce((prev, [id, result]) => ({ ...prev, [id]: result }), {});
+
       return res.json({
         id: `${req.params[0]}-job`,
         search_id: req.params[0],
@@ -101,6 +110,9 @@ class IntegrationEnvironment extends JSDomEnvironment {
     const { port } = this.server.address();
 
     this.global.api_url = `http://localhost:${port}${prefix}`;
+
+    // eslint-disable-next-line global-require
+    this.global.window.fetch = require('node-fetch');
   }
 
   async setup() {

--- a/graylog2-web-interface/yarn.lock
+++ b/graylog2-web-interface/yarn.lock
@@ -4527,7 +4527,7 @@ colors@~0.6.0-1:
   resolved "https://registry.yarnpkg.com/colors/-/colors-0.6.2.tgz#2423fe6678ac0c5dae8852e5d0e5be08c997abcc"
   integrity sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w=
 
-combined-stream@^1.0.6, combined-stream@^1.0.8, combined-stream@~1.0.6:
+combined-stream@^1.0.6, combined-stream@~1.0.6:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
@@ -4595,7 +4595,7 @@ compare-oriented-cell@^1.0.1:
     cell-orientation "^1.0.1"
     compare-cell "^1.0.0"
 
-component-emitter@^1.2.1, component-emitter@^1.3.0:
+component-emitter@^1.2.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
   integrity sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==
@@ -4728,11 +4728,6 @@ cookie@0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.0.tgz#beb437e7022b3b6d49019d088665303ebe9c14ba"
   integrity sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==
-
-cookiejar@^2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/cookiejar/-/cookiejar-2.1.2.tgz#dd8a235530752f988f9a0844f3fc589e3111125c"
-  integrity sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA==
 
 copy-concurrently@^1.0.0:
   version "1.0.5"
@@ -6789,11 +6784,6 @@ fast-memoize@^2.5.1:
   resolved "https://registry.yarnpkg.com/fast-memoize/-/fast-memoize-2.5.1.tgz#c3519241e80552ce395e1a32dcdde8d1fd680f5d"
   integrity sha512-xdmw296PCL01tMOXx9mdJSmWY29jQgxyuZdq0rEHMu+Tpe1eOEtCycoG6chzlcrWsNgpZP7oL8RiQr7+G6Bl6g==
 
-fast-safe-stringify@^2.0.7:
-  version "2.0.7"
-  resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz#124aa885899261f68aedb42a7c080de9da608743"
-  integrity sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA==
-
 fastest-levenshtein@^1.0.12:
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz#9990f7d3a88cc5a9ffd1f1745745251700d497e2"
@@ -7104,15 +7094,6 @@ fork-ts-checker-webpack-plugin@^6.0.0:
     semver "^7.3.2"
     tapable "^1.0.0"
 
-form-data@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.0.tgz#31b7e39c85f1355b7139ee0c647cf0de7f83c682"
-  integrity sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==
-  dependencies:
-    asynckit "^0.4.0"
-    combined-stream "^1.0.8"
-    mime-types "^2.1.12"
-
 form-data@~2.3.2:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.3.tgz#dcce52c05f644f298c6a7ab936bd724ceffbf3a6"
@@ -7121,11 +7102,6 @@ form-data@~2.3.2:
     asynckit "^0.4.0"
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
-
-formidable@^1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/formidable/-/formidable-1.2.2.tgz#bf69aea2972982675f00865342b982986f6b8dd9"
-  integrity sha512-V8gLm+41I/8kguQ4/o1D3RIHRmhYFG4pnNyonvua+40rqcEmT4+V71yaZ3B457xbbgCsCfjSPi65u/W6vK1U5Q==
 
 formik@2.2.6:
   version "2.2.6"
@@ -10742,7 +10718,7 @@ merge2@^1.3.0:
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
 
-methods@^1.1.2, methods@~1.1.2:
+methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
   integrity sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=
@@ -10804,7 +10780,7 @@ mime@1.6.0, mime@^1.4.1:
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
   integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
 
-mime@^2.0.3, mime@^2.4.4, mime@^2.4.6:
+mime@^2.0.3, mime@^2.4.4:
   version "2.4.6"
   resolved "https://registry.yarnpkg.com/mime/-/mime-2.4.6.tgz#e5b407c90db442f2beb5b162373d07b69affa4d1"
   integrity sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA==
@@ -12627,7 +12603,7 @@ qs@6.7.0:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
   integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
 
-qs@^6.3.0, qs@^6.9.4:
+qs@^6.3.0:
   version "6.9.6"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.9.6.tgz#26ed3c8243a431b2924aca84cc90471f35d5a0ee"
   integrity sha512-TIRk4aqYLNoJUbd+g2lEdz5kLWIuTMRagAXxl78Q0RiVjAOugHmeKNGdd3cwo/ktpf9aL9epCfFqWDEKysUlLQ==
@@ -15179,28 +15155,6 @@ sugarss@^2.0.0:
   integrity sha512-WfxjozUk0UVA4jm+U1d736AUpzSrNsQcIbyOkoE364GrtWmIrFdk5lksEupgWMD4VaT/0kVx1dobpiDumSgmJQ==
   dependencies:
     postcss "^7.0.2"
-
-superagent-bluebird-promise@^4.1.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/superagent-bluebird-promise/-/superagent-bluebird-promise-4.2.0.tgz#0b6a6872cc830371cb9f4172dd0510751abd16b2"
-  integrity sha1-C2pocsyDA3HLn0Fy3QUQdRq9FrI=
-
-superagent@^6.1.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/superagent/-/superagent-6.1.0.tgz#09f08807bc41108ef164cfb4be293cebd480f4a6"
-  integrity sha512-OUDHEssirmplo3F+1HWKUrUjvnQuA+nZI6i/JJBdXb5eq9IyEQwPyPpqND+SSsxf6TygpBEkUjISVRN4/VOpeg==
-  dependencies:
-    component-emitter "^1.3.0"
-    cookiejar "^2.1.2"
-    debug "^4.1.1"
-    fast-safe-stringify "^2.0.7"
-    form-data "^3.0.0"
-    formidable "^1.2.2"
-    methods "^1.1.2"
-    mime "^2.4.6"
-    qs "^6.9.4"
-    readable-stream "^3.6.0"
-    semver "^7.3.2"
 
 supercluster@^7.0.0:
   version "7.1.0"

--- a/graylog2-web-interface/yarn.lock
+++ b/graylog2-web-interface/yarn.lock
@@ -11225,6 +11225,11 @@ node-dir@^0.1.10:
   dependencies:
     minimatch "^3.0.2"
 
+node-fetch@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
+  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
+
 node-forge@0.9.0:
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.9.0.tgz#d624050edbb44874adca12bb9a52ec63cb782579"

--- a/graylog2-web-interface/yarn.lock
+++ b/graylog2-web-interface/yarn.lock
@@ -12440,6 +12440,11 @@ promise-inflight@^1.0.1:
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
   integrity sha1-mEcocL8igTL8vdhoEputEsPAKeM=
 
+promise-polyfill@^8.2.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/promise-polyfill/-/promise-polyfill-8.2.0.tgz#367394726da7561457aba2133c9ceefbd6267da0"
+  integrity sha512-k/TC0mIcPVF6yHhUvwAp7cvL6I2fFV7TzF1DuGPI8mBh4QQazf36xCKEHKTZKRysEoTQoQdKyP25J8MPJp7j5g==
+
 promise@^7.1.1:
   version "7.3.1"
   resolved "https://registry.yarnpkg.com/promise/-/promise-7.3.1.tgz#064b72602b18f90f29192b8b1bc418ffd1ebd3bf"
@@ -16692,6 +16697,11 @@ whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.3, whatwg-encoding@^1.0.5:
   integrity sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==
   dependencies:
     iconv-lite "0.4.24"
+
+whatwg-fetch@^3.6.2:
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz#dced24f37f2624ed0281725d51d0e2e3fe677f8c"
+  integrity sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==
 
 whatwg-mimetype@^2.1.0, whatwg-mimetype@^2.2.0, whatwg-mimetype@^2.3.0:
   version "2.3.0"


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

This PR is replacing our usage of the `superagent` & `superagent-bluebird-promise` dependencies with the native [`fetch API`](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

When we started to migrate the Graylog Web Interface to an SPA, there was no native API that allowed us to communicate with the REST API in a friendly way. Therefore we employed `superagent` to handle this task for us. This has changed in the way that the fetch API is now around for quite some time and allows us to do everything that `superagent` does, without an external dependency.

As we do want to support IE11 now, we need to provide a `fetch` as well as a `Promise` polyfill for now. These are added and imported at startup. If we decide to drop support for IE11, we can easily remove those again.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

This has been tested with Chrome, Firefox and (most importantly) IE11 on Windows 10.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.