### PR TITLE
Add posibility to disable actions from plugin

### DIFF
--- a/graylog2-web-interface/src/views/components/widgets/ExtraWidgetActions.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/ExtraWidgetActions.test.tsx
@@ -40,6 +40,10 @@ describe('ExtraWidgetActions', () => {
     ...dummyActionWithoutIsHidden,
     isHidden: jest.fn(() => false),
   };
+  const dummyActionWhichIsDisabled = {
+    ...dummyActionWithoutIsHidden,
+    disabled: jest.fn(() => true),
+  };
 
   it('returns `null` if no action is configured', () => {
     const { container } = render(<ExtraWidgetActions onSelect={() => {}} widget={widget} />);
@@ -109,5 +113,16 @@ describe('ExtraWidgetActions', () => {
     render(<ExtraWidgetActions onSelect={() => {}} widget={widget} />);
 
     await screen.findByRole('separator');
+  });
+
+  it('renders a disabled action disabled', async () => {
+    asMock(usePluginEntities).mockReturnValue([dummyActionWhichIsDisabled]);
+
+    render(<ExtraWidgetActions onSelect={() => {}} widget={widget} />);
+
+    const menuItem = await screen.findByRole('presentation');
+
+    expect(menuItem).toHaveClass('disabled');
+    expect(dummyActionWhichIsDisabled.disabled).toHaveBeenCalledTimes(1);
   });
 });

--- a/graylog2-web-interface/src/views/components/widgets/ExtraWidgetActions.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/ExtraWidgetActions.tsx
@@ -32,15 +32,13 @@ const ExtraWidgetActions = ({ onSelect, widget }: Props) => {
   const pluginWidgetActions = usePluginEntities('views.widgets.actions');
   const extraWidgetActions = useMemo(() => pluginWidgetActions
     .filter(({ isHidden = () => false }) => !isHidden(widget))
-    .map(({ title, action, type, disabled }) => {
+    .map(({ title, action, type, disabled = () => false }) => {
       const _onSelect = (eventKey: string, e: MouseEvent) => {
         action(widget, { widgetFocusContext });
         onSelect(eventKey, e);
       };
 
-      const isDisabled = disabled && disabled();
-
-      return (<MenuItem key={`${type}-${widget.id}`} disabled={isDisabled} onSelect={_onSelect}>{title(widget)}</MenuItem>);
+      return (<MenuItem key={`${type}-${widget.id}`} disabled={disabled()} onSelect={_onSelect}>{title(widget)}</MenuItem>);
     }), [onSelect, pluginWidgetActions, widget, widgetFocusContext]);
 
   return extraWidgetActions.length > 0

--- a/graylog2-web-interface/src/views/components/widgets/ExtraWidgetActions.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/ExtraWidgetActions.tsx
@@ -32,13 +32,15 @@ const ExtraWidgetActions = ({ onSelect, widget }: Props) => {
   const pluginWidgetActions = usePluginEntities('views.widgets.actions');
   const extraWidgetActions = useMemo(() => pluginWidgetActions
     .filter(({ isHidden = () => false }) => !isHidden(widget))
-    .map(({ title, action, type }) => {
+    .map(({ title, action, type, disabled }) => {
       const _onSelect = (eventKey: string, e: MouseEvent) => {
         action(widget, { widgetFocusContext });
         onSelect(eventKey, e);
       };
 
-      return (<MenuItem key={`${type}-${widget.id}`} onSelect={_onSelect}>{title(widget)}</MenuItem>);
+      const isDisabled = disabled && disabled();
+
+      return (<MenuItem key={`${type}-${widget.id}`} disabled={isDisabled} onSelect={_onSelect}>{title(widget)}</MenuItem>);
     }), [onSelect, pluginWidgetActions, widget, widgetFocusContext]);
 
   return extraWidgetActions.length > 0

--- a/graylog2-web-interface/src/views/components/widgets/Types.ts
+++ b/graylog2-web-interface/src/views/components/widgets/Types.ts
@@ -30,4 +30,5 @@ export type WidgetActionType = {
   title: (w: Widget) => React.ReactNode,
   isHidden?: (w: Widget) => boolean,
   action: WidgetAction,
+  disabled?: () => boolean,
 };


### PR DESCRIPTION
## Motivation
Prior to this change, actions introduced by plugins where not able to be
disabled by the plugin.

## Description
This change will add a interface to check if the rendered action should
be disabled or not.

## How Has This Been Tested?
Tested with Enterprise plugin

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


