### PR TITLE
Fix HeatmapVisualization with empty data and smallest default value

### DIFF
--- a/graylog2-web-interface/src/views/components/visualizations/heatmap/HeatmapVisualization.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/heatmap/HeatmapVisualization.tsx
@@ -78,7 +78,7 @@ const _transposeMatrix = (z: Array<Array<any>> = []) => {
   return z[0].map((_, c) => { return z.map((r) => { return r[c]; }); });
 };
 
-const _findSmallestValue = (valuesFound: Array<Array<number>>) => valuesFound.reduce((result, valueArray) => valueArray.reduce((acc, value) => (acc > value ? value : acc), result), valuesFound[0][0]);
+const _findSmallestValue = (valuesFound: Array<Array<number>>) => valuesFound.reduce((result, valueArray) => valueArray.reduce((acc, value) => (acc > value ? value : acc), result), (valuesFound[0] || [])[0]);
 
 const _formatSeries = (visualizationConfig) => ({ valuesBySeries, xLabels }: {valuesBySeries: ValuesBySeries, xLabels: Array<any>}): ExtractedSeries => {
   const valuesFoundBySeries = values(valuesBySeries);

--- a/graylog2-web-interface/src/views/components/visualizations/heatmap/__tests__/HeatmapVisualization.test.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/heatmap/__tests__/HeatmapVisualization.test.tsx
@@ -27,6 +27,8 @@ import { AbsoluteTimeRange } from 'views/logic/queries/Query';
 import * as fixtures from './HeatmapVisualization.fixtures';
 
 import HeatmapVisualization from '../HeatmapVisualization';
+import VisualizationConfig from 'views/logic/aggregationbuilder/visualizations/VisualizationConfig';
+import HeatmapVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/HeatmapVisualizationConfig';
 
 jest.mock('../../GenericPlot', () => mockComponent('GenericPlot'));
 
@@ -64,6 +66,53 @@ describe('HeatmapVisualization', () => {
                                                 height={1024}
                                                 onChange={() => {}}
                                                 toggleEdit={() => {}}
+                                                width={800} />);
+    const genericPlot = wrapper.find('GenericPlot');
+
+    expect(genericPlot).toHaveProp('layout', plotLayout);
+    expect(genericPlot).toHaveProp('chartData', plotChartData);
+  });
+
+  it('generates correct props for plot component with empty data with use smallest value as default', () => {
+    const columnPivot = new Pivot('http_status', 'values');
+    const rowPivot = new Pivot('hour', 'values');
+    const series = new Series('count()');
+    const config = AggregationWidgetConfig.builder()
+      .rowPivots([rowPivot])
+      .columnPivots([columnPivot]).series([series])
+      .visualization('heatmap')
+      .visualizationConfig(HeatmapVisualizationConfig.empty().toBuilder().useSmallestAsDefault(true).build())
+      .build();
+    const effectiveTimerange: AbsoluteTimeRange = {
+      type: 'absolute',
+      from: '2019-10-22T11:54:35.850Z',
+      to: '2019-10-29T11:53:50.000Z',
+    };
+    const plotLayout = { yaxis: { fixedrange: true }, xaxis: { fixedrange: true }, margin: { b: 40 } };
+    const plotChartData = [
+      {
+        type: 'heatmap',
+        name: 'Heatmap Chart',
+        x: [],
+        y: [],
+        z: [],
+        text: [],
+        customdata: [],
+        hovertemplate: 'hour: %{y}<br>http_status: %{x}<br>%{text}: %{customdata}<extra></extra>',
+        colorscale: 'Viridis',
+        reversescale: false,
+      },
+    ];
+
+    const wrapper = mount(<HeatmapVisualization data={{ chart: [] }}
+                                                config={config}
+                                                effectiveTimerange={effectiveTimerange}
+                                                fields={Immutable.List()}
+                                                height={1024}
+                                                onChange={() => {
+                                                }}
+                                                toggleEdit={() => {
+                                                }}
                                                 width={800} />);
     const genericPlot = wrapper.find('GenericPlot');
 

--- a/graylog2-web-interface/src/views/components/visualizations/heatmap/__tests__/HeatmapVisualization.test.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/heatmap/__tests__/HeatmapVisualization.test.tsx
@@ -23,12 +23,11 @@ import Pivot from 'views/logic/aggregationbuilder/Pivot';
 import Series from 'views/logic/aggregationbuilder/Series';
 import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
 import { AbsoluteTimeRange } from 'views/logic/queries/Query';
+import HeatmapVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/HeatmapVisualizationConfig';
 
 import * as fixtures from './HeatmapVisualization.fixtures';
 
 import HeatmapVisualization from '../HeatmapVisualization';
-import VisualizationConfig from 'views/logic/aggregationbuilder/visualizations/VisualizationConfig';
-import HeatmapVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/HeatmapVisualizationConfig';
 
 jest.mock('../../GenericPlot', () => mockComponent('GenericPlot'));
 


### PR DESCRIPTION
## Motivation
Prior to this change, if the default value was set with the smallest
value and the provided data was empty, we raised an stacktraced.

## Description
This change will ensure the empty data does not get accessed where
nothing is defined.

## How Has This Been Tested?
Create a HeatmapVisualization and select a timerange without data.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


