### PR TITLE
Add Mongo-based storage for Data Adapter data.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/lookup/db/LookupStorage.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/db/LookupStorage.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog2.lookup.db;
 
 import com.mongodb.BasicDBObject;

--- a/graylog2-server/src/main/java/org/graylog2/lookup/db/LookupStorage.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/db/LookupStorage.java
@@ -1,0 +1,135 @@
+package org.graylog2.lookup.db;
+
+import com.mongodb.BasicDBObject;
+import com.mongodb.DB;
+import com.mongodb.DBCollection;
+import com.mongodb.WriteConcern;
+import org.bson.types.ObjectId;
+import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
+import org.graylog2.database.MongoConnection;
+import org.graylog2.lookup.dto.LookupStorageDto;
+import org.graylog2.plugin.Tools;
+import org.joda.time.DateTime;
+import org.mongojack.DBQuery;
+import org.mongojack.JacksonDBCollection;
+import org.mongojack.WriteResult;
+
+import javax.inject.Inject;
+
+import java.util.Optional;
+
+import static org.graylog2.lookup.dto.LookupStorageDto.FIELD_LOOKUP_KEY;
+import static org.graylog2.lookup.dto.LookupStorageDto.FIELD_UPDATED_AT;
+
+/**
+ * This class provides MongoDB-backed storage for data retrieved by Data Adapters.  Each Data Adapter's data will
+ * be stored in a unique MongoDB collection named "lut_data_adapter_storage_Data-Adapter-ID".  The init() method should
+ * be called when the Data Adapter is started and the tearDown() method should be called when the Data Adapter is
+ * deleted.
+ */
+public class LookupStorage {
+    private static final String TABLE_PREFIX = "lut_data_adapter_storage_";
+
+    private final JacksonDBCollection<LookupStorageDto, ObjectId> lookupCollection;
+
+    @Inject
+    public LookupStorage(MongoConnection mongoConnection,
+                         MongoJackObjectMapperProvider objectMapperProvider,
+                         String lookupTableId) {
+        DB mongoDatabase = mongoConnection.getDatabase();
+        DBCollection collection = mongoDatabase.getCollection(TABLE_PREFIX + lookupTableId);
+
+        lookupCollection = JacksonDBCollection.wrap(
+                collection,
+                LookupStorageDto.class,
+                ObjectId.class,
+                objectMapperProvider.get());
+    }
+
+    /**
+     * Set up a new MongoDB collection for a Data Adapter
+     */
+    public void init() {
+        lookupCollection.createIndex(
+                new BasicDBObject(FIELD_LOOKUP_KEY, 1),
+                new BasicDBObject("unique", true));
+    }
+
+    /**
+     * Add an entry to a Data Adapter's collection
+     * @param key
+     * @param data
+     */
+    public void add(String key, Object data) {
+        add(key, data, Tools.nowUTC(), false);
+    }
+
+    /**
+     * Add an entry to a Data Adapter's collection
+     * @param key
+     * @param data
+     * @param updateTime
+     */
+    public void add(String key, Object data, DateTime updateTime) {
+        add(key, data, updateTime, false);
+    }
+
+    /**
+     * Add an entry to a Data Adapter's collection.  If the fastWrites parameter is set to TRUE, unacknowledged writes
+     * will be used and any errors that occur while writing will not be reported.  This is only intended for use with
+     * large data sets (>= 1MM records) which cannot otherwise be processed in a timely fasion.
+     * @param key
+     * @param data
+     * @param updateTime
+     * @param fastWrites
+     */
+    public void add(String key, Object data, DateTime updateTime, boolean fastWrites) {
+        final WriteConcern writeConcern = fastWrites ? WriteConcern.UNACKNOWLEDGED : WriteConcern.ACKNOWLEDGED;
+        lookupCollection.update(DBQuery.is(FIELD_LOOKUP_KEY, key),
+                LookupStorageDto.builder().key(key).data(data).updatedAt(updateTime).build(),
+                true,
+                false,
+                writeConcern);
+    }
+
+    /**
+     * Retrieve the record for a particular lookup key
+     * @param key
+     * @return
+     */
+    public Optional<Object> lookup(String key) {
+        LookupStorageDto record = lookupCollection.findOne(DBQuery.is(FIELD_LOOKUP_KEY, key));
+        if (null == record) {
+            return Optional.empty();
+        } else {
+            return Optional.ofNullable(record.data());
+        }
+    }
+
+    /**
+     * Delete all records that have not been updated since the cutoff time.
+     * @param cutoff
+     * @return
+     */
+    public int deleteNotUpdatedSince(DateTime cutoff) {
+        WriteResult result = lookupCollection.remove(DBQuery.lessThan(FIELD_UPDATED_AT, cutoff));
+        return result.getN();
+    }
+
+    /**
+     * Delete all records from the collection.
+     * @return
+     */
+    public int purgeTable() {
+        WriteResult result = lookupCollection.remove(DBQuery.exists(FIELD_LOOKUP_KEY));
+        return result.getN();
+    }
+
+    /**
+     * Clean up a collection that is no longer needed.
+     */
+    public void tearDown() {
+        lookupCollection.dropIndexes();
+        lookupCollection.drop();
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/lookup/db/LookupStorageFactory.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/db/LookupStorageFactory.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog2.lookup.db;
 
 import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;

--- a/graylog2-server/src/main/java/org/graylog2/lookup/db/LookupStorageFactory.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/db/LookupStorageFactory.java
@@ -1,0 +1,24 @@
+package org.graylog2.lookup.db;
+
+import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
+import org.graylog2.database.MongoConnection;
+import org.graylog2.plugin.lookup.LookupDataAdapter;
+
+import javax.inject.Inject;
+
+public class LookupStorageFactory {
+
+    private final MongoConnection mongoConnection;
+    private final MongoJackObjectMapperProvider objectMapperProvider;
+
+    @Inject
+    public LookupStorageFactory(MongoConnection mongoConnection,
+                                MongoJackObjectMapperProvider objectMapperProvider) {
+        this.mongoConnection = mongoConnection;
+        this.objectMapperProvider = objectMapperProvider;
+    }
+
+    public LookupStorage getStorage(LookupDataAdapter dataAdapter) {
+        return new LookupStorage(mongoConnection, objectMapperProvider, dataAdapter.id());
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/lookup/dto/LookupStorageDto.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/dto/LookupStorageDto.java
@@ -1,0 +1,61 @@
+package org.graylog2.lookup.dto;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.auto.value.AutoValue;
+import org.graylog.autovalue.WithBeanGetter;
+import org.joda.time.DateTime;
+import org.mongojack.Id;
+import org.mongojack.ObjectId;
+
+import javax.annotation.Nullable;
+
+@AutoValue
+@WithBeanGetter
+@JsonDeserialize(builder = AutoValue_LookupStorageDto.Builder.class)
+public abstract class LookupStorageDto {
+    public static final String FIELD_ID = "id";
+    public static final String FIELD_LOOKUP_KEY = "lookup_key";
+    public static final String FIELD_LOOKUP_DATA = "lookup_data";
+    public static final String FIELD_UPDATED_AT = "updated_at";
+
+    @Id
+    @ObjectId
+    @Nullable
+    @JsonProperty(FIELD_ID)
+    public abstract String id();
+
+    @JsonProperty(FIELD_LOOKUP_KEY)
+    public abstract String key();
+
+    @JsonProperty(FIELD_LOOKUP_DATA)
+    public abstract Object data();
+
+    @JsonProperty(FIELD_UPDATED_AT)
+    public abstract DateTime updatedAt();
+
+    public static LookupStorageDto.Builder builder() {
+        return new AutoValue_LookupStorageDto.Builder();
+    }
+
+    @JsonAutoDetect
+    @AutoValue.Builder
+    public abstract static class Builder {
+        @Id
+        @ObjectId
+        @JsonProperty(FIELD_ID)
+        public abstract LookupStorageDto.Builder id(@Nullable String id);
+
+        @JsonProperty(FIELD_LOOKUP_KEY)
+        public abstract LookupStorageDto.Builder key(String key);
+
+        @JsonProperty(FIELD_LOOKUP_DATA)
+        public abstract LookupStorageDto.Builder data(Object data);
+
+        @JsonProperty(FIELD_UPDATED_AT)
+        public abstract LookupStorageDto.Builder updatedAt(DateTime updatedAt);
+
+        public abstract LookupStorageDto build();
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/lookup/dto/LookupStorageDto.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/dto/LookupStorageDto.java
@@ -7,6 +7,22 @@ import com.google.auto.value.AutoValue;
 import org.graylog.autovalue.WithBeanGetter;
 import org.joda.time.DateTime;
 import org.mongojack.Id;
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 import org.mongojack.ObjectId;
 
 import javax.annotation.Nullable;

--- a/graylog2-server/src/main/java/org/graylog2/lookup/dto/LookupStorageDto.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/dto/LookupStorageDto.java
@@ -1,12 +1,3 @@
-package org.graylog2.lookup.dto;
-
-import com.fasterxml.jackson.annotation.JsonAutoDetect;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.google.auto.value.AutoValue;
-import org.graylog.autovalue.WithBeanGetter;
-import org.joda.time.DateTime;
-import org.mongojack.Id;
 /*
  * Copyright (C) 2020 Graylog, Inc.
  *
@@ -23,6 +14,15 @@ import org.mongojack.Id;
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
+package org.graylog2.lookup.dto;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.auto.value.AutoValue;
+import org.graylog.autovalue.WithBeanGetter;
+import org.joda.time.DateTime;
+import org.mongojack.Id;
 import org.mongojack.ObjectId;
 
 import javax.annotation.Nullable;


### PR DESCRIPTION
## Description
Some Data Adapters download data from HTTP endpoints and store that data in memory.  This change adds an option for downloaded data sets to be stored in MongoDB instead, hopefully freeing up more memory.

## How Has This Been Tested?
This has been tested locally with a new Abuse.ch URLhaus Data Adapter.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

