### PR TITLE
Add sorting to aggregation wizard.

### DIFF
--- a/graylog2-web-interface/src/views/components/aggregationwizard/AggregationWizard.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/AggregationWizard.tsx
@@ -93,9 +93,9 @@ const _onSubmit = (formValues: WidgetConfigFormValues, onConfigChange: (newConfi
     }
 
     return toConfig;
-  }).reduce((prevConfig, toConfig) => toConfig(formValues, prevConfig), AggregationWidgetConfig.builder().build());
+  }).reduce((prevConfig, toConfig) => toConfig(formValues, prevConfig), AggregationWidgetConfig.builder());
 
-  onConfigChange(newConfig);
+  onConfigChange(newConfig.build());
 };
 
 const validateForm = (formValues: WidgetConfigFormValues) => {

--- a/graylog2-web-interface/src/views/components/aggregationwizard/AggregationWizard.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/AggregationWizard.tsx
@@ -119,7 +119,7 @@ const AggregationWizard = ({ onChange, config, children }: EditWidgetComponentPr
         <WidgetConfigForm onSubmit={(formValues: WidgetConfigFormValues) => _onSubmit(formValues, onChange)}
                           initialValues={initialFormValues}
                           validate={validateForm}>
-          {({ isValid, dirty, values, setValues }) => (
+          {({ isSubmitting, isValid, dirty, values, setValues }) => (
             <>
               <Section data-testid="add-element-section">
                 <AggregationElementSelect onElementCreate={(elementKey) => _onElementCreate(elementKey, values, setValues)}
@@ -132,7 +132,7 @@ const AggregationWizard = ({ onChange, config, children }: EditWidgetComponentPr
                                        onConfigChange={onChange} />
                 {dirty && (
                   <StyledButtonToolbar>
-                    <Button bsStyle="primary" className="pull-right" type="submit" disabled={!isValid}>Apply Changes</Button>
+                    <Button bsStyle="primary" className="pull-right" type="submit" disabled={!isValid || isSubmitting}>{isSubmitting ? 'Applying Changes' : 'Apply Changes'}</Button>
                   </StyledButtonToolbar>
                 )}
               </Section>

--- a/graylog2-web-interface/src/views/components/aggregationwizard/WidgetConfigForm.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/WidgetConfigForm.tsx
@@ -64,7 +64,11 @@ export type VisualizationConfigDefinition = {
   fields: Array<ConfigurationField>,
 };
 
-export type SortFormValues = {}
+export type SortFormValues = {
+  field: string,
+  direction: 'Ascending' | 'Descending',
+}
+
 export interface WidgetConfigFormValues {
   metrics?: Array<MetricFormValues>,
   groupBy?: {
@@ -72,7 +76,7 @@ export interface WidgetConfigFormValues {
     groupings: Array<GroupByFormValues>,
   },
   visualization?: VisualizationFormValues,
-  sort?: SortFormValues,
+  sort?: Array<SortFormValues>,
 }
 
 export interface WidgetConfigValidationErrors {

--- a/graylog2-web-interface/src/views/components/aggregationwizard/WidgetConfigForm.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/WidgetConfigForm.tsx
@@ -36,13 +36,16 @@ type GroupingField<T extends 'values' | 'time'> = {
 
 export type GroupingDirection = 'row' | 'column';
 
-export type DateGrouping = {
+export type BaseGrouping = {
   direction: GroupingDirection,
+};
+
+export type DateGrouping = BaseGrouping & {
   field: GroupingField<'time'>,
   interval: AutoTimeConfig | TimeUnitConfig,
-}
-export type ValuesGrouping = {
-  direction: GroupingDirection,
+};
+
+export type ValuesGrouping = BaseGrouping & {
   field: GroupingField<'values'>,
   limit: number,
 };
@@ -65,6 +68,7 @@ export type VisualizationConfigDefinition = {
 };
 
 export type SortFormValues = {
+  type: 'metric' | 'groupBy',
   field: string,
   direction: 'Ascending' | 'Descending',
 }

--- a/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/AggregationElementType.ts
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/AggregationElementType.ts
@@ -14,7 +14,7 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
+import AggregationWidgetConfig, { AggregationWidgetConfigBuilder } from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
 
 import type { WidgetConfigFormValues, WidgetConfigValidationErrors } from '../WidgetConfigForm';
 
@@ -24,7 +24,7 @@ export type AggregationElement = {
   allowCreate: (formValues: WidgetConfigFormValues) => boolean,
   order: number,
   addEmptyElement?: (formValues: WidgetConfigFormValues) => WidgetConfigFormValues,
-  toConfig?: (formValues: WidgetConfigFormValues, currentConfig: AggregationWidgetConfig) => AggregationWidgetConfig,
+  toConfig?: (formValues: WidgetConfigFormValues, currentConfigBuilder: AggregationWidgetConfigBuilder) => AggregationWidgetConfigBuilder,
   fromConfig?: (config: AggregationWidgetConfig) => Partial<WidgetConfigFormValues>,
   onCreate?: () => void,
   onDeleteAll?: (formValues: WidgetConfigFormValues) => WidgetConfigFormValues,

--- a/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/GroupByElement.ts
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/GroupByElement.ts
@@ -14,7 +14,7 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
+import AggregationWidgetConfig, { AggregationWidgetConfigBuilder } from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
 import Pivot, { TimeConfigType, ValuesConfigType } from 'views/logic/aggregationbuilder/Pivot';
 
 import type { AggregationElement } from './AggregationElementType';
@@ -155,16 +155,15 @@ const groupingToPivot = (grouping: GroupByFormValues) => {
   return new Pivot(grouping.field.field, grouping.field.type, pivotConfig);
 };
 
-const groupByToConfig = (groupBy: WidgetConfigFormValues['groupBy'], config: AggregationWidgetConfig) => {
+const groupByToConfig = (groupBy: WidgetConfigFormValues['groupBy'], config: AggregationWidgetConfigBuilder) => {
   const rowPivots = groupBy.groupings.filter((grouping) => grouping.direction === 'row').map(groupingToPivot);
   const columnPivots = groupBy.groupings.filter((grouping) => grouping.direction === 'column').map(groupingToPivot);
   const { columnRollup } = groupBy;
 
-  return config.toBuilder()
+  return config
     .rowPivots(rowPivots)
     .columnPivots(columnPivots)
-    .rollup(columnRollup)
-    .build();
+    .rollup(columnRollup);
 };
 
 export const emptyGrouping: ValuesGrouping = {
@@ -197,7 +196,7 @@ const GroupByElement: AggregationElement = {
       groupings: pivotsToGrouping(config),
     },
   }),
-  toConfig: (formValues: WidgetConfigFormValues, config: AggregationWidgetConfig) => groupByToConfig(formValues.groupBy, config),
+  toConfig: (formValues: WidgetConfigFormValues, configBuilder: AggregationWidgetConfigBuilder) => groupByToConfig(formValues.groupBy, configBuilder),
   component: GroupByConfiguration,
   validate: validateGroupBy,
 };

--- a/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/MetricElement.ts
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/MetricElement.ts
@@ -14,7 +14,7 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
+import AggregationWidgetConfig, { AggregationWidgetConfigBuilder } from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
 import Series, { parseSeries } from 'views/logic/aggregationbuilder/Series';
 import SeriesConfig from 'views/logic/aggregationbuilder/SeriesConfig';
 
@@ -98,10 +98,8 @@ const MetricElement: AggregationElement = {
   fromConfig: (config: AggregationWidgetConfig) => ({
     metrics: seriesToMetrics(config.series),
   }),
-  toConfig: (formValues: WidgetConfigFormValues, config: AggregationWidgetConfig) => config
-    .toBuilder()
-    .series(metricsToSeries(formValues.metrics))
-    .build(),
+  toConfig: (formValues: WidgetConfigFormValues, configBuilder: AggregationWidgetConfigBuilder) => configBuilder
+    .series(metricsToSeries(formValues.metrics)),
   component: MetricsConfiguration,
   validate: validateMetrics,
 };

--- a/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/SortElement.ts
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/SortElement.ts
@@ -14,8 +14,6 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import { isEmpty } from 'lodash';
-
 import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
 import Direction from 'views/logic/aggregationbuilder/Direction';
 import SortConfig from 'views/logic/aggregationbuilder/SortConfig';

--- a/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/SortElement.ts
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/SortElement.ts
@@ -58,6 +58,22 @@ const validateSorts = (values: WidgetConfigFormValues) => {
   return hasErrors(sortErrors) ? { sort: sortErrors } : {};
 };
 
+const configTypeToFormValueType = (type: 'pivot' | 'series') => {
+  switch (type) {
+    case 'pivot': return 'groupBy';
+    case 'series': return 'metric';
+    default: throw new Error(`Invalid sort type: ${type}`);
+  }
+};
+
+const formValueTypeToConfigType = (type: 'groupBy' | 'metric') => {
+  switch (type) {
+    case 'groupBy': return 'pivot';
+    case 'metric': return 'series';
+    default: throw new Error(`Invalid sort type: ${type}`);
+  }
+};
+
 const SortElement: AggregationElement = {
   title: 'Sort',
   key: 'sort',
@@ -66,12 +82,13 @@ const SortElement: AggregationElement = {
   component: SortConfiguration,
   fromConfig: (config: AggregationWidgetConfig) => ({
     sort: config.sort.map((s) => ({
+      type: configTypeToFormValueType(s.type),
       field: s.field,
       direction: s.direction?.direction,
     })),
   }),
   toConfig: (formValues: WidgetConfigFormValues, config: AggregationWidgetConfig) => config.toBuilder()
-    .sort(formValues.sort.map((sort) => new SortConfig('foo', sort.field, Direction.fromString(sort.direction))))
+    .sort(formValues.sort.map((sort) => new SortConfig(formValueTypeToConfigType(sort.type), sort.field, Direction.fromString(sort.direction))))
     .build(),
   validate: validateSorts,
 };

--- a/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/SortElement.ts
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/SortElement.ts
@@ -25,6 +25,39 @@ import type { AggregationElement } from './AggregationElementType';
 import SortConfiguration from '../elementConfiguration/SortConfiguration';
 import { WidgetConfigFormValues } from '../WidgetConfigForm';
 
+type SortError = {
+  field?: string,
+  direction?: string,
+}
+
+const hasErrors = <T extends {}>(errors: Array<T>): boolean => {
+  return errors.filter((error) => Object.keys(error).length > 0).length > 0;
+};
+
+const validateSorts = (values: WidgetConfigFormValues) => {
+  const errors = {};
+
+  if (!values.sort) {
+    return errors;
+  }
+
+  const sortErrors = values.sort.map((sort) => {
+    const sortError: SortError = {};
+
+    if (!sort.field || sort.field === '') {
+      sortError.field = 'Field is required.';
+    }
+
+    if (!sort.direction) {
+      sortError.direction = 'Direction is required.';
+    }
+
+    return sortError;
+  });
+
+  return hasErrors(sortErrors) ? { sort: sortErrors } : {};
+};
+
 const SortElement: AggregationElement = {
   title: 'Sort',
   key: 'sort',
@@ -40,6 +73,7 @@ const SortElement: AggregationElement = {
   toConfig: (formValues: WidgetConfigFormValues, config: AggregationWidgetConfig) => config.toBuilder()
     .sort(formValues.sort.map((sort) => new SortConfig('foo', sort.field, Direction.fromString(sort.direction))))
     .build(),
+  validate: validateSorts,
 };
 
 export default SortElement;

--- a/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/SortElement.ts
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/SortElement.ts
@@ -14,7 +14,7 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
+import AggregationWidgetConfig, { AggregationWidgetConfigBuilder } from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
 import Direction from 'views/logic/aggregationbuilder/Direction';
 import SortConfig from 'views/logic/aggregationbuilder/SortConfig';
 
@@ -85,9 +85,8 @@ const SortElement: AggregationElement = {
       direction: s.direction?.direction,
     })),
   }),
-  toConfig: (formValues: WidgetConfigFormValues, config: AggregationWidgetConfig) => config.toBuilder()
-    .sort(formValues.sort.map((sort) => new SortConfig(formValueTypeToConfigType(sort.type), sort.field, Direction.fromString(sort.direction))))
-    .build(),
+  toConfig: (formValues: WidgetConfigFormValues, configBuilder: AggregationWidgetConfigBuilder) => configBuilder
+    .sort(formValues.sort.map((sort) => new SortConfig(formValueTypeToConfigType(sort.type), sort.field, Direction.fromString(sort.direction)))),
   validate: validateSorts,
 };
 

--- a/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/SortElement.ts
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/SortElement.ts
@@ -16,6 +16,10 @@
  */
 import { isEmpty } from 'lodash';
 
+import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
+import Direction from 'views/logic/aggregationbuilder/Direction';
+import SortConfig from 'views/logic/aggregationbuilder/SortConfig';
+
 import type { AggregationElement } from './AggregationElementType';
 
 import SortConfiguration from '../elementConfiguration/SortConfiguration';
@@ -27,6 +31,15 @@ const SortElement: AggregationElement = {
   order: 3,
   allowCreate: (formValues: WidgetConfigFormValues) => isEmpty(formValues.sort),
   component: SortConfiguration,
+  fromConfig: (config: AggregationWidgetConfig) => ({
+    sort: config.sort.map((s) => ({
+      field: s.field,
+      direction: s.direction?.direction,
+    })),
+  }),
+  toConfig: (formValues: WidgetConfigFormValues, config: AggregationWidgetConfig) => config.toBuilder()
+    .sort(formValues.sort.map((sort) => new SortConfig('foo', sort.field, Direction.fromString(sort.direction))))
+    .build(),
 };
 
 export default SortElement;

--- a/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/SortElement.ts
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/SortElement.ts
@@ -78,7 +78,7 @@ const SortElement: AggregationElement = {
   title: 'Sort',
   key: 'sort',
   order: 3,
-  allowCreate: (formValues: WidgetConfigFormValues) => isEmpty(formValues.sort),
+  allowCreate: () => true,
   component: SortConfiguration,
   fromConfig: (config: AggregationWidgetConfig) => ({
     sort: config.sort.map((s) => ({

--- a/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/VisualizationElement.ts
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/VisualizationElement.ts
@@ -17,7 +17,7 @@
 import { isEmpty } from 'lodash';
 import { PluginStore } from 'graylog-web-plugin/plugin';
 
-import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
+import AggregationWidgetConfig, { AggregationWidgetConfigBuilder } from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
 import VisualizationConfig from 'views/logic/aggregationbuilder/visualizations/VisualizationConfig';
 
 import type { AggregationElement } from './AggregationElementType';
@@ -58,12 +58,10 @@ const fromConfig = (config: AggregationWidgetConfig) => ({
     eventAnnotation: config.eventAnnotation,
   },
 });
-const toConfig = (formValues: WidgetConfigFormValues, currentConfig: AggregationWidgetConfig) => currentConfig
-  .toBuilder()
+const toConfig = (formValues: WidgetConfigFormValues, configBuilder: AggregationWidgetConfigBuilder) => configBuilder
   .visualization(formValues.visualization.type)
   .visualizationConfig(formValuesToVisualizationConfig(formValues.visualization.type, formValues.visualization.config))
-  .eventAnnotation(formValues.visualization.eventAnnotation)
-  .build();
+  .eventAnnotation(formValues.visualization.eventAnnotation);
 
 const hasErrors = (errors: { [key: string]: string }) => Object.values(errors)
   .filter((value) => value !== undefined)

--- a/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/Sort.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/Sort.tsx
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 import * as React from 'react';
 import { Field, useFormikContext } from 'formik';
 

--- a/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/Sort.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/Sort.tsx
@@ -1,0 +1,49 @@
+import * as React from 'react';
+import { Field } from 'formik';
+
+import FormikInput from 'components/common/FormikInput';
+import Select from 'components/common/Select';
+import { Input } from 'components/bootstrap';
+
+type Props = {
+  index: number,
+}
+
+const directionOptions = [
+  { label: 'Ascending', value: 'Ascending' },
+  { label: 'Descending', value: 'Descending' },
+];
+
+const Sort = ({ index }: Props) => {
+  return (
+    <>
+      <FormikInput id="field"
+                   label="Field"
+                   placeholder="Specify field/metric to be sorted on"
+                   name={`sort.${index}.field`}
+                   labelClassName="col-sm-3"
+                   wrapperClassName="col-sm-9" />
+
+      <Field name={`sort.${index}.direction`}>
+        {({ field: { name, value, onChange }, meta: { error } }) => (
+          <Input id="direction-select"
+                 label="Direction"
+                 error={error}
+                 labelClassName="col-sm-3"
+                 wrapperClassName="col-sm-9">
+            <Select options={directionOptions}
+                    clearable={false}
+                    name={name}
+                    value={value}
+                    aria-label="Select direction for sorting"
+                    onChange={(newValue) => {
+                      onChange({ target: { name, value: newValue } });
+                    }} />
+          </Input>
+        )}
+      </Field>
+    </>
+  );
+};
+
+export default Sort;

--- a/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/Sort.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/Sort.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
-import { Field } from 'formik';
+import { Field, useFormikContext } from 'formik';
 
-import FormikInput from 'components/common/FormikInput';
 import Select from 'components/common/Select';
 import { Input } from 'components/bootstrap';
+import { MetricFormValues, WidgetConfigFormValues } from 'views/components/aggregationwizard/WidgetConfigForm';
 
 type Props = {
   index: number,
@@ -14,15 +14,35 @@ const directionOptions = [
   { label: 'Descending', value: 'Descending' },
 ];
 
+const formatSeries = (metric: MetricFormValues) => (metric.name ? metric.name : `${metric.function}(${metric.field ?? ''})`);
+
 const Sort = ({ index }: Props) => {
+  const { values } = useFormikContext<WidgetConfigFormValues>();
+  const { metrics = [] } = values;
+
+  const metricsOptions = metrics.map(formatSeries).map((metric) => ({ label: metric, value: metric }));
+
   return (
     <>
-      <FormikInput id="field"
-                   label="Field"
-                   placeholder="Specify field/metric to be sorted on"
-                   name={`sort.${index}.field`}
-                   labelClassName="col-sm-3"
-                   wrapperClassName="col-sm-9" />
+      <Field name={`sort.${index}.field`}>
+        {({ field: { name, value, onChange }, meta: { error } }) => (
+          <Input id="field-select"
+                 label="Field"
+                 error={error}
+                 labelClassName="col-sm-3"
+                 wrapperClassName="col-sm-9">
+            <Select options={metricsOptions}
+                    clearable={false}
+                    name={name}
+                    value={value}
+                    placeholder="Specify field/metric to be sorted on"
+                    aria-label="Select field for sorting"
+                    onChange={(newValue) => {
+                      onChange({ target: { name, value: newValue } });
+                    }} />
+          </Input>
+        )}
+      </Field>
 
       <Field name={`sort.${index}.direction`}>
         {({ field: { name, value, onChange }, meta: { error } }) => (

--- a/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/SortConfiguration.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/SortConfiguration.tsx
@@ -33,6 +33,7 @@ const SortConfiguration = () => {
                   <>
                     <div>
                       {sort.map((s, index) => (
+                        // eslint-disable-next-line react/no-array-index-key
                         <ElementConfigurationSection key={`sort-${index}`}>
                           <Sort index={index} />
                         </ElementConfigurationSection>

--- a/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/SortConfiguration.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/SortConfiguration.tsx
@@ -15,20 +15,28 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
+import { FieldArray, useFormikContext } from 'formik';
 
-import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
+import { WidgetConfigFormValues } from 'views/components/aggregationwizard/WidgetConfigForm';
+import ElementConfigurationSection
+  from 'views/components/aggregationwizard/elementConfiguration/ElementConfigurationSection';
+import Sort from 'views/components/aggregationwizard/elementConfiguration/Sort';
 
-type Props = {
-  config: AggregationWidgetConfig,
-  onConfigChange: (newConfig: AggregationWidgetConfig) => void
-}
+const SortConfiguration = () => {
+  const { values } = useFormikContext<WidgetConfigFormValues>();
+  const { sort } = values;
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const SortConfiguration = ({ config, onConfigChange }: Props) => {
   return (
-    <>
-      Configuration Elements
-    </>
+    <FieldArray name="sort"
+                render={() => (
+                  <>
+                    {sort.map((s, index) => (
+                      <ElementConfigurationSection key={`sort-${index}`}>
+                        <Sort index={index} />
+                      </ElementConfigurationSection>
+                    ))}
+                  </>
+                )} />
   );
 };
 

--- a/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/SortConfiguration.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/SortConfiguration.tsx
@@ -17,6 +17,7 @@
 import * as React from 'react';
 import { FieldArray, useFormikContext } from 'formik';
 
+import { Button, ButtonToolbar } from 'components/graylog';
 import { WidgetConfigFormValues } from 'views/components/aggregationwizard/WidgetConfigForm';
 import ElementConfigurationSection
   from 'views/components/aggregationwizard/elementConfiguration/ElementConfigurationSection';
@@ -28,13 +29,20 @@ const SortConfiguration = () => {
 
   return (
     <FieldArray name="sort"
-                render={() => (
+                render={({ push }) => (
                   <>
-                    {sort.map((s, index) => (
-                      <ElementConfigurationSection key={`sort-${index}`}>
-                        <Sort index={index} />
-                      </ElementConfigurationSection>
-                    ))}
+                    <div>
+                      {sort.map((s, index) => (
+                        <ElementConfigurationSection key={`sort-${index}`}>
+                          <Sort index={index} />
+                        </ElementConfigurationSection>
+                      ))}
+                    </div>
+                    <ButtonToolbar>
+                      <Button className="pull-right" bsSize="small" type="button" onClick={() => push({})}>
+                        Add a Sort
+                      </Button>
+                    </ButtonToolbar>
                   </>
                 )} />
   );

--- a/graylog2-web-interface/src/views/logic/aggregationbuilder/AggregationWidgetConfig.ts
+++ b/graylog2-web-interface/src/views/logic/aggregationbuilder/AggregationWidgetConfig.ts
@@ -297,3 +297,5 @@ class Builder {
     );
   }
 }
+
+export type AggregationWidgetConfigBuilder = InstanceType<typeof Builder>;

--- a/graylog2-web-interface/src/views/logic/aggregationbuilder/SortConfig.ts
+++ b/graylog2-web-interface/src/views/logic/aggregationbuilder/SortConfig.ts
@@ -28,20 +28,22 @@ export type SortConfigJson = {
   direction: DirectionJson,
 };
 
+type SortConfigType = 'pivot' | 'series';
+
 type InternalState = {
-  type: string,
+  type: SortConfigType,
   field: string,
   direction: Direction,
 };
 
 export default class SortConfig {
-  static PIVOT_TYPE = 'pivot';
+  static PIVOT_TYPE = 'pivot' as const;
 
-  static SERIES_TYPE = 'series';
+  static SERIES_TYPE = 'series' as const;
 
   private readonly _value: InternalState;
 
-  constructor(type: string, field: string, direction: Direction) {
+  constructor(type: SortConfigType, field: string, direction: Direction) {
     this._value = { type, field, direction };
   }
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is adding the sorting section to the aggregation wizard, which allows the user to configure a sorting of the displayed values by selecting from a list of configured metrics and fields which are in use by the aggregation.

This PR is also slightly changing the `toConfig` signatures. Instead of passing around an `AggregationWizardConfig`, its `Builder` is used. The main reason is that `Builder.build` is performing some validation (checking if the configured sorts do match the configured pivots) that rely on the object being complete before it's built, but it also has some performance benefits by avoiding unneeded object/builder creations.

Fixes #9740.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.