### PR TITLE
Always show elements configuration actions in aggregation builder, by positioning them as sticky.

### DIFF
--- a/graylog2-web-interface/packages/jest-preset-graylog/jest-preset.js
+++ b/graylog2-web-interface/packages/jest-preset-graylog/jest-preset.js
@@ -26,6 +26,7 @@ module.exports = {
     'jest-localstorage-mock',
     require.resolve('./lib/setup-files/mock-FetchProvider.js'),
     require.resolve('./lib/setup-files/mock-Version.js'),
+    require.resolve('./lib/setup-files/mock-IntersectionObserver.js'),
     require.resolve('./lib/setup-files/console-warnings-fail-tests.js'),
     'jest-canvas-mock',
   ],

--- a/graylog2-web-interface/packages/jest-preset-graylog/src/setup-files/mock-IntersectionObserver.js
+++ b/graylog2-web-interface/packages/jest-preset-graylog/src/setup-files/mock-IntersectionObserver.js
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+const observe = jest.fn();
+const unobserve = jest.fn();
+
+window.IntersectionObserver = jest.fn(() => ({
+  observe,
+  unobserve,
+}));

--- a/graylog2-web-interface/src/views/components/aggregationwizard/AggregationWizard.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/AggregationWizard.tsx
@@ -18,9 +18,7 @@ import * as React from 'react';
 import styled from 'styled-components';
 import { EditWidgetComponentProps } from 'views/types';
 
-import { ButtonToolbar } from 'components/graylog';
 import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
-import Button from 'components/graylog/Button';
 
 import WidgetConfigForm, { WidgetConfigFormValues } from './WidgetConfigForm';
 import AggregationElementSelect from './AggregationElementSelect';
@@ -106,10 +104,6 @@ const validateForm = (formValues: WidgetConfigFormValues) => {
   return elementValidationResults.reduce((prev, cur) => ({ ...prev, ...cur }), {});
 };
 
-const StyledButtonToolbar = styled(ButtonToolbar)`
-  margin-top: 5px;
-`;
-
 const AggregationWizard = ({ onChange, config, children }: EditWidgetComponentProps<AggregationWidgetConfig>) => {
   const initialFormValues = _initialFormValues(config);
 
@@ -119,7 +113,7 @@ const AggregationWizard = ({ onChange, config, children }: EditWidgetComponentPr
         <WidgetConfigForm onSubmit={(formValues: WidgetConfigFormValues) => _onSubmit(formValues, onChange)}
                           initialValues={initialFormValues}
                           validate={validateForm}>
-          {({ isSubmitting, isValid, dirty, values, setValues }) => (
+          {({ values, setValues }) => (
             <>
               <Section data-testid="add-element-section">
                 <AggregationElementSelect onElementCreate={(elementKey) => _onElementCreate(elementKey, values, setValues)}
@@ -130,11 +124,6 @@ const AggregationWizard = ({ onChange, config, children }: EditWidgetComponentPr
                 <ElementsConfiguration aggregationElementsByKey={aggregationElementsByKey}
                                        config={config}
                                        onConfigChange={onChange} />
-                {dirty && (
-                  <StyledButtonToolbar>
-                    <Button bsStyle="primary" className="pull-right" type="submit" disabled={!isValid || isSubmitting}>{isSubmitting ? 'Applying Changes' : 'Apply Changes'}</Button>
-                  </StyledButtonToolbar>
-                )}
               </Section>
             </>
           )}

--- a/graylog2-web-interface/src/views/components/aggregationwizard/ElementsConfiguration.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/ElementsConfiguration.tsx
@@ -16,12 +16,19 @@
  */
 import * as React from 'react';
 import { useFormikContext } from 'formik';
-import AggregationWidgetConfig from 'src/views/logic/aggregationbuilder/AggregationWidgetConfig';
 import { isEmpty } from 'lodash';
+import styled from 'styled-components';
+
+import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
 
 import ElementConfigurationContainer from './elementConfiguration/ElementConfigurationContainer';
+import ElementsConfigurationActions from './ElementsConfigurationActions';
 import type { AggregationElement } from './aggregationElements/AggregationElementType';
 import type { WidgetConfigFormValues } from './WidgetConfigForm';
+
+const Container = styled.div`
+  position: relative;
+`;
 
 const _sortConfiguredElements = (
   values: WidgetConfigFormValues,
@@ -31,6 +38,7 @@ const _sortConfiguredElements = (
     aggregationElementsByKey[elementKey1].order - aggregationElementsByKey[elementKey2].order
   ),
 );
+
 type Props = {
   aggregationElementsByKey: { [elementKey: string]: AggregationElement }
   config: AggregationWidgetConfig,
@@ -38,7 +46,7 @@ type Props = {
 }
 
 const ElementsConfiguration = ({ aggregationElementsByKey, config, onConfigChange }: Props) => {
-  const { values, setValues } = useFormikContext<WidgetConfigFormValues>();
+  const { values, setValues, dirty } = useFormikContext<WidgetConfigFormValues>();
 
   const _onDeleteElement = (aggregationElement) => {
     if (typeof aggregationElement.onDeleteAll !== 'function') {
@@ -49,30 +57,33 @@ const ElementsConfiguration = ({ aggregationElementsByKey, config, onConfigChang
   };
 
   return (
-    <div>
-      {_sortConfiguredElements(values, aggregationElementsByKey).map(([elementKey, elementFormValues]) => {
-        if (isEmpty(elementFormValues)) {
-          return null;
-        }
+    <Container>
+      <div>
+        {_sortConfiguredElements(values, aggregationElementsByKey).map(([elementKey, elementFormValues]) => {
+          if (isEmpty(elementFormValues)) {
+            return null;
+          }
 
-        const aggregationElement = aggregationElementsByKey[elementKey];
+          const aggregationElement = aggregationElementsByKey[elementKey];
 
-        if (!aggregationElement) {
-          throw new Error(`Aggregation element with key ${elementKey} is missing but configured for this widget.`);
-        }
+          if (!aggregationElement) {
+            throw new Error(`Aggregation element with key ${elementKey} is missing but configured for this widget.`);
+          }
 
-        const AggregationElementComponent = aggregationElement.component;
+          const AggregationElementComponent = aggregationElement.component;
 
-        return (
-          <ElementConfigurationContainer isPermanentElement={aggregationElement.onDeleteAll === undefined}
-                                         title={aggregationElement.title}
-                                         onDeleteAll={() => _onDeleteElement(aggregationElement)}
-                                         key={aggregationElement.key}>
-            <AggregationElementComponent config={config} onConfigChange={onConfigChange} />
-          </ElementConfigurationContainer>
-        );
-      })}
-    </div>
+          return (
+            <ElementConfigurationContainer isPermanentElement={aggregationElement.onDeleteAll === undefined}
+                                           title={aggregationElement.title}
+                                           onDeleteAll={() => _onDeleteElement(aggregationElement)}
+                                           key={aggregationElement.key}>
+              <AggregationElementComponent config={config} onConfigChange={onConfigChange} />
+            </ElementConfigurationContainer>
+          );
+        })}
+      </div>
+      {dirty && <ElementsConfigurationActions />}
+    </Container>
   );
 };
 

--- a/graylog2-web-interface/src/views/components/aggregationwizard/ElementsConfigurationActions.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/ElementsConfigurationActions.tsx
@@ -17,14 +17,14 @@
 import * as React from 'react';
 import { useEffect, useState } from 'react';
 import { useFormikContext } from 'formik';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
 import { ButtonToolbar } from 'components/graylog';
 import Button from 'components/graylog/Button';
 
 import type { WidgetConfigFormValues } from './WidgetConfigForm';
 
-const ConfigActions = styled.div<{ isStuck: boolean }>(({ theme, isStuck }) => `
+const ConfigActions = styled.div<{ scrolledToBottom: boolean }>(({ theme, scrolledToBottom }) => css`
   position: sticky;
   width: 100%;
   bottom: 0px;
@@ -35,7 +35,7 @@ const ConfigActions = styled.div<{ isStuck: boolean }>(({ theme, isStuck }) => `
   :before {
     box-shadow: 1px -2px 3px rgb(0 0 0 / 25%);
     content: ' ';
-    display: ${isStuck ? 'block' : 'none'};
+    display: ${scrolledToBottom ? 'block' : 'none'};
     height: 3px;
     position: absolute;
     left: 0;
@@ -44,7 +44,7 @@ const ConfigActions = styled.div<{ isStuck: boolean }>(({ theme, isStuck }) => `
   }
 `);
 
-const VisiblityIndicator = styled.div`
+const ScrolledToBottomIndicator = styled.div`
   width: 100%;
   position: absolute;
   bottom: 0px;
@@ -52,16 +52,16 @@ const VisiblityIndicator = styled.div`
   z-index: 0;
 `;
 
-const useIsStuck = (): {
-  setVisibilityIndicatorRef: (ref: HTMLDivElement) => void,
-  isStuck: boolean
+const useScrolledToBottom = (): {
+  setScrolledToBottomIndicatorRef: (ref: HTMLDivElement) => void,
+  scrolledToBottom: boolean
 } => {
-  const [visibilityIndicatorRef, setVisibilityIndicatorRef] = useState(null);
-  const [isStuck, setIsStuck] = useState(false);
+  const [visibilityIndicatorRef, setScrolledToBottomIndicatorRef] = useState(null);
+  const [scrolledToBottom, setScrolledToBottom] = useState(false);
 
   useEffect(() => {
     const observer = new IntersectionObserver(([entry]) => {
-      setIsStuck(!entry.isIntersecting);
+      setScrolledToBottom(!entry.isIntersecting);
     }, { threshold: 0.9 });
 
     if (visibilityIndicatorRef) {
@@ -75,23 +75,23 @@ const useIsStuck = (): {
     };
   }, [visibilityIndicatorRef]);
 
-  return { setVisibilityIndicatorRef, isStuck };
+  return { setScrolledToBottomIndicatorRef, scrolledToBottom };
 };
 
 const ElementsConfigurationActions = () => {
   const { isSubmitting, isValid } = useFormikContext<WidgetConfigFormValues>();
-  const { setVisibilityIndicatorRef, isStuck } = useIsStuck();
+  const { setScrolledToBottomIndicatorRef, scrolledToBottom } = useScrolledToBottom();
 
   return (
     <>
-      <ConfigActions isStuck={isStuck}>
+      <ConfigActions scrolledToBottom={scrolledToBottom}>
         <ButtonToolbar>
           <Button bsStyle="primary" className="pull-right" type="submit" disabled={!isValid || isSubmitting}>
             {isSubmitting ? 'Applying Changes' : 'Apply Changes'}
           </Button>
         </ButtonToolbar>
       </ConfigActions>
-      <VisiblityIndicator ref={setVisibilityIndicatorRef} />
+      <ScrolledToBottomIndicator ref={setScrolledToBottomIndicatorRef} />
     </>
   );
 };

--- a/graylog2-web-interface/src/views/components/aggregationwizard/ElementsConfigurationActions.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/ElementsConfigurationActions.tsx
@@ -56,7 +56,7 @@ const useScrolledToBottom = (): {
   setScrolledToBottomIndicatorRef: (ref: HTMLDivElement) => void,
   scrolledToBottom: boolean
 } => {
-  const [visibilityIndicatorRef, setScrolledToBottomIndicatorRef] = useState(null);
+  const [scrolledToBottomIndicatorRef, setScrolledToBottomIndicatorRef] = useState(null);
   const [scrolledToBottom, setScrolledToBottom] = useState(false);
 
   useEffect(() => {
@@ -64,16 +64,16 @@ const useScrolledToBottom = (): {
       setScrolledToBottom(!entry.isIntersecting);
     }, { threshold: 0.9 });
 
-    if (visibilityIndicatorRef) {
-      observer.observe(visibilityIndicatorRef);
+    if (scrolledToBottomIndicatorRef) {
+      observer.observe(scrolledToBottomIndicatorRef);
     }
 
     return () => {
-      if (visibilityIndicatorRef) {
-        observer.unobserve(visibilityIndicatorRef);
+      if (scrolledToBottomIndicatorRef) {
+        observer.unobserve(scrolledToBottomIndicatorRef);
       }
     };
-  }, [visibilityIndicatorRef]);
+  }, [scrolledToBottomIndicatorRef]);
 
   return { setScrolledToBottomIndicatorRef, scrolledToBottom };
 };

--- a/graylog2-web-interface/src/views/components/aggregationwizard/ElementsConfigurationActions.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/ElementsConfigurationActions.tsx
@@ -47,8 +47,8 @@ const ConfigActions = styled.div<{ isStuck: boolean }>(({ theme, isStuck }) => `
 const VisiblityIndicator = styled.div`
   width: 100%;
   position: absolute;
-  bottom: 1px;
-  height: 10px;
+  bottom: 0px;
+  height: 5px;
   z-index: 0;
 `;
 
@@ -62,7 +62,7 @@ const useIsStuck = (): {
   useEffect(() => {
     const observer = new IntersectionObserver(([entry]) => {
       setIsStuck(!entry.isIntersecting);
-    }, { threshold: 1 });
+    }, { threshold: 0.9 });
 
     if (visiblilityIndicatorRef) {
       observer.observe(visiblilityIndicatorRef);

--- a/graylog2-web-interface/src/views/components/aggregationwizard/ElementsConfigurationActions.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/ElementsConfigurationActions.tsx
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import { useEffect, useState } from 'react';
+import { useFormikContext } from 'formik';
+import styled from 'styled-components';
+
+import { ButtonToolbar } from 'components/graylog';
+import Button from 'components/graylog/Button';
+
+import type { WidgetConfigFormValues } from './WidgetConfigForm';
+
+const ConfigActions = styled.div<{ isStuck: boolean }>(({ theme, isStuck }) => `
+  position: sticky;
+  width: 100%;
+  bottom: 0px;
+  padding-top: 5px;
+  background: ${theme.colors.global.contentBackground};
+  z-indes: 1;
+
+  :before {
+    box-shadow: 1px -2px 3px rgb(0 0 0 / 25%);
+    content: ' ';
+    display: ${isStuck ? 'block' : 'none'};
+    height: 3px;
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 0;
+  }
+`);
+
+const VisiblityIndicator = styled.div`
+  width: 100%;
+  position: absolute;
+  bottom: 1px;
+  height: 10px;
+  z-index: 0;
+`;
+
+const useIsStuck = (): {
+  setVisibilityIndicatorRef: (ref: HTMLDivElement) => void,
+  isStuck: boolean
+} => {
+  const [visiblilityIndicatorRef, setVisibilityIndicatorRef] = useState(null);
+  const [isStuck, setIsStuck] = useState(false);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(([entry]) => {
+      setIsStuck(!entry.isIntersecting);
+    }, { threshold: 1 });
+
+    if (visiblilityIndicatorRef) {
+      observer.observe(visiblilityIndicatorRef);
+    }
+
+    return () => {
+      if (visiblilityIndicatorRef) {
+        observer.unobserve(visiblilityIndicatorRef);
+      }
+    };
+  }, [visiblilityIndicatorRef]);
+
+  return { setVisibilityIndicatorRef, isStuck };
+};
+
+const ElementsConfigurationActions = () => {
+  const { isSubmitting, isValid } = useFormikContext<WidgetConfigFormValues>();
+  const { setVisibilityIndicatorRef, isStuck } = useIsStuck();
+
+  return (
+    <>
+      <ConfigActions isStuck={isStuck}>
+        <ButtonToolbar>
+          <Button bsStyle="primary" className="pull-right" type="submit" disabled={!isValid || isSubmitting}>
+            {isSubmitting ? 'Applying Changes' : 'Apply Changes'}
+          </Button>
+        </ButtonToolbar>
+      </ConfigActions>
+      <VisiblityIndicator ref={setVisibilityIndicatorRef} />
+    </>
+  );
+};
+
+export default ElementsConfigurationActions;

--- a/graylog2-web-interface/src/views/components/aggregationwizard/ElementsConfigurationActions.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/ElementsConfigurationActions.tsx
@@ -30,7 +30,7 @@ const ConfigActions = styled.div<{ isStuck: boolean }>(({ theme, isStuck }) => `
   bottom: 0px;
   padding-top: 5px;
   background: ${theme.colors.global.contentBackground};
-  z-indes: 1;
+  z-index: 1;
 
   :before {
     box-shadow: 1px -2px 3px rgb(0 0 0 / 25%);

--- a/graylog2-web-interface/src/views/components/aggregationwizard/ElementsConfigurationActions.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/ElementsConfigurationActions.tsx
@@ -56,7 +56,7 @@ const useIsStuck = (): {
   setVisibilityIndicatorRef: (ref: HTMLDivElement) => void,
   isStuck: boolean
 } => {
-  const [visiblilityIndicatorRef, setVisibilityIndicatorRef] = useState(null);
+  const [visibilityIndicatorRef, setVisibilityIndicatorRef] = useState(null);
   const [isStuck, setIsStuck] = useState(false);
 
   useEffect(() => {
@@ -64,16 +64,16 @@ const useIsStuck = (): {
       setIsStuck(!entry.isIntersecting);
     }, { threshold: 0.9 });
 
-    if (visiblilityIndicatorRef) {
-      observer.observe(visiblilityIndicatorRef);
+    if (visibilityIndicatorRef) {
+      observer.observe(visibilityIndicatorRef);
     }
 
     return () => {
-      if (visiblilityIndicatorRef) {
-        observer.unobserve(visiblilityIndicatorRef);
+      if (visibilityIndicatorRef) {
+        observer.unobserve(visibilityIndicatorRef);
       }
     };
-  }, [visiblilityIndicatorRef]);
+  }, [visibilityIndicatorRef]);
 
   return { setVisibilityIndicatorRef, isStuck };
 };

--- a/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/ElementConfigurationContainer.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/ElementConfigurationContainer.tsx
@@ -24,7 +24,7 @@ const Wrapper = styled.div(({ theme }) => css`
   border: 1px solid ${theme.colors.variant.lighter.default};
   padding: 6px 6px 3px 6px;
   border-radius: 6px;
-  margin-bottom: 10px;
+  margin-bottom: 6px;
 
   :last-child {
     margin-bottom: 0;


### PR DESCRIPTION
## Description
With this PR we are displaying the "Apply Changes" button of the element configuration column as sticky. We want to ensure that the user does not have to scroll to be able to submit the configuration changes.

I've displayed a box shadow for the actions row which includes the "Apply changes" button.
![image](https://user-images.githubusercontent.com/46300478/114000651-79552080-985b-11eb-8485-63280bfdb045.png)
Otherwise it is harder to understand which content can be scrolled. We are hiding this box shadow, when the user scrolled to the very bottom. I've used an `IntersectionObserver` to check if the user scrolled to the bottom. It has many benefits over an `onScroll` solution. Not only in terms of performance, we also do not need to worry about updating the styling when the user resizes the browser.

## Screenshots (if appropriate):
Before this change:
![image](https://user-images.githubusercontent.com/46300478/113866323-76035b80-97ad-11eb-8ec6-62250cf406f2.png)

After this change:
![image](https://user-images.githubusercontent.com/46300478/113866262-64ba4f00-97ad-11eb-8daf-32f167b76ad8.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

