### PR TITLE
Fix permission check for notifcations in event definitions

### DIFF
--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventDefinitionSummary.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventDefinitionSummary.jsx
@@ -216,7 +216,7 @@ class EventDefinitionSummary extends React.Component {
     const { currentUser } = this.props;
 
     const effectiveDefinitionNotifications = definitionNotifications
-      .filter((n) => isPermitted(currentUser.permissions, `eventnotifications:read${n.notification_id}`));
+      .filter((n) => isPermitted(currentUser.permissions, `eventnotifications:read:${n.notification_id}`));
     const notificationsWithMissingPermissions = definitionNotifications
       .filter((n) => !effectiveDefinitionNotifications.map((nObj) => nObj.notification_id).includes(n.notification_id));
     const warning = notificationsWithMissingPermissions.length > 0

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/NotificationsForm.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/NotificationsForm.jsx
@@ -75,7 +75,7 @@ class NotificationsForm extends React.Component {
     const { showAddNotificationForm } = this.state;
 
     const notificationIds = eventDefinition.notifications.map((n) => n.notification_id);
-    const missingPermissions = notificationIds.filter((id) => !isPermitted(currentUser.permissions, `eventnotifications:read${id}`));
+    const missingPermissions = notificationIds.filter((id) => !isPermitted(currentUser.permissions, `eventnotifications:read:${id}`));
 
     if (missingPermissions.length > 0) {
       return (


### PR DESCRIPTION
## Motivation
Prior to this change, the permissions check was broken for notification
when displaying the event definition summary or edit it.

## Description
This change will fix the template string which was missing a colon.

## Notes
Special kudos to @mpfz0r 

## How it was tested
- Create a user which has only a reader role
- Share a stream with the created user
- Share a notification with the created user
- Create a event definition where stream and notification is used
- Share the event definition with the user
- Log in as user and have look at the event definition, where you should be able to see the notification without error.

### Needs backport to 4.0.x