### PR TITLE
Always show element select in aggregation builder by positioning it as sticky.

### DIFF
--- a/graylog2-web-interface/packages/jest-preset-graylog/jest-preset.js
+++ b/graylog2-web-interface/packages/jest-preset-graylog/jest-preset.js
@@ -26,6 +26,7 @@ module.exports = {
     'jest-localstorage-mock',
     require.resolve('./lib/setup-files/mock-FetchProvider.js'),
     require.resolve('./lib/setup-files/mock-Version.js'),
+    require.resolve('./lib/setup-files/mock-IntersectionObserver.js'),
     require.resolve('./lib/setup-files/console-warnings-fail-tests.js'),
     'jest-canvas-mock',
   ],

--- a/graylog2-web-interface/packages/jest-preset-graylog/src/setup-files/mock-IntersectionObserver.js
+++ b/graylog2-web-interface/packages/jest-preset-graylog/src/setup-files/mock-IntersectionObserver.js
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+const observe = jest.fn();
+const unobserve = jest.fn();
+
+window.IntersectionObserver = jest.fn(() => ({
+  observe,
+  unobserve,
+}));

--- a/graylog2-web-interface/src/views/components/aggregationwizard/AggregationWizard.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/AggregationWizard.tsx
@@ -40,6 +40,7 @@ const Wrapper = styled.div`
 `;
 
 const Controls = styled.div`
+  position: relative;
   height: 100%;
   min-width: 300px;
   max-width: 500px;
@@ -50,14 +51,6 @@ const Controls = styled.div`
 const Visualization = styled.div`
   height: 100%;
   flex: 3;
-`;
-
-const Section = styled.div`
-  margin-bottom: 10px;
-
-  :last-child {
-    margin-bottom: 0;
-  }
 `;
 
 const _onElementCreate = (
@@ -115,16 +108,15 @@ const AggregationWizard = ({ onChange, config, children }: EditWidgetComponentPr
                           validate={validateForm}>
           {({ values, setValues }) => (
             <>
-              <Section data-testid="add-element-section">
-                <AggregationElementSelect onElementCreate={(elementKey) => _onElementCreate(elementKey, values, setValues)}
-                                          aggregationElements={aggregationElements}
-                                          formValues={values} />
-              </Section>
-              <Section data-testid="configure-elements-section">
-                <ElementsConfiguration aggregationElementsByKey={aggregationElementsByKey}
-                                       config={config}
-                                       onConfigChange={onChange} />
-              </Section>
+
+              <AggregationElementSelect onElementCreate={(elementKey) => _onElementCreate(elementKey, values, setValues)}
+                                        aggregationElements={aggregationElements}
+                                        formValues={values} />
+
+              <ElementsConfiguration aggregationElementsByKey={aggregationElementsByKey}
+                                     config={config}
+                                     onConfigChange={onChange} />
+
             </>
           )}
         </WidgetConfigForm>

--- a/graylog2-web-interface/src/views/components/aggregationwizard/AggregationWizard.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/AggregationWizard.tsx
@@ -18,9 +18,7 @@ import * as React from 'react';
 import styled from 'styled-components';
 import { EditWidgetComponentProps } from 'views/types';
 
-import { ButtonToolbar } from 'components/graylog';
 import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
-import Button from 'components/graylog/Button';
 
 import WidgetConfigForm, { WidgetConfigFormValues } from './WidgetConfigForm';
 import AggregationElementSelect from './AggregationElementSelect';
@@ -106,10 +104,6 @@ const validateForm = (formValues: WidgetConfigFormValues) => {
   return elementValidationResults.reduce((prev, cur) => ({ ...prev, ...cur }), {});
 };
 
-const StyledButtonToolbar = styled(ButtonToolbar)`
-  margin-top: 5px;
-`;
-
 const AggregationWizard = ({ onChange, config, children }: EditWidgetComponentProps<AggregationWidgetConfig>) => {
   const initialFormValues = _initialFormValues(config);
 
@@ -119,7 +113,7 @@ const AggregationWizard = ({ onChange, config, children }: EditWidgetComponentPr
         <WidgetConfigForm onSubmit={(formValues: WidgetConfigFormValues) => _onSubmit(formValues, onChange)}
                           initialValues={initialFormValues}
                           validate={validateForm}>
-          {({ isSubmitting, isValid, dirty, values, setValues }) => (
+          {({ values, setValues }) => (
             <>
               <Section data-testid="add-element-section">
                 <AggregationElementSelect onElementCreate={(elementKey) => _onElementCreate(elementKey, values, setValues)}
@@ -130,11 +124,6 @@ const AggregationWizard = ({ onChange, config, children }: EditWidgetComponentPr
                 <ElementsConfiguration aggregationElementsByKey={aggregationElementsByKey}
                                        config={config}
                                        onConfigChange={onChange} />
-                {dirty && (
-                  <StyledButtonToolbar>
-                    <Button bsStyle="primary" className="pull-right" type="submit" disabled={!isValid || isSubmitting}>{isSubmitting ? 'Applying Changes' : 'Apply Changes'}</Button>
-                  </StyledButtonToolbar>
-                )}
               </Section>
             </>
           )}

--- a/graylog2-web-interface/src/views/components/aggregationwizard/ElementsConfiguration.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/ElementsConfiguration.tsx
@@ -16,12 +16,19 @@
  */
 import * as React from 'react';
 import { useFormikContext } from 'formik';
-import AggregationWidgetConfig from 'src/views/logic/aggregationbuilder/AggregationWidgetConfig';
 import { isEmpty } from 'lodash';
+import styled from 'styled-components';
+
+import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
 
 import ElementConfigurationContainer from './elementConfiguration/ElementConfigurationContainer';
+import ElementsConfigurationActions from './ElementsConfigurationActions';
 import type { AggregationElement } from './aggregationElements/AggregationElementType';
 import type { WidgetConfigFormValues } from './WidgetConfigForm';
+
+const Container = styled.div`
+  position: relative;
+`;
 
 const _sortConfiguredElements = (
   values: WidgetConfigFormValues,
@@ -31,6 +38,7 @@ const _sortConfiguredElements = (
     aggregationElementsByKey[elementKey1].order - aggregationElementsByKey[elementKey2].order
   ),
 );
+
 type Props = {
   aggregationElementsByKey: { [elementKey: string]: AggregationElement }
   config: AggregationWidgetConfig,
@@ -38,7 +46,7 @@ type Props = {
 }
 
 const ElementsConfiguration = ({ aggregationElementsByKey, config, onConfigChange }: Props) => {
-  const { values, setValues } = useFormikContext<WidgetConfigFormValues>();
+  const { values, setValues, dirty } = useFormikContext<WidgetConfigFormValues>();
 
   const _onDeleteElement = (aggregationElement) => {
     if (typeof aggregationElement.onDeleteAll !== 'function') {
@@ -49,30 +57,33 @@ const ElementsConfiguration = ({ aggregationElementsByKey, config, onConfigChang
   };
 
   return (
-    <div>
-      {_sortConfiguredElements(values, aggregationElementsByKey).map(([elementKey, elementFormValues]) => {
-        if (isEmpty(elementFormValues)) {
-          return null;
-        }
+    <Container>
+      <div>
+        {_sortConfiguredElements(values, aggregationElementsByKey).map(([elementKey, elementFormValues]) => {
+          if (isEmpty(elementFormValues)) {
+            return null;
+          }
 
-        const aggregationElement = aggregationElementsByKey[elementKey];
+          const aggregationElement = aggregationElementsByKey[elementKey];
 
-        if (!aggregationElement) {
-          throw new Error(`Aggregation element with key ${elementKey} is missing but configured for this widget.`);
-        }
+          if (!aggregationElement) {
+            throw new Error(`Aggregation element with key ${elementKey} is missing but configured for this widget.`);
+          }
 
-        const AggregationElementComponent = aggregationElement.component;
+          const AggregationElementComponent = aggregationElement.component;
 
-        return (
-          <ElementConfigurationContainer isPermanentElement={aggregationElement.onDeleteAll === undefined}
-                                         title={aggregationElement.title}
-                                         onDeleteAll={() => _onDeleteElement(aggregationElement)}
-                                         key={aggregationElement.key}>
-            <AggregationElementComponent config={config} onConfigChange={onConfigChange} />
-          </ElementConfigurationContainer>
-        );
-      })}
-    </div>
+          return (
+            <ElementConfigurationContainer isPermanentElement={aggregationElement.onDeleteAll === undefined}
+                                           title={aggregationElement.title}
+                                           onDeleteAll={() => _onDeleteElement(aggregationElement)}
+                                           key={aggregationElement.key}>
+              <AggregationElementComponent config={config} onConfigChange={onConfigChange} />
+            </ElementConfigurationContainer>
+          );
+        })}
+      </div>
+      {dirty && <ElementsConfigurationActions />}
+    </Container>
   );
 };
 

--- a/graylog2-web-interface/src/views/components/aggregationwizard/ElementsConfiguration.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/ElementsConfiguration.tsx
@@ -57,7 +57,7 @@ const ElementsConfiguration = ({ aggregationElementsByKey, config, onConfigChang
   };
 
   return (
-    <Container>
+    <Container data-testid="configure-elements-section">
       <div>
         {_sortConfiguredElements(values, aggregationElementsByKey).map(([elementKey, elementFormValues]) => {
           if (isEmpty(elementFormValues)) {

--- a/graylog2-web-interface/src/views/components/aggregationwizard/ElementsConfigurationActions.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/ElementsConfigurationActions.tsx
@@ -47,7 +47,7 @@ const ConfigActions = styled.div<{ isStuck: boolean }>(({ theme, isStuck }) => `
 const VisiblityIndicator = styled.div`
   width: 100%;
   position: absolute;
-  bottom: 0px;
+  top: 0;
   height: 5px;
   z-index: 0;
 `;

--- a/graylog2-web-interface/src/views/components/aggregationwizard/ElementsConfigurationActions.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/ElementsConfigurationActions.tsx
@@ -47,8 +47,8 @@ const ConfigActions = styled.div<{ isStuck: boolean }>(({ theme, isStuck }) => `
 const VisiblityIndicator = styled.div`
   width: 100%;
   position: absolute;
-  bottom: 1px;
-  height: 10px;
+  bottom: 0px;
+  height: 5px;
   z-index: 0;
 `;
 
@@ -62,7 +62,7 @@ const useIsStuck = (): {
   useEffect(() => {
     const observer = new IntersectionObserver(([entry]) => {
       setIsStuck(!entry.isIntersecting);
-    }, { threshold: 1 });
+    }, { threshold: 0.9 });
 
     if (visiblilityIndicatorRef) {
       observer.observe(visiblilityIndicatorRef);

--- a/graylog2-web-interface/src/views/components/aggregationwizard/ElementsConfigurationActions.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/ElementsConfigurationActions.tsx
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import { useEffect, useState } from 'react';
+import { useFormikContext } from 'formik';
+import styled from 'styled-components';
+
+import { ButtonToolbar } from 'components/graylog';
+import Button from 'components/graylog/Button';
+
+import type { WidgetConfigFormValues } from './WidgetConfigForm';
+
+const ConfigActions = styled.div<{ isStuck: boolean }>(({ theme, isStuck }) => `
+  position: sticky;
+  width: 100%;
+  bottom: 0px;
+  padding-top: 5px;
+  background: ${theme.colors.global.contentBackground};
+  z-indes: 1;
+
+  :before {
+    box-shadow: 1px -2px 3px rgb(0 0 0 / 25%);
+    content: ' ';
+    display: ${isStuck ? 'block' : 'none'};
+    height: 3px;
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 0;
+  }
+`);
+
+const VisiblityIndicator = styled.div`
+  width: 100%;
+  position: absolute;
+  bottom: 1px;
+  height: 10px;
+  z-index: 0;
+`;
+
+const useIsStuck = (): {
+  setVisibilityIndicatorRef: (ref: HTMLDivElement) => void,
+  isStuck: boolean
+} => {
+  const [visiblilityIndicatorRef, setVisibilityIndicatorRef] = useState(null);
+  const [isStuck, setIsStuck] = useState(false);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(([entry]) => {
+      setIsStuck(!entry.isIntersecting);
+    }, { threshold: 1 });
+
+    if (visiblilityIndicatorRef) {
+      observer.observe(visiblilityIndicatorRef);
+    }
+
+    return () => {
+      if (visiblilityIndicatorRef) {
+        observer.unobserve(visiblilityIndicatorRef);
+      }
+    };
+  }, [visiblilityIndicatorRef]);
+
+  return { setVisibilityIndicatorRef, isStuck };
+};
+
+const ElementsConfigurationActions = () => {
+  const { isSubmitting, isValid } = useFormikContext<WidgetConfigFormValues>();
+  const { setVisibilityIndicatorRef, isStuck } = useIsStuck();
+
+  return (
+    <>
+      <ConfigActions isStuck={isStuck}>
+        <ButtonToolbar>
+          <Button bsStyle="primary" className="pull-right" type="submit" disabled={!isValid || isSubmitting}>
+            {isSubmitting ? 'Applying Changes' : 'Apply Changes'}
+          </Button>
+        </ButtonToolbar>
+      </ConfigActions>
+      <VisiblityIndicator ref={setVisibilityIndicatorRef} />
+    </>
+  );
+};
+
+export default ElementsConfigurationActions;

--- a/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/ElementConfigurationContainer.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/ElementConfigurationContainer.tsx
@@ -24,7 +24,7 @@ const Wrapper = styled.div(({ theme }) => css`
   border: 1px solid ${theme.colors.variant.lighter.default};
   padding: 6px 6px 3px 6px;
   border-radius: 6px;
-  margin-bottom: 10px;
+  margin-bottom: 6px;
 
   :last-child {
     margin-bottom: 0;


### PR DESCRIPTION
## Description
With https://github.com/Graylog2/graylog2-server/pull/10379 we've positioned the elements config actions button sticky, to ensure they are always visible. This PR demonstrates the same change for the element select. We want to ensure that the user does not have to scroll to be able to add an aggregation element.

This is still a draft PR because we need to discuss if we really want position the element select this way. With the current implementation we have less space available for the elements configuration. Imo it is ok, but another solution could be to always display the element select at the bottom next to the "Apply Changes" button.

Examples with 1366 x 768:
Before: 
![image](https://user-images.githubusercontent.com/46300478/113887355-b66cd480-97c1-11eb-83d9-35fd59eabf3c.png)
After: 
![image](https://user-images.githubusercontent.com/46300478/113887663-fa5fd980-97c1-11eb-8d4c-e49bd0c48a4f.png)

