### PR TITLE
Simplify identification of each aggregation element in aggregation builder.

### DIFF
--- a/graylog2-web-interface/src/views/components/aggregationwizard/AggregationWizard.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/AggregationWizard.tsx
@@ -60,15 +60,15 @@ const Section = styled.div`
   }
 `;
 
-const _onElementCreate = (
+const onAddElementSection = (
   elementKey: string,
   values: WidgetConfigFormValues,
   setValues: (formValues: WidgetConfigFormValues) => void,
 ) => {
   const aggregationElement = aggregationElementsByKey[elementKey];
 
-  if (aggregationElement?.addEmptyElement) {
-    setValues(aggregationElement.addEmptyElement(values));
+  if (aggregationElement?.addEmptySection) {
+    setValues(aggregationElement.addEmptySection(values));
   } else {
     setValues({
       ...values,
@@ -116,13 +116,14 @@ const AggregationWizard = ({ onChange, config, children }: EditWidgetComponentPr
           {({ values, setValues }) => (
             <>
               <Section data-testid="add-element-section">
-                <AggregationElementSelect onElementCreate={(elementKey) => _onElementCreate(elementKey, values, setValues)}
+                <AggregationElementSelect onElementCreate={(elementKey) => onAddElementSection(elementKey, values, setValues)}
                                           aggregationElements={aggregationElements}
                                           formValues={values} />
               </Section>
               <Section data-testid="configure-elements-section">
                 <ElementsConfiguration aggregationElementsByKey={aggregationElementsByKey}
                                        config={config}
+                                       onAddElementSection={onAddElementSection}
                                        onConfigChange={onChange} />
               </Section>
             </>

--- a/graylog2-web-interface/src/views/components/aggregationwizard/AggregationWizard.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/AggregationWizard.tsx
@@ -41,9 +41,10 @@ const Wrapper = styled.div`
 
 const Controls = styled.div`
   height: 100%;
-  min-width: 300px;
+  min-width: 315px;
   max-width: 500px;
-  flex: 1;
+  flex: 1.2;
+  padding-right: 15px;
   overflow-y: auto;
 `;
 

--- a/graylog2-web-interface/src/views/components/aggregationwizard/AggregationWizard.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/AggregationWizard.tsx
@@ -60,7 +60,7 @@ const Section = styled.div`
   }
 `;
 
-const onAddElementSection = (
+const onAddEmptyElement = (
   elementKey: string,
   values: WidgetConfigFormValues,
   setValues: (formValues: WidgetConfigFormValues) => void,
@@ -116,14 +116,14 @@ const AggregationWizard = ({ onChange, config, children }: EditWidgetComponentPr
           {({ values, setValues }) => (
             <>
               <Section data-testid="add-element-section">
-                <AggregationElementSelect onElementCreate={(elementKey) => onAddElementSection(elementKey, values, setValues)}
+                <AggregationElementSelect onElementCreate={(elementKey) => onAddEmptyElement(elementKey, values, setValues)}
                                           aggregationElements={aggregationElements}
                                           formValues={values} />
               </Section>
               <Section data-testid="configure-elements-section">
                 <ElementsConfiguration aggregationElementsByKey={aggregationElementsByKey}
                                        config={config}
-                                       onAddElementSection={onAddElementSection}
+                                       onAddEmptyElement={onAddEmptyElement}
                                        onConfigChange={onChange} />
               </Section>
             </>

--- a/graylog2-web-interface/src/views/components/aggregationwizard/AggregationWizard.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/AggregationWizard.tsx
@@ -67,8 +67,8 @@ const onAddElementSection = (
 ) => {
   const aggregationElement = aggregationElementsByKey[elementKey];
 
-  if (aggregationElement?.addEmptySection) {
-    setValues(aggregationElement.addEmptySection(values));
+  if (aggregationElement?.addEmptyElement) {
+    setValues(aggregationElement.addEmptyElement(values));
   } else {
     setValues({
       ...values,

--- a/graylog2-web-interface/src/views/components/aggregationwizard/ElementsConfiguration.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/ElementsConfiguration.tsx
@@ -70,7 +70,7 @@ const ElementsConfiguration = ({ aggregationElementsByKey, config, onConfigChang
           const AggregationElementComponent = aggregationElement.component;
 
           return (
-            <ElementConfigurationContainer allowAddSection={aggregationElement.allowCreate(values)}
+            <ElementConfigurationContainer allowAddEmptyElement={aggregationElement.allowCreate(values)}
                                            title={aggregationElement.title}
                                            titleSingular={aggregationElement.titleSingular}
                                            onAddElementSection={() => onAddElementSection(aggregationElement.key, values, setValues)}

--- a/graylog2-web-interface/src/views/components/aggregationwizard/ElementsConfiguration.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/ElementsConfiguration.tsx
@@ -72,6 +72,7 @@ const ElementsConfiguration = ({ aggregationElementsByKey, config, onConfigChang
           return (
             <ElementConfigurationContainer allowAddSection={aggregationElement.allowCreate(values)}
                                            title={aggregationElement.title}
+                                           titleSingular={aggregationElement.titleSingular}
                                            onAddElementSection={() => onAddElementSection(aggregationElement.key, values, setValues)}
                                            key={aggregationElement.key}>
               <AggregationElementComponent config={config} onConfigChange={onConfigChange} />

--- a/graylog2-web-interface/src/views/components/aggregationwizard/ElementsConfiguration.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/ElementsConfiguration.tsx
@@ -43,14 +43,14 @@ type Props = {
   aggregationElementsByKey: { [elementKey: string]: AggregationElement }
   config: AggregationWidgetConfig,
   onConfigChange: (config: AggregationWidgetConfig) => void,
-  onAddElementSection: (
+  onAddEmptyElement: (
     elementKey: string,
     values: WidgetConfigFormValues,
     setValues: (formValues: WidgetConfigFormValues) => void,
   ) => void,
 }
 
-const ElementsConfiguration = ({ aggregationElementsByKey, config, onConfigChange, onAddElementSection }: Props) => {
+const ElementsConfiguration = ({ aggregationElementsByKey, config, onConfigChange, onAddEmptyElement }: Props) => {
   const { values, setValues, dirty } = useFormikContext<WidgetConfigFormValues>();
 
   return (
@@ -73,7 +73,7 @@ const ElementsConfiguration = ({ aggregationElementsByKey, config, onConfigChang
             <ElementConfigurationContainer allowAddEmptyElement={aggregationElement.allowCreate(values)}
                                            title={aggregationElement.title}
                                            titleSingular={aggregationElement.titleSingular}
-                                           onAddElementSection={() => onAddElementSection(aggregationElement.key, values, setValues)}
+                                           onAddEmptyElement={() => onAddEmptyElement(aggregationElement.key, values, setValues)}
                                            key={aggregationElement.key}>
               <AggregationElementComponent config={config} onConfigChange={onConfigChange} />
             </ElementConfigurationContainer>

--- a/graylog2-web-interface/src/views/components/aggregationwizard/ElementsConfiguration.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/ElementsConfiguration.tsx
@@ -43,18 +43,15 @@ type Props = {
   aggregationElementsByKey: { [elementKey: string]: AggregationElement }
   config: AggregationWidgetConfig,
   onConfigChange: (config: AggregationWidgetConfig) => void,
+  onAddElementSection: (
+    elementKey: string,
+    values: WidgetConfigFormValues,
+    setValues: (formValues: WidgetConfigFormValues) => void,
+  ) => void,
 }
 
-const ElementsConfiguration = ({ aggregationElementsByKey, config, onConfigChange }: Props) => {
+const ElementsConfiguration = ({ aggregationElementsByKey, config, onConfigChange, onAddElementSection }: Props) => {
   const { values, setValues, dirty } = useFormikContext<WidgetConfigFormValues>();
-
-  const _onDeleteElement = (aggregationElement) => {
-    if (typeof aggregationElement.onDeleteAll !== 'function') {
-      return;
-    }
-
-    setValues(aggregationElement.onDeleteAll(values));
-  };
 
   return (
     <Container>
@@ -73,9 +70,9 @@ const ElementsConfiguration = ({ aggregationElementsByKey, config, onConfigChang
           const AggregationElementComponent = aggregationElement.component;
 
           return (
-            <ElementConfigurationContainer isPermanentElement={aggregationElement.onDeleteAll === undefined}
+            <ElementConfigurationContainer allowAddSection={aggregationElement.allowCreate(values)}
                                            title={aggregationElement.title}
-                                           onDeleteAll={() => _onDeleteElement(aggregationElement)}
+                                           onAddElementSection={() => onAddElementSection(aggregationElement.key, values, setValues)}
                                            key={aggregationElement.key}>
               <AggregationElementComponent config={config} onConfigChange={onConfigChange} />
             </ElementConfigurationContainer>

--- a/graylog2-web-interface/src/views/components/aggregationwizard/ElementsConfigurationActions.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/ElementsConfigurationActions.tsx
@@ -32,7 +32,7 @@ const ConfigActions = styled.div<{ scrolledToBottom: boolean }>(({ theme, scroll
   background: ${theme.colors.global.contentBackground};
   z-index: 1;
 
-  :before {
+  ::before {
     box-shadow: 1px -2px 3px rgb(0 0 0 / 25%);
     content: ' ';
     display: ${scrolledToBottom ? 'block' : 'none'};

--- a/graylog2-web-interface/src/views/components/aggregationwizard/ElementsConfigurationActions.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/ElementsConfigurationActions.tsx
@@ -27,7 +27,7 @@ import type { WidgetConfigFormValues } from './WidgetConfigForm';
 const ConfigActions = styled.div<{ scrolledToBottom: boolean }>(({ theme, scrolledToBottom }) => css`
   position: sticky;
   width: 100%;
-  bottom: 0px;
+  bottom: 0;
   padding-top: 5px;
   background: ${theme.colors.global.contentBackground};
   z-index: 1;
@@ -47,7 +47,7 @@ const ConfigActions = styled.div<{ scrolledToBottom: boolean }>(({ theme, scroll
 const ScrolledToBottomIndicator = styled.div`
   width: 100%;
   position: absolute;
-  bottom: 0px;
+  bottom: 0;
   height: 5px;
   z-index: 0;
 `;

--- a/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/AggregationElementType.ts
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/AggregationElementType.ts
@@ -20,6 +20,7 @@ import type { WidgetConfigFormValues, WidgetConfigValidationErrors } from '../Wi
 
 export type AggregationElement = {
   title: string,
+  titleSingular?: string,
   key: string,
   allowCreate: (formValues: WidgetConfigFormValues) => boolean,
   order: number,

--- a/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/AggregationElementType.ts
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/AggregationElementType.ts
@@ -24,7 +24,7 @@ export type AggregationElement = {
   key: string,
   allowCreate: (formValues: WidgetConfigFormValues) => boolean,
   order: number,
-  addEmptySection?: (formValues: WidgetConfigFormValues) => WidgetConfigFormValues,
+  addEmptyElement?: (formValues: WidgetConfigFormValues) => WidgetConfigFormValues,
   removeElementSection?: (index: number, formValues) => WidgetConfigFormValues,
   toConfig?: (formValues: WidgetConfigFormValues, currentConfigBuilder: AggregationWidgetConfigBuilder) => AggregationWidgetConfigBuilder,
   fromConfig?: (config: AggregationWidgetConfig) => Partial<WidgetConfigFormValues>,

--- a/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/AggregationElementType.ts
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/AggregationElementType.ts
@@ -23,7 +23,7 @@ export type AggregationElement = {
   key: string,
   allowCreate: (formValues: WidgetConfigFormValues) => boolean,
   order: number,
-  addEmptyElement?: (formValues: WidgetConfigFormValues) => WidgetConfigFormValues,
+  addEmptySection?: (formValues: WidgetConfigFormValues) => WidgetConfigFormValues,
   removeElementSection?: (index: number, formValues) => WidgetConfigFormValues,
   toConfig?: (formValues: WidgetConfigFormValues, currentConfigBuilder: AggregationWidgetConfigBuilder) => AggregationWidgetConfigBuilder,
   fromConfig?: (config: AggregationWidgetConfig) => Partial<WidgetConfigFormValues>,

--- a/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/GroupByElement.ts
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/GroupByElement.ts
@@ -177,6 +177,7 @@ export const emptyGrouping: ValuesGrouping = {
 
 const GroupByElement: AggregationElement = {
   title: 'Group By',
+  titleSingular: 'Grouping',
   key: 'groupBy',
   order: 1,
   allowCreate: () => true,

--- a/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/GroupByElement.ts
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/GroupByElement.ts
@@ -181,7 +181,7 @@ const GroupByElement: AggregationElement = {
   key: 'groupBy',
   order: 1,
   allowCreate: () => true,
-  addEmptySection: (formValues: WidgetConfigFormValues): WidgetConfigFormValues => ({
+  addEmptyElement: (formValues: WidgetConfigFormValues): WidgetConfigFormValues => ({
     ...formValues,
     groupBy: {
       columnRollup: 'columnRollup' in formValues.groupBy ? formValues.groupBy.columnRollup : true,

--- a/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/GroupByElement.ts
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/GroupByElement.ts
@@ -180,7 +180,7 @@ const GroupByElement: AggregationElement = {
   key: 'groupBy',
   order: 1,
   allowCreate: () => true,
-  addEmptyElement: (formValues: WidgetConfigFormValues): WidgetConfigFormValues => ({
+  addEmptySection: (formValues: WidgetConfigFormValues): WidgetConfigFormValues => ({
     ...formValues,
     groupBy: {
       columnRollup: 'columnRollup' in formValues.groupBy ? formValues.groupBy.columnRollup : true,

--- a/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/ElementConfigurationContainer.test.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/ElementConfigurationContainer.test.tsx
@@ -23,7 +23,7 @@ describe('ElementConfigurationContainer', () => {
   it('should render elements passed as children', () => {
     render(
       <ElementConfigurationContainer allowAddEmptyElement
-                                     onAddElementSection={() => {}}
+                                     onAddEmptyElement={() => {}}
                                      title="Aggregation Element Title">
         Children of Dune
       </ElementConfigurationContainer>,
@@ -35,7 +35,7 @@ describe('ElementConfigurationContainer', () => {
   it('should render title', () => {
     render(
       <ElementConfigurationContainer allowAddEmptyElement
-                                     onAddElementSection={() => {}}
+                                     onAddEmptyElement={() => {}}
                                      title="Aggregation Element Title">
         Children of Dune
       </ElementConfigurationContainer>,
@@ -44,12 +44,12 @@ describe('ElementConfigurationContainer', () => {
     expect(screen.getByText('Aggregation Element Title')).toBeInTheDocument();
   });
 
-  it('should call on onAddElementSection when adding a section', async () => {
-    const onAddElementSectionMock = jest.fn();
+  it('should call on onAddEmptyElement when adding a section', async () => {
+    const onAddEmptyElementMock = jest.fn();
 
     render(
       <ElementConfigurationContainer allowAddEmptyElement
-                                     onAddElementSection={onAddElementSectionMock}
+                                     onAddEmptyElement={onAddEmptyElementMock}
                                      title="Aggregation Element Title">
         Children of Dune
       </ElementConfigurationContainer>,
@@ -59,13 +59,13 @@ describe('ElementConfigurationContainer', () => {
 
     fireEvent.click(addButton);
 
-    expect(onAddElementSectionMock).toHaveBeenCalledTimes(1);
+    expect(onAddEmptyElementMock).toHaveBeenCalledTimes(1);
   });
 
   it('should not display add section icon if adding element section is not allowed', async () => {
     render(
       <ElementConfigurationContainer allowAddEmptyElement={false}
-                                     onAddElementSection={() => {}}
+                                     onAddEmptyElement={() => {}}
                                      title="Aggregation Element Title">
         Children of Dune
       </ElementConfigurationContainer>,

--- a/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/ElementConfigurationContainer.test.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/ElementConfigurationContainer.test.tsx
@@ -55,7 +55,7 @@ describe('ElementConfigurationContainer', () => {
       </ElementConfigurationContainer>,
     );
 
-    const addButton = screen.getByTitle('Add new section for Aggregation Element Title');
+    const addButton = screen.getByTitle('Add a Aggregation Element Title');
 
     fireEvent.click(addButton);
 
@@ -71,6 +71,6 @@ describe('ElementConfigurationContainer', () => {
       </ElementConfigurationContainer>,
     );
 
-    expect(screen.queryByTitle('Add new section for Aggregation Element Title')).not.toBeInTheDocument();
+    expect(screen.queryByTitle('Add a Aggregation Element Title')).not.toBeInTheDocument();
   });
 });

--- a/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/ElementConfigurationContainer.test.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/ElementConfigurationContainer.test.tsx
@@ -22,7 +22,7 @@ import ElementConfigurationContainer from './ElementConfigurationContainer';
 describe('ElementConfigurationContainer', () => {
   it('should render elements passed as children', () => {
     render(
-      <ElementConfigurationContainer allowAddSection
+      <ElementConfigurationContainer allowAddEmptyElement
                                      onAddElementSection={() => {}}
                                      title="Aggregation Element Title">
         Children of Dune
@@ -34,7 +34,7 @@ describe('ElementConfigurationContainer', () => {
 
   it('should render title', () => {
     render(
-      <ElementConfigurationContainer allowAddSection
+      <ElementConfigurationContainer allowAddEmptyElement
                                      onAddElementSection={() => {}}
                                      title="Aggregation Element Title">
         Children of Dune
@@ -48,7 +48,7 @@ describe('ElementConfigurationContainer', () => {
     const onAddElementSectionMock = jest.fn();
 
     render(
-      <ElementConfigurationContainer allowAddSection
+      <ElementConfigurationContainer allowAddEmptyElement
                                      onAddElementSection={onAddElementSectionMock}
                                      title="Aggregation Element Title">
         Children of Dune
@@ -64,7 +64,7 @@ describe('ElementConfigurationContainer', () => {
 
   it('should not display add section icon if adding element section is not allowed', async () => {
     render(
-      <ElementConfigurationContainer allowAddSection={false}
+      <ElementConfigurationContainer allowAddEmptyElement={false}
                                      onAddElementSection={() => {}}
                                      title="Aggregation Element Title">
         Children of Dune

--- a/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/ElementConfigurationContainer.test.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/ElementConfigurationContainer.test.tsx
@@ -22,8 +22,8 @@ import ElementConfigurationContainer from './ElementConfigurationContainer';
 describe('ElementConfigurationContainer', () => {
   it('should render elements passed as children', () => {
     render(
-      <ElementConfigurationContainer isPermanentElement={false}
-                                     onDeleteAll={() => {}}
+      <ElementConfigurationContainer allowAddSection
+                                     onAddElementSection={() => {}}
                                      title="Aggregation Element Title">
         Children of Dune
       </ElementConfigurationContainer>,
@@ -34,8 +34,8 @@ describe('ElementConfigurationContainer', () => {
 
   it('should render title', () => {
     render(
-      <ElementConfigurationContainer isPermanentElement={false}
-                                     onDeleteAll={() => {}}
+      <ElementConfigurationContainer allowAddSection
+                                     onAddElementSection={() => {}}
                                      title="Aggregation Element Title">
         Children of Dune
       </ElementConfigurationContainer>,
@@ -44,33 +44,33 @@ describe('ElementConfigurationContainer', () => {
     expect(screen.getByText('Aggregation Element Title')).toBeInTheDocument();
   });
 
-  it('should call on delete when clicking delete icon', async () => {
-    const onDeleteAllMock = jest.fn();
+  it('should call on onAddElementSection when adding a section', async () => {
+    const onAddElementSectionMock = jest.fn();
 
     render(
-      <ElementConfigurationContainer isPermanentElement={false}
-                                     onDeleteAll={onDeleteAllMock}
+      <ElementConfigurationContainer allowAddSection
+                                     onAddElementSection={onAddElementSectionMock}
                                      title="Aggregation Element Title">
         Children of Dune
       </ElementConfigurationContainer>,
     );
 
-    const deleteButton = screen.getByTitle('Remove Aggregation Element Title');
+    const addButton = screen.getByTitle('Add new section for Aggregation Element Title');
 
-    fireEvent.click(deleteButton);
+    fireEvent.click(addButton);
 
-    expect(onDeleteAllMock).toHaveBeenCalledTimes(1);
+    expect(onAddElementSectionMock).toHaveBeenCalledTimes(1);
   });
 
-  it('should not display delete icon if element is permanent', async () => {
+  it('should not display add section icon if adding element section is not allowed', async () => {
     render(
-      <ElementConfigurationContainer isPermanentElement
-                                     onDeleteAll={() => {}}
+      <ElementConfigurationContainer allowAddSection={false}
+                                     onAddElementSection={() => {}}
                                      title="Aggregation Element Title">
         Children of Dune
       </ElementConfigurationContainer>,
     );
 
-    expect(screen.queryByTitle('Remove Aggregation Element Title')).not.toBeInTheDocument();
+    expect(screen.queryByTitle('Add new section for Aggregation Element Title')).not.toBeInTheDocument();
   });
 });

--- a/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/ElementConfigurationContainer.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/ElementConfigurationContainer.tsx
@@ -53,7 +53,7 @@ const Wrapper = styled.div(({ theme }) => css`
   }
 `);
 
-const Header = styled.div`
+const Header = styled.div(({ theme }) => css`
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -66,29 +66,25 @@ const Header = styled.div`
     content: ' ';
     top: 50%;
     width: 100%;
-    border-bottom: 1px solid grey;
+    border-bottom: 1px solid ${theme.utils.contrastingColor(theme.colors.global.contentBackground, 'AA')};
     position: absolute;
   }
+`);
 
-  button {
-    color: #1f1f1f;
-  }
-`;
-
-const ElementTitle = styled.div`
-  background: white;
+const ElementTitle = styled.div(({ theme }) => css`
+  background-color: ${theme.colors.global.contentBackground};
   z-index: 1;
   padding-right: 8px;
-`;
+`);
 
-const ElementActions = styled.div`
-  background: white;
+const ElementActions = styled.div(({ theme }) => css`
+  background-color: ${theme.colors.global.contentBackground};
   z-index: 1;
   padding-left: 5px;
-`;
+`);
 
 const StyledIconButton = styled(IconButton)(({ theme }) => `
-  color: ${theme.colors.variant.primary};
+  color: ${theme.colors.global.textDefault};
 `);
 
 type Props = {

--- a/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/ElementConfigurationContainer.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/ElementConfigurationContainer.tsx
@@ -96,6 +96,7 @@ type Props = {
   children: React.ReactNode,
   onAddElementSection: () => void,
   title: string,
+  titleSingular?: string,
 }
 
 const ElementConfigurationContainer = ({
@@ -103,6 +104,7 @@ const ElementConfigurationContainer = ({
   allowAddSection,
   onAddElementSection,
   title,
+  titleSingular,
 }: Props) => {
   return (
     <Wrapper>
@@ -112,7 +114,7 @@ const ElementConfigurationContainer = ({
         </ElementTitle>
         <ElementActions>
           {allowAddSection && (
-            <StyledIconButton title={`Add new section for ${title}`} name="plus" onClick={onAddElementSection} />
+            <StyledIconButton title={`Add a ${titleSingular ?? title}`} name="plus" onClick={onAddElementSection} />
           )}
         </ElementActions>
       </Header>
@@ -121,6 +123,10 @@ const ElementConfigurationContainer = ({
       </div>
     </Wrapper>
   );
+};
+
+ElementConfigurationContainer.defaultProps = {
+  titleSingular: undefined,
 };
 
 export default ElementConfigurationContainer;

--- a/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/ElementConfigurationContainer.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/ElementConfigurationContainer.tsx
@@ -62,7 +62,7 @@ const Header = styled.div(({ theme }) => css`
   font-weight: bold;
   position: relative;
 
-  :before {
+  ::before {
     content: ' ';
     top: 50%;
     width: 100%;

--- a/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/ElementConfigurationContainer.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/ElementConfigurationContainer.tsx
@@ -20,9 +20,6 @@ import styled, { css } from 'styled-components';
 import IconButton from 'components/common/IconButton';
 
 const Wrapper = styled.div(({ theme }) => css`
-  background-color: ${theme.colors.variant.lightest.default};
-  border: 1px solid ${theme.colors.variant.lighter.default};
-  padding: 6px 6px 3px 6px;
   border-radius: 6px;
   margin-bottom: 6px;
 

--- a/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/ElementConfigurationContainer.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/ElementConfigurationContainer.tsx
@@ -20,8 +20,8 @@ import styled, { css } from 'styled-components';
 import IconButton from 'components/common/IconButton';
 
 const Wrapper = styled.div(({ theme }) => css`
-  border-radius: 6px;
   margin-bottom: 6px;
+  border-radius: 6px;
 
   :last-child {
     margin-bottom: 0;

--- a/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/ElementConfigurationContainer.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/ElementConfigurationContainer.tsx
@@ -94,7 +94,7 @@ const StyledIconButton = styled(IconButton)(({ theme }) => `
 type Props = {
   allowAddEmptyElement: boolean,
   children: React.ReactNode,
-  onAddElementSection: () => void,
+  onAddEmptyElement: () => void,
   title: string,
   titleSingular?: string,
 }
@@ -102,7 +102,7 @@ type Props = {
 const ElementConfigurationContainer = ({
   children,
   allowAddEmptyElement,
-  onAddElementSection,
+  onAddEmptyElement,
   title,
   titleSingular,
 }: Props) => {
@@ -114,7 +114,7 @@ const ElementConfigurationContainer = ({
         </ElementTitle>
         <ElementActions>
           {allowAddEmptyElement && (
-            <StyledIconButton title={`Add a ${titleSingular ?? title}`} name="plus" onClick={onAddElementSection} />
+            <StyledIconButton title={`Add a ${titleSingular ?? title}`} name="plus" onClick={onAddEmptyElement} />
           )}
         </ElementActions>
       </Header>

--- a/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/ElementConfigurationContainer.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/ElementConfigurationContainer.tsx
@@ -92,7 +92,7 @@ const StyledIconButton = styled(IconButton)(({ theme }) => `
 `);
 
 type Props = {
-  allowAddSection: boolean,
+  allowAddEmptyElement: boolean,
   children: React.ReactNode,
   onAddElementSection: () => void,
   title: string,
@@ -101,7 +101,7 @@ type Props = {
 
 const ElementConfigurationContainer = ({
   children,
-  allowAddSection,
+  allowAddEmptyElement,
   onAddElementSection,
   title,
   titleSingular,
@@ -113,7 +113,7 @@ const ElementConfigurationContainer = ({
           {title}
         </ElementTitle>
         <ElementActions>
-          {allowAddSection && (
+          {allowAddEmptyElement && (
             <StyledIconButton title={`Add a ${titleSingular ?? title}`} name="plus" onClick={onAddElementSection} />
           )}
         </ElementActions>

--- a/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/ElementConfigurationContainer.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/ElementConfigurationContainer.tsx
@@ -56,31 +56,65 @@ const Wrapper = styled.div(({ theme }) => css`
 const Header = styled.div`
   display: flex;
   justify-content: space-between;
-  margin-bottom: 5px;
+  align-items: center;
+  margin-bottom: 1px;
+  min-height: 26px;
+  font-weight: bold;
+  position: relative;
+
+  :before {
+    content: ' ';
+    top: 50%;
+    width: 100%;
+    border-bottom: 1px solid grey;
+    position: absolute;
+  }
+
+  button {
+    color: #1f1f1f;
+  }
 `;
 
+const ElementTitle = styled.div`
+  background: white;
+  z-index: 1;
+  padding-right: 8px;
+`;
+
+const ElementActions = styled.div`
+  background: white;
+  z-index: 1;
+  padding-left: 5px;
+`;
+
+const StyledIconButton = styled(IconButton)(({ theme }) => `
+  color: ${theme.colors.variant.primary};
+`);
+
 type Props = {
+  allowAddSection: boolean,
   children: React.ReactNode,
-  isPermanentElement: boolean,
-  onDeleteAll: () => void
+  onAddElementSection: () => void,
   title: string,
 }
 
 const ElementConfigurationContainer = ({
   children,
-  isPermanentElement,
-  onDeleteAll,
+  allowAddSection,
+  onAddElementSection,
   title,
 }: Props) => {
   return (
     <Wrapper>
       <Header>
-        <div>{title}</div>
-        <div>
-          {!isPermanentElement && (
-            <IconButton title={`Remove ${title}`} name="trash" onClick={onDeleteAll} />
+        <ElementTitle>
+          {title}
+        </ElementTitle>
+        <ElementActions>
+          {allowAddSection && (
+            <StyledIconButton title={`Add new section for ${title}`} name="plus" onClick={onAddElementSection} />
           )}
-        </div>
+        </ElementActions>
       </Header>
       <div>
         {children}

--- a/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/ElementConfigurationSection.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/ElementConfigurationSection.tsx
@@ -20,8 +20,10 @@ import styled, { css } from 'styled-components';
 import { IconButton } from 'components/common';
 
 const SectionContainer = styled.div(({ theme }) => css`
-  border-bottom: 1px solid ${theme.colors.variant.lighter.default};
+  background-color: ${theme.colors.variant.lightest.default};
+  border-radius: 3px;
   margin-bottom: 5px;
+  padding: 6px 6px 3px 6px;
 
   :last-of-type {
     border-bottom: 0;

--- a/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/ElementConfigurationSection.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/ElementConfigurationSection.tsx
@@ -21,12 +21,12 @@ import { IconButton } from 'components/common';
 
 const SectionContainer = styled.div(({ theme }) => css`
   background-color: ${theme.colors.variant.lightest.default};
-  border-radius: 3px;
   margin-bottom: 5px;
   padding: 6px 6px 3px 6px;
+  border-radius: 3px;
+  border: 1px solid ${theme.colors.variant.lighter.default};
 
   :last-of-type {
-    border-bottom: 0;
     margin-bottom: 0;
   }
 `);

--- a/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/GroupByConfiguration.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/GroupByConfiguration.tsx
@@ -56,16 +56,6 @@ const GroupByConfiguration = () => {
       <FieldArray name="groupBy.groupings"
                   render={(arrayHelpers) => (
                     <>
-                      <div>
-                        {groupBy.groupings.map((grouping, index) => {
-                          return (
-                            // eslint-disable-next-line react/no-array-index-key
-                            <ElementConfigurationSection key={`grouping-${index}`} onRemove={() => removeGrouping(index)}>
-                              <GroupBy index={index} />
-                            </ElementConfigurationSection>
-                          );
-                        })}
-                      </div>
                       <ActionsBar>
                         <Field name="groupBy.columnRollup">
                           {({ field: { name, onChange, value } }) => (
@@ -81,12 +71,17 @@ const GroupByConfiguration = () => {
                             </Checkbox>
                           )}
                         </Field>
-                        <ButtonToolbar>
-                          <Button className="pull-right" bsSize="small" type="button" onClick={() => arrayHelpers.push(emptyGrouping)}>
-                            Add Grouping
-                          </Button>
-                        </ButtonToolbar>
                       </ActionsBar>
+                      <div>
+                        {groupBy.groupings.map((grouping, index) => {
+                          return (
+                            // eslint-disable-next-line react/no-array-index-key
+                            <ElementConfigurationSection key={`grouping-${index}`} onRemove={() => removeGrouping(index)}>
+                              <GroupBy index={index} />
+                            </ElementConfigurationSection>
+                          );
+                        })}
+                      </div>
                     </>
                   )} />
     </>

--- a/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/GroupByConfiguration.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/GroupByConfiguration.tsx
@@ -20,20 +20,13 @@ import { useFormikContext, FieldArray, Field } from 'formik';
 import styled from 'styled-components';
 
 import { HoverForHelp } from 'components/common';
-import { Button, ButtonToolbar, Checkbox } from 'components/graylog';
+import { Checkbox } from 'components/graylog';
 
 import ElementConfigurationSection from './ElementConfigurationSection';
 import GroupBy from './GroupBy';
 
-import GroupByElement, { emptyGrouping } from '../aggregationElements/GroupByElement';
+import GroupByElement from '../aggregationElements/GroupByElement';
 import { WidgetConfigFormValues } from '../WidgetConfigForm';
-
-const ActionsBar = styled.div`
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 3px;
-`;
 
 const RollupColumnsLabel = styled.div`
   display: flex;
@@ -53,25 +46,23 @@ const GroupByConfiguration = () => {
 
   return (
     <>
+      <Field name="groupBy.columnRollup">
+        {({ field: { name, onChange, value } }) => (
+          <Checkbox onChange={() => onChange({ target: { name, value: !groupBy.columnRollup } })}
+                    checked={value}
+                    disabled={disableColumnRollup}>
+            <RollupColumnsLabel>
+              Rollup Columns
+              <RollupHoverForHelp title="Rollup Columns">
+                When rollup is enabled, an additional trace totalling individual subtraces will be included.
+              </RollupHoverForHelp>
+            </RollupColumnsLabel>
+          </Checkbox>
+        )}
+      </Field>
       <FieldArray name="groupBy.groupings"
-                  render={(arrayHelpers) => (
+                  render={() => (
                     <>
-                      <ActionsBar>
-                        <Field name="groupBy.columnRollup">
-                          {({ field: { name, onChange, value } }) => (
-                            <Checkbox onChange={() => onChange({ target: { name, value: !groupBy.columnRollup } })}
-                                      checked={value}
-                                      disabled={disableColumnRollup}>
-                              <RollupColumnsLabel>
-                                Rollup Columns
-                                <RollupHoverForHelp title="Rollup Columns">
-                                  When rollup is enabled, an additional trace totalling individual subtraces will be included.
-                                </RollupHoverForHelp>
-                              </RollupColumnsLabel>
-                            </Checkbox>
-                          )}
-                        </Field>
-                      </ActionsBar>
                       <div>
                         {groupBy.groupings.map((grouping, index) => {
                           return (

--- a/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/MetricsConfiguration.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/MetricsConfiguration.tsx
@@ -47,11 +47,6 @@ const MetricsConfiguration = () => {
                           );
                         })}
                       </div>
-                      <ButtonToolbar>
-                        <Button className="pull-right" bsSize="small" type="button" onClick={() => arrayHelpers.push({})}>
-                          Add a Metric
-                        </Button>
-                      </ButtonToolbar>
                     </>
                   )} />
     </>

--- a/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/MetricsConfiguration.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/MetricsConfiguration.tsx
@@ -18,8 +18,6 @@ import * as React from 'react';
 import { useCallback } from 'react';
 import { useFormikContext, FieldArray } from 'formik';
 
-import { Button, ButtonToolbar } from 'components/graylog';
-
 import ElementConfigurationSection from './ElementConfigurationSection';
 import Metric from './Metric';
 
@@ -33,23 +31,21 @@ const MetricsConfiguration = () => {
   }, [setValues, values]);
 
   return (
-    <>
-      <FieldArray name="metrics"
-                  render={(arrayHelpers) => (
-                    <>
-                      <div>
-                        {metrics.map((metric, index) => {
-                          return (
-                          // eslint-disable-next-line react/no-array-index-key
-                            <ElementConfigurationSection key={`metrics-${index}`} onRemove={() => removeMetric(index)}>
-                              <Metric index={index} />
-                            </ElementConfigurationSection>
-                          );
-                        })}
-                      </div>
-                    </>
-                  )} />
-    </>
+    <FieldArray name="metrics"
+                render={() => (
+                  <>
+                    <div>
+                      {metrics.map((metric, index) => {
+                        return (
+                        // eslint-disable-next-line react/no-array-index-key
+                          <ElementConfigurationSection key={`metrics-${index}`} onRemove={() => removeMetric(index)}>
+                            <Metric index={index} />
+                          </ElementConfigurationSection>
+                        );
+                      })}
+                    </div>
+                  </>
+                )} />
   );
 };
 

--- a/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/SortConfiguration.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/SortConfiguration.tsx
@@ -17,7 +17,6 @@
 import * as React from 'react';
 import { FieldArray, useFormikContext } from 'formik';
 
-import { Button, ButtonToolbar } from 'components/graylog';
 import { WidgetConfigFormValues } from 'views/components/aggregationwizard/WidgetConfigForm';
 import ElementConfigurationSection
   from 'views/components/aggregationwizard/elementConfiguration/ElementConfigurationSection';

--- a/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/SortConfiguration.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/SortConfiguration.tsx
@@ -29,7 +29,7 @@ const SortConfiguration = () => {
 
   return (
     <FieldArray name="sort"
-                render={({ push }) => (
+                render={() => (
                   <>
                     <div>
                       {sort.map((s, index) => (
@@ -39,11 +39,6 @@ const SortConfiguration = () => {
                         </ElementConfigurationSection>
                       ))}
                     </div>
-                    <ButtonToolbar>
-                      <Button className="pull-right" bsSize="small" type="button" onClick={() => push({})}>
-                        Add a Sort
-                      </Button>
-                    </ButtonToolbar>
                   </>
                 )} />
   );

--- a/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/VisualizationConfiguration.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/VisualizationConfiguration.tsx
@@ -27,6 +27,8 @@ import VisualizationConfigurationOptions from 'views/components/aggregationwizar
 import { WidgetConfigFormValues } from 'views/components/aggregationwizard/WidgetConfigForm';
 import { TIMESTAMP_FIELD } from 'views/Constants';
 
+import ElementConfigurationSection from './ElementConfigurationSection';
+
 const isTimeline = (values: WidgetConfigFormValues) => {
   if (!values.groupBy?.groupings || values.groupBy.groupings.length === 0) {
     return false;
@@ -62,7 +64,7 @@ const VisualizationConfiguration = () => {
   const isTimelineChart = isTimeline(values);
 
   return (
-    <div>
+    <ElementConfigurationSection>
       <Field name="visualization.type">
         {({ field: { name, value }, meta: { error } }) => (
           <Input id="visualization-type-select"
@@ -99,7 +101,7 @@ const VisualizationConfiguration = () => {
 
       )}
       <VisualizationConfigurationOptions name="visualization.config" fields={currentVisualizationType.config?.fields ?? []} />
-    </div>
+    </ElementConfigurationSection>
   );
 };
 


### PR DESCRIPTION
## Description
We've recently updated the aggregation builder layout, the config options are now displayed on the left side of the visualization.
![image](https://user-images.githubusercontent.com/46300478/114036597-81738700-9880-11eb-88fe-35a9535c6653.png)

In comparison with the previous implementation (where every config option had a fixed position) it is now slightly harder to identify the position aggregation element.

With this PR we are simplifying the identification by adjusting the layout as follows:
![image](https://user-images.githubusercontent.com/46300478/114037245-170f1680-9881-11eb-9ad0-a85d255ff204.png)

We are also:
- replacing the "Add an element section" buttons with the plus icon next to the title, to reduce the height of each aggregation element.
- Changing the position of the "Rollup columns" option.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

