### PR TITLE
Hide save and load controls when editing a widget

### DIFF
--- a/graylog2-web-interface/src/views/components/DashboardSearchBar.test.tsx
+++ b/graylog2-web-interface/src/views/components/DashboardSearchBar.test.tsx
@@ -21,6 +21,10 @@ import MockStore from 'helpers/mocking/StoreMock';
 
 import { GlobalOverrideActions } from 'views/stores/GlobalOverrideStore';
 import { SearchActions } from 'views/stores/SearchStore';
+import WidgetFocusContext, {
+  WidgetEditingState,
+  WidgetFocusingState
+} from 'views/components/contexts/WidgetFocusContext';
 
 import DashboardSearchBar from './DashboardSearchBar';
 
@@ -99,5 +103,47 @@ describe('DashboardSearchBar', () => {
     fireEvent.click(searchButton);
 
     await waitFor(() => expect(GlobalOverrideActions.set).toHaveBeenCalledWith({ type: 'relative', from: 300 }, ''));
+  });
+
+  it('should hide the save and load controls if a widget is being edited', () => {
+    const focusedWidget: WidgetEditingState = { id: 'foo', editing: true, focusing: true };
+    const widgetFocusContext = {
+      focusedWidget,
+      setWidgetFocusing: () => {},
+      setWidgetEditing: () => {},
+      unsetWidgetFocusing: () => {},
+      unsetWidgetEditing: () => {},
+    };
+
+    render(
+      <WidgetFocusContext.Provider value={widgetFocusContext}>
+        <DashboardSearchBar onExecute={onExecute} config={config} />
+      </WidgetFocusContext.Provider>,
+    );
+
+    const saveBtn = screen.queryByText('View Actions');
+
+    expect(saveBtn).toBeNull();
+  });
+
+  it('should show the save and load controls if a widget is not being edited', async () => {
+    const focusedWidget: WidgetFocusingState = { id: 'foo', editing: false, focusing: true };
+    const widgetFocusContext = {
+      focusedWidget,
+      setWidgetFocusing: () => {},
+      setWidgetEditing: () => {},
+      unsetWidgetFocusing: () => {},
+      unsetWidgetEditing: () => {},
+    };
+
+    render(
+      <WidgetFocusContext.Provider value={widgetFocusContext}>
+        <DashboardSearchBar onExecute={onExecute} config={config} />
+      </WidgetFocusContext.Provider>,
+    );
+
+    const saveBtn = await screen.findByText('View Actions');
+
+    expect(saveBtn).not.toBeNull();
   });
 });

--- a/graylog2-web-interface/src/views/components/DashboardSearchBar.test.tsx
+++ b/graylog2-web-interface/src/views/components/DashboardSearchBar.test.tsx
@@ -23,7 +23,7 @@ import { GlobalOverrideActions } from 'views/stores/GlobalOverrideStore';
 import { SearchActions } from 'views/stores/SearchStore';
 import WidgetFocusContext, {
   WidgetEditingState,
-  WidgetFocusingState
+  WidgetFocusingState,
 } from 'views/components/contexts/WidgetFocusContext';
 
 import DashboardSearchBar from './DashboardSearchBar';

--- a/graylog2-web-interface/src/views/components/DashboardSearchBar.tsx
+++ b/graylog2-web-interface/src/views/components/DashboardSearchBar.tsx
@@ -34,6 +34,7 @@ import { GlobalOverrideActions, GlobalOverrideStore } from 'views/stores/GlobalO
 import type { QueryString, TimeRange } from 'views/logic/queries/Query';
 import TopRow from 'views/components/searchbar/TopRow';
 import { SearchesConfig } from 'components/search/SearchConfig';
+import WidgetFocusContext from 'views/components/contexts/WidgetFocusContext';
 
 import DashboardSearchForm from './DashboardSearchBarForm';
 import TimeRangeInput from './searchbar/TimeRangeInput';
@@ -60,63 +61,67 @@ const DashboardSearchBar = ({ config, globalOverride, disableSearch = false, onE
   const limitDuration = moment.duration(config.query_time_range_limit).asSeconds() ?? 0;
 
   return (
-    <ScrollToHint value={queryString}>
-      <Row className="content">
-        <Col md={12}>
-          <DashboardSearchForm initialValues={{ timerange, queryString }}
-                               limitDuration={limitDuration}
-                               onSubmit={submitForm}>
-            {({ dirty, isSubmitting, isValid, handleSubmit, values, setFieldValue }) => (
-              <>
-                <TopRow>
-                  <Col lg={8} md={9} xs={10}>
-                    <TimeRangeInput disabled={disableSearch}
-                                    onChange={(nextTimeRange) => setFieldValue('timerange', nextTimeRange)}
-                                    value={values?.timerange}
-                                    hasErrorOnMount={!isValid}
-                                    noOverride />
-                  </Col>
-                  <Col lg={4} md={3} xs={2}>
-                    <RefreshControls />
-                  </Col>
-                </TopRow>
+    <WidgetFocusContext.Consumer>
+      {({ focusedWidget: { editing } = { editing: false } }) => (
+        <ScrollToHint value={queryString}>
+          <Row className="content">
+            <Col md={12}>
+              <DashboardSearchForm initialValues={{ timerange, queryString }}
+                                   limitDuration={limitDuration}
+                                   onSubmit={submitForm}>
+                {({ dirty, isSubmitting, isValid, handleSubmit, values, setFieldValue }) => (
+                  <>
+                    <TopRow>
+                      <Col lg={8} md={9} xs={10}>
+                        <TimeRangeInput disabled={disableSearch}
+                                        onChange={(nextTimeRange) => setFieldValue('timerange', nextTimeRange)}
+                                        value={values?.timerange}
+                                        hasErrorOnMount={!isValid}
+                                        noOverride />
+                      </Col>
+                      <Col lg={4} md={3} xs={2}>
+                        <RefreshControls />
+                      </Col>
+                    </TopRow>
 
-                <Row className="no-bm">
-                  <Col md={8} lg={9}>
-                    <div className="pull-right search-help">
-                      <DocumentationLink page={DocsHelper.PAGES.SEARCH_QUERY_LANGUAGE}
-                                         title="Search query syntax documentation"
-                                         text={<Icon name="lightbulb" />} />
-                    </div>
-                    <SearchButton disabled={disableSearch || isSubmitting || !isValid}
-                                  glyph="filter"
-                                  dirty={dirty} />
+                    <Row className="no-bm">
+                      <Col md={8} lg={9}>
+                        <div className="pull-right search-help">
+                          <DocumentationLink page={DocsHelper.PAGES.SEARCH_QUERY_LANGUAGE}
+                                             title="Search query syntax documentation"
+                                             text={<Icon name="lightbulb" />} />
+                        </div>
+                        <SearchButton disabled={disableSearch || isSubmitting || !isValid}
+                                      glyph="filter"
+                                      dirty={dirty} />
 
-                    <Field name="queryString">
-                      {({ field: { name, value, onChange } }) => (
-                        <QueryInput value={value}
-                                    placeholder="Apply filter to all widgets"
-                                    onChange={(newQuery) => {
-                                      onChange({ target: { value: newQuery, name } });
+                        <Field name="queryString">
+                          {({ field: { name, value, onChange } }) => (
+                            <QueryInput value={value}
+                                        placeholder="Apply filter to all widgets"
+                                        onChange={(newQuery) => {
+                                          onChange({ target: { value: newQuery, name } });
 
-                                      return Promise.resolve(newQuery);
-                                    }}
-                                    onExecute={handleSubmit as () => void} />
-                      )}
-                    </Field>
-                  </Col>
-                  <Col md={4} lg={3}>
-                    <div className="pull-right">
-                      <ViewActionsMenu />
-                    </div>
-                  </Col>
-                </Row>
-              </>
-            )}
-          </DashboardSearchForm>
-        </Col>
-      </Row>
-    </ScrollToHint>
+                                          return Promise.resolve(newQuery);
+                                        }}
+                                        onExecute={handleSubmit as () => void} />
+                          )}
+                        </Field>
+                      </Col>
+                      <Col md={4} lg={3}>
+                        <div className="pull-right">
+                          {!editing && <ViewActionsMenu />}
+                        </div>
+                      </Col>
+                    </Row>
+                  </>
+                )}
+              </DashboardSearchForm>
+            </Col>
+          </Row>
+        </ScrollToHint>
+      )}
+    </WidgetFocusContext.Consumer>
   );
 };
 

--- a/graylog2-web-interface/src/views/components/SearchBar.test.tsx
+++ b/graylog2-web-interface/src/views/components/SearchBar.test.tsx
@@ -22,6 +22,9 @@ import mockAction from 'helpers/mocking/MockAction';
 import { SearchActions } from 'views/stores/SearchStore';
 // eslint-disable-next-line import/no-named-default
 import { default as MockQuery } from 'views/logic/queries/Query';
+import WidgetFocusContext, {
+  WidgetEditingState, WidgetFocusingState,
+} from 'views/components/contexts/WidgetFocusContext';
 
 import SearchBar from './SearchBar';
 
@@ -39,7 +42,7 @@ jest.mock('stores/streams/StreamsStore', () => MockStore(
 ));
 
 jest.mock('views/components/searchbar/QueryInput', () => 'query-input');
-jest.mock('views/components/searchbar/saved-search/SavedSearchControls', () => 'saved-search-controls');
+jest.mock('views/components/searchbar/saved-search/SavedSearchControls', () => jest.fn(() => <div>Saved Search Controls</div>));
 
 jest.mock('views/stores/CurrentQueryStore', () => ({
   CurrentQueryStore: MockStore(['getInitialState', () => MockQuery.builder()
@@ -100,5 +103,47 @@ describe('SearchBar', () => {
       expect(searchButton).toHaveAttribute('disabled');
       expect(timeRangeButton.firstChild).toHaveClass('fa-exclamation-triangle');
     });
+  });
+
+  it('should hide the save load controls if editing the widget', () => {
+    const focusedWidget: WidgetEditingState = { id: 'foo', editing: true, focusing: true };
+    const widgetFocusContext = {
+      focusedWidget,
+      setWidgetFocusing: () => {},
+      setWidgetEditing: () => {},
+      unsetWidgetFocusing: () => {},
+      unsetWidgetEditing: () => {},
+    };
+
+    render(
+      <WidgetFocusContext.Provider value={widgetFocusContext}>
+        <SearchBar config={config} />
+      </WidgetFocusContext.Provider>,
+    );
+
+    const saveBtn = screen.queryByText('Saved Search Controls');
+
+    expect(saveBtn).toBeNull();
+  });
+
+  it('should show the save load controls if the widget is not edited', async () => {
+    const focusedWidget: WidgetFocusingState = { id: 'foo', editing: false, focusing: true };
+    const widgetFocusContext = {
+      focusedWidget,
+      setWidgetFocusing: () => {},
+      setWidgetEditing: () => {},
+      unsetWidgetFocusing: () => {},
+      unsetWidgetEditing: () => {},
+    };
+
+    render(
+      <WidgetFocusContext.Provider value={widgetFocusContext}>
+        <SearchBar config={config} />
+      </WidgetFocusContext.Provider>,
+    );
+
+    const saveBtn = await screen.findByText('Saved Search Controls');
+
+    expect(saveBtn).not.toBeNull();
   });
 });

--- a/graylog2-web-interface/src/views/components/SearchBar.tsx
+++ b/graylog2-web-interface/src/views/components/SearchBar.tsx
@@ -43,6 +43,7 @@ import Query, { createElasticsearchQueryString, filtersForQuery, filtersToStream
 import type { FilterType, QueryId } from 'views/logic/queries/Query';
 import type { SearchesConfig } from 'components/search/SearchConfig';
 import type { SearchBarFormValues } from 'views/Constants';
+import WidgetFocusContext from 'views/components/contexts/WidgetFocusContext';
 
 import SearchBarForm from './searchbar/SearchBarForm';
 
@@ -105,74 +106,78 @@ const SearchBar = ({
   const _onSubmit = (values) => onSubmit(values, currentQuery);
 
   return (
-    <ScrollToHint value={query.query_string}>
-      <Row className="content">
-        <Col md={12}>
-          <SearchBarForm initialValues={{ timerange, streams, queryString }}
-                         limitDuration={limitDuration}
-                         onSubmit={_onSubmit}>
-            {({ dirty, isSubmitting, isValid, handleSubmit, values, setFieldValue }) => (
-              <>
-                <TopRow>
-                  <Col md={5}>
-                    <TimeRangeInput disabled={disableSearch}
-                                    onChange={(nextTimeRange) => setFieldValue('timerange', nextTimeRange)}
-                                    value={values?.timerange}
-                                    hasErrorOnMount={!isValid} />
-                  </Col>
+    <WidgetFocusContext.Consumer>
+      {({ focusedWidget: { editing } = { editing: false } }) => (
+        <ScrollToHint value={query.query_string}>
+          <Row className="content">
+            <Col md={12}>
+              <SearchBarForm initialValues={{ timerange, streams, queryString }}
+                             limitDuration={limitDuration}
+                             onSubmit={_onSubmit}>
+                {({ dirty, isSubmitting, isValid, handleSubmit, values, setFieldValue }) => (
+                  <>
+                    <TopRow>
+                      <Col md={5}>
+                        <TimeRangeInput disabled={disableSearch}
+                                        onChange={(nextTimeRange) => setFieldValue('timerange', nextTimeRange)}
+                                        value={values?.timerange}
+                                        hasErrorOnMount={!isValid} />
+                      </Col>
 
-                  <Col mdHidden lgHidden>
-                    <HorizontalSpacer />
-                  </Col>
+                      <Col mdHidden lgHidden>
+                        <HorizontalSpacer />
+                      </Col>
 
-                  <FlexCol md={7}>
-                    <StreamWrap>
-                      <Field name="streams">
-                        {({ field: { name, value, onChange } }) => (
-                          <StreamsFilter value={value}
-                                         streams={availableStreams}
-                                         onChange={(newStreams) => onChange({ target: { value: newStreams, name } })} />
-                        )}
-                      </Field>
-                    </StreamWrap>
+                      <FlexCol md={7}>
+                        <StreamWrap>
+                          <Field name="streams">
+                            {({ field: { name, value, onChange } }) => (
+                              <StreamsFilter value={value}
+                                             streams={availableStreams}
+                                             onChange={(newStreams) => onChange({ target: { value: newStreams, name } })} />
+                            )}
+                          </Field>
+                        </StreamWrap>
 
-                    <RefreshControls />
-                  </FlexCol>
-                </TopRow>
+                        <RefreshControls />
+                      </FlexCol>
+                    </TopRow>
 
-                <Row className="no-bm">
-                  <Col md={9} xs={8}>
-                    <div className="pull-right search-help">
-                      <DocumentationLink page={DocsHelper.PAGES.SEARCH_QUERY_LANGUAGE}
-                                         title="Search query syntax documentation"
-                                         text={<Icon name="lightbulb" />} />
-                    </div>
-                    <SearchButton disabled={disableSearch || isSubmitting || !isValid}
-                                  dirty={dirty} />
+                    <Row className="no-bm">
+                      <Col md={9} xs={8}>
+                        <div className="pull-right search-help">
+                          <DocumentationLink page={DocsHelper.PAGES.SEARCH_QUERY_LANGUAGE}
+                                             title="Search query syntax documentation"
+                                             text={<Icon name="lightbulb" />} />
+                        </div>
+                        <SearchButton disabled={disableSearch || isSubmitting || !isValid}
+                                      dirty={dirty} />
 
-                    <Field name="queryString">
-                      {({ field: { name, value, onChange } }) => (
-                        <QueryInput value={value}
-                                    placeholder={'Type your search query here and press enter. E.g.: ("not found" AND http) OR http_response_code:[400 TO 404]'}
-                                    onChange={(newQuery) => {
-                                      onChange({ target: { value: newQuery, name } });
+                        <Field name="queryString">
+                          {({ field: { name, value, onChange } }) => (
+                            <QueryInput value={value}
+                                        placeholder={'Type your search query here and press enter. E.g.: ("not found" AND http) OR http_response_code:[400 TO 404]'}
+                                        onChange={(newQuery) => {
+                                          onChange({ target: { value: newQuery, name } });
 
-                                      return Promise.resolve(newQuery);
-                                    }}
-                                    onExecute={handleSubmit as () => void} />
-                      )}
-                    </Field>
-                  </Col>
-                  <Col md={3} xs={4} className="pull-right" aria-label="Search Meta Buttons">
-                    <SavedSearchControls />
-                  </Col>
-                </Row>
-              </>
-            )}
-          </SearchBarForm>
-        </Col>
-      </Row>
-    </ScrollToHint>
+                                          return Promise.resolve(newQuery);
+                                        }}
+                                        onExecute={handleSubmit as () => void} />
+                          )}
+                        </Field>
+                      </Col>
+                      <Col md={3} xs={4} className="pull-right" aria-label="Search Meta Buttons">
+                        {!editing && <SavedSearchControls />}
+                      </Col>
+                    </Row>
+                  </>
+                )}
+              </SearchBarForm>
+            </Col>
+          </Row>
+        </ScrollToHint>
+      )}
+    </WidgetFocusContext.Consumer>
   );
 };
 


### PR DESCRIPTION
## Motivation
Prior to this change, a page which was displaying a widget in edit mode,
the page was rendering two Save buttons. Also the complexity of states
to handle on each of the controls was not worth the gain.

## Description
This change will hide the view controls on dashboard and the saved
search controls on a search.

## How Has This Been Tested?
- Edit a widget and see the controls disappear

## Screenshots (if appropriate):
![Graylog (45)](https://user-images.githubusercontent.com/448763/114039982-7a01ad00-9883-11eb-86e7-49506c61365e.png)

Fixes #10337 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)