### PR TITLE
CSV File adapter: Use AllowedAuxiliaryPathChecker in File path UI validation

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/lookup/adapters/CSVFileDataAdapter.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/adapters/CSVFileDataAdapter.java
@@ -303,7 +303,7 @@ public class CSVFileDataAdapter extends LookupDataAdapter {
             final Path path = Paths.get(path());
             if (!context.getPathChecker().fileIsInAllowedPath(path)) {
                 errors.put("path", ALLOWED_PATH_ERROR);
-                return;
+                return Optional.of(errors);
             }
 
             if (!Files.exists(path)) {

--- a/graylog2-server/src/main/java/org/graylog2/lookup/adapters/CSVFileDataAdapter.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/adapters/CSVFileDataAdapter.java
@@ -62,7 +62,16 @@ public class CSVFileDataAdapter extends LookupDataAdapter {
     private static final Logger LOG = LoggerFactory.getLogger(CSVFileDataAdapter.class);
 
     public static final String NAME = "csvfile";
-    public static final String ALLOWED_PATH_ERROR = "The specified CSV file is not in an allowed path.";
+
+    /**
+     * If the AllowedAuxiliaryPathChecker is enabled (one or more paths provided to the allowed_auxiliary_paths server
+     * configuration property), then this error path will also be triggered for cases where the file does not exist.
+     * This is unavoidable, since the AllowedAuxiliaryPathChecker tries to resolve symbolic links and relative paths,
+     * which cannot be done if the file does not exist. Therefore this error message also indicates the possibility
+     * that the file does not exist.
+     */
+    public static final String ALLOWED_PATH_ERROR =
+            "The specified CSV file either does not exist or is not in an allowed path.";
 
     private final Config config;
     private final AllowedAuxiliaryPathChecker pathChecker;
@@ -303,6 +312,9 @@ public class CSVFileDataAdapter extends LookupDataAdapter {
             final Path path = Paths.get(path());
             if (!context.getPathChecker().fileIsInAllowedPath(path)) {
                 errors.put("path", ALLOWED_PATH_ERROR);
+
+                // Intentionally return here, because in the Cloud context, we should not perform the following checks
+                // to report to the user whether or not a file exists.
                 return Optional.of(errors);
             }
 

--- a/graylog2-server/src/main/java/org/graylog2/lookup/adapters/CSVFileDataAdapter.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/adapters/CSVFileDataAdapter.java
@@ -303,6 +303,7 @@ public class CSVFileDataAdapter extends LookupDataAdapter {
             final Path path = Paths.get(path());
             if (!context.getPathChecker().fileIsInAllowedPath(path)) {
                 errors.put("path", ALLOWED_PATH_ERROR);
+                return;
             }
 
             if (!Files.exists(path)) {

--- a/graylog2-server/src/main/java/org/graylog2/lookup/adapters/CSVFileDataAdapter.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/adapters/CSVFileDataAdapter.java
@@ -297,10 +297,14 @@ public class CSVFileDataAdapter extends LookupDataAdapter {
         }
 
         @Override
-        public Optional<Multimap<String, String>> validate() {
+        public Optional<Multimap<String, String>> validate(LookupDataAdapterValidationContext context) {
             final ArrayListMultimap<String, String> errors = ArrayListMultimap.create();
 
             final Path path = Paths.get(path());
+            if (!context.getPathChecker().fileIsInAllowedPath(path)) {
+                errors.put("path", ALLOWED_PATH_ERROR);
+            }
+
             if (!Files.exists(path)) {
                 errors.put("path", "The file does not exist.");
             } else if (!Files.isReadable(path)) {

--- a/graylog2-server/src/main/java/org/graylog2/lookup/adapters/LookupDataAdapterValidationContext.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/adapters/LookupDataAdapterValidationContext.java
@@ -17,6 +17,7 @@
 package org.graylog2.lookup.adapters;
 
 import com.google.inject.Inject;
+import org.graylog2.lookup.AllowedAuxiliaryPathChecker;
 import org.graylog2.system.urlwhitelist.UrlWhitelistService;
 
 /**
@@ -24,13 +25,20 @@ import org.graylog2.system.urlwhitelist.UrlWhitelistService;
  */
 public class LookupDataAdapterValidationContext {
     private final UrlWhitelistService urlWhitelistService;
+    private final AllowedAuxiliaryPathChecker pathChecker;
 
     @Inject
-    public LookupDataAdapterValidationContext(UrlWhitelistService urlWhitelistService) {
+    public LookupDataAdapterValidationContext(UrlWhitelistService urlWhitelistService,
+                                              AllowedAuxiliaryPathChecker pathChecker) {
         this.urlWhitelistService = urlWhitelistService;
+        this.pathChecker = pathChecker;
     }
 
     public UrlWhitelistService getUrlWhitelistService() {
         return urlWhitelistService;
+    }
+
+    public AllowedAuxiliaryPathChecker getPathChecker() {
+        return pathChecker;
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/lookup/adapters/CSVFileDataAdapterTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/lookup/adapters/CSVFileDataAdapterTest.java
@@ -107,7 +107,7 @@ public class CSVFileDataAdapterTest {
         csvFileDataAdapter = new CSVFileDataAdapter("id", "name", config, new MetricRegistry(), pathChecker);
         assertThatThrownBy(() -> csvFileDataAdapter.doStart())
                 .isExactlyInstanceOf(IllegalStateException.class)
-                .hasMessageStartingWith("The specified CSV file is not in an allowed path.");
+                .hasMessageStartingWith(CSVFileDataAdapter.ALLOWED_PATH_ERROR);
     }
 
     @Test
@@ -183,7 +183,7 @@ public class CSVFileDataAdapterTest {
         when(pathChecker.fileIsInAllowedPath(any(Path.class))).thenReturn(false);
         final Optional<Multimap<String, String>> result = config.validate(validationContext);
         assertTrue(result.isPresent());
-        assertEquals("The specified CSV file is not in an allowed path.",
+        assertEquals(CSVFileDataAdapter.ALLOWED_PATH_ERROR,
                      String.join("", result.get().asMap().get("path")));
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Use the [AllowedAuxiliaryPathChecker](https://github.com/Graylog2/graylog2-server/blob/master/graylog2-server/src/main/java/org/graylog2/lookup/AllowedAuxiliaryPathChecker.java#L30) (and therefore the `allowed_auxiliary_paths` server configuration file parameter) for the CSV Lookup adapter UI validation for the File path field. This ensures that the user cannot use the UI validation on the File path field to inspect if arbitrary directories and files exist on the file system in the Cloud context as described in https://github.com/Graylog2/graylog-plugin-cloud/issues/830. The AllowedAuxiliaryPathChecker was already being used in the process of starting the CSV File adapter (see https://github.com/Graylog2/graylog2-server/pull/10244), and this adds the same check for the UI validation.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes https://github.com/Graylog2/graylog-plugin-cloud/issues/830, which is a security concern in the Cloud context.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested in the UI to verify that when `allowed_auxiliary_paths` values are specified, the UI will not attempt to perform validation for file paths that are outside of the specified permitted directories.

Also tested that when `allowed_auxiliary_paths` values are not specified, that the file existence and readability checks are performed normally as expected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

