### PR TITLE
Support + in index set prefixes.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/MongoIndexSet.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/MongoIndexSet.java
@@ -104,12 +104,12 @@ public class MongoIndexSet implements IndexSet {
         // Part of the pattern can be configured in IndexSetConfig. If set we use the indexMatchPattern from the config.
         if (isNullOrEmpty(config.indexMatchPattern())) {
             // This pattern requires that we check that each index prefix is unique and unambiguous to avoid false matches.
-            this.indexPattern = Pattern.compile("^" + config.indexPrefix() + SEPARATOR + "\\d+(?:" + RESTORED_ARCHIVE_SUFFIX + ")?");
-            this.deflectorIndexPattern = Pattern.compile("^" + config.indexPrefix() + SEPARATOR + "\\d+");
+            this.indexPattern = Pattern.compile("^" + Pattern.quote(config.indexPrefix()) + SEPARATOR + "\\d+(?:" + RESTORED_ARCHIVE_SUFFIX + ")?");
+            this.deflectorIndexPattern = Pattern.compile("^" + Pattern.quote(config.indexPrefix()) + SEPARATOR + "\\d+");
         } else {
             // This pattern requires that we check that each index prefix is unique and unambiguous to avoid false matches.
-            this.indexPattern = Pattern.compile("^" + config.indexMatchPattern() + SEPARATOR + "\\d+(?:" + RESTORED_ARCHIVE_SUFFIX + ")?");
-            this.deflectorIndexPattern = Pattern.compile("^" + config.indexMatchPattern() + SEPARATOR + "\\d+");
+            this.indexPattern = Pattern.compile("^" + Pattern.quote(config.indexMatchPattern()) + SEPARATOR + "\\d+(?:" + RESTORED_ARCHIVE_SUFFIX + ")?");
+            this.deflectorIndexPattern = Pattern.compile("^" + Pattern.quote(config.indexMatchPattern()) + SEPARATOR + "\\d+");
         }
 
         // The index wildcard can be configured in IndexSetConfig. If not set we use a default one based on the index

--- a/graylog2-server/src/test/java/org/graylog2/indexer/MongoIndexSetTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/MongoIndexSetTest.java
@@ -322,4 +322,14 @@ public class MongoIndexSetTest {
 
         verify(indices, times(1)).cycleAlias("graylog_deflector", indexName);
     }
+
+    @Test
+    public void identifiesIndicesWithPlusAsBeingManaged() {
+        final IndexSetConfig configWithPlus = config.toBuilder().indexPrefix("some+index").build();
+        final String indexName = configWithPlus.indexPrefix() + "_0";
+
+        final MongoIndexSet mongoIndexSet = new MongoIndexSet(configWithPlus, indices, nodeId, indexRangeService, auditEventSender, systemJobManager, jobFactory, activityWriter);
+
+        assertThat(mongoIndexSet.isManagedIndex(indexName)).isTrue();
+    }
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

**Note:** This PR requires a backport to `4.0.`.

This PR is making a couple of changes to support the + character in index set prefixes. The required changes were:

  - Properly URL encode `+` in names when creating the index template
  - Quote `+` when creating the regular expression used to match indices     against the prefix

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

When an index set is configured with a `+` in the index set prefix, all kinds of issues show up, making it effectively unusable. Indices are not identified to belong to this index set, creation of new indices for this index set do not have the proper index template.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.