### PR TITLE
Adding `lang="en"` to html tag, to declare the language of the web application.

### DIFF
--- a/graylog2-web-interface/templates/index.html.template
+++ b/graylog2-web-interface/templates/index.html.template
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html<% if(htmlWebpackPlugin.files.manifest) { %> manifest="<%= htmlWebpackPlugin.files.manifest %>"<% } %>>
+<html<% if(htmlWebpackPlugin.files.manifest) { %> manifest="<%= htmlWebpackPlugin.files.manifest %>"<% } %> lang="en">
   <head>
     <meta charset="UTF-8">
     <title><%=htmlWebpackPlugin.options.title || 'Webpack App'%></title>


### PR DESCRIPTION
## Description
Adding the lang attribute to the html tag declares the language of the web application. This will assist the browser and enable support for e.g. hyphenation. (https://developer.mozilla.org/en-US/docs/Web/CSS/hyphens)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

