### PR TITLE
Defining theme input placeholder color for common `Select` component.

### DIFF
--- a/graylog2-web-interface/src/components/common/Select.tsx
+++ b/graylog2-web-interface/src/components/common/Select.tsx
@@ -131,6 +131,7 @@ const singleValueAndPlaceholder = ({ theme }) => (base) => ({
 
 const placeholder = ({ theme }) => (base) => ({
   ...base,
+  color: theme.colors.input.placeholder,
   lineHeight: '28px',
   fontFamily: theme.fonts.family.body,
   fontSize: theme.fonts.size.body,

--- a/graylog2-web-interface/src/components/configurationforms/__snapshots__/ListField.test.tsx.snap
+++ b/graylog2-web-interface/src/components/configurationforms/__snapshots__/ListField.test.tsx.snap
@@ -46,7 +46,7 @@ exports[`<ListField> should render an empty field 1`] = `
             class="css-1hio1c"
           >
             <div
-              class="css-1nlt8zk-placeholder"
+              class="css-1fbh878-placeholder"
             >
               Select list field
             </div>


### PR DESCRIPTION
## Description
With this PR we are defining the theme input placeholder color for the `Select` component.

Before (slightly different input and select placeholder color):
![image](https://user-images.githubusercontent.com/46300478/114204422-76405a00-9959-11eb-927e-0b5cb0118dfc.png)

After:
![image](https://user-images.githubusercontent.com/46300478/114204230-3da08080-9959-11eb-8681-22c6612bae7e.png)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

