### PR TITLE
Do not display group by section in aggregation builder if widget has no groupings.

### DIFF
--- a/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.groupBy.test.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.groupBy.test.tsx
@@ -16,7 +16,7 @@
  */
 import React from 'react';
 import * as Immutable from 'immutable';
-import { act, fireEvent, render, screen, waitFor } from 'wrappedTestingLibrary';
+import { act, fireEvent, render, screen, waitFor, within } from 'wrappedTestingLibrary';
 import selectEvent from 'react-select-event';
 import userEvent from '@testing-library/user-event';
 import { PluginRegistration, PluginStore } from 'graylog-web-plugin/plugin';
@@ -181,6 +181,18 @@ describe('AggregationWizard', () => {
 
     await screen.findByText('took_ms');
     await screen.findByText('timestamp');
+  });
+
+  it('should not display group by section if config has no pivots', () => {
+    const config = widgetConfig
+      .toBuilder()
+      .build();
+
+    renderSUT({ config });
+
+    const configureElementsSection = screen.getByTestId('configure-elements-section');
+
+    expect(within(configureElementsSection).queryByText('Group By')).not.toBeInTheDocument();
   });
 
   it('should correctly change config', async () => {

--- a/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/GroupByElement.ts
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/GroupByElement.ts
@@ -197,15 +197,24 @@ const GroupByElement: AggregationElement = {
       ],
     },
   }),
-  removeElementSection: ((index, formValues) => ({
-    ...formValues,
-    groupBy: {
-      columnRollup: formValues.groupBy ? formValues.groupBy.columnRollup : true,
-      groupings: [
-        ...(formValues.groupBy ? formValues.groupBy.groupings.filter((value, i) => (index !== i)) : []),
-      ],
-    },
-  })),
+  removeElementSection: ((index, formValues) => {
+    const newFormValues = { ...formValues };
+    const newGroupings = formValues.groupBy?.groupings.filter((value, i) => (index !== i));
+
+    if (isEmpty(newGroupings)) {
+      delete newFormValues.groupBy;
+
+      return newFormValues;
+    }
+
+    return ({
+      ...newFormValues,
+      groupBy: {
+        columnRollup: newFormValues.groupBy.columnRollup ?? true,
+        groupings: newGroupings,
+      },
+    });
+  }),
   fromConfig: (config: AggregationWidgetConfig) => {
     const groupings = pivotsToGrouping(config);
 

--- a/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/GroupByElement.ts
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/GroupByElement.ts
@@ -158,6 +158,10 @@ const groupingToPivot = (grouping: GroupByFormValues) => {
 };
 
 const groupByToConfig = (groupBy: WidgetConfigFormValues['groupBy'], config: AggregationWidgetConfigBuilder) => {
+  if (!groupBy) {
+    return config;
+  }
+
   const rowPivots = groupBy.groupings.filter((grouping) => grouping.direction === 'row').map(groupingToPivot);
   const columnPivots = groupBy.groupings.filter((grouping) => grouping.direction === 'column').map(groupingToPivot);
   const { columnRollup } = groupBy;

--- a/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/GroupByElement.ts
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/GroupByElement.ts
@@ -209,8 +209,12 @@ const GroupByElement: AggregationElement = {
   fromConfig: (config: AggregationWidgetConfig) => {
     const groupings = pivotsToGrouping(config);
 
+    if (isEmpty(groupings)) {
+      return undefined;
+    }
+
     return {
-      groupBy: isEmpty(groupings) ? undefined : {
+      groupBy: {
         columnRollup: config.rollup,
         groupings,
       },


### PR DESCRIPTION
## Description
Before this change the group by section was visible in the widget edit mode, for example after creating a new widget. The section was displayed because the form value for `groupBy` was not empty.

With this change we are ensuring that `fromConfig` of the group by element returns `undefined` if no grouping exists.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

