### PR TITLE
Implement all properties for applying execution state

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/MessageList.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/MessageList.java
@@ -103,19 +103,20 @@ public abstract class MessageList implements SearchType {
 
     @Override
     public SearchType applyExecutionContext(ObjectMapper objectMapper, JsonNode state) {
-        final boolean hasLimit = state.hasNonNull("limit");
-        final boolean hasOffset = state.hasNonNull("offset");
-        if (hasLimit || hasOffset) {
-            final Builder builder = toBuilder();
-            if (hasLimit) {
-                builder.limit(state.path("limit").asInt());
-            }
-            if (hasOffset) {
-                builder.offset(state.path("offset").asInt());
-            }
-            return builder.build();
-        }
-        return this;
+        final Builder builder = toBuilder();
+        final PartialMessageList partialMessageList = objectMapper.convertValue(state, PartialMessageList.class);
+
+        partialMessageList.name().ifPresent(builder::name);
+        partialMessageList.filter().ifPresent(builder::filter);
+        partialMessageList.limit().ifPresent(builder::limit);
+        partialMessageList.offset().ifPresent(builder::offset);
+        partialMessageList.sort().ifPresent(builder::sort);
+        partialMessageList.decorators().ifPresent(builder::decorators);
+        partialMessageList.timerange().ifPresent(builder::timerange);
+        partialMessageList.query().ifPresent(builder::query);
+        partialMessageList.streams().ifPresent(builder::streams);
+
+        return builder.build();
     }
 
     @AutoValue.Builder

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/PartialMessageList.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/PartialMessageList.java
@@ -1,0 +1,129 @@
+package org.graylog.plugins.views.search.searchtypes;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.auto.value.AutoValue;
+import org.graylog.plugins.views.search.Filter;
+import org.graylog.plugins.views.search.engine.BackendQuery;
+import org.graylog.plugins.views.search.timeranges.DerivedTimeRange;
+import org.graylog.plugins.views.search.timeranges.OffsetRange;
+import org.graylog2.decorators.Decorator;
+import org.graylog2.decorators.DecoratorImpl;
+import org.graylog2.plugin.indexer.searches.timeranges.AbsoluteRange;
+import org.graylog2.plugin.indexer.searches.timeranges.KeywordRange;
+import org.graylog2.plugin.indexer.searches.timeranges.RelativeRange;
+import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
+
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+@AutoValue
+@JsonTypeName(PartialMessageList.NAME)
+@JsonDeserialize(builder = PartialMessageList.Builder.class)
+public abstract class PartialMessageList {
+    public static final String NAME = "messages";
+
+    public abstract Optional<String> type();
+
+    @JsonProperty
+    public abstract Optional<String> id();
+
+    @JsonProperty
+    public abstract Optional<String> name();
+
+    @JsonProperty
+    public abstract Optional<Filter> filter();
+
+    @JsonProperty
+    public abstract Optional<Integer> limit();
+
+    @JsonProperty
+    public abstract Optional<Integer> offset();
+
+    @JsonProperty
+    public abstract Optional<List<Sort>> sort();
+
+    @JsonProperty
+    public abstract Optional<List<Decorator>> decorators();
+
+    @JsonProperty
+    public abstract Optional<DerivedTimeRange> timerange();
+
+    @JsonProperty
+    public abstract Optional<BackendQuery> query();
+
+    @JsonProperty
+    public abstract Optional<Set<String>> streams();
+
+    @JsonCreator
+    public static PartialMessageList.Builder builder() {
+        return new AutoValue_PartialMessageList.Builder()
+                .type(NAME);
+    }
+
+    public abstract PartialMessageList.Builder toBuilder();
+
+    @AutoValue.Builder
+    public abstract static class Builder {
+        @JsonCreator
+        public static PartialMessageList.Builder createDefault() {
+            return builder();
+        }
+
+        @JsonProperty
+        public abstract PartialMessageList.Builder type(@Nullable String type);
+
+        @JsonProperty
+        public abstract PartialMessageList.Builder id(@Nullable String id);
+
+        @JsonProperty
+        public abstract PartialMessageList.Builder name(@Nullable String name);
+
+        @JsonProperty
+        public abstract PartialMessageList.Builder filter(@Nullable Filter filter);
+
+        @JsonProperty
+        @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "type", visible = true)
+        @JsonSubTypes({
+                @JsonSubTypes.Type(name = AbsoluteRange.ABSOLUTE, value = AbsoluteRange.class),
+                @JsonSubTypes.Type(name = RelativeRange.RELATIVE, value = RelativeRange.class),
+                @JsonSubTypes.Type(name = KeywordRange.KEYWORD, value = KeywordRange.class),
+                @JsonSubTypes.Type(name = OffsetRange.OFFSET, value = OffsetRange.class)
+        })
+        public PartialMessageList.Builder timerange(@Nullable TimeRange timerange) {
+            return timerange(timerange == null ? null : DerivedTimeRange.of(timerange));
+        }
+        public abstract PartialMessageList.Builder timerange(@Nullable DerivedTimeRange timerange);
+
+        @JsonProperty
+        public abstract PartialMessageList.Builder query(@Nullable BackendQuery query);
+
+        @JsonProperty
+        public abstract PartialMessageList.Builder streams(@Nullable Set<String> streams);
+
+        @JsonProperty
+        public abstract PartialMessageList.Builder limit(@Nullable Integer limit);
+
+        @JsonProperty
+        public abstract PartialMessageList.Builder offset(@Nullable Integer offset);
+
+        @JsonProperty
+        public abstract PartialMessageList.Builder sort(@Nullable List<Sort> sort);
+
+        @JsonProperty("decorators")
+        public PartialMessageList.Builder _decorators(@Nullable List<DecoratorImpl> decorators) {
+            return decorators(new ArrayList<>(decorators));
+        }
+
+        public abstract PartialMessageList.Builder decorators(@Nullable List<Decorator> decorators);
+
+        public abstract PartialMessageList build();
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/PartialMessageList.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/PartialMessageList.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog.plugins.views.search.searchtypes;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/PartialPivot.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/PartialPivot.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog.plugins.views.search.searchtypes.pivot;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/PartialPivot.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/PartialPivot.java
@@ -1,0 +1,133 @@
+package org.graylog.plugins.views.search.searchtypes.pivot;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.auto.value.AutoValue;
+import org.graylog.plugins.views.search.Filter;
+import org.graylog.plugins.views.search.engine.BackendQuery;
+import org.graylog.plugins.views.search.timeranges.DerivedTimeRange;
+import org.graylog.plugins.views.search.timeranges.OffsetRange;
+import org.graylog2.plugin.indexer.searches.timeranges.AbsoluteRange;
+import org.graylog2.plugin.indexer.searches.timeranges.KeywordRange;
+import org.graylog2.plugin.indexer.searches.timeranges.RelativeRange;
+import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
+
+import javax.annotation.Nullable;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.google.common.collect.ImmutableList.of;
+
+@AutoValue
+@JsonTypeName(PartialPivot.NAME)
+@JsonDeserialize(builder = PartialPivot.Builder.class)
+public abstract class PartialPivot {
+    public static final String NAME = "pivot";
+
+    @JsonProperty
+    public abstract Optional<String> type();
+
+    @JsonProperty
+    public abstract Optional<String> id();
+
+    @JsonProperty
+    public abstract Optional<String> name();
+
+    @JsonProperty("row_groups")
+    public abstract Optional<List<BucketSpec>> rowGroups();
+
+    @JsonProperty("column_groups")
+    public abstract Optional<List<BucketSpec>> columnGroups();
+
+    @JsonProperty
+    public abstract Optional<List<SeriesSpec>> series();
+
+    @JsonProperty
+    public abstract Optional<List<SortSpec>> sort();
+
+    @JsonProperty
+    public abstract Optional<Boolean> rollup();
+
+    @JsonProperty
+    public abstract Optional<Filter> filter();
+
+    @JsonProperty
+    public abstract Optional<DerivedTimeRange> timerange();
+
+    @JsonProperty
+    public abstract Optional<BackendQuery> query();
+
+    @JsonProperty
+    public abstract Optional<Set<String>> streams();
+
+    public abstract PartialPivot.Builder toBuilder();
+
+    public static PartialPivot.Builder builder() {
+        return new AutoValue_PartialPivot.Builder()
+                .type(NAME);
+    }
+
+    @AutoValue.Builder
+    public static abstract class Builder {
+        @JsonCreator
+        public static PartialPivot.Builder createDefault() {
+            return builder()
+                    .sort(Collections.emptyList())
+                    .streams(Collections.emptySet());
+        }
+
+        @JsonProperty
+        public abstract PartialPivot.Builder type(@Nullable String type);
+
+        @JsonProperty
+        public abstract PartialPivot.Builder id(@Nullable String id);
+
+        @JsonProperty
+        public abstract PartialPivot.Builder name(@Nullable String name);
+
+        @JsonProperty("row_groups")
+        public abstract PartialPivot.Builder rowGroups(@Nullable List<BucketSpec> rowGroups);
+
+        @JsonProperty("column_groups")
+        public abstract PartialPivot.Builder columnGroups(@Nullable List<BucketSpec> columnGroups);
+
+        @JsonProperty
+        public abstract PartialPivot.Builder series(@Nullable List<SeriesSpec> series);
+
+        @JsonProperty
+        public abstract PartialPivot.Builder sort(@Nullable List<SortSpec> sort);
+
+        @JsonProperty
+        public abstract PartialPivot.Builder rollup(@Nullable Boolean rollup);
+
+        @JsonProperty
+        public abstract PartialPivot.Builder filter(@Nullable Filter filter);
+
+        @JsonProperty
+        @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "type", visible = true)
+        @JsonSubTypes({
+                @JsonSubTypes.Type(name = AbsoluteRange.ABSOLUTE, value = AbsoluteRange.class),
+                @JsonSubTypes.Type(name = RelativeRange.RELATIVE, value = RelativeRange.class),
+                @JsonSubTypes.Type(name = KeywordRange.KEYWORD, value = KeywordRange.class),
+                @JsonSubTypes.Type(name = OffsetRange.OFFSET, value = OffsetRange.class)
+        })
+        public PartialPivot.Builder timerange(@Nullable TimeRange timerange) {
+            return timerange(timerange == null ? null : DerivedTimeRange.of(timerange));
+        }
+        public abstract PartialPivot.Builder timerange(@Nullable DerivedTimeRange timerange);
+
+        @JsonProperty
+        public abstract PartialPivot.Builder query(@Nullable BackendQuery query);
+
+        @JsonProperty
+        public abstract PartialPivot.Builder streams(@Nullable Set<String> streams);
+
+        public abstract PartialPivot build();
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/Pivot.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/Pivot.java
@@ -25,16 +25,16 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
-import org.graylog.plugins.views.search.timeranges.DerivedTimeRange;
 import org.graylog.plugins.views.search.Filter;
 import org.graylog.plugins.views.search.SearchType;
 import org.graylog.plugins.views.search.engine.BackendQuery;
+import org.graylog.plugins.views.search.timeranges.DerivedTimeRange;
+import org.graylog.plugins.views.search.timeranges.OffsetRange;
 import org.graylog2.contentpacks.EntityDescriptorIds;
 import org.graylog2.contentpacks.model.entities.PivotEntity;
 import org.graylog2.contentpacks.model.entities.SearchTypeEntity;
 import org.graylog2.plugin.indexer.searches.timeranges.AbsoluteRange;
 import org.graylog2.plugin.indexer.searches.timeranges.KeywordRange;
-import org.graylog.plugins.views.search.timeranges.OffsetRange;
 import org.graylog2.plugin.indexer.searches.timeranges.RelativeRange;
 import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
 
@@ -86,7 +86,20 @@ public abstract class Pivot implements SearchType {
 
     @Override
     public SearchType applyExecutionContext(ObjectMapper objectMapper, JsonNode state) {
-        return this;
+        final Builder builder = toBuilder();
+        final PartialPivot partialPivot = objectMapper.convertValue(state, PartialPivot.class);
+
+        partialPivot.name().ifPresent(builder::name);
+        partialPivot.rowGroups().ifPresent(builder::rowGroups);
+        partialPivot.columnGroups().ifPresent(builder::columnGroups);
+        partialPivot.series().ifPresent(builder::series);
+        partialPivot.rollup().ifPresent(builder::rollup);
+        partialPivot.filter().ifPresent(builder::filter);
+        partialPivot.timerange().ifPresent(builder::timerange);
+        partialPivot.query().ifPresent(builder::query);
+        partialPivot.streams().ifPresent(builder::streams);
+
+        return builder.build();
     }
 
     public static Builder builder() {


### PR DESCRIPTION
## Motivation
When we reexectue a single search type and want to only change certain
attributes we send these properties in the global override. But until
now we only had a small set of properties from the execution state we
supported to be overrideen.

## Description
This change will now implement:
1. Partial value classes
   which mirror the actual value callses so we can easy serialize the
   values execution state
2. And then use the builder of the value class to fill up the overriden
   properties.


## How Has This Been Tested?
- Create Message Table in search or dashboard
- Change the page and it still works.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
