### PR TITLE
Validate visualization-specific constraints in aggregation builder.

### DIFF
--- a/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.corevisualizations.test.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.corevisualizations.test.tsx
@@ -26,6 +26,9 @@ import AggregationWizard from 'views/components/aggregationwizard/AggregationWiz
 import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
 import AreaVisualization from 'views/components/visualizations/area/AreaVisualization';
 import AreaVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/AreaVisualizationConfig';
+import Series from 'views/logic/aggregationbuilder/Series';
+import FieldTypesContext, { FieldTypes } from 'views/components/contexts/FieldTypesContext';
+import Pivot from 'views/logic/aggregationbuilder/Pivot';
 
 const plugin: PluginRegistration = { exports: { visualizationTypes: bindings } };
 
@@ -34,8 +37,14 @@ const widgetConfig = AggregationWidgetConfig
   .visualization('table')
   .build();
 
+const fieldTypes: FieldTypes = {
+  all: Immutable.List([]),
+  queryFields: Immutable.Map(),
+};
 const SimpleAggregationWizard = (props) => (
-  <AggregationWizard config={widgetConfig} editing id="widget-id" type="AGGREGATION" fields={Immutable.List([])} onChange={() => {}} {...props} />
+  <FieldTypesContext.Provider value={fieldTypes}>
+    <AggregationWizard config={widgetConfig} editing id="widget-id" type="AGGREGATION" fields={Immutable.List([])} onChange={() => {}} {...props} />
+  </FieldTypesContext.Provider>
 );
 
 const submitButton = async () => screen.findByText('Apply Changes');
@@ -78,21 +87,21 @@ describe('AggregationWizard/Core Visualizations', () => {
   });
 
   it.each`
-    visualization      | fields
-    ${'Area Chart'}    | ${['Interpolation']}
-    ${'Bar Chart'}     | ${['Mode']}
-    ${'Line Chart'}    | ${['Interpolation']}
-    ${'Heatmap'}       | ${['Default Value']}
-    ${'Pie Chart'}     | ${[]}
-    ${'Scatter Plot'}  | ${[]}
-    ${'Single Number'} | ${[]}
-    ${'World Map'}     | ${[]}
-  `('expects mandatory fields for $visualization', async ({ visualization, fields }: { visualization: string, fields: Array<string> }) => {
+    visualization      | fields               | disabled
+    ${'Area Chart'}    | ${['Interpolation']} | ${true}
+    ${'Bar Chart'}     | ${['Mode']}          | ${true}
+    ${'Line Chart'}    | ${['Interpolation']} | ${true}
+    ${'Heatmap'}       | ${['Default Value']} | ${true}
+    ${'Pie Chart'}     | ${[]}                | ${true}
+    ${'Scatter Plot'}  | ${[]}                | ${true}
+    ${'Single Number'} | ${[]}                | ${false}
+    ${'World Map'}     | ${[]}                | ${false}
+  `('expects mandatory fields for $visualization', async ({ visualization, fields, disabled }: { visualization: string, fields: Array<string>, disabled: boolean }) => {
     render(<SimpleAggregationWizard />);
 
     await selectEvent.select(await visualizationSelect(), visualization);
 
-    if (fields.length > 0) {
+    if (disabled) {
       await expectSubmitButtonToBeDisabled();
     } else {
       await expectSubmitButtonNotToBeDisabled();
@@ -107,8 +116,9 @@ describe('AggregationWizard/Core Visualizations', () => {
 
   it('creates Area Chart config when all required fields are present', async () => {
     const onChange = jest.fn();
+    const areaChartConfig = widgetConfig.toBuilder().series([Series.create('count')]).build();
 
-    render(<SimpleAggregationWizard onChange={onChange} />);
+    render(<SimpleAggregationWizard onChange={onChange} config={areaChartConfig} />);
 
     await selectOption('Select visualization type', 'Area Chart');
 
@@ -127,8 +137,9 @@ describe('AggregationWizard/Core Visualizations', () => {
 
   it('creates Bar Chart config when all required fields are present', async () => {
     const onChange = jest.fn();
+    const barChartConfig = widgetConfig.toBuilder().series([Series.create('count')]).build();
 
-    render(<SimpleAggregationWizard onChange={onChange} />);
+    render(<SimpleAggregationWizard onChange={onChange} config={barChartConfig} />);
 
     await selectOption('Select visualization type', 'Bar Chart');
 
@@ -147,8 +158,9 @@ describe('AggregationWizard/Core Visualizations', () => {
 
   it('creates Line Chart config when all required fields are present', async () => {
     const onChange = jest.fn();
+    const lineChartConfig = widgetConfig.toBuilder().series([Series.create('count')]).build();
 
-    render(<SimpleAggregationWizard onChange={onChange} />);
+    render(<SimpleAggregationWizard onChange={onChange} config={lineChartConfig} />);
 
     await selectOption('Select visualization type', 'Line Chart');
 
@@ -167,8 +179,13 @@ describe('AggregationWizard/Core Visualizations', () => {
 
   it('creates Heatmap config when all required fields are present', async () => {
     const onChange = jest.fn();
+    const heatMapConfig = widgetConfig.toBuilder()
+      .rowPivots([Pivot.create('foo', 'values')])
+      .columnPivots([Pivot.create('bar', 'values')])
+      .series([Series.create('count')])
+      .build();
 
-    render(<SimpleAggregationWizard onChange={onChange} />);
+    render(<SimpleAggregationWizard onChange={onChange} config={heatMapConfig} />);
 
     await selectOption('Select visualization type', 'Heatmap');
 
@@ -239,5 +256,25 @@ describe('AggregationWizard/Core Visualizations', () => {
       visualization: 'table',
       visualizationConfig: expect.objectContaining({}),
     })));
+  });
+
+  describe('has visualization-specific validation for aggregation config', () => {
+    it.each`
+    visualization      | error
+    ${'Area Chart'}    | ${'Area chart requires at least one metric'}
+    ${'Bar Chart'}     | ${'Bar chart requires at least one metric'}
+    ${'Heatmap'}       | ${'Heatmap requires at least two groupings. At least one metric must be configured.'}
+    ${'Line Chart'}    | ${'Line chart requires at least one metric'}
+    ${'Pie Chart'}     | ${'Pie chart requires at least one metric'}
+    ${'Scatter Plot'}  | ${'Scatter plot requires at least one metric'}
+  `('expects constraints for $visualization', async ({ visualization, error }: { visualization: string, error: string }) => {
+      render(<SimpleAggregationWizard />);
+
+      await selectOption('Select visualization type', visualization);
+
+      await expectSubmitButtonToBeDisabled();
+
+      await waitFor(() => screen.findByText(error));
+    });
   });
 });

--- a/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/VisualizationElement.ts
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/VisualizationElement.ts
@@ -16,6 +16,7 @@
  */
 import { isEmpty } from 'lodash';
 import { PluginStore } from 'graylog-web-plugin/plugin';
+import { VisualizationType } from 'views/types';
 
 import AggregationWidgetConfig, { AggregationWidgetConfigBuilder } from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
 import VisualizationConfig from 'views/logic/aggregationbuilder/visualizations/VisualizationConfig';
@@ -68,6 +69,17 @@ const hasErrors = (errors: { [key: string]: string }) => Object.values(errors)
   .filter((value) => value !== undefined)
   .length > 0;
 
+const validateConfig = (visualizationType: VisualizationType, config: VisualizationConfigFormValues) => {
+  const { fields = [] } = visualizationType.config;
+
+  return fields
+    .filter((field) => 'required' in field && field.required)
+    .filter((field) => !field.isShown || field.isShown(config))
+    .filter(({ name }) => config[name] === undefined || config[name] === '')
+    .map(({ name, title }) => ({ [name]: `${title} is required.` }))
+    .reduce((prev, cur) => ({ ...prev, ...cur }), {});
+};
+
 const validate = (formValues: WidgetConfigFormValues) => {
   const { visualization: { type, config } } = formValues;
 
@@ -77,20 +89,15 @@ const validate = (formValues: WidgetConfigFormValues) => {
 
   const visualizationType = findVisualizationType(type);
 
-  if (visualizationType.config) {
-    const { fields = [] } = visualizationType.config;
+  const visualizationErrors = visualizationType.validate?.(formValues) ?? {};
 
-    const configErrors = fields
-      .filter((field) => 'required' in field && field.required)
-      .filter((field) => !field.isShown || field.isShown(config))
-      .filter(({ name }) => config[name] === undefined || config[name] === '')
-      .map(({ name, title }) => ({ [name]: `${title} is required.` }))
-      .reduce((prev, cur) => ({ ...prev, ...cur }), {});
+  const configErrors = visualizationType.config
+    ? validateConfig(visualizationType, config)
+    : {};
 
-    return hasErrors(configErrors) ? { visualization: { config: configErrors } } : {};
-  }
-
-  return {};
+  return hasErrors(configErrors) || hasErrors(visualizationErrors)
+    ? { visualization: { ...visualizationErrors, config: configErrors } }
+    : {};
 };
 
 const VisualizationElement: AggregationElement = {

--- a/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/VisualizationElement.ts
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/VisualizationElement.ts
@@ -65,7 +65,7 @@ const toConfig = (formValues: WidgetConfigFormValues, configBuilder: Aggregation
   .visualizationConfig(formValuesToVisualizationConfig(formValues.visualization.type, formValues.visualization.config))
   .eventAnnotation(formValues.visualization.eventAnnotation);
 
-const hasErrors = (errors: { [key: string]: string }) => Object.values(errors)
+const hasErrors = (errors: {}) => Object.values(errors)
   .filter((value) => value !== undefined)
   .length > 0;
 

--- a/graylog2-web-interface/src/views/components/visualizations/area/bindings.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/area/bindings.tsx
@@ -18,10 +18,13 @@ import type { VisualizationType } from 'views/types';
 
 import AreaVisualization from 'views/components/visualizations/area/AreaVisualization';
 import AreaVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/AreaVisualizationConfig';
+import { hasAtLeastOneMetric } from 'views/components/visualizations/validations';
 
 type AreaVisualizationConfigFormValues = {
   interpolation: 'linear' | 'step-after' | 'spline';
 };
+
+const validate = hasAtLeastOneMetric('Area chart');
 
 const areaChart: VisualizationType = {
   type: AreaVisualization.type,
@@ -39,6 +42,7 @@ const areaChart: VisualizationType = {
     }],
   },
   capabilities: ['event-annotations'],
+  validate,
 };
 
 export default areaChart;

--- a/graylog2-web-interface/src/views/components/visualizations/bar/bindings.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/bar/bindings.tsx
@@ -19,10 +19,13 @@ import type { VisualizationType } from 'views/types';
 
 import BarVisualization from 'views/components/visualizations/bar/BarVisualization';
 import BarVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/BarVisualizationConfig';
+import { hasAtLeastOneMetric } from 'views/components/visualizations/validations';
 
 type BarVisualizationConfigFormValues = {
   barmode: 'group' | 'stack' | 'relative' | 'overlay',
 };
+
+const validate = hasAtLeastOneMetric('Bar chart');
 
 const barChart: VisualizationType = {
   type: BarVisualization.type,
@@ -71,6 +74,7 @@ const barChart: VisualizationType = {
     }],
   },
   capabilities: ['event-annotations'],
+  validate,
 };
 
 export default barChart;

--- a/graylog2-web-interface/src/views/components/visualizations/heatmap/bindings.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/heatmap/bindings.tsx
@@ -19,6 +19,11 @@ import type { VisualizationType } from 'views/types';
 import HeatmapVisualization from 'views/components/visualizations/heatmap/HeatmapVisualization';
 import HeatmapVisualizationConfig, { COLORSCALES } from 'views/logic/aggregationbuilder/visualizations/HeatmapVisualizationConfig';
 import { defaultCompare } from 'views/logic/DefaultCompare';
+import { WidgetConfigFormValues } from 'views/components/aggregationwizard/WidgetConfigForm';
+import {
+  areAtLeastNGroupingsConfigured,
+  areAtLeastNMetricsConfigured,
+} from 'views/components/visualizations/validations';
 
 type HeatMapVisualizationConfigFormValues = {
   colorScale: typeof COLORSCALES[number],
@@ -28,6 +33,28 @@ type HeatMapVisualizationConfigFormValues = {
   zMax: number
   useSmallestAsDefault: boolean,
   defaultValue: number,
+};
+
+const validate = (formValues: WidgetConfigFormValues) => {
+  const errors = [];
+
+  if (!areAtLeastNGroupingsConfigured(formValues, 2)) {
+    errors.push('Heatmap requires at least two groupings.');
+  } else {
+    const groupingDirections = formValues.groupBy.groupings.map((grouping) => grouping.direction);
+
+    if (!groupingDirections.includes('row') || !groupingDirections.includes('column')) {
+      errors.push('Groupings must include row and column groupings.');
+    }
+  }
+
+  if (!areAtLeastNMetricsConfigured(formValues, 1)) {
+    errors.push('At least one metric must be configured.');
+  }
+
+  return errors.length > 0
+    ? { type: errors.join(' ') }
+    : {};
 };
 
 const heatmap: VisualizationType = {
@@ -79,6 +106,7 @@ const heatmap: VisualizationType = {
       required: true,
     }],
   },
+  validate,
 };
 
 export default heatmap;

--- a/graylog2-web-interface/src/views/components/visualizations/line/bindings.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/line/bindings.tsx
@@ -18,10 +18,13 @@ import type { VisualizationType } from 'views/types';
 
 import LineVisualization from 'views/components/visualizations/line/LineVisualization';
 import LineVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/LineVisualizationConfig';
+import { hasAtLeastOneMetric } from 'views/components/visualizations/validations';
 
 type LineVisualizationConfigFormValues = {
   interpolation: 'linear' | 'step-after' | 'spline';
 };
+
+const validate = hasAtLeastOneMetric('Line chart');
 
 const lineChart: VisualizationType = {
   type: LineVisualization.type,
@@ -39,6 +42,7 @@ const lineChart: VisualizationType = {
     }],
   },
   capabilities: ['event-annotations'],
+  validate,
 };
 
 export default lineChart;

--- a/graylog2-web-interface/src/views/components/visualizations/pie/bindings.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/pie/bindings.tsx
@@ -17,11 +17,15 @@
 import type { VisualizationType } from 'views/types';
 
 import PieVisualization from 'views/components/visualizations/pie/PieVisualization';
+import { hasAtLeastOneMetric } from 'views/components/visualizations/validations';
+
+const validate = hasAtLeastOneMetric('Pie chart');
 
 const pieChart: VisualizationType = {
   type: PieVisualization.type,
   displayName: 'Pie Chart',
   component: PieVisualization,
+  validate,
 };
 
 export default pieChart;

--- a/graylog2-web-interface/src/views/components/visualizations/scatter/bindings.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/scatter/bindings.tsx
@@ -17,12 +17,16 @@
 import type { VisualizationType } from 'views/types';
 
 import ScatterVisualization from 'views/components/visualizations/scatter/ScatterVisualization';
+import { hasAtLeastOneMetric } from 'views/components/visualizations/validations';
+
+const validate = hasAtLeastOneMetric('Scatter plot');
 
 const scatterChart: VisualizationType = {
   type: ScatterVisualization.type,
   displayName: 'Scatter Plot',
   component: ScatterVisualization,
   capabilities: ['event-annotations'],
+  validate,
 };
 
 export default scatterChart;

--- a/graylog2-web-interface/src/views/components/visualizations/validations.ts
+++ b/graylog2-web-interface/src/views/components/visualizations/validations.ts
@@ -1,0 +1,8 @@
+import { WidgetConfigFormValues } from 'views/components/aggregationwizard/WidgetConfigForm';
+
+export const areAtLeastNMetricsConfigured = (formValues: WidgetConfigFormValues, minimumMetrics: number) => formValues.metrics?.length >= minimumMetrics;
+export const areAtLeastNGroupingsConfigured = (formValues: WidgetConfigFormValues, minimumGroupings: number) => formValues.groupBy?.groupings?.length >= minimumGroupings;
+
+export const hasAtLeastOneMetric = (name: string) => (formValues: WidgetConfigFormValues) => (!areAtLeastNMetricsConfigured(formValues, 1)
+  ? { type: `${name} requires at least one metric` }
+  : {});

--- a/graylog2-web-interface/src/views/components/visualizations/validations.ts
+++ b/graylog2-web-interface/src/views/components/visualizations/validations.ts
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 import { WidgetConfigFormValues } from 'views/components/aggregationwizard/WidgetConfigForm';
 
 export const areAtLeastNMetricsConfigured = (formValues: WidgetConfigFormValues, minimumMetrics: number) => formValues.metrics?.length >= minimumMetrics;

--- a/graylog2-web-interface/src/views/types.d.ts
+++ b/graylog2-web-interface/src/views/types.d.ts
@@ -30,7 +30,11 @@ import { Completer } from 'views/components/searchbar/SearchBarAutocompletions';
 import { Result } from 'views/components/widgets/Widget';
 import { Widgets } from 'views/stores/WidgetStore';
 import { OverrideProps } from 'views/components/WidgetOverrideElements';
-import { VisualizationConfigDefinition, VisualizationConfigFormValues } from 'views/components/aggregationwizard/WidgetConfigForm';
+import {
+  VisualizationConfigDefinition,
+  VisualizationConfigFormValues,
+  WidgetConfigFormValues,
+} from 'views/components/aggregationwizard/WidgetConfigForm';
 
 interface EditWidgetComponentProps<Config extends WidgetConfig = WidgetConfig> {
   children: React.ReactNode,
@@ -123,6 +127,7 @@ interface VisualizationType {
   component: VisualizationComponent;
   config?: VisualizationConfigDefinition;
   capabilities?: Array<VisualizationCapability>;
+  validate?: (formValues: WidgetConfigFormValues) => { [key: string]: string | any };
 }
 
 interface ResultHandler<T, R> {

--- a/graylog2-web-interface/src/views/types.d.ts
+++ b/graylog2-web-interface/src/views/types.d.ts
@@ -16,6 +16,7 @@
  */
 import React from 'react';
 import * as Immutable from 'immutable';
+import { FormikErrors } from 'formik';
 
 import Widget from 'views/logic/widgets/Widget';
 import { ActionDefinition } from 'views/components/actions/ActionHandler';
@@ -33,6 +34,7 @@ import { OverrideProps } from 'views/components/WidgetOverrideElements';
 import {
   VisualizationConfigDefinition,
   VisualizationConfigFormValues,
+  VisualizationFormValues,
   WidgetConfigFormValues,
 } from 'views/components/aggregationwizard/WidgetConfigForm';
 
@@ -127,7 +129,7 @@ interface VisualizationType {
   component: VisualizationComponent;
   config?: VisualizationConfigDefinition;
   capabilities?: Array<VisualizationCapability>;
-  validate?: (formValues: WidgetConfigFormValues) => { [key: string]: string | any };
+  validate?: (formValues: WidgetConfigFormValues) => FormikErrors<VisualizationFormValues>;
 }
 
 interface ResultHandler<T, R> {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR introduces a validation-specific `validate` function in the `VisualizationType`, which allows raising validation errors when this visualization is selected in the aggregation builder wizard.

This allows us to validate that the specific requirements for a given visualization are satisfied. This is used to check if:

  - At least one metric is configured for area/bar/line/pie charts/scatter plot/heatmap
  - At least two groupings are configured, at least one row and at least one column one for the heatmap

If at least one constraint is not fulfilled, submitting the current configuration is disabled and a validation error is shown.

This is supposed to help guiding the user to a working configuration and creates a space to display helpful information what is missing/misconfigured.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![visualization-validation](https://user-images.githubusercontent.com/41929/114404326-e3e0c600-9ba5-11eb-8491-cea0f37f491c.gif)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.