### PR TITLE
Using better defaults for area/bar/line charts.

### DIFF
--- a/graylog2-web-interface/src/views/components/aggregationwizard/WidgetConfigForm.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/WidgetConfigForm.tsx
@@ -60,10 +60,13 @@ export type VisualizationFormValues = {
   eventAnnotation?: boolean,
 };
 
-export type VisualizationConfigDefinition = {
-  fromConfig: (config: VisualizationConfig | undefined) => VisualizationConfigFormValues,
-  toConfig: (formValues: VisualizationConfigFormValues) => VisualizationConfig,
-  createConfig?: () => Partial<VisualizationConfigFormValues>,
+export type VisualizationConfigDefinition<
+  ConfigType extends VisualizationConfig = VisualizationConfig,
+  ConfigFormValuesType extends VisualizationConfigFormValues = VisualizationConfigFormValues
+  > = {
+  fromConfig: (config: ConfigType | undefined) => ConfigFormValuesType,
+  toConfig: (formValues: ConfigFormValuesType) => ConfigType,
+  createConfig?: () => Partial<ConfigFormValuesType>,
   fields: Array<ConfigurationField>,
 };
 

--- a/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.corevisualizations.test.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.corevisualizations.test.tsx
@@ -86,32 +86,14 @@ describe('AggregationWizard/Core Visualizations', () => {
     await screen.findByText('World Map');
   });
 
-  it.each`
-    visualization      | fields               | disabled
-    ${'Area Chart'}    | ${['Interpolation']} | ${true}
-    ${'Bar Chart'}     | ${['Mode']}          | ${true}
-    ${'Line Chart'}    | ${['Interpolation']} | ${true}
-    ${'Heatmap'}       | ${['Default Value']} | ${true}
-    ${'Pie Chart'}     | ${[]}                | ${true}
-    ${'Scatter Plot'}  | ${[]}                | ${true}
-    ${'Single Number'} | ${[]}                | ${false}
-    ${'World Map'}     | ${[]}                | ${false}
-  `('expects mandatory fields for $visualization', async ({ visualization, fields, disabled }: { visualization: string, fields: Array<string>, disabled: boolean }) => {
+  it('heat map expects mandatory default value field', async () => {
     render(<SimpleAggregationWizard />);
 
-    await selectEvent.select(await visualizationSelect(), visualization);
+    await selectEvent.select(await visualizationSelect(), 'Heatmap');
 
-    if (disabled) {
-      await expectSubmitButtonToBeDisabled();
-    } else {
-      await expectSubmitButtonNotToBeDisabled();
-    }
+    await expectSubmitButtonToBeDisabled();
 
-    const validationErrors = screen.queryAllByText(/ is required/);
-    const erroredFields = validationErrors.map((f) => f.innerHTML)
-      .map((text) => text.replace(' is required.', ''));
-
-    expect(erroredFields).toEqual(fields);
+    await screen.findByText(/Default Value is required/);
   });
 
   it('creates Area Chart config when all required fields are present', async () => {

--- a/graylog2-web-interface/src/views/components/visualizations/area/bindings.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/area/bindings.tsx
@@ -24,18 +24,18 @@ type AreaVisualizationConfigFormValues = {
   interpolation: 'linear' | 'step-after' | 'spline';
 };
 
-const DEFAULT_INTERPOLATION: AreaVisualizationConfigFormValues['interpolation'] = 'linear';
+const DEFAULT_INTERPOLATION = 'linear';
 
 const validate = hasAtLeastOneMetric('Area chart');
 
-const areaChart: VisualizationType = {
+const areaChart: VisualizationType<AreaVisualizationConfig, AreaVisualizationConfigFormValues> = {
   type: AreaVisualization.type,
   displayName: 'Area Chart',
   component: AreaVisualization,
   config: {
-    createConfig: (): AreaVisualizationConfigFormValues => ({ interpolation: DEFAULT_INTERPOLATION }),
-    fromConfig: (config: AreaVisualizationConfig): AreaVisualizationConfigFormValues => ({ interpolation: config.interpolation }),
-    toConfig: (formValues: AreaVisualizationConfigFormValues): AreaVisualizationConfig => AreaVisualizationConfig.create(formValues.interpolation),
+    createConfig: () => ({ interpolation: DEFAULT_INTERPOLATION }),
+    fromConfig: (config: AreaVisualizationConfig) => ({ interpolation: config.interpolation }),
+    toConfig: (formValues: AreaVisualizationConfigFormValues) => AreaVisualizationConfig.create(formValues.interpolation),
     fields: [{
       name: 'interpolation',
       title: 'Interpolation',

--- a/graylog2-web-interface/src/views/components/visualizations/area/bindings.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/area/bindings.tsx
@@ -24,6 +24,8 @@ type AreaVisualizationConfigFormValues = {
   interpolation: 'linear' | 'step-after' | 'spline';
 };
 
+const DEFAULT_INTERPOLATION: AreaVisualizationConfigFormValues['interpolation'] = 'linear';
+
 const validate = hasAtLeastOneMetric('Area chart');
 
 const areaChart: VisualizationType = {
@@ -31,6 +33,7 @@ const areaChart: VisualizationType = {
   displayName: 'Area Chart',
   component: AreaVisualization,
   config: {
+    createConfig: (): AreaVisualizationConfigFormValues => ({ interpolation: DEFAULT_INTERPOLATION }),
     fromConfig: (config: AreaVisualizationConfig): AreaVisualizationConfigFormValues => ({ interpolation: config.interpolation }),
     toConfig: (formValues: AreaVisualizationConfigFormValues): AreaVisualizationConfig => AreaVisualizationConfig.create(formValues.interpolation),
     fields: [{

--- a/graylog2-web-interface/src/views/components/visualizations/bar/bindings.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/bar/bindings.tsx
@@ -35,7 +35,7 @@ const barChart: VisualizationType<BarVisualizationConfig, BarVisualizationConfig
   component: BarVisualization,
   config: {
     createConfig: () => ({ barmode: DEFAULT_BARMODE }),
-    fromConfig: (config: BarVisualizationConfig | undefined) => ({ barmode: config?.barmode ?? 'group' }),
+    fromConfig: (config: BarVisualizationConfig | undefined) => ({ barmode: config?.barmode ?? DEFAULT_BARMODE }),
     toConfig: (formValues: BarVisualizationConfigFormValues) => BarVisualizationConfig.create(formValues.barmode),
     fields: [{
       name: 'barmode',

--- a/graylog2-web-interface/src/views/components/visualizations/bar/bindings.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/bar/bindings.tsx
@@ -25,18 +25,18 @@ type BarVisualizationConfigFormValues = {
   barmode: 'group' | 'stack' | 'relative' | 'overlay',
 };
 
-const DEFAULT_BARMODE: BarVisualizationConfigFormValues['barmode'] = 'group';
+const DEFAULT_BARMODE = 'group';
 
 const validate = hasAtLeastOneMetric('Bar chart');
 
-const barChart: VisualizationType = {
+const barChart: VisualizationType<BarVisualizationConfig, BarVisualizationConfigFormValues> = {
   type: BarVisualization.type,
   displayName: 'Bar Chart',
   component: BarVisualization,
   config: {
-    createConfig: (): BarVisualizationConfigFormValues => ({ barmode: DEFAULT_BARMODE }),
-    fromConfig: (config: BarVisualizationConfig | undefined): BarVisualizationConfigFormValues => ({ barmode: config?.barmode ?? 'group' }),
-    toConfig: (formValues: BarVisualizationConfigFormValues): BarVisualizationConfig => BarVisualizationConfig.create(formValues.barmode),
+    createConfig: () => ({ barmode: DEFAULT_BARMODE }),
+    fromConfig: (config: BarVisualizationConfig | undefined) => ({ barmode: config?.barmode ?? 'group' }),
+    toConfig: (formValues: BarVisualizationConfigFormValues) => BarVisualizationConfig.create(formValues.barmode),
     fields: [{
       name: 'barmode',
       title: 'Mode',

--- a/graylog2-web-interface/src/views/components/visualizations/bar/bindings.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/bar/bindings.tsx
@@ -25,6 +25,8 @@ type BarVisualizationConfigFormValues = {
   barmode: 'group' | 'stack' | 'relative' | 'overlay',
 };
 
+const DEFAULT_BARMODE: BarVisualizationConfigFormValues['barmode'] = 'group';
+
 const validate = hasAtLeastOneMetric('Bar chart');
 
 const barChart: VisualizationType = {
@@ -32,6 +34,7 @@ const barChart: VisualizationType = {
   displayName: 'Bar Chart',
   component: BarVisualization,
   config: {
+    createConfig: (): BarVisualizationConfigFormValues => ({ barmode: DEFAULT_BARMODE }),
     fromConfig: (config: BarVisualizationConfig | undefined): BarVisualizationConfigFormValues => ({ barmode: config?.barmode ?? 'group' }),
     toConfig: (formValues: BarVisualizationConfigFormValues): BarVisualizationConfig => BarVisualizationConfig.create(formValues.barmode),
     fields: [{

--- a/graylog2-web-interface/src/views/components/visualizations/heatmap/bindings.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/heatmap/bindings.tsx
@@ -57,17 +57,17 @@ const validate = (formValues: WidgetConfigFormValues) => {
     : {};
 };
 
-const heatmap: VisualizationType = {
+const heatmap: VisualizationType<HeatmapVisualizationConfig, HeatMapVisualizationConfigFormValues> = {
   type: HeatmapVisualization.type,
   displayName: 'Heatmap',
   component: HeatmapVisualization,
   config: {
-    fromConfig: ({ autoScale, colorScale, reverseScale, defaultValue, useSmallestAsDefault, zMax, zMin }: HeatmapVisualizationConfig): HeatMapVisualizationConfigFormValues => ({
+    fromConfig: ({ autoScale, colorScale, reverseScale, defaultValue, useSmallestAsDefault, zMax, zMin }: HeatmapVisualizationConfig) => ({
       autoScale, colorScale, reverseScale, defaultValue, useSmallestAsDefault, zMax, zMin,
     }),
     toConfig: ({ autoScale = false, colorScale, reverseScale = false, useSmallestAsDefault, zMax, zMin, defaultValue }: HeatMapVisualizationConfigFormValues) => HeatmapVisualizationConfig
       .create(colorScale, reverseScale, autoScale, zMin, zMax, useSmallestAsDefault, defaultValue),
-    createConfig: (): Partial<HeatMapVisualizationConfigFormValues> => ({ colorScale: 'Viridis', autoScale: true }),
+    createConfig: () => ({ colorScale: 'Viridis', autoScale: true }),
     fields: [{
       name: 'colorScale',
       title: 'Color Scale',

--- a/graylog2-web-interface/src/views/components/visualizations/line/bindings.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/line/bindings.tsx
@@ -24,6 +24,8 @@ type LineVisualizationConfigFormValues = {
   interpolation: 'linear' | 'step-after' | 'spline';
 };
 
+const DEFAULT_INTERPOLATION: LineVisualizationConfigFormValues['interpolation'] = 'linear';
+
 const validate = hasAtLeastOneMetric('Line chart');
 
 const lineChart: VisualizationType = {
@@ -31,6 +33,7 @@ const lineChart: VisualizationType = {
   displayName: 'Line Chart',
   component: LineVisualization,
   config: {
+    createConfig: (): LineVisualizationConfigFormValues => ({ interpolation: DEFAULT_INTERPOLATION }),
     fromConfig: (config: LineVisualizationConfig | undefined): LineVisualizationConfigFormValues => ({ interpolation: config?.interpolation }),
     toConfig: (formValues: LineVisualizationConfigFormValues): LineVisualizationConfig => LineVisualizationConfig.create(formValues.interpolation),
     fields: [{

--- a/graylog2-web-interface/src/views/components/visualizations/line/bindings.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/line/bindings.tsx
@@ -24,18 +24,18 @@ type LineVisualizationConfigFormValues = {
   interpolation: 'linear' | 'step-after' | 'spline';
 };
 
-const DEFAULT_INTERPOLATION: LineVisualizationConfigFormValues['interpolation'] = 'linear';
+const DEFAULT_INTERPOLATION = 'linear';
 
 const validate = hasAtLeastOneMetric('Line chart');
 
-const lineChart: VisualizationType = {
+const lineChart: VisualizationType<LineVisualizationConfig, LineVisualizationConfigFormValues> = {
   type: LineVisualization.type,
   displayName: 'Line Chart',
   component: LineVisualization,
   config: {
-    createConfig: (): LineVisualizationConfigFormValues => ({ interpolation: DEFAULT_INTERPOLATION }),
-    fromConfig: (config: LineVisualizationConfig | undefined): LineVisualizationConfigFormValues => ({ interpolation: config?.interpolation }),
-    toConfig: (formValues: LineVisualizationConfigFormValues): LineVisualizationConfig => LineVisualizationConfig.create(formValues.interpolation),
+    createConfig: () => ({ interpolation: DEFAULT_INTERPOLATION }),
+    fromConfig: (config: LineVisualizationConfig | undefined) => ({ interpolation: config?.interpolation }),
+    toConfig: (formValues: LineVisualizationConfigFormValues) => LineVisualizationConfig.create(formValues.interpolation),
     fields: [{
       name: 'interpolation',
       title: 'Interpolation',

--- a/graylog2-web-interface/src/views/components/visualizations/number/bindings.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/number/bindings.tsx
@@ -25,12 +25,12 @@ type NumberVisualizationConfigFormValues = {
   trend_preference: 'LOWER' | 'NEUTRAL' | 'HIGHER',
 };
 
-const singleNumber: VisualizationType = {
+const singleNumber: VisualizationType<NumberVisualizationConfig, NumberVisualizationConfigFormValues> = {
   type: NumberVisualization.type,
   displayName: 'Single Number',
   component: NumberVisualization,
   config: {
-    fromConfig: (config: NumberVisualizationConfig | undefined): NumberVisualizationConfigFormValues => ({ trend: config?.trend, trend_preference: config?.trendPreference }),
+    fromConfig: (config: NumberVisualizationConfig | undefined) => ({ trend: config?.trend, trend_preference: config?.trendPreference }),
     toConfig: ({ trend = false, trend_preference }: NumberVisualizationConfigFormValues) => NumberVisualizationConfig.create(trend, trend_preference),
     fields: [{
       name: 'trend',

--- a/graylog2-web-interface/src/views/types.d.ts
+++ b/graylog2-web-interface/src/views/types.d.ts
@@ -37,6 +37,7 @@ import {
   VisualizationFormValues,
   WidgetConfigFormValues,
 } from 'views/components/aggregationwizard/WidgetConfigForm';
+import VisualizationConfig from 'views/logic/aggregationbuilder/visualizations/VisualizationConfig';
 
 interface EditWidgetComponentProps<Config extends WidgetConfig = WidgetConfig> {
   children: React.ReactNode,
@@ -123,11 +124,11 @@ export interface VisualizationCapabilities {
 
 export type VisualizationCapability = keyof VisualizationCapabilities;
 
-interface VisualizationType {
+interface VisualizationType<ConfigType extends VisualizationConfig = VisualizationConfig, ConfigFormValuesType extends VisualizationConfigFormValues = VisualizationConfigFormValues> {
   type: string;
   displayName: string;
   component: VisualizationComponent;
-  config?: VisualizationConfigDefinition;
+  config?: VisualizationConfigDefinition<ConfigType, ConfigFormValuesType>;
   capabilities?: Array<VisualizationCapability>;
   validate?: (formValues: WidgetConfigFormValues) => FormikErrors<VisualizationFormValues>;
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is setting defaults for the interpolation/barmode config options for the area/bar/line charts. These options are mandatory, but are not required to show an initial chart, so defining defaults for them allows the user to get faster initial results while still allowing to tweak them.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.