### PR TITLE
Execute search only for focused widget

### DIFF
--- a/graylog2-web-interface/src/views/actions/SearchActions.ts
+++ b/graylog2-web-interface/src/views/actions/SearchActions.ts
@@ -40,6 +40,8 @@ export type SearchExecutionResult = {
   widgetMapping: WidgetMapping,
 };
 
+export type FilterSearchTypes = string[];
+
 type SearchActionsType = RefluxActions<{
   create: (search: Search) => Promise<CreateSearchResponse>,
   execute: (state: SearchExecutionState) => Promise<SearchExecutionResult>,
@@ -51,6 +53,7 @@ type SearchActionsType = RefluxActions<{
   refresh: () => Promise<void>,
   get: (searchId: SearchId) => Promise<SearchJson>,
   parameters: (parameters: (Array<Parameter> | Immutable.List<Parameter>)) => Promise<View>,
+  setFilterSearchTypes: (FilterSearchTypes) => Promise<void>,
 }>;
 
 const SearchActions: SearchActionsType = singletonActions(
@@ -76,6 +79,9 @@ const SearchActions: SearchActionsType = singletonActions(
     },
     refresh: {
       asyncResult: true,
+    },
+    setFilterSearchTypes: {
+      asyncResult: false,
     },
   }),
 );

--- a/graylog2-web-interface/src/views/actions/SearchActions.ts
+++ b/graylog2-web-interface/src/views/actions/SearchActions.ts
@@ -40,7 +40,7 @@ export type SearchExecutionResult = {
   widgetMapping: WidgetMapping,
 };
 
-export type FilterSearchTypes = string[];
+export type WidgetsToSearch = string[];
 
 type SearchActionsType = RefluxActions<{
   create: (search: Search) => Promise<CreateSearchResponse>,
@@ -53,7 +53,7 @@ type SearchActionsType = RefluxActions<{
   refresh: () => Promise<void>,
   get: (searchId: SearchId) => Promise<SearchJson>,
   parameters: (parameters: (Array<Parameter> | Immutable.List<Parameter>)) => Promise<View>,
-  setFilterSearchTypes: (FilterSearchTypes) => Promise<void>,
+  setWidgetsToSearch: (filter: WidgetsToSearch) => Promise<void>,
 }>;
 
 const SearchActions: SearchActionsType = singletonActions(
@@ -80,7 +80,7 @@ const SearchActions: SearchActionsType = singletonActions(
     refresh: {
       asyncResult: true,
     },
-    setFilterSearchTypes: {
+    setWidgetsToSearch: {
       asyncResult: false,
     },
   }),

--- a/graylog2-web-interface/src/views/components/Search.test.tsx
+++ b/graylog2-web-interface/src/views/components/Search.test.tsx
@@ -56,7 +56,7 @@ jest.mock('views/stores/ViewMetadataStore', () => ({
 jest.mock('views/stores/SearchStore', () => ({
   SearchActions: {
     execute: jest.fn(() => Promise.resolve()),
-    setFilterSearchTypes: jest.fn(),
+    setWidgetsToSearch: jest.fn(),
   },
   SearchStore: MockStore(
     ['listen', () => jest.fn()],
@@ -262,7 +262,7 @@ describe('Search', () => {
       });
   });
 
-  it('refreshing after query change parses search metadata first', (done) => {
+  it('refreshing after query change parses search metadata first', () => {
     const wrapper = mount(<SimpleSearch />);
 
     const searchBar = wrapper.find(DashboardSearchBar);
@@ -272,11 +272,9 @@ describe('Search', () => {
 
     const promise = cb(view as View);
 
-    promise.then(() => {
+    return promise.then(() => {
       expect(SearchMetadataActions.parseSearch).toHaveBeenCalled();
       expect(SearchActions.execute).toHaveBeenCalled();
-
-      done();
     });
   });
 

--- a/graylog2-web-interface/src/views/components/Search.test.tsx
+++ b/graylog2-web-interface/src/views/components/Search.test.tsx
@@ -56,6 +56,7 @@ jest.mock('views/stores/ViewMetadataStore', () => ({
 jest.mock('views/stores/SearchStore', () => ({
   SearchActions: {
     execute: jest.fn(() => Promise.resolve()),
+    setFilterSearchTypes: jest.fn(),
   },
   SearchStore: MockStore(
     ['listen', () => jest.fn()],

--- a/graylog2-web-interface/src/views/components/Search.test.tsx
+++ b/graylog2-web-interface/src/views/components/Search.test.tsx
@@ -57,6 +57,7 @@ jest.mock('views/stores/SearchStore', () => ({
   SearchActions: {
     execute: jest.fn(() => Promise.resolve()),
     setWidgetsToSearch: jest.fn(),
+    executeWithCurrentState: jest.fn(),
   },
   SearchStore: MockStore(
     ['listen', () => jest.fn()],

--- a/graylog2-web-interface/src/views/components/contexts/WidgetFocusProvider.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/WidgetFocusProvider.tsx
@@ -82,8 +82,12 @@ const useSyncStateWithQueryParams = ({ focusedWidget, focusUriParams, setFocused
       }
 
       setFocusedWidget(nextFocusedWidget);
-      const filter = nextFocusedWidget?.id ? [nextFocusedWidget.id] : undefined;
-      SearchActions.setFilterSearchTypes(filter);
+      const filter = nextFocusedWidget?.id ? [nextFocusedWidget.id] : null;
+      SearchActions.setWidgetsToSearch(filter);
+
+      if (filter === null) {
+        SearchActions.executeWithCurrentState();
+      }
     }
   }, [focusedWidget, setFocusedWidget, widgets, focusUriParams]);
 };

--- a/graylog2-web-interface/src/views/components/contexts/WidgetFocusProvider.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/WidgetFocusProvider.tsx
@@ -24,6 +24,7 @@ import URI from 'urijs';
 import { useStore } from 'stores/connect';
 import useQuery from 'routing/useQuery';
 import { WidgetStore } from 'views/stores/WidgetStore';
+import { SearchActions } from 'views/stores/SearchStore';
 
 import WidgetFocusContext, { FocusContextState } from './WidgetFocusContext';
 
@@ -81,6 +82,8 @@ const useSyncStateWithQueryParams = ({ focusedWidget, focusUriParams, setFocused
       }
 
       setFocusedWidget(nextFocusedWidget);
+      const filter = nextFocusedWidget?.id ? [nextFocusedWidget.id] : undefined;
+      SearchActions.setFilterSearchTypes(filter);
     }
   }, [focusedWidget, setFocusedWidget, widgets, focusUriParams]);
 };

--- a/graylog2-web-interface/src/views/stores/SearchStore.ts
+++ b/graylog2-web-interface/src/views/stores/SearchStore.ts
@@ -26,7 +26,7 @@ import { SearchMetadataActions } from 'views/stores/SearchMetadataStore';
 import { SearchJobActions } from 'views/stores/SearchJobStore';
 import { ViewStore, ViewActions } from 'views/stores/ViewStore';
 import SearchResult from 'views/logic/SearchResult';
-import SearchActions from 'views/actions/SearchActions';
+import SearchActions, { FilterSearchTypes } from 'views/actions/SearchActions';
 import Search from 'views/logic/search/Search';
 import type { CreateSearchResponse, SearchId, SearchExecutionResult } from 'views/actions/SearchActions';
 import GlobalOverride from 'views/logic/search/GlobalOverride';
@@ -55,6 +55,7 @@ export type SearchStoreState = {
   search: Search,
   result: SearchResult,
   widgetMapping: WidgetMapping,
+  filterSearchTypes: FilterSearchTypes | undefined | null;
 };
 
 export const SearchStore: Store<SearchStoreState> = singletonStore(
@@ -169,6 +170,10 @@ export const SearchStore: Store<SearchStoreState> = singletonStore(
       return this._executePromise(executionState, startActionPromise, handleSearchResult);
     },
 
+    setFilterSearchTypes(filter: FilterSearchTypes) {
+      this.filterSearchTypes = filter;
+    },
+
     executeWithCurrentState(): Promise<SearchExecutionResult> {
       const promise = SearchActions.execute(this.executionState);
 
@@ -186,13 +191,27 @@ export const SearchStore: Store<SearchStoreState> = singletonStore(
       return promise;
     },
 
-    _executePromise(executionState: SearchExecutionState, startActionPromise: (promise: Promise<SearchResult>) => void, handleSearchResult: (result: SearchResult) => SearchResult): Promise<SearchExecutionResult> {
+    _executePromise(executionStateParam: SearchExecutionState, startActionPromise: (promise: Promise<SearchResult>) => void, handleSearchResult: (result: SearchResult) => SearchResult): Promise<SearchExecutionResult> {
+      const { filterSearchTypes } = this._state();
+
       if (this.executePromise && this.executePromise.cancel) {
         this.executePromise.cancel();
       }
 
       if (this.search) {
         const { widgetMapping, search } = this.view;
+
+        let executionStateBuilder = executionStateParam.toBuilder();
+
+        if (filterSearchTypes) {
+          const { globalOverride = GlobalOverride.empty() } = executionStateParam;
+          const keepSearchTypes = filterSearchTypes.map((widgetId) => widgetMapping.get(widgetId))
+            .reduce((acc, searchTypeSet) => [...acc, ...searchTypeSet.toArray()], globalOverride.keepSearchTypes || []);
+          const newGlobalOverride = globalOverride.toBuilder().keepSearchTypes(keepSearchTypes).build();
+          executionStateBuilder = executionStateBuilder.globalOverride(newGlobalOverride);
+        }
+
+        const executionState = executionStateBuilder.build();
 
         this.executePromise = this.trackJob(search, executionState)
           .then((result: SearchResult) => {
@@ -213,7 +232,7 @@ export const SearchStore: Store<SearchStoreState> = singletonStore(
     },
 
     _state(): SearchStoreState {
-      return { search: this.search, result: this.result, widgetMapping: this.widgetMapping };
+      return { search: this.search, result: this.result, widgetMapping: this.widgetMapping, filterSearchTypes: this.filterSearchTypes };
     },
 
     _trigger() {

--- a/graylog2-web-interface/src/views/stores/SearchStore.ts
+++ b/graylog2-web-interface/src/views/stores/SearchStore.ts
@@ -26,7 +26,7 @@ import { SearchMetadataActions } from 'views/stores/SearchMetadataStore';
 import { SearchJobActions } from 'views/stores/SearchJobStore';
 import { ViewStore, ViewActions } from 'views/stores/ViewStore';
 import SearchResult from 'views/logic/SearchResult';
-import SearchActions, { FilterSearchTypes } from 'views/actions/SearchActions';
+import SearchActions, { WidgetsToSearch } from 'views/actions/SearchActions';
 import Search from 'views/logic/search/Search';
 import type { CreateSearchResponse, SearchId, SearchExecutionResult } from 'views/actions/SearchActions';
 import GlobalOverride from 'views/logic/search/GlobalOverride';
@@ -55,7 +55,7 @@ export type SearchStoreState = {
   search: Search,
   result: SearchResult,
   widgetMapping: WidgetMapping,
-  filterSearchTypes: FilterSearchTypes | undefined | null;
+  widgetsToSearch: WidgetsToSearch | null;
 };
 
 export const SearchStore: Store<SearchStoreState> = singletonStore(
@@ -170,8 +170,8 @@ export const SearchStore: Store<SearchStoreState> = singletonStore(
       return this._executePromise(executionState, startActionPromise, handleSearchResult);
     },
 
-    setFilterSearchTypes(filter: FilterSearchTypes) {
-      this.filterSearchTypes = filter;
+    setWidgetsToSearch(widgetIds: WidgetsToSearch) {
+      this.widgetsToSearch = widgetIds;
     },
 
     executeWithCurrentState(): Promise<SearchExecutionResult> {
@@ -192,7 +192,7 @@ export const SearchStore: Store<SearchStoreState> = singletonStore(
     },
 
     _executePromise(executionStateParam: SearchExecutionState, startActionPromise: (promise: Promise<SearchResult>) => void, handleSearchResult: (result: SearchResult) => SearchResult): Promise<SearchExecutionResult> {
-      const { filterSearchTypes } = this._state();
+      const { widgetsToSearch } = this._state();
 
       if (this.executePromise && this.executePromise.cancel) {
         this.executePromise.cancel();
@@ -203,9 +203,9 @@ export const SearchStore: Store<SearchStoreState> = singletonStore(
 
         let executionStateBuilder = executionStateParam.toBuilder();
 
-        if (filterSearchTypes) {
+        if (widgetsToSearch) {
           const { globalOverride = GlobalOverride.empty() } = executionStateParam;
-          const keepSearchTypes = filterSearchTypes.map((widgetId) => widgetMapping.get(widgetId))
+          const keepSearchTypes = widgetsToSearch.map((widgetId) => widgetMapping.get(widgetId))
             .reduce((acc, searchTypeSet) => [...acc, ...searchTypeSet.toArray()], globalOverride.keepSearchTypes || []);
           const newGlobalOverride = globalOverride.toBuilder().keepSearchTypes(keepSearchTypes).build();
           executionStateBuilder = executionStateBuilder.globalOverride(newGlobalOverride);
@@ -232,7 +232,7 @@ export const SearchStore: Store<SearchStoreState> = singletonStore(
     },
 
     _state(): SearchStoreState {
-      return { search: this.search, result: this.result, widgetMapping: this.widgetMapping, filterSearchTypes: this.filterSearchTypes };
+      return { search: this.search, result: this.result, widgetMapping: this.widgetMapping, widgetsToSearch: this.widgetsToSearch };
     },
 
     _trigger() {


### PR DESCRIPTION
## Motivation
Prior to this change, whenever a search was executed the search was
executed for all widgets, regardless if they are seen or not.

## Description
This change will add a SearchAction which sets a filter by which the
search types will be filtered before beeing send to the server.
This filter will be set from the widget focus provider when ever a
widget gets focused or edited.

## How Has This Been Tested?
- Set a widget into focus and execute a search
- Check the result via webconsole

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Fixes #10250 

/jenkins-pr-deps Graylog2/graylog-plugin-enterprise#2192