### PR TITLE
Disable event annotation option if visualization does not support it.

### DIFF
--- a/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/VisualizationElement.ts
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/VisualizationElement.ts
@@ -58,6 +58,7 @@ const fromConfig = (config: AggregationWidgetConfig) => ({
     eventAnnotation: config.eventAnnotation,
   },
 });
+
 const toConfig = (formValues: WidgetConfigFormValues, configBuilder: AggregationWidgetConfigBuilder) => configBuilder
   .visualization(formValues.visualization.type)
   .visualizationConfig(formValuesToVisualizationConfig(formValues.visualization.type, formValues.visualization.config))

--- a/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/VisualizationConfiguration.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/VisualizationConfiguration.tsx
@@ -62,6 +62,7 @@ const VisualizationConfiguration = () => {
   }, [findVisualizationType, setFieldValue]);
 
   const isTimelineChart = isTimeline(values);
+  const supportsEventAnnotations = currentVisualizationType.capabilities?.includes('event-annotations') ?? false;
 
   return (
     <ElementConfigurationSection>
@@ -86,7 +87,7 @@ const VisualizationConfiguration = () => {
           </Input>
         )}
       </Field>
-      {isTimelineChart && (
+      {isTimelineChart && supportsEventAnnotations && (
         <Field name="visualization.eventAnnotation">
           {({ field: { name, value, onChange }, meta: { error } }) => (
             <Input id={`${name}-input`}

--- a/graylog2-web-interface/src/views/components/visualizations/area/bindings.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/area/bindings.tsx
@@ -38,6 +38,7 @@ const areaChart: VisualizationType = {
       required: true,
     }],
   },
+  capabilities: ['event-annotations'],
 };
 
 export default areaChart;

--- a/graylog2-web-interface/src/views/components/visualizations/bar/bindings.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/bar/bindings.tsx
@@ -70,6 +70,7 @@ const barChart: VisualizationType = {
       },
     }],
   },
+  capabilities: ['event-annotations'],
 };
 
 export default barChart;

--- a/graylog2-web-interface/src/views/components/visualizations/line/bindings.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/line/bindings.tsx
@@ -38,6 +38,7 @@ const lineChart: VisualizationType = {
       required: true,
     }],
   },
+  capabilities: ['event-annotations'],
 };
 
 export default lineChart;

--- a/graylog2-web-interface/src/views/components/visualizations/scatter/bindings.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/scatter/bindings.tsx
@@ -22,6 +22,7 @@ const scatterChart: VisualizationType = {
   type: ScatterVisualization.type,
   displayName: 'Scatter Plot',
   component: ScatterVisualization,
+  capabilities: ['event-annotations'],
 };
 
 export default scatterChart;

--- a/graylog2-web-interface/src/views/types.d.ts
+++ b/graylog2-web-interface/src/views/types.d.ts
@@ -111,11 +111,18 @@ type NumericField = BaseRequiredField & {
 
 type ConfigurationField = SelectField | BooleanField | NumericField;
 
+export interface VisualizationCapabilities {
+  'event-annotations': undefined,
+}
+
+export type VisualizationCapability = keyof VisualizationCapabilities;
+
 interface VisualizationType {
   type: string;
   displayName: string;
   component: VisualizationComponent;
   config?: VisualizationConfigDefinition;
+  capabilities?: Array<VisualizationCapability>;
 }
 
 interface ResultHandler<T, R> {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This change is introducing a `capabilities` field for a visualization type, which can be used to describe which optional features a given visualization supports. The valid keys for this field are implemented through an interface, so it can be extended from plugins through declaration merging.

These capabilities are effectively used in this PR to disable event annotations for heatmap/single number/pie chart/world map visualizations, which do not support displaying event annotations.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.