### PR TITLE
Fix case inconsistencies with ES cluster health status

### DIFF
--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/ClusterAdapterES7.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/ClusterAdapterES7.java
@@ -54,6 +54,7 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import java.util.Collection;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -180,7 +181,7 @@ public class ClusterAdapterES7 implements ClusterAdapter {
     }
 
     private ClusterHealth clusterHealthFrom(ClusterHealthResponse response) {
-        return ClusterHealth.create(response.getStatus().toString(),
+        return ClusterHealth.create(response.getStatus().toString().toLowerCase(Locale.ENGLISH),
                 ClusterHealth.ShardStatus.create(
                         response.getActiveShards(),
                         response.getInitializingShards(),

--- a/graylog2-web-interface/src/components/indexers/IndexerClusterHealthSummary.jsx
+++ b/graylog2-web-interface/src/components/indexers/IndexerClusterHealthSummary.jsx
@@ -33,8 +33,12 @@ class IndexerClusterHealthSummary extends React.Component {
     health: PropTypes.object.isRequired,
   };
 
+  _formatHealthStatus = ({ status }) => {
+    return status.toLowerCase();
+  };
+
   _alertClassForHealth = (health) => {
-    switch (health.status) {
+    switch (this._formatHealthStatus(health)) {
       case 'green': return 'success';
       case 'yellow': return 'warning';
       case 'red': return 'danger';
@@ -43,9 +47,9 @@ class IndexerClusterHealthSummary extends React.Component {
   };
 
   _formatTextForHealth = (health) => {
-    const text = `Elasticsearch cluster is ${health.status}.`;
+    const text = `Elasticsearch cluster is ${this._formatHealthStatus(health)}.`;
 
-    switch (health.status) {
+    switch (this._formatHealthStatus(health)) {
       case 'green': return text;
       case 'yellow':
       case 'red': return <strong>{text}</strong>;
@@ -54,7 +58,7 @@ class IndexerClusterHealthSummary extends React.Component {
   };
 
   _iconNameForHealth = (health) => {
-    switch (health.status) {
+    switch (this._formatHealthStatus(health)) {
       case 'green': return 'check-circle';
       case 'yellow': return 'exclamation-triangle';
       case 'red': return 'ambulance';


### PR DESCRIPTION
This PR makes makes two changes in the way we report ES cluster health status and handle it in the web interface.

First, it fixes an inconsistency in the returned case for the health status between Elasticsearch versions. This is what the API returned before the changes, now it will use lower case in both cases:

**ES6**
`GET /api/system/indexer/cluster/health`

```
{"status":"green","shards":{"active":60,"initializing":0,"relocating":0,"unassigned":0}}
```

**ES7**
`GET /api/system/indexer/cluster/health`

```
{"status":"GREEN","shards":{"active":10,"initializing":0,"relocating":0,"unassigned":0}}
```

Additionally, it ensures the UI works in a case independent way, so the correct status is displayed regardless of the returned case.

Fixes #10407 

This PR needs to be backported into 4.0.