### PR TITLE
Disabling Github Actions if PR is not from fork.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,8 @@ on:
 
 jobs:
   build:
+    if: ${{ github.base_ref == 'Graylog2:master' }}
+
     runs-on: ubuntu-latest 
 
     steps:


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This change is temporarily disabling the Github Actions build if the current PR is not from a fork. For these, we have a Jenkins run. For forks, we do not run that one, so we should at least have a Github Actions build.

The reason for disabling Github Actions is that we are seeing test failures for no reason repeatedly. It looks like there is some kind of resource exhaustion that leads to not being able to bind a port reliably. We do not see this for our Jenkins builds.

The way this is implemented was a bit of trial and error, due to being unable to find precise information on the structure of the `github.base_ref` variable in the official Github Actions docs. It looks like it's `master` for non-forks and `Graylog2:master` for forks. Therefore I am skipping the build if it's not the latter.

