### PR TITLE
Fix case inconsistencies with ES cluster health status (#10428)

### DIFF
--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/ClusterAdapterES7.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/ClusterAdapterES7.java
@@ -54,6 +54,7 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import java.util.Collection;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -180,7 +181,7 @@ public class ClusterAdapterES7 implements ClusterAdapter {
     }
 
     private ClusterHealth clusterHealthFrom(ClusterHealthResponse response) {
-        return ClusterHealth.create(response.getStatus().toString(),
+        return ClusterHealth.create(response.getStatus().toString().toLowerCase(Locale.ENGLISH),
                 ClusterHealth.ShardStatus.create(
                         response.getActiveShards(),
                         response.getInitializingShards(),

--- a/graylog2-web-interface/src/components/indexers/IndexerClusterHealthSummary.jsx
+++ b/graylog2-web-interface/src/components/indexers/IndexerClusterHealthSummary.jsx
@@ -33,8 +33,12 @@ class IndexerClusterHealthSummary extends React.Component {
     health: PropTypes.object.isRequired,
   };
 
+  _formatHealthStatus = ({ status }) => {
+    return status.toLowerCase();
+  };
+
   _alertClassForHealth = (health) => {
-    switch (health.status) {
+    switch (this._formatHealthStatus(health)) {
       case 'green': return 'success';
       case 'yellow': return 'warning';
       case 'red': return 'danger';
@@ -43,9 +47,9 @@ class IndexerClusterHealthSummary extends React.Component {
   };
 
   _formatTextForHealth = (health) => {
-    const text = `Elasticsearch cluster is ${health.status}.`;
+    const text = `Elasticsearch cluster is ${this._formatHealthStatus(health)}.`;
 
-    switch (health.status) {
+    switch (this._formatHealthStatus(health)) {
       case 'green': return text;
       case 'yellow':
       case 'red': return <strong>{text}</strong>;
@@ -54,7 +58,7 @@ class IndexerClusterHealthSummary extends React.Component {
   };
 
   _iconNameForHealth = (health) => {
-    switch (health.status) {
+    switch (this._formatHealthStatus(health)) {
       case 'green': return 'check-circle';
       case 'yellow': return 'exclamation-triangle';
       case 'red': return 'ambulance';


### PR DESCRIPTION
* Use consistent case for ES cluster health status

The cluster health status on ES6 was a lowercase string but on ES7 is
uppercase. This change transforms the status in ES7 into a lowercase
string.

* Make IndexerClusterHealthSummary case independent

The component made comparisons of ES cluster health status in a case
dependent way, causing #10407. This change ensures all comparisons
are done in a case independent way.

Fixes #10407

(cherry picked from commit b8f9cad7588a91f85cd8c58f8ef4ab04738b1b87)

Backport of #10428 