### PR TITLE
Log failed messages and full stack trace on processing errors (#10421)

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/shared/buffers/processors/ProcessBufferProcessor.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/buffers/processors/ProcessBufferProcessor.java
@@ -115,13 +115,25 @@ public class ProcessBufferProcessor implements WorkHandler<MessageEvent> {
         currentMessage = msg;
         incomingMessages.mark();
 
-        LOG.debug("Starting to process message <{}>.", msg.getId());
+        if (LOG.isTraceEnabled()) {
+            LOG.trace("Starting to process message <{}>.", msg.getId());
+        }
 
         try (final Timer.Context ignored = processTime.time()) {
             handleMessage(msg);
-            LOG.debug("Finished processing message <{}>. Writing to output buffer.", msg.getId());
+            if (LOG.isTraceEnabled()) {
+                LOG.trace("Finished processing message <{}>. Writing to output buffer.", msg.getId());
+            }
         } catch (Exception e) {
-            LOG.warn("Unable to process message <{}>: {}", msg.getId(), e);
+            if (LOG.isDebugEnabled()) {
+                // Log warning including the stacktrace
+                LOG.warn("Unable to process message <{}>:", msg.getId(), e);
+                // Log full message content to aid debugging
+                LOG.debug("Failed message <{}>: {}", msg.getId(), msg.toDumpString());
+            } else {
+                // Only logs a single line warning without stacktrace
+                LOG.warn("Unable to process message <{}>: {}", msg.getId(), e);
+            }
         } finally {
             currentMessage = null;
             outgoingMessages.mark();


### PR DESCRIPTION
Previously there was no way to find out which messages failed in
processing and where they failed.

This change adjusts the log levels in ProcessBufferProcessor to allow
stack trace and message content logging on DEBUG level.

Refs #10319

(cherry picked from commit 6f38abf881d80fec16c1b61c29661e9b355a8e35)