### PR TITLE
Allow using the same LDAP attribute for different config settings

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/security/authservice/backend/LDAPAuthServiceBackend.java
+++ b/graylog2-server/src/main/java/org/graylog/security/authservice/backend/LDAPAuthServiceBackend.java
@@ -41,6 +41,7 @@ import javax.annotation.Nullable;
 import javax.inject.Inject;
 import java.security.GeneralSecurityException;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -275,14 +276,19 @@ public class LDAPAuthServiceBackend implements AuthServiceBackend {
                 .put("login_success", loginSuccess);
 
         if (user != null) {
-            userDetails.put("user_details", ImmutableMap.<String, String>builder()
-                    .put("dn", user.dn())
-                    .put(config.userUniqueIdAttribute(), user.base64UniqueId())
-                    .put(config.userNameAttribute(), user.username())
-                    .put(config.userFullNameAttribute(), user.fullName())
-                    .put("email", user.email())
-                    .build()
-            );
+            // Use regular HashMap to allow duplicates. Users might use the same attribute for name and full name.
+            // See: https://github.com/Graylog2/graylog2-server/issues/10069
+            final Map<String, String> attributes = new HashMap<>();
+
+            attributes.put("dn", user.dn());
+            // Use a special key for the unique ID attribute. If users use something like "uid" for the unique ID,
+            // it might be confusing to see a base64 encoded value instead of the plain text one.
+            attributes.put("unique_id (" + config.userUniqueIdAttribute() + ")", user.base64UniqueId());
+            attributes.put(config.userNameAttribute(), user.username());
+            attributes.put(config.userFullNameAttribute(), user.fullName());
+            attributes.put("email", user.email());
+
+            userDetails.put("user_details", ImmutableMap.copyOf(attributes));
         } else {
             userDetails.put("user_details", ImmutableMap.of());
         }

--- a/graylog2-server/src/main/java/org/graylog/security/authservice/ldap/UnboundLDAPConnector.java
+++ b/graylog2-server/src/main/java/org/graylog/security/authservice/ldap/UnboundLDAPConnector.java
@@ -262,10 +262,6 @@ public class UnboundLDAPConnector {
             if (OBJECT_CLASS_ATTRIBUTE.equalsIgnoreCase(attribute.getBaseName())) {
                 continue;
             }
-            // We already set the unique ID above
-            if (uniqueIdAttribute.equalsIgnoreCase(attribute.getBaseName())) {
-                continue;
-            }
 
             if (attribute.needsBase64Encoding()) {
                 for (final byte[] value : attribute.getValueByteArrays()) {


### PR DESCRIPTION
Some users want to use the same attribute (e.g. "cn") for different
config settings. (e.g. name and full name)

Also don't skip the unique ID attribute when collecting user attributes.
This is an issue when the same attribute is used for the unique
attribute and another config setting (note recommended) because the
attribute will be missing from user details.

Adjust the LDAP login test output to use a special key for the unique ID
attribute to avoid confusion because of the base64 encoded value.

Fixes #10069

This needs to be backported to 4.0 once it has been reviewed, tested and merged.