### PR TITLE
Don't run index jobs for missing indices (#10438)

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/SetIndexReadOnlyJob.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/SetIndexReadOnlyJob.java
@@ -62,6 +62,10 @@ public class SetIndexReadOnlyJob extends SystemJob {
 
     @Override
     public void execute() {
+        if (!indices.exists(index)) {
+            log.debug("Not running job for deleted index <{}>", index);
+            return;
+        }
         if (indices.isClosed(index)) {
             log.debug("Not running job for closed index <{}>", index);
             return;

--- a/graylog2-server/src/main/java/org/graylog2/indexer/indices/jobs/OptimizeIndexJob.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indices/jobs/OptimizeIndexJob.java
@@ -59,6 +59,10 @@ public class OptimizeIndexJob extends SystemJob {
 
     @Override
     public void execute() {
+        if (!indices.exists(index)) {
+            LOG.debug("Not running job for deleted index <{}>", index);
+            return;
+        }
         if (indices.isClosed(index)) {
             LOG.debug("Not running job for closed index <{}>", index);
             return;

--- a/graylog2-server/src/main/java/org/graylog2/indexer/indices/jobs/SetIndexReadOnlyAndCalculateRangeJob.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indices/jobs/SetIndexReadOnlyAndCalculateRangeJob.java
@@ -63,6 +63,10 @@ public class SetIndexReadOnlyAndCalculateRangeJob extends SystemJob {
 
     @Override
     public void execute() {
+        if (!indices.exists(indexName)) {
+            LOG.debug("Not running job for deleted index <{}>", indexName);
+            return;
+        }
         if (indices.isClosed(indexName)) {
             LOG.debug("Not running job for closed index <{}>", indexName);
             return;

--- a/graylog2-server/src/main/java/org/graylog2/indexer/ranges/CreateNewSingleIndexRangeJob.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/ranges/CreateNewSingleIndexRangeJob.java
@@ -60,6 +60,10 @@ public class CreateNewSingleIndexRangeJob extends RebuildIndexRangesJob {
 
     @Override
     public void execute() {
+        if (!indices.exists(indexName)) {
+            LOG.debug("Not running job for deleted index <{}>", indexName);
+            return;
+        }
         if (indices.isClosed(indexName)) {
             LOG.debug("Not running job for closed index <{}>", indexName);
             return;


### PR DESCRIPTION
The SetIndexReadOnlyJob, SetIndexReadOnlyAndCalculateRangeJob,
OptimizeIndexJob and CreateNewSingleIndexRangeJob jobs
might throw an exception when running "indices.isClosed(indexName)" when
the index doesn't exist anymore.

Some of these jobs are executed with a delay so it might happen that the
index retention already deleted the index when these jobs are started.

This adds a "indices.exist(indexName)" check at the very beginning.

(cherry picked from commit 6330620df5e216473349b2ea034d124b703ee647)