### PR TITLE
Adjust entity dependency resolver to ignore outputs for dashboards (backport)

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/security/entities/EntityDependencyResolver.java
+++ b/graylog2-server/src/main/java/org/graylog/security/entities/EntityDependencyResolver.java
@@ -48,6 +48,7 @@ public class EntityDependencyResolver {
     // E.g. To view a stream with a custom output, a user does not need output permissions
     private static final Map<GRNType, Set<ModelType>> IGNORED_DEPENDENCIES = ImmutableMap.<GRNType, Set<ModelType>>builder()
             .put(GRNTypes.STREAM, ImmutableSet.of(ModelTypes.OUTPUT_V1))
+            .put(GRNTypes.DASHBOARD, ImmutableSet.of(ModelTypes.OUTPUT_V1))
             .build();
 
     @Inject


### PR DESCRIPTION


We previously added an exception to ignore outputs when sharing streams.
This is also required for sharing dashboards because output dependencies
might get pulled in transitively via streams.

Fixes Graylog2/graylog-plugin-enterprise#2131

(cherry picked from commit 5606787097f68c87da4c33f6e89a4fb59a747205)

