### PR TITLE
Separate `useStore` store registration and props mapping logic.

### DIFF
--- a/graylog2-web-interface/src/stores/__tests__/connect.test.tsx
+++ b/graylog2-web-interface/src/stores/__tests__/connect.test.tsx
@@ -341,7 +341,7 @@ describe('useStore', () => {
   });
 
   it('does not reregister if props mapper is provided as arrow function', () => {
-    SimpleStore.listen = jest.fn(SimpleStore.listen);
+    const listenSpy = jest.spyOn(SimpleStore, 'listen');
 
     const ComponentWithPropsMapper = ({ propsMapper }: { propsMapper: (state: { value: number }) => ({ value: number }) }) => {
       const { value } = useStore(SimpleStore, propsMapper) || { value: undefined };
@@ -355,10 +355,9 @@ describe('useStore', () => {
 
     wrapper.setProps({ propsMapper: ({ value: v } = { value: 0 }) => ({ value: v * 2 }) });
     act(() => SimpleStore.setValue(42));
-    wrapper.update();
 
     expect(wrapper).toHaveText('Value is: 84');
 
-    expect(SimpleStore.listen).toHaveBeenCalledTimes(2);
+    expect(listenSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/graylog2-web-interface/src/stores/connect.tsx
+++ b/graylog2-web-interface/src/stores/connect.tsx
@@ -15,7 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useMemo } from 'react';
 import { isFunction } from 'lodash';
 import { Optional } from 'utility-types';
 
@@ -40,19 +40,19 @@ export function useStore<U>(store: StoreType<U>): U;
 export function useStore<U, M extends (props: U) => any>(store: StoreType<U>, propsMapper: M): ReturnType<M>;
 
 export function useStore(store, propsMapper = id) {
-  const [storeState, setStoreState] = useState(() => propsMapper(store.getInitialState()));
+  const [storeState, setStoreState] = useState(() => store.getInitialState());
   const storeStateRef = useRef(storeState);
 
+  const mappedStoreState = useMemo(() => propsMapper(storeState), [propsMapper, storeState]);
+
   useEffect(() => store.listen((newState) => {
-    const mappedProps = propsMapper(newState);
-
-    if (!isDeepEqual(mappedProps, storeStateRef.current)) {
-      setStoreState(mappedProps);
-      storeStateRef.current = mappedProps;
+    if (!isDeepEqual(newState, storeStateRef.current)) {
+      setStoreState(newState);
+      storeStateRef.current = newState;
     }
-  }), [propsMapper, store]);
+  }), [store]);
 
-  return storeState;
+  return mappedStoreState;
 }
 
 /**

--- a/graylog2-web-interface/src/views/components/contexts/WidgetFocusProvider.test.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/WidgetFocusProvider.test.tsx
@@ -44,6 +44,8 @@ jest.mock('views/stores/WidgetStore', () => ({
   },
 }));
 
+jest.mock('views/actions/SearchActions');
+
 describe('WidgetFocusProvider', () => {
   beforeEach(() => {
     useLocation.mockReturnValue({


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is separating the store registration and the props mapping logic
in the `useStore` custom hook. This is avoiding a bug where passing a
props mapper function as an inline arrow function leads to missed state
updates.

Passing a props mapper function as a constant (either by extracting it
to a constant scoped outside of the component calling `useStore`, or
using `useCallback` if it is using props/state from the component) is
still recommended, but merely for performance reasons and not for
correctness.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.