### PR TITLE
Allow using the same LDAP attribute for different config settings (#10437)

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/security/authservice/backend/ADAuthServiceBackend.java
+++ b/graylog2-server/src/main/java/org/graylog/security/authservice/backend/ADAuthServiceBackend.java
@@ -39,6 +39,7 @@ import javax.annotation.Nullable;
 import javax.inject.Inject;
 import java.security.GeneralSecurityException;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
@@ -263,15 +264,20 @@ public class ADAuthServiceBackend implements AuthServiceBackend {
                 .put("login_success", loginSuccess);
 
         if (user != null) {
-            userDetails.put("user_details", ImmutableMap.<String, String>builder()
-                    .put("dn", user.dn())
-                    .put("account_enabled", String.valueOf(user.accountIsEnabled()))
-                    .put(AD_OBJECT_GUID, user.base64UniqueId())
-                    .put(config.userNameAttribute(), user.username())
-                    .put(config.userFullNameAttribute(), user.fullName())
-                    .put("email", user.email())
-                    .build()
-            );
+            // Use regular HashMap to allow duplicates. Users might use the same attribute for name and full name.
+            // See: https://github.com/Graylog2/graylog2-server/issues/10069
+            final Map<String, String> attributes = new HashMap<>();
+
+            attributes.put("dn", user.dn());
+            attributes.put("account_enabled", String.valueOf(user.accountIsEnabled()));
+            // Use a special key for the unique ID attribute. If users use something like "uid" for the unique ID,
+            // it might be confusing to see a base64 encoded value instead of the plain text one.
+            attributes.put("unique_id (" + AD_OBJECT_GUID + ")", user.base64UniqueId());
+            attributes.put(config.userNameAttribute(), user.username());
+            attributes.put(config.userFullNameAttribute(), user.fullName());
+            attributes.put("email", user.email());
+
+            userDetails.put("user_details", ImmutableMap.copyOf(attributes));
         } else {
             userDetails.put("user_details", ImmutableMap.of());
         }

--- a/graylog2-server/src/main/java/org/graylog/security/authservice/ldap/UnboundLDAPConnector.java
+++ b/graylog2-server/src/main/java/org/graylog/security/authservice/ldap/UnboundLDAPConnector.java
@@ -263,10 +263,6 @@ public class UnboundLDAPConnector {
             if (OBJECT_CLASS_ATTRIBUTE.equalsIgnoreCase(attribute.getBaseName())) {
                 continue;
             }
-            // We already set the unique ID above
-            if (uniqueIdAttribute.equalsIgnoreCase(attribute.getBaseName())) {
-                continue;
-            }
 
             if (attribute.needsBase64Encoding()) {
                 for (final byte[] value : attribute.getValueByteArrays()) {


### PR DESCRIPTION

Some users want to use the same attribute (e.g. "cn") for different
config settings. (e.g. name and full name)

Also don't skip the unique ID attribute when collecting user attributes.
This is an issue when the same attribute is used for the unique
attribute and another config setting (note recommended) because the
attribute will be missing from user details.

Adjust the LDAP login test output to use a special key for the unique ID
attribute to avoid confusion because of the base64 encoded value.

Fixes #10069

(cherry picked from commit 7e64e6a8113ee66b0afdadda81df107884848a80)


