### PR TITLE
Make new aggregation builder wizard the new default.

### DIFF
--- a/graylog2-web-interface/src/views/bindings.tsx
+++ b/graylog2-web-interface/src/views/bindings.tsx
@@ -153,9 +153,9 @@ const exports: PluginExports = {
       defaultWidth: 4,
       reportStyle: () => ({ width: 600 }),
       visualizationComponent: AggregationBuilder,
-      editComponent: AppConfig.isFeatureEnabled('aggregation-wizard')
-        ? AggregationWizard
-        : AggregationControls,
+      editComponent: AppConfig.isFeatureEnabled('legacy-aggregation-wizard')
+        ? AggregationControls
+        : AggregationWizard,
       needsControlledHeight: (widget: Widget) => {
         const widgetVisualization = get(widget, 'config.visualization');
         const flexibleHeightWidgets = [


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This change is toggling the feature flag used for the new aggregation
builder wizard. It removes the `aggregation-wizard` feature flag and
introduces the `legacy-aggregation-wizard` feature flag. The new
aggregation builder wizard is now active by default. If the old
aggregation builder ui is desired, the `legacy-aggregation-wizard` can
be used like this to enable it:

```
FEATURES=legacy-aggregation-wizard yarn start
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.