### PR TITLE
Update name of selected aggregation sort field correctly, when naming related metric.

### DIFF
--- a/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/Sort.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/Sort.tsx
@@ -72,7 +72,7 @@ const Sort = ({ index }: Props) => {
   const selectedOption = currentSort ? options.findIndex((option) => (option.type === currentSort.type && option.field === currentSort.field)) : undefined;
 
   return (
-    <div data-testid={`sort-element-${index}`}>
+    <>
       <Field name={`sort.${index}.field`}>
         {({ field: { name, onChange }, meta: { error } }) => {
           return (
@@ -108,8 +108,8 @@ const Sort = ({ index }: Props) => {
             <Select options={directionOptions}
                     clearable={false}
                     name={name}
-                    aria-label="Select direction for sorting"
                     value={value}
+                    aria-label="Select direction for sorting"
                     size="small"
                     onChange={(newValue) => {
                       onChange({ target: { name, value: newValue } });
@@ -117,7 +117,7 @@ const Sort = ({ index }: Props) => {
           </Input>
         )}
       </Field>
-    </div>
+    </>
   );
 };
 

--- a/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/Sort.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/Sort.tsx
@@ -34,12 +34,21 @@ const directionOptions = [
   { label: 'Descending', value: 'Descending' },
 ];
 
-const formatSeries = (metric: MetricFormValues) => (metric.name ? metric.name : `${metric.function}(${metric.field ?? ''})`);
+const formatSeries = (metric: MetricFormValues) => {
+  const readableField = `${metric.function}(${metric.field ?? ''})`;
+
+  return {
+    label: metric.name || readableField,
+    field: readableField,
+  };
+};
+
 const formatGrouping = (grouping: GroupByFormValues) => grouping.field.field;
 
 type OptionValue = {
   type: 'metric' | 'groupBy',
   field: string,
+  label: string
 };
 
 type Option = {
@@ -50,21 +59,20 @@ type Option = {
 const Sort = ({ index }: Props) => {
   const { values, setFieldValue } = useFormikContext<WidgetConfigFormValues>();
   const { metrics = [], groupBy: { groupings = [] } = {} } = values;
-
-  const metricsOptions: Array<OptionValue> = metrics.map(formatSeries).map((metric) => ({ type: 'metric', field: metric }));
-  const rowPivotOptions: Array<OptionValue> = groupings.filter((grouping) => (grouping.direction === 'row')).map(formatGrouping).map((groupBy) => ({ type: 'groupBy', field: groupBy }));
+  const metricsOptions: Array<OptionValue> = metrics.map(formatSeries).map(({ field, label }) => ({ type: 'metric', field, label }));
+  const rowPivotOptions: Array<OptionValue> = groupings.filter((grouping) => (grouping.direction === 'row')).map(formatGrouping).map((groupBy) => ({ type: 'groupBy', field: groupBy, label: groupBy }));
   const options = [
     ...metricsOptions,
     ...rowPivotOptions,
   ];
 
-  const numberIndexedOptions: Array<Option> = options.map((option, idx) => ({ label: option.field, value: idx }));
+  const numberIndexedOptions: Array<Option> = options.map((option, idx) => ({ label: option.label, value: idx }));
 
   const currentSort = values.sort[index];
   const selectedOption = currentSort ? options.findIndex((option) => (option.type === currentSort.type && option.field === currentSort.field)) : undefined;
 
   return (
-    <>
+    <div data-testid={`sort-element-${index}`}>
       <Field name={`sort.${index}.field`}>
         {({ field: { name, onChange }, meta: { error } }) => {
           return (
@@ -100,8 +108,8 @@ const Sort = ({ index }: Props) => {
             <Select options={directionOptions}
                     clearable={false}
                     name={name}
-                    value={value}
                     aria-label="Select direction for sorting"
+                    value={value}
                     size="small"
                     onChange={(newValue) => {
                       onChange({ target: { name, value: newValue } });
@@ -109,7 +117,7 @@ const Sort = ({ index }: Props) => {
           </Input>
         )}
       </Field>
-    </>
+    </div>
   );
 };
 


### PR DESCRIPTION
## Description

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Before this change naming a metric, which is being selected as a field for a sort element, "emptied" the related sort field select.
Before defining a metric name:
![image](https://user-images.githubusercontent.com/46300478/115582024-d4116200-a2c8-11eb-901f-0cf0c06e9147.png)

After defining a metric name:
![image](https://user-images.githubusercontent.com/46300478/115581714-8eed3000-a2c8-11eb-93f4-3d8b510516f9.png)

With this change the selected sort field option will always show the correct label:
![image](https://user-images.githubusercontent.com/46300478/115582169-f6a37b00-a2c8-11eb-937b-4c8d3648e828.png)

I tried to write a test for this case, but we can't  test it easily, because it is only a visual bug and the form state is still correct.
Testing if a `react-select` component displays the correct label for the selected option is not possible, as far as I know.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

