### PR TITLE
Adjust ADAuthServiceBackend login test output

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/security/authservice/backend/ADAuthServiceBackend.java
+++ b/graylog2-server/src/main/java/org/graylog/security/authservice/backend/ADAuthServiceBackend.java
@@ -42,6 +42,7 @@ import javax.annotation.Nullable;
 import javax.inject.Inject;
 import java.security.GeneralSecurityException;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -295,15 +296,20 @@ public class ADAuthServiceBackend implements AuthServiceBackend {
                 .put("login_success", loginSuccess);
 
         if (user != null) {
-            userDetails.put("user_details", ImmutableMap.<String, String>builder()
-                    .put("dn", user.dn())
-                    .put("account_enabled", String.valueOf(user.accountIsEnabled()))
-                    .put(AD_OBJECT_GUID, user.base64UniqueId())
-                    .put(config.userNameAttribute(), user.username())
-                    .put(config.userFullNameAttribute(), user.fullName())
-                    .put("email", user.email())
-                    .build()
-            );
+            // Use regular HashMap to allow duplicates. Users might use the same attribute for name and full name.
+            // See: https://github.com/Graylog2/graylog2-server/issues/10069
+            final Map<String, String> attributes = new HashMap<>();
+
+            attributes.put("dn", user.dn());
+            attributes.put("account_enabled", String.valueOf(user.accountIsEnabled()));
+            // Use a special key for the unique ID attribute. If users use something like "uid" for the unique ID,
+            // it might be confusing to see a base64 encoded value instead of the plain text one.
+            attributes.put("unique_id (" + AD_OBJECT_GUID + ")", user.base64UniqueId());
+            attributes.put(config.userNameAttribute(), user.username());
+            attributes.put(config.userFullNameAttribute(), user.fullName());
+            attributes.put("email", user.email());
+
+            userDetails.put("user_details", ImmutableMap.copyOf(attributes));
         } else {
             userDetails.put("user_details", ImmutableMap.of());
         }


### PR DESCRIPTION
Adjust the AD login test output to use a special key for the unique ID
attribute to avoid confusion because of the base64 encoded value.

Similar to the change in #10437.

Fixes #10069

This should be backported to 4.0 once it has been merged.