### PR TITLE
Fixing route leave prompt for focused mode on dashboards.

### DIFF
--- a/graylog2-web-interface/src/components/common/ConfirmLeaveDialog.tsx
+++ b/graylog2-web-interface/src/components/common/ConfirmLeaveDialog.tsx
@@ -16,7 +16,7 @@
  */
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import { Prompt } from 'react-router-dom';
+import { Prompt, useLocation } from 'react-router-dom';
 import { useCallback, useEffect } from 'react';
 
 import AppConfig from 'util/AppConfig';
@@ -29,11 +29,10 @@ type Props = {
 };
 
 const ConfirmLeaveDialog = ({ question }: Props) => {
-  const handleLeavePage = useCallback((e) => {
-    if (AppConfig.gl2DevMode()) {
-      return null;
-    }
+  const location = useLocation();
+  const isLeavingPage = useCallback((newLocation) => (newLocation.pathname !== location.pathname ? question : true), [location.pathname, question]);
 
+  const handleLeavePage = useCallback((e) => {
     e.returnValue = question;
 
     return question;
@@ -48,7 +47,7 @@ const ConfirmLeaveDialog = ({ question }: Props) => {
   }, [handleLeavePage]);
 
   return (
-    <Prompt when={!AppConfig.gl2DevMode()} message={question} />
+    <Prompt message={isLeavingPage} />
   );
 };
 

--- a/graylog2-web-interface/src/components/common/ConfirmLeaveDialog.tsx
+++ b/graylog2-web-interface/src/components/common/ConfirmLeaveDialog.tsx
@@ -33,6 +33,10 @@ const ConfirmLeaveDialog = ({ question }: Props) => {
   const isLeavingPage = useCallback((newLocation) => (newLocation.pathname !== location.pathname ? question : true), [location.pathname, question]);
 
   const handleLeavePage = useCallback((e) => {
+    if (AppConfig.gl2DevMode()) {
+      return null;
+    }
+
     e.returnValue = question;
 
     return question;

--- a/graylog2-web-interface/src/components/common/ConfirmLeaveDialog.tsx
+++ b/graylog2-web-interface/src/components/common/ConfirmLeaveDialog.tsx
@@ -47,7 +47,7 @@ const ConfirmLeaveDialog = ({ question }: Props) => {
   }, [handleLeavePage]);
 
   return (
-    <Prompt message={isLeavingPage} />
+    <Prompt when={!AppConfig.gl2DevMode()} message={isLeavingPage} />
   );
 };
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Prior to this change, the route leave prompt asking the user for confirmation if the current view is dirty and the route is left was unconditionally triggered for any route history action. This means it is also triggered when query parameters are being added to the current URL.

With the introduction of the focused mode and its use during widget editing, this lead to the phenomenon that the prompt was always triggered when a widget on an unsaved dashboard was focused, e.g. for editing.

This change is now adding a check to the `Prompt` component used to generate the confirmation prompt, checking if the new location is a different path than the current one. Therefore it is not triggered if only the query parameters are changing.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.