### PR TITLE
Reenable Github Actions.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,8 +5,6 @@ on:
 
 jobs:
   build:
-    if: ${{ github.base_ref == 'Graylog2:master' }}
-
     runs-on: ubuntu-latest 
 
     steps:


### PR DESCRIPTION
Due to the underlying issue being fixed (see actions/virtual-environments#3186), we can now reenable Github Actions for all builds.