### PR TITLE
Timerange Info for dashboard widgets

### DIFF
--- a/graylog2-web-interface/src/components/common/TextOverflowEllipsis.tsx
+++ b/graylog2-web-interface/src/components/common/TextOverflowEllipsis.tsx
@@ -25,16 +25,21 @@ const Wrapper = styled.div`
 
 type Props = {
   children: string,
+  titleOverride?: string,
 };
 
 /**
  * Component that signals text overflow to users by using an ellipsis.
  * The parent component needs a concrete width.
  */
-const TextOverflowEllipsis = ({ children }: Props) => (
-  <Wrapper title={children}>
+const TextOverflowEllipsis = ({ children, titleOverride }: Props) => (
+  <Wrapper title={titleOverride || children}>
     {children}
   </Wrapper>
 );
+
+TextOverflowEllipsis.defaultProps = {
+  titleOverride: undefined,
+};
 
 export default TextOverflowEllipsis;

--- a/graylog2-web-interface/src/contexts/ThemeAndUserProvider.jsx
+++ b/graylog2-web-interface/src/contexts/ThemeAndUserProvider.jsx
@@ -22,16 +22,19 @@ import GlobalThemeStyles from 'theme/GlobalThemeStyles';
 
 import CurrentUserPreferencesProvider from './CurrentUserPreferencesProvider';
 import CurrentUserProvider from './CurrentUserProvider';
+import TimeLocalizeProvider from './TimeLocalizeProvider';
 
 const ThemeAndUserProvider = ({ children }) => {
   return (
     <CurrentUserProvider>
-      <CurrentUserPreferencesProvider>
-        <GraylogThemeProvider>
-          <GlobalThemeStyles />
-          {children}
-        </GraylogThemeProvider>
-      </CurrentUserPreferencesProvider>
+      <TimeLocalizeProvider>
+        <CurrentUserPreferencesProvider>
+          <GraylogThemeProvider>
+            <GlobalThemeStyles />
+            {children}
+          </GraylogThemeProvider>
+        </CurrentUserPreferencesProvider>
+      </TimeLocalizeProvider>
     </CurrentUserProvider>
   );
 };

--- a/graylog2-web-interface/src/contexts/TimeLocalizeContext.tsx
+++ b/graylog2-web-interface/src/contexts/TimeLocalizeContext.tsx
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+
+import { singleton } from 'views/logic/singleton';
+
+export type TimeLocalizeContextType = {
+  localizeTime: (string) => string,
+};
+
+const TimeLocalizeContext = React.createContext<TimeLocalizeContextType | undefined>(undefined);
+
+export default singleton('contexts.TimeLocalizeContext', () => TimeLocalizeContext);

--- a/graylog2-web-interface/src/contexts/TimeLocalizeProvider.test.tsx
+++ b/graylog2-web-interface/src/contexts/TimeLocalizeProvider.test.tsx
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import { useContext } from 'react';
+import { render, screen } from 'wrappedTestingLibrary';
+import moment from 'moment-timezone';
+import { alice } from 'fixtures/users';
+
+import TimeLocalizeProvider, { ACCEPTED_FORMATS } from 'contexts/TimeLocalizeProvider';
+import TimeLocalizeContext from 'contexts/TimeLocalizeContext';
+import CurrentUserContext from 'contexts/CurrentUserContext';
+import User from 'logic/users/User';
+
+const TestTimestamp = ({ timestamp }: { timestamp: string }) => {
+  const { localizeTime } = useContext(TimeLocalizeContext);
+
+  return (<div>{localizeTime(timestamp)}</div>);
+};
+
+const SUT = ({ timestamp, user }: { timestamp: string, user: User }) => (
+  <CurrentUserContext.Provider value={user.toJSON()}>
+    <TimeLocalizeProvider>
+      <TestTimestamp timestamp={timestamp} />
+    </TimeLocalizeProvider>,
+  </CurrentUserContext.Provider>
+);
+
+describe('TimeLocalizeProvider', () => {
+  it('should provide a function which converts a date time string to local time of user', () => {
+    const user = alice.toBuilder().timezone('Asia/Tokyo').build();
+
+    render(<SUT timestamp="2021-03-27T14:32:31.894Z" user={user} />);
+
+    expect(screen.getByText('2021-03-27 23:32:31.894 +09:00')).toBeInTheDocument();
+  });
+
+  it('should provide a function which converts a date time string to local time of user without timezone', () => {
+    const user = alice.toBuilder().timezone(undefined).build();
+
+    render(<SUT timestamp="2021-03-27T14:32:31.894Z" user={user} />);
+
+    const browserTz = moment.tz.guess();
+    const result = moment.tz('2021-03-27T14:32:31.894Z', ACCEPTED_FORMATS.ISO_8601, true, browserTz)
+      .format(ACCEPTED_FORMATS.TIMESTAMP_TZ);
+
+    expect(screen.getByText(result)).toBeInTheDocument();
+  });
+});

--- a/graylog2-web-interface/src/contexts/TimeLocalizeProvider.tsx
+++ b/graylog2-web-interface/src/contexts/TimeLocalizeProvider.tsx
@@ -1,0 +1,67 @@
+/*
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import { useCallback } from 'react';
+import { get } from 'lodash';
+import moment from 'moment-timezone';
+
+import TimeLocalizeContext from 'contexts/TimeLocalizeContext';
+import { useStore } from 'stores/connect';
+import CombinedProvider from 'injection/CombinedProvider';
+import AppConfig from 'util/AppConfig';
+
+type Props = {
+  children: React.ReactChildren | React.ReactChild,
+};
+
+const { CurrentUserStore } = CombinedProvider.get('CurrentUser');
+
+const ACCEPTED_FORMATS = {
+  DATE: 'YYYY-MM-DD',
+  TIME: 'HH:mm:ss.SSS',
+  DATETIME: 'YYYY-MM-DD HH:mm:ss', // Use to show local times when decimal second precision is not important
+  DATETIME_TZ: 'YYYY-MM-DD HH:mm:ss Z', // Use when decimal second precision is not important, but TZ is
+  TIMESTAMP: 'YYYY-MM-DD HH:mm:ss.SSS', // Use to show local time & date when decimal second precision is important
+  // (e.g. search results)
+  TIMESTAMP_TZ: 'YYYY-MM-DD HH:mm:ss.SSS Z', // Use to show times when decimal second precision is important, in a different TZ
+  COMPLETE: 'dddd D MMMM YYYY, HH:mm ZZ', // Easy to read date time, specially useful for graphs
+  ISO_8601: 'YYYY-MM-DDTHH:mm:ss.SSSZ', // Standard, but not really nice to read. Mostly used for machine communication
+};
+
+const TimeLocalizeProvider = ({ children }: Props) => {
+  const currentUser = useStore(CurrentUserStore, (state) => get(state, 'currentUser'));
+
+  const getUserTimezone = useCallback(() => {
+    if (currentUser?.timezone) {
+      return currentUser.timezone;
+    }
+
+    return moment.tz.guess() || AppConfig.rootTimeZone() || 'UTC';
+  }, [currentUser.timezone]);
+
+  const localizeTime = useCallback((time) => {
+    const dateTime = moment.tz(time.trim(), Object.values(ACCEPTED_FORMATS), true, getUserTimezone());
+
+    return dateTime.format(ACCEPTED_FORMATS.TIMESTAMP_TZ);
+  }, [getUserTimezone]);
+
+  return (
+    <TimeLocalizeContext.Provider value={{ localizeTime }}>
+      {children}
+    </TimeLocalizeContext.Provider>
+  );
+};
+
+export default TimeLocalizeProvider;

--- a/graylog2-web-interface/src/contexts/TimeLocalizeProvider.tsx
+++ b/graylog2-web-interface/src/contexts/TimeLocalizeProvider.tsx
@@ -15,22 +15,18 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { useCallback } from 'react';
-import { get } from 'lodash';
+import { useCallback, useContext } from 'react';
 import moment from 'moment-timezone';
 
-import TimeLocalizeContext from 'contexts/TimeLocalizeContext';
-import { useStore } from 'stores/connect';
-import CombinedProvider from 'injection/CombinedProvider';
+import TimeLocalizeContext, { TimeLocalizeContextType } from 'contexts/TimeLocalizeContext';
 import AppConfig from 'util/AppConfig';
+import CurrentUserContext from 'contexts/CurrentUserContext';
 
 type Props = {
-  children: React.ReactChildren | React.ReactChild,
+  children: React.ReactChildren | React.ReactChild | ((timeLocalize: TimeLocalizeContextType) => Element),
 };
 
-const { CurrentUserStore } = CombinedProvider.get('CurrentUser');
-
-const ACCEPTED_FORMATS = {
+export const ACCEPTED_FORMATS = {
   DATE: 'YYYY-MM-DD',
   TIME: 'HH:mm:ss.SSS',
   DATETIME: 'YYYY-MM-DD HH:mm:ss', // Use to show local times when decimal second precision is not important
@@ -42,8 +38,12 @@ const ACCEPTED_FORMATS = {
   ISO_8601: 'YYYY-MM-DDTHH:mm:ss.SSSZ', // Standard, but not really nice to read. Mostly used for machine communication
 };
 
+/**
+ * Provides a function to convert a ACCEPTED_FORMAT of a timestamp into a timestamp converted to the users timezone.
+ * @param children React components.
+ */
 const TimeLocalizeProvider = ({ children }: Props) => {
-  const currentUser = useStore(CurrentUserStore, (state) => get(state, 'currentUser'));
+  const currentUser = useContext(CurrentUserContext);
 
   const getUserTimezone = useCallback(() => {
     if (currentUser?.timezone) {

--- a/graylog2-web-interface/src/contexts/TimeLocalizeProvider.tsx
+++ b/graylog2-web-interface/src/contexts/TimeLocalizeProvider.tsx
@@ -1,4 +1,6 @@
 /*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the Server Side Public License, version 1,
  * as published by MongoDB, Inc.

--- a/graylog2-web-interface/src/views/components/searchbar/TimeRangeDisplay.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/TimeRangeDisplay.tsx
@@ -22,6 +22,7 @@ import DateTime from 'logic/datetimes/DateTime';
 import type { TimeRange, NoTimeRangeOverride } from 'views/logic/queries/Query';
 import StoreProvider from 'injection/StoreProvider';
 import { isTypeKeyword, isTypeRelativeWithStartOnly, isTypeRelativeWithEnd } from 'views/typeGuards/timeRange';
+import { readableRange } from 'views/logic/queries/TimeRangeToString';
 
 type Props = {
   timerange: TimeRange | NoTimeRangeOverride | null | undefined,
@@ -54,11 +55,6 @@ const TimeRangeWrapper = styled.p(({ theme }) => css`
   }
 `);
 
-const readableRange = (timerange: TimeRange, fieldName: 'range' | 'from' | 'to', placeholder = 'All Time') => {
-  return !timerange[fieldName] ? placeholder : DateTime.now()
-    .subtract(timerange[fieldName] * 1000)
-    .fromNow();
-};
 
 const dateOutput = (timerange: TimeRange) => {
   let from = EMPTY_RANGE;

--- a/graylog2-web-interface/src/views/components/widgets/TimerangeInfo.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/TimerangeInfo.test.tsx
@@ -17,11 +17,22 @@
 import React from 'react';
 import { render, screen } from 'wrappedTestingLibrary';
 import { MockStore } from 'helpers/mocking';
+import asMock from 'helpers/mocking/AsMock';
 
 import Widget from 'views/logic/widgets/Widget';
 import TimeLocalizeContext from 'contexts/TimeLocalizeContext';
+import { GlobalOverrideStore, GlobalOverrideStoreState } from 'views/stores/GlobalOverrideStore';
+import GlobalOverride from 'views/logic/search/GlobalOverride';
 
 import TimerangeInfo from './TimerangeInfo';
+
+jest.mock('views/stores/GlobalOverrideStore', () => ({
+  GlobalOverrideStore: MockStore(
+    ['listen', () => jest.fn()],
+    'get',
+    ['getInitialState', jest.fn()],
+  ),
+}));
 
 jest.mock('views/stores/SearchStore', () => ({
   SearchStore: MockStore(
@@ -103,5 +114,18 @@ describe('TimerangeInfo', () => {
     render(<SUT widget={keywordWidget} />);
 
     expect(screen.getByText('5 minutes ago')).toBeInTheDocument();
+  });
+
+  it('should display global override', () => {
+    const state: GlobalOverrideStoreState = GlobalOverride.empty().toBuilder().timerange({ type: 'relative', range: 3000 }).build();
+    asMock(GlobalOverrideStore.getInitialState).mockReturnValue(state);
+
+    const keywordWidget = widget.toBuilder()
+      .timerange({ type: 'keyword', keyword: '5 minutes ago' })
+      .build();
+
+    render(<SUT widget={keywordWidget} />);
+
+    expect(screen.getByText('Global Override: an hour ago - Now')).toBeInTheDocument();
   });
 });

--- a/graylog2-web-interface/src/views/components/widgets/TimerangeInfo.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/TimerangeInfo.test.tsx
@@ -15,20 +15,63 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import React from 'react';
+import * as Immutable from 'immutable';
 import { render, screen } from 'wrappedTestingLibrary';
+import { MockStore } from 'helpers/mocking';
 
 import Widget from 'views/logic/widgets/Widget';
 
 import TimerangeInfo from './TimerangeInfo';
 
+jest.mock('views/stores/SearchStore', () => ({
+  SearchStore: MockStore(
+    ['listen', () => jest.fn()],
+    'get',
+    ['getInitialState', () => ({
+      result: {
+        results: {
+          'active-query-id': {
+            searchTypes: {
+              'search-type-id': {
+                effective_timerange: {
+                  type: 'absolute', from: '2021-03-27T14:32:31.894Z', to: '2021-04-26T14:32:48.000Z',
+                },
+              },
+            },
+          },
+        },
+      },
+      widgetMapping: {
+        get: jest.fn(() => ({
+          first: jest.fn(() => 'search-type-id'),
+        })),
+      },
+    })],
+  ),
+}));
+
 describe('TimerangeInfo', () => {
   const widget = Widget.empty();
+
+  it('should display the effective timerange as title', () => {
+    const relativeWidget = widget.toBuilder().timerange({ type: 'relative', range: 3000 }).build();
+    render(<TimerangeInfo widget={relativeWidget} activeQuery="active-query-id" widgetId="widget-id" />);
+
+    expect(screen.getByTitle('2021-03-27T14:32:31.894Z - 2021-04-26T14:32:48.000Z')).toBeInTheDocument();
+  });
 
   it('should display a relative timerange', () => {
     const relativeWidget = widget.toBuilder().timerange({ type: 'relative', range: 3000 }).build();
     render(<TimerangeInfo widget={relativeWidget} />);
 
     expect(screen.getByText('an hour ago - Now')).toBeInTheDocument();
+  });
+
+  it('should display a relative timerange with from and to', () => {
+    const relativeWidget = widget.toBuilder().timerange({ type: 'relative', from: 3000, to: 2000 }).build();
+    render(<TimerangeInfo widget={relativeWidget} />);
+
+    expect(screen.getByText('an hour ago - 33 minutes ago')).toBeInTheDocument();
   });
 
   it('should display a All Time', () => {

--- a/graylog2-web-interface/src/views/components/widgets/TimerangeInfo.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/TimerangeInfo.test.tsx
@@ -28,7 +28,14 @@ describe('TimerangeInfo', () => {
     const relativeWidget = widget.toBuilder().timerange({ type: 'relative', range: 3000 }).build();
     render(<TimerangeInfo widget={relativeWidget} />);
 
-    expect(screen.getByText('an hour ago')).toBeInTheDocument();
+    expect(screen.getByText('an hour ago - Now')).toBeInTheDocument();
+  });
+
+  it('should display a All Time', () => {
+    const relativeWidget = widget.toBuilder().timerange({ type: 'relative', range: 0 }).build();
+    render(<TimerangeInfo widget={relativeWidget} />);
+
+    expect(screen.getByText('All Time')).toBeInTheDocument();
   });
 
   it('should display a absolute timerange', () => {

--- a/graylog2-web-interface/src/views/components/widgets/TimerangeInfo.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/TimerangeInfo.test.tsx
@@ -15,11 +15,11 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import React from 'react';
-import * as Immutable from 'immutable';
 import { render, screen } from 'wrappedTestingLibrary';
 import { MockStore } from 'helpers/mocking';
 
 import Widget from 'views/logic/widgets/Widget';
+import TimeLocalizeContext from 'contexts/TimeLocalizeContext';
 
 import TimerangeInfo from './TimerangeInfo';
 
@@ -53,30 +53,36 @@ jest.mock('views/stores/SearchStore', () => ({
 describe('TimerangeInfo', () => {
   const widget = Widget.empty();
 
+  const SUT = (props) => (
+    <TimeLocalizeContext.Provider value={{ localizeTime: (str) => str }}>
+      <TimerangeInfo {...props} />
+    </TimeLocalizeContext.Provider>
+  );
+
   it('should display the effective timerange as title', () => {
     const relativeWidget = widget.toBuilder().timerange({ type: 'relative', range: 3000 }).build();
-    render(<TimerangeInfo widget={relativeWidget} activeQuery="active-query-id" widgetId="widget-id" />);
+    render(<SUT widget={relativeWidget} activeQuery="active-query-id" widgetId="widget-id" />);
 
     expect(screen.getByTitle('2021-03-27T14:32:31.894Z - 2021-04-26T14:32:48.000Z')).toBeInTheDocument();
   });
 
   it('should display a relative timerange', () => {
     const relativeWidget = widget.toBuilder().timerange({ type: 'relative', range: 3000 }).build();
-    render(<TimerangeInfo widget={relativeWidget} />);
+    render(<SUT widget={relativeWidget} />);
 
     expect(screen.getByText('an hour ago - Now')).toBeInTheDocument();
   });
 
   it('should display a relative timerange with from and to', () => {
     const relativeWidget = widget.toBuilder().timerange({ type: 'relative', from: 3000, to: 2000 }).build();
-    render(<TimerangeInfo widget={relativeWidget} />);
+    render(<SUT widget={relativeWidget} />);
 
     expect(screen.getByText('an hour ago - 33 minutes ago')).toBeInTheDocument();
   });
 
   it('should display a All Time', () => {
     const relativeWidget = widget.toBuilder().timerange({ type: 'relative', range: 0 }).build();
-    render(<TimerangeInfo widget={relativeWidget} />);
+    render(<SUT widget={relativeWidget} />);
 
     expect(screen.getByText('All Time')).toBeInTheDocument();
   });
@@ -85,7 +91,7 @@ describe('TimerangeInfo', () => {
     const absoluteWidget = widget.toBuilder()
       .timerange({ type: 'absolute', from: '2021-03-27T14:32:31.894Z', to: '2021-04-26T14:32:48.000Z' })
       .build();
-    render(<TimerangeInfo widget={absoluteWidget} />);
+    render(<SUT widget={absoluteWidget} />);
 
     expect(screen.getByText('2021-03-27T14:32:31.894Z - 2021-04-26T14:32:48.000Z')).toBeInTheDocument();
   });
@@ -94,7 +100,7 @@ describe('TimerangeInfo', () => {
     const keywordWidget = widget.toBuilder()
       .timerange({ type: 'keyword', keyword: '5 minutes ago' })
       .build();
-    render(<TimerangeInfo widget={keywordWidget} />);
+    render(<SUT widget={keywordWidget} />);
 
     expect(screen.getByText('5 minutes ago')).toBeInTheDocument();
   });

--- a/graylog2-web-interface/src/views/components/widgets/TimerangeInfo.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/TimerangeInfo.test.tsx
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import React from 'react';
+import { render, screen } from 'wrappedTestingLibrary';
+
+import Widget from 'views/logic/widgets/Widget';
+
+import TimerangeInfo from './TimerangeInfo';
+
+describe('TimerangeInfo', () => {
+  const widget = Widget.empty();
+
+  it('should display a relative timerange', () => {
+    const relativeWidget = widget.toBuilder().timerange({ type: 'relative', range: 3000 }).build();
+    render(<TimerangeInfo widget={relativeWidget} />);
+
+    expect(screen.getByText('an hour ago')).toBeInTheDocument();
+  });
+
+  it('should display a absolute timerange', () => {
+    const absoluteWidget = widget.toBuilder()
+      .timerange({ type: 'absolute', from: '2021-03-27T14:32:31.894Z', to: '2021-04-26T14:32:48.000Z' })
+      .build();
+    render(<TimerangeInfo widget={absoluteWidget} />);
+
+    expect(screen.getByText('2021-03-27T14:32:31.894Z - 2021-04-26T14:32:48.000Z')).toBeInTheDocument();
+  });
+
+  it('should display a keyword timerange', () => {
+    const keywordWidget = widget.toBuilder()
+      .timerange({ type: 'keyword', keyword: '5 minutes ago' })
+      .build();
+    render(<TimerangeInfo widget={keywordWidget} />);
+
+    expect(screen.getByText('5 minutes ago')).toBeInTheDocument();
+  });
+});

--- a/graylog2-web-interface/src/views/components/widgets/TimerangeInfo.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/TimerangeInfo.tsx
@@ -40,7 +40,7 @@ const Wrapper = styled.div(({ theme }) => css`
 const TimerangeInfo = ({ className, widget, activeQuery, widgetId }: Props) => {
   const configuredTimerange = timerangeToString(widget.timerange || DEFAULT_TIMERANGE);
   const { result, widgetMapping } = useStore(SearchStore);
-  const searchTypeId = widgetMapping.get(widgetId).first();
+  const searchTypeId = widgetId ? widgetMapping.get(widgetId).first() : undefined;
   const effectiveTimerange = activeQuery && searchTypeId ? result?.results[activeQuery].searchTypes[searchTypeId].effective_timerange : {};
   const effectiveTimerangeString = timerangeToString(effectiveTimerange);
 

--- a/graylog2-web-interface/src/views/components/widgets/TimerangeInfo.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/TimerangeInfo.tsx
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import styled, { css } from 'styled-components';
+
+import { TextOverflowEllipsis } from 'components/common';
+import { AbsoluteTimeRange } from 'views/logic/queries/Query';
+import { Result } from 'views/components/widgets/Widget';
+import Widget from 'views/logic/widgets/Widget';
+import timerangeToString from 'views/logic/queries/TimeRangeToString';
+
+type Props = {
+  className?: string,
+  widget: Widget,
+};
+
+const Wrapper = styled.div(({ theme }) => css`
+  font-size: ${theme.fonts.size.tiny};
+  color: ${theme.colors.gray[30]};
+  width: max-content;
+`);
+
+const TimerangeInfo = ({ className, widget }: Props) => {
+  const configuredTimerange = timerangeToString(widget.timerange);
+
+  return (
+    <Wrapper className={className}>
+      <TextOverflowEllipsis>
+        {configuredTimerange}
+      </TextOverflowEllipsis>
+    </Wrapper>
+  );
+};
+
+TimerangeInfo.defaultProps = {
+  className: undefined,
+};
+
+export default TimerangeInfo;

--- a/graylog2-web-interface/src/views/components/widgets/TimerangeInfo.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/TimerangeInfo.tsx
@@ -15,6 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
+import { useContext } from 'react';
 import styled, { css } from 'styled-components';
 
 import { TextOverflowEllipsis } from 'components/common';
@@ -23,6 +24,7 @@ import timerangeToString from 'views/logic/queries/TimeRangeToString';
 import { DEFAULT_TIMERANGE } from 'views/Constants';
 import { useStore } from 'stores/connect';
 import { SearchStore } from 'views/stores/SearchStore';
+import TimeLocalizeContext from 'contexts/TimeLocalizeContext';
 
 type Props = {
   className?: string,
@@ -38,11 +40,13 @@ const Wrapper = styled.div(({ theme }) => css`
 `);
 
 const TimerangeInfo = ({ className, widget, activeQuery, widgetId }: Props) => {
-  const configuredTimerange = timerangeToString(widget.timerange || DEFAULT_TIMERANGE);
+  const { localizeTime } = useContext(TimeLocalizeContext);
+  const configuredTimerange = timerangeToString(widget.timerange || DEFAULT_TIMERANGE, localizeTime);
   const { result, widgetMapping } = useStore(SearchStore);
   const searchTypeId = widgetId ? widgetMapping.get(widgetId).first() : undefined;
-  const effectiveTimerange = activeQuery && searchTypeId ? result?.results[activeQuery].searchTypes[searchTypeId].effective_timerange : {};
-  const effectiveTimerangeString = timerangeToString(effectiveTimerange);
+  const effectiveTimerange = activeQuery && searchTypeId ? result?.results[activeQuery]
+    .searchTypes[searchTypeId].effective_timerange : {};
+  const effectiveTimerangeString = timerangeToString(effectiveTimerange, localizeTime);
 
   return (
     <Wrapper className={className}>

--- a/graylog2-web-interface/src/views/components/widgets/TimerangeInfo.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/TimerangeInfo.tsx
@@ -18,8 +18,6 @@ import * as React from 'react';
 import styled, { css } from 'styled-components';
 
 import { TextOverflowEllipsis } from 'components/common';
-import { AbsoluteTimeRange } from 'views/logic/queries/Query';
-import { Result } from 'views/components/widgets/Widget';
 import Widget from 'views/logic/widgets/Widget';
 import timerangeToString from 'views/logic/queries/TimeRangeToString';
 

--- a/graylog2-web-interface/src/views/components/widgets/TimerangeInfo.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/TimerangeInfo.tsx
@@ -20,6 +20,7 @@ import styled, { css } from 'styled-components';
 import { TextOverflowEllipsis } from 'components/common';
 import Widget from 'views/logic/widgets/Widget';
 import timerangeToString from 'views/logic/queries/TimeRangeToString';
+import { DEFAULT_TIMERANGE } from 'views/Constants';
 
 type Props = {
   className?: string,
@@ -33,7 +34,7 @@ const Wrapper = styled.div(({ theme }) => css`
 `);
 
 const TimerangeInfo = ({ className, widget }: Props) => {
-  const configuredTimerange = timerangeToString(widget.timerange);
+  const configuredTimerange = timerangeToString(widget.timerange || DEFAULT_TIMERANGE);
 
   return (
     <Wrapper className={className}>

--- a/graylog2-web-interface/src/views/components/widgets/TimerangeInfo.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/TimerangeInfo.tsx
@@ -21,10 +21,14 @@ import { TextOverflowEllipsis } from 'components/common';
 import Widget from 'views/logic/widgets/Widget';
 import timerangeToString from 'views/logic/queries/TimeRangeToString';
 import { DEFAULT_TIMERANGE } from 'views/Constants';
+import { useStore } from 'stores/connect';
+import { SearchStore } from 'views/stores/SearchStore';
 
 type Props = {
   className?: string,
   widget: Widget,
+  activeQuery?: string,
+  widgetId?: string,
 };
 
 const Wrapper = styled.div(({ theme }) => css`
@@ -33,12 +37,16 @@ const Wrapper = styled.div(({ theme }) => css`
   width: max-content;
 `);
 
-const TimerangeInfo = ({ className, widget }: Props) => {
+const TimerangeInfo = ({ className, widget, activeQuery, widgetId }: Props) => {
   const configuredTimerange = timerangeToString(widget.timerange || DEFAULT_TIMERANGE);
+  const { result, widgetMapping } = useStore(SearchStore);
+  const searchTypeId = widgetMapping.get(widgetId).first();
+  const effectiveTimerange = activeQuery && searchTypeId ? result?.results[activeQuery].searchTypes[searchTypeId].effective_timerange : {};
+  const effectiveTimerangeString = timerangeToString(effectiveTimerange);
 
   return (
     <Wrapper className={className}>
-      <TextOverflowEllipsis>
+      <TextOverflowEllipsis titleOverride={effectiveTimerangeString}>
         {configuredTimerange}
       </TextOverflowEllipsis>
     </Wrapper>
@@ -47,6 +55,8 @@ const TimerangeInfo = ({ className, widget }: Props) => {
 
 TimerangeInfo.defaultProps = {
   className: undefined,
+  activeQuery: undefined,
+  widgetId: undefined,
 };
 
 export default TimerangeInfo;

--- a/graylog2-web-interface/src/views/components/widgets/TimerangeInfo.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/TimerangeInfo.tsx
@@ -25,6 +25,7 @@ import { DEFAULT_TIMERANGE } from 'views/Constants';
 import { useStore } from 'stores/connect';
 import { SearchStore } from 'views/stores/SearchStore';
 import TimeLocalizeContext from 'contexts/TimeLocalizeContext';
+import { GlobalOverrideStore } from 'views/stores/GlobalOverrideStore';
 
 type Props = {
   className?: string,
@@ -41,8 +42,14 @@ const Wrapper = styled.div(({ theme }) => css`
 
 const TimerangeInfo = ({ className, widget, activeQuery, widgetId }: Props) => {
   const { localizeTime } = useContext(TimeLocalizeContext);
-  const configuredTimerange = timerangeToString(widget.timerange || DEFAULT_TIMERANGE, localizeTime);
   const { result, widgetMapping } = useStore(SearchStore);
+  const globalOverride = useStore(GlobalOverrideStore);
+
+  const globalTimerangeString = globalOverride?.timerange
+    ? `Global Override: ${timerangeToString(globalOverride.timerange)}` : undefined;
+
+  const configuredTimerange = timerangeToString(widget.timerange || DEFAULT_TIMERANGE, localizeTime);
+
   const searchTypeId = widgetId ? widgetMapping.get(widgetId).first() : undefined;
   const effectiveTimerange = activeQuery && searchTypeId ? result?.results[activeQuery]
     .searchTypes[searchTypeId].effective_timerange : {};
@@ -51,7 +58,7 @@ const TimerangeInfo = ({ className, widget, activeQuery, widgetId }: Props) => {
   return (
     <Wrapper className={className}>
       <TextOverflowEllipsis titleOverride={effectiveTimerangeString}>
-        {configuredTimerange}
+        {globalTimerangeString || configuredTimerange}
       </TextOverflowEllipsis>
     </Wrapper>
   );

--- a/graylog2-web-interface/src/views/components/widgets/Widget.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/Widget.tsx
@@ -279,7 +279,7 @@ class Widget extends React.Component<Props, State> {
           )}
           <WidgetFooter>
             <IfDashboard>
-              { !editing && <TimerangeInfo widget={widget} /> }
+              { !editing && <TimerangeInfo widget={widget} activeQuery={view.activeQuery} widgetId={id} /> }
             </IfDashboard>
           </WidgetFooter>
         </WidgetFrame>

--- a/graylog2-web-interface/src/views/components/widgets/Widget.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/Widget.tsx
@@ -36,6 +36,7 @@ import type { AbsoluteTimeRange } from 'views/logic/queries/Query';
 import WidgetFocusContext from 'views/components/contexts/WidgetFocusContext';
 import type VisualizationConfig from 'views/logic/aggregationbuilder/visualizations/VisualizationConfig';
 import TimerangeInfo from 'views/components/widgets/TimerangeInfo';
+import IfDashboard from 'views/components/dashboard/IfDashboard';
 
 import WidgetFrame from './WidgetFrame';
 import WidgetHeader from './WidgetHeader';
@@ -277,7 +278,9 @@ class Widget extends React.Component<Props, State> {
             </WidgetErrorBoundary>
           )}
           <WidgetFooter>
-            <TimerangeInfo widget={widget} />
+            <IfDashboard>
+              { !editing && <TimerangeInfo widget={widget} /> }
+            </IfDashboard>
           </WidgetFooter>
         </WidgetFrame>
       </WidgetColorContext>

--- a/graylog2-web-interface/src/views/components/widgets/Widget.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/Widget.tsx
@@ -17,6 +17,7 @@
 import * as React from 'react';
 import * as Immutable from 'immutable';
 import PropTypes from 'prop-types';
+import styled from 'styled-components';
 
 import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
 import connect from 'stores/connect';
@@ -34,6 +35,7 @@ import type { Rows } from 'views/logic/searchtypes/pivot/PivotHandler';
 import type { AbsoluteTimeRange } from 'views/logic/queries/Query';
 import WidgetFocusContext from 'views/components/contexts/WidgetFocusContext';
 import type VisualizationConfig from 'views/logic/aggregationbuilder/visualizations/VisualizationConfig';
+import TimerangeInfo from 'views/components/widgets/TimerangeInfo';
 
 import WidgetFrame from './WidgetFrame';
 import WidgetHeader from './WidgetHeader';
@@ -94,6 +96,12 @@ const _visualizationForType = (type) => {
 const _editComponentForType = (type) => {
   return widgetDefinition(type).editComponent;
 };
+
+const WidgetFooter = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: flex-end;
+`;
 
 class Widget extends React.Component<Props, State> {
   static propTypes = {
@@ -268,6 +276,9 @@ class Widget extends React.Component<Props, State> {
               {visualization}
             </WidgetErrorBoundary>
           )}
+          <WidgetFooter>
+            <TimerangeInfo widget={widget} />
+          </WidgetFooter>
         </WidgetFrame>
       </WidgetColorContext>
     );

--- a/graylog2-web-interface/src/views/components/widgets/WidgetFrame.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/WidgetFrame.jsx
@@ -21,7 +21,7 @@ import styled, { css } from 'styled-components';
 const WidgetWrap = styled.div(({ theme }) => css`
   height: inherit;
   margin: 0;
-  padding: 12px 15px 15px 15px;
+  padding: 12px 15px 6px 15px;
   display: flex;
   flex-direction: column;
 
@@ -176,6 +176,7 @@ export default class extends React.Component {
 
     return (
       <WidgetWrap ref={(elem) => { this._widgetNode = elem; }}
+                  style={{ overflow: 'hidden' }}
                   data-widget-id={widgetId}>
         {children}
       </WidgetWrap>

--- a/graylog2-web-interface/src/views/logic/queries/TimeRangeToString.ts
+++ b/graylog2-web-interface/src/views/logic/queries/TimeRangeToString.ts
@@ -37,22 +37,22 @@ const relativeTimeRangeToString = (timerange: RelativeTimeRange): string => {
   return `${readableRange(timerange, 'from')} - ${readableRange(timerange, 'to', 'Now')}`;
 };
 
-const absoluteTimeRangeToString = (timerange: AbsoluteTimeRange): string => {
+const absoluteTimeRangeToString = (timerange: AbsoluteTimeRange, localizer = (str) => str): string => {
   const { from, to } = timerange;
 
-  return `${from} - ${to}`;
+  return `${localizer(from)} - ${localizer(to)}`;
 };
 
 const keywordTimeRangeToString = (timerange: KeywordTimeRange): string => {
   return timerange.keyword;
 };
 
-const TimeRangeToString = (timerange?: TimeRange): string => {
+const TimeRangeToString = (timerange?: TimeRange, localizer?: (string) => string): string => {
   const { type } = timerange || {};
 
   switch (type) {
     case 'relative': return relativeTimeRangeToString(timerange as RelativeTimeRange);
-    case 'absolute': return absoluteTimeRangeToString(timerange as AbsoluteTimeRange);
+    case 'absolute': return absoluteTimeRangeToString(timerange as AbsoluteTimeRange, localizer);
     case 'keyword': return keywordTimeRangeToString(timerange as KeywordTimeRange);
 
     default: {

--- a/graylog2-web-interface/src/views/logic/queries/TimeRangeToString.ts
+++ b/graylog2-web-interface/src/views/logic/queries/TimeRangeToString.ts
@@ -16,7 +16,7 @@
  */
 
 import { AbsoluteTimeRange, KeywordTimeRange, RelativeTimeRange, TimeRange } from 'views/logic/queries/Query';
-import { isTypeRelative } from 'views/typeGuards/timeRange';
+import { isTypeRelativeWithStartOnly } from 'views/typeGuards/timeRange';
 import DateTime from 'logic/datetimes/DateTime';
 
 export const readableRange = (timerange: TimeRange, fieldName: 'range' | 'from' | 'to', placeholder = 'All Time') => {
@@ -26,11 +26,15 @@ export const readableRange = (timerange: TimeRange, fieldName: 'range' | 'from' 
 };
 
 const relativeTimeRangeToString = (timerange: RelativeTimeRange): string => {
-  if (isTypeRelative(timerange)) {
-    return readableRange(timerange, 'range');
+  if (isTypeRelativeWithStartOnly(timerange)) {
+    if (timerange.range === 0) {
+      return 'All Time';
+    }
+
+    return `${readableRange(timerange, 'range')} - Now`;
   }
 
-  return `${readableRange(timerange, 'from')} - ${readableRange(timerange, 'to')}`;
+  return `${readableRange(timerange, 'from')} - ${readableRange(timerange, 'to', 'Now')}`;
 };
 
 const absoluteTimeRangeToString = (timerange: AbsoluteTimeRange): string => {

--- a/graylog2-web-interface/src/views/logic/queries/TimeRangeToString.ts
+++ b/graylog2-web-interface/src/views/logic/queries/TimeRangeToString.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+
+import { AbsoluteTimeRange, KeywordTimeRange, RelativeTimeRange, TimeRange } from 'views/logic/queries/Query';
+import { isTypeRelative } from 'views/typeGuards/timeRange';
+import DateTime from 'logic/datetimes/DateTime';
+
+export const readableRange = (timerange: TimeRange, fieldName: 'range' | 'from' | 'to', placeholder = 'All Time') => {
+  return !timerange[fieldName] ? placeholder : DateTime.now()
+    .subtract(timerange[fieldName] * 1000)
+    .fromNow();
+};
+
+const relativeTimeRangeToString = (timerange: RelativeTimeRange): string => {
+  if (isTypeRelative(timerange)) {
+    return readableRange(timerange, 'range');
+  }
+
+  return `${readableRange(timerange, 'from')} - ${readableRange(timerange, 'to')}`;
+};
+
+const absoluteTimeRangeToString = (timerange: AbsoluteTimeRange): string => {
+  const { from, to } = timerange;
+
+  return `${from} - ${to}`;
+};
+
+const keywordTimeRangeToString = (timerange: KeywordTimeRange): string => {
+  return timerange.keyword;
+};
+
+const TimeRangeToString = (timerange?: TimeRange): string => {
+  const { type } = timerange || {};
+
+  switch (type) {
+    case 'relative': return relativeTimeRangeToString(timerange as RelativeTimeRange);
+    case 'absolute': return absoluteTimeRangeToString(timerange as AbsoluteTimeRange);
+    case 'keyword': return keywordTimeRangeToString(timerange as KeywordTimeRange);
+
+    default: {
+      return '';
+    }
+  }
+};
+
+export default TimeRangeToString;


### PR DESCRIPTION
## Description
Display the configured time range of a widget in dashboards.

## Motivation and Context
Having a different time range for each widget configured on a dashboard, can make it hard to remember those settings.
So we now display that information in the footer of the widget.

## How Has This Been Tested?
- Create a widget
- Set relative/absolute/keyword timerange
- Check the result in the dashboard

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

![Graylog (2)](https://user-images.githubusercontent.com/448763/116102505-0ea34200-a6af-11eb-9eb3-13cdf717a23c.png)

