### PR TITLE
Add a new input plugin to accept array or stream of messages over http

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/inputs/codecs/CodecsModule.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/codecs/CodecsModule.java
@@ -40,5 +40,6 @@ public class CodecsModule extends Graylog2Module {
         installCodec(mapBinder, RandomHttpMessageCodec.class);
         installCodec(mapBinder, GelfCodec.class);
         installCodec(mapBinder, JsonPathCodec.class);
+        installCodec(mapBinder, GelfBatchCodec.class);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/inputs/codecs/GelfBatchCodec.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/codecs/GelfBatchCodec.java
@@ -1,0 +1,381 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.inputs.codecs;
+
+import com.eaio.uuid.UUID;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.inject.assistedinject.Assisted;
+import org.apache.commons.lang3.StringUtils;
+import org.graylog2.inputs.codecs.gelf.GELFMessage;
+import org.graylog2.inputs.transports.TcpTransport;
+import org.graylog2.plugin.Message;
+import org.graylog2.plugin.ResolvableInetSocketAddress;
+import org.graylog2.plugin.Tools;
+import org.graylog2.plugin.configuration.Configuration;
+import org.graylog2.plugin.configuration.ConfigurationRequest;
+import org.graylog2.plugin.configuration.fields.ConfigurationField;
+import org.graylog2.plugin.configuration.fields.NumberField;
+import org.graylog2.plugin.inputs.annotations.Codec;
+import org.graylog2.plugin.inputs.annotations.ConfigClass;
+import org.graylog2.plugin.inputs.annotations.FactoryClass;
+import org.graylog2.plugin.inputs.codecs.AbstractCodec;
+import org.graylog2.plugin.inputs.codecs.CodecAggregator;
+import org.graylog2.plugin.inputs.codecs.MultiMessageCodec;
+import org.graylog2.plugin.inputs.transports.NettyTransport;
+import org.graylog2.plugin.journal.RawMessage;
+import org.joda.time.DateTime;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.inject.Inject;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Map;
+
+@Codec(name = "gelfbatch", displayName = "GELFBATCH")
+public class GelfBatchCodec extends AbstractCodec implements MultiMessageCodec {
+    private static final Logger log = LoggerFactory.getLogger(GelfBatchCodec.class);
+    private static final String CK_DECOMPRESS_SIZE_LIMIT = "decompress_size_limit";
+    private static final int DEFAULT_DECOMPRESS_SIZE_LIMIT = 8388608;
+
+    private final GelfChunkAggregator aggregator;
+    private final ObjectMapper objectMapper;
+    private final long decompressSizeLimit;
+
+    @Inject
+    public GelfBatchCodec(@Assisted Configuration configuration, GelfChunkAggregator aggregator) {
+        super(configuration);
+        this.aggregator = aggregator;
+        this.objectMapper = new ObjectMapper().enable(
+                JsonParser.Feature.ALLOW_UNQUOTED_CONTROL_CHARS,
+                JsonParser.Feature.ALLOW_TRAILING_COMMA);
+        this.decompressSizeLimit = configuration.getInt(CK_DECOMPRESS_SIZE_LIMIT, DEFAULT_DECOMPRESS_SIZE_LIMIT);
+    }
+
+    private static String stringValue(final JsonNode json, final String fieldName) {
+        if (json != null) {
+            final JsonNode value = json.get(fieldName);
+
+            if (value != null) {
+                return value.asText();
+            }
+        }
+        return null;
+    }
+
+    private static long longValue(final JsonNode json, final String fieldName) {
+        if (json != null) {
+            final JsonNode value = json.get(fieldName);
+
+            if (value != null) {
+                return value.asLong(-1L);
+            }
+        }
+        return -1L;
+    }
+
+    private static int intValue(final JsonNode json, final String fieldName) {
+        if (json != null) {
+            final JsonNode value = json.get(fieldName);
+
+            if (value != null) {
+                return value.asInt(-1);
+            }
+        }
+        return -1;
+    }
+
+    private static double timestampValue(final JsonNode json) {
+        final JsonNode value = json.path(Message.FIELD_TIMESTAMP);
+        if (value.isNumber()) {
+            return value.asDouble(-1.0);
+        } else if (value.isTextual()) {
+            try {
+                return Double.parseDouble(value.asText());
+            } catch (NumberFormatException e) {
+                log.debug("Unable to parse timestamp", e);
+                return -1.0;
+            }
+        } else {
+            return -1.0;
+        }
+    }
+
+    @Nullable
+    @Override
+    public Message decode(@Nonnull final RawMessage rawMessage) {
+        final GELFMessage gelfMessage = new GELFMessage(rawMessage.getPayload(), rawMessage.getRemoteAddress());
+        final String json = gelfMessage.getJSON(decompressSizeLimit);
+        final JsonNode node = decodeJson(json);
+
+        return decodeOne(node, rawMessage, 0);
+    }
+
+    private JsonNode decodeJson(final String json) {
+        final JsonNode node;
+        try {
+            node = objectMapper.readTree(json);
+        } catch (final Exception e) {
+            log.error("Could not parse JSON, first 400 characters: " +
+                    StringUtils.abbreviate(json, 403), e);
+            throw new IllegalStateException("JSON is null/could not be parsed (invalid JSON)", e);
+        }
+        return node;
+    }
+
+    private Message decodeOne(final JsonNode node, @Nonnull RawMessage rawMessage, int position) {
+        validateGELFMessage(node, rawMessage.getId(), rawMessage.getRemoteAddress(), position);
+
+        // Timestamp.
+        final double messageTimestamp = timestampValue(node);
+        final DateTime timestamp;
+        if (messageTimestamp <= 0) {
+            timestamp = rawMessage.getTimestamp();
+        } else {
+            // we treat this as a unix timestamp
+            timestamp = Tools.dateTimeFromDouble(messageTimestamp);
+        }
+
+        final Message message = new Message(
+                stringValue(node, "short_message"),
+                stringValue(node, "host"),
+                timestamp
+        );
+
+        message.addField(Message.FIELD_FULL_MESSAGE, stringValue(node, "full_message"));
+
+        final String file = stringValue(node, "file");
+
+        if (file != null && !file.isEmpty()) {
+            message.addField("file", file);
+        }
+
+        final long line = longValue(node, "line");
+        if (line > -1) {
+            message.addField("line", line);
+        }
+
+        // Level is set by server if not specified by client.
+        final int level = intValue(node, "level");
+        if (level > -1) {
+            message.addField("level", level);
+        }
+
+        // Facility is set by server if not specified by client.
+        final String facility = stringValue(node, "facility");
+        if (facility != null && !facility.isEmpty()) {
+            message.addField("facility", facility);
+        }
+
+        // Add additional data if there is some.
+        final Iterator<Map.Entry<String, JsonNode>> fields = node.fields();
+
+        while (fields.hasNext()) {
+            final Map.Entry<String, JsonNode> entry = fields.next();
+
+            String key = entry.getKey();
+            // Do not index useless GELF "version" field.
+            if ("version".equals(key)) {
+                continue;
+            }
+
+            // Don't include GELF syntax underscore in message field key.
+            if (key.startsWith("_") && key.length() > 1) {
+                key = key.substring(1);
+            }
+
+            // We already set short_message and host as message and source. Do not add as fields again.
+            if ("short_message".equals(key) || "host".equals(key)) {
+                continue;
+            }
+
+            // Skip standard or already set fields.
+            if (message.getField(key) != null || Message.RESERVED_FIELDS.contains(key) && !Message.RESERVED_SETTABLE_FIELDS.contains(key)) {
+                continue;
+            }
+
+            // Convert JSON containers to Strings, and pick a suitable number representation.
+            final JsonNode value = entry.getValue();
+
+            final Object fieldValue;
+            if (value.isContainerNode()) {
+                fieldValue = value.toString();
+            } else if (value.isFloatingPointNumber()) {
+                fieldValue = value.asDouble();
+            } else if (value.isIntegralNumber()) {
+                fieldValue = value.asLong();
+            } else if (value.isNull()) {
+                log.debug("Field [{}] is NULL. Skipping.", key);
+                continue;
+            } else if (value.isTextual()) {
+                fieldValue = value.asText();
+            } else {
+                log.debug("Field [{}] has unknown value type. Skipping.", key);
+                continue;
+            }
+
+            message.addField(key, fieldValue);
+        }
+
+        return message;
+    }
+
+    private void validateGELFMessage(JsonNode jsonNode, UUID id, ResolvableInetSocketAddress remoteAddress,
+                                     int position) {
+
+        final String prefix = "GELF message <" + id + (position > 0 ? "#" + position : "") +"> " +
+                (remoteAddress == null ? "" : "(received from <" + remoteAddress + ">) ");
+
+        final JsonNode hostNode = jsonNode.path("host");
+        if (hostNode.isMissingNode()) {
+            log.warn(prefix + "is missing mandatory \"host\" field.");
+        } else {
+            if (!hostNode.isTextual()) {
+                throw new IllegalArgumentException(prefix + "has invalid \"host\": " + hostNode.asText());
+            }
+            if (StringUtils.isBlank(hostNode.asText())) {
+                throw new IllegalArgumentException(prefix + "has empty mandatory \"host\" field.");
+            }
+        }
+
+        final JsonNode shortMessageNode = jsonNode.path("short_message");
+        final JsonNode messageNode = jsonNode.path("message");
+        if (!shortMessageNode.isMissingNode()) {
+            if (!shortMessageNode.isTextual()) {
+                throw new IllegalArgumentException(prefix + "has invalid \"short_message\": " + shortMessageNode.asText());
+            }
+            if (StringUtils.isBlank(shortMessageNode.asText()) && StringUtils.isBlank(messageNode.asText())) {
+                throw new IllegalArgumentException(prefix + "has empty mandatory \"short_message\" field.");
+            }
+        } else if (!messageNode.isMissingNode()) {
+            if (!messageNode.isTextual()) {
+                throw new IllegalArgumentException(prefix + "has invalid \"message\": " + messageNode.asText());
+            }
+            if (StringUtils.isBlank(messageNode.asText())) {
+                throw new IllegalArgumentException(prefix + "has empty mandatory \"message\" field.");
+            }
+        } else {
+            throw new IllegalArgumentException(prefix + "is missing mandatory \"short_message\" or \"message\" field.");
+        }
+
+        final JsonNode timestampNode = jsonNode.path("timestamp");
+        if (timestampNode.isValueNode() && !timestampNode.isNumber()) {
+            log.warn(prefix + "has invalid \"timestamp\": {}  (type: {})", timestampNode.asText(), timestampNode.getNodeType().name());
+        }
+    }
+
+    @Nullable
+    @Override
+    public CodecAggregator getAggregator() {
+        return aggregator;
+    }
+
+    @Nullable
+    @Override
+    public Collection<Message> decodeMessages(@Nonnull RawMessage rawMessage) {
+        final GELFMessage gelfMessage = new GELFMessage(rawMessage.getPayload(), rawMessage.getRemoteAddress());
+        final String json = gelfMessage.getJSON(decompressSizeLimit);
+
+        final JsonNode node = decodeJson(json);
+        ArrayList<Message> messages = new ArrayList<>();
+
+        try {
+            if (node.isArray()) {
+                for (int i = 0; i < node.size(); i++) {
+                    try {
+                        messages.add(decodeOne(node.get(i), rawMessage, i));
+                    }catch (Exception e) {
+                        log.warn("error decoding json array",e);
+                    }
+                }
+            } else {
+                int i=0;
+                for (String jsonChunk : json.split("\\r?\\n")) {
+                    try {
+                        final JsonNode jsonChunkNode = decodeJson(jsonChunk);
+                        messages.add(decodeOne(jsonChunkNode, rawMessage,i));
+                        i++;
+                    } catch (Exception ignored) {
+                        log.warn("debug json messages {}",json);
+                        log.warn("error decoding json message",ignored);
+                    }
+                }
+            }
+        }catch (Exception e){
+            //should not happen since we are checking both array and normal string
+            log.warn("error checking the node type",e);
+        }
+
+        if (messages.isEmpty()) {
+            throw new IllegalStateException("could not find any valid json in the packet");
+        }
+
+        return messages;
+    }
+
+    @FactoryClass
+    public interface Factory extends AbstractCodec.Factory<GelfBatchCodec> {
+        @Override
+        GelfBatchCodec create(Configuration configuration);
+
+        @Override
+        Config getConfig();
+
+        @Override
+        Descriptor getDescriptor();
+    }
+
+    @ConfigClass
+    public static class Config extends AbstractCodec.Config {
+        @Override
+        public ConfigurationRequest getRequestedConfiguration() {
+            final ConfigurationRequest requestedConfiguration = super.getRequestedConfiguration();
+            requestedConfiguration.addField(new NumberField(
+                    CK_DECOMPRESS_SIZE_LIMIT,
+                    "Decompressed size limit",
+                    DEFAULT_DECOMPRESS_SIZE_LIMIT,
+                    "The maximum number of bytes after decompression.",
+                    ConfigurationField.Optional.OPTIONAL));
+
+            return requestedConfiguration;
+        }
+
+        @Override
+        public void overrideDefaultValues(@Nonnull ConfigurationRequest cr) {
+            if (cr.containsField(NettyTransport.CK_PORT)) {
+                cr.getField(NettyTransport.CK_PORT).setDefaultValue(12201);
+            }
+
+            // GELF TCP always needs null-byte delimiter!
+            if (cr.containsField(TcpTransport.CK_USE_NULL_DELIMITER)) {
+                cr.getField(TcpTransport.CK_USE_NULL_DELIMITER).setDefaultValue(true);
+            }
+        }
+    }
+
+    public static class Descriptor extends AbstractCodec.Descriptor {
+        @Inject
+        public Descriptor() {
+            super(GelfBatchCodec.class.getAnnotation(Codec.class).displayName());
+        }
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/inputs/gelf/http/GELFHttpBatchInput.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/gelf/http/GELFHttpBatchInput.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.inputs.gelf.http;
+
+import com.codahale.metrics.MetricRegistry;
+import com.google.inject.assistedinject.Assisted;
+import com.google.inject.assistedinject.AssistedInject;
+import org.graylog2.inputs.codecs.GelfBatchCodec;
+import org.graylog2.inputs.codecs.GelfCodec;
+import org.graylog2.inputs.transports.HttpTransport;
+import org.graylog2.plugin.LocalMetricRegistry;
+import org.graylog2.plugin.ServerStatus;
+import org.graylog2.plugin.configuration.Configuration;
+import org.graylog2.plugin.inputs.MessageInput;
+
+import javax.inject.Inject;
+
+public class GELFHttpBatchInput extends MessageInput {
+
+    private static final String NAME = "GELF HTTP-BATCH";
+
+    @AssistedInject
+    public GELFHttpBatchInput(MetricRegistry metricRegistry,
+                              @Assisted Configuration configuration,
+                              HttpTransport.Factory httpTransportFactory,
+                              GelfBatchCodec.Factory gelfBatchCodecFactory, LocalMetricRegistry localRegistry, Config config, Descriptor descriptor, ServerStatus serverStatus) {
+        super(metricRegistry, configuration, httpTransportFactory.create(configuration),
+                localRegistry,
+                gelfBatchCodecFactory.create(configuration), config, descriptor, serverStatus);
+    }
+
+    public interface Factory extends MessageInput.Factory<GELFHttpBatchInput> {
+        @Override
+        GELFHttpBatchInput create(Configuration configuration);
+
+        @Override
+        Config getConfig();
+
+        @Override
+        Descriptor getDescriptor();
+    }
+
+    public static class Descriptor extends MessageInput.Descriptor {
+        @Inject
+        public Descriptor() {
+            super(NAME, false, "");
+        }
+    }
+
+    public static class Config extends MessageInput.Config {
+        @Inject
+        public Config(HttpTransport.Factory transport, GelfBatchCodec.Factory codec) {
+            super(transport.getConfig(), codec.getConfig());
+        }
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/inputs/transports/netty/HttpHandler.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/transports/netty/HttpHandler.java
@@ -57,7 +57,8 @@ public class HttpHandler extends SimpleChannelInboundHandler<HttpRequest> {
         }
 
         final boolean correctPath = "/gelf".equals(request.uri());
-        if (correctPath && request instanceof FullHttpRequest) {
+        final boolean correctPathBatch = "/gelfbatch".equals(request.uri());
+        if ((correctPath || correctPathBatch) && request instanceof FullHttpRequest) {
             final FullHttpRequest fullHttpRequest = (FullHttpRequest) request;
             final ByteBuf buffer = fullHttpRequest.content();
 

--- a/graylog2-server/src/main/java/org/graylog2/shared/bindings/MessageInputBindings.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/bindings/MessageInputBindings.java
@@ -37,6 +37,7 @@ import org.graylog2.inputs.syslog.udp.SyslogUDPInput;
 import org.graylog2.inputs.transports.TransportsModule;
 import org.graylog2.plugin.inject.Graylog2Module;
 import org.graylog2.plugin.inputs.MessageInput;
+import org.graylog2.inputs.gelf.http.GELFHttpBatchInput;
 
 public class MessageInputBindings extends Graylog2Module {
     @Override
@@ -61,6 +62,7 @@ public class MessageInputBindings extends Graylog2Module {
         installInput(inputMapBinder, GELFAMQPInput.class, GELFAMQPInput.Factory.class);
         installInput(inputMapBinder, GELFKafkaInput.class, GELFKafkaInput.Factory.class);
         installInput(inputMapBinder, JsonPathInput.class, JsonPathInput.Factory.class);
+        installInput(inputMapBinder, GELFHttpBatchInput.class, GELFHttpBatchInput.Factory.class);
 
         install(new BeatsInputPluginModule());
     }

--- a/graylog2-server/src/test/java/org/graylog2/inputs/codecs/GelfBatchCodecTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/inputs/codecs/GelfBatchCodecTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.inputs.codecs;
+
+import org.graylog2.plugin.configuration.Configuration;
+import org.graylog2.plugin.journal.RawMessage;
+import org.graylog2.plugin.Message;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+
+public class GelfBatchCodecTest {
+    @Rule
+    public final MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    @Rule
+    public final ExpectedException expectedException = ExpectedException.none();
+
+    @Mock
+    private GelfChunkAggregator aggregator;
+
+    private GelfBatchCodec codec;
+
+    @Before
+    public void setUp() {
+        codec = new GelfBatchCodec(new Configuration(Collections.emptyMap()), aggregator);
+    }
+
+    @Test
+    public void decodeMessagesSuccedsWithStream() throws Exception {
+        final String json = "{"
+                + "\"version\": \"1.1\","
+                + "\"host\": \"example.org\","
+                + "\"short_message\": \"A short message that helps you identify what is going on\","
+                + "\"_version\": \"5.11\""
+                + "}"
+                + "\n"
+                + "{"
+                + "\"version\": \"1.1\","
+                + "\"host\": \"example.org\","
+                + "\"short_message\": \"A short message that helps you identify what is going on\","
+                + "\"_version\": \"3.11\","
+                + "\"foo\": \"bar\""
+                + "}";
+
+        final RawMessage rawMessage = new RawMessage(json.getBytes(StandardCharsets.UTF_8));
+        final ArrayList<Message> messages = (ArrayList<Message>) codec.decodeMessages(rawMessage);
+
+        assertThat(messages).isNotNull();
+        assertThat(messages).size().isEqualTo(2);
+        assertThat(messages.get(0).getField("version")).isEqualTo("5.11");
+        assertThat(messages.get(0).getField("source")).isEqualTo("example.org");
+        assertThat(messages.get(1).getField("version")).isEqualTo("3.11");
+        assertThat(messages.get(1).getField("foo")).isEqualTo("bar");
+    }
+
+
+    @Test
+    public void decodeMessagesSucceedsWithArray() throws Exception {
+        final String json = "[{"
+                + "\"version\": \"1.1\","
+                + "\"host\": \"example.org\","
+                + "\"short_message\": \"A short message that helps you identify what is going on\","
+                + "\"_version\": \"5.11\""
+                + "}"
+                + ","
+                + "{"
+                + "\"version\": \"1.1\","
+                + "\"host\": \"example.org\","
+                + "\"short_message\": \"A short message that helps you identify what is going on\","
+                + "\"_version\": \"3.11\","
+                + "\"foo\": \"bar\""
+                + "}]";
+
+        final RawMessage rawMessage = new RawMessage(json.getBytes(StandardCharsets.UTF_8));
+        final ArrayList<Message> messages = (ArrayList<Message>) codec.decodeMessages(rawMessage);
+
+        assertThat(messages).isNotNull();
+        assertThat(messages).size().isEqualTo(2);
+        assertThat(messages.get(0).getField("version")).isEqualTo("5.11");
+        assertThat(messages.get(0).getField("source")).isEqualTo("example.org");
+        assertThat(messages.get(1).getField("version")).isEqualTo("3.11");
+        assertThat(messages.get(1).getField("foo")).isEqualTo("bar");
+    }
+
+    @Test
+    public void decodeMessagesSucceedsWithMinimalMessages() throws Exception {
+        assertThat(codec.decodeMessages(new RawMessage("{\"short_message\":\"0\"}".getBytes(StandardCharsets.UTF_8)))).isNotNull();
+        assertThat(codec.decodeMessages(new RawMessage("{\"message\":\"0\"}".getBytes(StandardCharsets.UTF_8)))).isNotNull();
+    }
+
+    @Test
+    public void decodeMessagesFailsWithEmptyMessage() throws Exception {
+        final String json = "[{"
+                + "\"version\": \"1.1\","
+                + "\"host\": \"example.org\","
+                + "\"message\": \"\""
+                + "}]";
+
+        final RawMessage rawMessage = new RawMessage(json.getBytes(StandardCharsets.UTF_8));
+
+        assertThatIllegalStateException().isThrownBy(() -> codec.decodeMessages(rawMessage))
+                .withNoCause()
+                .withMessageMatching("could not find any valid json in the packet");
+    }
+
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
See [#5924](https://github.com/Graylog2/graylog2-server/pull/5924) and [#8333](https://github.com/Graylog2/graylog2-server/pull/8333)
A new http input plugin to accept multiple messages in each request for the http protocol

## Motivation and Context
The new HTTP-BATCH input plugin accepts an array or multiple comma separated gelf input objects. The current Gelf HTTP input plugin accepts only a single message and can easily become expensive when sending a huge number of messages per second and thus reducing the throughput of the overall system. 
With the help of the new plugin the system should be able to accept more messages in each request and reduce the connection overhead  and increasing the throughput

The messages can be split by a new line or even be sent as an array . This way the plugin covers different log emitters like fluentbit and fluentd

example 1:
```
{
    "version": "1.1",
    "host": "example.org",
    "short_message": "A short message that helps you identify what is going on",
    "_version": "5.11"
}
\n
{
    "version": "1.1",
    "host": "example.org",
    "short_message": "A short message that helps you identify what is going on",
    "_version": "3.11",
    "foo": "bar"
"}
```

example 2:
```
[
    {
        "version": "1.1",
        "host": "example.org",
        "short_message": "A short message that helps you identify what is going on",
        "_version": "5.11"
    }
    ,
    {
        "version": "1.1",
        "host": "example.org",
        "short_message": "A short message that helps you identify what is going on",
        "_version": "3.11",
        "foo": "bar"
    }
]
```

## How Has This Been Tested?
Locally and also running it as part of patched version and did not observe any issues
Performed a load test by sending an array of messages with concurrent connections and observed that the messages were processed to complete.  
All the tests are passing and also added new tests for the http-batch input

Results from load test demonstrating improvement in throughput

Machine Type : t2.2xlarge 
Without Batch : 10k Messages/sec(msg payload 1KB)
Payload : 10 messages/ request
With Batch: 20K messages/sec(msg payload 1KB)
Ran it for a time period of 10 minutes and saw the system holding up well .




## Screenshots (if appropriate):
![Graylog-UI](https://user-images.githubusercontent.com/538577/115982777-2d94bd80-a563-11eb-9ddb-5f26e36b5cd9.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

