### PR TITLE
Do not display dashboard pages tabs when focusing a widget.

### DIFF
--- a/graylog2-web-interface/src/views/components/Search.dashboard.test.tsx
+++ b/graylog2-web-interface/src/views/components/Search.dashboard.test.tsx
@@ -1,0 +1,145 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import Immutable from 'immutable';
+import { render, waitFor, screen } from 'wrappedTestingLibrary';
+import { StoreMock as MockStore } from 'helpers/mocking';
+import asMock from 'helpers/mocking/AsMock';
+import mockComponent from 'helpers/mocking/MockComponent';
+import mockAction from 'helpers/mocking/MockAction';
+
+import { StreamsActions } from 'views/stores/StreamsStore';
+import { WidgetStore } from 'views/stores/WidgetStore';
+import { QueryFiltersStore } from 'views/stores/QueryFiltersStore';
+import { SearchActions } from 'views/stores/SearchStore';
+import { SearchConfigActions } from 'views/stores/SearchConfigStore';
+import { ViewStore } from 'views/stores/ViewStore';
+import { FieldTypesActions } from 'views/stores/FieldTypesStore';
+import { SearchMetadataStore } from 'views/stores/SearchMetadataStore';
+import View from 'views/logic/views/View';
+
+import Search from './Search';
+import WidgetFocusProvider from './contexts/WidgetFocusProvider';
+import WidgetFocusContext from './contexts/WidgetFocusContext';
+
+jest.mock('views/stores/ViewMetadataStore', () => ({
+  ViewMetadataStore: MockStore(
+    ['listen', () => jest.fn()],
+    'get',
+    ['getInitialState', () => ({
+      activeQuery: 'beef-dead',
+    })],
+  ),
+}));
+
+const mockedQueryIds = Immutable.List(['query-id-1', 'query-id-2']);
+
+jest.mock('views/stores/QueryIdsStore', () => ({
+  QueryIdsStore: {
+    listen: () => jest.fn(),
+    getInitialState: () => mockedQueryIds,
+  },
+}));
+
+const mockedQueryTitles = Immutable.Map({
+  'query-id-1': 'First dashboard page',
+  'query-id-2': 'Second dashboard page',
+});
+
+jest.mock('views/stores/QueryTitlesStore', () => ({
+  QueryTitlesStore: {
+    listen: () => jest.fn(),
+    getInitialState: () => mockedQueryTitles,
+  },
+}));
+
+jest.mock('views/components/SearchResult', () => () => <div>Mocked search results</div>);
+jest.mock('views/components/DashboardSearchBar', () => mockComponent('DashboardSearchBar'));
+jest.mock('components/layout/Footer', () => mockComponent('Footer'));
+jest.mock('views/components/contexts/WidgetFocusProvider', () => jest.fn());
+
+describe('Dashboard Search', () => {
+  beforeEach(() => {
+    WidgetStore.listen = jest.fn(() => jest.fn());
+    QueryFiltersStore.listen = jest.fn(() => jest.fn());
+    // @ts-ignore
+    SearchActions.execute = jest.fn(() => jest.fn());
+    StreamsActions.refresh = mockAction(jest.fn());
+    SearchConfigActions.refresh = mockAction(jest.fn());
+
+    ViewStore.getInitialState = jest.fn(() => ({
+      view: View.create().toBuilder().type(View.Type.Dashboard).build(),
+      dirty: false,
+      isNew: true,
+      activeQuery: 'foobar',
+    }));
+
+    FieldTypesActions.all = mockAction(jest.fn(async () => {}));
+    SearchMetadataStore.listen = jest.fn(() => jest.fn());
+    SearchActions.refresh = mockAction(jest.fn(() => Promise.resolve()));
+
+    asMock(WidgetFocusProvider as React.FunctionComponent).mockImplementation(({ children }) => (
+      <WidgetFocusContext.Provider value={{
+        focusedWidget: undefined,
+        setWidgetFocusing: () => {},
+        setWidgetEditing: () => {},
+        unsetWidgetFocusing: () => {},
+        unsetWidgetEditing: () => {},
+      }}>
+        {children}
+      </WidgetFocusContext.Provider>
+    ));
+  });
+
+  const SimpleSearch = (props) => (
+    <Search location={{ query: {}, pathname: '/search', search: '' }}
+            searchRefreshHooks={[]}
+            {...props} />
+  );
+
+  it('should list tabs for dashboard pages', async () => {
+    render(<SimpleSearch />);
+
+    await waitFor(() => expect(screen.getByText('First dashboard page')).toBeInTheDocument());
+
+    expect(screen.getByText('Second dashboard page')).toBeInTheDocument();
+  });
+
+  it('should not list tabs for pages when focussing a widget', async () => {
+    asMock(WidgetFocusProvider as React.FunctionComponent).mockImplementation(({ children }) => (
+      <WidgetFocusContext.Provider value={{
+        focusedWidget: {
+          id: 'widget-id',
+          editing: true,
+          focusing: true,
+        },
+        setWidgetFocusing: () => {},
+        setWidgetEditing: () => {},
+        unsetWidgetFocusing: () => {},
+        unsetWidgetEditing: () => {},
+      }}>{children}
+      </WidgetFocusContext.Provider>
+    ));
+
+    render(<SimpleSearch />);
+
+    await waitFor(() => expect(screen.getByText('Mocked search results')).toBeInTheDocument());
+
+    expect(screen.queryByText('First dashboard page')).not.toBeInTheDocument();
+    expect(screen.queryByText('Second dashboard page')).not.toBeInTheDocument();
+  });
+});

--- a/graylog2-web-interface/src/views/components/Search.dashboard.test.tsx
+++ b/graylog2-web-interface/src/views/components/Search.dashboard.test.tsx
@@ -119,7 +119,7 @@ describe('Dashboard Search', () => {
     expect(screen.getByText('Second dashboard page')).toBeInTheDocument();
   });
 
-  it('should not list tabs for pages when focussing a widget', async () => {
+  it('should not list tabs for pages when focusing a widget', async () => {
     asMock(WidgetFocusProvider as React.FunctionComponent).mockImplementation(({ children }) => (
       <WidgetFocusContext.Provider value={{
         focusedWidget: {

--- a/graylog2-web-interface/src/views/components/Search.tsx
+++ b/graylog2-web-interface/src/views/components/Search.tsx
@@ -175,52 +175,56 @@ const Search = ({ location }: Props) => {
 
   return (
     <WidgetFocusProvider>
-      <CurrentViewTypeProvider>
-        <IfInteractive>
-          <IfDashboard>
-            <WindowLeaveMessage />
-          </IfDashboard>
-        </IfInteractive>
-        <InteractiveContext.Consumer>
-          {(interactive) => (
-            <SearchPageLayoutProvider>
-              <DefaultFieldTypesProvider>
-                <ViewAdditionalContextProvider>
-                  <HighlightingRulesProvider>
-                    <GridContainer id="main-row" interactive={interactive}>
-                      <IfInteractive>
-                        <ConnectedSidebar>
-                          <FieldsOverview />
-                        </ConnectedSidebar>
-                      </IfInteractive>
-                      <SearchArea>
-                        <IfInteractive>
-                          <HeaderElements />
-                          <IfDashboard>
-                            <DashboardSearchBarWithStatus onExecute={refreshIfNotUndeclared} />
-                          </IfDashboard>
-                          <IfSearch>
-                            <SearchBarWithStatus onExecute={refreshIfNotUndeclared} />
-                          </IfSearch>
+      <WidgetFocusContext.Consumer>
+        {({ focusedWidget: { focusing: focusingWidget } = { focusing: false } }) => (
+          <CurrentViewTypeProvider>
+            <IfInteractive>
+              <IfDashboard>
+                <WindowLeaveMessage />
+              </IfDashboard>
+            </IfInteractive>
+            <InteractiveContext.Consumer>
+              {(interactive) => (
+                <SearchPageLayoutProvider>
+                  <DefaultFieldTypesProvider>
+                    <ViewAdditionalContextProvider>
+                      <HighlightingRulesProvider>
+                        <GridContainer id="main-row" interactive={interactive}>
+                          <IfInteractive>
+                            <ConnectedSidebar>
+                              <FieldsOverview />
+                            </ConnectedSidebar>
+                          </IfInteractive>
+                          <SearchArea>
+                            <IfInteractive>
+                              <HeaderElements />
+                              <IfDashboard>
+                                <DashboardSearchBarWithStatus onExecute={refreshIfNotUndeclared} />
+                              </IfDashboard>
+                              <IfSearch>
+                                <SearchBarWithStatus onExecute={refreshIfNotUndeclared} />
+                              </IfSearch>
 
-                          <QueryBarElements />
+                              <QueryBarElements />
 
-                          <IfDashboard>
-                            <QueryBar />
-                          </IfDashboard>
-                        </IfInteractive>
-                        <HighlightMessageInQuery>
-                          <SearchResult />
-                        </HighlightMessageInQuery>
-                      </SearchArea>
-                    </GridContainer>
-                  </HighlightingRulesProvider>
-                </ViewAdditionalContextProvider>
-              </DefaultFieldTypesProvider>
-            </SearchPageLayoutProvider>
-          )}
-        </InteractiveContext.Consumer>
-      </CurrentViewTypeProvider>
+                              <IfDashboard>
+                                {!focusingWidget && <QueryBar />}
+                              </IfDashboard>
+                            </IfInteractive>
+                            <HighlightMessageInQuery>
+                              <SearchResult />
+                            </HighlightMessageInQuery>
+                          </SearchArea>
+                        </GridContainer>
+                      </HighlightingRulesProvider>
+                    </ViewAdditionalContextProvider>
+                  </DefaultFieldTypesProvider>
+                </SearchPageLayoutProvider>
+              )}
+            </InteractiveContext.Consumer>
+          </CurrentViewTypeProvider>
+        )}
+      </WidgetFocusContext.Consumer>
     </WidgetFocusProvider>
   );
 };


### PR DESCRIPTION
## Description
## Motivation and Context
Before this change we displayed the dashboard pages tabs when focusing or editing a widget.
![image](https://user-images.githubusercontent.com/46300478/116373653-d8300900-a80d-11eb-9527-178e3580341d.png)

Now we are hiding them in the two mentioned cases. This change has some benefits:
- we provide more space for the widget frame which is especially helpful when editing a widget on smaller screens.
- it is slightly easier to differentiate between a focused widget and unfocused widget.
- the layout for a focused widget is more clear.

![image](https://user-images.githubusercontent.com/46300478/116373871-0f9eb580-a80e-11eb-8aaf-733ae4a7cba7.png)

Please note, I created a separate test file (`Search.dashboard.test.tsx`) to test the dashboard related functionality. It can be a suitable place for further dashboard related tests. For example when we hide the dashboard on widget edit.

Fixes #10493

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

