### PR TITLE
Reduce search page layout margins to provide more space for content

### DIFF
--- a/graylog2-web-interface/src/components/common/ReactGridContainer.jsx
+++ b/graylog2-web-interface/src/components/common/ReactGridContainer.jsx
@@ -271,7 +271,7 @@ class ReactGridContainer extends React.Component {
                                      cols={columns}
                                      rowHeight={rowHeight}
                                      containerPadding={[0, 0]}
-                                     margin={[10, 10]}
+                                     margin={[6, 6]}
                                      isResizable={isResizable}
                                      measureBeforeMount={measureBeforeMount}
         // Do not allow dragging from elements inside a `.actions` css class. This is

--- a/graylog2-web-interface/src/components/graylog/Row.tsx
+++ b/graylog2-web-interface/src/components/graylog/Row.tsx
@@ -21,7 +21,7 @@ import styled, { css } from 'styled-components';
 export const RowContentStyles = css(({ theme }) => css`
   background-color: ${theme.colors.global.contentBackground};
   border: 1px solid ${theme.colors.variant.lighter.default};
-  margin-bottom: 9px;
+  margin-bottom: 6px;
   border-radius: 4px;
 `);
 

--- a/graylog2-web-interface/src/components/layout/Footer.tsx
+++ b/graylog2-web-interface/src/components/layout/Footer.tsx
@@ -51,7 +51,7 @@ const StyledFooter = styled.footer(({ theme }) => css`
 
   /* This combination of padding and box-sizing is required to fix a firefox flexbox bug */
   box-sizing: content-box;
-  padding-bottom: 15px;
+  padding-bottom: 9px;
 
   @media print {
     display: none;

--- a/graylog2-web-interface/src/components/layout/PageContentLayout.tsx
+++ b/graylog2-web-interface/src/components/layout/PageContentLayout.tsx
@@ -35,7 +35,7 @@ const Container = styled.div`
   width: 100%;
 
   /* Bottom gap is defined by the footer */
-  padding: 15px 15px 0 15px;
+  padding: 9px 9px 0 9px;
 `;
 
 const StyledGrid = styled(Grid)`

--- a/graylog2-web-interface/src/components/login/__snapshots__/LoginBox.test.jsx.snap
+++ b/graylog2-web-interface/src/components/login/__snapshots__/LoginBox.test.jsx.snap
@@ -4,7 +4,7 @@ exports[`LoginBox renders a button after the input if buttonAfter is passed 1`] 
 .c0.content {
   background-color: #fff;
   border: 1px solid #d0d0d0;
-  margin-bottom: 9px;
+  margin-bottom: 6px;
   border-radius: 4px;
 }
 

--- a/graylog2-web-interface/src/pages/__snapshots__/ShowMessagePage.test.tsx.snap
+++ b/graylog2-web-interface/src/pages/__snapshots__/ShowMessagePage.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`ShowMessagePage renders for generic event 1`] = `
 .c0.content {
   background-color: #fff;
   border: 1px solid #d0d0d0;
-  margin-bottom: 9px;
+  margin-bottom: 6px;
   border-radius: 4px;
 }
 
@@ -93,7 +93,7 @@ exports[`ShowMessagePage renders for generic message 1`] = `
 .c0.content {
   background-color: #fff;
   border: 1px solid #d0d0d0;
-  margin-bottom: 9px;
+  margin-bottom: 6px;
   border-radius: 4px;
 }
 

--- a/graylog2-web-interface/src/views/components/DashboardSearchBar.tsx
+++ b/graylog2-web-interface/src/views/components/DashboardSearchBar.tsx
@@ -38,6 +38,7 @@ import WidgetFocusContext from 'views/components/contexts/WidgetFocusContext';
 
 import DashboardSearchForm from './DashboardSearchBarForm';
 import TimeRangeInput from './searchbar/TimeRangeInput';
+import SearchBarContainer from './SearchBarContainer';
 
 type Props = {
   config: SearchesConfig,
@@ -64,61 +65,59 @@ const DashboardSearchBar = ({ config, globalOverride, disableSearch = false, onE
     <WidgetFocusContext.Consumer>
       {({ focusedWidget: { editing } = { editing: false } }) => (
         <ScrollToHint value={queryString}>
-          <Row className="content">
-            <Col md={12}>
-              <DashboardSearchForm initialValues={{ timerange, queryString }}
-                                   limitDuration={limitDuration}
-                                   onSubmit={submitForm}>
-                {({ dirty, isSubmitting, isValid, handleSubmit, values, setFieldValue }) => (
-                  <>
-                    <TopRow>
-                      <Col lg={8} md={9} xs={10}>
-                        <TimeRangeInput disabled={disableSearch}
-                                        onChange={(nextTimeRange) => setFieldValue('timerange', nextTimeRange)}
-                                        value={values?.timerange}
-                                        hasErrorOnMount={!isValid}
-                                        noOverride />
-                      </Col>
-                      <Col lg={4} md={3} xs={2}>
-                        <RefreshControls />
-                      </Col>
-                    </TopRow>
+          <SearchBarContainer>
+            <DashboardSearchForm initialValues={{ timerange, queryString }}
+                                 limitDuration={limitDuration}
+                                 onSubmit={submitForm}>
+              {({ dirty, isSubmitting, isValid, handleSubmit, values, setFieldValue }) => (
+                <>
+                  <TopRow>
+                    <Col lg={8} md={9} xs={10}>
+                      <TimeRangeInput disabled={disableSearch}
+                                      onChange={(nextTimeRange) => setFieldValue('timerange', nextTimeRange)}
+                                      value={values?.timerange}
+                                      hasErrorOnMount={!isValid}
+                                      noOverride />
+                    </Col>
+                    <Col lg={4} md={3} xs={2}>
+                      <RefreshControls />
+                    </Col>
+                  </TopRow>
 
-                    <Row className="no-bm">
-                      <Col md={8} lg={9}>
-                        <div className="pull-right search-help">
-                          <DocumentationLink page={DocsHelper.PAGES.SEARCH_QUERY_LANGUAGE}
-                                             title="Search query syntax documentation"
-                                             text={<Icon name="lightbulb" />} />
-                        </div>
-                        <SearchButton disabled={disableSearch || isSubmitting || !isValid}
-                                      glyph="filter"
-                                      dirty={dirty} />
+                  <Row className="no-bm">
+                    <Col md={8} lg={9}>
+                      <div className="pull-right search-help">
+                        <DocumentationLink page={DocsHelper.PAGES.SEARCH_QUERY_LANGUAGE}
+                                           title="Search query syntax documentation"
+                                           text={<Icon name="lightbulb" />} />
+                      </div>
+                      <SearchButton disabled={disableSearch || isSubmitting || !isValid}
+                                    glyph="filter"
+                                    dirty={dirty} />
 
-                        <Field name="queryString">
-                          {({ field: { name, value, onChange } }) => (
-                            <QueryInput value={value}
-                                        placeholder="Apply filter to all widgets"
-                                        onChange={(newQuery) => {
-                                          onChange({ target: { value: newQuery, name } });
+                      <Field name="queryString">
+                        {({ field: { name, value, onChange } }) => (
+                          <QueryInput value={value}
+                                      placeholder="Apply filter to all widgets"
+                                      onChange={(newQuery) => {
+                                        onChange({ target: { value: newQuery, name } });
 
-                                          return Promise.resolve(newQuery);
-                                        }}
-                                        onExecute={handleSubmit as () => void} />
-                          )}
-                        </Field>
-                      </Col>
-                      <Col md={4} lg={3}>
-                        <div className="pull-right">
-                          {!editing && <ViewActionsMenu />}
-                        </div>
-                      </Col>
-                    </Row>
-                  </>
-                )}
-              </DashboardSearchForm>
-            </Col>
-          </Row>
+                                        return Promise.resolve(newQuery);
+                                      }}
+                                      onExecute={handleSubmit as () => void} />
+                        )}
+                      </Field>
+                    </Col>
+                    <Col md={4} lg={3}>
+                      <div className="pull-right">
+                        {!editing && <ViewActionsMenu />}
+                      </div>
+                    </Col>
+                  </Row>
+                </>
+              )}
+            </DashboardSearchForm>
+          </SearchBarContainer>
         </ScrollToHint>
       )}
     </WidgetFocusContext.Consumer>

--- a/graylog2-web-interface/src/views/components/SearchBar.tsx
+++ b/graylog2-web-interface/src/views/components/SearchBar.tsx
@@ -45,6 +45,7 @@ import type { SearchesConfig } from 'components/search/SearchConfig';
 import type { SearchBarFormValues } from 'views/Constants';
 import WidgetFocusContext from 'views/components/contexts/WidgetFocusContext';
 
+import SearchBarContainer from './SearchBarContainer';
 import SearchBarForm from './searchbar/SearchBarForm';
 
 type Props = {
@@ -66,7 +67,7 @@ const StreamWrap = styled.div`
   flex: 1;
   
   > div {
-    margin-right: 24px;
+    margin-right: 18px;
   }
 `;
 
@@ -109,72 +110,70 @@ const SearchBar = ({
     <WidgetFocusContext.Consumer>
       {({ focusedWidget: { editing } = { editing: false } }) => (
         <ScrollToHint value={query.query_string}>
-          <Row className="content">
-            <Col md={12}>
-              <SearchBarForm initialValues={{ timerange, streams, queryString }}
-                             limitDuration={limitDuration}
-                             onSubmit={_onSubmit}>
-                {({ dirty, isSubmitting, isValid, handleSubmit, values, setFieldValue }) => (
-                  <>
-                    <TopRow>
-                      <Col md={5}>
-                        <TimeRangeInput disabled={disableSearch}
-                                        onChange={(nextTimeRange) => setFieldValue('timerange', nextTimeRange)}
-                                        value={values?.timerange}
-                                        hasErrorOnMount={!isValid} />
-                      </Col>
+          <SearchBarContainer>
+            <SearchBarForm initialValues={{ timerange, streams, queryString }}
+                           limitDuration={limitDuration}
+                           onSubmit={_onSubmit}>
+              {({ dirty, isSubmitting, isValid, handleSubmit, values, setFieldValue }) => (
+                <>
+                  <TopRow>
+                    <Col md={5}>
+                      <TimeRangeInput disabled={disableSearch}
+                                      onChange={(nextTimeRange) => setFieldValue('timerange', nextTimeRange)}
+                                      value={values?.timerange}
+                                      hasErrorOnMount={!isValid} />
+                    </Col>
 
-                      <Col mdHidden lgHidden>
-                        <HorizontalSpacer />
-                      </Col>
+                    <Col mdHidden lgHidden>
+                      <HorizontalSpacer />
+                    </Col>
 
-                      <FlexCol md={7}>
-                        <StreamWrap>
-                          <Field name="streams">
-                            {({ field: { name, value, onChange } }) => (
-                              <StreamsFilter value={value}
-                                             streams={availableStreams}
-                                             onChange={(newStreams) => onChange({ target: { value: newStreams, name } })} />
-                            )}
-                          </Field>
-                        </StreamWrap>
-
-                        <RefreshControls />
-                      </FlexCol>
-                    </TopRow>
-
-                    <Row className="no-bm">
-                      <Col md={9} xs={8}>
-                        <div className="pull-right search-help">
-                          <DocumentationLink page={DocsHelper.PAGES.SEARCH_QUERY_LANGUAGE}
-                                             title="Search query syntax documentation"
-                                             text={<Icon name="lightbulb" />} />
-                        </div>
-                        <SearchButton disabled={disableSearch || isSubmitting || !isValid}
-                                      dirty={dirty} />
-
-                        <Field name="queryString">
+                    <FlexCol md={7}>
+                      <StreamWrap>
+                        <Field name="streams">
                           {({ field: { name, value, onChange } }) => (
-                            <QueryInput value={value}
-                                        placeholder={'Type your search query here and press enter. E.g.: ("not found" AND http) OR http_response_code:[400 TO 404]'}
-                                        onChange={(newQuery) => {
-                                          onChange({ target: { value: newQuery, name } });
-
-                                          return Promise.resolve(newQuery);
-                                        }}
-                                        onExecute={handleSubmit as () => void} />
+                            <StreamsFilter value={value}
+                                           streams={availableStreams}
+                                           onChange={(newStreams) => onChange({ target: { value: newStreams, name } })} />
                           )}
                         </Field>
-                      </Col>
-                      <Col md={3} xs={4} className="pull-right" aria-label="Search Meta Buttons">
-                        {!editing && <SavedSearchControls />}
-                      </Col>
-                    </Row>
-                  </>
-                )}
-              </SearchBarForm>
-            </Col>
-          </Row>
+                      </StreamWrap>
+
+                      <RefreshControls />
+                    </FlexCol>
+                  </TopRow>
+
+                  <Row className="no-bm">
+                    <Col md={9} xs={8}>
+                      <div className="pull-right search-help">
+                        <DocumentationLink page={DocsHelper.PAGES.SEARCH_QUERY_LANGUAGE}
+                                           title="Search query syntax documentation"
+                                           text={<Icon name="lightbulb" />} />
+                      </div>
+                      <SearchButton disabled={disableSearch || isSubmitting || !isValid}
+                                    dirty={dirty} />
+
+                      <Field name="queryString">
+                        {({ field: { name, value, onChange } }) => (
+                          <QueryInput value={value}
+                                      placeholder={'Type your search query here and press enter. E.g.: ("not found" AND http) OR http_response_code:[400 TO 404]'}
+                                      onChange={(newQuery) => {
+                                        onChange({ target: { value: newQuery, name } });
+
+                                        return Promise.resolve(newQuery);
+                                      }}
+                                      onExecute={handleSubmit as () => void} />
+                        )}
+                      </Field>
+                    </Col>
+                    <Col md={3} xs={4} className="pull-right" aria-label="Search Meta Buttons">
+                      {!editing && <SavedSearchControls />}
+                    </Col>
+                  </Row>
+                </>
+              )}
+            </SearchBarForm>
+          </SearchBarContainer>
         </ScrollToHint>
       )}
     </WidgetFocusContext.Consumer>

--- a/graylog2-web-interface/src/views/components/SearchBarContainer.tsx
+++ b/graylog2-web-interface/src/views/components/SearchBarContainer.tsx
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import styled from 'styled-components';
+
+import { RowContentStyles } from 'components/graylog/Row';
+
+const SearchBarContainer = styled.div`
+  ${RowContentStyles}
+  padding: 9px;
+  margin-left: -15px;
+  margin-right: -15px;
+
+  .row {
+    margin-left: -9px;
+    margin-right: -9px;
+  }
+
+  div[class*="col-"] {
+    padding-right: 9px;
+    padding-left: 9px;
+  }
+`;
+
+export default SearchBarContainer;

--- a/graylog2-web-interface/src/views/components/SearchResult.tsx
+++ b/graylog2-web-interface/src/views/components/SearchResult.tsx
@@ -43,7 +43,6 @@ type IndicatorProps = {
 const StyledRow = styled(Row)(({ $hasFocusedWidget }: { $hasFocusedWidget: boolean }) => css`
   height: ${$hasFocusedWidget ? '100%' : 'auto'};
   overflow: ${$hasFocusedWidget ? 'auto' : 'visible'};
-  margin-bottom: 10px;
 `);
 
 const StyledCol = styled(Col)`

--- a/graylog2-web-interface/src/views/components/widgets/EditMessageList.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/EditMessageList.tsx
@@ -19,7 +19,6 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { $PropertyType } from 'utility-types';
 import { EditWidgetComponentProps } from 'views/types';
-
 import SortConfig from 'views/logic/aggregationbuilder/SortConfig';
 import { Row, Col, Checkbox } from 'components/graylog';
 import FieldSelect from 'views/components/widgets/FieldSelect';

--- a/graylog2-web-interface/src/views/components/widgets/WidgetFrame.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/WidgetFrame.jsx
@@ -21,7 +21,7 @@ import styled, { css } from 'styled-components';
 const WidgetWrap = styled.div(({ theme }) => css`
   height: inherit;
   margin: 0;
-  padding: 12px 15px 6px 15px;
+  padding: 7px 9px 6px 9px;
   display: flex;
   flex-direction: column;
 


### PR DESCRIPTION
## Description
## Motivation and Context
This PR includes the following changes to reduce the search page layout margins:
- reducing global footer padding and search page footer margin.
- reducing widget paddings.
- reducing search bar and dashboard search bar paddings.
- reducing page content layout and bottom margin of content rows.

This way:
- smaller widget display more content.
- the widget edit mode displays more controls on screens with a comparable small height.

Before:
![image](https://user-images.githubusercontent.com/46300478/116379570-6bb80880-a813-11eb-896b-af398c385cc5.png)

After:
![image](https://user-images.githubusercontent.com/46300478/116893811-aebe1580-ac31-11eb-8026-6d16ae1ddd7c.png)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.


/jenkins-pr-deps Graylog2/graylog-plugin-enterprise#2217