### PR TITLE
Do not display dashboard search bar when editing a widget.

### DIFF
--- a/graylog2-web-interface/src/views/components/Search.dashboard.test.tsx
+++ b/graylog2-web-interface/src/views/components/Search.dashboard.test.tsx
@@ -68,9 +68,27 @@ jest.mock('views/stores/QueryTitlesStore', () => ({
 }));
 
 jest.mock('views/components/SearchResult', () => () => <div>Mocked search results</div>);
-jest.mock('views/components/DashboardSearchBar', () => mockComponent('DashboardSearchBar'));
+jest.mock('views/components/DashboardSearchBar', () => () => <div>Mocked dashboard search bar</div>);
 jest.mock('components/layout/Footer', () => mockComponent('Footer'));
 jest.mock('views/components/contexts/WidgetFocusProvider', () => jest.fn());
+
+const mockWidgetEditing = () => {
+  asMock(WidgetFocusProvider as React.FunctionComponent).mockImplementation(({ children }) => (
+    <WidgetFocusContext.Provider value={{
+      focusedWidget: {
+        id: 'widget-id',
+        editing: true,
+        focusing: true,
+      },
+      setWidgetFocusing: () => {},
+      setWidgetEditing: () => {},
+      unsetWidgetFocusing: () => {},
+      unsetWidgetEditing: () => {},
+    }}>
+      {children}
+    </WidgetFocusContext.Provider>
+  ));
+};
 
 describe('Dashboard Search', () => {
   beforeEach(() => {
@@ -120,26 +138,27 @@ describe('Dashboard Search', () => {
   });
 
   it('should not list tabs for pages when focusing a widget', async () => {
-    asMock(WidgetFocusProvider as React.FunctionComponent).mockImplementation(({ children }) => (
-      <WidgetFocusContext.Provider value={{
-        focusedWidget: {
-          id: 'widget-id',
-          editing: true,
-          focusing: true,
-        },
-        setWidgetFocusing: () => {},
-        setWidgetEditing: () => {},
-        unsetWidgetFocusing: () => {},
-        unsetWidgetEditing: () => {},
-      }}>{children}
-      </WidgetFocusContext.Provider>
-    ));
-
+    mockWidgetEditing();
     render(<SimpleSearch />);
 
     await waitFor(() => expect(screen.getByText('Mocked search results')).toBeInTheDocument());
 
     expect(screen.queryByText('First dashboard page')).not.toBeInTheDocument();
     expect(screen.queryByText('Second dashboard page')).not.toBeInTheDocument();
+  });
+
+  it('should display dashboard search bar', async () => {
+    render(<SimpleSearch />);
+
+    await waitFor(() => expect(screen.getByText('Mocked dashboard search bar')).toBeInTheDocument());
+  });
+
+  it('should not display dashboard search bar on widget edit', async () => {
+    mockWidgetEditing();
+    render(<SimpleSearch />);
+
+    await waitFor(() => expect(screen.getByText('Mocked search results')).toBeInTheDocument());
+
+    expect(screen.queryByText('Mocked dashboard search bar')).not.toBeInTheDocument();
   });
 });

--- a/graylog2-web-interface/src/views/components/Search.tsx
+++ b/graylog2-web-interface/src/views/components/Search.tsx
@@ -176,7 +176,7 @@ const Search = ({ location }: Props) => {
   return (
     <WidgetFocusProvider>
       <WidgetFocusContext.Consumer>
-        {({ focusedWidget: { focusing: focusingWidget } = { focusing: false } }) => (
+        {({ focusedWidget: { focusing: focusingWidget, editing: editingWidget } = { focusing: false, editing: false } }) => (
           <CurrentViewTypeProvider>
             <IfInteractive>
               <IfDashboard>
@@ -199,7 +199,7 @@ const Search = ({ location }: Props) => {
                             <IfInteractive>
                               <HeaderElements />
                               <IfDashboard>
-                                <DashboardSearchBarWithStatus onExecute={refreshIfNotUndeclared} />
+                                {!editingWidget && <DashboardSearchBarWithStatus onExecute={refreshIfNotUndeclared} />}
                               </IfDashboard>
                               <IfSearch>
                                 <SearchBarWithStatus onExecute={refreshIfNotUndeclared} />


### PR DESCRIPTION
## Description
## Motivation and Context

As described in https://github.com/Graylog2/graylog2-server/issues/10213 we've recently changed the way we are displaying the aggregation builder (widget edit mode). It is no longer being displayed in a modal but inline below the search bar. To display a cleaner layout and to provide more space for the aggregation builder, we decided to hide the dashboard search bar on widget edit. This especially benefits screens with a smaller height.

Before (without active dashboard filter):
![image](https://user-images.githubusercontent.com/46300478/116386791-65795a80-a81a-11eb-9d46-037da27ee320.png)

After (without active dashboard filter):
![image](https://user-images.githubusercontent.com/46300478/116386577-3662e900-a81a-11eb-9bff-184b0c640794.png)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

Refs https://github.com/Graylog2/graylog2-server/issues/10213

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

