### PR TITLE
Implement Cancellable Promise

### DIFF
--- a/graylog2-web-interface/src/logic/rest/CancellablePromise.test.ts
+++ b/graylog2-web-interface/src/logic/rest/CancellablePromise.test.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import CancellablePromise from 'logic/rest/CancellablePromise';
+
+describe('CancellablePromise', () => {
+  it('should cancel a promise', () => {
+    const promise = CancellablePromise.of(Promise.resolve(() => true)).cancel();
+
+    expect(promise.isCancelled()).toBeTruthy();
+  });
+
+  it('should implement then', async () => {
+    return CancellablePromise.of(Promise.resolve('ハチ公')).then((result) => {
+      expect(result).toBe('ハチ公');
+    });
+  });
+
+  it('should implement finally', () => {
+    CancellablePromise.of(Promise.resolve('ハチ公')).finally(() => {
+      expect(true).toBeTruthy();
+    });
+
+    return Promise.resolve(() => {
+      expect.assertions(1);
+    });
+  });
+
+  it('should implement catch', () => {
+    return CancellablePromise.of(Promise.resolve(() => {
+      throw new Error('ハチ公');
+    })).catch((error) => {
+      expect(error).toBe('ハチ公');
+    });
+  });
+});

--- a/graylog2-web-interface/src/logic/rest/CancellablePromise.ts
+++ b/graylog2-web-interface/src/logic/rest/CancellablePromise.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+class CancellablePromise<T> implements Promise<T> {
+  private _isCanceled: boolean;
+
+  private _promise: Promise<T>;
+
+  private constructor(promise: Promise<T>, isCancelled = false) {
+    this._promise = promise;
+    this._isCanceled = isCancelled;
+  }
+
+  [Symbol.toStringTag]: string;
+
+  then<TResult1 = T, TResult2 = never>(onfulfilled?: (value: T) => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>) {
+    return new CancellablePromise(this._promise.then(onfulfilled, onrejected), this._isCanceled);
+  }
+
+  catch<TResult = never>(onrejected?: (reason: any) => TResult | PromiseLike<TResult>) {
+    return new CancellablePromise(this._promise.catch(onrejected), this._isCanceled);
+  }
+
+  finally(onfinally?: () => void) {
+    return new CancellablePromise(this._promise.finally(onfinally), this._isCanceled);
+  }
+
+  static of<R>(promise: Promise<R>) {
+    return new CancellablePromise<R>(promise);
+  }
+
+  public cancel() {
+    this._isCanceled = true;
+
+    return this;
+  }
+
+  public isCancelled() {
+    return this._isCanceled;
+  }
+}
+
+export default CancellablePromise;


### PR DESCRIPTION
## Motivation
Prior to this change, we rely in our code on the cancellbale promise
interface from bluebird promise. But we want to use the native promise
implementation.

## Description
This change will add a wrapper class arround the promise from native
`window.fetch` which will set a cancel flag which can be accessed later
to check if a promise was cancelled.

## Note
This does not mean the then chain will be stopped. This cannot be done
with the native promise implementation. But we can check if someone
wants us to ignore the result.

Fixes #10488

## How Has This Been Tested?
- Go to the grok patterns page and see the grok patterns load again.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
