### PR TITLE
Do not display pluggable view header elements in aggregation builder.

### DIFF
--- a/graylog2-web-interface/src/views/components/widgets/EditWidgetFrame.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/EditWidgetFrame.tsx
@@ -26,7 +26,6 @@ import SaveOrCancelButtons from 'views/components/widgets/SaveOrCancelButtons';
 
 import WidgetQueryControls from '../WidgetQueryControls';
 import IfDashboard from '../dashboard/IfDashboard';
-import HeaderElements from '../HeaderElements';
 import WidgetOverrideElements from '../WidgetOverrideElements';
 
 const Container = styled.div`
@@ -71,7 +70,6 @@ const EditWidgetFrame = ({ children, onCancel, onFinish }: Props) => {
         <IfDashboard>
           <QueryControls>
             <QueryEditModeContext.Provider value="widget">
-              <HeaderElements />
               <WidgetQueryControls />
             </QueryEditModeContext.Provider>
           </QueryControls>


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Before this change we displayed the pluggable view header elements at the top
of the search page and at the top of the aggregation builder.
This was necessary because we previously displayed the aggregation builder in a
modal. Now were we display the aggregation builder inline, below the
search bar, we no longer need to display them in the aggregation builder
as well.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

