### PR TITLE
Replacing `views/Select` with `common/Select` in `FieldSortSelect`.

### DIFF
--- a/graylog2-web-interface/src/views/components/widgets/FieldSortSelect.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/FieldSortSelect.test.tsx
@@ -15,8 +15,9 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import React from 'react';
-import { render, fireEvent } from 'wrappedTestingLibrary';
+import { render, screen, waitFor } from 'wrappedTestingLibrary';
 import { List } from 'immutable';
+import selectEvent from 'react-select-event';
 
 import Direction from 'views/logic/aggregationbuilder/Direction';
 import FieldType, { Property } from 'views/logic/fieldtypes/FieldType';
@@ -35,14 +36,23 @@ describe('FieldSortSelect', () => {
   const sort = [new SortConfig('pivot', 'http_method', Direction.Ascending)];
 
   it('should display current sort as selected option', () => {
-    const { getByText } = render(<FieldSortSelect fields={fields} onChange={() => {}} sort={sort} />);
+    render(<FieldSortSelect fields={fields} onChange={() => {}} sort={sort} />);
 
-    expect(getByText('http_method')).not.toBeNull();
+    expect(screen.getByText('http_method')).not.toBeNull();
   });
 
-  it('should open menu when focused', async () => {
-    const { findByText, container } = render(<FieldSortSelect fields={fields} onChange={() => {}} sort={sort} />);
-    fireEvent.focus(container.getElementsByTagName('input')[0]);
-    await findByText(/2 results available./);
+  it('should select field and update sort', async () => {
+    const onChangeStub = jest.fn();
+    render(<FieldSortSelect fields={fields} onChange={onChangeStub} sort={sort} />);
+
+    const fieldSelect = screen.getByLabelText('Select field for sorting');
+    await selectEvent.openMenu(fieldSelect);
+
+    await selectEvent.select(fieldSelect, 'date');
+
+    const updateSort = [new SortConfig('pivot', 'date', Direction.Ascending)];
+    await waitFor(() => expect(onChangeStub).toHaveBeenCalledTimes(1));
+
+    expect(onChangeStub).toHaveBeenCalledWith(updateSort);
   });
 });

--- a/graylog2-web-interface/src/views/components/widgets/FieldSortSelect.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/FieldSortSelect.tsx
@@ -15,6 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
+import { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import * as Immutable from 'immutable';
 
@@ -23,7 +24,7 @@ import { defaultCompare } from 'views/logic/DefaultCompare';
 import Direction from 'views/logic/aggregationbuilder/Direction';
 import FieldTypeMapping from 'views/logic/fieldtypes/FieldTypeMapping';
 import SortConfig from 'views/logic/aggregationbuilder/SortConfig';
-import Select from 'views/components/Select';
+import Select from 'components/common/Select';
 
 type Props = {
   fields: Immutable.List<FieldTypeMapping>,
@@ -36,26 +37,21 @@ type Option = {
   value: number,
 };
 
-const findOptionByLabel = (options: Immutable.List<Option>, label: string) => options.find((option) => option.label === label);
+const findOptionByLabel = (options: Array<Option>, label: string) => options.find((option) => option.label === label);
 
-const findOptionByValue = (options: Immutable.List<Option>, value: number) => options.find((option) => option.value === value);
+const findOptionByValue = (options: Array<Option>, value: number) => options.find((option) => option.value === value);
 
-const currentValue = (sort: Array<SortConfig>, options: Immutable.List<Option>) => sort && sort.length > 0 && findOptionByLabel(options, sort[0].field);
+const currentValue = (sort: Array<SortConfig>, options: Array<Option>) => sort && sort.length > 0 && findOptionByLabel(options, sort[0].field)?.value;
 
-const sortedOptions = (fields: Immutable.List<FieldTypeMapping>) => {
+const sortedOptions = (fields: Immutable.List<FieldTypeMapping>): Array<Option> => {
   return fields.sort(
     (field1, field2) => defaultCompare(field1.name, field2.name),
   ).map(
     (field, idx) => ({ label: field.name, value: idx }),
-  ).toList();
+  ).toArray();
 };
 
-const onOptionChange = (options: Immutable.List<Option>, onChange, newValue, reason) => {
-  if (reason.action === 'clear') {
-    return onChange([]);
-  }
-
-  const { value } = newValue;
+const onOptionChange = (options: Array<Option>, onChange, value) => {
   const option = findOptionByValue(options, value);
 
   if (!option) {
@@ -68,13 +64,14 @@ const onOptionChange = (options: Immutable.List<Option>, onChange, newValue, rea
 };
 
 const FieldSortSelect = ({ fields, onChange, sort }: Props) => {
-  const options = sortedOptions(fields);
+  const options = useMemo(() => sortedOptions(fields), [fields]);
 
   return (
     <Select placeholder="None: click to add fields"
-            onChange={(newValue, reason) => onOptionChange(options, onChange, newValue, reason)}
-            options={options.toJS()}
-            isClearable
+            onChange={(newValue) => onOptionChange(options, onChange, newValue)}
+            options={options}
+            clearable={false}
+            aria-label="Select field for sorting"
             value={currentValue(sort, options)} />
   );
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is replacing the select component for the `FieldSortSelect`. UI
wise there is not a big difference between these components and in the
future we want to rely on only one `Select` component. The common select
component can also be tested more easily with `react-select-event`,
which will help us with the `react-select` update.

With this PR we are also removing the option to clear the `FieldSortSelect`, since it did had no effect.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

