### PR TITLE
Do not throw error on dashboards with undeclared query parameters or on widget creation.

### DIFF
--- a/graylog2-web-interface/src/views/components/widgets/TimerangeInfo.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/TimerangeInfo.test.tsx
@@ -122,7 +122,7 @@ describe('TimerangeInfo', () => {
 
   it('should display global override', () => {
     const state: GlobalOverrideStoreState = GlobalOverride.empty().toBuilder().timerange({ type: 'relative', range: 3000 }).build();
-    asMock(GlobalOverrideStore.getInitialState).mockReturnValue(state);
+    asMock(GlobalOverrideStore.getInitialState).mockReturnValueOnce(state);
 
     const keywordWidget = widget.toBuilder()
       .timerange({ type: 'keyword', keyword: '5 minutes ago' })

--- a/graylog2-web-interface/src/views/components/widgets/TimerangeInfo.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/TimerangeInfo.test.tsx
@@ -15,14 +15,17 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import React from 'react';
+import Immutable from 'immutable';
 import { render, screen } from 'wrappedTestingLibrary';
 import { MockStore } from 'helpers/mocking';
 import asMock from 'helpers/mocking/AsMock';
 
+import Search from 'views/logic/search/Search';
 import Widget from 'views/logic/widgets/Widget';
 import TimeLocalizeContext from 'contexts/TimeLocalizeContext';
 import { GlobalOverrideStore, GlobalOverrideStoreState } from 'views/stores/GlobalOverrideStore';
 import GlobalOverride from 'views/logic/search/GlobalOverride';
+import { SearchStore } from 'views/stores/SearchStore';
 
 import TimerangeInfo from './TimerangeInfo';
 
@@ -34,30 +37,31 @@ jest.mock('views/stores/GlobalOverrideStore', () => ({
   ),
 }));
 
-jest.mock('views/stores/SearchStore', () => ({
-  SearchStore: MockStore(
-    ['listen', () => jest.fn()],
-    'get',
-    ['getInitialState', () => ({
-      result: {
-        results: {
-          'active-query-id': {
-            searchTypes: {
-              'search-type-id': {
-                effective_timerange: {
-                  type: 'absolute', from: '2021-03-27T14:32:31.894Z', to: '2021-04-26T14:32:48.000Z',
-                },
-              },
+const mockSearchStoreState = (storeState = {}) => ({
+  result: {
+    results: {
+      'active-query-id': {
+        searchTypes: {
+          'search-type-id': {
+            effective_timerange: {
+              type: 'absolute', from: '2021-03-27T14:32:31.894Z', to: '2021-04-26T14:32:48.000Z',
             },
           },
         },
       },
-      widgetMapping: {
-        get: jest.fn(() => ({
-          first: jest.fn(() => 'search-type-id'),
-        })),
-      },
-    })],
+    },
+  },
+  widgetMapping: Immutable.Map({ 'widget-id': Immutable.Set(['search-type-id']) }),
+  search: Search.create(),
+  widgetsToSearch: undefined,
+  ...storeState,
+});
+
+jest.mock('views/stores/SearchStore', () => ({
+  SearchStore: MockStore(
+    ['listen', () => jest.fn()],
+    'get',
+    ['getInitialState', jest.fn(() => mockSearchStoreState())],
   ),
 }));
 
@@ -75,6 +79,24 @@ describe('TimerangeInfo', () => {
     render(<SUT widget={relativeWidget} activeQuery="active-query-id" widgetId="widget-id" />);
 
     expect(screen.getByTitle('2021-03-27T14:32:31.894Z - 2021-04-26T14:32:48.000Z')).toBeInTheDocument();
+  });
+
+  it('should not throw error when related search type is empty', () => {
+    const relativeWidget = widget.toBuilder().timerange({ type: 'relative', range: 3000 }).build();
+
+    asMock(SearchStore.getInitialState).mockReturnValueOnce(mockSearchStoreState({
+      result: {
+        results: {
+          'active-query-id': {
+            searchTypes: {},
+          },
+        },
+      },
+    }));
+
+    render(<SUT widget={relativeWidget} activeQuery="active-query-id" widgetId="widget-id" />);
+
+    expect(screen.getByText('an hour ago - Now')).toBeInTheDocument();
   });
 
   it('should display a relative timerange', () => {

--- a/graylog2-web-interface/src/views/components/widgets/TimerangeInfo.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/TimerangeInfo.test.tsx
@@ -81,24 +81,6 @@ describe('TimerangeInfo', () => {
     expect(screen.getByTitle('2021-03-27T14:32:31.894Z - 2021-04-26T14:32:48.000Z')).toBeInTheDocument();
   });
 
-  it('should not throw error when related search type is empty', () => {
-    const relativeWidget = widget.toBuilder().timerange({ type: 'relative', range: 3000 }).build();
-
-    asMock(SearchStore.getInitialState).mockReturnValueOnce(mockSearchStoreState({
-      result: {
-        results: {
-          'active-query-id': {
-            searchTypes: {},
-          },
-        },
-      },
-    }));
-
-    render(<SUT widget={relativeWidget} activeQuery="active-query-id" widgetId="widget-id" />);
-
-    expect(screen.getByText('an hour ago - Now')).toBeInTheDocument();
-  });
-
   it('should display a relative timerange', () => {
     const relativeWidget = widget.toBuilder().timerange({ type: 'relative', range: 3000 }).build();
     render(<SUT widget={relativeWidget} />);
@@ -149,5 +131,33 @@ describe('TimerangeInfo', () => {
     render(<SUT widget={keywordWidget} />);
 
     expect(screen.getByText('Global Override: an hour ago - Now')).toBeInTheDocument();
+  });
+
+  it('should not throw error when related search type is empty', () => {
+    const relativeWidget = widget.toBuilder().timerange({ type: 'relative', range: 3000 }).build();
+
+    asMock(SearchStore.getInitialState).mockReturnValueOnce(mockSearchStoreState({
+      result: {
+        results: {
+          'active-query-id': {
+            searchTypes: {},
+          },
+        },
+      },
+    }));
+
+    render(<SUT widget={relativeWidget} activeQuery="active-query-id" widgetId="widget-id" />);
+
+    expect(screen.getByText('an hour ago - Now')).toBeInTheDocument();
+  });
+
+  it('should not throw error and display default time range when widget id does not exist in search widget mapping', () => {
+    asMock(SearchStore.getInitialState).mockReturnValueOnce(mockSearchStoreState({
+      widgetMapping: Immutable.Map(),
+    }));
+
+    render(<SUT widget={widget} activeQuery="active-query-id" widgetId="widget-id" />);
+
+    expect(screen.getByText('5 minutes ago - Now')).toBeInTheDocument();
   });
 });

--- a/graylog2-web-interface/src/views/components/widgets/TimerangeInfo.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/TimerangeInfo.tsx
@@ -53,7 +53,7 @@ const TimerangeInfo = ({ className, widget, activeQuery, widgetId }: Props) => {
 
   const configuredTimerange = timerangeToString(widget.timerange || DEFAULT_TIMERANGE, localizeTime);
 
-  const searchTypeId = widgetId ? widgetMapping.get(widgetId).first() : undefined;
+  const searchTypeId = widgetId ? widgetMapping.get(widgetId)?.first() : undefined;
 
   const effectiveTimerange = (activeQuery && searchTypeId) ? getEffectiveWidgetTimerange(result, activeQuery, searchTypeId) : undefined;
   const effectiveTimerangeString = effectiveTimerange ? timerangeToString(effectiveTimerange, localizeTime) : 'Effective widget time range is currently not available.';

--- a/graylog2-web-interface/src/views/components/widgets/TimerangeInfo.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/TimerangeInfo.tsx
@@ -40,6 +40,9 @@ const Wrapper = styled.div(({ theme }) => css`
   width: max-content;
 `);
 
+const getEffectiveWidgetTimerange = (result, activeQuery, searchTypeId) => result?.results[activeQuery]
+  .searchTypes[searchTypeId]?.effective_timerange;
+
 const TimerangeInfo = ({ className, widget, activeQuery, widgetId }: Props) => {
   const { localizeTime } = useContext(TimeLocalizeContext);
   const { result, widgetMapping } = useStore(SearchStore);
@@ -51,9 +54,9 @@ const TimerangeInfo = ({ className, widget, activeQuery, widgetId }: Props) => {
   const configuredTimerange = timerangeToString(widget.timerange || DEFAULT_TIMERANGE, localizeTime);
 
   const searchTypeId = widgetId ? widgetMapping.get(widgetId).first() : undefined;
-  const effectiveTimerange = activeQuery && searchTypeId ? result?.results[activeQuery]
-    .searchTypes[searchTypeId].effective_timerange : {};
-  const effectiveTimerangeString = timerangeToString(effectiveTimerange, localizeTime);
+
+  const effectiveTimerange = (activeQuery && searchTypeId) ? getEffectiveWidgetTimerange(result, activeQuery, searchTypeId) : undefined;
+  const effectiveTimerangeString = effectiveTimerange ? timerangeToString(effectiveTimerange, localizeTime) : 'Effective widget time range is currently not available.';
 
   return (
     <Wrapper className={className}>


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

We've recently implemented a time range info for dashboard widgets https://github.com/Graylog2/graylog2-server/pull/10508. This PR is fixing a runtime error which occurred when no search types exist.
This is the case when a filter with an undeclared parameter is being applied.

It also fixes another runtime error which occurred after creating a new widget, because it was not yet listen in the search widget mapping.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

