### PR TITLE
Collection of smaller improvements for saved searches overview

### DIFF
--- a/graylog2-web-interface/src/components/graylog/ListGroupItem.jsx
+++ b/graylog2-web-interface/src/components/graylog/ListGroupItem.jsx
@@ -80,23 +80,27 @@ const StyledListGroupItem = styled(BootstrapListGroupItem)(({ theme }) => css`
   background-color: ${theme.colors.global.contentBackground};
   border: 0;
 
+  padding: 10px 10px 5px 10px;
+
   .list-group-item-heading {
-    font-weight: bold;
+    font-size: ${theme.fonts.size.h5};
+  }
+
+  .list-group-item-text {
+    margin-bottom: 5px;
   }
 
   a&,
   button& {
-    color: ${theme.colors.global.link};
+    color: ${theme.colors.global.textDefault};
 
     .list-group-item-heading {
       color: ${theme.colors.variant.darkest.default};
-      font-weight: bold;
     }
 
     &:hover:not(.disabled),
     &:focus:not(.disabled) {
       background-color: ${theme.colors.variant.lightest.default};
-      color: ${theme.colors.global.linkHover};
 
       &.active {
         color: ${theme.colors.variant.darkest.default};
@@ -118,7 +122,6 @@ const StyledListGroupItem = styled(BootstrapListGroupItem)(({ theme }) => css`
 
     .list-group-item-heading {
       color: inherit;
-      font-weight: bold;
     }
 
     .list-group-item-text {
@@ -138,7 +141,6 @@ const StyledListGroupItem = styled(BootstrapListGroupItem)(({ theme }) => css`
     .list-group-item-heading > small,
     .list-group-item-heading > .small {
       color: inherit;
-      font-weight: bold;
     }
 
     .list-group-item-text {

--- a/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchControls.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchControls.tsx
@@ -34,7 +34,7 @@ import ExportModal from 'views/components/export/ExportModal';
 import ViewTypeLabel from 'views/components/ViewTypeLabel';
 import EntityShareModal from 'components/permissions/EntityShareModal';
 import CurrentUserContext from 'contexts/CurrentUserContext';
-import * as Permissions from 'views/Permissions';
+import * as ViewsPermissions from 'views/Permissions';
 import type { UserJSON } from 'logic/users/User';
 import ViewPropertiesModal from 'views/components/views/ViewPropertiesModal';
 import { loadAsDashboard, loadNewSearch } from 'views/logic/views/Actions';
@@ -58,7 +58,7 @@ type State = {
 
 const _isAllowedToEdit = (view: View, currentUser: UserJSON | undefined | null) => (
   view.owner === currentUser?.username
-  || isPermitted(currentUser?.permissions, [Permissions.View.Edit(view.id)])
+  || isPermitted(currentUser?.permissions, [ViewsPermissions.View.Edit(view.id)])
 );
 
 class SavedSearchControls extends React.Component<Props, State> {
@@ -256,7 +256,8 @@ class SavedSearchControls extends React.Component<Props, State> {
                     </Button>
                     {showList && (
                       <SavedSearchList deleteSavedSearch={this.deleteSavedSearch}
-                                       toggleModal={this.toggleListModal} />
+                                       toggleModal={this.toggleListModal}
+                                       activeSavedSearchId={view.id} />
                     )}
                     <ShareButton entityType="search"
                                  entityId={view.id}

--- a/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchList.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchList.test.tsx
@@ -15,30 +15,32 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import React from 'react';
-import { render, fireEvent } from 'wrappedTestingLibrary';
+import { render, fireEvent, screen, waitFor } from 'wrappedTestingLibrary';
+import asMock from 'helpers/mocking/AsMock';
 
 import View from 'views/logic/views/View';
 import ViewLoaderContext from 'views/logic/ViewLoaderContext';
+import { SavedSearchesActions } from 'views/stores/SavedSearchesStore';
 
 import SavedSearchList from './SavedSearchList';
 
-const createViewsResponse = (count = 1) => {
-  const views = [];
+const createPaginatedSearches = (count = 1) => {
+  const views: Array<View> = [];
 
   if (count > 0) {
     // eslint-disable-next-line no-plusplus
     for (let i = 0; i < count; i++) {
       views.push(
         View.builder()
-          .id(`foo-bar-${i}`)
-          .title(`test-${i}`)
+          .id(`search-id-${i}`)
+          .title(`search-title-${i}`)
           .description('desc')
           .build(),
       );
     }
   }
 
-  return {
+  return Promise.resolve({
     pagination: {
       total: count,
       page: count > 0 ? count : 0,
@@ -46,36 +48,52 @@ const createViewsResponse = (count = 1) => {
       count,
     },
     list: views,
-  };
+  });
 };
+
+jest.mock('views/stores/SavedSearchesStore', () => ({
+  SavedSearchesStore: {
+    listen: jest.fn(),
+  },
+  SavedSearchesActions: {
+    search: jest.fn(),
+  },
+}));
 
 describe('SavedSearchList', () => {
   describe('render the SavedSearchList', () => {
-    it('should render empty', () => {
-      const views = createViewsResponse(0);
-      const { baseElement } = render(<SavedSearchList toggleModal={() => {}}
-                                                      deleteSavedSearch={() => Promise.resolve(views[0])}
-                                                      views={views} />);
+    it('should render empty', async () => {
+      const views = createPaginatedSearches(0);
+      asMock(SavedSearchesActions.search).mockReturnValueOnce(views);
 
-      expect(baseElement).not.toBeNull();
+      render(<SavedSearchList toggleModal={() => {}}
+                              deleteSavedSearch={() => Promise.resolve(views[0])}
+                              activeSavedSearchId="search-id-0" />);
+
+      await screen.findByText('No saved searches found.');
     });
 
-    it('should render with views', () => {
-      const views = createViewsResponse(1);
-      const { baseElement } = render(<SavedSearchList toggleModal={() => {}}
-                                                      deleteSavedSearch={() => Promise.resolve(views[0])}
-                                                      views={views} />);
+    it('should render with views', async () => {
+      const views = createPaginatedSearches(2);
+      asMock(SavedSearchesActions.search).mockReturnValueOnce(views);
 
-      expect(baseElement).not.toBeNull();
+      render(<SavedSearchList toggleModal={() => {}}
+                              deleteSavedSearch={() => Promise.resolve(views[0])}
+                              activeSavedSearchId="search-id-0" />);
+
+      await screen.findByText('search-title-0');
+      await screen.findByText('search-title-1');
     });
 
-    it('should handle toggle modal', () => {
+    it('should handle toggle modal', async () => {
       const onToggleModal = jest.fn();
-      const views = createViewsResponse(1);
-
+      const views = createPaginatedSearches(1);
+      asMock(SavedSearchesActions.search).mockReturnValueOnce(views);
       const { getByText } = render(<SavedSearchList toggleModal={onToggleModal}
                                                     deleteSavedSearch={() => Promise.resolve(views[0])}
-                                                    views={views} />);
+                                                    activeSavedSearchId="search-id-0" />);
+
+      await screen.findByText('search-title-0');
 
       const cancel = getByText('Cancel');
 
@@ -84,33 +102,40 @@ describe('SavedSearchList', () => {
       expect(onToggleModal).toBeCalledTimes(1);
     });
 
-    it('should call `onDelete` if saved search is deleted', () => {
+    it('should call `onDelete` if saved search is deleted', async () => {
       window.confirm = jest.fn(() => true);
-      const views = createViewsResponse(1);
+      const views = createPaginatedSearches(1);
+      asMock(SavedSearchesActions.search).mockReturnValueOnce(views);
       const onDelete = jest.fn(() => Promise.resolve(views[0]));
-      const { getByTestId } = render(<SavedSearchList toggleModal={() => {}}
-                                                      deleteSavedSearch={onDelete}
-                                                      views={views} />);
-      const deleteBtn = getByTestId('delete-foo-bar-0');
+
+      render(<SavedSearchList toggleModal={() => {}}
+                              deleteSavedSearch={onDelete}
+                              activeSavedSearchId="search-id-0" />);
+
+      await screen.findByText('search-title-0');
+      const deleteBtn = screen.getByTitle('Delete search search-title-0');
 
       fireEvent.click(deleteBtn);
 
       expect(window.confirm).toBeCalledTimes(1);
-      expect(onDelete).toBeCalledTimes(1);
+
+      await waitFor(() => expect(onDelete).toBeCalledTimes(1));
     });
 
-    it('should call load function from context', () => {
-      const onLoad = jest.fn(() => { return new Promise(() => {}); });
-      const views = createViewsResponse(1);
+    it('should call load function from context', async () => {
+      const onLoad = jest.fn(() => new Promise(() => {}));
+      const views = createPaginatedSearches(1);
+      asMock(SavedSearchesActions.search).mockReturnValueOnce(views);
 
-      const { getByText } = render(
+      render(
         <ViewLoaderContext.Provider value={onLoad}>
           <SavedSearchList toggleModal={() => {}}
                            deleteSavedSearch={() => Promise.resolve(views[0])}
-                           views={views} />
+                           activeSavedSearchId="search-id-0" />
         </ViewLoaderContext.Provider>,
       );
-      const listItem = getByText('test-0');
+
+      const listItem = await screen.findByText('search-title-0');
 
       fireEvent.click(listItem);
 

--- a/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchList.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchList.tsx
@@ -39,6 +39,10 @@ type State = {
   perPage: number,
 };
 
+const StyledListGroup = styled.div`
+  clear: both;
+`;
+
 const AlertIcon = styled(Icon)(({ theme }) => css`
   margin-right: 6px;
   color: ${theme.colors.variant.primary};
@@ -173,7 +177,7 @@ class SavedSearchList extends React.Component<Props, State> {
                        activePage={page}
                        totalItems={total}
                        pageSize={perPage}>
-          <ListGroup>{savedSearchList}</ListGroup>
+          <StyledListGroup>{savedSearchList}</StyledListGroup>
         </PaginatedList>
       )
       : (

--- a/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchList.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchList.tsx
@@ -26,6 +26,7 @@ import { Icon, PaginatedList, SearchForm, Spinner } from 'components/common';
 import View from 'views/logic/views/View';
 import ViewLoaderContext from 'views/logic/ViewLoaderContext';
 import { ViewManagementActions } from 'views/stores/ViewManagementStore';
+import UserNotification from 'util/UserNotification';
 
 type Props = {
   toggleModal: () => void,
@@ -102,6 +103,9 @@ const _loadSavesSearches = (pagination, setLoading, setPaginatedSavedSearches) =
   SavedSearchesActions.search(pagination).then((paginatedSavedSearches) => {
     setPaginatedSavedSearches(paginatedSavedSearches);
     setLoading(false);
+  }).catch((error) => {
+    UserNotification.error(`Fetching saved searches failed with status: ${error}`,
+      'Could not retrieve saved searches');
   });
 };
 

--- a/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchList.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchList.tsx
@@ -59,7 +59,7 @@ const DeleteButton = styled.span`
 const DEFAULT_PAGINATION = {
   query: '',
   page: 1,
-  perPage: 5,
+  perPage: 10,
 };
 
 class SavedSearchList extends React.Component<Props, State> {
@@ -172,8 +172,7 @@ class SavedSearchList extends React.Component<Props, State> {
         <PaginatedList onChange={this.handlePageChange}
                        activePage={page}
                        totalItems={total}
-                       pageSize={perPage}
-                       pageSizes={[5, 10, 15]}>
+                       pageSize={perPage}>
           <ListGroup>{savedSearchList}</ListGroup>
         </PaginatedList>
       )

--- a/graylog2-web-interface/src/views/stores/SavedSearchesStore.ts
+++ b/graylog2-web-interface/src/views/stores/SavedSearchesStore.ts
@@ -19,26 +19,13 @@ import Reflux from 'reflux';
 import * as URLUtils from 'util/URLUtils';
 import { singletonActions, singletonStore } from 'views/logic/singleton';
 import fetch from 'logic/rest/FetchProvider';
-import UserNotification from 'util/UserNotification';
 import type { RefluxActions } from 'stores/StoreTypes';
 
 import type { PaginatedViews, SortField, SortOrder } from './ViewManagementStore';
 
-import View from '../logic/views/View';
-
 export type SavedSearchesActionsType = RefluxActions<{
   search: (query?: string, page?: number, perPage?: number, sortBy?: SortField, order?: SortOrder) => Promise<PaginatedViews>,
 }>;
-
-export type SavedSearchesState = {
-  list: Array<View> | undefined,
-  pagination: {
-    total: number,
-    page: number,
-    perPage: number,
-    count: number,
-  },
-};
 
 const SavedSearchesActions: SavedSearchesActionsType = singletonActions(
   'views.SavedSearches',
@@ -53,46 +40,23 @@ const SavedSearchesStore = singletonStore(
   'views.SavedSearches',
   () => Reflux.createStore({
     listenables: [SavedSearchesActions],
-    searches: undefined,
-    pagination: {
-      total: 0,
-      count: 0,
-      page: 1,
-      perPage: 10,
-    },
 
-    getInitialState() {
-      return {
-        pagination: this.pagination,
-        list: this.searches,
-      };
-    },
-
-    search(query = '', page = 1, perPage = 10, sortBy = 'title', order = 'asc') {
+    search({ query = '', page = 1, perPage = 10, sortBy = 'title', order = 'asc' }): Promise<PaginatedViews> {
       const promise = fetch('GET', `${savedSearchesUrl}?query=${query}&page=${page}&per_page=${perPage}&sort=${sortBy}&order=${order}`)
-        .then((response) => {
-          this.searches = response.views;
-
-          this.pagination = {
-            total: response.total,
+        .then((response) => ({
+          list: response.views,
+          pagination: {
             count: response.count,
             page: response.page,
             perPage: response.per_page,
-          };
-
-          this.trigger({
-            list: this.searches,
-            pagination: this.pagination,
-          });
-
-          return response;
-        })
-        .catch((error) => {
-          UserNotification.error(`Fetching saved searches failed with status: ${error}`,
-            'Could not retrieve saved searches');
-        });
+            query: response.query,
+            total: response.total,
+          },
+        }));
 
       SavedSearchesActions.search.promise(promise);
+
+      return promise;
     },
   }),
 );


### PR DESCRIPTION
## Description
## Motivation and Context
This PR contains a collection of smaller improvements for the saved search overview:

- Displaying the saved search summary.
- Displaying a loading spinner while loading saved searches.
- Only displaying "not found" info when API returned no saved searches, before this change we displayed the info while loading searches.
- Using default page sizes and increasing default page size from 5 to 10.
- Fixing floating of page size select, it was part of the first list item.
- Displaying selected saved search as active.

For these improvements I decided to implement the following refactorings:
- Transforming `SavedSearchesList` from class component to functional component.
- Moving the list state from the `SavedSearchesStore` to the `SavedSearchesList`

Fixes: #10130

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

