### PR TITLE
Separate integration and unit tests in frontend.

### DIFF
--- a/graylog2-server/pom.xml
+++ b/graylog2-server/pom.xml
@@ -972,6 +972,16 @@
                                 </configuration>
                             </execution>
                             <execution>
+                                <id>yarn test</id>
+                                <goals>
+                                    <goal>yarn</goal>
+                                </goals>
+                                <phase>test</phase>
+                                <configuration>
+                                    <arguments>test:integration</arguments>
+                                </configuration>
+                            </execution>
+                            <execution>
                                 <id>yarn tsc</id>
                                 <goals>
                                     <goal>yarn</goal>

--- a/graylog2-server/pom.xml
+++ b/graylog2-server/pom.xml
@@ -972,7 +972,7 @@
                                 </configuration>
                             </execution>
                             <execution>
-                                <id>yarn test</id>
+                                <id>yarn test:integration</id>
                                 <goals>
                                     <goal>yarn</goal>
                                 </goals>

--- a/graylog2-web-interface/jest.it.config.js
+++ b/graylog2-web-interface/jest.it.config.js
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 const config = {
   preset: 'jest-preset-graylog',
   setupFiles: [

--- a/graylog2-web-interface/jest.it.config.js
+++ b/graylog2-web-interface/jest.it.config.js
@@ -1,0 +1,14 @@
+const config = {
+  preset: 'jest-preset-graylog',
+  setupFiles: [
+    '<rootDir>/test/setup-jest.js',
+  ],
+  setupFilesAfterEnv: [
+    'jest-enzyme',
+    '<rootDir>/test/configure-testing-library.js',
+  ],
+  testEnvironment: '<rootDir>/test/integration-environment.js',
+  testRegex: '\\.it\\.[jt]sx?$',
+};
+
+module.exports = config;

--- a/graylog2-web-interface/package.json
+++ b/graylog2-web-interface/package.json
@@ -22,6 +22,7 @@
     "lint:styles:path": "stylelint --syntax css-in-js",
     "lint:changes": "./dev/lintChanges.sh",
     "test": "jest",
+    "test:integration": "jest --config jest.it.config.js",
     "check-production-build": "node checkProductionBuild.js"
   },
   "eslintConfig": {

--- a/graylog2-web-interface/src/views/spec/CreateNewDashboard.it.tsx
+++ b/graylog2-web-interface/src/views/spec/CreateNewDashboard.it.tsx
@@ -1,6 +1,3 @@
-/**
- * @jest-environment <rootDir>/test/integration-environment.js
- */
 /*
  * Copyright (C) 2020 Graylog, Inc.
  *


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is implementing some structural changes that separate runs for unit and integration tests in the frontend. This allows us to:

  - prevent rejected promises from integration tests leaking to other tests, causing false negatives
  - tune timeouts separately, as integration tests tend towards requiring higher timeout due to the increased complexity

It works by defining a second jest configuration file with a different test file name spec and defaulting to the integration test environment.
This means that:

  - unit tests still should be named `*.(test|spec).[jt]s(x)?` (and all `.[jt]s(x)?` files in the `__tests__` folder)
  - integration tests should be named `*.it.[jt]s(x)?`

The expected end result is to make the frontend tests run more reliable without having to disable the `CreateNewDashboard` integration test, so we can continue improving that test and the category of integration
tests.

<!--- Provide a general summary of your changes in the Title above -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.