### PR TITLE
Add validation that a sort does not work on timebased charts

### DIFF
--- a/graylog2-web-interface/src/views/components/aggregationwizard/WidgetConfigForm.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/WidgetConfigForm.tsx
@@ -92,7 +92,7 @@ export interface WidgetConfigValidationErrors {
   metrics?: Array<{ [key: string]: string }>,
   groupBy?: { groupings: Array<{ [key: string]: string }> },
   visualization?: { [key: string]: string | any },
-  sort?: { [key: string]: string },
+  sort?: Array<{ [key: string]: string }>,
 }
 
 type Props = {

--- a/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/SortElement.test.ts
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/SortElement.test.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import { SortFormValues, WidgetConfigFormValues } from 'views/components/aggregationwizard/WidgetConfigForm';
+
+import SortElement from './SortElement';
+
+describe('SortElement', () => {
+  describe('Validation', () => {
+    const { validate } = SortElement;
+
+    it('should assert field is present', () => {
+      const values: WidgetConfigFormValues = { sort: [{ direction: 'Ascending', id: 'foob' }] };
+      const result = validate(values);
+
+      expect(result.sort[0].field).toBe('Field is required.');
+    });
+
+    it('should not fail if field and direction is present', () => {
+      const values: WidgetConfigFormValues = { sort: [{ field: 'action', direction: 'Ascending', id: 'foob' }] };
+      const result = validate(values);
+
+      expect(result.sort).toBeUndefined();
+    });
+
+    it('should assert direction is present', () => {
+      const values: WidgetConfigFormValues = { sort: [{ field: 'action', id: 'foob' }] };
+      const result = validate(values);
+
+      expect(result.sort[0].direction).toBe('Direction is required.');
+    });
+
+    it('should show an error if a time based group by and a non datatable is present', () => {
+      const values: WidgetConfigFormValues = {
+        sort: [{ field: 'action', direction: 'Ascending', id: 'foob' }],
+        groupBy: {
+          columnRollup: false,
+          groupings:
+            [{
+              id: 'foob',
+              direction: 'row',
+              field: { field: 'time', type: 'time' },
+              interval: { type: 'timeunit', value: 3, unit: 'seconds' },
+            }],
+        },
+        visualization: { type: 'chart' },
+      };
+      const result = validate(values);
+
+      expect(result.sort[0].field).toBe('Sort on non data table with time based row grouping does not work.');
+    });
+  });
+});

--- a/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/SortElement.test.ts
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/SortElement.test.ts
@@ -14,7 +14,7 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import { SortFormValues, WidgetConfigFormValues } from 'views/components/aggregationwizard/WidgetConfigForm';
+import { WidgetConfigFormValues } from 'views/components/aggregationwizard/WidgetConfigForm';
 
 import SortElement from './SortElement';
 

--- a/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/SortElement.ts
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/SortElement.ts
@@ -52,6 +52,13 @@ const validateSorts = (values: WidgetConfigFormValues) => {
       sortError.direction = 'Direction is required.';
     }
 
+    const timeRowExists = !!values.groupBy?.groupings.find((g) => g.direction === 'row' && g.field.type === 'time');
+    const nonDataTableVisExists = values.visualization && values.visualization.type !== 'table';
+
+    if (timeRowExists && nonDataTableVisExists) {
+      sortError.field = 'Sort on non data table with time based row grouping does not work.';
+    }
+
     return sortError;
   });
 


### PR DESCRIPTION
## Motivation
Prior to this change, the user could configure sort elements on the
aggregation widget. But it either had not effect or it only broke the
visualization on timebase graphic charts.

## Description
This change will introduce a validaton to check if the sort element was
introduced together with a non table visualization and a timebase row
groupby.

## How Has This Been Tested?
- Add a sorting to a histogram

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Fixes #10416
