### PR TITLE
Do not quote index match pattern for index management check pattern.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/MongoIndexSet.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/MongoIndexSet.java
@@ -102,15 +102,12 @@ public class MongoIndexSet implements IndexSet {
         this.activityWriter = requireNonNull(activityWriter);
 
         // Part of the pattern can be configured in IndexSetConfig. If set we use the indexMatchPattern from the config.
-        if (isNullOrEmpty(config.indexMatchPattern())) {
-            // This pattern requires that we check that each index prefix is unique and unambiguous to avoid false matches.
-            this.indexPattern = Pattern.compile("^" + Pattern.quote(config.indexPrefix()) + SEPARATOR + "\\d+(?:" + RESTORED_ARCHIVE_SUFFIX + ")?");
-            this.deflectorIndexPattern = Pattern.compile("^" + Pattern.quote(config.indexPrefix()) + SEPARATOR + "\\d+");
-        } else {
-            // This pattern requires that we check that each index prefix is unique and unambiguous to avoid false matches.
-            this.indexPattern = Pattern.compile("^" + Pattern.quote(config.indexMatchPattern()) + SEPARATOR + "\\d+(?:" + RESTORED_ARCHIVE_SUFFIX + ")?");
-            this.deflectorIndexPattern = Pattern.compile("^" + Pattern.quote(config.indexMatchPattern()) + SEPARATOR + "\\d+");
-        }
+        final String indexPattern = isNullOrEmpty(config.indexMatchPattern())
+                ? Pattern.quote(config.indexPrefix())
+                : config.indexMatchPattern();
+
+        this.indexPattern = Pattern.compile("^" + indexPattern + SEPARATOR + "\\d+(?:" + RESTORED_ARCHIVE_SUFFIX + ")?");
+        this.deflectorIndexPattern = Pattern.compile("^" + indexPattern + SEPARATOR + "\\d+");
 
         // The index wildcard can be configured in IndexSetConfig. If not set we use a default one based on the index
         // prefix.


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

**Note:** This needs to be backported to `4.0`.

In #10392 we added quoting for the patterns used to identify if an index is managed by an index set. This works fine unless `IndexSetConfig#indexMatchPattern` is defined. The index match pattern can contain special characters and regex terms deliberately, which must not be quoted. The index match pattern is currently used by archiving, which lead to it not being able to identify indices belonging to the restored archives index set.

This PR is removing quoting for the index match pattern. Any usage of the index match pattern must ensure that all special characters are quoted properly.

In a future PR I would suggest that the index match pattern can not be set through the REST API. It is currently not exposed through the frontend, the only use case is a programmatic one in archiving and it can introduce a lot of issues if the input is not quoted properly, while the benefit of it's exposure through the REST API is very small and the ability to introduce very subtle issues is big.

Fixes Graylog2/graylog-plugin-enterprise#2216.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.