### PR TITLE
Decrease Jest workers used to optimize build time.

### DIFF
--- a/graylog2-web-interface/package.json
+++ b/graylog2-web-interface/package.json
@@ -21,8 +21,8 @@
     "lint:styles": "stylelint './src/**/*.{js,jsx,ts,tsx}' --syntax css-in-js",
     "lint:styles:path": "stylelint --syntax css-in-js",
     "lint:changes": "./dev/lintChanges.sh",
-    "test": "jest",
-    "test:integration": "jest --config jest.it.config.js",
+    "test": "jest --maxWorkers=50%",
+    "test:integration": "jest --maxWorkers=50% --config jest.it.config.js",
     "check-production-build": "node checkProductionBuild.js"
   },
   "eslintConfig": {


### PR DESCRIPTION
Decreasing the number of workers used for frontend tests to improve build time and stability. 

## Description
Set the number of workers in the Jest worker pool to 50%.

## Motivation and Context
This will help reduce the number of intermittent timeouts in frontend tests. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

