### PR TITLE
Encode usernames used in URLs

### DIFF
--- a/graylog2-web-interface/src/stores/roles/AuthzRolesStore.ts
+++ b/graylog2-web-interface/src/stores/roles/AuthzRolesStore.ts
@@ -59,13 +59,19 @@ const _responseToPaginatedUserList = ({ count, total, page, per_page, query, use
   },
 });
 
+const encodeApiUrl = (apiRoute: (...args: Array<string>) => { url: string }, uriParams: Array<string> = []): string => {
+  const encodedUriParams = uriParams.map((param) => encodeURIComponent(param));
+
+  return apiRoute(...encodedUriParams).url;
+};
+
 const AuthzRolesStore: Store<{}> = singletonStore(
   'AuthzRoles',
   () => Reflux.createStore({
     listenables: [AuthzRolesActions],
 
     load(roleId: $PropertyType<Role, 'id'>): Promise<Role> {
-      const url = qualifyUrl(ApiRoutes.AuthzRolesController.load(encodeURIComponent(roleId)).url);
+      const url = qualifyUrl(encodeApiUrl(ApiRoutes.AuthzRolesController.load, [roleId]));
       const promise = fetch('GET', url).then(Role.fromJSON);
 
       AuthzRolesActions.load.promise(promise);
@@ -74,7 +80,7 @@ const AuthzRolesStore: Store<{}> = singletonStore(
     },
 
     delete(roleId: string): Promise<void> {
-      const url = qualifyUrl(ApiRoutes.AuthzRolesController.delete(encodeURIComponent(roleId)).url);
+      const url = qualifyUrl(encodeApiUrl(ApiRoutes.AuthzRolesController.delete, [roleId]));
       const promise = fetch('DELETE', url);
 
       AuthzRolesActions.delete.promise(promise);
@@ -83,7 +89,7 @@ const AuthzRolesStore: Store<{}> = singletonStore(
     },
 
     addMembers(roleId: string, usernames: Immutable.Set<string>): Promise<Role> {
-      const { url } = ApiRoutes.AuthzRolesController.addMembers(roleId);
+      const url = encodeApiUrl(ApiRoutes.AuthzRolesController.addMembers, [roleId]);
       const promise = fetch('PUT', qualifyUrl(url), usernames.toArray());
 
       AuthzRolesActions.addMembers.promise(promise);
@@ -92,7 +98,7 @@ const AuthzRolesStore: Store<{}> = singletonStore(
     },
 
     removeMember(roleId: string, username: string): Promise<Role> {
-      const { url } = ApiRoutes.AuthzRolesController.removeMember(roleId, username);
+      const url = encodeApiUrl(ApiRoutes.AuthzRolesController.removeMember, [roleId, username]);
       const promise = fetch('DELETE', qualifyUrl(url));
 
       AuthzRolesActions.removeMember.promise(promise);
@@ -101,7 +107,8 @@ const AuthzRolesStore: Store<{}> = singletonStore(
     },
 
     loadUsersForRole(roleId: string, roleName: string, { page, perPage, query }: Pagination): Promise<PaginatedUsers> {
-      const url = PaginationURL(ApiRoutes.AuthzRolesController.loadUsersForRole(roleId).url, page, perPage, query);
+      const apiUrl = encodeApiUrl(ApiRoutes.AuthzRolesController.loadUsersForRole, [roleId]);
+      const url = PaginationURL(apiUrl, page, perPage, query);
 
       const promise = fetch('GET', qualifyUrl(url))
         .then(_responseToPaginatedUserList);
@@ -112,7 +119,8 @@ const AuthzRolesStore: Store<{}> = singletonStore(
     },
 
     loadRolesForUser(username: string, { page, perPage, query }: Pagination): Promise<PaginatedRoles> {
-      const url = PaginationURL(ApiRoutes.AuthzRolesController.loadRolesForUser(username).url, page, perPage, query);
+      const apiUrl = encodeApiUrl(ApiRoutes.AuthzRolesController.loadRolesForUser, [username]);
+      const url = PaginationURL(apiUrl, page, perPage, query);
 
       const promise = fetch('GET', qualifyUrl(url))
         .then(_responseToPaginatedList);
@@ -123,7 +131,8 @@ const AuthzRolesStore: Store<{}> = singletonStore(
     },
 
     loadRolesPaginated({ page, perPage, query }: Pagination): Promise<PaginatedRoles> {
-      const url = PaginationURL(ApiRoutes.AuthzRolesController.list().url, page, perPage, query);
+      const apiUrl = encodeApiUrl(ApiRoutes.AuthzRolesController.list);
+      const url = PaginationURL(apiUrl, page, perPage, query);
 
       const promise = fetch('GET', qualifyUrl(url))
         .then(_responseToPaginatedList);

--- a/graylog2-web-interface/src/stores/users/PreferencesStore.ts
+++ b/graylog2-web-interface/src/stores/users/PreferencesStore.ts
@@ -75,7 +75,7 @@ const PreferencesStore = Reflux.createStore({
 
   saveUserPreferences(userName: string, preferences: PreferencesUpdateMap, callback: (preferences: PreferencesUpdateMap) => void = () => {}, displaySuccessNotification = true): void {
     const convertedPreferences = convertPreferences(preferences);
-    const url = `${this.URL + userName}/preferences`;
+    const url = `${this.URL + encodeURIComponent(userName)}/preferences`;
     const promise = fetch('PUT', url, { preferences: convertedPreferences })
       .then(() => {
         if (displaySuccessNotification) {
@@ -93,7 +93,7 @@ const PreferencesStore = Reflux.createStore({
     return promise;
   },
   loadUserPreferences(userName: string, callback: (preferences: PreferencesMap) => void = () => {}): void {
-    const url = this.URL + userName;
+    const url = this.URL + encodeURIComponent(userName);
 
     const failCallback = (errorThrown) => {
       UserNotification.error(


### PR DESCRIPTION
Usernames may contain some URL reserved characters that may break API calls. This PR fixes those instances where we were not yet encoding usernames.

For what I could see, this only affects roles and user preferences API requests.

Fixes #10530

The fix needs to be backported into 4.0.