### PR TITLE
Encode usernames used in URLs - 4.0

### DIFF
--- a/graylog2-web-interface/src/stores/roles/AuthzRolesStore.js
+++ b/graylog2-web-interface/src/stores/roles/AuthzRolesStore.js
@@ -61,13 +61,19 @@ const _responseToPaginatedUserList = ({ count, total, page, per_page, query, use
   },
 });
 
+const encodeApiUrl = (apiRoute: (...args: Array<string>) => { url: string }, uriParams: Array<string> = []): string => {
+  const encodedUriParams = uriParams.map((param) => encodeURIComponent(param));
+
+  return apiRoute(...encodedUriParams).url;
+};
+
 const AuthzRolesStore: Store<{}> = singletonStore(
   'AuthzRoles',
   () => Reflux.createStore({
     listenables: [AuthzRolesActions],
 
     load(roleId: $PropertyType<Role, 'id'>): Promise<Role> {
-      const url = qualifyUrl(ApiRoutes.AuthzRolesController.load(encodeURIComponent(roleId)).url);
+      const url = qualifyUrl(encodeApiUrl(ApiRoutes.AuthzRolesController.load, [roleId]));
       const promise = fetch('GET', url).then(Role.fromJSON);
 
       AuthzRolesActions.load.promise(promise);
@@ -76,7 +82,7 @@ const AuthzRolesStore: Store<{}> = singletonStore(
     },
 
     delete(roleId: string): Promise<void> {
-      const url = qualifyUrl(ApiRoutes.AuthzRolesController.delete(encodeURIComponent(roleId)).url);
+      const url = qualifyUrl(encodeApiUrl(ApiRoutes.AuthzRolesController.delete, [roleId]));
       const promise = fetch('DELETE', url);
 
       AuthzRolesActions.delete.promise(promise);
@@ -85,7 +91,7 @@ const AuthzRolesStore: Store<{}> = singletonStore(
     },
 
     addMembers(roleId: string, usernames: Immutable.Set<string>): Promise<Role> {
-      const { url } = ApiRoutes.AuthzRolesController.addMembers(roleId);
+      const url = encodeApiUrl(ApiRoutes.AuthzRolesController.addMembers, [roleId]);
       const promise = fetch('PUT', qualifyUrl(url), usernames.toArray());
 
       AuthzRolesActions.addMembers.promise(promise);
@@ -94,7 +100,7 @@ const AuthzRolesStore: Store<{}> = singletonStore(
     },
 
     removeMember(roleId: string, username: string): Promise<Role> {
-      const { url } = ApiRoutes.AuthzRolesController.removeMember(roleId, username);
+      const url = encodeApiUrl(ApiRoutes.AuthzRolesController.removeMember, [roleId, username]);
       const promise = fetch('DELETE', qualifyUrl(url));
 
       AuthzRolesActions.removeMember.promise(promise);
@@ -103,7 +109,8 @@ const AuthzRolesStore: Store<{}> = singletonStore(
     },
 
     loadUsersForRole(roleId: string, roleName: string, { page, perPage, query }: Pagination): Promise<PaginatedUsers> {
-      const url = PaginationURL(ApiRoutes.AuthzRolesController.loadUsersForRole(roleId).url, page, perPage, query);
+      const apiUrl = encodeApiUrl(ApiRoutes.AuthzRolesController.loadUsersForRole, [roleId]);
+      const url = PaginationURL(apiUrl, page, perPage, query);
 
       const promise = fetch('GET', qualifyUrl(url))
         .then(_responseToPaginatedUserList);
@@ -114,7 +121,8 @@ const AuthzRolesStore: Store<{}> = singletonStore(
     },
 
     loadRolesForUser(username: string, { page, perPage, query }: Pagination): Promise<PaginatedRoles> {
-      const url = PaginationURL(ApiRoutes.AuthzRolesController.loadRolesForUser(username).url, page, perPage, query);
+      const apiUrl = encodeApiUrl(ApiRoutes.AuthzRolesController.loadRolesForUser, [username]);
+      const url = PaginationURL(apiUrl, page, perPage, query);
 
       const promise = fetch('GET', qualifyUrl(url))
         .then(_responseToPaginatedList);
@@ -125,7 +133,8 @@ const AuthzRolesStore: Store<{}> = singletonStore(
     },
 
     loadRolesPaginated({ page, perPage, query }: Pagination): Promise<PaginatedRoles> {
-      const url = PaginationURL(ApiRoutes.AuthzRolesController.list().url, page, perPage, query);
+      const apiUrl = encodeApiUrl(ApiRoutes.AuthzRolesController.list);
+      const url = PaginationURL(apiUrl, page, perPage, query);
 
       const promise = fetch('GET', qualifyUrl(url))
         .then(_responseToPaginatedList);

--- a/graylog2-web-interface/src/stores/users/PreferencesStore.js
+++ b/graylog2-web-interface/src/stores/users/PreferencesStore.js
@@ -64,7 +64,7 @@ const PreferencesStore = Reflux.createStore({
 
   saveUserPreferences(userName: string, preferences: PreferencesMap, callback: (preferences: PreferencesMap) => void = () => {}, displaySuccessNotification: boolean = true): void {
     const convertedPreferences = convertPreferences(preferences);
-    const url = `${this.URL + userName}/preferences`;
+    const url = `${this.URL + encodeURIComponent(userName)}/preferences`;
     const promise = fetch('PUT', url, { preferences: convertedPreferences })
       .then(() => {
         if (displaySuccessNotification) {
@@ -82,7 +82,7 @@ const PreferencesStore = Reflux.createStore({
     return promise;
   },
   loadUserPreferences(userName: string, callback: (preferences: PreferencesMap) => void = () => {}): void {
-    const url = this.URL + userName;
+    const url = this.URL + encodeURIComponent(userName);
 
     const failCallback = (errorThrown) => {
       UserNotification.error(


### PR DESCRIPTION
Usernames may contain some URL reserved characters that may break API
calls. This PR fixes those instances where we were not yet encoding
usernames.

Fixes #10530, backport of #10566
