### PR TITLE
Handle session expiration properly in frontend.

### DIFF
--- a/graylog2-web-interface/src/logic/errors/FetchError.ts
+++ b/graylog2-web-interface/src/logic/errors/FetchError.ts
@@ -32,6 +32,8 @@ type Additional = {
 }
 
 export default class FetchError extends Error {
+  name: 'FetchError';
+
   responseMessage: string;
 
   additional: Additional;
@@ -40,18 +42,12 @@ export default class FetchError extends Error {
 
   constructor(message, additional) {
     super(message);
-    this.message = message ?? additional?.message ?? 'Undefined error.';
+    this.name = 'FetchError';
 
-    /* eslint-disable no-console */
-    try {
-      this.responseMessage = additional.body ? additional.body.message : undefined;
+    const details = additional?.body?.message ?? 'Not available';
+    this.message = `There was an error fetching a resource: ${message}. Additional information: ${details}`;
 
-      console.error(`There was an error fetching a resource: ${this.message}.`,
-        `Additional information: ${additional.body && additional.body.message ? additional.body.message : 'Not available'}`);
-    } catch (e) {
-      console.error(`There was an error fetching a resource: ${this.message}. No additional information available.`);
-    }
-    /* eslint-enable no-console */
+    this.responseMessage = additional?.body?.message ?? undefined;
 
     this.additional = additional;
     this.status = additional?.status; // Shortcut, as this is often used

--- a/graylog2-web-interface/src/logic/rest/FetchProvider.test.ts
+++ b/graylog2-web-interface/src/logic/rest/FetchProvider.test.ts
@@ -16,7 +16,6 @@
  */
 import express from 'express';
 import nodeFetch from 'node-fetch';
-import suppressConsole from 'helpers/suppressConsole';
 
 import fetch, { fetchFile } from './FetchProvider';
 

--- a/graylog2-web-interface/src/logic/rest/FetchProvider.test.ts
+++ b/graylog2-web-interface/src/logic/rest/FetchProvider.test.ts
@@ -16,14 +16,32 @@
  */
 import express from 'express';
 import nodeFetch from 'node-fetch';
+import suppressConsole from 'helpers/suppressConsole';
 
 import fetch, { fetchFile } from './FetchProvider';
 
 jest.unmock('./FetchProvider');
 
-jest.mock('stores/sessions/SessionStore', () => ({
-  isLoggedIn: jest.fn(() => true),
-  getSessionId: jest.fn(() => 'foobar'),
+jest.mock('injection/StoreProvider', () => ({
+  getStore: (key) => ({
+    Session: {
+      isLoggedIn: jest.fn(() => true),
+      getSessionId: jest.fn(() => 'foobar'),
+    },
+  }[key]),
+}));
+
+const mockLogout = jest.fn();
+
+jest.mock('injection/ActionsProvider', () => ({
+  getActions: (key) => ({
+    Session: {
+      logout: mockLogout,
+    },
+    ServerAvailability: {
+      reportSuccess: jest.fn(),
+    },
+  }[key]),
 }));
 
 const PORT = 0;
@@ -57,6 +75,10 @@ const setUpServer = () => {
     } else {
       res.status(500).end();
     }
+  });
+
+  app.get('/simulatesSessionExpiration', (req, res) => {
+    res.status(401).end();
   });
 
   return app.listen(PORT, () => {});
@@ -96,5 +118,14 @@ describe('FetchProvider', () => {
     const result = await fetchFile('POST', `${baseUrl}/failIfWrongAcceptHeader`, {}, 'text/csv');
 
     expect(result).toEqual('foo,bar,baz');
+  });
+
+  it('removes local session if 401 is returned', async () => {
+    const error = await fetch('GET', `${baseUrl}/simulatesSessionExpiration`).catch((e) => e);
+
+    expect(error.name).toEqual('FetchError');
+    expect(error.message).toEqual('There was an error fetching a resource: Unauthorized. Additional information: Not available');
+
+    expect(mockLogout).toHaveBeenCalledWith('foobar');
   });
 });

--- a/graylog2-web-interface/src/logic/rest/FetchProvider.ts
+++ b/graylog2-web-interface/src/logic/rest/FetchProvider.ts
@@ -133,7 +133,7 @@ export class Builder {
         return noContent ? null : resp.json();
       }
 
-      throw new FetchError(resp.statusText, resp);
+      throw resp;
     };
 
     this.errorHandler = (error) => onServerError(error);
@@ -152,7 +152,7 @@ export class Builder {
         return resp.text();
       }
 
-      throw new FetchError(resp.statusText, resp);
+      this.errorHandler(resp);
     };
 
     this.errorHandler = (error) => onServerError(error);
@@ -173,7 +173,7 @@ export class Builder {
         return resp.json();
       }
 
-      throw new FetchError(resp.statusText, resp);
+      throw resp;
     };
 
     this.errorHandler = (error) => onServerError(error, onUnauthorized);
@@ -203,7 +203,8 @@ export class Builder {
       method: this.method,
       headers,
       body: this.body ? this.body.body : undefined,
-    })).then(this.responseHandler, this.errorHandler);
+    })).then(this.responseHandler, this.errorHandler)
+      .catch(this.errorHandler);
   }
 }
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Through the transition from superagent to the native fetch API (#10342), a different behavior for request errors was introduced. A non-successful request does not trigger a promise rejection automatically, so an additional `catch` call in the promise chain is required in order to handle e.g. session expirations (which result in a 401 for subsequent requests) properly.

This change is correcting handling of errored responses, adds tests and cleans up the `FetchError` class by removing explicit `console.error` calls in its constructor, leaving this to the environment for uncaught promise rejections, but adding proper `name` & `message` fields so the class cleanly extends the `Error` type.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.