### PR TITLE
Do not execute validation of widget config form twice when changing value of field inside `FieldArray`.

### DIFF
--- a/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/GroupByConfiguration.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/GroupByConfiguration.tsx
@@ -71,6 +71,7 @@ const GroupByConfiguration = () => {
         </Field>
       )}
       <FieldArray name="groupBy.groupings"
+                  validateOnChange={false}
                   render={() => (
                     <SortableList items={groupBy?.groupings}
                                   onMoveItem={(newGroupings) => setFieldValue('groupBy.groupings', newGroupings)}

--- a/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/MetricsConfiguration.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/MetricsConfiguration.tsx
@@ -28,6 +28,7 @@ const MetricsConfiguration = () => {
 
   return (
     <FieldArray name="metrics"
+                validateOnChange={false}
                 render={({ remove }) => (
                   <>
                     <div>

--- a/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/SortConfiguration.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/SortConfiguration.tsx
@@ -30,6 +30,7 @@ const SortConfiguration = () => {
 
   return (
     <FieldArray name="sort"
+                validateOnChange={false}
                 render={({ remove }) => (
                   <SortableList items={sort}
                                 onMoveItem={(newSort) => setFieldValue('sort', newSort)}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

By default `validateOnChange` of the `Formik` and `FieldArray` component is
`true`. One side effect is that the custom validate method is being
executed twice when changing any value. With this change we are only
executing the validation once, by setting `validateOnChange` to `false`
for the `FieldArray`s.

This change will improve the experience when typing text into an input, because the input is more responsive.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

