### PR TITLE
Change RequestFilter ordering

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/RequestIdFilter.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/RequestIdFilter.java
@@ -26,7 +26,7 @@ import javax.ws.rs.container.ContainerRequestFilter;
 import java.io.IOException;
 
 // Needs to run before ShiroAuthorizationFilter
-@Priority(Priorities.AUTHORIZATION - 20)
+@Priority(Priorities.AUTHENTICATION - 9)
 public class RequestIdFilter implements ContainerRequestFilter {
     public final static String X_REQUEST_ID = "X-Request-Id";
 

--- a/graylog2-server/src/main/java/org/graylog2/shared/security/ShiroRequestHeadersBinder.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/security/ShiroRequestHeadersBinder.java
@@ -31,7 +31,7 @@ import java.util.Optional;
  * This filter makes the request headers accessible within Shiro's {@link ThreadContext}.
  */
 // Needs to run after RequestIdFilter
-@Priority(Priorities.AUTHORIZATION - 10)
+@Priority(Priorities.AUTHENTICATION - 8)
 public class ShiroRequestHeadersBinder implements ContainerRequestFilter {
     public static final String REQUEST_HEADERS = "REQUEST_HEADERS";
 


### PR DESCRIPTION
The ShiroRequestHeadersBinder needs to run before the ShiroAuthenticationFilter.
Otherwise the X-Graylog-No-Session-Extension header is
not set to the ThreadContext and thus a user session
will be extended by periodical UI requests.

Refs #10577 (and fixes part of it)

