### PR TITLE
Blocked OutputBufferProcessor on Output update / removal

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/buffers/processors/OutputBufferProcessor.java
+++ b/graylog2-server/src/main/java/org/graylog2/buffers/processors/OutputBufferProcessor.java
@@ -171,10 +171,12 @@ public class OutputBufferProcessor implements WorkHandler<MessageEvent> {
     private Future<?> processMessage(final Message msg, final MessageOutput output, final CountDownLatch doneSignal) {
         if (output == null) {
             LOG.error("Output was null!");
+            doneSignal.countDown();
             return Futures.immediateCancelledFuture();
         }
         if (!output.isRunning()) {
             LOG.debug("Skipping stopped output {}", output.getClass().getName());
+            doneSignal.countDown();
             return Futures.immediateCancelledFuture();
         }
 


### PR DESCRIPTION
## Description
This PR simply counts down the latch where it was missed to do so.

## Motivation and Context
During investigation of https://github.com/Graylog2/graylog2-server/issues/10168 it turned out
that, IF at least one of non-default Outputs was requested to shut down,
THEN all available instances of `OutputBufferProcessor` get blocked (for
the period configured in `output_module_timeout`) while waiting for the
non-default Outputs to hand over a message down the flow.

It causes troubles in the following discovered scenarios:

 1) an Output is deleted from a stream
 2) Output's configuration is changed, what implies Output's restart

As result it leads to the default Output (ES Output) getting blocked
until the lock is released after reaching `output_module_timeout`. It
explains 'the visualization stops showing messages' mentioned in the
reported bug (no new messages in Elastic Search). Also if ring buffer's
capacity of OutputBuffer is fully exhausted, one can observe high CPU
utilization due to the blocked pipeline.

TODO:

 1) Follow up with the bug reporter and sort out values of the following
 config props: `ring_size` and `output_module_timeout`
 2) Discuss whether it's a good idea to keep communication with the
 default and customer-provided Outputs in the same thread

## How Has This Been Tested?
The changes have been tested manually. Covered the aforementioned 
scenarios of Output removal and Output's configuration update.

To achieve the state of the blocked pipeline the following configuration
was used:
* `output_module_timeout` = 120000
* `ring_size` = 8192

Apart from that, the inputs have to be heavily loaded (tested with 5 
parallel processes sending logs in a loop with no delay).

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

