### PR TITLE
Use default values for scaling & interpolation if absent.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/widgets/aggregation/AutoIntervalDTO.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/widgets/aggregation/AutoIntervalDTO.java
@@ -36,6 +36,10 @@ public abstract class AutoIntervalDTO implements IntervalDTO {
     public abstract String type();
 
     @JsonProperty(FIELD_SCALING)
+    public double scalingWithDefault() {
+        return scaling().orElse(1.0);
+    }
+
     public abstract Optional<Double> scaling();
 
     @AutoValue.Builder

--- a/graylog2-web-interface/src/views/components/visualizations/line/bindings.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/line/bindings.tsx
@@ -24,8 +24,6 @@ type LineVisualizationConfigFormValues = {
   interpolation: 'linear' | 'step-after' | 'spline';
 };
 
-const DEFAULT_INTERPOLATION = 'linear';
-
 const validate = hasAtLeastOneMetric('Line chart');
 
 const lineChart: VisualizationType<LineVisualizationConfig, LineVisualizationConfigFormValues> = {
@@ -33,8 +31,8 @@ const lineChart: VisualizationType<LineVisualizationConfig, LineVisualizationCon
   displayName: 'Line Chart',
   component: LineVisualization,
   config: {
-    createConfig: () => ({ interpolation: DEFAULT_INTERPOLATION }),
-    fromConfig: (config: LineVisualizationConfig | undefined) => ({ interpolation: config?.interpolation }),
+    createConfig: () => ({ interpolation: LineVisualizationConfig.DEFAULT_INTERPOLATION }),
+    fromConfig: (config: LineVisualizationConfig | undefined) => ({ interpolation: config?.interpolation ?? LineVisualizationConfig.DEFAULT_INTERPOLATION }),
     toConfig: (formValues: LineVisualizationConfigFormValues) => LineVisualizationConfig.create(formValues.interpolation),
     fields: [{
       name: 'interpolation',

--- a/graylog2-web-interface/src/views/logic/aggregationbuilder/visualizations/LineVisualizationConfig.ts
+++ b/graylog2-web-interface/src/views/logic/aggregationbuilder/visualizations/LineVisualizationConfig.ts
@@ -31,6 +31,8 @@ export type LineVisualizationConfigJSON = {
 export default class LineVisualizationConfig extends VisualizationConfig {
   private readonly _value: InternalState;
 
+  static readonly DEFAULT_INTERPOLATION: InterpolationMode = 'linear';
+
   constructor(interpolation: $PropertyType<InternalState, 'interpolation'>) {
     super();
     this._value = { interpolation };
@@ -50,7 +52,7 @@ export default class LineVisualizationConfig extends VisualizationConfig {
   }
 
   static empty() {
-    return new LineVisualizationConfig('linear');
+    return new LineVisualizationConfig(this.DEFAULT_INTERPOLATION);
   }
 
   toJSON() {
@@ -59,10 +61,8 @@ export default class LineVisualizationConfig extends VisualizationConfig {
     return { interpolation };
   }
 
-  static fromJSON(type: string, value: LineVisualizationConfigJSON = { interpolation: 'linear' }) {
-    const { interpolation = 'linear' } = value;
-
-    return LineVisualizationConfig.create(interpolation);
+  static fromJSON(type: string, value: LineVisualizationConfigJSON) {
+    return LineVisualizationConfig.create(value?.interpolation ?? this.DEFAULT_INTERPOLATION);
   }
 }
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Prior to this PR, when editing the "Messages over time" widget of the "Sources" dashboard, the user immediately ends up in a state where validation is failing due to missing `scaling` and `interpolation` values. Those are missing in the widget we generated in the migration in the first place. Any further editing of the widget results in a valid widget.

This PR is returning a default value (`1.0`) for scaling in the backend if the factor is absent. In addition, when editing a widget with a line chart visualization, it's interpolation value is assigned a default value for the form values if it (or the complete visualization config) is missing.

Fixes #10546.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.