### PR TITLE
Centralize timeout multiplier handling in tests.

### DIFF
--- a/graylog2-web-interface/packages/jest-preset-graylog/jest-preset.js
+++ b/graylog2-web-interface/packages/jest-preset-graylog/jest-preset.js
@@ -14,8 +14,7 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-
-const TIMEOUT_MULTIPLIER = Number.parseFloat(process.env.TIMEOUT_MULTIPLIER);
+const { applyTimeoutMultiplier } = require('./lib/timeouts');
 
 module.exports = {
   rootDir: '../../',
@@ -54,6 +53,6 @@ module.exports = {
   testPathIgnorePatterns: [
     '.fixtures.[jt]s$',
   ],
-  testTimeout: (Number.isFinite(TIMEOUT_MULTIPLIER) ? TIMEOUT_MULTIPLIER : 1.0) * 5000,
+  testTimeout: applyTimeoutMultiplier(5000),
   reporters: ['default', 'jest-junit'],
 };

--- a/graylog2-web-interface/packages/jest-preset-graylog/src/timeouts.js
+++ b/graylog2-web-interface/packages/jest-preset-graylog/src/timeouts.js
@@ -1,0 +1,5 @@
+const parsedTimeoutMultiplier = Number.parseFloat(process.env.TIMEOUT_MULTIPLIER);
+
+export const timeoutMultiplier = () => (Number.isFinite(parsedTimeoutMultiplier) ? parsedTimeoutMultiplier : 1.0);
+
+export const applyTimeoutMultiplier = (x) => x * timeoutMultiplier();

--- a/graylog2-web-interface/packages/jest-preset-graylog/src/timeouts.js
+++ b/graylog2-web-interface/packages/jest-preset-graylog/src/timeouts.js
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 const parsedTimeoutMultiplier = Number.parseFloat(process.env.TIMEOUT_MULTIPLIER);
 
 export const timeoutMultiplier = () => (Number.isFinite(parsedTimeoutMultiplier) ? parsedTimeoutMultiplier : 1.0);

--- a/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.groupBy.test.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.groupBy.test.tsx
@@ -20,6 +20,7 @@ import { act, fireEvent, render, screen, waitFor, within } from 'wrappedTestingL
 import selectEvent from 'react-select-event';
 import userEvent from '@testing-library/user-event';
 import { PluginRegistration, PluginStore } from 'graylog-web-plugin/plugin';
+import { applyTimeoutMultiplier } from 'jest-preset-graylog/lib/timeouts';
 
 import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
 import DataTable from 'views/components/datatable/DataTable';
@@ -31,7 +32,7 @@ import dataTable from 'views/components/datatable/bindings';
 
 import AggregationWizard from '../AggregationWizard';
 
-const extendedTimeout = (Number(process.env.TIMEOUT_MULTIPLIER) || 1) * 15000;
+const extendedTimeout = applyTimeoutMultiplier(15000);
 
 const widgetConfig = AggregationWidgetConfig
   .builder()

--- a/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.sort.test.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.sort.test.tsx
@@ -20,6 +20,7 @@ import { render, within, screen, waitFor, fireEvent } from 'wrappedTestingLibrar
 import selectEvent from 'react-select-event';
 import userEvent from '@testing-library/user-event';
 import { PluginRegistration, PluginStore } from 'graylog-web-plugin/plugin';
+import { applyTimeoutMultiplier } from 'jest-preset-graylog/lib/timeouts';
 
 import Direction from 'views/logic/aggregationbuilder/Direction';
 import SortConfig from 'views/logic/aggregationbuilder/SortConfig';
@@ -33,7 +34,7 @@ import Pivot from 'views/logic/aggregationbuilder/Pivot';
 
 import AggregationWizard from '../AggregationWizard';
 
-const extendedTimeout = (Number(process.env.TIMEOUT_MULTIPLIER) || 1) * 15000;
+const extendedTimeout = applyTimeoutMultiplier(15000);
 
 const fieldType = new FieldType('field_type', ['numeric'], []);
 const fieldTypeMapping1 = new FieldTypeMapping('took_ms', fieldType);

--- a/graylog2-web-interface/src/views/spec/CreateNewDashboard.it.tsx
+++ b/graylog2-web-interface/src/views/spec/CreateNewDashboard.it.tsx
@@ -18,6 +18,7 @@ import * as React from 'react';
 import { render, fireEvent } from 'wrappedTestingLibrary';
 import { PluginManifest, PluginStore } from 'graylog-web-plugin/plugin';
 import { StoreMock as MockStore } from 'helpers/mocking';
+import { applyTimeoutMultiplier } from 'jest-preset-graylog/lib/timeouts';
 
 import history from 'util/History';
 import Routes from 'routing/Routes';
@@ -80,13 +81,12 @@ jest.mock('views/components/searchbar/QueryInput', () => () => <span>Query Edito
 
 jest.unmock('logic/rest/FetchProvider');
 
+const finderTimeout = applyTimeoutMultiplier(15000);
+const testTimeout = applyTimeoutMultiplier(30000);
+
 describe('Create a new dashboard', () => {
   beforeAll(() => {
     PluginStore.register(new PluginManifest({}, viewsBindings));
-  });
-
-  beforeEach(() => {
-    jest.setTimeout(30000);
   });
 
   const SimpleAppRouter = () => (
@@ -101,17 +101,17 @@ describe('Create a new dashboard', () => {
     const { findByText, findAllByText } = render(<SimpleAppRouter />);
     history.push(Routes.DASHBOARDS);
 
-    const buttons = await findAllByText('Create new dashboard', {}, { timeout: 15000 });
+    const buttons = await findAllByText('Create new dashboard', {}, { timeout: finderTimeout });
 
     fireEvent.click(buttons[0]);
-    await findByText(/This dashboard has no widgets yet/, {}, { timeout: 15000 });
-  });
+    await findByText(/This dashboard has no widgets yet/, {}, { timeout: finderTimeout });
+  }, testTimeout);
 
   it('by going to the new dashboards endpoint', async () => {
     const { findByText } = render(<SimpleAppRouter />);
 
     history.push(Routes.pluginRoute('DASHBOARDS_NEW'));
 
-    await findByText(/This dashboard has no widgets yet/, {}, { timeout: 15000 });
-  });
+    await findByText(/This dashboard has no widgets yet/, {}, { timeout: finderTimeout });
+  }, testTimeout);
 });

--- a/graylog2-web-interface/test/configure-testing-library.js
+++ b/graylog2-web-interface/test/configure-testing-library.js
@@ -15,9 +15,8 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import { configure } from '@testing-library/react';
+import { timeoutMultiplier, applyTimeoutMultiplier } from 'jest-preset-graylog/lib/timeouts';
 
-const TIMEOUT_MULTIPLIER = Number.parseFloat(process.env.TIMEOUT_MULTIPLIER);
-
-if (Number.isFinite(TIMEOUT_MULTIPLIER)) {
-  configure((existingConfig) => ({ ...existingConfig, asyncUtilTimeout: TIMEOUT_MULTIPLIER * existingConfig.asyncUtilTimeout }));
+if (timeoutMultiplier() !== 1.0) {
+  configure((existingConfig) => ({ ...existingConfig, asyncUtilTimeout: applyTimeoutMultiplier(existingConfig.asyncUtilTimeout) }));
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

In a couple of places we need to set custom timeouts for jest tests. In these cases we should take the `TIMEOUT_MULTIPLIER` env variable into account. In order to avoid having to handle that over and over again (parsing, validating, applying it), this change is adding two functions to the `jest-preset-graylog` module:
    
  - `timeoutMultiplier()`: returning the raw multiplier, `1.0` if not
    set or not parseable
  - `applyTimeoutMultiplier(x: number)`: applies the configured timeout
    multiplier to any given timeout
    
The latter function should be used in tests to apply the multiplier to any custom timeout override.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.