### PR TITLE
Use ColorMapper for event annotations

### DIFF
--- a/graylog2-web-interface/package.json
+++ b/graylog2-web-interface/package.json
@@ -21,7 +21,7 @@
     "lint:styles": "stylelint './src/**/*.{js,jsx,ts,tsx}' --syntax css-in-js",
     "lint:styles:path": "stylelint --syntax css-in-js",
     "lint:changes": "./dev/lintChanges.sh",
-    "test": "jest --maxWorkers=50%",
+    "test": "jest --maxWorkers=3",
     "test:integration": "jest --maxWorkers=50% --config jest.it.config.js",
     "check-production-build": "node checkProductionBuild.js"
   },

--- a/graylog2-web-interface/package.json
+++ b/graylog2-web-interface/package.json
@@ -21,7 +21,7 @@
     "lint:styles": "stylelint './src/**/*.{js,jsx,ts,tsx}' --syntax css-in-js",
     "lint:styles:path": "stylelint --syntax css-in-js",
     "lint:changes": "./dev/lintChanges.sh",
-    "test": "jest --maxWorkers=3",
+    "test": "jest --maxWorkers=50%",
     "test:integration": "jest --maxWorkers=50% --config jest.it.config.js",
     "check-production-build": "node checkProductionBuild.js"
   },

--- a/graylog2-web-interface/src/views/components/aggregationwizard/AggregationWizard.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/AggregationWizard.tsx
@@ -71,7 +71,7 @@ const onCreateElement = (
   }
 };
 
-const _onSubmit = (formValues: WidgetConfigFormValues, onConfigChange: (newConfig: AggregationWidgetConfig) => void, oldConfig = AggregationWidgetConfig.builder()) => {
+const _onSubmit = (formValues: WidgetConfigFormValues, onConfigChange: (newConfig: AggregationWidgetConfig) => void, oldConfig = AggregationWidgetConfig.builder().build()) => {
   const toConfigByKey = Object.fromEntries(aggregationElements.map(({ key, toConfig }) => [key, toConfig]));
 
   const newConfig = Object.keys(formValues).map((key) => {

--- a/graylog2-web-interface/src/views/components/aggregationwizard/AggregationWizard.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/AggregationWizard.tsx
@@ -71,7 +71,7 @@ const onCreateElement = (
   }
 };
 
-const _onSubmit = (formValues: WidgetConfigFormValues, onConfigChange: (newConfig: AggregationWidgetConfig) => void) => {
+const _onSubmit = (formValues: WidgetConfigFormValues, onConfigChange: (newConfig: AggregationWidgetConfig) => void, oldConfig = AggregationWidgetConfig.builder()) => {
   const toConfigByKey = Object.fromEntries(aggregationElements.map(({ key, toConfig }) => [key, toConfig]));
 
   const newConfig = Object.keys(formValues).map((key) => {
@@ -82,7 +82,7 @@ const _onSubmit = (formValues: WidgetConfigFormValues, onConfigChange: (newConfi
     }
 
     return toConfig;
-  }).reduce((prevConfig, toConfig) => toConfig(formValues, prevConfig), AggregationWidgetConfig.builder());
+  }).reduce((prevConfig, toConfig) => toConfig(formValues, prevConfig), oldConfig.toBuilder());
 
   onConfigChange(newConfig.build());
 };
@@ -99,7 +99,7 @@ const AggregationWizard = ({ onChange, config, children }: EditWidgetComponentPr
   const initialFormValues = _initialFormValues(config);
 
   return (
-    <WidgetConfigForm onSubmit={(formValues: WidgetConfigFormValues) => _onSubmit(formValues, onChange)}
+    <WidgetConfigForm onSubmit={(formValues: WidgetConfigFormValues) => _onSubmit(formValues, onChange, config)}
                       initialValues={initialFormValues}
                       validate={validateForm}>
       <>

--- a/graylog2-web-interface/src/views/components/visualizations/ColorMapper.ts
+++ b/graylog2-web-interface/src/views/components/visualizations/ColorMapper.ts
@@ -38,13 +38,20 @@ class ColorMapper {
     return defaultChartColors[this._currentDefaultColor];
   }
 
-  get(name) {
+  get(name, defaultColor?) {
     const color = this._value.get(name);
 
     if (color) {
       this._incrementColor();
 
       return color;
+    }
+
+    if (defaultColor) {
+      this._incrementColor();
+      this._value = this._value.set(name, defaultColor);
+
+      return defaultColor;
     }
 
     const newColor = this._nextFreeColor();

--- a/graylog2-web-interface/src/views/components/visualizations/ColorMapper.ts
+++ b/graylog2-web-interface/src/views/components/visualizations/ColorMapper.ts
@@ -17,6 +17,7 @@
 import { Map } from 'immutable';
 
 import { defaultChartColors } from 'views/components/visualizations/Colors';
+import { eventsDisplayName } from 'views/logic/searchtypes/events/EventHandler';
 
 class ColorMapper {
   private _value: Map<string, string>;
@@ -42,13 +43,18 @@ class ColorMapper {
     const color = this._value.get(name);
 
     if (color) {
-      this._incrementColor();
+      if (name !== eventsDisplayName) {
+        this._incrementColor();
+      }
 
       return color;
     }
 
     if (defaultColor) {
-      this._incrementColor();
+      if (name !== eventsDisplayName) {
+        this._incrementColor();
+      }
+
       this._value = this._value.set(name, defaultColor);
 
       return defaultColor;

--- a/graylog2-web-interface/src/views/components/visualizations/GenericPlot.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/GenericPlot.tsx
@@ -23,7 +23,7 @@ import { Overlay, RootCloseWrapper } from 'react-overlays';
 import { Popover } from 'components/graylog';
 import ColorPicker from 'components/common/ColorPicker';
 import Plot from 'views/components/visualizations/plotly/AsyncPlot';
-import { colors as defaultColors, defaultChartColors } from 'views/components/visualizations/Colors';
+import { colors as defaultColors } from 'views/components/visualizations/Colors';
 import ColorMapper from 'views/components/visualizations/ColorMapper';
 import { eventsDisplayName } from 'views/logic/searchtypes/events/EventHandler';
 

--- a/graylog2-web-interface/src/views/components/visualizations/GenericPlot.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/GenericPlot.tsx
@@ -25,7 +25,7 @@ import ColorPicker from 'components/common/ColorPicker';
 import Plot from 'views/components/visualizations/plotly/AsyncPlot';
 import { colors as defaultColors } from 'views/components/visualizations/Colors';
 import ColorMapper from 'views/components/visualizations/ColorMapper';
-import { eventsDisplayName } from 'views/logic/searchtypes/events/EventHandler';
+import { EVENT_COLOR, eventsDisplayName } from 'views/logic/searchtypes/events/EventHandler';
 
 import ChartColorContext from './ChartColorContext';
 import styles from './GenericPlot.lazy.css';
@@ -215,7 +215,7 @@ class GenericPlot extends React.Component<GenericPlotProps, State> {
         {({ colors, setColor }) => {
           plotLayout.shapes = plotLayout.shapes.map((shape) => ({
             ...shape,
-            line: { color: colors.get(eventsDisplayName) },
+            line: { color: colors.get(eventsDisplayName, EVENT_COLOR) },
           }));
 
           const newChartData = chartData.map((chart) => {
@@ -227,7 +227,7 @@ class GenericPlot extends React.Component<GenericPlotProps, State> {
               }
 
               if (chart?.name === eventsDisplayName) {
-                const eventColor = colors.get(eventsDisplayName);
+                const eventColor = colors.get(eventsDisplayName, EVENT_COLOR);
 
                 conf.marker = { color: eventColor, size: 5 };
               }

--- a/graylog2-web-interface/src/views/components/visualizations/GenericPlot.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/GenericPlot.tsx
@@ -23,8 +23,9 @@ import { Overlay, RootCloseWrapper } from 'react-overlays';
 import { Popover } from 'components/graylog';
 import ColorPicker from 'components/common/ColorPicker';
 import Plot from 'views/components/visualizations/plotly/AsyncPlot';
-import { colors as defaultColors } from 'views/components/visualizations/Colors';
+import { colors as defaultColors, defaultChartColors } from 'views/components/visualizations/Colors';
 import ColorMapper from 'views/components/visualizations/ColorMapper';
+import { eventsDisplayName } from 'views/logic/searchtypes/events/EventHandler';
 
 import ChartColorContext from './ChartColorContext';
 import styles from './GenericPlot.lazy.css';
@@ -41,6 +42,7 @@ type LegendConfig = {
 type ChartMarker = {
   colors?: Array<string>,
   color?: string,
+  size?: number,
 };
 
 export type ChartConfig = {
@@ -150,6 +152,7 @@ class GenericPlot extends React.Component<GenericPlotProps, State> {
   render() {
     const { chartData, layout, setChartColor, theme } = this.props;
     const defaultLayout = {
+      shapes: [],
       autosize: true,
       showlegend: true,
       margin: {
@@ -210,12 +213,23 @@ class GenericPlot extends React.Component<GenericPlotProps, State> {
     return (
       <ChartColorContext.Consumer>
         {({ colors, setColor }) => {
+          plotLayout.shapes = plotLayout.shapes.map((shape) => ({
+            ...shape,
+            line: { color: colors.get(eventsDisplayName) },
+          }));
+
           const newChartData = chartData.map((chart) => {
             if (setChartColor && colors) {
               const conf = setChartColor(chart, colors);
 
               if (chart.type === 'pie') {
                 conf.outsidetextfont = { color: theme.colors.global.textDefault };
+              }
+
+              if (chart?.name === eventsDisplayName) {
+                const eventColor = colors.get(eventsDisplayName);
+
+                conf.marker = { color: eventColor, size: 5 };
               }
 
               if (conf.line || conf.marker) {

--- a/graylog2-web-interface/src/views/components/visualizations/PlotLegend.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/PlotLegend.tsx
@@ -28,6 +28,7 @@ import { CurrentViewStateStore } from 'views/stores/CurrentViewStateStore';
 import { Popover } from 'components/graylog';
 import FieldType from 'views/logic/fieldtypes/FieldType';
 import { colors as defaultColors } from 'views/components/visualizations/Colors';
+import { EVENT_COLOR, eventsDisplayName } from 'views/logic/searchtypes/events/EventHandler';
 import WidgetFocusContext from 'views/components/contexts/WidgetFocusContext';
 
 const ColorHint = styled.div(({ color }) => `
@@ -150,6 +151,7 @@ const PlotLegend = ({ children, config, chartData, labelMapper = defaultLabelMap
   }
 
   const tableCells = labels.sort(stringLenSort).map((value) => {
+    const defaultColor = value === eventsDisplayName ? EVENT_COLOR : undefined;
     let val: React.ReactNode = value;
 
     if (columnPivots.length === 1) {
@@ -159,7 +161,7 @@ const PlotLegend = ({ children, config, chartData, labelMapper = defaultLabelMap
     return (
       <LegendCell key={value}>
         <LegendEntry>
-          <ColorHint aria-label="Color Hint" onClick={_onOpenColorPicker(value)} color={colors.get(value)} />
+          <ColorHint aria-label="Color Hint" onClick={_onOpenColorPicker(value)} color={colors.get(value, defaultColor)} />
           <ValueContainer>
             {val}
           </ValueContainer>

--- a/graylog2-web-interface/src/views/components/visualizations/area/AreaVisualization.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/area/AreaVisualization.tsx
@@ -58,7 +58,7 @@ const AreaVisualization = makeVisualization(({ config, data, effectiveTimerange,
   const layout: { shapes?: Shapes } = {};
 
   if (config.eventAnnotation && data.events) {
-    const { eventChartData, shapes } = EventHandler.toVisualizationData(data.events, config.formattingSettings);
+    const { eventChartData, shapes } = EventHandler.toVisualizationData(data.events);
 
     chartDataResult.push(eventChartData);
     layout.shapes = shapes;

--- a/graylog2-web-interface/src/views/components/visualizations/bar/BarVisualization.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/bar/BarVisualization.tsx
@@ -95,7 +95,7 @@ const BarVisualization = makeVisualization(({ config, data, effectiveTimerange, 
   const chartDataResult = chartData(config, rows, 'bar', _seriesGenerator);
 
   if (config.eventAnnotation && data.events) {
-    const { eventChartData, shapes } = EventHandler.toVisualizationData(data.events, config.formattingSettings);
+    const { eventChartData, shapes } = EventHandler.toVisualizationData(data.events);
 
     chartDataResult.push(eventChartData);
     layout.shapes = shapes;

--- a/graylog2-web-interface/src/views/components/visualizations/line/LineVisualization.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/line/LineVisualization.tsx
@@ -57,7 +57,7 @@ const LineVisualization = makeVisualization(({ config, data, effectiveTimerange,
   const layout: { shapes?: Shapes } = {};
 
   if (config.eventAnnotation && data.events) {
-    const { eventChartData, shapes } = EventHandler.toVisualizationData(data.events, config.formattingSettings);
+    const { eventChartData, shapes } = EventHandler.toVisualizationData(data.events);
 
     chartDataResult.push(eventChartData);
     layout.shapes = shapes;

--- a/graylog2-web-interface/src/views/components/visualizations/scatter/ScatterVisualization.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/scatter/ScatterVisualization.tsx
@@ -27,12 +27,14 @@ import XYPlot from '../XYPlot';
 
 const seriesGenerator = (type, name, labels, values) => ({ type, name, x: labels, y: values, mode: 'markers' });
 
+const setChartColor = (chart, colors) => ({ marker: { color: colors.get(chart.name) } });
+
 const ScatterVisualization = makeVisualization(({ config, data, effectiveTimerange, height }: VisualizationComponentProps) => {
   const chartDataResult = chartData(config, data.chart || Object.values(data)[0], 'scatter', seriesGenerator);
   const layout: { shapes?: Shapes } = {};
 
   if (config.eventAnnotation && data.events) {
-    const { eventChartData, shapes } = EventHandler.toVisualizationData(data.events, config.formattingSettings);
+    const { eventChartData, shapes } = EventHandler.toVisualizationData(data.events);
 
     chartDataResult.push(eventChartData);
     layout.shapes = shapes;
@@ -41,6 +43,7 @@ const ScatterVisualization = makeVisualization(({ config, data, effectiveTimeran
   return (
     <XYPlot config={config}
             chartData={chartDataResult}
+            setChartColor={setChartColor}
             plotLayout={layout}
             height={height}
             effectiveTimerange={effectiveTimerange} />

--- a/graylog2-web-interface/src/views/logic/searchtypes/events/EventHandler.test.ts
+++ b/graylog2-web-interface/src/views/logic/searchtypes/events/EventHandler.test.ts
@@ -39,14 +39,10 @@ describe('EventHandler convert', () => {
   });
 
   it('should convert events to char data', () => {
-    const result = EventHandler.toChartData(groupByTimestamp([event]), WidgetFormattingSettings.builder().build(), 'UTC');
+    const result = EventHandler.toChartData(groupByTimestamp([event]), 'UTC');
 
     expect(result).toEqual({
       hovertemplate: '%{text}',
-      marker: {
-        color: '#d3d3d3',
-        size: 5,
-      },
       mode: 'markers',
       opacity: 0.5,
       name: 'Alerts',
@@ -58,14 +54,10 @@ describe('EventHandler convert', () => {
   });
 
   it('should convert events to char data and use new timezone', () => {
-    const result = EventHandler.toChartData(groupByTimestamp([event]), WidgetFormattingSettings.builder().build(), 'CET');
+    const result = EventHandler.toChartData(groupByTimestamp([event]), 'CET');
 
     expect(result).toEqual({
       hovertemplate: '%{text}',
-      marker: {
-        color: '#d3d3d3',
-        size: 5,
-      },
       mode: 'markers',
       opacity: 0.5,
       name: 'Alerts',
@@ -77,14 +69,10 @@ describe('EventHandler convert', () => {
   });
 
   it('should group duplicate events by timestamp and convert events to char data', () => {
-    const result = EventHandler.toChartData(groupByTimestamp([event, event, event]), WidgetFormattingSettings.builder().build(), 'UTC');
+    const result = EventHandler.toChartData(groupByTimestamp([event, event, event]), 'UTC');
 
     expect(result).toEqual({
       hovertemplate: '%{text}',
-      marker: {
-        color: '#d3d3d3',
-        size: 5,
-      },
       mode: 'markers',
       opacity: 0.5,
       name: 'Alerts',
@@ -96,16 +84,10 @@ describe('EventHandler convert', () => {
   });
 
   it('should keep the color set by the user', () => {
-    const result = EventHandler.toChartData(groupByTimestamp([event]), WidgetFormattingSettings.builder()
-      .chartColors({ Alerts: '#ffffff' })
-      .build(), 'UTC');
+    const result = EventHandler.toChartData(groupByTimestamp([event]), 'UTC');
 
     expect(result).toEqual({
       hovertemplate: '%{text}',
-      marker: {
-        color: '#ffffff',
-        size: 5,
-      },
       mode: 'markers',
       opacity: 0.5,
       name: 'Alerts',
@@ -117,7 +99,7 @@ describe('EventHandler convert', () => {
   });
 
   it('should convert events to shape data', () => {
-    const result = EventHandler.toShapeData([event.timestamp], undefined, 'UTC');
+    const result = EventHandler.toShapeData([event.timestamp], 'UTC');
 
     expect(result[0]).toEqual({
       layer: 'below',
@@ -128,14 +110,11 @@ describe('EventHandler convert', () => {
       x0: '2019-11-14T08:53:35.000+00:00',
       x1: '2019-11-14T08:53:35.000+00:00',
       opacity: 0.5,
-      line: {
-        color: '#d3d3d3',
-      },
     });
   });
 
   it('should convert events to shape data with new timezone', () => {
-    const result = EventHandler.toShapeData([event.timestamp], undefined, 'CET');
+    const result = EventHandler.toShapeData([event.timestamp], 'CET');
 
     expect(result[0]).toEqual({
       layer: 'below',
@@ -146,28 +125,6 @@ describe('EventHandler convert', () => {
       x0: '2019-11-14T09:53:35.000+01:00',
       x1: '2019-11-14T09:53:35.000+01:00',
       opacity: 0.5,
-      line: {
-        color: '#d3d3d3',
-      },
-    });
-  });
-
-  it('should convert events to shape data with custom color', () => {
-    const widgetFormattingSettings = WidgetFormattingSettings.create({ Alerts: '#ffffff' });
-    const result = EventHandler.toShapeData([event.timestamp], widgetFormattingSettings, 'UTC');
-
-    expect(result[0]).toEqual({
-      layer: 'below',
-      type: 'line',
-      yref: 'paper',
-      y0: 0,
-      y1: 1,
-      x0: '2019-11-14T08:53:35.000+00:00',
-      x1: '2019-11-14T08:53:35.000+00:00',
-      opacity: 0.5,
-      line: {
-        color: '#ffffff',
-      },
     });
   });
 });

--- a/graylog2-web-interface/src/views/logic/searchtypes/events/EventHandler.test.ts
+++ b/graylog2-web-interface/src/views/logic/searchtypes/events/EventHandler.test.ts
@@ -16,8 +16,6 @@
  */
 import { groupBy } from 'lodash';
 
-import WidgetFormattingSettings from 'views/logic/aggregationbuilder/WidgetFormattingSettings';
-
 import type { Event } from './EventHandler';
 import EventHandler from './EventHandler';
 

--- a/graylog2-web-interface/src/views/logic/searchtypes/events/EventHandler.ts
+++ b/graylog2-web-interface/src/views/logic/searchtypes/events/EventHandler.ts
@@ -42,15 +42,14 @@ type Shape = {
   x0: string,
   x1: string,
   opacity: number,
-  line: {
+  line?: {
     color: string,
   },
 };
 
 export type Shapes = Array<Shape>;
 
-const eventsDisplayName = 'Alerts';
-const defaultColor = '#d3d3d3';
+export const eventsDisplayName = 'Alerts';
 
 const formatTimestamp = (timestamp, tz = 'UTC'): string => {
   // the `true` parameter prevents returning the iso string in UTC (http://momentjs.com/docs/#/displaying/as-iso-string/)
@@ -62,16 +61,15 @@ export default {
     return events;
   },
 
-  toVisualizationData(events: Events = [],
-    formattingSettings: WidgetFormattingSettings = WidgetFormattingSettings.create({})): { eventChartData: ChartDefinition, shapes: Shapes } {
+  toVisualizationData(events: Events = []): { eventChartData: ChartDefinition, shapes: Shapes } {
     const currentUser = CurrentUserStore.get();
     const tz = currentUser ? currentUser.timezone : 'UTC';
 
     const groupedEvents: GroupedEvents = groupBy(events, (e) => e.timestamp);
 
     return {
-      eventChartData: this.toChartData(groupedEvents, formattingSettings, tz),
-      shapes: this.toShapeData(Object.keys(groupedEvents), formattingSettings, tz),
+      eventChartData: this.toChartData(groupedEvents, tz),
+      shapes: this.toShapeData(Object.keys(groupedEvents), tz),
     };
   },
 
@@ -89,9 +87,7 @@ export default {
     });
   },
 
-  toChartData(events: GroupedEvents, formattingSettings: WidgetFormattingSettings, tz: string): ChartDefinition {
-    const { chartColors } = formattingSettings;
-    const chartColor = chartColors[eventsDisplayName] || defaultColor;
+  toChartData(events: GroupedEvents, tz: string): ChartDefinition {
     const values = this.transformGroupedEvents(events);
     const xValues: Array<string> = values.map((v) => formatTimestamp(v[0], tz));
     const textValues: Array<string> = values.map((e) => {
@@ -112,17 +108,10 @@ export default {
       x: xValues,
       y: yValues,
       text: textValues,
-      marker: {
-        size: 5,
-        color: chartColor,
-      },
     };
   },
 
-  toShapeData(timestamps: Array<string>, formattingSettings: WidgetFormattingSettings = WidgetFormattingSettings.create({}), tz: string): Shapes {
-    const { chartColors } = formattingSettings;
-    const shapeColor = chartColors[eventsDisplayName] || defaultColor;
-
+  toShapeData(timestamps: Array<string>, tz: string): Shapes {
     return timestamps.map((timestamp) => {
       const formattedTimestamp = formatTimestamp(timestamp, tz);
 
@@ -135,9 +124,6 @@ export default {
         x0: formattedTimestamp,
         x1: formattedTimestamp,
         opacity: 0.5,
-        line: {
-          color: shapeColor,
-        },
       };
     });
   },

--- a/graylog2-web-interface/src/views/logic/searchtypes/events/EventHandler.ts
+++ b/graylog2-web-interface/src/views/logic/searchtypes/events/EventHandler.ts
@@ -32,6 +32,8 @@ export type Event = {
 
 export type Events = Array<Event>;
 
+export const EVENT_COLOR = '#d3d3d3';
+
 type GroupedEvents = { [key: string]: Events };
 
 type Shape = {

--- a/graylog2-web-interface/src/views/logic/searchtypes/events/EventHandler.ts
+++ b/graylog2-web-interface/src/views/logic/searchtypes/events/EventHandler.ts
@@ -17,7 +17,6 @@
 import moment from 'moment-timezone';
 import { groupBy } from 'lodash';
 
-import WidgetFormattingSettings from 'views/logic/aggregationbuilder/WidgetFormattingSettings';
 import type { ChartDefinition } from 'views/components/visualizations/ChartData';
 import CombinedProvider from 'injection/CombinedProvider';
 

--- a/graylog2-web-interface/src/views/logic/searchtypes/events/__snapshots__/EventHandler.test.ts.snap
+++ b/graylog2-web-interface/src/views/logic/searchtypes/events/__snapshots__/EventHandler.test.ts.snap
@@ -4,10 +4,6 @@ exports[`EventHandler convert should convert events to chart data and shapes 1`]
 Object {
   "eventChartData": Object {
     "hovertemplate": "%{text}",
-    "marker": Object {
-      "color": "#d3d3d3",
-      "size": 5,
-    },
     "mode": "markers",
     "name": "Alerts",
     "opacity": 0.5,
@@ -25,9 +21,6 @@ Object {
   "shapes": Array [
     Object {
       "layer": "below",
-      "line": Object {
-        "color": "#d3d3d3",
-      },
       "opacity": 0.5,
       "type": "line",
       "x0": "2019-11-14T08:53:35.000+00:00",


### PR DESCRIPTION
## Motivation
Before the change the event annotation color was not stable from the
beginning since it was not taking its color from the color mapper.

## Description
This PR will use the color mapper to add the color of the event
annotation.

Fixes #10340

## How Has This Been Tested?
- Create a histogram
- activate event annotation
- change the color of the event annotation

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
