### PR TITLE
Allow emptying relative range value inputs in date time picker when entering new value.

### DIFF
--- a/graylog2-web-interface/src/views/components/searchbar/date-time-picker/RelativeRangeSelect.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/date-time-picker/RelativeRangeSelect.tsx
@@ -21,10 +21,10 @@ import styled, { css } from 'styled-components';
 import moment from 'moment';
 
 import { RELATIVE_RANGE_TYPES } from 'views/Constants';
-import Input from 'components/bootstrap/Input';
 import { Select } from 'components/common';
 import { isTypeRelative } from 'views/typeGuards/timeRange';
 
+import RelativeRangeValueInput from './RelativeRangeValueInput';
 import type { TimeRangeDropDownFormValues } from './TimeRangeDropdown';
 import ConfiguredRelativeTimeRangeSelector from './ConfiguredRelativeTimeRangeSelector';
 
@@ -97,7 +97,7 @@ const ConfiguredWrapper = styled.div`
   justify-self: end;
 `;
 
-const getValue = (fieldName, value: number | '', unsetRangeValue, previousRangeType?: moment.unitOfTime.DurationConstructor) => RELATIVE_RANGE_TYPES.map(({ type }) => {
+const getValue = (fieldName, value: number | null, unsetRangeValue, previousRangeType?: moment.unitOfTime.DurationConstructor) => RELATIVE_RANGE_TYPES.map(({ type }) => {
   const unsetRange = value === unsetRangeValue;
   const diff = moment.duration(value, 'seconds').as(type);
   const valueInputIsEmpty = value === null;
@@ -166,8 +166,8 @@ const RelativeRangeSelectInner = ({
   fieldName,
   limitDuration,
 }: Required<Props> & {
-  value: number | '',
-  onChange: (changeEvent: { target: { name: string, value: string } }) => void,
+  value: number | null,
+  onChange: (changeEvent: { target: { name: string, value: number | null } }) => void,
   name: string,
   error: string | undefined,
 }) => {
@@ -179,16 +179,16 @@ const RelativeRangeSelectInner = ({
     rangeValue: inputValue.rangeValue, rangeType: inputValue.rangeType, value, fieldName, unsetRangeValue, setInputValue,
   });
 
-  const _onChange = (nextValue) => {
+  const _onChange = React.useCallback((nextValue) => {
     onChange({ target: { name, value: nextValue } });
-  };
+  }, [name, onChange]);
 
-  const _onChangeTime = (event) => {
+  const _onChangeTime = React.useCallback((event) => {
     const inputIsEmpty = event.target.value === '';
     const newTimeValue = inputIsEmpty ? null : moment.duration(event.target.value || 1, inputValue.rangeType).asSeconds();
 
     _onChange(newTimeValue);
-  };
+  }, [_onChange, inputValue.rangeType]);
 
   const _onChangeType = (type) => {
     const newTimeValue = moment.duration(inputValue.rangeValue || 1, type).asSeconds();
@@ -226,16 +226,12 @@ const RelativeRangeSelectInner = ({
                disabled={disableUnsetRange} />{unsetRangeLabel}
       </RangeCheck>
       <InputWrap>
-        <Input id={`relative-timerange-${fieldName}-value`}
-               name={`relative-timerange-${fieldName}-value`}
-               disabled={disabled || inputValue.unsetRange}
-               type="number"
-               min="1"
-               value={inputValue.rangeValue === null ? '' : inputValue.rangeValue}
-               className="mousetrap"
-               title={`Set the ${fieldName} value`}
-               onChange={_onChangeTime}
-               bsStyle={error ? 'error' : null} />
+        <RelativeRangeValueInput disabled={disabled}
+                                 error={error}
+                                 fieldName={fieldName}
+                                 onChange={_onChangeTime}
+                                 unsetRange={inputValue.unsetRange}
+                                 value={inputValue.rangeValue} />
       </InputWrap>
       <StyledSelect id={`relative-timerange-${fieldName}-length`}
                     name={`relative-timerange-${fieldName}-length`}

--- a/graylog2-web-interface/src/views/components/searchbar/date-time-picker/RelativeRangeValueInput.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/date-time-picker/RelativeRangeValueInput.tsx
@@ -27,7 +27,7 @@ type Props = {
   value: number | null
 }
 
-const RangeValueInput = React.memo(({ fieldName, unsetRange, value, onChange, disabled, error }: Props) => (
+const RelativeRangeValueInput = React.memo(({ fieldName, unsetRange, value, onChange, disabled, error }: Props) => (
   <Input id={`relative-timerange-${fieldName}-value`}
          name={`relative-timerange-${fieldName}-value`}
          disabled={disabled || unsetRange}
@@ -40,4 +40,4 @@ const RangeValueInput = React.memo(({ fieldName, unsetRange, value, onChange, di
          bsStyle={error ? 'error' : null} />
 ));
 
-export default RangeValueInput;
+export default RelativeRangeValueInput;

--- a/graylog2-web-interface/src/views/components/searchbar/date-time-picker/RelativeRangeValueInput.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/date-time-picker/RelativeRangeValueInput.tsx
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+
+import Input from 'components/bootstrap/Input';
+
+type Props = {
+  disabled: boolean,
+  error: string | undefined,
+  fieldName: 'range' | 'from' | 'to',
+  onChange: (changeEvent: { target: { name: string, value: string } }) => void,
+  unsetRange: boolean,
+  value: number | null
+}
+
+const RangeValueInput = React.memo(({ fieldName, unsetRange, value, onChange, disabled, error }: Props) => (
+  <Input id={`relative-timerange-${fieldName}-value`}
+         name={`relative-timerange-${fieldName}-value`}
+         disabled={disabled || unsetRange}
+         type="number"
+         min="1"
+         value={value === null ? '' : value}
+         className="mousetrap"
+         title={`Set the ${fieldName} value`}
+         onChange={onChange}
+         bsStyle={error ? 'error' : null} />
+));
+
+export default RangeValueInput;

--- a/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TimeRangeDropdown.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TimeRangeDropdown.test.tsx
@@ -18,50 +18,12 @@ import React from 'react';
 import { fireEvent, render, screen, waitFor } from 'wrappedTestingLibrary';
 import { StoreMock as MockStore } from 'helpers/mocking';
 import { act } from 'react-dom/test-utils';
+import mockSearchClusterConfig from 'fixtures/searchClusterConfig';
 
 import ToolsStore from 'stores/tools/ToolsStore';
 
 import { DateTimeContext } from './DateTimeProvider';
 import OriginalTimeRangeDropDown, { TimeRangeDropdownProps } from './TimeRangeDropdown';
-
-const mockSearchClusterConfig = {
-  query_time_range_limit: 'P3D',
-  relative_timerange_options: {
-    PT10M: 'Search in the last 5 minutes',
-    PT15M: 'Search in the last 15 minutes',
-    PT30M: 'Search in the last 30 minutes',
-    PT1H: 'Search in the last 1 hour',
-    PT2H: 'Search in the last 2 hours',
-    PT8H: 'Search in the last 8 hours',
-    P1D: 'Search in the last 1 day',
-    P2D: 'Search in the last 2 days',
-    P5D: 'Search in the last 5 days',
-    P7D: 'Search in the last 7 days',
-    P14D: 'Search in the last 14 days',
-    P30D: 'Search in the last 30 days',
-    PT0S: 'Search in all messages',
-    P45D: '45 last days',
-  },
-  surrounding_timerange_options: {
-    PT1S: '1 second',
-    PT5S: '5 seconds',
-    PT10S: '10 seconds',
-    PT30S: '30 seconds',
-    PT1M: '1 minute',
-    PT5M: '5 minutes',
-    PT3M: '3 minutes',
-  },
-  surrounding_filter_fields: [
-    'file',
-    'source',
-    'gl2_source_input',
-    'source_file',
-  ],
-  analysis_disabled_fields: [
-    'full_message',
-    'message',
-  ],
-};
 
 jest.mock('views/stores/SearchConfigStore', () => ({
   SearchConfigActions: {

--- a/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TimeRangeDropdown.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TimeRangeDropdown.tsx
@@ -209,6 +209,14 @@ export const dateTimeValidate = (nextTimeRange, limitDuration) => {
       }
     }
 
+    if (nextTimeRange.from === null) {
+      errors.nextTimeRange = { ...errors.nextTimeRange, from: 'Cannot be empty.' };
+    }
+
+    if (nextTimeRange.to === null) {
+      errors.nextTimeRange = { ...errors.nextTimeRange, to: 'Cannot be empty.' };
+    }
+
     if (nextTimeRange.from && nextTimeRange.from <= nextTimeRange.to) {
       errors.nextTimeRange = { ...errors.nextTimeRange, to: timeRangeError };
     }

--- a/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TimeRangeDropdown.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TimeRangeDropdown.tsx
@@ -213,7 +213,7 @@ export const dateTimeValidate = (nextTimeRange, limitDuration) => {
       errors.nextTimeRange = { ...errors.nextTimeRange, from: 'Cannot be empty.' };
     }
 
-    if (nextTimeRange.to === null) {
+    if (nextTimeRange.from && nextTimeRange.to === null) {
       errors.nextTimeRange = { ...errors.nextTimeRange, to: 'Cannot be empty.' };
     }
 

--- a/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TimerangeDropdown.relativeTimeRange.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TimerangeDropdown.relativeTimeRange.test.tsx
@@ -1,0 +1,138 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import React from 'react';
+import { render, screen, waitFor } from 'wrappedTestingLibrary';
+import { NoTimeRangeOverride } from 'src/views/logic/queries/Query';
+import { StoreMock as MockStore } from 'helpers/mocking';
+import { SearchBarFormValues } from 'src/views/Constants';
+import userEvent from '@testing-library/user-event';
+import mockSearchClusterConfig from 'fixtures/searchClusterConfig';
+
+import { DateTimeContext } from './DateTimeProvider';
+import OriginalTimeRangeDropDown from './TimeRangeDropdown';
+
+jest.mock('views/stores/SearchConfigStore', () => ({
+  SearchConfigActions: {
+    refresh: jest.fn(() => Promise.resolve()),
+  },
+  SearchConfigStore: MockStore(
+    ['listen', () => jest.fn()],
+    'get',
+    ['searchesClusterConfig', () => mockSearchClusterConfig],
+    ['getInitialState', () => mockSearchClusterConfig],
+    ['refresh', () => jest.fn()],
+  ),
+}));
+
+jest.mock('stores/tools/ToolsStore', () => ({}));
+
+const defaultProps = {
+  currentTimeRange: {
+    type: 'relative',
+    from: 300,
+  },
+  noOverride: false,
+  setCurrentTimeRange: jest.fn(),
+  toggleDropdownShow: jest.fn(),
+} as const;
+
+type Props = {
+  noOverride?: boolean,
+  currentTimeRange: SearchBarFormValues['timerange'] | NoTimeRangeOverride,
+  setCurrentTimeRange: (nextTimeRange: SearchBarFormValues['timerange'] | NoTimeRangeOverride) => void,
+  toggleDropdownShow: () => void,
+};
+
+const TimeRangeDropdown = (allProps: Props) => (
+  <DateTimeContext.Provider value={{
+    limitDuration: 259200,
+  }}>
+    <OriginalTimeRangeDropDown {...allProps} />
+  </DateTimeContext.Provider>
+);
+
+describe('TimeRangeDropdown relative time range', () => {
+  it('Display warning when emptying from range value input', async () => {
+    render(<TimeRangeDropdown {...defaultProps} />);
+
+    const fromRangeValueInput = screen.getByTitle('Set the from value');
+    const submitButton = screen.getByRole('button', {
+      name: /apply/i,
+    });
+
+    userEvent.type(fromRangeValueInput, '{backspace}');
+
+    await screen.findByText('Cannot be empty.');
+
+    expect(submitButton).toBeDisabled();
+  });
+
+  it('Display warning when emptying to range value input', async () => {
+    const props = {
+      ...defaultProps,
+      currentTimeRange: {
+        type: 'relative',
+        from: 300,
+        to: 240,
+      },
+    };
+    render(<TimeRangeDropdown {...props} />);
+
+    const toRangeValueInput = screen.getByTitle('Set the to value');
+    const submitButton = screen.getByRole('button', {
+      name: /apply/i,
+    });
+
+    userEvent.type(toRangeValueInput, '{backspace}');
+
+    await screen.findByText('Cannot be empty.');
+
+    expect(submitButton).toBeDisabled();
+  });
+
+  it('allow emptying from and to ranges and typing in completely new values', async () => {
+    const setCurrentTimeRangeStub = jest.fn();
+    const props = {
+      ...defaultProps,
+      currentTimeRange: {
+        type: 'relative',
+        from: 300,
+        to: 240,
+      },
+      setCurrentTimeRange: setCurrentTimeRangeStub,
+    };
+    render(<TimeRangeDropdown {...props} />);
+
+    const fromRangeValueInput = screen.getByTitle('Set the from value');
+    const toRangeValueInput = screen.getByTitle('Set the to value');
+    const submitButton = screen.getByRole('button', {
+      name: /apply/i,
+    });
+
+    userEvent.type(fromRangeValueInput, '{backspace}7');
+    userEvent.type(toRangeValueInput, '{backspace}6');
+    userEvent.click(submitButton);
+
+    await waitFor(() => expect(setCurrentTimeRangeStub).toHaveBeenCalledTimes(1));
+
+    expect(setCurrentTimeRangeStub).toHaveBeenCalledWith({
+      type: 'relative',
+      from: 420,
+      to: 360,
+    });
+  });
+});

--- a/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TimerangeDropdown.relativeTimeRange.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TimerangeDropdown.relativeTimeRange.test.tsx
@@ -58,7 +58,7 @@ const TimeRangeDropdown = (allProps: TimeRangeDropdownProps) => (
 );
 
 describe('TimeRangeDropdown relative time range', () => {
-  it('Display warning when emptying from range value input', async () => {
+  it('display warning when emptying from range value input', async () => {
     render(<TimeRangeDropdown {...defaultProps} />);
 
     const fromRangeValueInput = screen.getByTitle('Set the from value');
@@ -73,7 +73,7 @@ describe('TimeRangeDropdown relative time range', () => {
     expect(submitButton).toBeDisabled();
   });
 
-  it('Display warning when emptying to range value input', async () => {
+  it('display warning when emptying to range value input', async () => {
     const props = {
       ...defaultProps,
       currentTimeRange: {

--- a/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TimerangeDropdown.relativeTimeRange.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TimerangeDropdown.relativeTimeRange.test.tsx
@@ -16,14 +16,12 @@
  */
 import React from 'react';
 import { render, screen, waitFor } from 'wrappedTestingLibrary';
-import { NoTimeRangeOverride } from 'src/views/logic/queries/Query';
 import { StoreMock as MockStore } from 'helpers/mocking';
-import { SearchBarFormValues } from 'src/views/Constants';
 import userEvent from '@testing-library/user-event';
 import mockSearchClusterConfig from 'fixtures/searchClusterConfig';
 
 import { DateTimeContext } from './DateTimeProvider';
-import OriginalTimeRangeDropDown from './TimeRangeDropdown';
+import OriginalTimeRangeDropDown, { TimeRangeDropdownProps } from './TimeRangeDropdown';
 
 jest.mock('views/stores/SearchConfigStore', () => ({
   SearchConfigActions: {
@@ -48,16 +46,10 @@ const defaultProps = {
   noOverride: false,
   setCurrentTimeRange: jest.fn(),
   toggleDropdownShow: jest.fn(),
+  position: 'bottom',
 } as const;
 
-type Props = {
-  noOverride?: boolean,
-  currentTimeRange: SearchBarFormValues['timerange'] | NoTimeRangeOverride,
-  setCurrentTimeRange: (nextTimeRange: SearchBarFormValues['timerange'] | NoTimeRangeOverride) => void,
-  toggleDropdownShow: () => void,
-};
-
-const TimeRangeDropdown = (allProps: Props) => (
+const TimeRangeDropdown = (allProps: TimeRangeDropdownProps) => (
   <DateTimeContext.Provider value={{
     limitDuration: 259200,
   }}>

--- a/graylog2-web-interface/test/fixtures/searchClusterConfig.ts
+++ b/graylog2-web-interface/test/fixtures/searchClusterConfig.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+
+const searchClusterConfig = {
+  query_time_range_limit: 'P3D',
+  relative_timerange_options: {
+    PT10M: 'Search in the last 5 minutes',
+    PT15M: 'Search in the last 15 minutes',
+    PT30M: 'Search in the last 30 minutes',
+    PT1H: 'Search in the last 1 hour',
+    PT2H: 'Search in the last 2 hours',
+    PT8H: 'Search in the last 8 hours',
+    P1D: 'Search in the last 1 day',
+    P2D: 'Search in the last 2 days',
+    P5D: 'Search in the last 5 days',
+    P7D: 'Search in the last 7 days',
+    P14D: 'Search in the last 14 days',
+    P30D: 'Search in the last 30 days',
+    PT0S: 'Search in all messages',
+    P45D: '45 last days',
+  },
+  surrounding_timerange_options: {
+    PT1S: '1 second',
+    PT5S: '5 seconds',
+    PT10S: '10 seconds',
+    PT30S: '30 seconds',
+    PT1M: '1 minute',
+    PT5M: '5 minutes',
+    PT3M: '3 minutes',
+  },
+  surrounding_filter_fields: [
+    'file',
+    'source',
+    'gl2_source_input',
+    'source_file',
+  ],
+  analysis_disabled_fields: [
+    'full_message',
+    'message',
+  ],
+};
+
+export default searchClusterConfig;


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Before this change it was not possible to temporary empty the relative
range value inputs. When a user tried to remove all numbers, we
automatically inserted a 1. We mainly did this because we are always
updating the form state `onChange`. If we would define for example
`undefined` for the relative range value, we would loose the
information which range type is selected. The range type is
being inferred based on the time range form value.

For example if the form state value for the relative range is 300, the
`RelativeRangeSelect` displays: 5 (range value) minutes (range type).

With this PR we are implementing a separate state for the `RelativeRangeSelect` which controls the
relative range inputs. We are still updating the form state
`onChange`. Every time the form state changes we are synchronizing the
`RelativeRangeSelect`. When a user empties the range value input, we are
defining `null` for the range form state. By implementing a separate state, we
are able to remember the previous selected range type and consider the
type when the user defines a completely new range value.

Please note, this PR is a suggestion for a short-term solution, long-term we should split up the relative range states in the date time picker form and use e.g. `from: { value: 5, type 'minutes' }` instead of `from: 300` (seconds) and justmigrate the value when opening or submitting the date time picker. This way we do not need to manage two states.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

