### PR TITLE
Change RequestFilter ordering (#10578)

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/RequestIdFilter.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/RequestIdFilter.java
@@ -26,7 +26,7 @@ import javax.ws.rs.container.ContainerRequestFilter;
 import java.io.IOException;
 
 // Needs to run before ShiroAuthorizationFilter
-@Priority(Priorities.AUTHORIZATION - 20)
+@Priority(Priorities.AUTHENTICATION - 9)
 public class RequestIdFilter implements ContainerRequestFilter {
     public final static String X_REQUEST_ID = "X-Request-Id";
 

--- a/graylog2-server/src/main/java/org/graylog2/shared/security/ShiroRequestHeadersBinder.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/security/ShiroRequestHeadersBinder.java
@@ -23,6 +23,8 @@ import javax.annotation.Priority;
 import javax.ws.rs.Priorities;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
 import javax.ws.rs.core.MultivaluedMap;
 import java.io.IOException;
 import java.util.Optional;
@@ -31,9 +33,9 @@ import java.util.Optional;
  * This filter makes the request headers accessible within Shiro's {@link ThreadContext}.
  */
 // Needs to run after RequestIdFilter
-@Priority(Priorities.AUTHORIZATION - 10)
-public class ShiroRequestHeadersBinder implements ContainerRequestFilter {
-    public static final String REQUEST_HEADERS = "REQUEST_HEADERS";
+@Priority(Priorities.AUTHENTICATION - 8)
+public class ShiroRequestHeadersBinder implements ContainerRequestFilter, ContainerResponseFilter {
+    private static final String REQUEST_HEADERS = "REQUEST_HEADERS";
 
     @Override
     public void filter(ContainerRequestContext requestContext) throws IOException {
@@ -52,5 +54,11 @@ public class ShiroRequestHeadersBinder implements ContainerRequestFilter {
             }
         }
         return Optional.empty();
+    }
+
+    @Override
+    public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) throws IOException {
+        // Ensure removal of request headers to avoid leaking them for the next request
+        ThreadContext.remove(REQUEST_HEADERS);
     }
 }


### PR DESCRIPTION
The ShiroRequestHeadersBinder needs to run before the
ShiroAuthenticationFilter.
Otherwise the X-Graylog-No-Session-Extension header is
not set to the ThreadContext and thus a user session
will be extended by periodical UI requests.

Also ensure removal of request headers from ThreadContext.

Fixes #10577

Co-authored-by: Bernd Ahlers <bernd@graylog.com>

(cherry picked from commit 3de64e993e9c4d7992899a037e46919fe67b49b6)
