### PR TITLE
Hide PlotLegend with only one element

### DIFF
--- a/graylog2-web-interface/src/views/components/visualizations/PlotLegend.test.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/PlotLegend.test.tsx
@@ -22,6 +22,7 @@ import PlotLegend from 'views/components/visualizations/PlotLegend';
 import ColorMapper from 'views/components/visualizations/ColorMapper';
 import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
 import Pivot from 'views/logic/aggregationbuilder/Pivot';
+import WidgetFocusContext from 'views/components/contexts/WidgetFocusContext';
 
 import ChartColorContext from './ChartColorContext';
 
@@ -48,11 +49,19 @@ const config = AggregationWidgetConfig.builder().columnPivots(columnPivots).buil
 
 // eslint-disable-next-line react/require-default-props
 const SUT = ({ chartDataProp = chartData }: { chartDataProp?: Array<{ name: string }>}) => (
-  <ChartColorContext.Provider value={{ colors, setColor }}>
-    <PlotLegend config={config} chartData={chartDataProp}>
-      <div>Plot</div>
-    </PlotLegend>
-  </ChartColorContext.Provider>
+  <WidgetFocusContext.Provider value={{
+    focusedWidget: undefined,
+    setWidgetFocusing: jest.fn(),
+    unsetWidgetFocusing: jest.fn(),
+    unsetWidgetEditing: jest.fn(),
+    setWidgetEditing: jest.fn(),
+  }}>
+    <ChartColorContext.Provider value={{ colors, setColor }}>
+      <PlotLegend config={config} chartData={chartDataProp}>
+        <div>Plot</div>
+      </PlotLegend>
+    </ChartColorContext.Provider>
+  </WidgetFocusContext.Provider>
 );
 
 describe('PlotLegend', () => {
@@ -73,7 +82,7 @@ describe('PlotLegend', () => {
     const colorHints = await screen.findAllByLabelText('Color Hint');
     fireEvent.click(colorHints[0]);
 
-    await screen.getByText('Configuration for name1');
+    screen.getByText('Configuration for name1');
     const color = screen.getByTitle('#b71c1c');
     fireEvent.click(color);
 
@@ -96,5 +105,11 @@ describe('PlotLegend', () => {
     render(<SUT chartDataProp={charDataProp} />);
     await screen.findByText('name1');
     await screen.findByText('name11');
+  });
+
+  it('should hide with a single values', async () => {
+    render(<SUT chartDataProp={[{ name: 'name1' }]} />);
+
+    expect(screen.queryByText('name1')).not.toBeInTheDocument();
   });
 });

--- a/graylog2-web-interface/src/views/components/visualizations/PlotLegend.test.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/PlotLegend.test.tsx
@@ -23,6 +23,7 @@ import ColorMapper from 'views/components/visualizations/ColorMapper';
 import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
 import Pivot from 'views/logic/aggregationbuilder/Pivot';
 import WidgetFocusContext from 'views/components/contexts/WidgetFocusContext';
+import Series from 'views/logic/aggregationbuilder/Series';
 
 import ChartColorContext from './ChartColorContext';
 
@@ -48,7 +49,7 @@ const columnPivots = [Pivot.create('field1', 'unknown')];
 const config = AggregationWidgetConfig.builder().columnPivots(columnPivots).build();
 
 // eslint-disable-next-line react/require-default-props
-const SUT = ({ chartDataProp = chartData }: { chartDataProp?: Array<{ name: string }>}) => (
+const SUT = ({ chartDataProp = chartData, plotConfig = config }: { chartDataProp?: Array<{ name: string, }>, plotConfig?: AggregationWidgetConfig }) => (
   <WidgetFocusContext.Provider value={{
     focusedWidget: undefined,
     setWidgetFocusing: jest.fn(),
@@ -57,7 +58,7 @@ const SUT = ({ chartDataProp = chartData }: { chartDataProp?: Array<{ name: stri
     setWidgetEditing: jest.fn(),
   }}>
     <ChartColorContext.Provider value={{ colors, setColor }}>
-      <PlotLegend config={config} chartData={chartDataProp}>
+      <PlotLegend config={plotConfig} chartData={chartDataProp}>
         <div>Plot</div>
       </PlotLegend>
     </ChartColorContext.Provider>
@@ -108,7 +109,8 @@ describe('PlotLegend', () => {
   });
 
   it('should hide with a single values', async () => {
-    render(<SUT chartDataProp={[{ name: 'name1' }]} />);
+    const plotConfig = AggregationWidgetConfig.builder().series([Series.forFunction('count')]).build();
+    render(<SUT chartDataProp={[{ name: 'name1' }]} plotConfig={plotConfig} />);
 
     expect(screen.queryByText('name1')).not.toBeInTheDocument();
   });

--- a/graylog2-web-interface/src/views/components/visualizations/PlotLegend.test.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/PlotLegend.test.tsx
@@ -22,6 +22,7 @@ import PlotLegend from 'views/components/visualizations/PlotLegend';
 import ColorMapper from 'views/components/visualizations/ColorMapper';
 import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
 import Pivot from 'views/logic/aggregationbuilder/Pivot';
+import WidgetFocusContext from 'views/components/contexts/WidgetFocusContext';
 import Series from 'views/logic/aggregationbuilder/Series';
 
 import ChartColorContext from './ChartColorContext';
@@ -49,11 +50,19 @@ const config = AggregationWidgetConfig.builder().columnPivots(columnPivots).buil
 
 // eslint-disable-next-line react/require-default-props
 const SUT = ({ chartDataProp = chartData, plotConfig = config }: { chartDataProp?: Array<{ name: string, }>, plotConfig?: AggregationWidgetConfig }) => (
-  <ChartColorContext.Provider value={{ colors, setColor }}>
-    <PlotLegend config={plotConfig} chartData={chartDataProp}>
-      <div>Plot</div>
-    </PlotLegend>
-  </ChartColorContext.Provider>
+  <WidgetFocusContext.Provider value={{
+    focusedWidget: undefined,
+    setWidgetFocusing: jest.fn(),
+    unsetWidgetFocusing: jest.fn(),
+    unsetWidgetEditing: jest.fn(),
+    setWidgetEditing: jest.fn(),
+  }}>
+    <ChartColorContext.Provider value={{ colors, setColor }}>
+      <PlotLegend config={plotConfig} chartData={chartDataProp}>
+        <div>Plot</div>
+      </PlotLegend>
+    </ChartColorContext.Provider>
+  </WidgetFocusContext.Provider>
 );
 
 describe('PlotLegend', () => {

--- a/graylog2-web-interface/src/views/components/visualizations/PlotLegend.test.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/PlotLegend.test.tsx
@@ -22,7 +22,6 @@ import PlotLegend from 'views/components/visualizations/PlotLegend';
 import ColorMapper from 'views/components/visualizations/ColorMapper';
 import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
 import Pivot from 'views/logic/aggregationbuilder/Pivot';
-import WidgetFocusContext from 'views/components/contexts/WidgetFocusContext';
 import Series from 'views/logic/aggregationbuilder/Series';
 
 import ChartColorContext from './ChartColorContext';
@@ -50,19 +49,11 @@ const config = AggregationWidgetConfig.builder().columnPivots(columnPivots).buil
 
 // eslint-disable-next-line react/require-default-props
 const SUT = ({ chartDataProp = chartData, plotConfig = config }: { chartDataProp?: Array<{ name: string, }>, plotConfig?: AggregationWidgetConfig }) => (
-  <WidgetFocusContext.Provider value={{
-    focusedWidget: undefined,
-    setWidgetFocusing: jest.fn(),
-    unsetWidgetFocusing: jest.fn(),
-    unsetWidgetEditing: jest.fn(),
-    setWidgetEditing: jest.fn(),
-  }}>
-    <ChartColorContext.Provider value={{ colors, setColor }}>
-      <PlotLegend config={plotConfig} chartData={chartDataProp}>
-        <div>Plot</div>
-      </PlotLegend>
-    </ChartColorContext.Provider>
-  </WidgetFocusContext.Provider>
+  <ChartColorContext.Provider value={{ colors, setColor }}>
+    <PlotLegend config={plotConfig} chartData={chartDataProp}>
+      <div>Plot</div>
+    </PlotLegend>
+  </ChartColorContext.Provider>
 );
 
 describe('PlotLegend', () => {

--- a/graylog2-web-interface/src/views/components/visualizations/PlotLegend.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/PlotLegend.tsx
@@ -28,6 +28,7 @@ import { CurrentViewStateStore } from 'views/stores/CurrentViewStateStore';
 import { Popover } from 'components/graylog';
 import FieldType from 'views/logic/fieldtypes/FieldType';
 import { colors as defaultColors } from 'views/components/visualizations/Colors';
+import WidgetFocusContext from 'views/components/contexts/WidgetFocusContext';
 
 const ColorHint = styled.div(({ color }) => `
   cursor: pointer;
@@ -94,6 +95,7 @@ const PlotLegend = ({ children, config, chartData, labelMapper = defaultLabelMap
   const labels: Array<string> = labelMapper(chartData);
   const { activeQuery } = useStore(CurrentViewStateStore);
   const { colors, setColor } = useContext(ChartColorContext);
+  const { focusedWidget } = useContext(WidgetFocusContext);
 
   const chunkCells = (cells, columnCount) => {
     const { length } = cells;
@@ -161,6 +163,10 @@ const PlotLegend = ({ children, config, chartData, labelMapper = defaultLabelMap
       </LegendCell>
     );
   });
+
+  if (tableCells.length <= 1 && (!focusedWidget || !focusedWidget.editing)) {
+    return <>{children}</>;
+  }
 
   const result = chunkCells(tableCells, 5).map((cells, index) => (
     // eslint-disable-next-line react/no-array-index-key

--- a/graylog2-web-interface/src/views/components/visualizations/PlotLegend.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/PlotLegend.tsx
@@ -28,6 +28,7 @@ import { CurrentViewStateStore } from 'views/stores/CurrentViewStateStore';
 import { Popover } from 'components/graylog';
 import FieldType from 'views/logic/fieldtypes/FieldType';
 import { colors as defaultColors } from 'views/components/visualizations/Colors';
+import WidgetFocusContext from 'views/components/contexts/WidgetFocusContext';
 
 const ColorHint = styled.div(({ color }) => `
   cursor: pointer;
@@ -94,6 +95,7 @@ const PlotLegend = ({ children, config, chartData, labelMapper = defaultLabelMap
   const labels: Array<string> = labelMapper(chartData);
   const { activeQuery } = useStore(CurrentViewStateStore);
   const { colors, setColor } = useContext(ChartColorContext);
+  const { focusedWidget } = useContext(WidgetFocusContext);
 
   const chunkCells = (cells, columnCount) => {
     const { length } = cells;
@@ -143,7 +145,7 @@ const PlotLegend = ({ children, config, chartData, labelMapper = defaultLabelMap
     setColorPickerConfig(undefined);
   }, [setColor]);
 
-  if (series.length <= 1 && columnPivots.length <= 0) {
+  if ((!focusedWidget || !focusedWidget.editing) && series.length <= 1 && columnPivots.length <= 0) {
     return <>{children}</>;
   }
 

--- a/graylog2-web-interface/src/views/components/visualizations/PlotLegend.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/PlotLegend.tsx
@@ -28,7 +28,6 @@ import { CurrentViewStateStore } from 'views/stores/CurrentViewStateStore';
 import { Popover } from 'components/graylog';
 import FieldType from 'views/logic/fieldtypes/FieldType';
 import { colors as defaultColors } from 'views/components/visualizations/Colors';
-import WidgetFocusContext from 'views/components/contexts/WidgetFocusContext';
 
 const ColorHint = styled.div(({ color }) => `
   cursor: pointer;
@@ -95,7 +94,6 @@ const PlotLegend = ({ children, config, chartData, labelMapper = defaultLabelMap
   const labels: Array<string> = labelMapper(chartData);
   const { activeQuery } = useStore(CurrentViewStateStore);
   const { colors, setColor } = useContext(ChartColorContext);
-  const { focusedWidget } = useContext(WidgetFocusContext);
 
   const chunkCells = (cells, columnCount) => {
     const { length } = cells;
@@ -145,7 +143,7 @@ const PlotLegend = ({ children, config, chartData, labelMapper = defaultLabelMap
     setColorPickerConfig(undefined);
   }, [setColor]);
 
-  if ((!focusedWidget || !focusedWidget.editing) && series.length <= 1 && columnPivots.length <= 0) {
+  if (series.length <= 1 && columnPivots.length <= 0) {
     return <>{children}</>;
   }
 

--- a/graylog2-web-interface/src/views/components/visualizations/PlotLegend.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/PlotLegend.tsx
@@ -91,7 +91,7 @@ const defaultLabelMapper = (data: Array<{ name: string }>) => data.map(({ name }
 
 const PlotLegend = ({ children, config, chartData, labelMapper = defaultLabelMapper }: Props) => {
   const [colorPickerConfig, setColorPickerConfig] = useState<ColorPickerConfig | undefined>();
-  const { columnPivots } = config;
+  const { columnPivots, series } = config;
   const labels: Array<string> = labelMapper(chartData);
   const { activeQuery } = useStore(CurrentViewStateStore);
   const { colors, setColor } = useContext(ChartColorContext);
@@ -145,6 +145,10 @@ const PlotLegend = ({ children, config, chartData, labelMapper = defaultLabelMap
     setColorPickerConfig(undefined);
   }, [setColor]);
 
+  if ((!focusedWidget || !focusedWidget.editing) && series.length <= 1 && columnPivots.length <= 0) {
+    return <>{children}</>;
+  }
+
   const tableCells = labels.sort(stringLenSort).map((value) => {
     let val: React.ReactNode = value;
 
@@ -163,10 +167,6 @@ const PlotLegend = ({ children, config, chartData, labelMapper = defaultLabelMap
       </LegendCell>
     );
   });
-
-  if (tableCells.length <= 1 && (!focusedWidget || !focusedWidget.editing)) {
-    return <>{children}</>;
-  }
 
   const result = chunkCells(tableCells, 5).map((cells, index) => (
     // eslint-disable-next-line react/no-array-index-key


### PR DESCRIPTION
## Motivation
Prior to this change, we always displayed the plot legend. But this is
taking valuable space and the description should already mention what is
displayed.

## Description
This change tests if there is only one element to display and hides the
plotlegend otherwise. If the widget is in edit mode the plot legend will always be shown so the user can edit the color.

Fixes #10581

## How Has This Been Tested?
- Created a aggregation with only one metric and row pivot
- Added another aggregation with one metric, a row pivot and a column pivot.

## Screenshots (if appropriate):
![Graylog (9)](https://user-images.githubusercontent.com/448763/117953717-95465900-b316-11eb-9b3a-829b07b1c8d9.png)


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
