### PR TITLE
Do not require a defaultValue to be set in Heatmap

### DIFF
--- a/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.corevisualizations.test.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.corevisualizations.test.tsx
@@ -86,16 +86,6 @@ describe('AggregationWizard/Core Visualizations', () => {
     await screen.findByText('World Map');
   });
 
-  it('heat map expects mandatory default value field', async () => {
-    render(<SimpleAggregationWizard />);
-
-    await selectEvent.select(await visualizationSelect(), 'Heatmap');
-
-    await expectSubmitButtonToBeDisabled();
-
-    await screen.findByText(/Default Value is required/);
-  });
-
   it('creates Area Chart config when all required fields are present', async () => {
     const onChange = jest.fn();
     const areaChartConfig = widgetConfig.toBuilder().series([Series.create('count')]).build();
@@ -170,8 +160,6 @@ describe('AggregationWizard/Core Visualizations', () => {
     render(<SimpleAggregationWizard onChange={onChange} config={heatMapConfig} />);
 
     await selectOption('Select visualization type', 'Heatmap');
-
-    await expectSubmitButtonToBeDisabled();
 
     const useSmallestAsDefault = await screen.findByRole('checkbox', { name: 'Use smallest as default' });
     userEvent.click(useSmallestAsDefault);

--- a/graylog2-web-interface/src/views/components/visualizations/heatmap/bindings.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/heatmap/bindings.tsx
@@ -103,7 +103,7 @@ const heatmap: VisualizationType<HeatmapVisualizationConfig, HeatMapVisualizatio
       type: 'numeric',
       title: 'Default Value',
       isShown: (values: HeatMapVisualizationConfigFormValues) => !values?.useSmallestAsDefault,
-      required: true,
+      required: false,
     }],
   },
   validate,


### PR DESCRIPTION
## Motivation
Prior to this change, the defaultValue was required to be set
for a heatmap. But there is no technical reason for that.

## Description
This change will set the required field to false and adjust the tests.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

