### PR TITLE
Change back REQUEST_HEADERS access to public

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/shared/security/ShiroRequestHeadersBinder.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/security/ShiroRequestHeadersBinder.java
@@ -35,7 +35,7 @@ import java.util.Optional;
 // Needs to run after RequestIdFilter
 @Priority(Priorities.AUTHENTICATION - 8)
 public class ShiroRequestHeadersBinder implements ContainerRequestFilter, ContainerResponseFilter {
-    private static final String REQUEST_HEADERS = "REQUEST_HEADERS";
+    public static final String REQUEST_HEADERS = "REQUEST_HEADERS";
 
     @Override
     public void filter(ContainerRequestContext requestContext) throws IOException {


### PR DESCRIPTION
In https://github.com/Graylog2/graylog2-server/pull/10578 we changed the `REQUEST_HEADERS` `public` access modifier to `private`, causing the cloud master build to fail, since one of the classes uses that constant in its code. This PR reverts that change to fix the build. 