### PR TITLE
Fix creatable select focus and "create value" option label problem.

### DIFF
--- a/graylog2-web-interface/src/components/common/Select.tsx
+++ b/graylog2-web-interface/src/components/common/Select.tsx
@@ -15,8 +15,8 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import lodash from 'lodash';
 import PropTypes from 'prop-types';
+import { isEqual, find } from 'lodash';
 import { DefaultTheme, withTheme } from 'styled-components';
 import ReactSelect, { components as Components, createFilter } from 'react-select';
 import CreatableSelect from 'react-select/creatable';
@@ -372,7 +372,7 @@ class Select extends React.Component<Props, State> {
       this.setState({ value: nextProps.value });
     }
 
-    if (inputProps !== nextProps.inputProps
+    if (!isEqual(inputProps, nextProps.inputProps)
       || optionRenderer !== nextProps.optionRenderer
       || valueRenderer !== nextProps.valueRenderer) {
       this.setState({ customComponents: this.getCustomComponents(inputProps, optionRenderer, valueRenderer) });
@@ -439,7 +439,7 @@ class Select extends React.Component<Props, State> {
         [valueKey]: v,
         [displayKey]: v,
       };
-      const option = lodash.find(options, predicate);
+      const option = find(options, predicate);
 
       return option || predicate;
     });

--- a/graylog2-web-interface/src/components/common/Select.tsx
+++ b/graylog2-web-interface/src/components/common/Select.tsx
@@ -533,7 +533,7 @@ class Select extends React.Component<Props, State> {
                        isMulti={isMulti}
                        isDisabled={isDisabled}
                        isClearable={isClearable}
-                       getOptionLabel={(option) => option[displayKey]}
+                       getOptionLabel={(option) => option[displayKey] || option.label}
                        getOptionValue={(option) => option[valueKey]}
                        filterOption={customFilter}
                        components={mergedComponents}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

With this PR we are fixing two problems with the createble select (`common/Select` component with `allowCreate` props):

-  Display "Create value" option label correctly when using `displayKey` select prop.
- Prevent loosing focus when removing content of creatable select input.
Before this change it was possible to loose the react creatable select focus
after removing its content, because we updated the component state unnecessarily.
With this change we ensure that we only update the state when necessary.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

