### PR TITLE
With configured Version-probing, wait for ES to come up if not available straight away

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchClientConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchClientConfiguration.java
@@ -48,11 +48,11 @@ public class ElasticsearchClientConfiguration {
     @Parameter(value = "elasticsearch_idle_timeout")
     Duration elasticsearchIdleTimeout = Duration.seconds(-1L);
 
-    @Parameter(value = "elasticsearch_connection_retries", validators = {PositiveIntegerValidator.class})
-    int elasticsearchConnectionRetries = 0;
+    @Parameter(value = "elasticsearch_version_probe_attempts", validators = {PositiveIntegerValidator.class})
+    int elasticsearchVersionProbeAttempts = 0;
 
-    @Parameter(value = "elasticsearch_connection_retry_wait", validators = {PositiveDurationValidator.class})
-    Duration elasticsearchConnectionRetryWait = Duration.seconds(5L);
+    @Parameter(value = "elasticsearch_version_probe_delay", validators = {PositiveDurationValidator.class})
+    Duration elasticsearchVersionProbeDelay = Duration.seconds(5L);
 
     @Parameter(value = "elasticsearch_max_total_connections", validators = {PositiveIntegerValidator.class})
     int elasticsearchMaxTotalConnections = 200;

--- a/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchClientConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchClientConfiguration.java
@@ -48,6 +48,12 @@ public class ElasticsearchClientConfiguration {
     @Parameter(value = "elasticsearch_idle_timeout")
     Duration elasticsearchIdleTimeout = Duration.seconds(-1L);
 
+    @Parameter(value = "elasticsearch_connection_retries", validators = {PositiveIntegerValidator.class})
+    int elasticsearchConnectionRetries = 0;
+
+    @Parameter(value = "elasticsearch_connection_retry_wait", validators = {PositiveDurationValidator.class})
+    Duration elasticsearchConnectionRetryWait = Duration.seconds(5L);
+
     @Parameter(value = "elasticsearch_max_total_connections", validators = {PositiveIntegerValidator.class})
     int elasticsearchMaxTotalConnections = 200;
 

--- a/graylog2-server/src/main/java/org/graylog2/storage/providers/ElasticsearchVersionProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/storage/providers/ElasticsearchVersionProvider.java
@@ -28,7 +28,6 @@ import javax.inject.Named;
 import javax.inject.Provider;
 import javax.inject.Singleton;
 import java.net.URI;
-import com.github.joschi.jadconfig.util.Duration;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
@@ -43,14 +42,10 @@ public class ElasticsearchVersionProvider implements Provider<Version> {
     private final List<URI> elasticsearchHosts;
     private final VersionProbe versionProbe;
     private final AtomicCache<Optional<Version>> cachedVersion;
-    private final int connectionRetries;
-    private final Duration connectionRetryWait;
 
     @Inject
     public ElasticsearchVersionProvider(@Named("elasticsearch_version") @Nullable Version versionOverride,
                                         @Named("elasticsearch_hosts") List<URI> elasticsearchHosts,
-                                        @Named("elasticsearch_connection_retries") int elasticsearchConnectionRetries,
-                                        @Named("elasticsearch_connection_retry_wait") Duration elasticsearchConnectionRetryWait,
                                         VersionProbe versionProbe,
                                         AtomicCache<Optional<Version>> cachedVersion) {
 
@@ -58,48 +53,23 @@ public class ElasticsearchVersionProvider implements Provider<Version> {
         this.elasticsearchHosts = elasticsearchHosts;
         this.versionProbe = versionProbe;
         this.cachedVersion = cachedVersion;
-        this.connectionRetries = elasticsearchConnectionRetries;
-        this.connectionRetryWait = elasticsearchConnectionRetryWait;
-    }
-
-    private Optional<Version> probeForVersionAndRetry() throws ElasticsearchProbeException {
-        // if we don't want to wait for ES to be up and there is an explicit version set, return
-        if(connectionRetries < 1 && versionOverride.isPresent())
-            return Optional.empty();
-
-        int i = 0;
-        // try at least once to satisfy if no explicit version is set but also if there should be no retries
-        do {
-            try {
-                final Optional<Version> probedVersion = this.versionProbe.probe(this.elasticsearchHosts);
-                if(probedVersion.isPresent()) {
-                    LOG.info("Elasticsearch cluster is running v" + probedVersion.get());
-                    return probedVersion;
-                }
-                if(i < this.connectionRetries) {
-                    LOG.warn("Failed to connect to Elasticsearch. Retry {} from {}", i+1, this.connectionRetries);
-                    Thread.sleep(this.connectionRetryWait.toMilliseconds());
-                }
-            } catch (InterruptedException iex) {
-                LOG.warn("Failed to connect to Elasticsearch. Retry {} from {}", i+1, this.connectionRetries);
-            }
-            i++;
-        } while (i <= this.connectionRetries);
-
-        throw new ElasticsearchProbeException(NO_HOST_REACHABLE_ERROR + "!");
-    }
-
-    private Version explicitVersion() {
-        final Version explicitVersion = versionOverride.get();
-        LOG.info("Elasticsearch version set to " + explicitVersion + " - disabling version probe.");
-        return explicitVersion;
     }
 
     @Override
     public Version get() {
+        if (this.versionOverride.isPresent()) {
+            final Version explicitVersion = versionOverride.get();
+            LOG.info("Elasticsearch version set to " + explicitVersion + " - disabling version probe.");
+            return explicitVersion;
+        }
+
         try {
-            final Version probedVersion = this.cachedVersion.get(this::probeForVersionAndRetry).orElseThrow(() -> new ElasticsearchProbeException(NO_HOST_REACHABLE_ERROR + "!"));
-            return this.versionOverride.isPresent() ? explicitVersion() : probedVersion;
+            return this.cachedVersion.get(() -> {
+                final Optional<Version> probedVersion = this.versionProbe.probe(this.elasticsearchHosts);
+                probedVersion.ifPresent(version -> LOG.info("Elasticsearch cluster is running v" + version));
+                return probedVersion;
+            })
+                    .orElseThrow(() -> new ElasticsearchProbeException(NO_HOST_REACHABLE_ERROR + "!"));
         } catch (ExecutionException | InterruptedException e) {
             throw new ElasticsearchProbeException(NO_HOST_REACHABLE_ERROR + ": ", e);
         }

--- a/graylog2-server/src/main/java/org/graylog2/storage/providers/ElasticsearchVersionProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/storage/providers/ElasticsearchVersionProvider.java
@@ -27,9 +27,8 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Provider;
 import javax.inject.Singleton;
-import java.io.IOException;
 import java.net.URI;
-import java.time.Duration;
+import com.github.joschi.jadconfig.util.Duration;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
@@ -79,7 +78,7 @@ public class ElasticsearchVersionProvider implements Provider<Version> {
                 }
                 if(i < this.connectionRetries) {
                     LOG.warn("Failed to connect to Elasticsearch. Retry {} from {}", i+1, this.connectionRetries);
-                    Thread.sleep(this.connectionRetryWait.toMillis());
+                    Thread.sleep(this.connectionRetryWait.toMilliseconds());
                 }
             } catch (InterruptedException iex) {
                 LOG.warn("Failed to connect to Elasticsearch. Retry {} from {}", i+1, this.connectionRetries);

--- a/graylog2-server/src/main/java/org/graylog2/storage/providers/ElasticsearchVersionProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/storage/providers/ElasticsearchVersionProvider.java
@@ -27,7 +27,9 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Provider;
 import javax.inject.Singleton;
+import java.io.IOException;
 import java.net.URI;
+import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
@@ -42,10 +44,14 @@ public class ElasticsearchVersionProvider implements Provider<Version> {
     private final List<URI> elasticsearchHosts;
     private final VersionProbe versionProbe;
     private final AtomicCache<Optional<Version>> cachedVersion;
+    private final int connectionRetries;
+    private final Duration connectionRetryWait;
 
     @Inject
     public ElasticsearchVersionProvider(@Named("elasticsearch_version") @Nullable Version versionOverride,
                                         @Named("elasticsearch_hosts") List<URI> elasticsearchHosts,
+                                        @Named("elasticsearch_connection_retries") int elasticsearchConnectionRetries,
+                                        @Named("elasticsearch_connection_retry_wait") Duration elasticsearchConnectionRetryWait,
                                         VersionProbe versionProbe,
                                         AtomicCache<Optional<Version>> cachedVersion) {
 
@@ -53,23 +59,48 @@ public class ElasticsearchVersionProvider implements Provider<Version> {
         this.elasticsearchHosts = elasticsearchHosts;
         this.versionProbe = versionProbe;
         this.cachedVersion = cachedVersion;
+        this.connectionRetries = elasticsearchConnectionRetries;
+        this.connectionRetryWait = elasticsearchConnectionRetryWait;
+    }
+
+    private Optional<Version> probeForVersionAndRetry() throws ElasticsearchProbeException {
+        // if we don't want to wait for ES to be up and there is an explicit version set, return
+        if(connectionRetries < 1 && versionOverride.isPresent())
+            return Optional.empty();
+
+        int i = 0;
+        // try at least once to satisfy if no explicit version is set but also if there should be no retries
+        do {
+            try {
+                final Optional<Version> probedVersion = this.versionProbe.probe(this.elasticsearchHosts);
+                if(probedVersion.isPresent()) {
+                    LOG.info("Elasticsearch cluster is running v" + probedVersion.get());
+                    return probedVersion;
+                }
+                if(i < this.connectionRetries) {
+                    LOG.warn("Failed to connect to Elasticsearch. Retry {} from {}", i+1, this.connectionRetries);
+                    Thread.sleep(this.connectionRetryWait.toMillis());
+                }
+            } catch (InterruptedException iex) {
+                LOG.warn("Failed to connect to Elasticsearch. Retry {} from {}", i+1, this.connectionRetries);
+            }
+            i++;
+        } while (i <= this.connectionRetries);
+
+        throw new ElasticsearchProbeException(NO_HOST_REACHABLE_ERROR + "!");
+    }
+
+    private Version explicitVersion() {
+        final Version explicitVersion = versionOverride.get();
+        LOG.info("Elasticsearch version set to " + explicitVersion + " - disabling version probe.");
+        return explicitVersion;
     }
 
     @Override
     public Version get() {
-        if (this.versionOverride.isPresent()) {
-            final Version explicitVersion = versionOverride.get();
-            LOG.info("Elasticsearch version set to " + explicitVersion + " - disabling version probe.");
-            return explicitVersion;
-        }
-
         try {
-            return this.cachedVersion.get(() -> {
-                final Optional<Version> probedVersion = this.versionProbe.probe(this.elasticsearchHosts);
-                probedVersion.ifPresent(version -> LOG.info("Elasticsearch cluster is running v" + version));
-                return probedVersion;
-            })
-                    .orElseThrow(() -> new ElasticsearchProbeException(NO_HOST_REACHABLE_ERROR + "!"));
+            final Version probedVersion = this.cachedVersion.get(this::probeForVersionAndRetry).orElseThrow(() -> new ElasticsearchProbeException(NO_HOST_REACHABLE_ERROR + "!"));
+            return this.versionOverride.isPresent() ? explicitVersion() : probedVersion;
         } catch (ExecutionException | InterruptedException e) {
             throw new ElasticsearchProbeException(NO_HOST_REACHABLE_ERROR + ": ", e);
         }

--- a/graylog2-server/src/main/java/org/graylog2/storage/versionprobe/VersionProbe.java
+++ b/graylog2-server/src/main/java/org/graylog2/storage/versionprobe/VersionProbe.java
@@ -115,6 +115,12 @@ public class VersionProbe {
         }
     }
 
+    /**
+     * Try to connect to ES to extract the version info. If configured, retry multiple times with a delay if
+     * the inital connection is refused (e.g. ES starts up in a different container and is not ready yet)
+     * @param rootRoute
+     * @return
+     */
     private Optional<RootResponse> rootResponse(RootRoute rootRoute) {
         int i = 0;
         // try at least once
@@ -126,8 +132,10 @@ public class VersionProbe {
                         return Optional.ofNullable(response.body());
                     }
                 } catch (IOException e) {
+                    // catches "Connection Refused" etc.
                     LOG.error("Unable to retrieve version from Elasticsearch node: ", e);
                 }
+                // do not wait/show warning if this was the last try
                 if (i < this.connectionRetries) {
                     LOG.warn("Failed to connect to Elasticsearch. Retry {} from {}", i + 1, this.connectionRetries);
                     Thread.sleep(this.connectionRetryWait.toMilliseconds());

--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -189,17 +189,17 @@ plugin_dir = plugin
 # Default: http://127.0.0.1:9200
 #elasticsearch_hosts = http://node1:9200,http://user:password@node2:19200
 
-# Maximum number of retries to connect to elasticsearch on boot.
+# Maximum number of retries to connect to elasticsearch on boot for the version probe.
 #
-# Default: 0, don't wait
-#elasticsearch_connection_retries = 5
+# Default: 0, retry indefinitely with the given delay until a connection could be established
+#elasticsearch_version_probe_attempts = 5
 
-# Waiting time in between connection attempts for elasticsearch_connection_retries
+# Waiting time in between connection attempts for elasticsearch_version_probe_attempts
 #
 # Default: 5s
-#elasticsearch_connection_retry_wait = 5s
+#elasticsearch_version_probe_delay = 5s
 
-# Maximum amount of time to wait for successfull connection to Elasticsearch HTTP port.
+# Maximum amount of time to wait for successful connection to Elasticsearch HTTP port.
 #
 # Default: 10 Seconds
 #elasticsearch_connect_timeout = 10s

--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -189,6 +189,16 @@ plugin_dir = plugin
 # Default: http://127.0.0.1:9200
 #elasticsearch_hosts = http://node1:9200,http://user:password@node2:19200
 
+# Maximum number of retries to connect to elasticsearch on boot.
+#
+# Default: 0, don't wait
+#elasticsearch_connection_retries = 5
+
+# Waiting time in between connection attempts for elasticsearch_connection_retries
+#
+# Default: 5s
+#elasticsearch_connection_retry_wait = 5s
+
 # Maximum amount of time to wait for successfull connection to Elasticsearch HTTP port.
 #
 # Default: 10 Seconds


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds two parameters to the Elasticsearch (ES) version probe:
- elasticsearch_version_probe_attempts
- elasticsearch_version_probe_delay

If Graylog can not connect to ES on the first try, it retries according to the given parameters.

## Motivation and Context
Especially in container environments, you can not always be sure that all services come up or are ready in a certain order. Graylog is resilient in regard to this problem regarding MongoDB and if you have disabled ES version probing. 
If you want to probe for the ES version and the ES-instance is not ready to connect, this PR adds that you can retry for a certain amount of tries and also specify the interval to wait between connection attempts.
fixes #10580

## How Has This Been Tested?
manually, so far

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

