### PR TITLE
Use more secure TLS default ciphers

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/bootstrap/CmdLineTool.java
+++ b/graylog2-server/src/main/java/org/graylog2/bootstrap/CmdLineTool.java
@@ -49,6 +49,7 @@ import io.netty.util.internal.logging.Slf4JLoggerFactory;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.LoggerContext;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.graylog2.plugin.BaseConfiguration;
 import org.graylog2.plugin.DocsHelper;
 import org.graylog2.plugin.Plugin;
@@ -72,6 +73,7 @@ import org.slf4j.LoggerFactory;
 import java.lang.management.ManagementFactory;
 import java.nio.file.AccessDeniedException;
 import java.nio.file.Path;
+import java.security.Security;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -86,6 +88,10 @@ public abstract class CmdLineTool implements CliCommand {
     static {
         // Set up JDK Logging adapter, https://logging.apache.org/log4j/2.x/log4j-jul/index.html
         System.setProperty("java.util.logging.manager", "org.apache.logging.log4j.jul.LogManager");
+
+        // This needs to run before the first SSLContext is instantiated,
+        // because it sets up the default SSLAlgorithmConstraints
+        applySecuritySettings();
     }
 
     private static final Logger LOG = LoggerFactory.getLogger(CmdLineTool.class);
@@ -167,6 +173,26 @@ public abstract class CmdLineTool implements CliCommand {
      * Things that have to run before the {@link #startCommand()} method is being called.
      */
     protected void beforeStart() {}
+
+    private static void applySecuritySettings() {
+        // Disable insecure TLS parameters and algorithms by default.
+        // Prevent attacks like LOGJAM, LUCKY13, et al.
+        setSystemPropertyIfEmpty("jdk.tls.ephemeralDHKeySize", "2048");
+        setSystemPropertyIfEmpty("jdk.tls.rejectClientInitiatedRenegotiation", "true");
+
+        // Weirdly this is not a System property
+        Security.setProperty("jdk.tls.disabledAlgorithms", "CBC,3DES");
+
+        // Explicitly register Bouncy Castle as security provider.
+        // This allows us to use more key formats than with JCE
+        Security.addProvider(new BouncyCastleProvider());
+    }
+
+    private static void setSystemPropertyIfEmpty(String key, String value) {
+        if (System.getProperty(key) == null) {
+            System.setProperty(key, value);
+        }
+    }
 
     @Override
     public void run() {

--- a/graylog2-server/src/main/java/org/graylog2/bootstrap/Main.java
+++ b/graylog2-server/src/main/java/org/graylog2/bootstrap/Main.java
@@ -19,11 +19,9 @@ package org.graylog2.bootstrap;
 import com.github.rvesse.airline.Cli;
 import com.github.rvesse.airline.builder.CliBuilder;
 import com.google.common.collect.ImmutableSet;
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.graylog2.bootstrap.commands.CliCommandHelp;
 import org.graylog2.bootstrap.commands.ShowVersion;
 
-import java.security.Security;
 import java.util.ServiceLoader;
 
 public class Main {
@@ -44,9 +42,6 @@ public class Main {
         final Cli<CliCommand> cli = builder.build();
         final Runnable command = cli.parse(args);
 
-        // Explicitly register Bouncy Castle as security provider.
-        // This allows us to use more key formats than with JCE
-        Security.addProvider(new BouncyCastleProvider());
         command.run();
     }
 }


### PR DESCRIPTION
Our defaults (even with TLS 1.2 and 1.3 only)
were still susceptible to LOGJAM, LUCKY13 and a possible DoS attack.

We programatically use secure defaults for the JDK and for Netty with OpenSSL

Fixes https://github.com/Graylog2/graylog-plugin-enterprise/issues/2202
