### PR TITLE
Fix loading of Pipeline simulator page

### DIFF
--- a/graylog2-web-interface/src/components/messageloaders/RawMessageLoader.tsx
+++ b/graylog2-web-interface/src/components/messageloaders/RawMessageLoader.tsx
@@ -124,19 +124,21 @@ const RawMessageLoader = ({ onMessageLoaded, inputIdSelector, codecTypes, inputs
       return [{ value: 'none', label: 'Loading inputs...', disabled: true }];
     }
 
-    const inputIds = Object.keys(inputs);
-
-    if (inputIds.length === 0) {
+    if (inputs.size === 0) {
       return [{ value: 'none', label: 'No inputs available' }];
     }
 
-    return inputIds
-      .map((id) => {
-        const label = `${id} / ${inputs.get(id).title} / ${inputs.get(id).name}`;
+    const formattedInputs = [];
 
-        return { value: inputId, label: label };
-      })
-      .sort((inputA, inputB) => inputA.label.toLowerCase().localeCompare(inputB.label.toLowerCase()));
+    inputs
+      .sort((inputA, inputB) => inputA.title.toLowerCase().localeCompare(inputB.title.toLowerCase()))
+      .forEach((input, id) => {
+        const label = `${id} / ${input.title} / ${input.name}`;
+
+        formattedInputs.push({ value: id, label: label });
+      });
+
+    return formattedInputs;
   };
 
   const _onCodecSelect = (selectedCodec: string) => {

--- a/graylog2-web-interface/src/components/simulator/SimulationResults.jsx
+++ b/graylog2-web-interface/src/components/simulator/SimulationResults.jsx
@@ -172,13 +172,14 @@ class SimulationResults extends React.Component {
 
 SimulationResults.propTypes = {
   stream: PropTypes.object.isRequired,
-  originalMessage: PropTypes.object.isRequired,
+  originalMessage: PropTypes.object,
   simulationResults: PropTypes.object,
   isLoading: PropTypes.bool,
   error: PropTypes.object,
 };
 
 SimulationResults.defaultProps = {
+  originalMessage: undefined,
   simulationResults: undefined,
   isLoading: false,
   error: undefined,


### PR DESCRIPTION
This PR fixes the code formatting Inputs in `RawMessageLoader`, ensuring it does not throw an error while formatting Inputs and that it works as before, even if the `inputs` prop is now an `ImmutableJS.Map` object.

Fixes #10663
