### PR TITLE
Always apply all widget changes when saving aggregation builder.

### DIFF
--- a/graylog2-web-interface/src/views/components/WidgetQueryControls.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetQueryControls.tsx
@@ -86,7 +86,7 @@ const useBindApplySearchControlsChanges = (formRef) => {
   const { bindApplySearchControlsChanges } = useContext(WidgetEditApplyAllChangesContext);
 
   useEffect(() => {
-    const updateWidget = (newWidget: Widget) => {
+    bindApplySearchControlsChanges((newWidget: Widget) => {
       if (formRef.current) {
         const { dirty, values, isValid } = formRef.current;
 
@@ -95,10 +95,8 @@ const useBindApplySearchControlsChanges = (formRef) => {
         }
       }
 
-      return newWidget;
-    };
-
-    bindApplySearchControlsChanges(updateWidget);
+      return undefined;
+    });
   }, [formRef, bindApplySearchControlsChanges]);
 };
 

--- a/graylog2-web-interface/src/views/components/aggregationwizard/AggregationWizard.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/AggregationWizard.tsx
@@ -71,7 +71,7 @@ const onCreateElement = (
   }
 };
 
-const _onSubmit = (formValues: WidgetConfigFormValues, onConfigChange: (newConfig: AggregationWidgetConfig) => void, oldConfig = AggregationWidgetConfig.builder().build()) => {
+export const updateWidgetAggregationElements = (formValues: WidgetConfigFormValues, oldConfig = AggregationWidgetConfig.builder().build()) => {
   const toConfigByKey = Object.fromEntries(aggregationElements.map(({ key, toConfig }) => [key, toConfig]));
 
   const newConfig = Object.keys(formValues).map((key) => {
@@ -84,7 +84,13 @@ const _onSubmit = (formValues: WidgetConfigFormValues, onConfigChange: (newConfi
     return toConfig;
   }).reduce((prevConfig, toConfig) => toConfig(formValues, prevConfig), oldConfig.toBuilder());
 
-  onConfigChange(newConfig.build());
+  return newConfig.build();
+};
+
+const _onSubmit = (formValues: WidgetConfigFormValues, onConfigChange: (newConfig: AggregationWidgetConfig) => void, oldConfig: AggregationWidgetConfig) => {
+  const newConfig = updateWidgetAggregationElements(formValues, oldConfig);
+
+  return onConfigChange(newConfig);
 };
 
 const validateForm = (formValues: WidgetConfigFormValues) => {

--- a/graylog2-web-interface/src/views/components/aggregationwizard/AggregationWizard.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/AggregationWizard.tsx
@@ -107,6 +107,7 @@ const AggregationWizard = ({ onChange, config, children }: EditWidgetComponentPr
   return (
     <WidgetConfigForm onSubmit={(formValues: WidgetConfigFormValues) => _onSubmit(formValues, onChange, config)}
                       initialValues={initialFormValues}
+                      config={config}
                       validate={validateForm}>
       <>
         <Controls>

--- a/graylog2-web-interface/src/views/components/aggregationwizard/ElementsConfigurationActions.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/ElementsConfigurationActions.tsx
@@ -19,6 +19,7 @@ import { useEffect, useState } from 'react';
 import { useFormikContext } from 'formik';
 import styled, { css } from 'styled-components';
 
+import { Spinner } from 'components/common';
 import { ButtonToolbar } from 'components/graylog';
 import Button from 'components/graylog/Button';
 import AggregationElementSelect from 'views/components/aggregationwizard/AggregationElementSelect';
@@ -121,9 +122,9 @@ const ElementsConfigurationActions = () => {
           </SelectContainer>
 
           {dirty && (
-          <Button bsStyle="primary" className="pull-right" type="submit" disabled={!isValid || isSubmitting}>
-            {isSubmitting ? 'Applying Changes' : 'Apply Changes'}
-          </Button>
+            <Button bsStyle="success" className="pull-right" type="submit" disabled={!isValid || isSubmitting}>
+              {isSubmitting ? <Spinner text="Updating Preview" delay={0} /> : 'Update Preview'}
+            </Button>
           )}
         </ButtonToolbar>
       </ConfigActions>

--- a/graylog2-web-interface/src/views/components/aggregationwizard/WidgetConfigForm.test.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/WidgetConfigForm.test.tsx
@@ -18,6 +18,7 @@ import * as React from 'react';
 import { render, screen } from 'wrappedTestingLibrary';
 
 import WidgetConfigForm from 'views/components/aggregationwizard/WidgetConfigForm';
+import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
 
 import ValidationStateProvider from '../contexts/ValidationStateProvider';
 import ValidationStateContext from '../contexts/ValidationStateContext';
@@ -29,7 +30,7 @@ describe('WidgetConfigForm', () => {
         <ValidationStateContext.Consumer>
           {({ hasErrors }) => (
             <>
-              <WidgetConfigForm initialValues={{}} onSubmit={() => {}} validate={validate}>
+              <WidgetConfigForm initialValues={{}} onSubmit={() => {}} validate={validate} config={AggregationWidgetConfig.builder().build()}>
                 <span>Hello world!</span>
               </WidgetConfigForm>
               <span>{hasErrors ? 'Form has errors' : 'Form has no errors'}</span>

--- a/graylog2-web-interface/src/views/components/aggregationwizard/WidgetConfigForm.test.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/WidgetConfigForm.test.tsx
@@ -15,24 +15,28 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { useState } from 'react';
 import { render, screen } from 'wrappedTestingLibrary';
 
 import WidgetConfigForm from 'views/components/aggregationwizard/WidgetConfigForm';
 
-import { ValidationStateContext } from '../widgets/EditWidgetFrame';
+import ValidationStateProvider from '../contexts/ValidationStateProvider';
+import ValidationStateContext from '../contexts/ValidationStateContext';
 
 describe('WidgetConfigForm', () => {
   const WidgetConfigFormWithValidationState = ({ validate }: { validate: () => ({ [key: string]: string })}) => {
-    const [hasErrors, setHasErrors] = useState(false);
-
     return (
-      <ValidationStateContext.Provider value={[hasErrors, setHasErrors]}>
-        <WidgetConfigForm initialValues={{}} onSubmit={() => {}} validate={validate}>
-          <span>Hello world!</span>
-        </WidgetConfigForm>
-        <span>{hasErrors ? 'Form has errors' : 'Form has no errors'}</span>
-      </ValidationStateContext.Provider>
+      <ValidationStateProvider>
+        <ValidationStateContext.Consumer>
+          {({ hasErrors }) => (
+            <>
+              <WidgetConfigForm initialValues={{}} onSubmit={() => {}} validate={validate}>
+                <span>Hello world!</span>
+              </WidgetConfigForm>
+              <span>{hasErrors ? 'Form has errors' : 'Form has no errors'}</span>
+            </>
+          )}
+        </ValidationStateContext.Consumer>
+      </ValidationStateProvider>
     );
   };
 

--- a/graylog2-web-interface/src/views/components/aggregationwizard/WidgetConfigForm.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/WidgetConfigForm.tsx
@@ -24,7 +24,6 @@ import WidgetEditApplyAllChangesContext from 'views/components/contexts/WidgetEd
 import PropagateValidationState from 'views/components/aggregationwizard/PropagateValidationState';
 import VisualizationConfig from 'views/logic/aggregationbuilder/visualizations/VisualizationConfig';
 import { AutoTimeConfig, TimeUnitConfig } from 'views/logic/aggregationbuilder/Pivot';
-import WidgetConfig from 'views/logic/widgets/WidgetConfig';
 import type AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
 
 import { updateWidgetAggregationElements } from './AggregationWizard';
@@ -119,7 +118,7 @@ const useBindApplyElementConfigurationChanges = (formRef, config) => {
   const { bindApplyElementConfigurationChanges } = useContext(WidgetEditApplyAllChangesContext);
 
   useEffect(() => {
-    const updateWidgetConfig = (newWidgetConfig: WidgetConfig) => {
+    bindApplyElementConfigurationChanges(() => {
       if (formRef.current) {
         const { dirty, values, isValid } = formRef.current;
 
@@ -128,10 +127,8 @@ const useBindApplyElementConfigurationChanges = (formRef, config) => {
         }
       }
 
-      return newWidgetConfig;
-    };
-
-    bindApplyElementConfigurationChanges(updateWidgetConfig);
+      return undefined;
+    });
   }, [formRef, bindApplyElementConfigurationChanges, config]);
 };
 

--- a/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.corevisualizations.test.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.corevisualizations.test.tsx
@@ -47,7 +47,7 @@ const SimpleAggregationWizard = (props) => (
   </FieldTypesContext.Provider>
 );
 
-const submitButton = async () => screen.findByText('Apply Changes');
+const submitButton = async () => screen.findByText('Update Preview');
 
 const expectSubmitButtonToBeDisabled = async () => {
   expect(await submitButton()).toBeDisabled();

--- a/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.groupBy.test.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.groupBy.test.tsx
@@ -94,7 +94,7 @@ describe('AggregationWizard', () => {
       await selectEvent.select(fieldSelection, 'took_ms');
     });
 
-    const applyButton = await screen.findByRole('button', { name: 'Apply Changes' });
+    const applyButton = await screen.findByRole('button', { name: 'Update Preview' });
     fireEvent.click(applyButton);
 
     const pivot = Pivot.create('took_ms', 'values', { limit: 15 });
@@ -150,7 +150,7 @@ describe('AggregationWizard', () => {
       await selectEvent.select(fieldSelections[1], 'took_ms');
     });
 
-    const applyButton = await screen.findByRole('button', { name: 'Apply Changes' });
+    const applyButton = await screen.findByRole('button', { name: 'Update Preview' });
     fireEvent.click(applyButton);
 
     const pivot0 = Pivot.create('timestamp', 'time', { interval: { type: 'auto', scaling: 1 } });
@@ -211,7 +211,7 @@ describe('AggregationWizard', () => {
       await selectEvent.select(fieldSelection, 'took_ms');
     });
 
-    const applyButton = await screen.findByRole('button', { name: 'Apply Changes' });
+    const applyButton = await screen.findByRole('button', { name: 'Update Preview' });
     fireEvent.click(applyButton);
 
     const updatedConfig = widgetConfig
@@ -245,7 +245,7 @@ describe('AggregationWizard', () => {
     fireEvent.keyDown(firstItem, { key: 'Space', keyCode: 32 });
     await screen.findByText(/You have dropped the item/i);
 
-    const applyButton = await screen.findByRole('button', { name: 'Apply Changes' });
+    const applyButton = await screen.findByRole('button', { name: 'Update Preview' });
     fireEvent.click(applyButton);
 
     const updatedConfig = widgetConfig

--- a/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.groupBy.test.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.groupBy.test.tsx
@@ -53,6 +53,20 @@ const addElement = async (key: 'Grouping' | 'Metric' | 'Sort') => {
   await userEvent.click(await screen.findByRole('menuitem', { name: key }));
 };
 
+const selectField = async (fieldName) => {
+  const fieldSelection = await screen.findByLabelText('Field');
+
+  await act(async () => {
+    await selectEvent.openMenu(fieldSelection);
+    await selectEvent.select(fieldSelection, fieldName);
+  });
+};
+
+const submitWidgetConfigForm = async () => {
+  const applyButton = await screen.findByRole('button', { name: 'Update Preview' });
+  fireEvent.click(applyButton);
+};
+
 describe('AggregationWizard', () => {
   const renderSUT = (props = {}) => render(
     <FieldTypesContext.Provider value={fieldTypes}>
@@ -75,8 +89,7 @@ describe('AggregationWizard', () => {
   it('should require group by function when adding a group by element', async () => {
     renderSUT();
 
-    await userEvent.click(await screen.findByRole('button', { name: 'Add' }));
-    await userEvent.click(await screen.findByRole('menuitem', { name: 'Grouping' }));
+    await addElement('Grouping');
 
     await waitFor(() => expect(screen.getByText('Field is required.')).toBeInTheDocument());
   });
@@ -86,16 +99,8 @@ describe('AggregationWizard', () => {
     renderSUT({ onChange });
 
     await addElement('Grouping');
-
-    const fieldSelection = await screen.findByLabelText('Field');
-
-    await act(async () => {
-      await selectEvent.openMenu(fieldSelection);
-      await selectEvent.select(fieldSelection, 'took_ms');
-    });
-
-    const applyButton = await screen.findByRole('button', { name: 'Update Preview' });
-    fireEvent.click(applyButton);
+    await selectField('took_ms');
+    await submitWidgetConfigForm();
 
     const pivot = Pivot.create('took_ms', 'values', { limit: 15 });
     const updatedConfig = widgetConfig
@@ -112,13 +117,7 @@ describe('AggregationWizard', () => {
     renderSUT();
 
     await addElement('Grouping');
-
-    const fieldSelection = await screen.findByLabelText('Field');
-
-    await act(async () => {
-      await selectEvent.openMenu(fieldSelection);
-      await selectEvent.select(fieldSelection, 'timestamp');
-    });
+    await selectField('timestamp');
 
     const autoCheckbox = await screen.findByRole('checkbox', { name: 'Auto' });
     await screen.findByRole('slider', { name: /interval/i });
@@ -133,14 +132,7 @@ describe('AggregationWizard', () => {
     renderSUT({ onChange });
 
     await addElement('Grouping');
-
-    const fieldSelection = await screen.findByLabelText('Field');
-
-    await act(async () => {
-      await selectEvent.openMenu(fieldSelection);
-      await selectEvent.select(fieldSelection, 'timestamp');
-    });
-
+    await selectField('timestamp');
     await addElement('Grouping');
 
     const fieldSelections = await screen.findAllByLabelText('Field');
@@ -150,8 +142,7 @@ describe('AggregationWizard', () => {
       await selectEvent.select(fieldSelections[1], 'took_ms');
     });
 
-    const applyButton = await screen.findByRole('button', { name: 'Update Preview' });
-    fireEvent.click(applyButton);
+    await submitWidgetConfigForm();
 
     const pivot0 = Pivot.create('timestamp', 'time', { interval: { type: 'auto', scaling: 1 } });
     const pivot1 = Pivot.create('took_ms', 'values', { limit: 15 });
@@ -203,16 +194,8 @@ describe('AggregationWizard', () => {
     renderSUT({ onChange, config });
 
     await screen.findByText('timestamp');
-
-    const fieldSelection = await screen.findByLabelText('Field');
-
-    await act(async () => {
-      await selectEvent.openMenu(fieldSelection);
-      await selectEvent.select(fieldSelection, 'took_ms');
-    });
-
-    const applyButton = await screen.findByRole('button', { name: 'Update Preview' });
-    fireEvent.click(applyButton);
+    await selectField('took_ms');
+    await submitWidgetConfigForm();
 
     const updatedConfig = widgetConfig
       .toBuilder()
@@ -245,8 +228,7 @@ describe('AggregationWizard', () => {
     fireEvent.keyDown(firstItem, { key: 'Space', keyCode: 32 });
     await screen.findByText(/You have dropped the item/i);
 
-    const applyButton = await screen.findByRole('button', { name: 'Update Preview' });
-    fireEvent.click(applyButton);
+    await submitWidgetConfigForm();
 
     const updatedConfig = widgetConfig
       .toBuilder()

--- a/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.metric.test.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.metric.test.tsx
@@ -147,7 +147,7 @@ describe('AggregationWizard', () => {
       await selectEvent.select(fieldSelect, 'http_method');
     });
 
-    const applyButton = await screen.findByRole('button', { name: 'Apply Changes' });
+    const applyButton = await screen.findByRole('button', { name: 'Update Preview' });
     fireEvent.click(applyButton);
 
     const updatedSeriesConfig = SeriesConfig.empty().toBuilder().name('New name').build();
@@ -187,7 +187,7 @@ describe('AggregationWizard', () => {
     await selectEvent.openMenu(percentileInput);
     await selectEvent.select(percentileInput, '50');
 
-    const applyButton = await screen.findByRole('button', { name: 'Apply Changes' });
+    const applyButton = await screen.findByRole('button', { name: 'Update Preview' });
     fireEvent.click(applyButton);
 
     const updatedConfig = widgetConfig
@@ -225,7 +225,7 @@ describe('AggregationWizard', () => {
       await selectEvent.select(newFieldSelect, 'http_method');
     });
 
-    const applyButton = await screen.findByRole('button', { name: 'Apply Changes' });
+    const applyButton = await screen.findByRole('button', { name: 'Update Preview' });
     fireEvent.click(applyButton);
 
     const updatedConfig = config.toBuilder()
@@ -253,7 +253,7 @@ describe('AggregationWizard', () => {
     const removeMetricElementButton = screen.getByRole('button', { name: 'Remove Metric' });
     userEvent.click(removeMetricElementButton);
 
-    const applyButton = await screen.findByRole('button', { name: 'Apply Changes' });
+    const applyButton = await screen.findByRole('button', { name: 'Update Preview' });
     userEvent.click(applyButton);
 
     const updatedConfig = widgetConfig

--- a/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.sort.test.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.sort.test.tsx
@@ -111,7 +111,7 @@ describe('AggregationWizard', () => {
     await selectEvent.openMenu(sortDirectionSelect);
     await selectEvent.select(sortDirectionSelect, 'Descending');
 
-    const applyButton = await screen.findByRole('button', { name: 'Apply Changes' });
+    const applyButton = await screen.findByRole('button', { name: 'Update Preview' });
     userEvent.click(applyButton);
 
     const updatedConfig = widgetConfig
@@ -144,7 +144,7 @@ describe('AggregationWizard', () => {
     await selectEvent.openMenu(newSortDirectionSelect);
     await selectEvent.select(newSortDirectionSelect, 'Descending');
 
-    const applyButton = await screen.findByRole('button', { name: 'Apply Changes' });
+    const applyButton = await screen.findByRole('button', { name: 'Update Preview' });
     userEvent.click(applyButton);
 
     const updatedConfig = widgetConfig
@@ -180,7 +180,7 @@ describe('AggregationWizard', () => {
     await selectEvent.openMenu(newSortDirectionSelect);
     await selectEvent.select(newSortDirectionSelect, 'Descending');
 
-    const applyButton = await screen.findByRole('button', { name: 'Apply Changes' });
+    const applyButton = await screen.findByRole('button', { name: 'Update Preview' });
     userEvent.click(applyButton);
 
     const updatedConfig = widgetConfig
@@ -202,7 +202,7 @@ describe('AggregationWizard', () => {
     await addSortElement();
 
     const newSortContainer = await screen.findByTestId('sort-element-0');
-    const applyButton = await screen.findByRole('button', { name: 'Apply Changes' });
+    const applyButton = await screen.findByRole('button', { name: 'Update Preview' });
     await waitFor(() => expect(within(newSortContainer).getByText('Field is required.')).toBeInTheDocument());
     await waitFor(() => expect(expect(applyButton).toBeDisabled()));
   });
@@ -213,7 +213,7 @@ describe('AggregationWizard', () => {
     await addSortElement();
 
     const newSortContainer = await screen.findByTestId('sort-element-0');
-    const applyButton = await screen.findByRole('button', { name: 'Apply Changes' });
+    const applyButton = await screen.findByRole('button', { name: 'Update Preview' });
     await waitFor(() => expect(within(newSortContainer).getByText('Direction is required.')).toBeInTheDocument());
     await waitFor(() => expect(expect(applyButton).toBeDisabled()));
   });
@@ -230,7 +230,7 @@ describe('AggregationWizard', () => {
     const removeSortElementButton = screen.getByRole('button', { name: 'Remove Sort' });
     userEvent.click(removeSortElementButton);
 
-    const applyButton = await screen.findByRole('button', { name: 'Apply Changes' });
+    const applyButton = await screen.findByRole('button', { name: 'Update Preview' });
     userEvent.click(applyButton);
 
     const updatedConfig = widgetConfig
@@ -266,7 +266,7 @@ describe('AggregationWizard', () => {
     fireEvent.keyDown(firstItem, { key: 'Space', keyCode: 32 });
     await screen.findByText(/You have dropped the item/i);
 
-    const applyButton = await screen.findByRole('button', { name: 'Apply Changes' });
+    const applyButton = await screen.findByRole('button', { name: 'Update Preview' });
     fireEvent.click(applyButton);
 
     const updatedConfig = config

--- a/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.visualization.test.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.visualization.test.tsx
@@ -105,8 +105,10 @@ const visualizationPlugin: PluginRegistration = {
   },
 };
 
+const findWidgetConfigSubmitButton = () => screen.findByRole('button', { name: 'Update Preview' });
+
 const expectSubmitButtonToBeDisabled = async () => {
-  const submitButton = await screen.findByRole('button', { name: 'Update Preview' });
+  const submitButton = await findWidgetConfigSubmitButton();
 
   expect(submitButton).toBeDisabled();
 };
@@ -138,7 +140,7 @@ describe('AggregationWizard/Visualizations', () => {
     await selectEvent.openMenu(visualizationSelect);
     await selectEvent.select(visualizationSelect, 'Without Config');
 
-    userEvent.click(await screen.findByRole('button', { name: 'Update Preview' }));
+    userEvent.click(await findWidgetConfigSubmitButton());
 
     await waitFor(() => expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ visualization: 'withoutConfig', visualizationConfig: undefined })));
   });
@@ -155,7 +157,7 @@ describe('AggregationWizard/Visualizations', () => {
 
     fireEvent.change(factorInput, { target: { value: '10' } });
 
-    expect(await screen.findByRole('button', { name: 'Update Preview' })).not.toBeDisabled();
+    expect(await findWidgetConfigSubmitButton()).not.toBeDisabled();
 
     await selectOption('Select Mode', 'anothermode');
 
@@ -163,7 +165,7 @@ describe('AggregationWizard/Visualizations', () => {
 
     await selectOption('Select Favorite Color', 'Yellow');
 
-    const submitButton = await screen.findByRole('button', { name: 'Update Preview' });
+    const submitButton = await findWidgetConfigSubmitButton();
 
     expect(submitButton).not.toBeDisabled();
 
@@ -196,7 +198,7 @@ describe('AggregationWizard/Visualizations', () => {
 
     const updateViewportButton = await screen.findByRole('button', { name: 'Change Viewport' });
     userEvent.click(updateViewportButton);
-    const submitButton = await screen.findByRole('button', { name: 'Update Preview' });
+    const submitButton = await findWidgetConfigSubmitButton();
     userEvent.click(submitButton);
 
     await waitFor(() => expect(onChange).toHaveBeenCalledWith(expect.objectContaining({

--- a/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.visualization.test.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.visualization.test.tsx
@@ -106,7 +106,7 @@ const visualizationPlugin: PluginRegistration = {
 };
 
 const expectSubmitButtonToBeDisabled = async () => {
-  const submitButton = await screen.findByRole('button', { name: 'Apply Changes' });
+  const submitButton = await screen.findByRole('button', { name: 'Update Preview' });
 
   expect(submitButton).toBeDisabled();
 };
@@ -138,7 +138,7 @@ describe('AggregationWizard/Visualizations', () => {
     await selectEvent.openMenu(visualizationSelect);
     await selectEvent.select(visualizationSelect, 'Without Config');
 
-    userEvent.click(await screen.findByRole('button', { name: 'Apply Changes' }));
+    userEvent.click(await screen.findByRole('button', { name: 'Update Preview' }));
 
     await waitFor(() => expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ visualization: 'withoutConfig', visualizationConfig: undefined })));
   });
@@ -155,7 +155,7 @@ describe('AggregationWizard/Visualizations', () => {
 
     fireEvent.change(factorInput, { target: { value: '10' } });
 
-    expect(await screen.findByRole('button', { name: 'Apply Changes' })).not.toBeDisabled();
+    expect(await screen.findByRole('button', { name: 'Update Preview' })).not.toBeDisabled();
 
     await selectOption('Select Mode', 'anothermode');
 
@@ -163,7 +163,7 @@ describe('AggregationWizard/Visualizations', () => {
 
     await selectOption('Select Favorite Color', 'Yellow');
 
-    const submitButton = await screen.findByRole('button', { name: 'Apply Changes' });
+    const submitButton = await screen.findByRole('button', { name: 'Update Preview' });
 
     expect(submitButton).not.toBeDisabled();
 

--- a/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.visualization.test.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.visualization.test.tsx
@@ -196,7 +196,7 @@ describe('AggregationWizard/Visualizations', () => {
 
     const updateViewportButton = await screen.findByRole('button', { name: 'Change Viewport' });
     userEvent.click(updateViewportButton);
-    const submitButton = await screen.findByRole('button', { name: 'Apply Changes' });
+    const submitButton = await screen.findByRole('button', { name: 'Update Preview' });
     userEvent.click(submitButton);
 
     await waitFor(() => expect(onChange).toHaveBeenCalledWith(expect.objectContaining({

--- a/graylog2-web-interface/src/views/components/contexts/ValidationStateContext.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/ValidationStateContext.tsx
@@ -14,18 +14,18 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import { useContext, useEffect } from 'react';
-import { useFormikContext } from 'formik';
+import * as React from 'react';
 
-import ValidationStateContext from '../contexts/ValidationStateContext';
+import { singleton } from 'views/logic/singleton';
 
-const PropagateValidationState = ({ formKey }) => {
-  const { isValid } = useFormikContext();
-  const { setHasErrors } = useContext(ValidationStateContext);
-
-  useEffect(() => setHasErrors(formKey, !isValid), [formKey, isValid, setHasErrors]);
-
-  return null;
+export type ValidationState = {
+  hasErrors: boolean,
+  setHasErrors: (formKey: boolean, hasErrors: boolean) => void,
 };
 
-export default PropagateValidationState;
+const ValidationStateContext = React.createContext<ValidationState>({
+  hasErrors: false,
+  setHasErrors: () => {},
+});
+
+export default singleton('contexts.ValidationStateContext', () => ValidationStateContext);

--- a/graylog2-web-interface/src/views/components/contexts/ValidationStateProvider.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/ValidationStateProvider.tsx
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import { useCallback, useState } from 'react';
+
+import ValidationStateContext from './ValidationStateContext';
+
+type Props = {
+  children: React.ReactElement,
+};
+
+const ValidationStateProvider = ({ children }: Props) => {
+  const [hasErrorsMap, setHasErrorsMap] = useState({});
+
+  const setHasErrors = useCallback((sectionKey, hasErrors) => {
+    if (Boolean(hasErrorsMap[sectionKey]) !== hasErrors) {
+      setHasErrorsMap({
+        ...hasErrorsMap,
+        [sectionKey]: hasErrors,
+      });
+    }
+  }, [hasErrorsMap]);
+
+  const hasErrors = Object.values(hasErrorsMap).includes(true);
+
+  return (
+    <ValidationStateContext.Provider value={{ hasErrors, setHasErrors }}>
+      {children}
+    </ValidationStateContext.Provider>
+  );
+};
+
+export default ValidationStateProvider;

--- a/graylog2-web-interface/src/views/components/contexts/WidgetEditApplyAllChangesContext.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/WidgetEditApplyAllChangesContext.tsx
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import * as Immutable from 'immutable';
+import type Widget from 'src/views/logic/widgets/Widget';
+import type WidgetConfig from 'src/views/logic/widgets/WidgetConfig';
+import type { Widgets } from 'src/views/stores/WidgetStore';
+
+import { singleton } from 'views/logic/singleton';
+
+type ApplySearchControlsChanges = (widget: Widget) => Widget;
+type ApplyElementConfigurationChanges = (widgetConfig: WidgetConfig) => WidgetConfig;
+
+type WidgetEditApplyAllChangesContextValue = {
+  applyAllWidgetChanges: () => Promise<Widgets>,
+  bindApplyElementConfigurationChanges: (updateFn: ApplyElementConfigurationChanges) => void,
+  bindApplySearchControlsChanges: (updateFn: ApplySearchControlsChanges) => void,
+  isSubmitting: boolean,
+}
+
+const WidgetEditApplyAllChangesContext = React.createContext<WidgetEditApplyAllChangesContextValue>({
+  applyAllWidgetChanges: () => Promise.resolve(Immutable.OrderedMap()),
+  bindApplyElementConfigurationChanges: () => {},
+  bindApplySearchControlsChanges: () => {},
+  isSubmitting: false,
+});
+
+export default singleton('contexts.WidgetEditApplyAllChangesContext', () => WidgetEditApplyAllChangesContext);

--- a/graylog2-web-interface/src/views/components/contexts/WidgetEditApplyAllChangesContext.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/WidgetEditApplyAllChangesContext.tsx
@@ -15,10 +15,10 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import type Widget from 'src/views/logic/widgets/Widget';
-import type WidgetConfig from 'src/views/logic/widgets/WidgetConfig';
-import type { Widgets } from 'src/views/stores/WidgetStore';
 
+import type Widget from 'views/logic/widgets/Widget';
+import type WidgetConfig from 'views/logic/widgets/WidgetConfig';
+import type { Widgets } from 'views/stores/WidgetStore';
 import { singleton } from 'views/logic/singleton';
 
 type ApplySearchControlsChanges = (widget: Widget) => Widget | undefined;

--- a/graylog2-web-interface/src/views/components/contexts/WidgetEditApplyAllChangesContext.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/WidgetEditApplyAllChangesContext.tsx
@@ -15,25 +15,24 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import * as Immutable from 'immutable';
 import type Widget from 'src/views/logic/widgets/Widget';
 import type WidgetConfig from 'src/views/logic/widgets/WidgetConfig';
 import type { Widgets } from 'src/views/stores/WidgetStore';
 
 import { singleton } from 'views/logic/singleton';
 
-type ApplySearchControlsChanges = (widget: Widget) => Widget;
-type ApplyElementConfigurationChanges = (widgetConfig: WidgetConfig) => WidgetConfig;
+type ApplySearchControlsChanges = (widget: Widget) => Widget | undefined;
+type ApplyElementConfigurationChanges = (widgetConfig: WidgetConfig) => WidgetConfig | undefined;
 
 type WidgetEditApplyAllChangesContextValue = {
-  applyAllWidgetChanges: () => Promise<Widgets>,
+  applyAllWidgetChanges: () => Promise<Widgets | void>,
   bindApplyElementConfigurationChanges: (updateFn: ApplyElementConfigurationChanges) => void,
   bindApplySearchControlsChanges: (updateFn: ApplySearchControlsChanges) => void,
   isSubmitting: boolean,
 }
 
 const WidgetEditApplyAllChangesContext = React.createContext<WidgetEditApplyAllChangesContextValue>({
-  applyAllWidgetChanges: () => Promise.resolve(Immutable.OrderedMap()),
+  applyAllWidgetChanges: () => Promise.resolve(),
   bindApplyElementConfigurationChanges: () => {},
   bindApplySearchControlsChanges: () => {},
   isSubmitting: false,

--- a/graylog2-web-interface/src/views/components/contexts/WidgetEditApplyAllChangesProvider.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/WidgetEditApplyAllChangesProvider.tsx
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import { useState, useRef, useCallback } from 'react';
+
+import { WidgetActions } from 'views/stores/WidgetStore';
+import Widget from 'views/logic/widgets/Widget';
+import UserNotification from 'util/UserNotification';
+
+import WidgetEditApplyAllChangesContext from './WidgetEditApplyAllChangesContext';
+
+type Props = {
+  widget: Widget,
+  children: React.ReactNode,
+}
+
+const WidgetEditApplyAllChangesProvider = ({ children, widget }: Props) => {
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const applySearchControlsChanges = useRef(null);
+  const applyElementConfigurationChanges = useRef(null);
+
+  const bindApplySearchControlsChanges = useCallback((updateWidgetConfig) => {
+    applySearchControlsChanges.current = updateWidgetConfig;
+  }, []);
+
+  const bindApplyElementConfigurationChanges = useCallback((updateWidget) => {
+    applyElementConfigurationChanges.current = updateWidget;
+  }, []);
+
+  const applyAllWidgetChanges = useCallback(() => {
+    setIsSubmitting(true);
+    let newWidget = widget;
+
+    if (applySearchControlsChanges.current) {
+      newWidget = applySearchControlsChanges.current(newWidget);
+    }
+
+    if (applyElementConfigurationChanges.current) {
+      const newConfig = applyElementConfigurationChanges.current(newWidget.config);
+      newWidget = newWidget.toBuilder().config(newConfig).build();
+    }
+
+    return WidgetActions.update(widget.id, newWidget)
+      .catch((error) => {
+        UserNotification.error(`Applying widget changes failed with status: ${error}`);
+
+        return error;
+      }).finally(() => setIsSubmitting(false));
+  }, [widget]);
+
+  const contextValue = {
+    applyAllWidgetChanges,
+    bindApplyElementConfigurationChanges,
+    bindApplySearchControlsChanges,
+    isSubmitting,
+  };
+
+  return (
+    <WidgetEditApplyAllChangesContext.Provider value={contextValue}>
+      {children}
+    </WidgetEditApplyAllChangesContext.Provider>
+  );
+};
+
+export default WidgetEditApplyAllChangesProvider;

--- a/graylog2-web-interface/src/views/components/searchbar/SearchBarForm.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/SearchBarForm.tsx
@@ -15,9 +15,9 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
+import { useCallback } from 'react';
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
-import { useCallback } from 'react';
 import { Form, Formik } from 'formik';
 import { isFunction } from 'lodash';
 import type { FormikProps } from 'formik';
@@ -34,6 +34,7 @@ type Props = {
   limitDuration: number,
   onSubmit: (Values) => void | Promise<any>,
   validateOnMount?: boolean,
+  formRef?: React.Ref<FormikProps<SearchBarFormValues>>,
 }
 
 const StyledForm = styled(Form)`
@@ -42,7 +43,7 @@ const StyledForm = styled(Form)`
 
 const _isFunction = (children: Props['children']): children is (props: FormikProps<SearchBarFormValues>) => React.ReactElement => isFunction(children);
 
-const SearchBarForm = ({ initialValues, limitDuration, onSubmit, children, validateOnMount }: Props) => {
+const SearchBarForm = ({ initialValues, limitDuration, onSubmit, children, validateOnMount, formRef }: Props) => {
   const _onSubmit = useCallback(({ timerange, streams, queryString }) => {
     const newTimeRange = onSubmittingTimerange(timerange);
 
@@ -64,6 +65,7 @@ const SearchBarForm = ({ initialValues, limitDuration, onSubmit, children, valid
     <Formik initialValues={_initialValues}
             enableReinitialize
             onSubmit={_onSubmit}
+            innerRef={formRef}
             validate={({ timerange: nextTimeRange }) => dateTimeValidate(nextTimeRange, limitDuration)}
             validateOnMount={validateOnMount}>
       {(...args) => (
@@ -78,7 +80,7 @@ const SearchBarForm = ({ initialValues, limitDuration, onSubmit, children, valid
 };
 
 SearchBarForm.propTypes = {
-  initialValues: PropTypes.shape({
+  initialValues: PropTypes.exact({
     timerange: PropTypes.object.isRequired,
     queryString: PropTypes.string.isRequired,
     streams: PropTypes.arrayOf(PropTypes.string).isRequired,
@@ -90,6 +92,7 @@ SearchBarForm.propTypes = {
 
 SearchBarForm.defaultProps = {
   validateOnMount: true,
+  formRef: undefined,
 };
 
 export default SearchBarForm;

--- a/graylog2-web-interface/src/views/components/searchbar/StreamsFilter.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/StreamsFilter.jsx
@@ -29,6 +29,7 @@ const StreamsFilter = ({ disabled, value, streams, onChange }) => {
     <div style={{ position: 'relative' }} data-testid="streams-filter" title={placeholder}>
       <Select placeholder={placeholder}
               disabled={disabled}
+              inputProps={{ 'aria-label': placeholder }}
               displayKey="key"
               inputId="streams-filter"
               onChange={(selected) => onChange(selected === '' ? [] : selected.split(','))}

--- a/graylog2-web-interface/src/views/components/widgets/SaveOrCancelButtons.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/SaveOrCancelButtons.tsx
@@ -16,7 +16,10 @@
  */
 import * as React from 'react';
 import styled from 'styled-components';
+import { useContext } from 'react';
 
+import WidgetEditApplyAllChangesContext from 'views/components/contexts/WidgetEditApplyAllChangesContext';
+import { Spinner } from 'components/common';
 import { Button, ButtonToolbar } from 'components/graylog';
 
 const StyledButtonToolbar = styled(ButtonToolbar)`
@@ -29,12 +32,21 @@ type Props = {
   disableSave?: boolean,
 };
 
-const SaveOrCancelButtons = ({ onFinish, onCancel, disableSave = false }: Props) => (
-  <StyledButtonToolbar className="pull-right">
-    <Button onClick={onFinish} bsStyle="primary" disabled={disableSave}>Save</Button>
-    <Button onClick={onCancel}>Cancel</Button>
-  </StyledButtonToolbar>
-);
+const SaveOrCancelButtons = ({ onFinish, onCancel, disableSave = false }: Props) => {
+  const { applyAllWidgetChanges, isSubmitting } = useContext(WidgetEditApplyAllChangesContext);
+  const _onFinish = () => applyAllWidgetChanges().then(() => {
+    onFinish();
+  });
+
+  return (
+    <StyledButtonToolbar className="pull-right">
+      <Button onClick={_onFinish} bsStyle="primary" disabled={disableSave}>
+        {isSubmitting ? <Spinner text="Applying Changes" delay={0} /> : 'Apply Changes'}
+      </Button>
+      <Button onClick={onCancel}>Cancel</Button>
+    </StyledButtonToolbar>
+  );
+};
 
 SaveOrCancelButtons.defaultProps = {
   disableSave: false,

--- a/graylog2-web-interface/src/views/components/widgets/Widget.aggregations.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/Widget.aggregations.test.tsx
@@ -1,0 +1,230 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import React from 'react';
+import * as Immutable from 'immutable';
+import { render, waitFor, fireEvent, screen } from 'wrappedTestingLibrary';
+import mockAction from 'helpers/mocking/MockAction';
+import { PluginManifest, PluginStore } from 'graylog-web-plugin/plugin';
+import MockStore from 'helpers/mocking/StoreMock';
+import selectEvent from 'react-select-event';
+import userEvent from '@testing-library/user-event';
+import { applyTimeoutMultiplier } from 'jest-preset-graylog/lib/timeouts';
+import { createSearch } from 'fixtures/searches';
+
+import SeriesConfig from 'views/logic/aggregationbuilder/SeriesConfig';
+import Series from 'views/logic/aggregationbuilder/Series';
+import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
+import WidgetModel from 'views/logic/widgets/Widget';
+import { WidgetActions } from 'views/stores/WidgetStore';
+import WidgetPosition from 'views/logic/widgets/WidgetPosition';
+import View, { ViewType } from 'views/logic/views/View';
+import { ViewStore } from 'views/stores/ViewStore';
+import type { ViewStoreState } from 'views/stores/ViewStore';
+import { createElasticsearchQueryString } from 'views/logic/queries/Query';
+import viewsBindings from 'views/bindings';
+import DataTable from 'views/components/datatable/DataTable';
+
+import Widget from './Widget';
+import type { Props as WidgetComponentProps } from './Widget';
+
+import WidgetContext from '../contexts/WidgetContext';
+import WidgetFocusContext from '../contexts/WidgetFocusContext';
+import FieldTypesContext from '../contexts/FieldTypesContext';
+import ViewTypeContext from '../contexts/ViewTypeContext';
+
+const testTimeout = applyTimeoutMultiplier(30000);
+
+jest.mock('./WidgetHeader', () => 'widget-header');
+jest.mock('./WidgetColorContext', () => ({ children }) => children);
+
+jest.mock('views/stores/FieldTypesStore', () => ({
+  FieldTypesStore: MockStore(['getInitialState', () => ({ all: {}, queryFields: {} })]),
+}));
+
+jest.mock('views/stores/WidgetStore', () => ({
+  WidgetStore: MockStore(),
+  WidgetActions: {
+    update: mockAction(),
+  },
+}));
+
+jest.mock('views/stores/AggregationFunctionsStore', () => ({
+  getInitialState: jest.fn(() => ({
+    count: { type: 'count', description: 'Count' },
+  })),
+  listen: jest.fn(),
+}));
+
+jest.mock('views/stores/StreamsStore', () => ({
+  StreamsStore: MockStore(['getInitialState', () => ({
+    streams: [
+      { title: 'Stream 1', id: 'stream-id-1' },
+    ],
+  })]),
+}));
+
+const viewsPlugin = new PluginManifest({}, viewsBindings);
+
+describe('Aggregation Widget', () => {
+  beforeAll(() => {
+    PluginStore.register(viewsPlugin);
+  });
+
+  afterAll(() => {
+    PluginStore.unregister(viewsPlugin);
+  });
+
+  const dataTableWidget = WidgetModel.builder().newId()
+    .type('AGGREGATION')
+    .config(AggregationWidgetConfig.builder().visualization(DataTable.type).build())
+    .query(createElasticsearchQueryString(''))
+    .timerange({ type: 'relative', from: 300 })
+    .build();
+
+  const viewStoreState: ViewStoreState = {
+    activeQuery: 'query-id-1',
+    view: createSearch({ queryId: 'query-id-1' }),
+    isNew: false,
+    dirty: false,
+  };
+
+  beforeEach(() => {
+    ViewStore.getInitialState = jest.fn(() => viewStoreState);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.resetModules();
+  });
+
+  type AggregationWidgetProps = Partial<WidgetComponentProps> & {
+    viewType: ViewType,
+  }
+
+  const widgetFocusContextState = {
+    focusedWidget: undefined,
+    setWidgetFocusing: () => {},
+    setWidgetEditing: () => {},
+    unsetWidgetFocusing: () => {},
+    unsetWidgetEditing: () => {},
+  };
+
+  const AggregationWidget = ({
+    widget: propsWidget = dataTableWidget,
+    viewType,
+    ...props
+  }: AggregationWidgetProps) => (
+    <ViewTypeContext.Provider value={viewType}>
+      <FieldTypesContext.Provider value={{ all: Immutable.List(), queryFields: Immutable.Map() }}>
+        <WidgetFocusContext.Provider value={widgetFocusContextState}>
+          <WidgetContext.Provider value={propsWidget}>
+            <Widget widget={propsWidget}
+                    id="widgetId"
+                    fields={Immutable.List([])}
+                    onPositionsChange={() => {}}
+                    onSizeChange={() => {}}
+                    title="Widget Title"
+                    position={new WidgetPosition(1, 1, 1, 1)}
+                    {...props} />
+          </WidgetContext.Provider>
+        </WidgetFocusContext.Provider>
+      </FieldTypesContext.Provider>
+    </ViewTypeContext.Provider>
+  );
+
+  describe('on a dashboard', () => {
+    it('should update not submitted widget search controls and aggregation elements changes when clicking on "Apply Changes"', async () => {
+      const newSeries = Series.create('count').toBuilder().config(SeriesConfig.empty().toBuilder().name('Metric name').build()).build();
+      const updatedConfig = dataTableWidget.config
+        .toBuilder()
+        .series([newSeries])
+        .build();
+
+      const updatedWidget = dataTableWidget.toBuilder()
+        .config(updatedConfig)
+        .streams(['stream-id-1'])
+        .build();
+      render(<AggregationWidget editing viewType={View.Type.Dashboard} />);
+
+      // Change widget aggregation elements
+      const addMetricButton = await screen.findByRole('button', { name: 'Add a Metric' });
+      fireEvent.click(addMetricButton);
+
+      const nameInput = await screen.findByLabelText(/Name/);
+      userEvent.type(nameInput, 'Metric name');
+
+      const metricFieldSelect = screen.getByLabelText('Select a function');
+      await selectEvent.openMenu(metricFieldSelect);
+      await selectEvent.select(metricFieldSelect, 'Count');
+
+      await screen.findByRole('button', { name: 'Update Preview' });
+
+      // Change widget search controls
+      const streamsSelect = await screen.findByLabelText('Select streams the search should include. Searches in all streams if empty.');
+      await selectEvent.openMenu(streamsSelect);
+      await selectEvent.select(streamsSelect, 'Stream 1');
+
+      await screen.findByRole('button', {
+        name: /perform search \(changes were made after last search execution\)/i,
+      });
+
+      // Submit all changes
+      const saveButton = screen.getByText('Apply Changes');
+      fireEvent.click(saveButton);
+
+      await waitFor(() => expect(WidgetActions.update).toHaveBeenCalledTimes(1));
+
+      expect(WidgetActions.update).toHaveBeenCalledWith(expect.any(String), updatedWidget);
+    }, testTimeout);
+  });
+
+  describe('on a search', () => {
+    it('should update not submitted aggregation elements changes when clicking on "Apply Changes"', async () => {
+      const newSeries = Series.create('count').toBuilder().config(SeriesConfig.empty().toBuilder().name('Metric name').build()).build();
+      const updatedConfig = dataTableWidget.config
+        .toBuilder()
+        .series([newSeries])
+        .build();
+
+      const updatedWidget = dataTableWidget.toBuilder()
+        .config(updatedConfig)
+        .build();
+      render(<AggregationWidget editing viewType={View.Type.Dashboard} />);
+
+      // Change widget aggregation elements
+      const addMetricButton = await screen.findByRole('button', { name: 'Add a Metric' });
+      fireEvent.click(addMetricButton);
+
+      const nameInput = await screen.findByLabelText(/Name/);
+      userEvent.type(nameInput, 'Metric name');
+
+      const metricFieldSelect = screen.getByLabelText('Select a function');
+      await selectEvent.openMenu(metricFieldSelect);
+      await selectEvent.select(metricFieldSelect, 'Count');
+
+      await screen.findByRole('button', { name: 'Update Preview' });
+
+      // Submit all changes
+      const saveButton = screen.getByText('Apply Changes');
+      fireEvent.click(saveButton);
+
+      await waitFor(() => expect(WidgetActions.update).toHaveBeenCalledTimes(1));
+
+      expect(WidgetActions.update).toHaveBeenCalledWith(expect.any(String), updatedWidget);
+    }, testTimeout);
+  });
+});

--- a/graylog2-web-interface/src/views/components/widgets/Widget.aggregations.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/Widget.aggregations.test.tsx
@@ -146,6 +146,8 @@ describe('Aggregation Widget', () => {
     </ViewTypeContext.Provider>
   );
 
+  const findWidgetConfigSubmitButton = () => screen.findByRole('button', { name: 'Update Preview' });
+
   describe('on a dashboard', () => {
     it('should update not submitted widget search controls and aggregation elements changes when clicking on "Apply Changes"', async () => {
       const newSeries = Series.create('count').toBuilder().config(SeriesConfig.empty().toBuilder().name('Metric name').build()).build();
@@ -171,7 +173,7 @@ describe('Aggregation Widget', () => {
       await selectEvent.openMenu(metricFieldSelect);
       await selectEvent.select(metricFieldSelect, 'Count');
 
-      await screen.findByRole('button', { name: 'Update Preview' });
+      await findWidgetConfigSubmitButton();
 
       // Change widget search controls
       const streamsSelect = await screen.findByLabelText('Select streams the search should include. Searches in all streams if empty.');
@@ -216,7 +218,7 @@ describe('Aggregation Widget', () => {
       await selectEvent.openMenu(metricFieldSelect);
       await selectEvent.select(metricFieldSelect, 'Count');
 
-      await screen.findByRole('button', { name: 'Update Preview' });
+      await findWidgetConfigSubmitButton();
 
       // Submit all changes
       const saveButton = screen.getByText('Apply Changes');

--- a/graylog2-web-interface/src/views/components/widgets/Widget.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/Widget.test.tsx
@@ -17,26 +17,22 @@
 import React from 'react';
 import * as Immutable from 'immutable';
 import { render, waitFor, fireEvent, screen } from 'wrappedTestingLibrary';
-import { Map } from 'immutable';
 import mockComponent from 'helpers/mocking/MockComponent';
 import mockAction from 'helpers/mocking/MockAction';
 import { PluginRegistration, PluginStore } from 'graylog-web-plugin/plugin';
 import MockStore from 'helpers/mocking/StoreMock';
-import asMock from 'helpers/mocking/AsMock';
+import { createSearch } from 'fixtures/searches';
 
 import WidgetModel from 'views/logic/widgets/Widget';
 import { WidgetActions, Widgets } from 'views/stores/WidgetStore';
 import { TitlesActions, TitleTypes } from 'views/stores/TitlesStore';
 import WidgetPosition from 'views/logic/widgets/WidgetPosition';
-import View from 'views/logic/views/View';
 import { ViewStore } from 'views/stores/ViewStore';
 import type { ViewStoreState } from 'views/stores/ViewStore';
-import Search from 'views/logic/search/Search';
-import Query from 'views/logic/queries/Query';
-import ViewState from 'views/logic/views/ViewState';
 import { TitlesMap } from 'views/stores/TitleTypes';
 
-import Widget, { Result } from './Widget';
+import Widget from './Widget';
+import type { Props as WidgetComponentProps } from './Widget';
 
 import WidgetContext from '../contexts/WidgetContext';
 import WidgetFocusContext, { WidgetFocusContextType } from '../contexts/WidgetFocusContext';
@@ -44,6 +40,8 @@ import WidgetFocusContext, { WidgetFocusContextType } from '../contexts/WidgetFo
 jest.mock('../searchbar/QueryInput', () => mockComponent('QueryInput'));
 jest.mock('./WidgetHeader', () => 'widget-header');
 jest.mock('./WidgetColorContext', () => ({ children }) => children);
+
+// jest.mock('views/components/contexts/WidgetEditApplyAllChangesProvider', () => ({ children }) => <WidgetEditApplyAllChangesContext.Provider></>);
 
 jest.mock('views/stores/WidgetStore', () => ({
   WidgetStore: MockStore(),
@@ -89,22 +87,12 @@ describe('<Widget />', () => {
 
   const widget = WidgetModel.builder().newId()
     .type('dummy')
-    .config({})
+    .config({ queryId: 'query-id-1' })
     .build();
 
-  const viewState = ViewState.builder().build();
-  const query = Query.builder().id('query-id').build();
-  const searchSearch = Search.builder().queries([query]).id('search-1').build();
-  const search = View.builder()
-    .search(searchSearch)
-    .type(View.Type.Dashboard)
-    .state(Map({ 'query-id': viewState }))
-    .id('search-1')
-    .title('search 1')
-    .build();
   const viewStoreState: ViewStoreState = {
-    activeQuery: 'query-id',
-    view: search,
+    activeQuery: 'query-id-1',
+    view: createSearch(),
     isNew: false,
     dirty: false,
   };
@@ -118,17 +106,12 @@ describe('<Widget />', () => {
     jest.resetModules();
   });
 
-  type DummyWidgetProps = {
-    widget?: WidgetModel,
-    errors?: Array<{ description: string }>,
-    data?: { [key: string]: Result },
+  type DummyWidgetProps = Partial<WidgetComponentProps> & {
     focusedWidget?: WidgetFocusContextType['focusedWidget'],
     setWidgetFocusing?: WidgetFocusContextType['setWidgetFocusing'],
     setWidgetEditing?: WidgetFocusContextType['setWidgetEditing'],
     unsetWidgetFocusing?: WidgetFocusContextType['unsetWidgetFocusing'],
     unsetWidgetEditing?: WidgetFocusContextType['unsetWidgetEditing'],
-    title?: string,
-    editing?: boolean,
   }
 
   const DummyWidget = ({
@@ -283,11 +266,13 @@ describe('<Widget />', () => {
     expect(mockUnsetWidgetEditing).toHaveBeenCalledTimes(1);
   });
 
-  it('updates focus mode, on widget edit save', () => {
+  it('updates focus mode, on widget edit save', async () => {
     const mockUnsetWidgetEditing = jest.fn();
     render(<DummyWidget editing unsetWidgetEditing={mockUnsetWidgetEditing} />);
-    const saveButton = screen.getByText('Save');
+    const saveButton = screen.getByText('Apply Changes');
     fireEvent.click(saveButton);
+
+    await waitFor(() => expect(saveButton).not.toBeDisabled());
 
     expect(mockUnsetWidgetEditing).toHaveBeenCalledTimes(1);
   });
@@ -327,7 +312,7 @@ describe('<Widget />', () => {
     expect(WidgetActions.update).toHaveBeenCalledWith('widgetId', widgetWithConfig);
   });
 
-  it('does not restore original state of widget config when clicking "Finish Editing"', () => {
+  it('does not restore original state of widget config when clicking "Apply Changes"', async () => {
     const widgetWithConfig = WidgetModel.builder()
       .id('widgetId')
       .type('dummy')
@@ -343,9 +328,11 @@ describe('<Widget />', () => {
 
     expect(WidgetActions.updateConfig).toHaveBeenCalledWith('widgetId', { foo: 23 });
 
-    const saveButton = screen.getByText('Save');
+    const saveButton = screen.getByText('Apply Changes');
 
     fireEvent.click(saveButton);
+
+    await waitFor(() => expect(saveButton).not.toBeDisabled());
 
     expect(WidgetActions.update).not.toHaveBeenCalledWith('widgetId', { config: { foo: 42 }, id: 'widgetId', type: 'dummy' });
   });

--- a/graylog2-web-interface/src/views/components/widgets/Widget.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/Widget.test.tsx
@@ -41,8 +41,6 @@ jest.mock('../searchbar/QueryInput', () => mockComponent('QueryInput'));
 jest.mock('./WidgetHeader', () => 'widget-header');
 jest.mock('./WidgetColorContext', () => ({ children }) => children);
 
-// jest.mock('views/components/contexts/WidgetEditApplyAllChangesProvider', () => ({ children }) => <WidgetEditApplyAllChangesContext.Provider></>);
-
 jest.mock('views/stores/WidgetStore', () => ({
   WidgetStore: MockStore(),
   WidgetActions: {

--- a/graylog2-web-interface/src/views/components/widgets/Widget.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/Widget.tsx
@@ -50,7 +50,7 @@ import WidgetActionsMenu from './WidgetActionsMenu';
 
 import InteractiveContext from '../contexts/InteractiveContext';
 
-type Props = {
+export type Props = {
   id: string,
   view: ViewStoreState,
   widget: WidgetModel,

--- a/graylog2-web-interface/test/fixtures/searches.ts
+++ b/graylog2-web-interface/test/fixtures/searches.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+
+/* eslint-disable import/prefer-default-export */
+
+import { Map } from 'immutable';
+
+import Query from 'views/logic/queries/Query';
+import Search from 'views/logic/search/Search';
+import View from 'views/logic/views/View';
+import ViewState from 'views/logic/views/ViewState';
+
+export const createSearch = ({ searchId, queryId }: { searchId?: string, queryId?: string} = {}) => {
+  const exampleSearchId = searchId ?? 'search-id-1';
+  const exampleQueryId = queryId ?? 'query-id-1';
+
+  const viewState = ViewState.builder().build();
+  const query = Query.builder().id(exampleQueryId).build();
+  const searchSearch = Search.builder().queries([query]).id(exampleSearchId).build();
+
+  return View.builder()
+    .search(searchSearch)
+    .type(View.Type.Dashboard)
+    .state(Map({ [exampleQueryId]: viewState }))
+    .id(exampleSearchId)
+    .title('Search 1')
+    .build();
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Before this change we were only saving changes, when clicking on the “Save” button in the aggregation builder, which already have been applied by clicking the:
- search submit button, for widget search controls changes (on a dashboard)
- “Apply changes” button, for widget aggregation element changes.

With this PR we are always saving every valid search control and aggregation element change, when the user is saving the widget. Furthermore we:
- Renamed the aggregation elements “Apply Changes” button to “Update preview” and unified the background color with the search controls submit button.
- Renamed the widget edit “Save” button to “Apply Changes”

This way it is easier to understand what effect each button has.

Fixes: https://github.com/Graylog2/graylog2-server/issues/10560


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

