### PR TITLE
Prevent unnecessary search execution when unfocusing widget.

### DIFF
--- a/graylog2-web-interface/src/views/components/contexts/WidgetFocusProvider.test.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/WidgetFocusProvider.test.tsx
@@ -23,6 +23,7 @@ import { asMock } from 'helpers/mocking';
 import { WidgetStore } from 'views/stores/WidgetStore';
 import WidgetFocusProvider from 'views/components/contexts/WidgetFocusProvider';
 import WidgetFocusContext from 'views/components/contexts/WidgetFocusContext';
+import SearchActions from 'views/actions/SearchActions';
 
 const mockHistoryReplace = jest.fn();
 
@@ -54,15 +55,13 @@ describe('WidgetFocusProvider', () => {
     });
   });
 
-  const renderSUT = (consume) => {
-    render(
-      <WidgetFocusProvider>
-        <WidgetFocusContext.Consumer>
-          {consume}
-        </WidgetFocusContext.Consumer>
-      </WidgetFocusProvider>,
-    );
-  };
+  const renderSUT = (consume) => render(
+    <WidgetFocusProvider>
+      <WidgetFocusContext.Consumer>
+        {consume}
+      </WidgetFocusContext.Consumer>
+    </WidgetFocusProvider>,
+  );
 
   it('should update url on widget focus', () => {
     let contextValue;
@@ -176,5 +175,18 @@ describe('WidgetFocusProvider', () => {
     expect(contextValue.focusedWidget).toBe(undefined);
 
     expect(mockHistoryReplace).toBeCalledWith('');
+  });
+
+  it('should not trigger search execution when not leaving widget editing', async () => {
+    useLocation.mockReturnValue({
+      pathname: '',
+      search: '',
+    });
+
+    const consume = jest.fn();
+
+    renderSUT(consume);
+
+    expect(SearchActions.executeWithCurrentState).not.toHaveBeenCalled();
   });
 });

--- a/graylog2-web-interface/src/views/components/contexts/WidgetFocusProvider.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/WidgetFocusProvider.tsx
@@ -85,7 +85,7 @@ const useSyncStateWithQueryParams = ({ focusedWidget, focusUriParams, setFocused
       const filter = nextFocusedWidget?.id ? [nextFocusedWidget.id] : null;
       SearchActions.setWidgetsToSearch(filter);
 
-      if (filter === null) {
+      if (focusedWidget?.editing && filter === null) {
         SearchActions.executeWithCurrentState();
       }
     }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

When introducing functionality, which limits search execution to the widget which is currently edited, a change was added that performs a search execution when leaving edit mode. Unfortunately the condition which was used to determine if widget editing is left was too broad, so it is performed whenever the widget focusing state changes. This leads to e.g. double search execution when loading a new/saved search.

This PR is changing the condition to check if the previous state indicates widget editing mode and does not perform a new search execution otherwise.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.