### PR TITLE
Fix and centralize qualifying relative URLs with credentials.

### DIFF
--- a/graylog2-web-interface/package.json
+++ b/graylog2-web-interface/package.json
@@ -130,6 +130,7 @@
     "@types/plotly.js": "1.54.8",
     "@types/react-beautiful-dnd": "^13.0.0",
     "@types/react-plotly.js": "^2.2.4",
+    "@types/urijs": "^1.19.15",
     "assets-webpack-plugin": "^5.1.2",
     "babel-loader": "^8.2.2",
     "babel-plugin-add-module-exports": "^1.0.2",

--- a/graylog2-web-interface/src/components/content-packs/ContentPackDownloadControl.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackDownloadControl.jsx
@@ -16,7 +16,7 @@
  */
 import PropTypes from 'prop-types';
 import React from 'react';
-import URI from 'urijs';
+import { qualifyUrlWithSessionCredentials } from 'util/URLUtils';
 
 import ApiRoutes from 'routing/ApiRoutes';
 import { Modal, Button } from 'components/graylog';
@@ -42,17 +42,7 @@ class ContentPackDownloadControl extends React.Component {
   _getDownloadUrl() {
     const { contentPackId, revision } = this.props;
 
-    const url = new URI(URLUtils.qualifyUrl(
-      ApiRoutes.ContentPacksController.downloadRev(contentPackId, revision).url,
-    ));
-
-    if (URLUtils.areCredentialsInURLSupported()) {
-      url
-        .username(SessionStore.getSessionId())
-        .password('session');
-    }
-
-    return url.toString();
+    return qualifyUrlWithSessionCredentials(ApiRoutes.ContentPacksController.downloadRev(contentPackId, revision).url, SessionStore.getSessionId());
   }
 
   _closeModal() {

--- a/graylog2-web-interface/src/components/streamrules/StreamRuleForm.test.tsx
+++ b/graylog2-web-interface/src/components/streamrules/StreamRuleForm.test.tsx
@@ -16,6 +16,7 @@
  */
 import * as React from 'react';
 import { cleanup, render, fireEvent } from 'wrappedTestingLibrary';
+import { MockStore } from 'helpers/mocking';
 
 import StreamRuleForm from './StreamRuleForm';
 
@@ -25,6 +26,8 @@ jest.mock('components/common', () => ({
   // eslint-disable-next-line react/prop-types
   Icon: ({ children }) => (<div>{children}</div>),
 }));
+
+jest.mock('stores/inputs/InputsStore', () => MockStore(['getInitialState', () => ({ inputs: [] })]));
 
 describe('StreamRuleForm', () => {
   afterEach(() => {

--- a/graylog2-web-interface/src/pages/ConfigurationsPage.test.tsx
+++ b/graylog2-web-interface/src/pages/ConfigurationsPage.test.tsx
@@ -18,6 +18,7 @@ import * as React from 'react';
 import { render, screen } from 'wrappedTestingLibrary';
 import asMock from 'helpers/mocking/AsMock';
 import suppressConsole from 'helpers/suppressConsole';
+import MockStore from 'helpers/mocking/StoreMock';
 
 import ConfigurationsPage from 'pages/ConfigurationsPage';
 import usePluginEntities from 'views/logic/usePluginEntities';
@@ -27,6 +28,12 @@ jest.mock('views/logic/usePluginEntities');
 jest.mock('components/configurations/SearchesConfig', () => () => <span>Search Configuration</span>);
 jest.mock('components/configurations/MessageProcessorsConfig', () => () => <span>Message Processors Configuration</span>);
 jest.mock('components/configurations/SidecarConfig');
+
+jest.mock('stores/decorators/DecoratorsStore', () => ({
+  DecoratorsStore: MockStore(),
+}));
+
+jest.mock('stores/configurations/ConfigurationsStore', () => MockStore(['getInitialState', () => ({})]));
 
 const ComponentThrowingError = () => {
   throw Error('Boom!');

--- a/graylog2-web-interface/src/stores/users/UsersStore.ts
+++ b/graylog2-web-interface/src/stores/users/UsersStore.ts
@@ -106,7 +106,7 @@ const UsersStore: Store<undefined> = singletonStore('Users', () => Reflux.create
   },
 
   deleteToken(userId: string, tokenId: string): Promise<string[]> {
-    const url = qualifyUrl(ApiRoutes.UsersApiController.delete_token(encodeURIComponent(userId), encodeURIComponent(tokenId)).url, {});
+    const url = qualifyUrl(ApiRoutes.UsersApiController.delete_token(encodeURIComponent(userId), encodeURIComponent(tokenId)).url);
     const promise = fetch('DELETE', url);
     UsersActions.deleteToken.promise(promise);
 

--- a/graylog2-web-interface/src/util/URLUtils.test.ts
+++ b/graylog2-web-interface/src/util/URLUtils.test.ts
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 import { asMock } from 'helpers/mocking';
 
 import { qualifyUrl, qualifyUrlWithSessionCredentials } from 'util/URLUtils';

--- a/graylog2-web-interface/src/util/URLUtils.test.ts
+++ b/graylog2-web-interface/src/util/URLUtils.test.ts
@@ -1,0 +1,41 @@
+import { qualifyUrl, qualifyUrlWithSessionCredentials } from 'util/URLUtils';
+import { asMock } from 'helpers/mocking';
+
+import AppConfig from 'util/AppConfig';
+
+jest.mock('util/AppConfig');
+
+const oldLocation = window.location;
+
+const mockLocation = (url: string): Location => new URL(url) as unknown as Location;
+
+describe('qualifyUrl', () => {
+  afterEach(() => {
+    window.location = oldLocation;
+  });
+
+  it('qualifies url with hostname/scheme from current location if server url is relative', () => {
+    asMock(AppConfig.gl2ServerUrl).mockReturnValue('/api');
+    delete window.location;
+    window.location = mockLocation('https://something.foo:2342/gnarf/42?bar=23');
+
+    expect(qualifyUrl('/foo?baz=17')).toEqual('https://something.foo:2342/api/foo?baz=17');
+  });
+
+  it('qualifies url with server url only if it contains host and scheme', () => {
+    asMock(AppConfig.gl2ServerUrl).mockReturnValue('http://something.graylog.cloud/api');
+
+    expect(qualifyUrl('/foo')).toEqual('http://something.graylog.cloud/api/foo');
+  });
+});
+
+describe('qualifyUrlWithSessionCredentials', () => {
+  it('adds session credentials to url if server url is relative', () => {
+    asMock(AppConfig.gl2ServerUrl).mockReturnValue('/api');
+    delete window.location;
+    window.location = mockLocation('https://something.foo:2342/gnarf/42?bar=23');
+
+    expect(qualifyUrlWithSessionCredentials('/something/else/23', 'deadbeef'))
+      .toEqual('https://deadbeef:session@something.foo:2342/api/something/else/23');
+  });
+});

--- a/graylog2-web-interface/src/util/URLUtils.test.ts
+++ b/graylog2-web-interface/src/util/URLUtils.test.ts
@@ -1,6 +1,6 @@
-import { qualifyUrl, qualifyUrlWithSessionCredentials } from 'util/URLUtils';
 import { asMock } from 'helpers/mocking';
 
+import { qualifyUrl, qualifyUrlWithSessionCredentials } from 'util/URLUtils';
 import AppConfig from 'util/AppConfig';
 
 jest.mock('util/AppConfig');
@@ -27,6 +27,14 @@ describe('qualifyUrl', () => {
 
     expect(qualifyUrl('/foo')).toEqual('http://something.graylog.cloud/api/foo');
   });
+
+  it('is idempotent', () => {
+    asMock(AppConfig.gl2ServerUrl).mockReturnValue('http://something.graylog.cloud/api');
+
+    const qualifiedUrl = qualifyUrl('/foo');
+
+    expect(qualifyUrl(qualifiedUrl)).toEqual('http://something.graylog.cloud/api/foo');
+  });
 });
 
 describe('qualifyUrlWithSessionCredentials', () => {
@@ -37,5 +45,12 @@ describe('qualifyUrlWithSessionCredentials', () => {
 
     expect(qualifyUrlWithSessionCredentials('/something/else/23', 'deadbeef'))
       .toEqual('https://deadbeef:session@something.foo:2342/api/something/else/23');
+  });
+
+  it('adds session credentials to url that was already qualified', () => {
+    asMock(AppConfig.gl2ServerUrl).mockReturnValue('http://something.graylog.cloud/api');
+
+    expect(qualifyUrlWithSessionCredentials(qualifyUrl('/foo'), 'deadbeef'))
+      .toEqual('http://deadbeef:session@something.graylog.cloud/api/foo');
   });
 });

--- a/graylog2-web-interface/src/util/URLUtils.ts
+++ b/graylog2-web-interface/src/util/URLUtils.ts
@@ -43,7 +43,7 @@ const URLUtils = {
       return url;
     }
 
-    const absoluteServerUrl = qualifyRelativeURLWithCurrentHostname(AppConfig.gl2ServerUrl());
+    const absoluteServerUrl = qualifyRelativeURLWithCurrentHostname(AppConfig.gl2ServerUrl() ?? '');
 
     return new URI(absoluteServerUrl + url).normalizePathname().toString();
   },

--- a/graylog2-web-interface/src/util/URLUtils.ts
+++ b/graylog2-web-interface/src/util/URLUtils.ts
@@ -25,6 +25,8 @@ const ACCEPTED_PROTOCOLS = ['http:', 'https:'];
 const URLUtils = {
   parser: new UAParser(),
   qualifyUrl(url) {
+    const serverUrl = new URI(AppConfig.gl2ServerUrl());
+    if (serverUrl.)
     return new URI(AppConfig.gl2ServerUrl() + url).normalizePathname().toString();
   },
   appPrefixed(url) {

--- a/graylog2-web-interface/src/util/URLUtils.ts
+++ b/graylog2-web-interface/src/util/URLUtils.ts
@@ -37,6 +37,12 @@ const qualifyRelativeURLWithCurrentHostname = (url: string): string => {
 const URLUtils = {
   parser: new UAParser(),
   qualifyUrl(url: string) {
+    const parsedUrl = new URI(url);
+
+    if (parsedUrl.is('absolute')) {
+      return url;
+    }
+
     const absoluteServerUrl = qualifyRelativeURLWithCurrentHostname(AppConfig.gl2ServerUrl());
 
     return new URI(absoluteServerUrl + url).normalizePathname().toString();

--- a/graylog2-web-interface/src/util/URLUtils.ts
+++ b/graylog2-web-interface/src/util/URLUtils.ts
@@ -119,11 +119,13 @@ const URLUtils = {
   },
 };
 
-export const qualifyUrlWithSessionCredentials = (url: string, sessionId) => {
+export const qualifyUrlWithSessionCredentials = (url: string, sessionId: string) => {
   let result = new URI(URLUtils.qualifyUrl(url));
 
   if (URLUtils.areCredentialsInURLSupported()) {
-    result = result.username(sessionId)
+    const trimmedSessionId = sessionId !== undefined ? sessionId : '';
+
+    result = result.username(trimmedSessionId)
       .password('session');
   }
 

--- a/graylog2-web-interface/src/views/bindings.enterpriseWidgets.test.tsx
+++ b/graylog2-web-interface/src/views/bindings.enterpriseWidgets.test.tsx
@@ -27,6 +27,14 @@ jest.mock('views/stores/FieldTypesStore', () => ({
   FieldTypesStore: MockStore(['getInitialState', () => ({ all: {}, queryFields: {} })]),
 }));
 
+jest.mock('stores/configurations/ConfigurationsStore', () => ({
+  ConfigurationsStore: MockStore(),
+}));
+
+jest.mock('stores/decorators/DecoratorsStore', () => ({
+  DecoratorsStore: MockStore(),
+}));
+
 describe('Views bindings enterprise widgets', () => {
   const { enterpriseWidgets } = bindings;
   type WidgetConfig = {

--- a/graylog2-web-interface/src/views/bindings.fieldActions.test.tsx
+++ b/graylog2-web-interface/src/views/bindings.fieldActions.test.tsx
@@ -24,6 +24,14 @@ jest.mock('views/stores/FieldTypesStore', () => ({
   FieldTypesStore: MockStore(['getInitialState', () => ({ all: {}, queryFields: {} })]),
 }));
 
+jest.mock('stores/configurations/ConfigurationsStore', () => ({
+  ConfigurationsStore: MockStore(),
+}));
+
+jest.mock('stores/decorators/DecoratorsStore', () => ({
+  DecoratorsStore: MockStore(),
+}));
+
 describe('Views bindings field actions', () => {
   const { fieldActions } = bindings;
   const defaultArguments = {

--- a/graylog2-web-interface/src/views/bindings.routes.test.tsx
+++ b/graylog2-web-interface/src/views/bindings.routes.test.tsx
@@ -21,7 +21,7 @@ import { StreamSearchPage } from 'views/pages';
 import bindings from './bindings';
 
 jest.mock('util/AppConfig', () => ({
-  gl2ServerUrl: () => 'localhost:9000/api/',
+  gl2ServerUrl: () => 'http://localhost:9000/api/',
   gl2AppPathPrefix: jest.fn(() => '/gl2/'),
   isFeatureEnabled: () => false,
   isCloud: jest.fn(() => false),

--- a/graylog2-web-interface/src/views/bindings.tsx
+++ b/graylog2-web-interface/src/views/bindings.tsx
@@ -83,8 +83,8 @@ import HeatmapVisualizationConfiguration from 'views/components/aggregationbuild
 import HeatmapVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/HeatmapVisualizationConfig';
 import visualizationBindings from 'views/components/visualizations/bindings';
 import AggregationWizard from 'views/components/aggregationwizard/AggregationWizard';
-
 import { filterCloudValueActions } from 'util/conditional/filterValueActions';
+
 import type { ActionHandlerArguments } from './components/actions/ActionHandler';
 import NumberVisualizationConfig from './logic/aggregationbuilder/visualizations/NumberVisualizationConfig';
 import BarVisualizationConfiguration from './components/aggregationbuilder/BarVisualizationConfiguration';

--- a/graylog2-web-interface/src/views/bindings.valueActions.test.tsx
+++ b/graylog2-web-interface/src/views/bindings.valueActions.test.tsx
@@ -24,6 +24,14 @@ jest.mock('views/stores/FieldTypesStore', () => ({
   FieldTypesStore: MockStore(['getInitialState', () => ({ all: {}, queryFields: {} })]),
 }));
 
+jest.mock('stores/configurations/ConfigurationsStore', () => ({
+  ConfigurationsStore: MockStore(),
+}));
+
+jest.mock('stores/decorators/DecoratorsStore', () => ({
+  DecoratorsStore: MockStore(),
+}));
+
 describe('Views bindings value actions', () => {
   const { valueActions } = bindings;
   const defaultArguments = {

--- a/graylog2-web-interface/src/views/components/SearchResult.test.jsx
+++ b/graylog2-web-interface/src/views/components/SearchResult.test.jsx
@@ -20,6 +20,7 @@ import { act } from 'react-dom/test-utils';
 import { simpleFields, simpleQueryFields } from 'fixtures/fields';
 import { render } from 'wrappedTestingLibrary';
 import asMock from 'helpers/mocking/AsMock';
+import MockStore from 'helpers/mocking/StoreMock';
 
 import { SearchLoadingStateStore } from 'views/stores/SearchLoadingStateStore';
 import SearchResult from 'views/components/SearchResult';
@@ -55,6 +56,10 @@ jest.mock('views/stores/SearchLoadingStateStore', () => ({
     getInitialState: jest.fn(() => ({ isLoading: false })),
     listen: () => jest.fn(),
   },
+}));
+
+jest.mock('stores/configurations/ConfigurationsStore', () => ({
+  ConfigurationsStore: MockStore(),
 }));
 
 describe('SearchResult', () => {

--- a/graylog2-web-interface/src/views/components/contexts/WidgetFocusProvider.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/WidgetFocusProvider.tsx
@@ -57,11 +57,11 @@ const _updateQueryParams = (
     }
 
     if (newQueryParams.focusing) {
-      baseUri = baseUri.setSearch('focusing', true);
+      baseUri = baseUri.setSearch('focusing', String(true));
     }
 
     if (newQueryParams.editing) {
-      baseUri = baseUri.setSearch('editing', true);
+      baseUri = baseUri.setSearch('editing', String(true));
     }
   }
 

--- a/graylog2-web-interface/src/views/components/messagelist/MessageTableEntry.test.tsx
+++ b/graylog2-web-interface/src/views/components/messagelist/MessageTableEntry.test.tsx
@@ -17,8 +17,13 @@
 import * as React from 'react';
 import { mount } from 'wrappedEnzyme';
 import * as Immutable from 'immutable';
+import MockStore from 'helpers/mocking/StoreMock';
 
 import MessageTableEntry from './MessageTableEntry';
+
+jest.mock('stores/configurations/ConfigurationsStore', () => ({
+  ConfigurationsStore: MockStore(),
+}));
 
 describe('MessageTableEntry', () => {
   it('renders message for unknown selected fields', () => {

--- a/graylog2-web-interface/src/views/components/searchbar/TimeRangeInput.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/TimeRangeInput.test.tsx
@@ -16,8 +16,13 @@
  */
 import * as React from 'react';
 import { fireEvent, render, screen, waitFor, within } from 'wrappedTestingLibrary';
+import MockStore from 'helpers/mocking/StoreMock';
 
 import TimeRangeInput from 'views/components/searchbar/TimeRangeInput';
+
+jest.mock('stores/configurations/ConfigurationsStore', () => ({
+  ConfigurationsStore: MockStore(),
+}));
 
 describe('TimeRangeInput', () => {
   const defaultTimeRange = { type: 'relative', range: 300 };

--- a/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TabRelativeTimeRange.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TabRelativeTimeRange.test.tsx
@@ -17,8 +17,13 @@
 import React from 'react';
 import { fireEvent, render, screen } from 'wrappedTestingLibrary';
 import { Formik, Form } from 'formik';
+import MockStore from 'helpers/mocking/StoreMock';
 
 import TabRelativeTimeRange from './TabRelativeTimeRange';
+
+jest.mock('stores/configurations/ConfigurationsStore', () => ({
+  ConfigurationsStore: MockStore(),
+}));
 
 const defaultProps = {
   limitDuration: 0,

--- a/graylog2-web-interface/src/views/components/widgets/MessageTable.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageTable.test.tsx
@@ -18,6 +18,7 @@ import * as React from 'react';
 import { mount } from 'wrappedEnzyme';
 import * as Immutable from 'immutable';
 import suppressConsole from 'helpers/suppressConsole';
+import { MockStore } from 'helpers/mocking';
 
 import FieldTypeMapping from 'views/logic/fieldtypes/FieldTypeMapping';
 import FieldType from 'views/logic/fieldtypes/FieldType';
@@ -27,6 +28,10 @@ import MessageTable from './MessageTable';
 
 import InteractiveContext from '../contexts/InteractiveContext';
 import HighlightMessageContext from '../contexts/HighlightMessageContext';
+
+jest.mock('stores/configurations/ConfigurationsStore', () => ({
+  ConfigurationsStore: MockStore(),
+}));
 
 const messages = [
   {

--- a/graylog2-web-interface/src/views/hooks/SyncWithQueryParameters.ts
+++ b/graylog2-web-interface/src/views/hooks/SyncWithQueryParameters.ts
@@ -81,7 +81,7 @@ export const syncWithQueryParameters = (query: string, action: (string) => unkno
         .removeQuery('keyword')
         .removeQuery('relative');
       const uriWithTimerange = extractTimerangeParams(timerange)
-        .reduce((prev, [key, value]) => prev.setSearch(key, value), baseUri);
+        .reduce((prev, [key, value]) => prev.setSearch(key, String(value)), baseUri);
       const currentStreams = filtersToStreamSet(filter);
       const uri = currentStreams.isEmpty()
         ? uriWithTimerange.removeSearch('streams').toString()

--- a/graylog2-web-interface/src/views/logic/fieldactions/AddToAllTablesActionHandler.test.ts
+++ b/graylog2-web-interface/src/views/logic/fieldactions/AddToAllTablesActionHandler.test.ts
@@ -21,7 +21,7 @@ import Widget from 'views/logic/widgets/Widget';
 import AddToAllTablesActionHandler from 'views/logic/fieldactions/AddToAllTablesActionHandler';
 import { FieldTypes } from 'views/logic/fieldtypes/FieldType';
 import MessageWidgetConfig from 'views/logic/widgets/MessagesWidgetConfig';
-import { WidgetActions, WidgetStore } from 'views/stores/WidgetStore';
+import { WidgetActions, WidgetStore, WidgetStoreState } from 'views/stores/WidgetStore';
 
 describe('AddToAllTablesActionHandler', () => {
   it('should add a field to all message widgets', () => {
@@ -52,8 +52,7 @@ describe('AddToAllTablesActionHandler', () => {
 
     const expectedWidgets = Map([[expectedMessageWidget.id, expectedMessageWidget], [pivotWidget.id, pivotWidget]]);
 
-    // @ts-ignore
-    WidgetStore.getInitialState = jest.fn(() => widgets);
+    WidgetStore.getInitialState = jest.fn(() => widgets as WidgetStoreState);
 
     WidgetActions.updateWidgets = mockAction(jest.fn(async (newWidgets) => {
       expect(newWidgets).toEqual(expectedWidgets);

--- a/graylog2-web-interface/src/views/logic/views/ViewStateGenerator.ts
+++ b/graylog2-web-interface/src/views/logic/views/ViewStateGenerator.ts
@@ -26,8 +26,6 @@ import { resultHistogram, allMessagesTable } from '../Widgets';
 import WidgetPosition from '../widgets/WidgetPosition';
 import Widget from '../widgets/Widget';
 
-const { DecoratorsActions } = CombinedProvider.get('Decorators');
-
 type Result = {
   titles: { widget: { [key: string]: string } },
   widgets: Array<Widget>,
@@ -39,6 +37,7 @@ type DefaultWidgets = Record<ViewType, ViewCreator>;
 
 const _defaultWidgets: DefaultWidgets = {
   [View.Type.Search]: async (streamId: string | undefined | null) => {
+    const { DecoratorsActions } = CombinedProvider.get('Decorators');
     const decorators = await DecoratorsActions.list();
     const streamDecorators = decorators ? decorators.filter((decorator) => decorator.stream === streamId) : [];
     const histogram = resultHistogram();

--- a/graylog2-web-interface/src/views/stores/WidgetStore.ts
+++ b/graylog2-web-interface/src/views/stores/WidgetStore.ts
@@ -43,7 +43,7 @@ type WidgetActionsType = RefluxActions<{
   updateWidgets: (widgets: Immutable.Map<string, Widget>) => Promise<Widgets>,
 }>;
 
-type WidgetStoreState = Immutable.Map<string, Widget>;
+export type WidgetStoreState = Immutable.Map<string, Widget>;
 
 export const WidgetActions: WidgetActionsType = singletonActions(
   'views.Widget',

--- a/graylog2-web-interface/yarn.lock
+++ b/graylog2-web-interface/yarn.lock
@@ -2436,6 +2436,11 @@
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.3.tgz#9c088679876f374eb5983f150d4787aa6fb32d7e"
   integrity sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==
 
+"@types/urijs@^1.19.15":
+  version "1.19.15"
+  resolved "https://registry.yarnpkg.com/@types/urijs/-/urijs-1.19.15.tgz#0142b92b52d07c4ba97dd82e7a54a875332942ec"
+  integrity sha512-pEDVREIvkyRtzpWlO5nqsUgR/JpLv9+lAzvkERCwoH2jXxl+TmaTNshhL7gjQLhfqgFUzCM6ovmoB1JssTop1A==
+
 "@types/uuid@^3.4.5":
   version "3.4.7"
   resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-3.4.7.tgz#51d42247473bc00e38cc8dfaf70d936842a36c03"
@@ -8214,11 +8219,11 @@ graceful-fs@^4.2.4:
     "@babel/preset-env" "7.13.10"
     "@babel/preset-typescript" "7.13.0"
     create-react-class "15.7.0"
-    eslint-config-graylog "file:../../../../.cache/yarn/v6/npm-graylog-web-plugin-4.1.0-SNAPSHOT-39298249-290a-4227-acf4-ff09a6dd4593-1620999201685/node_modules/eslint-config-graylog"
+    eslint-config-graylog "file:../../../../.cache/yarn/v6/npm-graylog-web-plugin-4.1.0-SNAPSHOT-05809a76-9b6a-44df-9d0f-b39ca6dd7ee3-1621498713690/node_modules/eslint-config-graylog"
     formik "2.2.6"
     html-webpack-plugin "^4.2.0"
     javascript-natural-sort "0.7.1"
-    jest-preset-graylog "file:../../../../.cache/yarn/v6/npm-graylog-web-plugin-4.1.0-SNAPSHOT-39298249-290a-4227-acf4-ff09a6dd4593-1620999201685/node_modules/jest-preset-graylog"
+    jest-preset-graylog "file:../../../../.cache/yarn/v6/npm-graylog-web-plugin-4.1.0-SNAPSHOT-05809a76-9b6a-44df-9d0f-b39ca6dd7ee3-1621498713690/node_modules/jest-preset-graylog"
     jquery "3.5.1"
     moment "2.29.1"
     moment-timezone "0.5.31"
@@ -8232,7 +8237,7 @@ graceful-fs@^4.2.4:
     react-router-dom "5.2.0"
     reflux "0.2.13"
     styled-components "5.2.3"
-    stylelint-config-graylog "file:../../../../.cache/yarn/v6/npm-graylog-web-plugin-4.1.0-SNAPSHOT-39298249-290a-4227-acf4-ff09a6dd4593-1620999201685/node_modules/stylelint-config-graylog"
+    stylelint-config-graylog "file:../../../../.cache/yarn/v6/npm-graylog-web-plugin-4.1.0-SNAPSHOT-05809a76-9b6a-44df-9d0f-b39ca6dd7ee3-1621498713690/node_modules/stylelint-config-graylog"
     typescript "4.2.3"
     webpack "4.44.2"
     webpack-cleanup-plugin "0.5.1"


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

We are adding credentials to backend API-links in a couple of places to allow the browser to retrieve files directly from the backend. This happens by setting the session id as username, the literal string `session` as password.

This works fine, unless the backend API prefix is a relative URL. In this case invalid URLs are being generated. This makes it impossible for developers to test functionality like this using e.g. `devServer.js`.

This PR is changing this by:

  - checking if `AppConfig.gl2ServerUrl()` is a relative URL. If it is, it will be qualified by using scheme, hostname & port from `window.location
  - creating a `qualifyUrlWithSessionCredentials` function which can be used to augment any given backend API endpoint with current session credentials. This allows us to centralize this repeated pattern.

In addition, the PR is migrating `URLUtils` to TS and adds tests.

Fixes https://github.com/Graylog2/graylog2-server/issues/10548

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.