### PR TITLE
Centralize reused spacings in theme.

### DIFF
--- a/graylog2-web-interface/src/@types/styled-components/index.d.ts
+++ b/graylog2-web-interface/src/@types/styled-components/index.d.ts
@@ -22,7 +22,7 @@ declare module 'styled-components' {
   import type { Colors } from 'src/theme/colors';
   import type { Fonts } from 'src/theme/fonts';
   import type { Utils } from 'src/theme/utils';
-  import type { Margins } from 'src/theme/margins';
+  import type { Spacings } from 'src/theme/spacings';
   import type { ThemeMode } from 'src/theme/constants';
   // eslint-disable-next-line import/order
   import type { Breakpoints } from 'src/theme/breakpoints';
@@ -32,8 +32,8 @@ declare module 'styled-components' {
     colors: Colors,
     fonts: Fonts,
     utils: Utils,
-    margins: Margins,
     mode: ThemeMode,
+    spacings: Spacings,
     changeMode: (string) => void,
     components: { [component: string]: any }
   }

--- a/graylog2-web-interface/src/@types/styled-components/index.d.ts
+++ b/graylog2-web-interface/src/@types/styled-components/index.d.ts
@@ -22,6 +22,7 @@ declare module 'styled-components' {
   import type { Colors } from 'src/theme/colors';
   import type { Fonts } from 'src/theme/fonts';
   import type { Utils } from 'src/theme/utils';
+  import type { Margins } from 'src/theme/margins';
   import type { ThemeMode } from 'src/theme/constants';
   // eslint-disable-next-line import/order
   import type { Breakpoints } from 'src/theme/breakpoints';
@@ -31,6 +32,7 @@ declare module 'styled-components' {
     colors: Colors,
     fonts: Fonts,
     utils: Utils,
+    margins: Margins,
     mode: ThemeMode,
     changeMode: (string) => void,
     components: { [component: string]: any }

--- a/graylog2-web-interface/src/components/graylog/Row.tsx
+++ b/graylog2-web-interface/src/components/graylog/Row.tsx
@@ -21,7 +21,7 @@ import styled, { css } from 'styled-components';
 export const RowContentStyles = css(({ theme }) => css`
   background-color: ${theme.colors.global.contentBackground};
   border: 1px solid ${theme.colors.variant.lighter.default};
-  margin-bottom: ${theme.margins.row}px;
+  margin-bottom: ${theme.spacings.row}px;
   border-radius: 4px;
 `);
 

--- a/graylog2-web-interface/src/components/layout/Footer.tsx
+++ b/graylog2-web-interface/src/components/layout/Footer.tsx
@@ -28,7 +28,7 @@ const StyledFooter = styled.footer(({ theme }) => css`
 
   /* This combination of padding and box-sizing is required to fix a firefox flexbox bug */
   box-sizing: content-box;
-  padding-bottom: ${theme.margins.pageContent}px;
+  padding-bottom: ${theme.spacings.pageContent}px;
 
   @media print {
     display: none;

--- a/graylog2-web-interface/src/components/layout/Footer.tsx
+++ b/graylog2-web-interface/src/components/layout/Footer.tsx
@@ -28,7 +28,7 @@ const StyledFooter = styled.footer(({ theme }) => css`
 
   /* This combination of padding and box-sizing is required to fix a firefox flexbox bug */
   box-sizing: content-box;
-  padding-bottom: 9px;
+  padding-bottom: ${theme.margins.pageContent}px;
 
   @media print {
     display: none;

--- a/graylog2-web-interface/src/components/layout/PageContentLayout.tsx
+++ b/graylog2-web-interface/src/components/layout/PageContentLayout.tsx
@@ -28,7 +28,7 @@ type Props = {
 };
 
 const Container = styled.div(({ theme }) => {
-  const padding = theme.margins.pageContent;
+  const padding = theme.spacings.pageContent;
 
   return css`
     display: flex;

--- a/graylog2-web-interface/src/components/layout/PageContentLayout.tsx
+++ b/graylog2-web-interface/src/components/layout/PageContentLayout.tsx
@@ -16,7 +16,7 @@
  */
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
 import WithGlobalAppNotifications from 'components/notifications/WithGlobalAppNotifications';
 import { Grid } from 'components/graylog';
@@ -27,16 +27,20 @@ type Props = {
   className?: string
 };
 
-const Container = styled.div`
-  display: flex;
-  flex-direction: column;
-  overflow: auto;
-  height: 100%;
-  width: 100%;
+const Container = styled.div(({ theme }) => {
+  const padding = theme.margins.pageContent;
 
-  /* Bottom gap is defined by the footer */
-  padding: 9px 9px 0 9px;
-`;
+  return css`
+    display: flex;
+    flex-direction: column;
+    overflow: auto;
+    height: 100%;
+    width: 100%;
+
+    /* Bottom gap is defined by the footer */
+    padding: ${padding}px ${padding}px 0 ${padding}px;
+  `;
+});
 
 const StyledGrid = styled(Grid)`
   width: 100%;

--- a/graylog2-web-interface/src/theme/GraylogThemeProvider.tsx
+++ b/graylog2-web-interface/src/theme/GraylogThemeProvider.tsx
@@ -23,7 +23,7 @@ import buttonStyles from 'components/graylog/styles/buttonStyles';
 import aceEditorStyles from 'components/graylog/styles/aceEditorStyles';
 import usePluginEntities from 'views/logic/usePluginEntities';
 
-import { breakpoints, colors, fonts, utils } from './index';
+import { breakpoints, colors, fonts, utils, margins } from './index';
 import RegeneratableThemeContext from './RegeneratableThemeContext';
 import { Colors } from './colors';
 import { THEME_MODES, ThemeMode } from './constants';
@@ -52,6 +52,7 @@ function buildTheme(currentThemeColors, changeMode, mode): DefaultTheme {
   return {
     mode,
     changeMode,
+    margins,
     breakpoints,
     colors: currentThemeColors,
     fonts,

--- a/graylog2-web-interface/src/theme/GraylogThemeProvider.tsx
+++ b/graylog2-web-interface/src/theme/GraylogThemeProvider.tsx
@@ -23,7 +23,7 @@ import buttonStyles from 'components/graylog/styles/buttonStyles';
 import aceEditorStyles from 'components/graylog/styles/aceEditorStyles';
 import usePluginEntities from 'views/logic/usePluginEntities';
 
-import { breakpoints, colors, fonts, utils, margins } from './index';
+import { breakpoints, colors, fonts, utils, spacings } from './index';
 import RegeneratableThemeContext from './RegeneratableThemeContext';
 import { Colors } from './colors';
 import { THEME_MODES, ThemeMode } from './constants';
@@ -52,7 +52,7 @@ function buildTheme(currentThemeColors, changeMode, mode): DefaultTheme {
   return {
     mode,
     changeMode,
-    margins,
+    spacings,
     breakpoints,
     colors: currentThemeColors,
     fonts,

--- a/graylog2-web-interface/src/theme/index.ts
+++ b/graylog2-web-interface/src/theme/index.ts
@@ -19,12 +19,14 @@ import PropTypes from 'prop-types';
 import breakpoints, { breakpointPropTypes } from './breakpoints';
 import colors, { colorsPropTypes } from './colors';
 import fonts, { fontsPropTypes } from './fonts';
+import margins, { marginsPropTypes } from './margins';
 import utils, { utilsPropTypes } from './utils';
 
 const themePropTypes = PropTypes.shape({
   breakpoints: breakpointPropTypes,
   colors: colorsPropTypes,
   fonts: fontsPropTypes,
+  margins: marginsPropTypes,
   utils: utilsPropTypes,
 });
 
@@ -32,6 +34,7 @@ export {
   breakpoints,
   colors,
   fonts,
-  utils,
+  margins,
   themePropTypes,
+  utils,
 };

--- a/graylog2-web-interface/src/theme/index.ts
+++ b/graylog2-web-interface/src/theme/index.ts
@@ -19,14 +19,14 @@ import PropTypes from 'prop-types';
 import breakpoints, { breakpointPropTypes } from './breakpoints';
 import colors, { colorsPropTypes } from './colors';
 import fonts, { fontsPropTypes } from './fonts';
-import margins, { marginsPropTypes } from './margins';
+import spacings, { spacingsPropTypes } from './spacings';
 import utils, { utilsPropTypes } from './utils';
 
 const themePropTypes = PropTypes.shape({
   breakpoints: breakpointPropTypes,
   colors: colorsPropTypes,
   fonts: fontsPropTypes,
-  margins: marginsPropTypes,
+  spacings: spacingsPropTypes,
   utils: utilsPropTypes,
 });
 
@@ -34,7 +34,7 @@ export {
   breakpoints,
   colors,
   fonts,
-  margins,
+  spacings,
   themePropTypes,
   utils,
 };

--- a/graylog2-web-interface/src/theme/margins.ts
+++ b/graylog2-web-interface/src/theme/margins.ts
@@ -14,22 +14,26 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-// eslint-disable-next-line no-restricted-imports
-import { Row as BootstrapRow } from 'react-bootstrap';
-import styled, { css } from 'styled-components';
+import PropTypes from 'prop-types';
 
-export const RowContentStyles = css(({ theme }) => css`
-  background-color: ${theme.colors.global.contentBackground};
-  border: 1px solid ${theme.colors.variant.lighter.default};
-  margin-bottom: ${theme.margins.row}px;
-  border-radius: 4px;
-`);
+export type Margins = {
+  root: number,
+  row: number,
+  pageContent: number,
+};
 
-const Row = styled(BootstrapRow)`
-  &.content {
-    ${RowContentStyles}
-  }
-`;
+export const marginsPropTypes = PropTypes.shape({
+  root: PropTypes.number,
+  row: PropTypes.number,
+  pageContent: PropTypes.number,
+});
 
-/** @component */
-export default Row;
+const ROOT_MARGIN = 3;
+
+const margins: Margins = {
+  root: ROOT_MARGIN,
+  pageContent: ROOT_MARGIN * 3,
+  row: ROOT_MARGIN * 2,
+};
+
+export default margins;

--- a/graylog2-web-interface/src/theme/spacings.ts
+++ b/graylog2-web-interface/src/theme/spacings.ts
@@ -16,13 +16,13 @@
  */
 import PropTypes from 'prop-types';
 
-export type Margins = {
+export type Spacings = {
   root: number,
   row: number,
   pageContent: number,
 };
 
-export const marginsPropTypes = PropTypes.shape({
+export const spacingsPropTypes = PropTypes.shape({
   root: PropTypes.number,
   row: PropTypes.number,
   pageContent: PropTypes.number,
@@ -30,10 +30,10 @@ export const marginsPropTypes = PropTypes.shape({
 
 const ROOT_MARGIN = 3;
 
-const margins: Margins = {
+const spacings: Spacings = {
   root: ROOT_MARGIN,
   pageContent: ROOT_MARGIN * 3,
   row: ROOT_MARGIN * 2,
 };
 
-export default margins;
+export default spacings;

--- a/graylog2-web-interface/test/WrappingContainer.jsx
+++ b/graylog2-web-interface/test/WrappingContainer.jsx
@@ -20,7 +20,7 @@ import { ThemeProvider } from 'styled-components';
 import { Router } from 'react-router-dom';
 
 import history from 'util/History';
-import { breakpoints, colors, fonts, utils } from 'theme';
+import { breakpoints, colors, fonts, utils, margins } from 'theme';
 import { THEME_MODE_LIGHT } from 'theme/constants';
 import buttonStyles from 'components/graylog/styles/buttonStyles';
 import aceEditorStyles from 'components/graylog/styles/aceEditorStyles';
@@ -37,6 +37,7 @@ const WrappingContainer = ({ children }) => {
     mode: THEME_MODE_LIGHT,
     changeMode: () => {},
     breakpoints,
+    margins,
     colors: themeColors,
     fonts,
     components: {

--- a/graylog2-web-interface/test/WrappingContainer.jsx
+++ b/graylog2-web-interface/test/WrappingContainer.jsx
@@ -20,7 +20,7 @@ import { ThemeProvider } from 'styled-components';
 import { Router } from 'react-router-dom';
 
 import history from 'util/History';
-import { breakpoints, colors, fonts, utils, margins } from 'theme';
+import { breakpoints, colors, fonts, utils, spacings } from 'theme';
 import { THEME_MODE_LIGHT } from 'theme/constants';
 import buttonStyles from 'components/graylog/styles/buttonStyles';
 import aceEditorStyles from 'components/graylog/styles/aceEditorStyles';
@@ -37,7 +37,7 @@ const WrappingContainer = ({ children }) => {
     mode: THEME_MODE_LIGHT,
     changeMode: () => {},
     breakpoints,
-    margins,
+    spacings,
     colors: themeColors,
     fonts,
     components: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is creating a new section for the styled components theme called
spacings. By centralizing the spacings in the theme we can easily reuse them whenever we need to. It will
also make it easier to define margins and paddings relative to our commonly used spacings.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.


