### PR TITLE
Forwarder Plugin activation toggle

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/Configuration.java
+++ b/graylog2-server/src/main/java/org/graylog2/Configuration.java
@@ -168,6 +168,9 @@ public class Configuration extends BaseConfiguration {
     @Parameter(value = "elasticsearch_mute_deprecation_warnings")
     private boolean muteDeprecationWarnings = false;
 
+    @Parameter(value = "forwarder_enabled")
+    private boolean forwarderEnabled = false;
+
     public boolean isMuteDeprecationWarnings() {
         return muteDeprecationWarnings;
     }
@@ -337,6 +340,23 @@ public class Configuration extends BaseConfiguration {
 
     public Set<String> getEnabledTlsProtocols() {
         return enabledTlsProtocols;
+    }
+
+    /**
+     * The property is supposed to be migrated into the according plugin configuration
+     * as soon as required facilities for injection of plugin config beans into
+     * plugin beans are in place.
+     *
+     * Currently it's only possible for {@link org.graylog2.Configuration}.
+     * See {@link org.graylog2.plugin.Plugin}
+     *
+     * NB(!!!):
+     * Even though it's exposed as public API, it MUST NOT be used in the code.
+     * It's expected to be DELETED soon!
+     */
+    @Deprecated
+    public boolean isForwarderEnabled() {
+        return forwarderEnabled;
     }
 
     @ValidatorMethod

--- a/graylog2-server/src/main/java/org/graylog2/configuration/ExposedConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/ExposedConfiguration.java
@@ -88,6 +88,9 @@ public abstract class ExposedConfiguration {
     @JsonProperty("gc_warning_threshold")
     public abstract String gcWarningThreshold();
 
+    @JsonProperty("forwarder_enabled")
+    public abstract boolean forwarderEnabled();
+
     public static ExposedConfiguration create(Configuration configuration) {
         return create(
                 configuration.getInputbufferProcessors(),
@@ -107,7 +110,8 @@ public abstract class ExposedConfiguration {
                 configuration.getStreamProcessingMaxFaults(),
                 configuration.getOutputModuleTimeout(),
                 configuration.getStaleMasterTimeout(),
-                configuration.getGcWarningThreshold().toString());
+                configuration.getGcWarningThreshold().toString(),
+                configuration.isForwarderEnabled());
     }
 
     @JsonCreator
@@ -129,7 +133,8 @@ public abstract class ExposedConfiguration {
             @JsonProperty("stream_processing_max_faults") int streamProcessingMaxFaults,
             @JsonProperty("output_module_timeout") long outputModuleTimeout,
             @JsonProperty("stale_master_timeout") int staleMasterTimeout,
-            @JsonProperty("gc_warning_threshold") String gcWarningThreshold) {
+            @JsonProperty("gc_warning_threshold") String gcWarningThreshold,
+            @JsonProperty("forwarder_enabled") boolean forwarderEnabled) {
         return new AutoValue_ExposedConfiguration(
                 inputBufferProcessors,
                 processBufferProcessors,
@@ -148,7 +153,8 @@ public abstract class ExposedConfiguration {
                 streamProcessingMaxFaults,
                 outputModuleTimeout,
                 staleMasterTimeout,
-                gcWarningThreshold);
+                gcWarningThreshold,
+                forwarderEnabled);
     }
 
 }


### PR DESCRIPTION
Since currently there is no way to inject plugin's config into its plugin bean at the bootstrap phase (what's needed in its turn not to load some particular modules depending on the configuration), and it's only possible for the master `Configuration`, as a temporary solution it was decided to include this toggle property in `Configuration`. Later it's expected to be migrated into the according plugin config.