### PR TITLE
Make all WildcardPermission case sensitive

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/security/DefaultPermissionAndRoleResolver.java
+++ b/graylog2-server/src/main/java/org/graylog/security/DefaultPermissionAndRoleResolver.java
@@ -18,8 +18,8 @@ package org.graylog.security;
 
 import com.google.common.collect.ImmutableSet;
 import org.apache.shiro.authz.Permission;
-import org.apache.shiro.authz.permission.WildcardPermission;
 import org.graylog.grn.GRN;
+import org.graylog.security.permissions.CaseSensitiveWildcardPermission;
 import org.graylog.security.permissions.GRNPermission;
 import org.graylog2.shared.security.RestPermissions;
 import org.slf4j.Logger;
@@ -86,7 +86,7 @@ public class DefaultPermissionAndRoleResolver implements PermissionAndRoleResolv
                             if (permission.equals(RestPermissions.ENTITY_OWN)) {
                                 permissionsBuilder.add(GRNPermission.create(permission, target));
                             } else {
-                                permissionsBuilder.add(new WildcardPermission(permission + ":" + target.entity()));
+                                permissionsBuilder.add(new CaseSensitiveWildcardPermission(permission + ":" + target.entity()));
                             }
                         }
                     }

--- a/graylog2-server/src/main/java/org/graylog/security/permissions/CaseSensitiveWildcardPermission.java
+++ b/graylog2-server/src/main/java/org/graylog/security/permissions/CaseSensitiveWildcardPermission.java
@@ -1,0 +1,9 @@
+package org.graylog.security.permissions;
+
+import org.apache.shiro.authz.permission.WildcardPermission;
+
+public class CaseSensitiveWildcardPermission extends WildcardPermission {
+    public CaseSensitiveWildcardPermission(String wildcardString) {
+        super(wildcardString, true);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/security/permissions/CaseSensitiveWildcardPermission.java
+++ b/graylog2-server/src/main/java/org/graylog/security/permissions/CaseSensitiveWildcardPermission.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog.security.permissions;
 
 import org.apache.shiro.authz.permission.WildcardPermission;

--- a/graylog2-server/src/main/java/org/graylog2/migrations/V20200803120800_GrantsMigrations/GrantsMetaMigration.java
+++ b/graylog2-server/src/main/java/org/graylog2/migrations/V20200803120800_GrantsMigrations/GrantsMetaMigration.java
@@ -22,12 +22,12 @@ import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
-import org.apache.shiro.authz.permission.WildcardPermission;
 import org.graylog.grn.GRNRegistry;
 import org.graylog.grn.GRNType;
 import org.graylog.plugins.views.search.views.ViewService;
 import org.graylog.security.Capability;
 import org.graylog.security.DBGrantService;
+import org.graylog.security.permissions.CaseSensitiveWildcardPermission;
 import org.graylog2.database.MongoConnection;
 import org.graylog2.migrations.Migration;
 import org.graylog2.plugin.cluster.ClusterConfigService;
@@ -127,7 +127,7 @@ public class GrantsMetaMigration extends Migration {
     }
 
     // only needed to access protected getParts() method from WildcardPermission
-    public static class MigrationWildcardPermission extends WildcardPermission {
+    public static class MigrationWildcardPermission extends CaseSensitiveWildcardPermission {
         public MigrationWildcardPermission(String wildcardString) {
             super(wildcardString);
         }

--- a/graylog2-server/src/main/java/org/graylog2/security/InMemoryRolePermissionResolver.java
+++ b/graylog2-server/src/main/java/org/graylog2/security/InMemoryRolePermissionResolver.java
@@ -20,7 +20,7 @@ import com.google.common.collect.ImmutableMap;
 import org.apache.shiro.authz.Permission;
 import org.apache.shiro.authz.permission.AllPermission;
 import org.apache.shiro.authz.permission.RolePermissionResolver;
-import org.apache.shiro.authz.permission.WildcardPermission;
+import org.graylog.security.permissions.CaseSensitiveWildcardPermission;
 import org.graylog2.shared.users.Role;
 import org.graylog2.users.RoleService;
 import org.slf4j.Logger;
@@ -67,7 +67,7 @@ public class InMemoryRolePermissionResolver implements RolePermissionResolver {
             if (p.equals("*")) {
                 return new AllPermission();
             } else {
-                return new WildcardPermission(p);
+                return new CaseSensitiveWildcardPermission(p);
             }
         }).collect(Collectors.toList());
     }

--- a/graylog2-server/src/main/java/org/graylog2/security/realm/MongoDbAuthorizationRealm.java
+++ b/graylog2-server/src/main/java/org/graylog2/security/realm/MongoDbAuthorizationRealm.java
@@ -26,6 +26,7 @@ import org.apache.shiro.authc.AuthenticationToken;
 import org.apache.shiro.authz.AuthorizationInfo;
 import org.apache.shiro.authz.Permission;
 import org.apache.shiro.authz.SimpleAuthorizationInfo;
+import org.apache.shiro.authz.permission.WildcardPermissionResolver;
 import org.apache.shiro.realm.AuthorizingRealm;
 import org.apache.shiro.subject.PrincipalCollection;
 import org.graylog.grn.GRN;
@@ -67,6 +68,7 @@ public class MongoDbAuthorizationRealm extends AuthorizingRealm {
         setCachingEnabled(true);
         setCacheManager(mongoDbAuthorizationCacheManager);
         serverEventBus.register(this);
+        setPermissionResolver(new WildcardPermissionResolver(true));
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/security/realm/MongoDbAuthorizationRealm.java
+++ b/graylog2-server/src/main/java/org/graylog2/security/realm/MongoDbAuthorizationRealm.java
@@ -68,6 +68,7 @@ public class MongoDbAuthorizationRealm extends AuthorizingRealm {
         setCachingEnabled(true);
         setCacheManager(mongoDbAuthorizationCacheManager);
         serverEventBus.register(this);
+        // Use case sensitive permission resolver
         setPermissionResolver(new WildcardPermissionResolver(true));
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/security/realm/RootAccountRealm.java
+++ b/graylog2-server/src/main/java/org/graylog2/security/realm/RootAccountRealm.java
@@ -23,6 +23,7 @@ import org.apache.shiro.authc.SimpleAccount;
 import org.apache.shiro.authc.credential.HashedCredentialsMatcher;
 import org.apache.shiro.authz.Permission;
 import org.apache.shiro.authz.permission.AllPermission;
+import org.apache.shiro.authz.permission.WildcardPermissionResolver;
 import org.apache.shiro.realm.SimpleAccountRealm;
 import org.apache.shiro.subject.SimplePrincipalCollection;
 import org.apache.shiro.util.CollectionUtils;
@@ -43,6 +44,8 @@ public class RootAccountRealm extends SimpleAccountRealm {
         setCachingEnabled(false);
         setCredentialsMatcher(new HashedCredentialsMatcher("SHA-256"));
         setName("root-account-realm");
+        // Use case sensitive permission resolver
+        setPermissionResolver(new WildcardPermissionResolver(true));
 
         addRootAccount(rootUsername, rootPasswordSha2);
     }

--- a/graylog2-server/src/main/java/org/graylog2/users/UserImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/users/UserImpl.java
@@ -26,8 +26,8 @@ import com.google.inject.assistedinject.AssistedInject;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.shiro.authz.Permission;
 import org.apache.shiro.authz.permission.AllPermission;
-import org.apache.shiro.authz.permission.WildcardPermission;
 import org.bson.types.ObjectId;
+import org.graylog.security.permissions.CaseSensitiveWildcardPermission;
 import org.graylog2.Configuration;
 import org.graylog2.database.CollectionName;
 import org.graylog2.database.ObjectIdStringFunction;
@@ -241,7 +241,7 @@ public class UserImpl extends PersistedImpl implements User {
             if (p.equals("*")) {
                 return new AllPermission();
             } else {
-                return new WildcardPermission(p);
+                return new CaseSensitiveWildcardPermission(p);
             }
 
         }).collect(Collectors.toSet());

--- a/graylog2-server/src/main/java/org/graylog2/users/UserServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/users/UserServiceImpl.java
@@ -33,6 +33,7 @@ import org.bson.types.ObjectId;
 import org.graylog.grn.GRN;
 import org.graylog.grn.GRNRegistry;
 import org.graylog.security.PermissionAndRoleResolver;
+import org.graylog.security.permissions.CaseSensitiveWildcardPermission;
 import org.graylog.security.permissions.GRNPermission;
 import org.graylog2.Configuration;
 import org.graylog2.database.MongoConnection;
@@ -382,9 +383,9 @@ public class UserServiceImpl extends PersistedServiceImpl implements UserService
     public List<Permission> getPermissionsForUser(User user) {
         final GRN principal = grnRegistry.ofUser(user);
         final ImmutableSet.Builder<Permission> permSet = ImmutableSet.<Permission>builder()
-                .addAll(user.getPermissions().stream().map(WildcardPermission::new).collect(Collectors.toSet()))
+                .addAll(user.getPermissions().stream().map(CaseSensitiveWildcardPermission::new).collect(Collectors.toSet()))
                 .addAll(permissionAndRoleResolver.resolvePermissionsForPrincipal(principal))
-                .addAll(getUserPermissionsFromRoles(user).stream().map(WildcardPermission::new).collect(Collectors.toSet()));
+                .addAll(getUserPermissionsFromRoles(user).stream().map(CaseSensitiveWildcardPermission::new).collect(Collectors.toSet()));
 
         return permSet.build().asList();
     }

--- a/graylog2-server/src/test/java/org/graylog2/rest/models/users/responses/UserSummaryTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/rest/models/users/responses/UserSummaryTest.java
@@ -19,9 +19,9 @@ package org.graylog2.rest.models.users.responses;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
-import org.apache.shiro.authz.permission.WildcardPermission;
 import org.graylog.grn.GRNRegistry;
 import org.graylog.grn.GRNTypes;
+import org.graylog.security.permissions.CaseSensitiveWildcardPermission;
 import org.graylog.security.permissions.GRNPermission;
 import org.graylog2.plugin.database.users.User;
 import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
@@ -42,7 +42,7 @@ class UserSummaryTest {
             "Hans",
             "Dampf",
             "Hans Dampf",
-            ImmutableList.of(new WildcardPermission("dashboard:create:123")),
+            ImmutableList.of(new CaseSensitiveWildcardPermission("dashboard:create:123")),
             ImmutableList.of(GRNPermission.create(RestPermissions.ENTITY_OWN, grnRegistry.newGRN(GRNTypes.STREAM, "1234"))),
             null,
             null,

--- a/graylog2-server/src/test/java/org/graylog2/users/UserImplTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/users/UserImplTest.java
@@ -21,7 +21,7 @@ import com.google.common.collect.ImmutableMap;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.shiro.authz.Permission;
 import org.apache.shiro.authz.permission.AllPermission;
-import org.apache.shiro.authz.permission.WildcardPermission;
+import org.graylog.security.permissions.CaseSensitiveWildcardPermission;
 import org.graylog2.plugin.database.validators.ValidationResult;
 import org.graylog2.security.PasswordAlgorithmFactory;
 import org.graylog2.shared.security.Permissions;
@@ -155,10 +155,10 @@ public class UserImplTest {
                 UserImpl.PERMISSIONS, customPermissions);
         user = new UserImpl(passwordAlgorithmFactory, permissions, fields);
 
-        final Set<Permission> userSelfEditPermissions = permissions.userSelfEditPermissions("foobar").stream().map(WildcardPermission::new).collect(Collectors.toSet());
+        final Set<Permission> userSelfEditPermissions = permissions.userSelfEditPermissions("foobar").stream().map(CaseSensitiveWildcardPermission::new).collect(Collectors.toSet());
         assertThat(user.getObjectPermissions())
                 .containsAll(userSelfEditPermissions)
-                .contains(new WildcardPermission("subject:action"))
+                .contains(new CaseSensitiveWildcardPermission("subject:action"))
                 .extracting("class").containsOnlyOnce(AllPermission.class);
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/users/UserServiceImplTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/users/UserServiceImplTest.java
@@ -22,12 +22,12 @@ import com.google.common.collect.Sets;
 import com.google.common.eventbus.EventBus;
 import com.mongodb.BasicDBObjectBuilder;
 import com.mongodb.DBObject;
-import org.apache.shiro.authz.permission.WildcardPermission;
 import org.bson.types.ObjectId;
 import org.graylog.grn.GRN;
 import org.graylog.grn.GRNRegistry;
 import org.graylog.grn.GRNTypes;
 import org.graylog.security.PermissionAndRoleResolver;
+import org.graylog.security.permissions.CaseSensitiveWildcardPermission;
 import org.graylog.security.permissions.GRNPermission;
 import org.graylog.testing.mongodb.MongoDBFixtures;
 import org.graylog.testing.mongodb.MongoDBInstance;
@@ -331,14 +331,14 @@ public class UserServiceImplTest {
         final GRN userGRN = grnRegistry.ofUser(user);
         when(permissionAndRoleResolver.resolvePermissionsForPrincipal(userGRN))
                 .thenReturn(ImmutableSet.of(
-                        new WildcardPermission("perm:from:grant"),
+                        new CaseSensitiveWildcardPermission("perm:from:grant"),
                         ownerShipPermission));
 
         final String roleId = "12345";
         when(permissionAndRoleResolver.resolveRolesForPrincipal(userGRN)).thenReturn(ImmutableSet.of(roleId));
         when(permissionResolver.resolveStringPermission(roleId)).thenReturn(ImmutableSet.of("perm:from:role"));
 
-        assertThat(userService.getPermissionsForUser(user).stream().map(p -> p instanceof WildcardPermission ? p.toString() : p).collect(Collectors.toSet()))
+        assertThat(userService.getPermissionsForUser(user).stream().map(p -> p instanceof CaseSensitiveWildcardPermission ? p.toString() : p).collect(Collectors.toSet()))
                 .containsExactlyInAnyOrder("users:passwordchange:user", "users:edit:user", "foo:bar", "hello:world", "users:tokenlist:user",
                         "users:tokencreate:user", "users:tokenremove:user", "perm:from:grant", ownerShipPermission, "perm:from:role");
     }


### PR DESCRIPTION
When introducing the new permissions system in 4.0
we started using object instead of string permissions.

We did not notice that WildcardPermissions are by default case insensitive.
For most cases that didn't make a difference,
but returning the self-editing permissions to a user with a
non-lowercase name would change from something like

`users:edit:HORST` to `users:edit:horst`

Which would break the frontend permission checks
for these cases.

-> Introduce a new `CaseSensitiveWildcardPermission` class
   that changes this default.


Fixes: https://github.com/Graylog2/graylog2-server/issues/10700

/jenkins-pr-deps Graylog2/graylog-plugin-enterprise#2257