### PR TITLE
Add cluster-wide lookup table cache purge

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/lookup/LookupTableService.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/LookupTableService.java
@@ -27,6 +27,7 @@ import org.graylog2.lookup.db.DBLookupTableService;
 import org.graylog2.lookup.dto.CacheDto;
 import org.graylog2.lookup.dto.DataAdapterDto;
 import org.graylog2.lookup.dto.LookupTableDto;
+import org.graylog2.lookup.events.AdapterSharedStoresUpdated;
 import org.graylog2.lookup.events.CachesDeleted;
 import org.graylog2.lookup.events.CachesUpdated;
 import org.graylog2.lookup.events.DataAdaptersDeleted;
@@ -247,6 +248,18 @@ public class LookupTableService extends AbstractIdleService {
             // stop old caches
             existingCaches.build().forEach(AbstractIdleService::stopAsync);
         }, 0, TimeUnit.SECONDS);
+    }
+
+    @Subscribe
+    public void handleAdapterSharedStoreUpdate(AdapterSharedStoresUpdated updated) {
+        // When one node updates the data store shared by other data adapter instances in
+        // a cluster, then we need to purge the caches that depend on that data adapter on each node
+        scheduler.schedule(() -> updated.ids().stream().forEach( dataAdapterId -> {
+            liveTables.values().stream()
+                    .filter(table -> table.dataAdapter().id().equals(dataAdapterId))
+                    .map(LookupTable::cache)
+                    .forEach(LookupCache::purge);
+                }), 0, TimeUnit.SECONDS);
     }
 
     @Subscribe

--- a/graylog2-server/src/main/java/org/graylog2/lookup/events/AdapterSharedStoresUpdated.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/events/AdapterSharedStoresUpdated.java
@@ -35,6 +35,6 @@ public abstract class AdapterSharedStoresUpdated {
 
     @JsonCreator
     public static AdapterSharedStoresUpdated create(@JsonProperty("ids") Set<String> ids) {
-        return new AutoValue_Adapter_SharedStoresUpdated(ids);
+        return new AutoValue_AdapterSharedStoresUpdated(ids);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/lookup/events/AdapterSharedStoresUpdated.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/events/AdapterSharedStoresUpdated.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.lookup.events;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+
+import java.util.Collections;
+import java.util.Set;
+
+@AutoValue
+public abstract class AdapterSharedStoresUpdated {
+
+    @JsonProperty("ids")
+    public abstract Set<String> ids();
+
+    public static AdapterSharedStoresUpdated create(String id) {
+        return create(Collections.singleton(id));
+    }
+
+    @JsonCreator
+    public static AdapterSharedStoresUpdated create(@JsonProperty("ids") Set<String> ids) {
+        return new AutoValue_Adapter_SharedStoresUpdated(ids);
+    }
+}


### PR DESCRIPTION
## Description
As detailed in #10665, for DataAdapters where only a single instance is regularly refreshing the contents, we need a way to invalidate the lookuptable caches on all cluster nodes. Otherwise the non-master nodes in the cluster would still run with stale caches and report false lookup values.

This change adds that capability with the `AdapterSharedStoresUpdated` event type.

## How Has This Been Tested?
This has been tested in my local development environment.  Verified that when a Data Adapter sends an `AdapterSharedStoresUpdated` event on the event bus, all other nodes clear the appropriate lookup table caches.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

