### PR TITLE
Fix widget config form validation on aggregation element remove.

### DIFF
--- a/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/MetricElement.ts
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/MetricElement.ts
@@ -101,6 +101,10 @@ const MetricElement: AggregationElement = {
   }),
   toConfig: (formValues: WidgetConfigFormValues, configBuilder: AggregationWidgetConfigBuilder) => configBuilder
     .series(metricsToSeries(formValues.metrics)),
+  onRemove: ((index, formValues) => ({
+    ...formValues,
+    metrics: formValues.metrics.filter((value, i) => index !== i),
+  })),
   component: MetricsConfiguration,
   validate: validateMetrics,
 };

--- a/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/SortElement.ts
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/SortElement.ts
@@ -108,6 +108,10 @@ const SortElement: AggregationElement = {
   }),
   toConfig: (formValues: WidgetConfigFormValues, configBuilder: AggregationWidgetConfigBuilder) => configBuilder
     .sort(formValues.sort.map((sort) => new SortConfig(formValueTypeToConfigType(sort.type), sort.field, Direction.fromString(sort.direction)))),
+  onRemove: ((index, formValues) => ({
+    ...formValues,
+    sort: formValues.sort.filter((value, i) => index !== i),
+  })),
   validate: validateSorts,
 };
 

--- a/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/GroupByConfiguration.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/GroupByConfiguration.tsx
@@ -46,7 +46,7 @@ const RollupHoverForHelp = styled(HoverForHelp)`
 const GroupByConfiguration = () => {
   const { values: { groupBy }, values, setValues, setFieldValue } = useFormikContext<WidgetConfigFormValues>();
   const disableColumnRollup = !groupBy?.groupings?.find(({ direction }) => direction === 'column');
-  const removeGrouping = useCallback((index) => {
+  const removeGrouping = useCallback((index) => () => {
     setValues(GroupByElement.onRemove(index, values));
   }, [setValues, values]);
 
@@ -81,7 +81,7 @@ const GroupByConfiguration = () => {
                                                                    draggableProps={draggableProps}
                                                                    className={className}
                                                                    testIdPrefix={`grouping-${index}`}
-                                                                   onRemove={() => removeGrouping(index)}
+                                                                   onRemove={removeGrouping(index)}
                                                                    elementTitle={GroupByElement.title}
                                                                    ref={ref}>
                                       <GroupBy index={index} />

--- a/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/MetricsConfiguration.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/MetricsConfiguration.tsx
@@ -15,6 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
+import { useCallback } from 'react';
 import { useFormikContext, FieldArray } from 'formik';
 
 import ElementConfigurationContainer from './ElementConfigurationContainer';
@@ -24,19 +25,23 @@ import MetricElement from '../aggregationElements/MetricElement';
 import { WidgetConfigFormValues } from '../WidgetConfigForm';
 
 const MetricsConfiguration = () => {
-  const { values: { metrics } } = useFormikContext<WidgetConfigFormValues>();
+  const { values: { metrics }, setValues, values } = useFormikContext<WidgetConfigFormValues>();
+
+  const removeMetric = useCallback((index) => () => {
+    setValues(MetricElement.onRemove(index, values));
+  }, [setValues, values]);
 
   return (
     <FieldArray name="metrics"
                 validateOnChange={false}
-                render={({ remove }) => (
+                render={() => (
                   <>
                     <div>
                       {metrics.map((metric, index) => {
                         return (
-                        // eslint-disable-next-line react/no-array-index-key
+                          // eslint-disable-next-line react/no-array-index-key
                           <ElementConfigurationContainer key={`metrics-${index}`}
-                                                         onRemove={() => remove(index)}
+                                                         onRemove={removeMetric(index)}
                                                          elementTitle={MetricElement.title}>
                             <Metric index={index} />
                           </ElementConfigurationContainer>

--- a/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/SortConfiguration.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/SortConfiguration.tsx
@@ -15,6 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
+import { useCallback } from 'react';
 import { FieldArray, useFormikContext } from 'formik';
 
 import { SortableList } from 'components/common';
@@ -26,12 +27,15 @@ import { WidgetConfigFormValues } from 'views/components/aggregationwizard/Widge
 import SortElement from '../aggregationElements/SortElement';
 
 const SortConfiguration = () => {
-  const { values: { sort }, setFieldValue } = useFormikContext<WidgetConfigFormValues>();
+  const { values: { sort }, setFieldValue, setValues, values } = useFormikContext<WidgetConfigFormValues>();
+  const removeSort = useCallback((index) => () => {
+    setValues(SortElement.onRemove(index, values));
+  }, [setValues, values]);
 
   return (
     <FieldArray name="sort"
                 validateOnChange={false}
-                render={({ remove }) => (
+                render={() => (
                   <SortableList items={sort}
                                 onMoveItem={(newSort) => setFieldValue('sort', newSort)}
                                 customListItemRender={({ item, index, dragHandleProps, draggableProps, className, ref }) => (
@@ -40,7 +44,7 @@ const SortConfiguration = () => {
                                                                  draggableProps={draggableProps}
                                                                  className={className}
                                                                  testIdPrefix={`sort-${index}`}
-                                                                 onRemove={() => remove(index)}
+                                                                 onRemove={removeSort(index)}
                                                                  elementTitle={SortElement.title}
                                                                  ref={ref}>
                                     <Sort index={index} />


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Before this change the widget config form validation was not being
executed when removing an aggregation element. This is only the case
when we define `validateOnChange` for the related `FormikArray` component.
We recently disabled `validateOnChange` for the `FormikArray`s (#10574), because a side effect
was that the validation is being executed twice, when changing a related
input. Because of this conditions the most pragmatic approach is using
`setFieldValue` instead of the `FomikArray` method `remove`. I also
tried defining a `validationSchema` for the form, but it has the same
side effects.

Fixes #10679

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

