### PR TITLE
Reduce amount of clicks it needs to assign a role on user create.

### DIFF
--- a/graylog2-web-interface/src/components/users/UserCreate/UserCreate.tsx
+++ b/graylog2-web-interface/src/components/users/UserCreate/UserCreate.tsx
@@ -196,7 +196,10 @@ const UserCreate = () => {
                        labelClassName="col-sm-3"
                        wrapperClassName="col-sm-9"
                        label="Assign Roles">
-                  <RolesSelector onSubmit={_onAssignRole} assignedRolesIds={user.roles} identifier={(role) => role.name} />
+                  <RolesSelector onSubmit={_onAssignRole}
+                                 assignedRolesIds={user.roles}
+                                 identifier={(role) => role.name}
+                                 placeholder="Search and select roles" />
                 </Input>
 
                 <Input id="selected-roles-overview"

--- a/graylog2-web-interface/src/components/users/UserEdit/RolesSection.tsx
+++ b/graylog2-web-interface/src/components/users/UserEdit/RolesSection.tsx
@@ -94,7 +94,7 @@ const RolesSection = ({ user, onSubmit }: Props) => {
     <SectionComponent title="Roles" showLoading={loading}>
       <h3>Assign Roles</h3>
       <Container>
-        <RolesSelector onSubmit={_onAssignRole} assignedRolesIds={user.roles} identifier={(role) => role.name} />
+        <RolesSelector onSubmit={_onAssignRole} assignedRolesIds={user.roles} identifier={(role) => role.name} multi />
       </Container>
 
       <ErrorAlert onClose={setErrors}>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
Before this change the role select in the user create form was a multi
value select. Which means a user had to click once to select a relevant
role and once to submit the selection. With this change we are directly
submitting the selection when a user selects a role.

This solution is suitable for this case because we are not sending an
API request each time we are assigning a selected roles, like we do it on the user
edit page.

Fixes: https://github.com/Graylog2/graylog2-server/issues/9933

## How Has This Been Tested?
Tested the role assignment on the user create and edit page.

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

