### PR TITLE
Don't skip assembly step in full backend tests

### DIFF
--- a/graylog2-server/src/test/java/org/graylog/testing/graylognode/MavenPackager.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/graylognode/MavenPackager.java
@@ -32,7 +32,7 @@ import static org.graylog.testing.graylognode.ExecutableFileUtil.makeSureExecuta
 
 public class MavenPackager {
     private static final Logger LOG = LoggerFactory.getLogger(MavenPackager.class);
-    private static final String MVN_COMMAND = "mvn package -DskipTests -Dskip.web.build -Dforbiddenapis.skip=true -Dmaven.javadoc.skip=true -Dassembly.skipAssembly=true";
+    private static final String MVN_COMMAND = "mvn package -DskipTests -Dskip.web.build -Dforbiddenapis.skip=true -Dmaven.javadoc.skip=true";
 
     static void packageJarIfNecessary(Path projectDir) {
         if (isRunFromMaven()) {


### PR DESCRIPTION
Skipping the assembly step improves test time but it's required to
properly build e.g. the jar of the `graylog-storage-elasticsearch7`
module.

Before this change you could end up with broken tests by performing the following steps:

1. `$ mvn clean compile -DskipTests=true -Dskip.web.build -Dforbiddenapis.skip=true -Dmaven.javadoc.skip=true`
1. Run `BackendStartupIT` from your IDE

You'll notice that the test fails because the server doesn't start. The logs show the following error:
```
java.lang.ClassNotFoundException: org.graylog.shaded.elasticsearch7.org.elasticsearch.action.search.SearchResponse
```