### PR TITLE
Fix permission check for notifications in event definitions for non alert managers

### DIFF
--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/NotificationsForm.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/NotificationsForm.jsx
@@ -89,7 +89,7 @@ class NotificationsForm extends React.Component {
       );
     }
 
-    if (!isPermitted(currentUser.permissions, 'eventnotifications:read')) {
+    if (notifications.length < 1) {
       return (
         <Row>
           <Col md={6} lg={5}>


### PR DESCRIPTION
## Description
Users that do not have **Alerts Manager** role assigned but have instead **Event Definition Creator** and **Event Notification Creator** assigned are not able to choose a notification because the permission **eventnotifications:read** is missing.

## Motivation and Context
As both roles (**Alerts Manager** and **Event Notification Creator**) have the permission **eventnotifications:create** this will allow users with with the roles **Event Definition Creator** and **Event Notification Creator** to choose a notification

## How Has This Been Tested?
1. create user with roles Reader, User Inspector, Event Definition Creator and Event Notification Creator
2. create a notification
3. create an event definition
4. choose a notification

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Needs backport to 4.0.x