### PR TITLE
Reset page when searching on steam overview

### DIFF
--- a/graylog2-web-interface/src/components/streams/StreamComponent.jsx
+++ b/graylog2-web-interface/src/components/streams/StreamComponent.jsx
@@ -101,7 +101,7 @@ class StreamComponent extends React.Component {
 
   _onSearch = (query, resetLoadingCallback) => {
     const { pagination } = this.state;
-    const newPagination = Object.assign(pagination, { query: query });
+    const newPagination = { ...pagination, query: query, page: 1 };
 
     this.setState({ pagination: newPagination }, () => this.loadData(resetLoadingCallback));
   };
@@ -158,6 +158,7 @@ class StreamComponent extends React.Component {
     return (
       <div>
         <PaginatedList onChange={this._onPageChange}
+                       activePage={pagination.page}
                        totalItems={pagination.total}>
           <div style={{ marginBottom: 15 }}>
             <SearchForm onSearch={this._onSearch} onReset={this._onReset} useLoadingState />

--- a/graylog2-web-interface/src/components/streams/StreamComponent.jsx
+++ b/graylog2-web-interface/src/components/streams/StreamComponent.jsx
@@ -108,7 +108,7 @@ class StreamComponent extends React.Component {
 
   _onReset = () => {
     const { pagination } = this.state;
-    const newPagination = Object.assign(pagination, { query: '' });
+    const newPagination = { ...pagination, query: '', page: 1 };
 
     this.setState({ pagination: newPagination }, this.loadData);
   };


### PR DESCRIPTION
## Motivation
Prior to this change, if a user was on page 2 on the stream overview and
he was searching for an item on the first page, nothing was shown.

## Description
This change we reset the page when sending the search request which is
the correct behavior.

Fixes #10639 

## How Has This Been Tested?
- Got to Streams Overview
- Go to the second page
- Search for a stream from the first page

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


