### PR TITLE
Prevent HTTPPollTransport from stopping on non 2XX

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/inputs/transports/HttpPollTransport.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/transports/HttpPollTransport.java
@@ -154,6 +154,7 @@ public class HttpPollTransport extends ThrottleableTransport {
             if (isThrottled()) {
                 // this transport won't block, but we can simply skip this iteration
                 LOG.debug("Not polling HTTP resource {} because we are throttled.", url);
+                return;
             }
 
             final Request.Builder requestBuilder = new Request.Builder().get()
@@ -162,7 +163,8 @@ public class HttpPollTransport extends ThrottleableTransport {
 
             try (final Response r = httpClient.newCall(requestBuilder.build()).execute()) {
                 if (!r.isSuccessful()) {
-                    throw new RuntimeException("Expected successful HTTP status code [2xx], got " + r.code());
+                    LOG.error("Expected successful HTTP status code [2xx], got " + r.code());
+                    return;
                 }
 
                 input.processRawMessage(new RawMessage(r.body().bytes(), remoteAddress));


### PR DESCRIPTION
Fix for issue #9941 
As the ScheduledExecutorService stops any further execution when it received an Exception once, a HTTP response other than 2XX should be logged, but no exception should be thrown.

Additionally a return was missing in the Throttling section of this transport class.

## Description
Changed RuntimeException to LOG.error-statement to allow further executions of the scheduled task.

## Motivation and Context
Fix for issue #9941

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

