### PR TITLE
Use relative URLs for web interface assets served by Graylog server and backend API.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/RestTools.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/RestTools.java
@@ -120,6 +120,12 @@ public class RestTools {
         return uri;
     }
 
+    public static URI buildRelativeExternalUri(@NotNull MultivaluedMap<String, String> httpHeaders, @NotNull URI defaultUri) {
+        final URI externalUri = RestTools.buildExternalUri(httpHeaders, defaultUri);
+        final String path = externalUri.getPath() + (externalUri.getPath().endsWith("/") ? "" : "/");
+        return URI.create(path);
+    }
+
     public static String getPathFromResource(Resource resource) {
         String path = resource.getPath();
         Resource parent = resource.getParent();

--- a/graylog2-server/src/main/java/org/graylog2/rest/RestTools.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/RestTools.java
@@ -122,8 +122,7 @@ public class RestTools {
 
     public static URI buildRelativeExternalUri(@NotNull MultivaluedMap<String, String> httpHeaders, @NotNull URI defaultUri) {
         final URI externalUri = RestTools.buildExternalUri(httpHeaders, defaultUri);
-        final String path = externalUri.getPath() + (externalUri.getPath().endsWith("/") ? "" : "/");
-        return URI.create(path);
+        return URI.create(externalUri.getPath());
     }
 
     public static String getPathFromResource(Resource resource) {

--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/documentation/DocumentationBrowserResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/documentation/DocumentationBrowserResource.java
@@ -37,6 +37,7 @@ import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.io.IOException;
+import java.net.URI;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
@@ -89,8 +90,10 @@ public class DocumentationBrowserResource extends RestResource {
     public String allIndex(@Context HttpHeaders httpHeaders) throws IOException {
         final URL templateUrl = this.getClass().getResource("/swagger/index.html.template");
         final String template = Resources.toString(templateUrl, StandardCharsets.UTF_8);
+        final URI relativePath = RestTools.buildRelativeExternalUri(httpHeaders.getRequestHeaders(), httpConfiguration.getHttpExternalUri());
+
         final Map<String, Object> model = ImmutableMap.of(
-                "baseUri", RestTools.buildExternalUri(httpHeaders.getRequestHeaders(), httpConfiguration.getHttpExternalUri()).resolve(HttpConfiguration.PATH_API).toString(),
+                "baseUri", relativePath.resolve(HttpConfiguration.PATH_API).toString(),
                 "globalModePath", "global/index.html",
                 "globalUriMarker", "/global",
                 "showWarning", "true");

--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/documentation/DocumentationResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/documentation/DocumentationResource.java
@@ -109,7 +109,7 @@ public class DocumentationResource extends RestResource {
         URI baseUri;
         if (route.startsWith("global")) {
             route = route.replace("global", "");
-            baseUri = RestTools.buildExternalUri(httpHeaders.getRequestHeaders(), httpConfiguration.getHttpExternalUri()).resolve(HttpConfiguration.PATH_API);
+            baseUri = RestTools.buildRelativeExternalUri(httpHeaders.getRequestHeaders(), httpConfiguration.getHttpExternalUri()).resolve(HttpConfiguration.PATH_API);
         } else {
             baseUri = httpConfiguration.getHttpPublishUri().resolve(HttpConfiguration.PATH_API);
         }

--- a/graylog2-server/src/main/java/org/graylog2/web/DevelopmentIndexHtmlGenerator.java
+++ b/graylog2-server/src/main/java/org/graylog2/web/DevelopmentIndexHtmlGenerator.java
@@ -28,6 +28,7 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 import javax.ws.rs.core.MultivaluedMap;
 import java.io.IOException;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
@@ -52,9 +53,10 @@ public class DevelopmentIndexHtmlGenerator implements IndexHtmlGenerator {
 
     @Override
     public String get(MultivaluedMap<String, String> headers) {
+        final URI relativePath = RestTools.buildRelativeExternalUri(headers, httpConfiguration.getHttpExternalUri());
         final Map<String, Object> model = ImmutableMap.<String, Object>builder()
                 .put("title", "Graylog DEVELOPMENT Web Interface")
-                .put("appPrefix", RestTools.buildExternalUri(headers, httpConfiguration.getHttpExternalUri()))
+                .put("appPrefix", relativePath)
                 .build();
         return templateEngine.transform(getTemplate(), model);
     }

--- a/graylog2-server/src/main/java/org/graylog2/web/ProductionIndexHtmlGenerator.java
+++ b/graylog2-server/src/main/java/org/graylog2/web/ProductionIndexHtmlGenerator.java
@@ -26,6 +26,7 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 import javax.ws.rs.core.MultivaluedMap;
 import java.io.IOException;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
@@ -72,11 +73,14 @@ public class ProductionIndexHtmlGenerator implements IndexHtmlGenerator {
 
     @Override
     public String get(MultivaluedMap<String, String> headers) {
+        final URI externalUri = RestTools.buildExternalUri(headers, httpConfiguration.getHttpExternalUri());
+        final String path = externalUri.getPath() + (externalUri.getPath().endsWith("/") ? "" : "/");
+        final URI relativePath = URI.create(path);
         final Map<String, Object> model = ImmutableMap.<String, Object>builder()
                 .put("title", "Graylog Web Interface")
                 .put("cssFiles", cssFiles)
                 .put("jsFiles", sortedJsFiles)
-                .put("appPrefix", RestTools.buildExternalUri(headers, httpConfiguration.getHttpExternalUri()))
+                .put("appPrefix", relativePath)
                 .build();
         return templateEngine.transform(template, model);
     }

--- a/graylog2-server/src/main/java/org/graylog2/web/ProductionIndexHtmlGenerator.java
+++ b/graylog2-server/src/main/java/org/graylog2/web/ProductionIndexHtmlGenerator.java
@@ -73,9 +73,7 @@ public class ProductionIndexHtmlGenerator implements IndexHtmlGenerator {
 
     @Override
     public String get(MultivaluedMap<String, String> headers) {
-        final URI externalUri = RestTools.buildExternalUri(headers, httpConfiguration.getHttpExternalUri());
-        final String path = externalUri.getPath() + (externalUri.getPath().endsWith("/") ? "" : "/");
-        final URI relativePath = URI.create(path);
+        final URI relativePath = RestTools.buildRelativeExternalUri(headers, httpConfiguration.getHttpExternalUri());
         final Map<String, Object> model = ImmutableMap.<String, Object>builder()
                 .put("title", "Graylog Web Interface")
                 .put("cssFiles", cssFiles)

--- a/graylog2-server/src/main/java/org/graylog2/web/resources/AppConfigResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/web/resources/AppConfigResource.java
@@ -74,7 +74,7 @@ public class AppConfigResource {
             throw new RuntimeException("Unable to read AppConfig template while generating web interface configuration: ", e);
         }
 
-        final URI baseUri = RestTools.buildExternalUri(headers.getRequestHeaders(), httpConfiguration.getHttpExternalUri());
+        final URI baseUri = RestTools.buildRelativeExternalUri(headers.getRequestHeaders(), httpConfiguration.getHttpExternalUri());
         final Map<String, Object> model = ImmutableMap.of(
             "rootTimeZone", configuration.getRootTimeZone(),
             "serverUri", baseUri.resolve(HttpConfiguration.PATH_API),

--- a/graylog2-server/src/main/resources/swagger/lib/shred.bundle.js
+++ b/graylog2-server/src/main/resources/swagger/lib/shred.bundle.js
@@ -858,11 +858,19 @@ Object.defineProperties(Request.prototype, {
 
   url: {
     get: function() {
-      if (!this.scheme) { return null; }
-      return sprintf("%s://%s:%s%s",
-          this.scheme, this.host, this.port,
-          (this.proxy ? "/" : this.path) +
-          (this.query ? ("?" + this.query) : ""));
+      let result = '';
+      if (this.scheme) {
+        result += this.scheme + "://";
+      }
+
+      if (this.host) {
+        result += this.host;
+      }
+
+      if (this.port) {
+        result += ':' + this.port;
+      }
+      return result + (this.proxy ? "/" : this.path) + (this.query ? ("?" + this.query) : "");
     },
     set: function(_url) {
       _url = parseUri(_url);
@@ -895,13 +903,13 @@ Object.defineProperties(Request.prototype, {
 
   port: {
     get: function() {
-      if (!this._port) {
+      /*if (!this._port) {
         switch(this.scheme) {
           case "https": return this._port = 443;
           case "http":
           default: return this._port = 80;
         }
-      }
+      }*/
       return this._port;
     },
     set: function(value) { this._port = value; return this; },

--- a/graylog2-server/src/main/resources/swagger/lib/shred.bundle.js
+++ b/graylog2-server/src/main/resources/swagger/lib/shred.bundle.js
@@ -903,13 +903,6 @@ Object.defineProperties(Request.prototype, {
 
   port: {
     get: function() {
-      /*if (!this._port) {
-        switch(this.scheme) {
-          case "https": return this._port = 443;
-          case "http":
-          default: return this._port = 80;
-        }
-      }*/
       return this._port;
     },
     set: function(value) { this._port = value; return this; },


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Prior to this change, all web interface assets as well as all URLs going to the backdend REST API were qualified according from the following data points, in order of precedence:

 - The `X-Graylog-Server-URL` header of the request
 - The `http_external_uri` config setting
 - The `http_publish_uri` config setting

The result of this is used as the "effective external URI".

While this helps us supporting a couple of scenarios where the Graylog server is accessed through a reverse proxy, it also produces issues when naming schemes are different internally and externally and access from both directions is desired. The only scenario which works in these cases is configuring a valid `http_publish_uri`/`http_external_uri` for internal and using the `X-Graylog-Server-URL` on the proxy for external clients.

This is related to all of these settings being absolute URLs, resulting in generating absolute URLs for the web assets as well, unnecessarily.

In all of the cases this complexity of configuration would be unnecessary, if the references to the web assets and the backend API would be relative. This would support all of the aforementioned use cases and does not rely on proper configuration of any of the settings _in order to be able to load the web assets properly_ if there is no additional path prefix.

Therefore, this PR is determining the effective external URI in the same way as listed before, but takes only the path part of it to prefix all web assets.

These are the different scenarios, the current outcome and the desired outcome:

| http_publish_uri       | http_external_uri   | X-Graylog-Server-URL            | current                        | desired |
|------------------------|---------------------|---------------------------------|----------------------------------|---------|
| http://localhost:9000/ |                     |                                 | http://localhost:9000/           | /       |
| http://localhost:9000/ | https://graylog/foo |                                 | http://graylog/foo/              | /foo/   |
| http://localhost:9000/ | https://graylog/foo | https://something-else:8000/bar | https://something-else:8000/bar/ | /bar/   |


This helps us simplifying the http configuration for most scenarios while yielding a more reliable result when accessed internally as well as externally.

Fixes #10632.
Fixes #10267.


<!--- Provide a general summary of your changes in the Title above -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.