### PR TITLE
Avoid fetching widget field types if not on dashboard.

### DIFF
--- a/graylog2-web-interface/src/views/components/WidgetComponent.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetComponent.tsx
@@ -14,7 +14,7 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import React from 'react';
+import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import * as Immutable from 'immutable';
 
@@ -24,6 +24,8 @@ import WidgetClass from 'views/logic/widgets/Widget';
 import WidgetPosition from 'views/logic/widgets/WidgetPosition';
 import TFieldTypeMapping from 'views/logic/fieldtypes/FieldTypeMapping';
 import ExportSettingsContextProvider from 'views/components/ExportSettingsContextProvider';
+import ViewTypeContext from 'views/components/contexts/ViewTypeContext';
+import View from 'views/logic/views/View';
 
 import { WidgetDataMap, WidgetErrorsMap } from './widgets/WidgetPropTypes';
 import Widget from './widgets/Widget';
@@ -58,13 +60,16 @@ const WidgetComponent = ({
   const dataKey = widget.data || widget.id;
   const widgetData = data[dataKey];
   const widgetErrors = errors[widget.id] || [];
+  const viewType = useContext(ViewTypeContext);
+
+  const WidgetFieldTypesIfDashboard = viewType === View.Type.Dashboard ? WidgetFieldTypesContextProvider : React.Fragment;
 
   return (
     <DrilldownContextProvider widget={widget}>
       <WidgetContext.Provider value={widget}>
         <AdditionalContext.Provider value={{ widget }}>
           <ExportSettingsContextProvider>
-            <WidgetFieldTypesContextProvider>
+            <WidgetFieldTypesIfDashboard>
               <Widget data={widgetData}
                       editing={editing}
                       errors={widgetErrors}
@@ -77,7 +82,7 @@ const WidgetComponent = ({
                       title={title}
                       widget={widget}
                       width={width} />
-            </WidgetFieldTypesContextProvider>
+            </WidgetFieldTypesIfDashboard>
           </ExportSettingsContextProvider>
         </AdditionalContext.Provider>
       </WidgetContext.Provider>


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

In #10562, we introduced a more specific way to retrieve field types according to a timerange and stream selection. This is being used to fetch more precise field types for widgets on dashboards. Unfortunately, the `WidgetFieldTypesContextProvider` was used unconditionally to wrap all widgets, even if the current context is that of a Saved Search and not a Dashboard. On Saved Searches, field types are always the same due to the identical root query, therefore we do not need to fetch field types for each individual widget.

This PR is conditionally wrapping the widget component with the widget-specific field types provider if on a dashboard, and a fragment if on a search. This reduces the amound of overall field type requests.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.