### PR TITLE
Fix date format in outgoing traffic graphs

### DIFF
--- a/graylog2-web-interface/src/components/cluster/TrafficGraph.tsx
+++ b/graylog2-web-interface/src/components/cluster/TrafficGraph.tsx
@@ -37,7 +37,7 @@ const TrafficGraph = ({ width, traffic }: Props) => {
   const dailyTraffic = ndx.dimension((d) => moment(d.ts).format('YYYY-MM-DD'));
 
   const dailySums = dailyTraffic.group().reduceSum((d) => d.bytes);
-  const t = _.mapKeys(dailySums.all(), (entry) => moment.utc(entry.key, 'YYYY-MM-DD').unix() * 1000);
+  const t = _.mapKeys(dailySums.all(), (entry) => moment.utc(entry.key, 'YYYY-MM-DD').toISOString());
   const unixTraffic = _.mapValues(t, (val) => val.value);
   const chartData = [{
     type: 'bar',


### PR DESCRIPTION
## Motivation
Prior this change, we displayed the timestamps on the graph in the
timezone of the browser. That was because we gave plotly unix timestamps
without timezone information.

## Description
This change will use ISOString format to give plotly the desired
timezone (UTC). This leads to the effect that now time will be
displayed. Which is okay since it should describe a daily summary.

Fixes #10051

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
