### PR TITLE
Group selection on filtered content pack entities

### DIFF
--- a/graylog2-web-interface/src/components/content-packs/ContentPackSelection.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackSelection.jsx
@@ -142,9 +142,17 @@ class ContentPackSelection extends React.Component {
 
   _updateSelectionGroup = (type) => {
     const { selectedEntities, entities, onStateChange } = this.props;
+    const { isFiltered, filteredEntities } = this.state;
+
     const newSelection = cloneDeep(selectedEntities);
 
-    if (this._isGroupSelected(type)) {
+    if (isFiltered) {
+      if (newSelection[type]) {
+        newSelection[type] = [...newSelection[type], ...filteredEntities[type]];
+      } else {
+        newSelection[type] = filteredEntities[type];
+      }
+    } else if (this._isGroupSelected(type)) {
       newSelection[type] = [];
     } else {
       newSelection[type] = entities[type];


### PR DESCRIPTION
## Motivation
Prior to this change, when doing a filter on the content pack entity
selection the group selection would still select all entities in the
group.

## Description
Now only the filtered entities will be add to the selection.

## How Has This Been Tested?
![enhanced-entity-selection](https://user-images.githubusercontent.com/448763/119846700-aabca500-bf0a-11eb-9e14-db088c11dd54.gif)

Fixes #10727 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)