### PR TITLE
Fix request path matching in MessageExportFormatFilter

### DIFF
--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/MessageExportFormatFilterTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/MessageExportFormatFilterTest.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableSet;
 import org.apache.http.HttpHeaders;
 import org.glassfish.jersey.internal.util.collection.MultivaluedStringMap;
 import org.graylog.plugins.views.search.export.ExportFormat;
+import org.graylog2.configuration.HttpConfiguration;
 import org.graylog2.rest.MoreMediaTypes;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -46,7 +47,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class MessageExportFormatFilterTest {
-    private static final String VALID_PATH = "/views/search/messages";
+    private static final String VALID_PATH = HttpConfiguration.PATH_API + "views/search/messages";
     private static final ExportFormat disabledJsonExportFormat = new ExportFormat() {
         @Override
         public MediaType mimeType() {


### PR DESCRIPTION
The code accidentally matched API browser requests because the path
matching wasn't explicit enough.

This change adds the "api/" prefix to the checked target path and also
switches from "contains" to "endsWith".