### PR TITLE
Fixing world map viewport changes by maintaining related visualization config state in `WidgetConfigForm`.

### DIFF
--- a/graylog2-web-interface/src/views/components/aggregationbuilder/AggregationBuilder.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/AggregationBuilder.tsx
@@ -23,10 +23,11 @@ import type { FieldTypeMappingsList } from 'views/stores/FieldTypesStore';
 import type { Rows } from 'views/logic/searchtypes/pivot/PivotHandler';
 import type { Events } from 'views/logic/searchtypes/events/EventHandler';
 import type { AbsoluteTimeRange } from 'views/logic/queries/Query';
-import type VisualizationConfig from 'views/logic/aggregationbuilder/visualizations/VisualizationConfig';
 
 import EmptyAggregationContent from './EmptyAggregationContent';
 import FullSizeContainer from './FullSizeContainer';
+
+import type { VisualizationConfigFormValues } from '../aggregationwizard/WidgetConfigForm';
 
 const defaultVisualizationType = 'table';
 
@@ -86,7 +87,7 @@ const getResult = (value: RowResult | EventResult): Rows | Events => {
   return value.rows;
 };
 
-type OnVisualizationConfigChange = (newConfig: VisualizationConfig) => void;
+type OnVisualizationConfigChange = (newConfig: VisualizationConfigFormValues) => void;
 
 type AggregationBuilderProps = WidgetComponentProps<AggregationWidgetConfig> & {
   onVisualizationConfigChange: OnVisualizationConfigChange,

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/AggregationControls.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/AggregationControls.tsx
@@ -21,7 +21,6 @@ import { PluginStore } from 'graylog-web-plugin/plugin';
 import styled from 'styled-components';
 import { $PropertyType } from 'utility-types';
 import { EditWidgetComponentProps } from 'views/types';
-import VisualizationConfig from 'src/views/logic/aggregationbuilder/visualizations/VisualizationConfig';
 
 import { Col, Row } from 'components/graylog';
 import { defaultCompare } from 'views/logic/DefaultCompare';

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/AggregationControls.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/AggregationControls.tsx
@@ -21,6 +21,7 @@ import { PluginStore } from 'graylog-web-plugin/plugin';
 import styled from 'styled-components';
 import { $PropertyType } from 'utility-types';
 import { EditWidgetComponentProps } from 'views/types';
+import VisualizationConfig from 'src/views/logic/aggregationbuilder/visualizations/VisualizationConfig';
 
 import { Col, Row } from 'components/graylog';
 import { defaultCompare } from 'views/logic/DefaultCompare';
@@ -39,6 +40,8 @@ import DescriptionBox from './DescriptionBox';
 import SeriesFunctionsSuggester from './SeriesFunctionsSuggester';
 import EventListConfiguration from './EventListConfiguration';
 
+import worldMap, { WorldMapVisualizationConfigFormValues } from '../visualizations/worldmap/bindings';
+
 type Props = EditWidgetComponentProps<AggregationWidgetConfig>;
 
 type State = {
@@ -53,6 +56,7 @@ const Container = styled.div`
   grid-template-columns: 1fr;
   -ms-grid-columns: 1fr;
   height: 100%;
+  width: 100%;
 `;
 
 const TopRow = styled(Row)`
@@ -128,8 +132,13 @@ export default class AggregationControls extends React.Component<Props, State> {
     this._setAndPropagate((state) => ({ config: state.config.toBuilder().visualization(visualization).visualizationConfig(undefined).build() }));
   };
 
-  _onVisualizationConfigChange = (visualizationConfig: $PropertyType<$PropertyType<Props, 'config'>, 'visualizationConfig'>) => {
-    this._setAndPropagate((state) => ({ config: state.config.toBuilder().visualizationConfig(visualizationConfig).build() }));
+  _onVisualizationConfigChange = (visualizationConfigFormValues: WorldMapVisualizationConfigFormValues) => {
+    const { config } = this.props;
+
+    if (config.visualization === 'map') {
+      const newConfig = worldMap.config.toConfig(visualizationConfigFormValues);
+      this._setAndPropagate((state) => ({ config: state.config.toBuilder().visualizationConfig(newConfig).build() }));
+    }
   };
 
   _setAndPropagate = (fn: (State) => State) => this.setState(fn, this._propagateState);

--- a/graylog2-web-interface/src/views/components/aggregationwizard/AggregationWizard.test.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/AggregationWizard.test.tsx
@@ -52,7 +52,7 @@ describe('AggregationWizard', () => {
                          type="AGGREGATION"
                          fields={Immutable.List([])}
                          {...props}>
-        The Visualization
+        <>The Visualization</>
       </AggregationWizard>
     </FieldTypesContext.Provider>,
   );

--- a/graylog2-web-interface/src/views/components/aggregationwizard/AggregationWizard.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/AggregationWizard.tsx
@@ -95,7 +95,7 @@ const validateForm = (formValues: WidgetConfigFormValues) => {
   return elementValidationResults.reduce((prev, cur) => ({ ...prev, ...cur }), {});
 };
 
-const AggregationWizard = ({ onChange, config, children }: EditWidgetComponentProps<AggregationWidgetConfig>) => {
+const AggregationWizard = ({ onChange, config, children }: EditWidgetComponentProps<AggregationWidgetConfig> & { children: React.ReactElement }) => {
   const initialFormValues = _initialFormValues(config);
 
   return (

--- a/graylog2-web-interface/src/views/components/aggregationwizard/AggregationWizard.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/AggregationWizard.tsx
@@ -23,6 +23,7 @@ import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationW
 import WidgetConfigForm, { WidgetConfigFormValues } from './WidgetConfigForm';
 import ElementsConfiguration from './ElementsConfiguration';
 import aggregationElements from './aggregationElements';
+import Visualization from './Visualization';
 
 const aggregationElementsByKey = Object.fromEntries(aggregationElements.map((element) => ([element.key, element])));
 
@@ -40,11 +41,6 @@ const Controls = styled.div`
   flex: 1.2;
   padding-right: 15px;
   overflow-y: auto;
-`;
-
-const Visualization = styled.div`
-  height: 100%;
-  flex: 3;
 `;
 
 const Section = styled.div`
@@ -103,27 +99,23 @@ const AggregationWizard = ({ onChange, config, children }: EditWidgetComponentPr
   const initialFormValues = _initialFormValues(config);
 
   return (
-    <>
-      <Controls>
-        <WidgetConfigForm onSubmit={(formValues: WidgetConfigFormValues) => _onSubmit(formValues, onChange)}
-                          initialValues={initialFormValues}
-                          validate={validateForm}>
-          {() => (
-            <>
-              <Section data-testid="configure-elements-section">
-                <ElementsConfiguration aggregationElementsByKey={aggregationElementsByKey}
-                                       config={config}
-                                       onCreate={onCreateElement}
-                                       onConfigChange={onChange} />
-              </Section>
-            </>
-          )}
-        </WidgetConfigForm>
-      </Controls>
-      <Visualization>
-        {children}
-      </Visualization>
-    </>
+    <WidgetConfigForm onSubmit={(formValues: WidgetConfigFormValues) => _onSubmit(formValues, onChange)}
+                      initialValues={initialFormValues}
+                      validate={validateForm}>
+      <>
+        <Controls>
+          <Section data-testid="configure-elements-section">
+            <ElementsConfiguration aggregationElementsByKey={aggregationElementsByKey}
+                                   config={config}
+                                   onCreate={onCreateElement}
+                                   onConfigChange={onChange} />
+          </Section>
+        </Controls>
+        <Visualization>
+          {children}
+        </Visualization>
+      </>
+    </WidgetConfigForm>
   );
 };
 

--- a/graylog2-web-interface/src/views/components/aggregationwizard/Visualization.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/Visualization.tsx
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import { useMemo, useCallback } from 'react';
+import styled from 'styled-components';
+import { useFormikContext } from 'formik';
+
+import type { WidgetConfigFormValues } from './WidgetConfigForm';
+
+const Container = styled.div`
+  height: 100%;
+  flex: 3;
+`;
+
+type Props = {
+  children: React.ReactElement
+}
+
+const Visualization = ({ children }: Props) => {
+  const { setFieldValue, values } = useFormikContext<WidgetConfigFormValues>();
+
+  const onVisualizationConfigChange = useCallback((newVisualizationConfig) => {
+    setFieldValue('visualization', { ...values.visualization, config: { ...values.visualization.config, ...newVisualizationConfig } });
+  }, [values.visualization, setFieldValue]);
+
+  const childrenWithCallback = useMemo(() => React.Children.map(children, (child: React.ReactElement) => React.cloneElement(child, {
+    onVisualizationConfigChange: onVisualizationConfigChange,
+  })), [children, onVisualizationConfigChange]);
+
+  return (
+    <Container>
+      {childrenWithCallback}
+    </Container>
+  );
+};
+
+export default Visualization;

--- a/graylog2-web-interface/src/views/components/aggregationwizard/Visualization.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/Visualization.tsx
@@ -37,7 +37,7 @@ const Visualization = ({ children }: Props) => {
     setFieldValue('visualization', { ...values.visualization, config: { ...values.visualization.config, ...newVisualizationConfig } });
   }, [values.visualization, setFieldValue]);
 
-  const childrenWithCallback = useMemo(() => React.Children.map(children, (child: React.ReactElement) => React.cloneElement(child, {
+  const childrenWithCallback = useMemo(() => React.Children.map(children, (child) => React.cloneElement(child, {
     onVisualizationConfigChange: onVisualizationConfigChange,
   })), [children, onVisualizationConfigChange]);
 

--- a/graylog2-web-interface/src/views/components/aggregationwizard/WidgetConfigForm.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/WidgetConfigForm.tsx
@@ -17,10 +17,16 @@
 import * as React from 'react';
 import { Form, Formik, FormikProps } from 'formik';
 import { ConfigurationField } from 'views/types';
+import styled from 'styled-components';
 
 import PropagateValidationState from 'views/components/aggregationwizard/PropagateValidationState';
 import VisualizationConfig from 'views/logic/aggregationbuilder/visualizations/VisualizationConfig';
 import { AutoTimeConfig, TimeUnitConfig } from 'views/logic/aggregationbuilder/Pivot';
+
+const StyledForm = styled(Form)`
+  display: flex;
+  width: 100%;
+`;
 
 export type MetricFormValues = {
   function: string,
@@ -111,10 +117,10 @@ const WidgetConfigForm = ({ children, onSubmit, initialValues, validate }: Props
                                     validateOnMount
                                     onSubmit={onSubmit}>
       {(...args) => (
-        <Form className="form form-horizontal">
+        <StyledForm className="form form-horizontal">
           <PropagateValidationState />
           {typeof children === 'function' ? children(...args) : children}
-        </Form>
+        </StyledForm>
       )}
     </Formik>
   );

--- a/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.groupBy.test.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.groupBy.test.tsx
@@ -63,7 +63,7 @@ describe('AggregationWizard', () => {
                          fields={Immutable.List([])}
                          onChange={() => {}}
                          {...props}>
-        The Visualization
+        <>The Visualization</>
       </AggregationWizard>,
     </FieldTypesContext.Provider>,
   );

--- a/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.metric.test.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.metric.test.tsx
@@ -70,7 +70,7 @@ describe('AggregationWizard', () => {
                          type="AGGREGATION"
                          fields={Immutable.List([])}
                          {...props}>
-        The Visualization
+        <>The Visualization</>
       </AggregationWizard>
     </FieldTypesContext.Provider>,
   );

--- a/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.sort.test.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.sort.test.tsx
@@ -68,7 +68,7 @@ describe('AggregationWizard', () => {
                          type="AGGREGATION"
                          fields={Immutable.List([])}
                          {...props}>
-        The Visualization
+        <>The Visualization</>
       </AggregationWizard>
     </FieldTypesContext.Provider>,
   );

--- a/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/VisualizationConfigurationOptions.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/VisualizationConfigurationOptions.tsx
@@ -84,12 +84,11 @@ const VisualizationConfigurationOptions = ({ name: namePrefix, fields = [] }: Pr
       const Component = componentForType(field.type);
 
       const title = titleForField(field);
-      const componentProps = ('componentProps' in field ? field.componentProps : {});
 
       return (
         <Field key={`${namePrefix}.${field.name}`} name={`${namePrefix}.${field.name}`}>
           {({ field: { name, value, onChange }, meta: { error } }) => (
-            <Component key={`${namePrefix}.${field.name}`} name={name} value={value} onChange={onChange} error={error} field={field} title={title} {...componentProps} />
+            <Component key={`${namePrefix}.${field.name}`} name={name} value={value} onChange={onChange} error={error} field={field} title={title} />
           )}
         </Field>
       );

--- a/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/VisualizationConfigurationOptions.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/VisualizationConfigurationOptions.tsx
@@ -88,7 +88,7 @@ const VisualizationConfigurationOptions = ({ name: namePrefix, fields = [] }: Pr
       return (
         <Field key={`${namePrefix}.${field.name}`} name={`${namePrefix}.${field.name}`}>
           {({ field: { name, value, onChange }, meta: { error } }) => (
-            <Component key={`${namePrefix}.${field.name}`} name={name} value={value} onChange={onChange} error={error} field={field} title={title} />
+            <Component key={`${namePrefix}.${field.name}`} name={name} value={value} onChange={onChange} error={error} field={field} title={title} {...field.componentProps} />
           )}
         </Field>
       );

--- a/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/VisualizationConfigurationOptions.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/VisualizationConfigurationOptions.tsx
@@ -84,11 +84,12 @@ const VisualizationConfigurationOptions = ({ name: namePrefix, fields = [] }: Pr
       const Component = componentForType(field.type);
 
       const title = titleForField(field);
+      const componentProps = ('componentProps' in field ? field.componentProps : {});
 
       return (
         <Field key={`${namePrefix}.${field.name}`} name={`${namePrefix}.${field.name}`}>
           {({ field: { name, value, onChange }, meta: { error } }) => (
-            <Component key={`${namePrefix}.${field.name}`} name={name} value={value} onChange={onChange} error={error} field={field} title={title} {...field.componentProps} />
+            <Component key={`${namePrefix}.${field.name}`} name={name} value={value} onChange={onChange} error={error} field={field} title={title} {...componentProps} />
           )}
         </Field>
       );

--- a/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/VisualizationConfigurationOptions.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/VisualizationConfigurationOptions.tsx
@@ -23,15 +23,13 @@ import BooleanField from 'views/components/aggregationwizard/elementConfiguratio
 import { VisualizationConfigFormValues } from 'views/components/aggregationwizard/WidgetConfigForm';
 import { HoverForHelp } from 'components/common';
 
-import InputField from './configurationFields/InputField';
+import NumericField from './configurationFields/NumericField';
 import SelectField from './configurationFields/SelectField';
 
 type Props = {
   name: string,
   fields: Array<ConfigurationField>,
 };
-
-const NumericField = (props) => <InputField type="number" {...props} />;
 
 const TitleLabelWithHelp = styled.div`
   display: flex;

--- a/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/configurationFields/InputField.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/configurationFields/InputField.tsx
@@ -22,15 +22,16 @@ import { FieldComponentProps } from 'views/components/aggregationwizard/elementC
 
 type Props = FieldComponentProps & {
   type: 'numeric',
-  step?: string
 };
 
 const createEvent = (name: string, value: number) => ({ target: { name, value } }) as React.ChangeEvent<any>;
 
-const InputField = ({ type, onChange, value, error, name, title, field, step }: Props) => {
+const InputField = ({ type, onChange, value, error, name, title, field }: Props) => {
   const _onChange = useCallback((e: React.ChangeEvent<any>) => (type === 'numeric'
     ? onChange(createEvent(e.target.name, Number.parseFloat(e.target.value)))
     : onChange(e)), [onChange, type]);
+
+  const step = 'step' in field ? field.step : undefined;
 
   return (
     <Input id={`${name}-input`}
@@ -46,10 +47,6 @@ const InputField = ({ type, onChange, value, error, name, title, field, step }: 
            labelClassName="col-sm-3"
            wrapperClassName="col-sm-9" />
   );
-};
-
-InputField.defaultProps = {
-  step: undefined,
 };
 
 export default InputField;

--- a/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/configurationFields/InputField.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/configurationFields/InputField.tsx
@@ -22,11 +22,12 @@ import { FieldComponentProps } from 'views/components/aggregationwizard/elementC
 
 type Props = FieldComponentProps & {
   type: 'numeric',
+  step?: string
 };
 
 const createEvent = (name: string, value: number) => ({ target: { name, value } }) as React.ChangeEvent<any>;
 
-const InputField = ({ type, onChange, value, error, name, title, field }: Props) => {
+const InputField = ({ type, onChange, value, error, name, title, field, step }: Props) => {
   const _onChange = useCallback((e: React.ChangeEvent<any>) => (type === 'numeric'
     ? onChange(createEvent(e.target.name, Number.parseFloat(e.target.value)))
     : onChange(e)), [onChange, type]);
@@ -41,9 +42,14 @@ const InputField = ({ type, onChange, value, error, name, title, field }: Props)
            label={title}
            error={error}
            placeholder={field.description}
+           step={step}
            labelClassName="col-sm-3"
            wrapperClassName="col-sm-9" />
   );
+};
+
+InputField.defaultProps = {
+  step: undefined,
 };
 
 export default InputField;

--- a/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/configurationFields/NumericField.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/configurationFields/NumericField.tsx
@@ -16,37 +16,36 @@
  */
 import * as React from 'react';
 import { useCallback } from 'react';
+import type { NumericField as NumericFieldType } from 'views/types';
 
 import { Input } from 'components/bootstrap';
 import { FieldComponentProps } from 'views/components/aggregationwizard/elementConfiguration/VisualizationConfigurationOptions';
 
 type Props = FieldComponentProps & {
-  type: 'numeric',
+  field: NumericFieldType,
 };
 
 const createEvent = (name: string, value: number) => ({ target: { name, value } }) as React.ChangeEvent<any>;
 
-const InputField = ({ type, onChange, value, error, name, title, field }: Props) => {
-  const _onChange = useCallback((e: React.ChangeEvent<any>) => (type === 'numeric'
-    ? onChange(createEvent(e.target.name, Number.parseFloat(e.target.value)))
-    : onChange(e)), [onChange, type]);
-
-  const step = 'step' in field ? field.step : undefined;
+const NumericField = ({ onChange, value, error, name, title, field }: Props) => {
+  const _onChange = useCallback((e: React.ChangeEvent<any>) => {
+    onChange(createEvent(e.target.name, Number.parseFloat(e.target.value)));
+  }, [onChange]);
 
   return (
     <Input id={`${name}-input`}
            bsSize="small"
-           type={type}
+           type="number"
            name={name}
            onChange={_onChange}
            value={value ?? ''}
            label={title}
            error={error}
            placeholder={field.description}
-           step={step}
+           step={field.step}
            labelClassName="col-sm-3"
            wrapperClassName="col-sm-9" />
   );
 };
 
-export default InputField;
+export default NumericField;

--- a/graylog2-web-interface/src/views/components/visualizations/worldmap/WorldMapVisualization.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/worldmap/WorldMapVisualization.tsx
@@ -19,8 +19,6 @@ import PropTypes from 'prop-types';
 import { flow, fromPairs, get, zip, isEmpty } from 'lodash';
 
 import { AggregationType, AggregationResult } from 'views/components/aggregationbuilder/AggregationBuilderPropTypes';
-import WorldMapVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/WorldMapVisualizationConfig';
-import Viewport from 'views/logic/aggregationbuilder/visualizations/Viewport';
 import type { VisualizationComponentProps } from 'views/components/aggregationbuilder/AggregationBuilder';
 import type { Rows } from 'views/logic/searchtypes/pivot/PivotHandler';
 import type Pivot from 'views/logic/aggregationbuilder/Pivot';
@@ -82,15 +80,12 @@ const WorldMapVisualization = makeVisualization(({ config, data, editing, onChan
   const viewport = get(config, 'visualizationConfig.viewport');
 
   const _onChange = (newViewport) => {
-    const visualizationConfig = (config.visualizationConfig
-      // FIXME: Ugly hack to get the builder type consistent
-      ? config.visualizationConfig.toBuilder() as unknown as ReturnType<typeof WorldMapVisualizationConfig['builder']>
-      : WorldMapVisualizationConfig.builder())
-      .viewport(Viewport.create(newViewport.center, newViewport.zoom))
-      .build();
-
     if (editing) {
-      onChange(visualizationConfig);
+      onChange({
+        zoom: newViewport.zoom,
+        centerX: newViewport.center[0],
+        centerY: newViewport.center[1],
+      });
     }
   };
 

--- a/graylog2-web-interface/src/views/components/visualizations/worldmap/WorldMapVisualization.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/worldmap/WorldMapVisualization.tsx
@@ -18,6 +18,7 @@ import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { flow, fromPairs, get, zip, isEmpty } from 'lodash';
 
+import type Viewport from 'views/logic/aggregationbuilder/visualizations/Viewport';
 import { AggregationType, AggregationResult } from 'views/components/aggregationbuilder/AggregationBuilderPropTypes';
 import type { VisualizationComponentProps } from 'views/components/aggregationbuilder/AggregationBuilder';
 import type { Rows } from 'views/logic/searchtypes/pivot/PivotHandler';
@@ -79,7 +80,7 @@ const WorldMapVisualization = makeVisualization(({ config, data, editing, onChan
 
   const viewport = get(config, 'visualizationConfig.viewport');
 
-  const _onChange = (newViewport) => {
+  const _onChange = (newViewport: Viewport) => {
     if (editing) {
       onChange({
         zoom: newViewport.zoom,

--- a/graylog2-web-interface/src/views/components/visualizations/worldmap/__tests__/WorldMapVisualization.test.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/worldmap/__tests__/WorldMapVisualization.test.tsx
@@ -22,7 +22,6 @@ import { mount } from 'wrappedEnzyme';
 import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
 import Viewport from 'views/logic/aggregationbuilder/visualizations/Viewport';
 import Series from 'views/logic/aggregationbuilder/Series';
-import WorldMapVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/WorldMapVisualizationConfig';
 import RenderCompletionCallback from 'views/components/widgets/RenderCompletionCallback';
 import { AbsoluteTimeRange } from 'views/logic/queries/Query';
 import { Rows } from 'views/logic/searchtypes/pivot/PivotHandler';
@@ -85,7 +84,11 @@ describe('WorldMapVisualization', () => {
 
     _onChange(viewport);
 
-    expect(onChange).toHaveBeenCalledWith(WorldMapVisualizationConfig.create(viewport));
+    expect(onChange).toHaveBeenCalledWith({
+      zoom: 0,
+      centerX: 0,
+      centerY: 0,
+    });
   });
 
   it('calls render completion callback after first render', () => {

--- a/graylog2-web-interface/src/views/components/visualizations/worldmap/bindings.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/worldmap/bindings.tsx
@@ -26,17 +26,29 @@ export type WorldMapVisualizationConfigFormValues = {
   centerY: number,
 };
 
+const DEFAULT_FORM_VALUES = {
+  zoom: 1,
+  centerX: -0.3515602939922709,
+  centerY: 0.703125,
+};
+
 const worldMap: VisualizationType = {
   type: WorldMapVisualization.type,
   displayName: 'World Map',
   component: WorldMapVisualization,
   config: {
-    createConfig: () => ({ zoom: 1, centerX: 0, centerY: 1 }),
-    fromConfig: (config: WorldMapVisualizationConfig) => ({
-      zoom: config?.viewport.zoom,
-      centerX: config?.viewport.center[0],
-      centerY: config?.viewport.center[1],
-    }),
+    createConfig: () => DEFAULT_FORM_VALUES,
+    fromConfig: (config: WorldMapVisualizationConfig) => {
+      if (!config) {
+        return DEFAULT_FORM_VALUES;
+      }
+
+      return {
+        zoom: config.viewport.zoom,
+        centerX: config.viewport.center[0],
+        centerY: config.viewport.center[1],
+      };
+    },
     toConfig: (formValues: WorldMapVisualizationConfigFormValues) => WorldMapVisualizationConfig.create(Viewport.create([formValues.centerX, formValues.centerY], formValues.zoom)),
     fields: [
       {

--- a/graylog2-web-interface/src/views/components/visualizations/worldmap/bindings.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/worldmap/bindings.tsx
@@ -62,18 +62,14 @@ const worldMap: VisualizationType = {
         title: 'Latitude',
         type: 'numeric',
         required: true,
-        componentProps: {
-          step: 'any',
-        },
+        step: 'any',
       },
       {
         name: 'centerY',
         title: 'Longitude',
         type: 'numeric',
         required: true,
-        componentProps: {
-          step: 'any',
-        },
+        step: 'any',
       },
     ],
   },

--- a/graylog2-web-interface/src/views/components/visualizations/worldmap/bindings.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/worldmap/bindings.tsx
@@ -31,7 +31,7 @@ const worldMap: VisualizationType = {
   displayName: 'World Map',
   component: WorldMapVisualization,
   config: {
-    createConfig: () => ({ zoom: 1, centerX: 1, centerY: 1 }),
+    createConfig: () => ({ zoom: 1, centerX: 0, centerY: 1 }),
     fromConfig: (config: WorldMapVisualizationConfig) => ({
       zoom: config.viewport?.zoom,
       centerX: config.viewport?.center[0],
@@ -50,15 +50,22 @@ const worldMap: VisualizationType = {
         title: 'Latitude',
         type: 'numeric',
         required: true,
+        componentProps: {
+          step: 'any',
+        },
       },
       {
         name: 'centerY',
         title: 'Longitude',
         type: 'numeric',
         required: true,
+        componentProps: {
+          step: 'any',
+        },
       },
     ],
   },
+
 };
 
 export default worldMap;

--- a/graylog2-web-interface/src/views/components/visualizations/worldmap/bindings.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/worldmap/bindings.tsx
@@ -28,8 +28,8 @@ export type WorldMapVisualizationConfigFormValues = {
 
 const DEFAULT_FORM_VALUES = {
   zoom: 1,
-  centerX: -0.3515602939922709,
-  centerY: 0.703125,
+  centerX: 0,
+  centerY: 0,
 };
 
 const worldMap: VisualizationType = {

--- a/graylog2-web-interface/src/views/components/visualizations/worldmap/bindings.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/worldmap/bindings.tsx
@@ -20,7 +20,7 @@ import Viewport from 'views/logic/aggregationbuilder/visualizations/Viewport';
 import WorldMapVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/WorldMapVisualizationConfig';
 import WorldMapVisualization from 'views/components/visualizations/worldmap/WorldMapVisualization';
 
-type WorldMapVisualizationConfigFormValues = {
+export type WorldMapVisualizationConfigFormValues = {
   zoom: number,
   centerX: number,
   centerY: number,

--- a/graylog2-web-interface/src/views/components/visualizations/worldmap/bindings.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/worldmap/bindings.tsx
@@ -33,9 +33,9 @@ const worldMap: VisualizationType = {
   config: {
     createConfig: () => ({ zoom: 1, centerX: 0, centerY: 1 }),
     fromConfig: (config: WorldMapVisualizationConfig) => ({
-      zoom: config.viewport?.zoom,
-      centerX: config.viewport?.center[0],
-      centerY: config.viewport?.center[1],
+      zoom: config?.viewport.zoom,
+      centerX: config?.viewport.center[0],
+      centerY: config?.viewport.center[1],
     }),
     toConfig: (formValues: WorldMapVisualizationConfigFormValues) => WorldMapVisualizationConfig.create(Viewport.create([formValues.centerX, formValues.centerY], formValues.zoom)),
     fields: [

--- a/graylog2-web-interface/src/views/components/visualizations/worldmap/bindings.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/worldmap/bindings.tsx
@@ -16,12 +16,49 @@
  */
 import type { VisualizationType } from 'views/types';
 
+import Viewport from 'views/logic/aggregationbuilder/visualizations/Viewport';
+import WorldMapVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/WorldMapVisualizationConfig';
 import WorldMapVisualization from 'views/components/visualizations/worldmap/WorldMapVisualization';
+
+type WorldMapVisualizationConfigFormValues = {
+  zoom: number,
+  centerX: number,
+  centerY: number,
+};
 
 const worldMap: VisualizationType = {
   type: WorldMapVisualization.type,
   displayName: 'World Map',
   component: WorldMapVisualization,
+  config: {
+    createConfig: () => ({ zoom: 1, centerX: 1, centerY: 1 }),
+    fromConfig: (config: WorldMapVisualizationConfig) => ({
+      zoom: config.viewport?.zoom,
+      centerX: config.viewport?.center[0],
+      centerY: config.viewport?.center[1],
+    }),
+    toConfig: (formValues: WorldMapVisualizationConfigFormValues) => WorldMapVisualizationConfig.create(Viewport.create([formValues.centerX, formValues.centerY], formValues.zoom)),
+    fields: [
+      {
+        name: 'zoom',
+        title: 'Zoom',
+        type: 'numeric',
+        required: true,
+      },
+      {
+        name: 'centerX',
+        title: 'Latitude',
+        type: 'numeric',
+        required: true,
+      },
+      {
+        name: 'centerY',
+        title: 'Longitude',
+        type: 'numeric',
+        required: true,
+      },
+    ],
+  },
 };
 
 export default worldMap;

--- a/graylog2-web-interface/src/views/types.d.ts
+++ b/graylog2-web-interface/src/views/types.d.ts
@@ -40,7 +40,7 @@ import {
 import VisualizationConfig from 'views/logic/aggregationbuilder/visualizations/VisualizationConfig';
 
 interface EditWidgetComponentProps<Config extends WidgetConfig = WidgetConfig> {
-  children: React.ReactNode,
+  children: React.ReactElement,
   config: Config,
   editing: boolean;
   id: string;

--- a/graylog2-web-interface/src/views/types.d.ts
+++ b/graylog2-web-interface/src/views/types.d.ts
@@ -112,7 +112,7 @@ type BooleanField = BaseField & {
   type: 'boolean',
 };
 
-type NumericField = BaseRequiredField & {
+export type NumericField = BaseRequiredField & {
   type: 'numeric',
   step?: string,
 };

--- a/graylog2-web-interface/src/views/types.d.ts
+++ b/graylog2-web-interface/src/views/types.d.ts
@@ -114,6 +114,9 @@ type BooleanField = BaseField & {
 
 type NumericField = BaseRequiredField & {
   type: 'numeric',
+  componentProps?: {
+    step: string,
+  }
 };
 
 type ConfigurationField = SelectField | BooleanField | NumericField;

--- a/graylog2-web-interface/src/views/types.d.ts
+++ b/graylog2-web-interface/src/views/types.d.ts
@@ -114,9 +114,7 @@ type BooleanField = BaseField & {
 
 type NumericField = BaseRequiredField & {
   type: 'numeric',
-  componentProps?: {
-    step: string,
-  }
+  step?: string,
 };
 
 type ConfigurationField = SelectField | BooleanField | NumericField;

--- a/graylog2-web-interface/src/views/types.d.ts
+++ b/graylog2-web-interface/src/views/types.d.ts
@@ -40,7 +40,7 @@ import {
 import VisualizationConfig from 'views/logic/aggregationbuilder/visualizations/VisualizationConfig';
 
 interface EditWidgetComponentProps<Config extends WidgetConfig = WidgetConfig> {
-  children: React.ReactElement,
+  children: React.ReactNode,
   config: Config,
   editing: boolean;
   id: string;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

As described in https://github.com/Graylog2/graylog2-server/issues/10671 the center and zoom level of a map visualization is not being saved anymore, when editing the widget. This error occured because we were maintaining the complete widget config in the `WidgetConfigForm` state. The `WidgetConfigForm` was only responsible for the configuration of aggregation elements (left column in the aggregation wizard builder).

With this PR we are also wrapping the visualization with the `WidgetConfigForm` in the aggregation wizard builder.
The visualization component can update the visualization config by calling the provided `onVisualizationConfigChange` prop. 

We are also:
- implementing the following inputs for the world map visualiztion config form: zoom, center x, center Y.
- adjusting the previously used `AggregationControls` component to still support editing the world map using the old aggregation builder.

Fixes: https://github.com/Graylog2/graylog2-server/issues/10671 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

