### PR TITLE
Removing not needed `type` attribute from message list `ValueRenderer` type

### DIFF
--- a/graylog2-web-interface/src/views/components/TypeSpecificValue.tsx
+++ b/graylog2-web-interface/src/views/components/TypeSpecificValue.tsx
@@ -58,7 +58,7 @@ const TypeSpecificValue = ({ field, value, render = defaultComponent, type = Fie
 
   switch (type.type) {
     case 'date': return <UserTimezoneTimestamp dateTime={value} render={render} field={field} />;
-    case 'boolean': return <Component value={String(value)} type={type} field={field} />;
+    case 'boolean': return <Component value={String(value)} field={field} />;
     default: return _formatValue(field, value, truncate, render, type);
   }
 };

--- a/graylog2-web-interface/src/views/components/Value.tsx
+++ b/graylog2-web-interface/src/views/components/Value.tsx
@@ -41,7 +41,7 @@ const defaultRenderer: ValueRenderer = ({ value }: ValueRendererProps) => value;
 
 const Value = ({ children, field, value, queryId, render = defaultRenderer, type = FieldType.Unknown }: Props) => {
   const RenderComponent: ValueRenderer = render || ((props: ValueRendererProps) => props.value);
-  const Component = (v) => <RenderComponent field={field} value={v.value} type={type} />;
+  const Component = ({ value: componentValue }) => <RenderComponent field={field} value={componentValue} />;
   const element = <TypeSpecificValue field={field} value={value} type={type} render={Component} />;
 
   return (

--- a/graylog2-web-interface/src/views/components/messagelist/decoration/ValueRenderer.ts
+++ b/graylog2-web-interface/src/views/components/messagelist/decoration/ValueRenderer.ts
@@ -16,12 +16,9 @@
  */
 import * as React from 'react';
 
-import FieldType from 'views/logic/fieldtypes/FieldType';
-
 export type ValueRendererProps = {
   field: string,
   value: any,
-  type: FieldType,
 };
 
 export type ValueRenderer = React.ComponentType<ValueRendererProps>;


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The `ValueRenderer` type is mainly being used for the `DecoratedValue`
component. The `DecoratedValue` component is using the `type`
prop. Removing the prop makes it easier to reuse the component.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

