### PR TITLE
Fix sorting of stream overview page

### DIFF
--- a/graylog2-web-interface/src/components/streams/StreamList.jsx
+++ b/graylog2-web-interface/src/components/streams/StreamList.jsx
@@ -58,13 +58,9 @@ const StreamList = createReactClass({
     );
   },
 
-  _sortByTitle(stream1, stream2) {
-    return stream1.title.localeCompare(stream2.title);
-  },
-
   render() {
     if (this.props.streams.length > 0) {
-      const streamList = this.props.streams.sort(this._sortByTitle).map(this._formatStream);
+      const streamList = this.props.streams.map(this._formatStream);
 
       return (
         <StreamsList>


### PR DESCRIPTION
## Motivation
Prior to this change, the backend send the streams in alphabetical order
but with regard of case sensitivity. The frontend would then sort the
streams again without case sensitivity which resulted in unsorted
looking streams.

## Description
This change will remove the second sorting on the frontend side and rely
on the backend sorting.

Fixes #10639 second part

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)