### PR TITLE
Fix handling of reopened indices and their aliases.

### DIFF
--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/IndicesAdapterES6.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/IndicesAdapterES6.java
@@ -178,9 +178,6 @@ public class IndicesAdapterES6 implements IndicesAdapter {
 
     @Override
     public Set<String> resolveAlias(String alias) {
-        // TODO: This is basically getting all indices and later we filter out the alias we want to check for.
-        //       This can be done in a more efficient way by either using the /_cat/aliases/<alias-name> API or
-        //       the regular /_alias/<alias-name> API.
         final GetSingleAlias request = new GetSingleAlias.Builder()
                 .alias(alias)
                 .build();

--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/indices/GetSingleAlias.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/indices/GetSingleAlias.java
@@ -1,0 +1,38 @@
+package org.graylog.storage.elasticsearch6.indices;
+
+import io.searchbox.action.AbstractMultiIndexActionBuilder;
+import io.searchbox.action.GenericResultAbstractAction;
+
+public class GetSingleAlias extends GenericResultAbstractAction {
+    private final String alias;
+
+    protected GetSingleAlias(GetSingleAlias.Builder builder) {
+        super(builder);
+        this.alias = builder.alias;
+        setURI(buildURI());
+    }
+
+    @Override
+    public String getRestMethodName() {
+        return "GET";
+    }
+
+    @Override
+    protected String buildURI() {
+        return super.buildURI() + "/_alias/" + this.alias;
+    }
+
+    public static class Builder extends AbstractMultiIndexActionBuilder<GetSingleAlias, GetSingleAlias.Builder> {
+        private String alias;
+
+        public Builder alias(String alias) {
+            this.alias = alias;
+            return this;
+        }
+
+        @Override
+        public GetSingleAlias build() {
+            return new GetSingleAlias(this);
+        }
+    }
+}

--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/indices/GetSingleAlias.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/indices/GetSingleAlias.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog.storage.elasticsearch6.indices;
 
 import io.searchbox.action.AbstractMultiIndexActionBuilder;

--- a/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
@@ -151,6 +151,10 @@ public class Indices {
         return indices.stream().findFirst();
     }
 
+    public Set<String> aliasTargets(String alias) {
+        return indicesAdapter.resolveAlias(alias);
+    }
+
     public void ensureIndexTemplate(IndexSet indexSet) {
         final IndexSetConfig indexSetConfig = indexSet.getConfig();
         final String templateName = indexSetConfig.indexTemplateName();
@@ -253,9 +257,9 @@ public class Indices {
     }
 
     public boolean isReopened(String indexName) {
-        final Optional<String> aliasTarget = aliasTarget(indexName + REOPENED_ALIAS_SUFFIX);
+        final Set<String> aliasTarget = aliasTargets(indexName + REOPENED_ALIAS_SUFFIX);
 
-        return aliasTarget.map(target -> target.equals(indexName)).orElse(false);
+        return !aliasTarget.isEmpty();
     }
 
     public Map<String, Boolean> areReopened(Collection<String> indices) {

--- a/graylog2-server/src/test/java/org/graylog2/indexer/indices/IndicesIT.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/indices/IndicesIT.java
@@ -456,4 +456,15 @@ public abstract class IndicesIT extends ElasticsearchBaseTest {
 
         indices.optimizeIndex("graylog_0", 1, Duration.minutes(1));
     }
+
+    @Test
+    public void aliasTargetReturnsListOfTargetsGivenAliasIsPointingToWithWildcards() {
+        final String index = client().createRandomIndex("indices_it_");
+        final String alias = "graylog_alias_target";
+        assertThat(indices.aliasTarget(alias)).isEmpty();
+
+        client().addAliasMapping(index, alias);
+
+        assertThat(indices.aliasTarget("graylog_alias_*")).contains(index);
+    }
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Prior to this change, retrieving the index sets (and their wildcards) containing reopened indices was broken, due to a number of issues.

This PR is fixing:

  - retrieving the list of targets for an index wildcard
  - checking if an index set wildcard contains reopened indices

This unbreaks the indices overview page after multiple indices were restored.

Fixes #10572.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.