### PR TITLE
Ensure that page content container obtains maximum height (relevant for Safari).

### DIFF
--- a/graylog2-web-interface/src/routing/App.tsx
+++ b/graylog2-web-interface/src/routing/App.tsx
@@ -38,6 +38,7 @@ const AppLayout = styled.div`
 const PageContent = styled.div`
   height: 100%;
   overflow: auto;
+  flex: 1;
 `;
 
 const ScrollToHint = styled.div(({ theme }) => css`


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

As described in #10756 the content of the aggregation builder can
disappear in Safari. While it is not completely clear what triggers this
behaviour, we can fix it by ensuring that the page content container
always obtains the maximum height.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

