### PR TITLE
Fix handling of null timerange when retrieving field types.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/FieldTypesForStreamsRequest.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/FieldTypesForStreamsRequest.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
 import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
 
+import javax.annotation.Nullable;
 import java.util.Optional;
 import java.util.Set;
 
@@ -42,10 +43,10 @@ public abstract class FieldTypesForStreamsRequest {
     @AutoValue.Builder
     public abstract static class Builder {
         @JsonProperty(FIELD_STREAMS)
-        public abstract Builder streams(Set<String> streams);
+        public abstract Builder streams(@Nullable Set<String> streams);
 
         @JsonProperty(FIELD_TIMERANGE)
-        public abstract Builder timerange(TimeRange timerange);
+        public abstract Builder timerange(@Nullable TimeRange timerange);
 
         public abstract FieldTypesForStreamsRequest build();
 

--- a/graylog2-web-interface/src/views/logic/fieldtypes/useFieldTypes.ts
+++ b/graylog2-web-interface/src/views/logic/fieldtypes/useFieldTypes.ts
@@ -33,7 +33,19 @@ type FieldTypesRequest = {
 const _deserializeFieldTypes = (response: FieldTypesResponse) => response
   .map((fieldTypeMapping) => FieldTypeMapping.fromJSON(fieldTypeMapping));
 
-const createFieldTypeRequest = (streams: Array<string>, timerange: TimeRange): FieldTypesRequest => ((streams && streams.length > 0) ? { streams, timerange } : { timerange });
+const createFieldTypeRequest = (streams: Array<string>, timerange: TimeRange): FieldTypesRequest => {
+  let request: FieldTypesRequest = {};
+
+  if (streams && streams.length > 0) {
+    request = { streams };
+  }
+
+  if (timerange) {
+    request = { ...request, timerange };
+  }
+
+  return request;
+};
 
 const fetchAllFieldTypes = (streams: Array<string>, timerange: TimeRange): Promise<Array<FieldTypeMapping>> => fetch('POST', fieldTypesUrl, createFieldTypeRequest(streams, timerange))
   .then(_deserializeFieldTypes);


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is fixing an issue with the `useFieldTypes` hook being used to retrieve field types for widgets in case where the widget has no custom time range. In these cases a `timerange` of `null` is passed, resulting in a 400 being returned by the backend and no field types being shown in the widget edit form.

This PR is doing two things to improve this:

 - Filter out the `timerange` prop from the request if it is `null`
 - Accept `null` values for `timerange` and `streams` in the backend

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.