### PR TITLE
Improve `suppressConsole` usage in frontend tests and fix two silently failing tests.

### DIFF
--- a/graylog2-web-interface/src/components/errors/ReportedErrorBoundary.test.tsx
+++ b/graylog2-web-interface/src/components/errors/ReportedErrorBoundary.test.tsx
@@ -38,7 +38,7 @@ describe('ReportedErrorBoundary', () => {
   it('displays runtime error page when react error got reported', async () => {
     const { getByText, queryByText } = render(<ReportedErrorBoundary>Hello World!</ReportedErrorBoundary>);
 
-    suppressConsole(() => {
+    await suppressConsole(() => {
       ErrorsActions.report(createReactError(new Error('The error message'), { componentStack: 'The component stack' }));
     });
 
@@ -52,7 +52,7 @@ describe('ReportedErrorBoundary', () => {
     const { getByText, queryByText } = render(<ReportedErrorBoundary>Hello World!</ReportedErrorBoundary>);
     const response = { status: 404, body: { message: 'The request error message' } };
 
-    suppressConsole(() => {
+    await suppressConsole(() => {
       ErrorsActions.report(createNotFoundError(new FetchError('The request error message', response.status, response)));
     });
 
@@ -66,7 +66,7 @@ describe('ReportedErrorBoundary', () => {
     const { getByText, queryByText } = render(<ReportedErrorBoundary>Hello World!</ReportedErrorBoundary>);
     const response = { status: 404, body: { message: 'The error message' } };
 
-    suppressConsole(() => {
+    await suppressConsole(() => {
       ErrorsActions.report({ ...createNotFoundError(new FetchError('The error message', response.status, response)), type: 'UnkownReportedError' });
     });
 
@@ -80,7 +80,7 @@ describe('ReportedErrorBoundary', () => {
     const { findByText, queryByText } = render(<ReportedErrorBoundary>Hello World!</ReportedErrorBoundary>);
     const response = { status: 403, body: { message: 'The request error message' } };
 
-    suppressConsole(() => {
+    await suppressConsole(() => {
       ErrorsActions.report(createUnauthorizedError(new FetchError('The request error message', response.status, response)));
     });
 
@@ -96,7 +96,7 @@ describe('ReportedErrorBoundary', () => {
 
     expect(getByText('Hello World!')).not.toBeNull();
 
-    suppressConsole(() => {
+    await suppressConsole(() => {
       ErrorsActions.report(createUnauthorizedError(new FetchError('The request error message', response.status, response)));
     });
 

--- a/graylog2-web-interface/src/components/errors/RouterErrorBoundary.test.tsx
+++ b/graylog2-web-interface/src/components/errors/RouterErrorBoundary.test.tsx
@@ -15,7 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import React from 'react';
-import { render } from 'wrappedTestingLibrary';
+import { render, screen } from 'wrappedTestingLibrary';
 import suppressConsole from 'helpers/suppressConsole';
 import mockComponent from 'helpers/mocking/MockComponent';
 
@@ -46,13 +46,13 @@ describe('RouterErrorBoundary', () => {
 
   it('displays error after catching', () => {
     suppressConsole(() => {
-      const { getByText } = render(
+      render(
         <RouterErrorBoundary>
           <ErroneusComponent />
         </RouterErrorBoundary>,
       );
-
-      expect(getByText('Oh no, a banana peel fell on the party gorilla\'s head!')).not.toBeNull();
     });
+
+    expect(screen.getByText('Oh no, a banana peel fell on the party gorilla\'s head!')).not.toBeNull();
   });
 });

--- a/graylog2-web-interface/src/components/errors/RouterErrorBoundary.test.tsx
+++ b/graylog2-web-interface/src/components/errors/RouterErrorBoundary.test.tsx
@@ -44,8 +44,8 @@ describe('RouterErrorBoundary', () => {
     expect(getByText('Hello World!')).not.toBeNull();
   });
 
-  it('displays error after catching', () => {
-    suppressConsole(() => {
+  it('displays error after catching', async () => {
+    await suppressConsole(() => {
       render(
         <RouterErrorBoundary>
           <ErroneusComponent />

--- a/graylog2-web-interface/src/components/errors/RuntimeErrorBoundary.test.tsx
+++ b/graylog2-web-interface/src/components/errors/RuntimeErrorBoundary.test.tsx
@@ -55,16 +55,16 @@ describe('RuntimeErrorBoundary', () => {
           <ErroneusComponent />
         </RuntimeErrorBoundary>,
       );
-
-      expect(ErrorsActions.report).toHaveBeenCalledTimes(1);
-
-      expect(ErrorsActions.report.mock.calls[0][0].error).toStrictEqual({
-        message: 'Oh no, a banana peel fell on the party gorilla\'s head!',
-        stack: 'This the stack trace.',
-      });
-
-      expect(ErrorsActions.report.mock.calls[0][0].type).toEqual(ReactErrorType);
-      expect(ErrorsActions.report.mock.calls[0][0].componentStack).not.toBeNull();
     });
+
+    expect(ErrorsActions.report).toHaveBeenCalledTimes(1);
+
+    expect(ErrorsActions.report.mock.calls[0][0].error).toStrictEqual({
+      message: 'Oh no, a banana peel fell on the party gorilla\'s head!',
+      stack: 'This the stack trace.',
+    });
+
+    expect(ErrorsActions.report.mock.calls[0][0].type).toEqual(ReactErrorType);
+    expect(ErrorsActions.report.mock.calls[0][0].componentStack).not.toBeNull();
   });
 });

--- a/graylog2-web-interface/src/components/errors/RuntimeErrorBoundary.test.tsx
+++ b/graylog2-web-interface/src/components/errors/RuntimeErrorBoundary.test.tsx
@@ -48,8 +48,8 @@ describe('RuntimeErrorBoundary', () => {
     expect(getByText('Hello World!')).not.toBe(null);
   });
 
-  it('calls display error action after catching', () => {
-    suppressConsole(() => {
+  it('calls display error action after catching', async () => {
+    await suppressConsole(() => {
       render(
         <RuntimeErrorBoundary>
           <ErroneusComponent />

--- a/graylog2-web-interface/src/pages/ConfigurationsPage.test.tsx
+++ b/graylog2-web-interface/src/pages/ConfigurationsPage.test.tsx
@@ -49,12 +49,12 @@ describe('ConfigurationsPage', () => {
 
     asMock(SidecarConfig).mockImplementation(ComponentThrowingError);
 
-    await suppressConsole(async () => {
+    suppressConsole(async () => {
       render(<ConfigurationsPage />);
-
-      await screen.findByText('Message Processors Configuration');
-      await screen.findByText('Boom!');
     });
+
+    await screen.findByText('Message Processors Configuration');
+    await screen.findByText('Boom!');
   });
 
   it('wraps plugin configuration elements with error boundary', async () => {

--- a/graylog2-web-interface/src/pages/StreamPermissionErrorPage.test.tsx
+++ b/graylog2-web-interface/src/pages/StreamPermissionErrorPage.test.tsx
@@ -26,10 +26,10 @@ import StreamPermissionErrorPage from './StreamPermissionErrorPage';
 jest.mock('components/layout/Footer', () => mockComponent('Footer'));
 
 describe('StreamPermissionErrorPage', () => {
-  it('displays fetch error', () => {
+  it('displays fetch error', async () => {
     const response = { status: 403, body: { message: 'The request error message', streams: ['stream-1-id', 'stream-2-id'], type: 'MissingStreamPermission' } };
 
-    suppressConsole(async () => {
+    await suppressConsole(() => {
       render(<StreamPermissionErrorPage error={new FetchError('The request error message', response.status, response)} missingStreamIds={['stream-1-id', 'stream-2-id']} />);
     });
 

--- a/graylog2-web-interface/src/pages/StreamPermissionErrorPage.test.tsx
+++ b/graylog2-web-interface/src/pages/StreamPermissionErrorPage.test.tsx
@@ -15,7 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import React from 'react';
-import { render } from 'wrappedTestingLibrary';
+import { render, screen } from 'wrappedTestingLibrary';
 import suppressConsole from 'helpers/suppressConsole';
 import mockComponent from 'helpers/mocking/MockComponent';
 
@@ -30,10 +30,10 @@ describe('StreamPermissionErrorPage', () => {
     const response = { status: 403, body: { message: 'The request error message', streams: ['stream-1-id', 'stream-2-id'], type: 'MissingStreamPermission' } };
 
     suppressConsole(async () => {
-      const { getByText } = render(<StreamPermissionErrorPage error={new FetchError('The request error message', response.status, response)} />);
-
-      expect(getByText('Missing Stream Permissions')).not.toBeNull();
-      expect(getByText('You need permissions for streams with the id: stream-1-id, stream-2-id.')).not.toBeNull();
+      render(<StreamPermissionErrorPage error={new FetchError('The request error message', response.status, response)} missingStreamIds={['stream-1-id', 'stream-2-id']} />);
     });
+
+    expect(screen.getByText('Missing Stream Permissions')).not.toBeNull();
+    expect(screen.getByText('You need permissions for streams with the id: stream-1-id, stream-2-id.')).not.toBeNull();
   });
 });

--- a/graylog2-web-interface/src/pages/UnauthorizedErrorPage.test.tsx
+++ b/graylog2-web-interface/src/pages/UnauthorizedErrorPage.test.tsx
@@ -26,10 +26,10 @@ import UnauthorizedErrorPage from './UnauthorizedErrorPage';
 jest.mock('components/layout/Footer', () => mockComponent('Footer'));
 
 describe('UnauthorizedErrorPage', () => {
-  it('displays fetch error', () => {
+  it('displays fetch error', async () => {
     const response = { status: 403, body: { message: 'The request error message' } };
 
-    suppressConsole(async () => {
+    await suppressConsole(() => {
       render(<UnauthorizedErrorPage error={new FetchError('The request error message', response.status, response)} />);
     });
 

--- a/graylog2-web-interface/src/pages/UnauthorizedErrorPage.test.tsx
+++ b/graylog2-web-interface/src/pages/UnauthorizedErrorPage.test.tsx
@@ -15,7 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import React from 'react';
-import { render } from 'wrappedTestingLibrary';
+import { render, screen } from 'wrappedTestingLibrary';
 import suppressConsole from 'helpers/suppressConsole';
 import mockComponent from 'helpers/mocking/MockComponent';
 
@@ -27,12 +27,13 @@ jest.mock('components/layout/Footer', () => mockComponent('Footer'));
 
 describe('UnauthorizedErrorPage', () => {
   it('displays fetch error', () => {
-    suppressConsole(async () => {
-      const response = { status: 403, body: { message: 'The request error message' } };
-      const { getByText } = render(<UnauthorizedErrorPage error={new FetchError('The request error message', response.status, response)} />);
+    const response = { status: 403, body: { message: 'The request error message' } };
 
-      expect(getByText('Missing Permissions')).not.toBeNull();
-      expect(getByText(/The request error message/)).not.toBeNull();
+    suppressConsole(async () => {
+      render(<UnauthorizedErrorPage error={new FetchError('The request error message', response.status, response)} />);
     });
+
+    expect(screen.getByText('Missing Permissions')).not.toBeNull();
+    expect(screen.getByText(/The request error message/)).not.toBeNull();
   });
 });

--- a/graylog2-web-interface/src/views/components/WidgetOverrideElements.test.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetOverrideElements.test.tsx
@@ -61,7 +61,7 @@ describe('WidgetOverrideElements', () => {
     const Component = () => <span>I was thrown!</span>;
 
     const OverridingElement = ({ override }) => {
-      useEffect(() => override(Component), []);
+      useEffect(() => override(Component), [override]);
 
       return null;
     };

--- a/graylog2-web-interface/src/views/components/WidgetOverrideElements.test.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetOverrideElements.test.tsx
@@ -44,7 +44,7 @@ describe('WidgetOverrideElements', () => {
   });
 
   it('propagates thrown errors', async () => {
-    suppressConsole(async () => {
+    await suppressConsole(() => {
       const throwElement = () => {
         throw new Error('The dungeon collapses, you die!');
       };

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/AggregationControls.test.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/AggregationControls.test.tsx
@@ -17,7 +17,7 @@
 import * as React from 'react';
 import * as Immutable from 'immutable';
 import { mount } from 'wrappedEnzyme';
-import { render } from 'wrappedTestingLibrary';
+import { render, screen } from 'wrappedTestingLibrary';
 import { PluginStore } from 'graylog-web-plugin/plugin';
 import asMock from 'helpers/mocking/AsMock';
 import suppressConsole from 'helpers/suppressConsole';
@@ -71,16 +71,16 @@ describe('AggregationControls', () => {
 
   it('should render with `undefined` fields', () => {
     suppressConsole(() => {
-      const { getByTestId } = render((
+      render((
         <SimpleAggregationControls config={config}
                                    fields={undefined}
                                    onChange={() => {}}>
           {children}
         </SimpleAggregationControls>
       ));
-
-      expect(getByTestId('dummy-component')).toHaveTextContent('The spice must flow.');
     });
+
+    expect(screen.getByTestId('dummy-component')).toHaveTextContent('The spice must flow.');
   });
 
   // NOTE: Why is this testing `HoverForHelp` component?

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/AggregationControls.test.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/AggregationControls.test.tsx
@@ -69,8 +69,8 @@ describe('AggregationControls', () => {
     expect(getByTestId('dummy-component')).toHaveTextContent('The spice must flow.');
   });
 
-  it('should render with `undefined` fields', () => {
-    suppressConsole(() => {
+  it('should render with `undefined` fields', async () => {
+    await suppressConsole(() => {
       render((
         <SimpleAggregationControls config={config}
                                    fields={undefined}

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/PivotSelect.test.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/PivotSelect.test.tsx
@@ -53,11 +53,13 @@ describe('PivotSelect', () => {
   });
 
   it('renders properly with `undefined` fields', () => {
-    suppressConsole(() => {
-      const wrapper = mount(<PivotSelect onChange={() => {}} value={[]} options={[]} />);
+    let wrapper;
 
-      expect(wrapper).not.toBeEmptyRender();
+    suppressConsole(() => {
+      wrapper = mount(<PivotSelect onChange={() => {}} value={[]} options={[]} />);
     });
+
+    expect(wrapper).not.toBeEmptyRender();
   });
 
   describe('upon pivot list change, field types are passed for new pivot generation', () => {

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/PivotSelect.test.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/PivotSelect.test.tsx
@@ -52,12 +52,8 @@ describe('PivotSelect', () => {
     expect(wrapper).not.toBeEmptyRender();
   });
 
-  it('renders properly with `undefined` fields', () => {
-    let wrapper;
-
-    suppressConsole(() => {
-      wrapper = mount(<PivotSelect onChange={() => {}} value={[]} options={[]} />);
-    });
+  it('renders properly with `undefined` fields', async () => {
+    const wrapper = await suppressConsole(() => mount(<PivotSelect onChange={() => {}} value={[]} options={[]} />));
 
     expect(wrapper).not.toBeEmptyRender();
   });

--- a/graylog2-web-interface/src/views/components/widgets/MessageTable.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageTable.test.tsx
@@ -76,13 +76,9 @@ describe('MessageTable', () => {
     expect(td.text()).toContain('frank.txt');
   });
 
-  it('renders a table entry for messages, even if fields are `undefined`', () => {
-    let wrapper;
-
+  it('renders a table entry for messages, even if fields are `undefined`', async () => {
     // Suppressing console to disable props warning because of `fields` being `undefined`.
-    suppressConsole(() => {
-      wrapper = mount(<SimpleMessageTable fields={undefined} />);
-    });
+    const wrapper = await suppressConsole(() => mount(<SimpleMessageTable fields={undefined} />));
 
     const messageTableEntry = wrapper.find('MessageTableEntry');
 

--- a/graylog2-web-interface/src/views/components/widgets/MessageTable.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageTable.test.tsx
@@ -77,13 +77,16 @@ describe('MessageTable', () => {
   });
 
   it('renders a table entry for messages, even if fields are `undefined`', () => {
+    let wrapper;
+
     // Suppressing console to disable props warning because of `fields` being `undefined`.
     suppressConsole(() => {
-      const wrapper = mount(<SimpleMessageTable fields={undefined} />);
-      const messageTableEntry = wrapper.find('MessageTableEntry');
-
-      expect(messageTableEntry).not.toBeEmptyRender();
+      wrapper = mount(<SimpleMessageTable fields={undefined} />);
     });
+
+    const messageTableEntry = wrapper.find('MessageTableEntry');
+
+    expect(messageTableEntry).not.toBeEmptyRender();
   });
 
   it('renders config fields in table head with correct order', () => {

--- a/graylog2-web-interface/test/fixtures/configurations.ts
+++ b/graylog2-web-interface/test/fixtures/configurations.ts
@@ -1,19 +1,19 @@
 /*
-* Copyright (C) 2020 Graylog, Inc.
-*
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the Server Side Public License, version 1,
-* as published by MongoDB, Inc.
-*
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-* Server Side Public License for more details.
-*
-* You should have received a copy of the Server Side Public License
-* along with this program. If not, see
-* <http://www.mongodb.com/licensing/server-side-public-license>.
-*/
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 
 /* eslint-disable import/prefer-default-export */
 export const configuration = {

--- a/graylog2-web-interface/test/fixtures/configurations.ts
+++ b/graylog2-web-interface/test/fixtures/configurations.ts
@@ -1,0 +1,36 @@
+/*
+* Copyright (C) 2020 Graylog, Inc.
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the Server Side Public License, version 1,
+* as published by MongoDB, Inc.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* Server Side Public License for more details.
+*
+* You should have received a copy of the Server Side Public License
+* along with this program. If not, see
+* <http://www.mongodb.com/licensing/server-side-public-license>.
+*/
+
+/* eslint-disable import/prefer-default-export */
+export const configuration = {
+  'org.graylog2.messageprocessors.MessageProcessorsConfig': {
+    processor_order: [
+      {
+        name: 'AWS Instance Name Lookup',
+        class_name: 'aws.classname',
+      },
+    ],
+    disabled_processors: [],
+  },
+  'org.graylog.plugins.sidecar.system.SidecarConfiguration': {
+    sidecar_configuration_override: false,
+    sidecar_expiration_threshold: 'P14D',
+    sidecar_inactive_threshold: 'PT1M',
+    sidecar_send_status: true,
+    sidecar_update_interval: 'PT30S',
+  },
+};

--- a/graylog2-web-interface/test/helpers/suppressConsole.ts
+++ b/graylog2-web-interface/test/helpers/suppressConsole.ts
@@ -23,7 +23,7 @@
  *
  * @param {function} fn - the function which should be called after disabling `console.error` and before restoring it.
  */
-const suppressConsole = <T extends () => any>(fn: T): Promise<ReturnType<T>> => {
+const suppressConsole = <T>(fn: () => T): Promise<T> => {
   /* eslint-disable no-console */
   const originalConsoleError = console.error;
   console.error = () => {};

--- a/graylog2-web-interface/test/helpers/suppressConsole.ts
+++ b/graylog2-web-interface/test/helpers/suppressConsole.ts
@@ -23,15 +23,16 @@
  *
  * @param {function} fn - the function which should be called after disabling `console.error` and before restoring it.
  */
-const suppressConsole = <T>(fn: () => T): Promise<T> => {
+const suppressConsole = async <R>(fn: () => R): Promise<R> => {
   /* eslint-disable no-console */
   const originalConsoleError = console.error;
   console.error = () => {};
 
-  return Promise.resolve(fn()).then((result) => result).finally(() => {
+  try {
+    return await fn();
+  } finally {
     console.error = originalConsoleError;
-  });
-
+  }
   /* eslint-enable no-console */
 };
 

--- a/graylog2-web-interface/test/helpers/suppressConsole.ts
+++ b/graylog2-web-interface/test/helpers/suppressConsole.ts
@@ -23,14 +23,17 @@
  *
  * @param {function} fn - the function which should be called after disabling `console.error` and before restoring it.
  */
-const suppressConsole = (fn: () => void) => {
+const suppressConsole = <T extends () => any>(fn: T): Promise<ReturnType<T>> => {
   /* eslint-disable no-console */
   const originalConsoleError = console.error;
   console.error = () => {};
 
-  fn();
+  return Promise.resolve(fn()).then((result) => {
+    console.error = originalConsoleError;
 
-  console.error = originalConsoleError;
+    return result;
+  });
+
   /* eslint-enable no-console */
 };
 

--- a/graylog2-web-interface/test/helpers/suppressConsole.ts
+++ b/graylog2-web-interface/test/helpers/suppressConsole.ts
@@ -28,10 +28,8 @@ const suppressConsole = <T>(fn: () => T): Promise<T> => {
   const originalConsoleError = console.error;
   console.error = () => {};
 
-  return Promise.resolve(fn()).then((result) => {
+  return Promise.resolve(fn()).then((result) => result).finally(() => {
     console.error = originalConsoleError;
-
-    return result;
   });
 
   /* eslint-enable no-console */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is improving the `suppressConsole` usage in tests by:
- wrapping only the necessary code with `suppressConsole`. Before this change the `StreamPermissionErrorPage.test` and `ConfigurationsPage.test` failed silently because the `expect` call was part of the `suppressConsole` callback.
-  always returning a Promise when using `suppressConsole`. In the `ConfigurationsPage.test` we are throwing an error after changing the component state when rendering the component. To handle this error properly we have to wait with the reset of `console.error` until we display the error message.
- always using `await` when using `suppressConsole`. This is now necessary to ensure we are resetting `console.error` in time. But it also ensures that the test fails when we have to use a check (like `expect` or `findBy*`) in the callback of `suppressConsole` and the check fails.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

