### PR TITLE
Use correct time range format when selecting relative range preset in search bar.

### DIFF
--- a/graylog2-web-interface/src/views/components/searchbar/TimeRangeDropdownButton.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/TimeRangeDropdownButton.test.tsx
@@ -58,7 +58,7 @@ describe('TimeRangeDropdownButton', () => {
 
     expect(setCurrentTimeRange).toHaveBeenCalledWith({
       type: 'relative',
-      from: 1800,
+      range: 1800,
     });
   });
 });

--- a/graylog2-web-interface/src/views/components/searchbar/TimeRangeDropdownButton.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/TimeRangeDropdownButton.tsx
@@ -66,7 +66,7 @@ const TimeRangeDropdownButton = ({
   const selectRelativeTimeRangePreset = (from) => {
     setCurrentTimeRange({
       type: 'relative',
-      from,
+      range: from,
     });
   };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context

Before this change we've updated the time range with e.g. `{ from: 300 }`.
This resulted in an error when selecting the `All Time` option.
We are now using the following format: `{ range: 300 }`. With this
format we are updating the time range in the same way like the `TimeRangeDropdown`.

Refs: https://github.com/Graylog2/graylog2-server/pull/10740

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

