### PR TITLE
Prevent event annotation checkbox to go uncontrolled.

### DIFF
--- a/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.corevisualizations.test.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.corevisualizations.test.tsx
@@ -149,6 +149,27 @@ describe('AggregationWizard/Core Visualizations', () => {
     })));
   });
 
+  it('allows enabling event annotations for visualizations supporting it', async () => {
+    const onChange = jest.fn();
+    const timelineConfig = widgetConfig.toBuilder()
+      .rowPivots([Pivot.create('timestamp', 'time', { interval: { type: 'auto', scaling: 1 } })])
+      .series([Series.create('count')])
+      .build();
+
+    render(<SimpleAggregationWizard onChange={onChange} config={timelineConfig} />);
+
+    await selectOption('Select visualization type', 'Line Chart');
+
+    userEvent.click(await screen.findByRole('checkbox', { name: /show event annotations/i }));
+
+    userEvent.click(await submitButton());
+
+    await waitFor(() => expect(onChange).toHaveBeenCalledWith(expect.objectContaining({
+      visualization: 'line',
+      eventAnnotation: true,
+    })));
+  });
+
   it('creates Heatmap config when all required fields are present', async () => {
     const onChange = jest.fn();
     const heatMapConfig = widgetConfig.toBuilder()

--- a/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/VisualizationElement.ts
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/VisualizationElement.ts
@@ -56,7 +56,7 @@ const fromConfig = (config: AggregationWidgetConfig) => ({
   visualization: {
     type: config.visualization,
     config: visualizationConfigToFormValues(config.visualization, config.visualizationConfig),
-    eventAnnotation: config.eventAnnotation,
+    eventAnnotation: config.eventAnnotation ?? false,
   },
 });
 

--- a/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/ElementConfigurationContainer.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/ElementConfigurationContainer.tsx
@@ -69,7 +69,7 @@ const ElementConfigurationContainer = forwardRef<HTMLDivElement, Props>(({ child
           <Icon name="bars" />
         </DragHandle>
       )}
-      {onRemove && <IconButton onClick={onRemove} name="trash" title={`Remove ${elementTitle}`} />}
+      {onRemove && <IconButton onClick={onRemove} name="trash-alt" title={`Remove ${elementTitle}`} />}
     </ElementActions>
   </Container>
 ));

--- a/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/VisualizationConfiguration.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/VisualizationConfiguration.tsx
@@ -99,7 +99,7 @@ const VisualizationConfiguration = () => {
       </Field>
       {isTimelineChart && supportsEventAnnotations && (
         <Field name="visualization.eventAnnotation">
-          {({ field: { name, value, onChange }, meta: { error } }) => (
+          {({ field: { name, value = false }, meta: { error } }) => (
             <Input id={`${name}-input`}
                    label="Show Event annotations"
                    error={error}
@@ -107,8 +107,8 @@ const VisualizationConfiguration = () => {
                    wrapperClassName="col-sm-1">
               <EventAnnotationCheckbox id={`${name}-input`}
                                        name={name}
-                                       onChange={onChange}
-                                       checked={value === true}
+                                       onChange={() => setFieldValue(name, !value)}
+                                       checked={value}
                                        className="pull-right" />
             </Input>
           )}

--- a/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/VisualizationConfiguration.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/VisualizationConfiguration.tsx
@@ -108,7 +108,7 @@ const VisualizationConfiguration = () => {
               <EventAnnotationCheckbox id={`${name}-input`}
                                        name={name}
                                        onChange={onChange}
-                                       checked={value}
+                                       checked={value === true}
                                        className="pull-right" />
             </Input>
           )}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

When changing the visualization type of a widget from any visualization that does not support event annotations to one that does, the event annotation checkbox becomes unusable. This is due to it being initialized with a value of `undefined`, which makes it work in an uncontrolled way. Toggling it afterwards provides a value, switching it over to a _controlled_ input, making future toggling impossible.

This change makes sure that a valid value is always passed to the checkbox, even if it's current state is `undefined`.

Fixes #10772.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.