### PR TITLE
Directly submit search bar form after selecting time range preset.

### DIFF
--- a/graylog2-web-interface/src/views/components/searchbar/TimeRangeDropdownButton.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/TimeRangeDropdownButton.test.tsx
@@ -14,12 +14,14 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import { fireEvent, render, screen } from 'wrappedTestingLibrary';
+import { fireEvent, render, screen, waitFor } from 'wrappedTestingLibrary';
+import { Formik } from 'formik';
 import * as React from 'react';
 import MockStore from 'helpers/mocking/StoreMock';
 import mockSearchClusterConfig from 'fixtures/searchClusterConfig';
 
 import TimeRangeDropdownButton from './TimeRangeDropdownButton';
+import type { Props as TimeRangeDropdownButtonProps } from './TimeRangeDropdownButton';
 
 jest.mock('stores/configurations/ConfigurationsStore', () => ({
   ConfigurationsStore: MockStore(),
@@ -36,9 +38,19 @@ jest.mock('views/stores/SearchConfigStore', () => ({
 }));
 
 describe('TimeRangeDropdownButton', () => {
+  type SUTProps = Partial<TimeRangeDropdownButtonProps> & {
+    onSubmit?: () => void
+  }
+
+  const SUTTimeRangeDropDownButton = ({ onSubmit = () => {}, ...props }: SUTProps) => (
+    <Formik initialValues={{ selectedFields: [] }} onSubmit={onSubmit}>
+      <TimeRangeDropdownButton toggleShow={() => {}} onPresetSelectOpen={() => {}} setCurrentTimeRange={() => {}} {...props}><></></TimeRangeDropdownButton>
+    </Formik>
+  );
+
   it('button can be clicked and Popover appears', async () => {
     const toggleShow = jest.fn();
-    render(<TimeRangeDropdownButton toggleShow={toggleShow} onPresetSelectOpen={() => {}} setCurrentTimeRange={() => {}}><></></TimeRangeDropdownButton>);
+    render(<SUTTimeRangeDropDownButton toggleShow={toggleShow}><></></SUTTimeRangeDropDownButton>);
 
     const timeRangeButton = screen.getByLabelText('Open Time Range Selector');
 
@@ -47,9 +59,10 @@ describe('TimeRangeDropdownButton', () => {
     expect(toggleShow).toHaveBeenCalled();
   });
 
-  it('changes time range when selecting relative time range preset', async () => {
+  it('changes time range and submits form when selecting relative time range preset', async () => {
     const setCurrentTimeRange = jest.fn();
-    render(<TimeRangeDropdownButton toggleShow={() => {}} onPresetSelectOpen={() => {}} setCurrentTimeRange={setCurrentTimeRange}><></></TimeRangeDropdownButton>);
+    const onSubmit = jest.fn();
+    render(<SUTTimeRangeDropDownButton setCurrentTimeRange={setCurrentTimeRange} onSubmit={onSubmit}><></></SUTTimeRangeDropDownButton>);
 
     const timeRangeButton = screen.getByLabelText('Open time range preset select');
     fireEvent.click(timeRangeButton);
@@ -60,5 +73,7 @@ describe('TimeRangeDropdownButton', () => {
       type: 'relative',
       range: 1800,
     });
+
+    waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
   });
 });

--- a/graylog2-web-interface/src/views/components/searchbar/TimeRangeDropdownButton.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/TimeRangeDropdownButton.tsx
@@ -18,6 +18,7 @@ import * as React from 'react';
 import { useRef } from 'react';
 import { Overlay } from 'react-overlays';
 import styled from 'styled-components';
+import { useFormikContext } from 'formik';
 
 import { TimeRange, NoTimeRangeOverride } from 'views/logic/queries/Query';
 import { ButtonGroup } from 'components/graylog';
@@ -25,7 +26,7 @@ import { ButtonGroup } from 'components/graylog';
 import RangePresetDropdown from './RangePresetDropdown';
 import TimeRangeButton from './TimeRangeButton';
 
-type Props = {
+export type Props = {
   children: React.ReactNode,
   disabled?: boolean,
   hasErrorOnMount?: boolean,
@@ -56,6 +57,7 @@ const TimeRangeDropdownButton = ({
   show,
   toggleShow,
 }: Props) => {
+  const { submitForm } = useFormikContext();
   const containerRef = useRef();
 
   const _onClick = (e) => {
@@ -68,6 +70,8 @@ const TimeRangeDropdownButton = ({
       type: 'relative',
       range: from,
     });
+
+    submitForm();
   };
 
   const _onPresetSelectToggle = (open: boolean) => {

--- a/graylog2-web-interface/src/views/components/searchbar/TimeRangeInput.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/TimeRangeInput.test.tsx
@@ -17,6 +17,7 @@
 import * as React from 'react';
 import { fireEvent, render, screen, waitFor, within } from 'wrappedTestingLibrary';
 import MockStore from 'helpers/mocking/StoreMock';
+import { Formik } from 'formik';
 
 import TimeRangeInput from 'views/components/searchbar/TimeRangeInput';
 
@@ -27,8 +28,14 @@ jest.mock('stores/configurations/ConfigurationsStore', () => ({
 describe('TimeRangeInput', () => {
   const defaultTimeRange = { type: 'relative', range: 300 };
 
+  const SUTTimeRangeInput = (props) => (
+    <Formik initialValues={{ selectedFields: [] }} onSubmit={() => {}}>
+      <TimeRangeInput value={defaultTimeRange} onChange={() => {}} {...props} />
+    </Formik>
+  );
+
   it('opens date picker dropdown when clicking button', async () => {
-    render(<TimeRangeInput value={defaultTimeRange} onChange={() => {}} />);
+    render(<SUTTimeRangeInput />);
 
     const button = await screen.findByRole('button', {
       name: /open time range selector/i,
@@ -41,7 +48,7 @@ describe('TimeRangeInput', () => {
   });
 
   it('displays relative time range of 5 minutes', async () => {
-    render(<TimeRangeInput value={defaultTimeRange} onChange={() => {}} />);
+    render(<SUTTimeRangeInput />);
 
     const from = await screen.findByTestId('from');
     await within(from).findByText(/5 minutes ago/i);
@@ -51,7 +58,7 @@ describe('TimeRangeInput', () => {
   });
 
   it('opens date picker dropdown when clicking summary', async () => {
-    render(<TimeRangeInput value={defaultTimeRange} onChange={() => {}} />);
+    render(<SUTTimeRangeInput />);
 
     fireEvent.click(await screen.findByText(/5 minutes ago/));
 
@@ -60,7 +67,7 @@ describe('TimeRangeInput', () => {
 
   it('calls callback when changing time range', async () => {
     const onChange = jest.fn();
-    render(<TimeRangeInput value={defaultTimeRange} onChange={onChange} />);
+    render(<SUTTimeRangeInput value={defaultTimeRange} onChange={onChange} />);
 
     fireEvent.click(await screen.findByText(/5 minutes ago/));
 
@@ -80,13 +87,13 @@ describe('TimeRangeInput', () => {
   });
 
   it('shows "No Override" if no time range is provided', async () => {
-    render(<TimeRangeInput value={{}} onChange={() => {}} />);
+    render(<SUTTimeRangeInput value={{}} onChange={() => {}} />);
 
     await screen.findByText('No Override');
   });
 
   it('shows all tabs if no `validTypes` prop is passed', async () => {
-    render(<TimeRangeInput onChange={() => {}} value={defaultTimeRange} />);
+    render(<SUTTimeRangeInput onChange={() => {}} value={defaultTimeRange} />);
 
     fireEvent.click(await screen.findByText(/5 minutes ago/));
 
@@ -96,7 +103,7 @@ describe('TimeRangeInput', () => {
   });
 
   it('shows only valid tabs if `validTypes` prop is passed', async () => {
-    render(<TimeRangeInput onChange={() => {}} value={defaultTimeRange} validTypes={['relative']} />);
+    render(<SUTTimeRangeInput onChange={() => {}} value={defaultTimeRange} validTypes={['relative']} />);
 
     fireEvent.click(await screen.findByText(/5 minutes ago/));
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

With https://github.com/Graylog2/graylog2-server/pull/10740 we implemented a select, which lists all configured time range presets, for all search bars (search, dashboard, widget edit mode). This allows quickly changing the search time range. To speed up this process even more, we've decided to submit the search form directly after selecting a time range preset. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested with the default search, saved search, on dashboards and in the widget edit mode.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

