### PR TITLE
Reduce `z-index` of widget focus container to fix stack order problem with sidebar and search bar streams filter.

### DIFF
--- a/graylog2-web-interface/src/views/components/AdaptableQueryTabs.tsx
+++ b/graylog2-web-interface/src/views/components/AdaptableQueryTabs.tsx
@@ -50,7 +50,6 @@ const StyledQueryNav = styled(Nav)(({ theme }) => css`
     border-bottom: 0;
     display: flex;
     white-space: nowrap;
-    z-index: 2; /* without it renders under widget management icons */
     position: relative;
     margin-bottom: -1px;
     padding-left: ${NAV_PADDING}px;

--- a/graylog2-web-interface/src/views/components/WidgetContainer.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetContainer.tsx
@@ -43,7 +43,7 @@ const WidgetContainer = ({ children, className, isFocused, style, ...rest }: Pro
       ...containerStyle,
       height: '100%',
       width: '100%',
-      zIndex: 5,
+      zIndex: 1,
       top: 0,
       left: 0,
     };

--- a/graylog2-web-interface/src/views/components/widgets/WidgetHeader.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/WidgetHeader.jsx
@@ -41,7 +41,6 @@ const WidgetDragHandle = styled(Icon)`
 
 const WidgetActionDropdown = styled.span`
   position: relative;
-  z-index: 1;
 `;
 
 const WidgetHeader = ({ children, onRename, hideDragHandle, title, loading }) => (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Before this change the widget focus / edit container had a higher `z-index` than:
- the sidebar overlay
![image](https://user-images.githubusercontent.com/46300478/120653744-46a55e00-c481-11eb-8138-36c69eb4218b.png)

- the search bar streams filter
![image](https://user-images.githubusercontent.com/46300478/120653601-237aae80-c481-11eb-8ee1-cd7825e86325.png)

This PR is fixing both problems by defining a lower `z-index` for the widget focus.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested with Chrome, Safari , Firefox and IE11 (because we added the `WidgetActionDropdown` in an IE11 related PR.)

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

