### PR TITLE
Fixing layout of empty aggregation.

### DIFF
--- a/graylog2-web-interface/src/views/components/aggregationbuilder/EmptyAggregationContent.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/EmptyAggregationContent.tsx
@@ -35,6 +35,10 @@ const Container = styled.div`
   height: inherit;
 `;
 
+const SpacedHeading = styled.h2`
+  margin-bottom: 20px;
+`;
+
 const EmptyAggregationContent = ({ toggleEdit, editing = false }: Props) => {
   const onRenderComplete = useContext(RenderCompletionCallback);
 
@@ -57,7 +61,7 @@ const EmptyAggregationContent = ({ toggleEdit, editing = false }: Props) => {
   return (
     <Container>
       <div>
-        <h2>Empty Aggregation</h2>
+        <SpacedHeading>Empty Aggregation</SpacedHeading>
 
         {text}
       </div>

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/EmptyAggregationContent.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/EmptyAggregationContent.tsx
@@ -15,7 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import React, { useContext, useEffect } from 'react';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
 import { Button } from 'components/graylog';
 import RenderCompletionCallback from 'views/components/widgets/RenderCompletionCallback';
@@ -35,9 +35,9 @@ const Container = styled.div`
   height: inherit;
 `;
 
-const SpacedHeading = styled.h2`
-  margin-bottom: 20px;
-`;
+const SpacedHeading = styled.h2(({ theme }) => css`
+  margin-bottom: ${theme.spacings.sm};
+`);
 
 const EmptyAggregationContent = ({ toggleEdit, editing = false }: Props) => {
   const onRenderComplete = useContext(RenderCompletionCallback);

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/EmptyAggregationContent.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/EmptyAggregationContent.tsx
@@ -15,8 +15,9 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import React, { useContext, useEffect } from 'react';
+import styled from 'styled-components';
 
-import { Jumbotron, Button } from 'components/graylog';
+import { Button } from 'components/graylog';
 import RenderCompletionCallback from 'views/components/widgets/RenderCompletionCallback';
 
 import InteractiveContext from '../contexts/InteractiveContext';
@@ -25,6 +26,14 @@ type Props = {
   toggleEdit: () => void,
   editing: boolean,
 };
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: inherit;
+`;
 
 const EmptyAggregationContent = ({ toggleEdit, editing = false }: Props) => {
   const onRenderComplete = useContext(RenderCompletionCallback);
@@ -46,11 +55,13 @@ const EmptyAggregationContent = ({ toggleEdit, editing = false }: Props) => {
     : (<p>Please {interactive ? <Button bsStyle="info" onClick={toggleEdit}>Edit</Button> : 'edit'} the widget to see results here.</p>);
 
   return (
-    <Jumbotron>
-      <h2>Empty Aggregation</h2>
-      <br />
-      {text}
-    </Jumbotron>
+    <Container>
+      <div>
+        <h2>Empty Aggregation</h2>
+
+        {text}
+      </div>
+    </Container>
   );
 };
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is fixing the layout of the empty aggregation content shown when
a new aggregation with empty configuration is added. Prior to this PR,
the widget's time range was not shown at the bottom right of the frame
on a dashboard and the content was not properly centered. This is fixed
in this PR.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

Before:

![image](https://user-images.githubusercontent.com/41929/120657320-acdfb000-c484-11eb-89d8-639de319bc76.png)

After:

![image](https://user-images.githubusercontent.com/41929/120657164-8de11e00-c484-11eb-87c2-62f76a441a83.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.