### PR TITLE
Adding a pixel of space below query tabs.

### DIFF
--- a/graylog2-web-interface/src/views/components/AdaptableQueryTabs.tsx
+++ b/graylog2-web-interface/src/views/components/AdaptableQueryTabs.tsx
@@ -51,7 +51,6 @@ const StyledQueryNav = styled(Nav)(({ theme }) => css`
     display: flex;
     white-space: nowrap;
     position: relative;
-    margin-bottom: -1px;
     padding-left: ${NAV_PADDING}px;
 
     > li {

--- a/graylog2-web-interface/src/views/components/QueryTabs.tsx
+++ b/graylog2-web-interface/src/views/components/QueryTabs.tsx
@@ -18,7 +18,6 @@ import * as React from 'react';
 import { useRef } from 'react';
 import * as Immutable from 'immutable';
 import PropTypes from 'prop-types';
-import styled from 'styled-components';
 import { SizeMe } from 'react-sizeme';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import { OrderedSet } from 'immutable';
@@ -40,15 +39,11 @@ export interface QueryTabsProps {
   titles: Immutable.Map<string, string>,
 }
 
-const StyledRow = styled(Row)`
-  margin-bottom: 1px;
-`;
-
 const QueryTabs = ({ onRemove, onSelect, onTitleChange, queries, selectedQueryId, titles }: QueryTabsProps) => {
   const queryTitleEditModal = useRef<QueryTitleEditModal | undefined | null>();
 
   return (
-    <StyledRow>
+    <Row>
       <Col>
         <SizeMe>
           {({ size }) => (size.width ? (
@@ -71,7 +66,7 @@ const QueryTabs = ({ onRemove, onSelect, onTitleChange, queries, selectedQueryId
         <QueryTitleEditModal onTitleChange={(newTitle: string) => onTitleChange(selectedQueryId, newTitle)}
                              ref={queryTitleEditModal} />
       </Col>
-    </StyledRow>
+    </Row>
   );
 };
 

--- a/graylog2-web-interface/src/views/components/QueryTabs.tsx
+++ b/graylog2-web-interface/src/views/components/QueryTabs.tsx
@@ -41,7 +41,7 @@ export interface QueryTabsProps {
 }
 
 const StyledRow = styled(Row)`
-  margin-bottom: 0;
+  margin-bottom: 1px;
 `;
 
 const QueryTabs = ({ onRemove, onSelect, onTitleChange, queries, selectedQueryId, titles }: QueryTabsProps) => {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This is a tiny styling fix that just cleans up styling and through this adds a pixel of space below the query tabs in order to prevent its lower border overlapping with the widget borders below it.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

Before:

![image](https://user-images.githubusercontent.com/41929/120658532-ce8d6700-c485-11eb-8862-7e56fe83e1ee.png)

After:
![image](https://user-images.githubusercontent.com/41929/120658420-b9183d00-c485-11eb-9bf1-21e71d859646.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.