### PR TITLE
Allow hiding preset dropdown of date time picker.

### DIFF
--- a/graylog2-web-interface/src/views/components/searchbar/TimeRangeDropdownButton.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/TimeRangeDropdownButton.tsx
@@ -33,6 +33,7 @@ type Props = {
   setCurrentTimeRange: (nextTimeRange: TimeRange | NoTimeRangeOverride) => void,
   show?: boolean,
   toggleShow: () => void,
+  showPresetDropdown?: boolean,
 };
 
 const StyledRangePresetDropdown = styled(RangePresetDropdown)`
@@ -54,6 +55,7 @@ const TimeRangeDropdownButton = ({
   onPresetSelectOpen,
   setCurrentTimeRange,
   show,
+  showPresetDropdown = true,
   toggleShow,
 }: Props) => {
   const containerRef = useRef();
@@ -76,18 +78,24 @@ const TimeRangeDropdownButton = ({
     }
   };
 
+  const dropdown = showPresetDropdown
+    ? (
+      <StyledRangePresetDropdown disabled={disabled}
+                                 displayTitle={false}
+                                 onChange={selectRelativeTimeRangePreset}
+                                 onToggle={_onPresetSelectToggle}
+                                 header="From (Until Now)"
+                                 bsSize={null} />
+    )
+    : null;
+
   return (
     <RelativePosition ref={containerRef}>
       <StyledButtonGroup>
         <TimeRangeButton hasError={hasErrorOnMount}
                          disabled={disabled}
                          onClick={_onClick} />
-        <StyledRangePresetDropdown disabled={disabled}
-                                   displayTitle={false}
-                                   onChange={selectRelativeTimeRangePreset}
-                                   onToggle={_onPresetSelectToggle}
-                                   header="From (Until Now)"
-                                   bsSize={null} />
+        {dropdown}
       </StyledButtonGroup>
       <Overlay show={show}
                trigger="click"
@@ -104,6 +112,7 @@ TimeRangeDropdownButton.defaultProps = {
   hasErrorOnMount: false,
   disabled: false,
   show: false,
+  showPresetDropdown: true,
 };
 
 export default TimeRangeDropdownButton;

--- a/graylog2-web-interface/src/views/components/searchbar/TimeRangeInput.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/TimeRangeInput.test.tsx
@@ -105,4 +105,22 @@ describe('TimeRangeInput', () => {
     expect(screen.queryByRole('tab', { name: 'Keyword' })).not.toBeInTheDocument();
     expect(screen.queryByRole('tab', { name: 'Absolute' })).not.toBeInTheDocument();
   });
+
+  it('shows a dropdown button allowing to quick-select presets', async () => {
+    render(<TimeRangeInput onChange={() => {}} value={defaultTimeRange} validTypes={['relative']} />);
+
+    const dropdown = await screen.findByRole('button', { name: /open time range preset select/i });
+
+    fireEvent.click(dropdown);
+
+    await screen.findByRole('heading', { name: 'From (Until Now)' });
+  });
+
+  it('allows hiding the dropdown button for quick-selecting presets', async () => {
+    render(<TimeRangeInput onChange={() => {}} value={defaultTimeRange} validTypes={['relative']} showPresetDropdown={false} />);
+
+    await screen.findByText(/5 minutes ago/);
+
+    expect(screen.queryByRole('button', { name: /open time range preset select/i })).not.toBeInTheDocument();
+  });
 });

--- a/graylog2-web-interface/src/views/components/searchbar/TimeRangeInput.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/TimeRangeInput.tsx
@@ -32,6 +32,7 @@ type Props = {
   noOverride?: boolean,
   onChange: (nextTimeRange: TimeRange | NoTimeRangeOverride) => void,
   position?: 'bottom'|'right',
+  showPresetDropdown?: boolean,
   validTypes?: Array<TimeRangeType>,
   value: TimeRange | NoTimeRangeOverride,
 };
@@ -42,7 +43,7 @@ const FlexContainer = styled.span`
   justify-content: space-between;
 `;
 
-const TimeRangeInput = ({ disabled, hasErrorOnMount, noOverride, value = {}, onChange, validTypes, position, className }: Props) => {
+const TimeRangeInput = ({ disabled, hasErrorOnMount, noOverride, value = {}, onChange, validTypes, position, className, showPresetDropdown = true }: Props) => {
   const [show, setShow] = useState(false);
 
   if (validTypes && value && 'type' in value && !validTypes.includes(value?.type)) {
@@ -59,6 +60,7 @@ const TimeRangeInput = ({ disabled, hasErrorOnMount, noOverride, value = {}, onC
                                toggleShow={toggleShow}
                                onPresetSelectOpen={hideTimeRangeDropDown}
                                setCurrentTimeRange={onChange}
+                               showPresetDropdown={showPresetDropdown}
                                hasErrorOnMount={hasErrorOnMount}>
         <TimeRangeDropdown currentTimeRange={value}
                            noOverride={noOverride}
@@ -87,6 +89,7 @@ TimeRangeInput.defaultProps = {
   noOverride: false,
   validTypes: undefined,
   position: 'bottom',
+  showPresetDropdown: true,
 };
 
 export default TimeRangeInput;


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is introducing a `showPresetDropdown` prop for the `TimeRangeInput` component, allowing to show/hide the preset dropdown button. This is useful when this component is reused in places where it is used to select a time range, but it is not desired for the change to have an immediate effect.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.