### PR TITLE
Close response on all non-successful response codes

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/lookup/adapters/dsvhttp/HTTPFileRetriever.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/adapters/dsvhttp/HTTPFileRetriever.java
@@ -146,6 +146,7 @@ public class HTTPFileRetriever {
 
             return response;
         } else {
+            response.close();
             if (response.code() != 304) {
                 throw new IOException("Request failed: " + response.message());
             }


### PR DESCRIPTION
## Description

Currently, when the `HTTPFileRetriever` includes the `If-Modified-Since` header and the file has not been changed, it returns `null` and fails to close the OkHttp `Response`.  This change ensures the `Response` object gets closed on any non-successful HTTP response code, including 304 Not Modified.

## How Has This Been Tested?
Tested locally by setting the URLhaus data adapter to refresh on a 2 minute interval, guaranteeing a 304 response.  Verified in the debugger that the OkHttp `Response` object was being closed and that there were no warning log messages about leaked connections.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

