### PR TITLE
Improving error logging for failed version probe requests.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/storage/versionprobe/Error.java
+++ b/graylog2-server/src/main/java/org/graylog2/storage/versionprobe/Error.java
@@ -1,0 +1,29 @@
+package org.graylog2.storage.versionprobe;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+
+import javax.annotation.Nullable;
+import java.util.Optional;
+
+@AutoValue
+@JsonAutoDetect
+@JsonIgnoreProperties(ignoreUnknown = true)
+public abstract class Error {
+    public abstract Optional<String> type();
+    public abstract Optional<String> reason();
+
+    @JsonCreator
+    public static Error create(@JsonProperty("type") @Nullable String type,
+                               @JsonProperty("reason") @Nullable String reason) {
+        return new AutoValue_Error(Optional.ofNullable(type), Optional.ofNullable(reason));
+    }
+
+    @Override
+    public String toString() {
+        return "type: " + type().orElse("n/a") + " - reason: " + reason().orElse("n/a");
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/storage/versionprobe/Error.java
+++ b/graylog2-server/src/main/java/org/graylog2/storage/versionprobe/Error.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog2.storage.versionprobe;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;

--- a/graylog2-server/src/main/java/org/graylog2/storage/versionprobe/ErrorResponse.java
+++ b/graylog2-server/src/main/java/org/graylog2/storage/versionprobe/ErrorResponse.java
@@ -1,0 +1,27 @@
+package org.graylog2.storage.versionprobe;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+
+import javax.annotation.Nullable;
+import java.util.Optional;
+
+@AutoValue
+@JsonAutoDetect
+@JsonIgnoreProperties(ignoreUnknown = true)
+public abstract class ErrorResponse {
+    public abstract Optional<Error> error();
+
+    @JsonCreator
+    public static ErrorResponse create(@JsonProperty("error") @Nullable Error error) {
+        return new AutoValue_ErrorResponse(Optional.ofNullable(error));
+    }
+
+    @Override
+    public String toString() {
+        return "Error response: " + error().map(Error::toString).orElse("unknown");
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/storage/versionprobe/ErrorResponse.java
+++ b/graylog2-server/src/main/java/org/graylog2/storage/versionprobe/ErrorResponse.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog2.storage.versionprobe;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;

--- a/graylog2-server/src/main/java/org/graylog2/storage/versionprobe/VersionProbe.java
+++ b/graylog2-server/src/main/java/org/graylog2/storage/versionprobe/VersionProbe.java
@@ -26,9 +26,11 @@ import com.google.common.base.Strings;
 import okhttp3.Credentials;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
+import okhttp3.ResponseBody;
 import org.graylog2.plugin.Version;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import retrofit2.Converter;
 import retrofit2.Response;
 import retrofit2.Retrofit;
 import retrofit2.converter.jackson.JacksonConverterFactory;
@@ -36,11 +38,13 @@ import retrofit2.converter.jackson.JacksonConverterFactory;
 import javax.inject.Inject;
 import javax.inject.Named;
 import java.io.IOException;
+import java.lang.annotation.Annotation;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
+import java.util.function.Consumer;
 
 public class VersionProbe {
     private static final Logger LOG = LoggerFactory.getLogger(VersionProbe.class);
@@ -99,7 +103,18 @@ public class VersionProbe {
 
         final RootRoute root = retrofit.create(RootRoute.class);
 
-        return rootResponse(root)
+        final Converter<ResponseBody, ErrorResponse> errorResponseConverter = retrofit.responseBodyConverter(ErrorResponse.class, new Annotation[0]);
+        final Consumer<ResponseBody> errorLogger = (responseBody) -> {
+            try {
+                final ErrorResponse errorResponse = errorResponseConverter.convert(responseBody);
+                LOG.error("Unable to retrieve version from Elasticsearch node {}:{}: {}", host.getHost(), host.getPort(), errorResponse);
+            } catch (IOException e) {
+                LOG.error("Unable to retrieve version from Elasticsearch node {}:{}: unknown error - an exception occurred while deserializing error response: {}", host.getHost(), host.getPort(), e);
+            }
+        };
+
+
+        return rootResponse(root, errorLogger)
                 .map(RootResponse::version)
                 .map(VersionResponse::number)
                 .flatMap(this::parseVersion);
@@ -135,11 +150,13 @@ public class VersionProbe {
         }
     }
 
-    private Optional<RootResponse> rootResponse(final RootRoute rootRoute) {
+    private Optional<RootResponse> rootResponse(final RootRoute rootRoute, Consumer<ResponseBody> errorLogger) {
         try {
             final Response<RootResponse> response = rootRoute.root().execute();
             if (response.isSuccessful()) {
                 return Optional.ofNullable(response.body());
+            } else {
+                errorLogger.accept(response.errorBody());
             }
         } catch (IOException e) {
             LOG.error("Unable to retrieve version from Elasticsearch node: ", e);

--- a/graylog2-server/src/main/java/org/graylog2/storage/versionprobe/VersionProbe.java
+++ b/graylog2-server/src/main/java/org/graylog2/storage/versionprobe/VersionProbe.java
@@ -28,6 +28,7 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.ResponseBody;
 import org.graylog2.plugin.Version;
+import org.graylog2.shared.utilities.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import retrofit2.Converter;
@@ -159,7 +160,10 @@ public class VersionProbe {
                 errorLogger.accept(response.errorBody());
             }
         } catch (IOException e) {
-            LOG.error("Unable to retrieve version from Elasticsearch node: ", e);
+            final String error = ExceptionUtils.formatMessageCause(e);
+            final String rootCause = ExceptionUtils.formatMessageCause(ExceptionUtils.getRootCause(e));
+            LOG.error("Unable to retrieve version from Elasticsearch node: {} - {}", error, rootCause);
+            LOG.debug("Complete exception for version probe error: ", e);
         }
         return Optional.empty();
     }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Prior to this PR, the error messages of version probe request responses returning a non-200 were silently swallowed. This prevented being able to find out e.g. if an authentication error during version probing happened.

This change is now parsing the error response which is returned by ES, passing the error message to a custom error consumer during version probing. This leads to better error messages, e.g. for an authentication error:

```
2021-06-04 11:51:58,133 ERROR: org.graylog2.storage.versionprobe.VersionProbe - Unable to retrieve version from Elasticsearch node localhost:9200: Error response: type: security_exception - reason: unable to authenticate user [elastic] for REST request [/]
2021-06-04 11:51:58,215 ERROR: org.graylog2.storage.versionprobe.VersionProbe - Unable to retrieve version from Elasticsearch node localhost:19200: Error response: type: security_exception - reason: unable to authenticate user [elastic] for REST request [/]
2021-06-04 11:51:58,291 ERROR: org.graylog2.storage.versionprobe.VersionProbe - Unable to retrieve version from Elasticsearch node localhost:29200: Error response: type: security_exception - reason: unable to authenticate user [elastic] for REST request [/]
```

In addition, logging for requests which fail early or get interrupted is abbreviated. This way errors show up like this:

```
2021-06-04 12:00:27,502 ERROR: org.graylog2.storage.versionprobe.VersionProbe - Unable to retrieve version from Elasticsearch node: Failed to connect to localhost/0:0:0:0:0:0:0:1:9200. - Connection refused (Connection refused).
2021-06-04 12:00:27,503 ERROR: org.graylog2.storage.versionprobe.VersionProbe - Unable to retrieve version from Elasticsearch node: Failed to connect to localhost/0:0:0:0:0:0:0:1:19200. - Connection refused (Connection refused).
2021-06-04 12:00:27,504 ERROR: org.graylog2.storage.versionprobe.VersionProbe - Unable to retrieve version from Elasticsearch node: Failed to connect to localhost/0:0:0:0:0:0:0:1:29200. - Connection refused (Connection refused).
```

instead of this (attention, long):

<details>

```
2021-06-04 12:06:39,271 ERROR: org.graylog2.storage.versionprobe.VersionProbe - Unable to retrieve version from Elasticsearch node: 
java.net.ConnectException: Failed to connect to localhost/0:0:0:0:0:0:0:1:9200
	at okhttp3.internal.connection.RealConnection.connectSocket(RealConnection.java:265) ~[okhttp-3.14.6.jar:?]
	at okhttp3.internal.connection.RealConnection.connect(RealConnection.java:183) ~[okhttp-3.14.6.jar:?]
	at okhttp3.internal.connection.ExchangeFinder.findConnection(ExchangeFinder.java:224) ~[okhttp-3.14.6.jar:?]
	at okhttp3.internal.connection.ExchangeFinder.findHealthyConnection(ExchangeFinder.java:108) ~[okhttp-3.14.6.jar:?]
	at okhttp3.internal.connection.ExchangeFinder.find(ExchangeFinder.java:88) ~[okhttp-3.14.6.jar:?]
	at okhttp3.internal.connection.Transmitter.newExchange(Transmitter.java:169) ~[okhttp-3.14.6.jar:?]
	at okhttp3.internal.connection.ConnectInterceptor.intercept(ConnectInterceptor.java:41) ~[okhttp-3.14.6.jar:?]
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:142) ~[okhttp-3.14.6.jar:?]
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:117) ~[okhttp-3.14.6.jar:?]
	at okhttp3.internal.cache.CacheInterceptor.intercept(CacheInterceptor.java:94) ~[okhttp-3.14.6.jar:?]
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:142) ~[okhttp-3.14.6.jar:?]
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:117) ~[okhttp-3.14.6.jar:?]
	at okhttp3.internal.http.BridgeInterceptor.intercept(BridgeInterceptor.java:93) ~[okhttp-3.14.6.jar:?]
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:142) ~[okhttp-3.14.6.jar:?]
	at okhttp3.internal.http.RetryAndFollowUpInterceptor.intercept(RetryAndFollowUpInterceptor.java:88) ~[okhttp-3.14.6.jar:?]
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:142) ~[okhttp-3.14.6.jar:?]
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:117) ~[okhttp-3.14.6.jar:?]
	at org.graylog2.storage.versionprobe.VersionProbe.lambda$addAuthenticationIfPresent$2(VersionProbe.java:120) ~[classes/:?]
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:142) ~[okhttp-3.14.6.jar:?]
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:117) ~[okhttp-3.14.6.jar:?]
	at okhttp3.RealCall.getResponseWithInterceptorChain(RealCall.java:229) ~[okhttp-3.14.6.jar:?]
	at okhttp3.RealCall.execute(RealCall.java:81) ~[okhttp-3.14.6.jar:?]
	at retrofit2.OkHttpCall.execute(OkHttpCall.java:204) ~[retrofit-2.9.0.jar:?]
	at org.graylog2.storage.versionprobe.VersionProbe.rootResponse(VersionProbe.java:140) ~[classes/:?]
	at org.graylog2.storage.versionprobe.VersionProbe.probeSingleHost(VersionProbe.java:102) ~[classes/:?]
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193) ~[?:1.8.0_265]
	at java.util.ArrayList$ArrayListSpliterator.tryAdvance(ArrayList.java:1361) ~[?:1.8.0_265]
	at java.util.stream.ReferencePipeline.forEachWithCancel(ReferencePipeline.java:126) ~[?:1.8.0_265]
	at java.util.stream.AbstractPipeline.copyIntoWithCancel(AbstractPipeline.java:499) ~[?:1.8.0_265]
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:486) ~[?:1.8.0_265]
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:472) ~[?:1.8.0_265]
	at java.util.stream.FindOps$FindOp.evaluateSequential(FindOps.java:152) ~[?:1.8.0_265]
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:1.8.0_265]
	at java.util.stream.ReferencePipeline.findFirst(ReferencePipeline.java:531) ~[?:1.8.0_265]
	at org.graylog2.storage.versionprobe.VersionProbe.probeAllHosts(VersionProbe.java:83) ~[classes/:?]
	at org.graylog2.storage.versionprobe.VersionProbe.lambda$probe$1(VersionProbe.java:71) ~[classes/:?]
	at com.github.rholder.retry.AttemptTimeLimiters$NoAttemptTimeLimit.call(AttemptTimeLimiters.java:78) ~[guava-retrying-2.0.0.jar:?]
	at com.github.rholder.retry.Retryer.call(Retryer.java:160) ~[guava-retrying-2.0.0.jar:?]
	at org.graylog2.storage.versionprobe.VersionProbe.probe(VersionProbe.java:71) ~[classes/:?]
	at org.graylog2.storage.providers.ElasticsearchVersionProvider.lambda$get$1(ElasticsearchVersionProvider.java:68) ~[classes/:?]
	at org.graylog2.storage.providers.AtomicCache.get(AtomicCache.java:37) [classes/:?]
	at org.graylog2.storage.providers.ElasticsearchVersionProvider.get(ElasticsearchVersionProvider.java:67) [classes/:?]
	at org.graylog2.storage.providers.ElasticsearchVersionProvider.get(ElasticsearchVersionProvider.java:35) [classes/:?]
	at com.google.inject.internal.ProviderInternalFactory.provision(ProviderInternalFactory.java:86) [guice-5.0.1.jar:?]
	at com.google.inject.internal.BoundProviderFactory.provision(BoundProviderFactory.java:72) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ProviderInternalFactory.circularGet(ProviderInternalFactory.java:60) [guice-5.0.1.jar:?]
	at com.google.inject.internal.BoundProviderFactory.get(BoundProviderFactory.java:59) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ProviderToInternalFactoryAdapter.get(ProviderToInternalFactoryAdapter.java:40) [guice-5.0.1.jar:?]
	at com.google.inject.internal.SingletonScope$1.get(SingletonScope.java:169) [guice-5.0.1.jar:?]
	at com.google.inject.internal.InternalFactoryToProviderAdapter.get(InternalFactoryToProviderAdapter.java:45) [guice-5.0.1.jar:?]
	at com.google.inject.internal.SingleParameterInjector.inject(SingleParameterInjector.java:40) [guice-5.0.1.jar:?]
	at com.google.inject.internal.SingleParameterInjector.getAll(SingleParameterInjector.java:60) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ConstructorInjector.provision(ConstructorInjector.java:113) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ConstructorInjector.construct(ConstructorInjector.java:91) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ConstructorBindingImpl$Factory.get(ConstructorBindingImpl.java:296) [guice-5.0.1.jar:?]
	at com.google.inject.internal.BoundProviderFactory.get(BoundProviderFactory.java:58) [guice-5.0.1.jar:?]
	at com.google.inject.internal.SingleParameterInjector.inject(SingleParameterInjector.java:40) [guice-5.0.1.jar:?]
	at com.google.inject.internal.SingleParameterInjector.getAll(SingleParameterInjector.java:60) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ConstructorInjector.provision(ConstructorInjector.java:113) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ConstructorInjector.construct(ConstructorInjector.java:91) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ConstructorBindingImpl$Factory.get(ConstructorBindingImpl.java:296) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ProviderToInternalFactoryAdapter.get(ProviderToInternalFactoryAdapter.java:40) [guice-5.0.1.jar:?]
	at com.google.inject.internal.SingletonScope$1.get(SingletonScope.java:169) [guice-5.0.1.jar:?]
	at com.google.inject.internal.InternalFactoryToProviderAdapter.get(InternalFactoryToProviderAdapter.java:45) [guice-5.0.1.jar:?]
	at com.google.inject.internal.SingleParameterInjector.inject(SingleParameterInjector.java:40) [guice-5.0.1.jar:?]
	at com.google.inject.internal.SingleParameterInjector.getAll(SingleParameterInjector.java:60) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ConstructorInjector.provision(ConstructorInjector.java:113) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ConstructorInjector.construct(ConstructorInjector.java:91) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ConstructorBindingImpl$Factory.get(ConstructorBindingImpl.java:296) [guice-5.0.1.jar:?]
	at com.google.inject.internal.FactoryProxy.get(FactoryProxy.java:60) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ProviderToInternalFactoryAdapter.get(ProviderToInternalFactoryAdapter.java:40) [guice-5.0.1.jar:?]
	at com.google.inject.internal.SingletonScope$1.get(SingletonScope.java:169) [guice-5.0.1.jar:?]
	at com.google.inject.internal.InternalFactoryToProviderAdapter.get(InternalFactoryToProviderAdapter.java:45) [guice-5.0.1.jar:?]
	at com.google.inject.internal.SingleParameterInjector.inject(SingleParameterInjector.java:40) [guice-5.0.1.jar:?]
	at com.google.inject.internal.SingleParameterInjector.getAll(SingleParameterInjector.java:60) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ConstructorInjector.provision(ConstructorInjector.java:113) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ConstructorInjector.construct(ConstructorInjector.java:91) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ConstructorBindingImpl$Factory.get(ConstructorBindingImpl.java:296) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ProviderToInternalFactoryAdapter.get(ProviderToInternalFactoryAdapter.java:40) [guice-5.0.1.jar:?]
	at com.google.inject.internal.SingletonScope$1.get(SingletonScope.java:169) [guice-5.0.1.jar:?]
	at com.google.inject.internal.InternalFactoryToProviderAdapter.get(InternalFactoryToProviderAdapter.java:45) [guice-5.0.1.jar:?]
	at com.google.inject.internal.SingleParameterInjector.inject(SingleParameterInjector.java:40) [guice-5.0.1.jar:?]
	at com.google.inject.internal.SingleParameterInjector.getAll(SingleParameterInjector.java:60) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ConstructorInjector.provision(ConstructorInjector.java:113) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ConstructorInjector.construct(ConstructorInjector.java:91) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ConstructorBindingImpl$Factory.get(ConstructorBindingImpl.java:296) [guice-5.0.1.jar:?]
	at com.google.inject.internal.FactoryProxy.get(FactoryProxy.java:60) [guice-5.0.1.jar:?]
	at com.google.inject.internal.SingleParameterInjector.inject(SingleParameterInjector.java:40) [guice-5.0.1.jar:?]
	at com.google.inject.internal.SingleParameterInjector.getAll(SingleParameterInjector.java:60) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ConstructorInjector.provision(ConstructorInjector.java:113) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ConstructorInjector.construct(ConstructorInjector.java:91) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ConstructorBindingImpl$Factory.get(ConstructorBindingImpl.java:296) [guice-5.0.1.jar:?]
	at com.google.inject.internal.FactoryProxy.get(FactoryProxy.java:60) [guice-5.0.1.jar:?]
	at com.google.inject.internal.SingleParameterInjector.inject(SingleParameterInjector.java:40) [guice-5.0.1.jar:?]
	at com.google.inject.internal.SingleParameterInjector.getAll(SingleParameterInjector.java:60) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ConstructorInjector.provision(ConstructorInjector.java:113) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ConstructorInjector.construct(ConstructorInjector.java:91) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ConstructorBindingImpl$Factory.get(ConstructorBindingImpl.java:296) [guice-5.0.1.jar:?]
	at com.google.inject.internal.FactoryProxy.get(FactoryProxy.java:60) [guice-5.0.1.jar:?]
	at com.google.inject.internal.SingleParameterInjector.inject(SingleParameterInjector.java:40) [guice-5.0.1.jar:?]
	at com.google.inject.internal.RealMultibinder$RealMultibinderProvider.doProvision(RealMultibinder.java:206) [guice-5.0.1.jar:?]
	at com.google.inject.internal.RealMultibinder$RealMultibinderProvider.doProvision(RealMultibinder.java:159) [guice-5.0.1.jar:?]
	at com.google.inject.internal.InternalProviderInstanceBindingImpl$Factory.get(InternalProviderInstanceBindingImpl.java:113) [guice-5.0.1.jar:?]
	at com.google.inject.internal.SingleParameterInjector.inject(SingleParameterInjector.java:40) [guice-5.0.1.jar:?]
	at com.google.inject.internal.SingleParameterInjector.getAll(SingleParameterInjector.java:60) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ConstructorInjector.provision(ConstructorInjector.java:113) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ConstructorInjector.construct(ConstructorInjector.java:91) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ConstructorBindingImpl$Factory.get(ConstructorBindingImpl.java:296) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ProviderToInternalFactoryAdapter.get(ProviderToInternalFactoryAdapter.java:40) [guice-5.0.1.jar:?]
	at com.google.inject.internal.SingletonScope$1.get(SingletonScope.java:169) [guice-5.0.1.jar:?]
	at com.google.inject.internal.InternalFactoryToProviderAdapter.get(InternalFactoryToProviderAdapter.java:45) [guice-5.0.1.jar:?]
	at com.google.inject.internal.FactoryProxy.get(FactoryProxy.java:60) [guice-5.0.1.jar:?]
	at com.google.inject.internal.SingleParameterInjector.inject(SingleParameterInjector.java:40) [guice-5.0.1.jar:?]
	at com.google.inject.internal.RealMultibinder$RealMultibinderProvider.doProvision(RealMultibinder.java:206) [guice-5.0.1.jar:?]
	at com.google.inject.internal.RealMultibinder$RealMultibinderProvider.doProvision(RealMultibinder.java:159) [guice-5.0.1.jar:?]
	at com.google.inject.internal.InternalProviderInstanceBindingImpl$Factory.get(InternalProviderInstanceBindingImpl.java:113) [guice-5.0.1.jar:?]
	at com.google.inject.internal.SingleFieldInjector.inject(SingleFieldInjector.java:50) [guice-5.0.1.jar:?]
	at com.google.inject.internal.MembersInjectorImpl.injectMembers(MembersInjectorImpl.java:146) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ConstructorInjector.provision(ConstructorInjector.java:124) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ConstructorInjector.construct(ConstructorInjector.java:91) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ConstructorBindingImpl$Factory.get(ConstructorBindingImpl.java:296) [guice-5.0.1.jar:?]
	at com.google.inject.internal.BoundProviderFactory.get(BoundProviderFactory.java:58) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ProviderToInternalFactoryAdapter.get(ProviderToInternalFactoryAdapter.java:40) [guice-5.0.1.jar:?]
	at com.google.inject.internal.SingletonScope$1.get(SingletonScope.java:169) [guice-5.0.1.jar:?]
	at com.google.inject.internal.InternalFactoryToProviderAdapter.get(InternalFactoryToProviderAdapter.java:45) [guice-5.0.1.jar:?]
	at com.google.inject.internal.InternalInjectorCreator.loadEagerSingletons(InternalInjectorCreator.java:213) [guice-5.0.1.jar:?]
	at com.google.inject.internal.InternalInjectorCreator.injectDynamically(InternalInjectorCreator.java:186) [guice-5.0.1.jar:?]
	at com.google.inject.internal.InternalInjectorCreator.build(InternalInjectorCreator.java:113) [guice-5.0.1.jar:?]
	at com.google.inject.Guice.createInjector(Guice.java:87) [guice-5.0.1.jar:?]
	at org.graylog2.shared.bindings.GuiceInjectorHolder.createInjector(GuiceInjectorHolder.java:34) [classes/:?]
	at org.graylog2.bootstrap.CmdLineTool.setupInjector(CmdLineTool.java:408) [classes/:?]
	at org.graylog2.bootstrap.CmdLineTool.run(CmdLineTool.java:230) [classes/:?]
	at org.graylog2.bootstrap.Main.main(Main.java:45) [classes/:?]
Caused by: java.net.ConnectException: Connection refused (Connection refused)
	at java.net.PlainSocketImpl.socketConnect(Native Method) ~[?:1.8.0_265]
	at java.net.AbstractPlainSocketImpl.doConnect(AbstractPlainSocketImpl.java:350) ~[?:1.8.0_265]
	at java.net.AbstractPlainSocketImpl.connectToAddress(AbstractPlainSocketImpl.java:206) ~[?:1.8.0_265]
	at java.net.AbstractPlainSocketImpl.connect(AbstractPlainSocketImpl.java:188) ~[?:1.8.0_265]
	at java.net.SocksSocketImpl.connect(SocksSocketImpl.java:392) ~[?:1.8.0_265]
	at java.net.Socket.connect(Socket.java:607) ~[?:1.8.0_265]
	at okhttp3.internal.platform.Platform.connectSocket(Platform.java:130) ~[okhttp-3.14.6.jar:?]
	at okhttp3.internal.connection.RealConnection.connectSocket(RealConnection.java:263) ~[okhttp-3.14.6.jar:?]
	... 132 more
2021-06-04 12:06:39,279 ERROR: org.graylog2.storage.versionprobe.VersionProbe - Unable to retrieve version from Elasticsearch node: 
java.net.ConnectException: Failed to connect to localhost/0:0:0:0:0:0:0:1:19200
	at okhttp3.internal.connection.RealConnection.connectSocket(RealConnection.java:265) ~[okhttp-3.14.6.jar:?]
	at okhttp3.internal.connection.RealConnection.connect(RealConnection.java:183) ~[okhttp-3.14.6.jar:?]
	at okhttp3.internal.connection.ExchangeFinder.findConnection(ExchangeFinder.java:224) ~[okhttp-3.14.6.jar:?]
	at okhttp3.internal.connection.ExchangeFinder.findHealthyConnection(ExchangeFinder.java:108) ~[okhttp-3.14.6.jar:?]
	at okhttp3.internal.connection.ExchangeFinder.find(ExchangeFinder.java:88) ~[okhttp-3.14.6.jar:?]
	at okhttp3.internal.connection.Transmitter.newExchange(Transmitter.java:169) ~[okhttp-3.14.6.jar:?]
	at okhttp3.internal.connection.ConnectInterceptor.intercept(ConnectInterceptor.java:41) ~[okhttp-3.14.6.jar:?]
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:142) ~[okhttp-3.14.6.jar:?]
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:117) ~[okhttp-3.14.6.jar:?]
	at okhttp3.internal.cache.CacheInterceptor.intercept(CacheInterceptor.java:94) ~[okhttp-3.14.6.jar:?]
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:142) ~[okhttp-3.14.6.jar:?]
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:117) ~[okhttp-3.14.6.jar:?]
	at okhttp3.internal.http.BridgeInterceptor.intercept(BridgeInterceptor.java:93) ~[okhttp-3.14.6.jar:?]
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:142) ~[okhttp-3.14.6.jar:?]
	at okhttp3.internal.http.RetryAndFollowUpInterceptor.intercept(RetryAndFollowUpInterceptor.java:88) ~[okhttp-3.14.6.jar:?]
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:142) ~[okhttp-3.14.6.jar:?]
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:117) ~[okhttp-3.14.6.jar:?]
	at org.graylog2.storage.versionprobe.VersionProbe.lambda$addAuthenticationIfPresent$2(VersionProbe.java:120) ~[classes/:?]
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:142) ~[okhttp-3.14.6.jar:?]
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:117) ~[okhttp-3.14.6.jar:?]
	at okhttp3.RealCall.getResponseWithInterceptorChain(RealCall.java:229) ~[okhttp-3.14.6.jar:?]
	at okhttp3.RealCall.execute(RealCall.java:81) ~[okhttp-3.14.6.jar:?]
	at retrofit2.OkHttpCall.execute(OkHttpCall.java:204) ~[retrofit-2.9.0.jar:?]
	at org.graylog2.storage.versionprobe.VersionProbe.rootResponse(VersionProbe.java:140) ~[classes/:?]
	at org.graylog2.storage.versionprobe.VersionProbe.probeSingleHost(VersionProbe.java:102) ~[classes/:?]
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193) ~[?:1.8.0_265]
	at java.util.ArrayList$ArrayListSpliterator.tryAdvance(ArrayList.java:1361) ~[?:1.8.0_265]
	at java.util.stream.ReferencePipeline.forEachWithCancel(ReferencePipeline.java:126) ~[?:1.8.0_265]
	at java.util.stream.AbstractPipeline.copyIntoWithCancel(AbstractPipeline.java:499) ~[?:1.8.0_265]
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:486) ~[?:1.8.0_265]
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:472) ~[?:1.8.0_265]
	at java.util.stream.FindOps$FindOp.evaluateSequential(FindOps.java:152) ~[?:1.8.0_265]
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:1.8.0_265]
	at java.util.stream.ReferencePipeline.findFirst(ReferencePipeline.java:531) ~[?:1.8.0_265]
	at org.graylog2.storage.versionprobe.VersionProbe.probeAllHosts(VersionProbe.java:83) ~[classes/:?]
	at org.graylog2.storage.versionprobe.VersionProbe.lambda$probe$1(VersionProbe.java:71) ~[classes/:?]
	at com.github.rholder.retry.AttemptTimeLimiters$NoAttemptTimeLimit.call(AttemptTimeLimiters.java:78) ~[guava-retrying-2.0.0.jar:?]
	at com.github.rholder.retry.Retryer.call(Retryer.java:160) ~[guava-retrying-2.0.0.jar:?]
	at org.graylog2.storage.versionprobe.VersionProbe.probe(VersionProbe.java:71) ~[classes/:?]
	at org.graylog2.storage.providers.ElasticsearchVersionProvider.lambda$get$1(ElasticsearchVersionProvider.java:68) ~[classes/:?]
	at org.graylog2.storage.providers.AtomicCache.get(AtomicCache.java:37) [classes/:?]
	at org.graylog2.storage.providers.ElasticsearchVersionProvider.get(ElasticsearchVersionProvider.java:67) [classes/:?]
	at org.graylog2.storage.providers.ElasticsearchVersionProvider.get(ElasticsearchVersionProvider.java:35) [classes/:?]
	at com.google.inject.internal.ProviderInternalFactory.provision(ProviderInternalFactory.java:86) [guice-5.0.1.jar:?]
	at com.google.inject.internal.BoundProviderFactory.provision(BoundProviderFactory.java:72) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ProviderInternalFactory.circularGet(ProviderInternalFactory.java:60) [guice-5.0.1.jar:?]
	at com.google.inject.internal.BoundProviderFactory.get(BoundProviderFactory.java:59) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ProviderToInternalFactoryAdapter.get(ProviderToInternalFactoryAdapter.java:40) [guice-5.0.1.jar:?]
	at com.google.inject.internal.SingletonScope$1.get(SingletonScope.java:169) [guice-5.0.1.jar:?]
	at com.google.inject.internal.InternalFactoryToProviderAdapter.get(InternalFactoryToProviderAdapter.java:45) [guice-5.0.1.jar:?]
	at com.google.inject.internal.SingleParameterInjector.inject(SingleParameterInjector.java:40) [guice-5.0.1.jar:?]
	at com.google.inject.internal.SingleParameterInjector.getAll(SingleParameterInjector.java:60) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ConstructorInjector.provision(ConstructorInjector.java:113) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ConstructorInjector.construct(ConstructorInjector.java:91) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ConstructorBindingImpl$Factory.get(ConstructorBindingImpl.java:296) [guice-5.0.1.jar:?]
	at com.google.inject.internal.BoundProviderFactory.get(BoundProviderFactory.java:58) [guice-5.0.1.jar:?]
	at com.google.inject.internal.SingleParameterInjector.inject(SingleParameterInjector.java:40) [guice-5.0.1.jar:?]
	at com.google.inject.internal.SingleParameterInjector.getAll(SingleParameterInjector.java:60) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ConstructorInjector.provision(ConstructorInjector.java:113) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ConstructorInjector.construct(ConstructorInjector.java:91) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ConstructorBindingImpl$Factory.get(ConstructorBindingImpl.java:296) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ProviderToInternalFactoryAdapter.get(ProviderToInternalFactoryAdapter.java:40) [guice-5.0.1.jar:?]
	at com.google.inject.internal.SingletonScope$1.get(SingletonScope.java:169) [guice-5.0.1.jar:?]
	at com.google.inject.internal.InternalFactoryToProviderAdapter.get(InternalFactoryToProviderAdapter.java:45) [guice-5.0.1.jar:?]
	at com.google.inject.internal.SingleParameterInjector.inject(SingleParameterInjector.java:40) [guice-5.0.1.jar:?]
	at com.google.inject.internal.SingleParameterInjector.getAll(SingleParameterInjector.java:60) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ConstructorInjector.provision(ConstructorInjector.java:113) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ConstructorInjector.construct(ConstructorInjector.java:91) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ConstructorBindingImpl$Factory.get(ConstructorBindingImpl.java:296) [guice-5.0.1.jar:?]
	at com.google.inject.internal.FactoryProxy.get(FactoryProxy.java:60) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ProviderToInternalFactoryAdapter.get(ProviderToInternalFactoryAdapter.java:40) [guice-5.0.1.jar:?]
	at com.google.inject.internal.SingletonScope$1.get(SingletonScope.java:169) [guice-5.0.1.jar:?]
	at com.google.inject.internal.InternalFactoryToProviderAdapter.get(InternalFactoryToProviderAdapter.java:45) [guice-5.0.1.jar:?]
	at com.google.inject.internal.SingleParameterInjector.inject(SingleParameterInjector.java:40) [guice-5.0.1.jar:?]
	at com.google.inject.internal.SingleParameterInjector.getAll(SingleParameterInjector.java:60) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ConstructorInjector.provision(ConstructorInjector.java:113) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ConstructorInjector.construct(ConstructorInjector.java:91) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ConstructorBindingImpl$Factory.get(ConstructorBindingImpl.java:296) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ProviderToInternalFactoryAdapter.get(ProviderToInternalFactoryAdapter.java:40) [guice-5.0.1.jar:?]
	at com.google.inject.internal.SingletonScope$1.get(SingletonScope.java:169) [guice-5.0.1.jar:?]
	at com.google.inject.internal.InternalFactoryToProviderAdapter.get(InternalFactoryToProviderAdapter.java:45) [guice-5.0.1.jar:?]
	at com.google.inject.internal.SingleParameterInjector.inject(SingleParameterInjector.java:40) [guice-5.0.1.jar:?]
	at com.google.inject.internal.SingleParameterInjector.getAll(SingleParameterInjector.java:60) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ConstructorInjector.provision(ConstructorInjector.java:113) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ConstructorInjector.construct(ConstructorInjector.java:91) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ConstructorBindingImpl$Factory.get(ConstructorBindingImpl.java:296) [guice-5.0.1.jar:?]
	at com.google.inject.internal.FactoryProxy.get(FactoryProxy.java:60) [guice-5.0.1.jar:?]
	at com.google.inject.internal.SingleParameterInjector.inject(SingleParameterInjector.java:40) [guice-5.0.1.jar:?]
	at com.google.inject.internal.SingleParameterInjector.getAll(SingleParameterInjector.java:60) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ConstructorInjector.provision(ConstructorInjector.java:113) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ConstructorInjector.construct(ConstructorInjector.java:91) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ConstructorBindingImpl$Factory.get(ConstructorBindingImpl.java:296) [guice-5.0.1.jar:?]
	at com.google.inject.internal.FactoryProxy.get(FactoryProxy.java:60) [guice-5.0.1.jar:?]
	at com.google.inject.internal.SingleParameterInjector.inject(SingleParameterInjector.java:40) [guice-5.0.1.jar:?]
	at com.google.inject.internal.SingleParameterInjector.getAll(SingleParameterInjector.java:60) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ConstructorInjector.provision(ConstructorInjector.java:113) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ConstructorInjector.construct(ConstructorInjector.java:91) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ConstructorBindingImpl$Factory.get(ConstructorBindingImpl.java:296) [guice-5.0.1.jar:?]
	at com.google.inject.internal.FactoryProxy.get(FactoryProxy.java:60) [guice-5.0.1.jar:?]
	at com.google.inject.internal.SingleParameterInjector.inject(SingleParameterInjector.java:40) [guice-5.0.1.jar:?]
	at com.google.inject.internal.RealMultibinder$RealMultibinderProvider.doProvision(RealMultibinder.java:206) [guice-5.0.1.jar:?]
	at com.google.inject.internal.RealMultibinder$RealMultibinderProvider.doProvision(RealMultibinder.java:159) [guice-5.0.1.jar:?]
	at com.google.inject.internal.InternalProviderInstanceBindingImpl$Factory.get(InternalProviderInstanceBindingImpl.java:113) [guice-5.0.1.jar:?]
	at com.google.inject.internal.SingleParameterInjector.inject(SingleParameterInjector.java:40) [guice-5.0.1.jar:?]
	at com.google.inject.internal.SingleParameterInjector.getAll(SingleParameterInjector.java:60) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ConstructorInjector.provision(ConstructorInjector.java:113) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ConstructorInjector.construct(ConstructorInjector.java:91) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ConstructorBindingImpl$Factory.get(ConstructorBindingImpl.java:296) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ProviderToInternalFactoryAdapter.get(ProviderToInternalFactoryAdapter.java:40) [guice-5.0.1.jar:?]
	at com.google.inject.internal.SingletonScope$1.get(SingletonScope.java:169) [guice-5.0.1.jar:?]
	at com.google.inject.internal.InternalFactoryToProviderAdapter.get(InternalFactoryToProviderAdapter.java:45) [guice-5.0.1.jar:?]
	at com.google.inject.internal.FactoryProxy.get(FactoryProxy.java:60) [guice-5.0.1.jar:?]
	at com.google.inject.internal.SingleParameterInjector.inject(SingleParameterInjector.java:40) [guice-5.0.1.jar:?]
	at com.google.inject.internal.RealMultibinder$RealMultibinderProvider.doProvision(RealMultibinder.java:206) [guice-5.0.1.jar:?]
	at com.google.inject.internal.RealMultibinder$RealMultibinderProvider.doProvision(RealMultibinder.java:159) [guice-5.0.1.jar:?]
	at com.google.inject.internal.InternalProviderInstanceBindingImpl$Factory.get(InternalProviderInstanceBindingImpl.java:113) [guice-5.0.1.jar:?]
	at com.google.inject.internal.SingleFieldInjector.inject(SingleFieldInjector.java:50) [guice-5.0.1.jar:?]
	at com.google.inject.internal.MembersInjectorImpl.injectMembers(MembersInjectorImpl.java:146) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ConstructorInjector.provision(ConstructorInjector.java:124) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ConstructorInjector.construct(ConstructorInjector.java:91) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ConstructorBindingImpl$Factory.get(ConstructorBindingImpl.java:296) [guice-5.0.1.jar:?]
	at com.google.inject.internal.BoundProviderFactory.get(BoundProviderFactory.java:58) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ProviderToInternalFactoryAdapter.get(ProviderToInternalFactoryAdapter.java:40) [guice-5.0.1.jar:?]
	at com.google.inject.internal.SingletonScope$1.get(SingletonScope.java:169) [guice-5.0.1.jar:?]
	at com.google.inject.internal.InternalFactoryToProviderAdapter.get(InternalFactoryToProviderAdapter.java:45) [guice-5.0.1.jar:?]
	at com.google.inject.internal.InternalInjectorCreator.loadEagerSingletons(InternalInjectorCreator.java:213) [guice-5.0.1.jar:?]
	at com.google.inject.internal.InternalInjectorCreator.injectDynamically(InternalInjectorCreator.java:186) [guice-5.0.1.jar:?]
	at com.google.inject.internal.InternalInjectorCreator.build(InternalInjectorCreator.java:113) [guice-5.0.1.jar:?]
	at com.google.inject.Guice.createInjector(Guice.java:87) [guice-5.0.1.jar:?]
	at org.graylog2.shared.bindings.GuiceInjectorHolder.createInjector(GuiceInjectorHolder.java:34) [classes/:?]
	at org.graylog2.bootstrap.CmdLineTool.setupInjector(CmdLineTool.java:408) [classes/:?]
	at org.graylog2.bootstrap.CmdLineTool.run(CmdLineTool.java:230) [classes/:?]
	at org.graylog2.bootstrap.Main.main(Main.java:45) [classes/:?]
Caused by: java.net.ConnectException: Connection refused (Connection refused)
	at java.net.PlainSocketImpl.socketConnect(Native Method) ~[?:1.8.0_265]
	at java.net.AbstractPlainSocketImpl.doConnect(AbstractPlainSocketImpl.java:350) ~[?:1.8.0_265]
	at java.net.AbstractPlainSocketImpl.connectToAddress(AbstractPlainSocketImpl.java:206) ~[?:1.8.0_265]
	at java.net.AbstractPlainSocketImpl.connect(AbstractPlainSocketImpl.java:188) ~[?:1.8.0_265]
	at java.net.SocksSocketImpl.connect(SocksSocketImpl.java:392) ~[?:1.8.0_265]
	at java.net.Socket.connect(Socket.java:607) ~[?:1.8.0_265]
	at okhttp3.internal.platform.Platform.connectSocket(Platform.java:130) ~[okhttp-3.14.6.jar:?]
	at okhttp3.internal.connection.RealConnection.connectSocket(RealConnection.java:263) ~[okhttp-3.14.6.jar:?]
	... 132 more
2021-06-04 12:06:39,281 ERROR: org.graylog2.storage.versionprobe.VersionProbe - Unable to retrieve version from Elasticsearch node: 
java.net.ConnectException: Failed to connect to localhost/0:0:0:0:0:0:0:1:29200
	at okhttp3.internal.connection.RealConnection.connectSocket(RealConnection.java:265) ~[okhttp-3.14.6.jar:?]
	at okhttp3.internal.connection.RealConnection.connect(RealConnection.java:183) ~[okhttp-3.14.6.jar:?]
	at okhttp3.internal.connection.ExchangeFinder.findConnection(ExchangeFinder.java:224) ~[okhttp-3.14.6.jar:?]
	at okhttp3.internal.connection.ExchangeFinder.findHealthyConnection(ExchangeFinder.java:108) ~[okhttp-3.14.6.jar:?]
	at okhttp3.internal.connection.ExchangeFinder.find(ExchangeFinder.java:88) ~[okhttp-3.14.6.jar:?]
	at okhttp3.internal.connection.Transmitter.newExchange(Transmitter.java:169) ~[okhttp-3.14.6.jar:?]
	at okhttp3.internal.connection.ConnectInterceptor.intercept(ConnectInterceptor.java:41) ~[okhttp-3.14.6.jar:?]
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:142) ~[okhttp-3.14.6.jar:?]
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:117) ~[okhttp-3.14.6.jar:?]
	at okhttp3.internal.cache.CacheInterceptor.intercept(CacheInterceptor.java:94) ~[okhttp-3.14.6.jar:?]
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:142) ~[okhttp-3.14.6.jar:?]
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:117) ~[okhttp-3.14.6.jar:?]
	at okhttp3.internal.http.BridgeInterceptor.intercept(BridgeInterceptor.java:93) ~[okhttp-3.14.6.jar:?]
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:142) ~[okhttp-3.14.6.jar:?]
	at okhttp3.internal.http.RetryAndFollowUpInterceptor.intercept(RetryAndFollowUpInterceptor.java:88) ~[okhttp-3.14.6.jar:?]
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:142) ~[okhttp-3.14.6.jar:?]
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:117) ~[okhttp-3.14.6.jar:?]
	at org.graylog2.storage.versionprobe.VersionProbe.lambda$addAuthenticationIfPresent$2(VersionProbe.java:120) ~[classes/:?]
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:142) ~[okhttp-3.14.6.jar:?]
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:117) ~[okhttp-3.14.6.jar:?]
	at okhttp3.RealCall.getResponseWithInterceptorChain(RealCall.java:229) ~[okhttp-3.14.6.jar:?]
	at okhttp3.RealCall.execute(RealCall.java:81) ~[okhttp-3.14.6.jar:?]
	at retrofit2.OkHttpCall.execute(OkHttpCall.java:204) ~[retrofit-2.9.0.jar:?]
	at org.graylog2.storage.versionprobe.VersionProbe.rootResponse(VersionProbe.java:140) ~[classes/:?]
	at org.graylog2.storage.versionprobe.VersionProbe.probeSingleHost(VersionProbe.java:102) ~[classes/:?]
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193) ~[?:1.8.0_265]
	at java.util.ArrayList$ArrayListSpliterator.tryAdvance(ArrayList.java:1361) ~[?:1.8.0_265]
	at java.util.stream.ReferencePipeline.forEachWithCancel(ReferencePipeline.java:126) ~[?:1.8.0_265]
	at java.util.stream.AbstractPipeline.copyIntoWithCancel(AbstractPipeline.java:499) ~[?:1.8.0_265]
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:486) ~[?:1.8.0_265]
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:472) ~[?:1.8.0_265]
	at java.util.stream.FindOps$FindOp.evaluateSequential(FindOps.java:152) ~[?:1.8.0_265]
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:1.8.0_265]
	at java.util.stream.ReferencePipeline.findFirst(ReferencePipeline.java:531) ~[?:1.8.0_265]
	at org.graylog2.storage.versionprobe.VersionProbe.probeAllHosts(VersionProbe.java:83) ~[classes/:?]
	at org.graylog2.storage.versionprobe.VersionProbe.lambda$probe$1(VersionProbe.java:71) ~[classes/:?]
	at com.github.rholder.retry.AttemptTimeLimiters$NoAttemptTimeLimit.call(AttemptTimeLimiters.java:78) ~[guava-retrying-2.0.0.jar:?]
	at com.github.rholder.retry.Retryer.call(Retryer.java:160) ~[guava-retrying-2.0.0.jar:?]
	at org.graylog2.storage.versionprobe.VersionProbe.probe(VersionProbe.java:71) ~[classes/:?]
	at org.graylog2.storage.providers.ElasticsearchVersionProvider.lambda$get$1(ElasticsearchVersionProvider.java:68) ~[classes/:?]
	at org.graylog2.storage.providers.AtomicCache.get(AtomicCache.java:37) [classes/:?]
	at org.graylog2.storage.providers.ElasticsearchVersionProvider.get(ElasticsearchVersionProvider.java:67) [classes/:?]
	at org.graylog2.storage.providers.ElasticsearchVersionProvider.get(ElasticsearchVersionProvider.java:35) [classes/:?]
	at com.google.inject.internal.ProviderInternalFactory.provision(ProviderInternalFactory.java:86) [guice-5.0.1.jar:?]
	at com.google.inject.internal.BoundProviderFactory.provision(BoundProviderFactory.java:72) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ProviderInternalFactory.circularGet(ProviderInternalFactory.java:60) [guice-5.0.1.jar:?]
	at com.google.inject.internal.BoundProviderFactory.get(BoundProviderFactory.java:59) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ProviderToInternalFactoryAdapter.get(ProviderToInternalFactoryAdapter.java:40) [guice-5.0.1.jar:?]
	at com.google.inject.internal.SingletonScope$1.get(SingletonScope.java:169) [guice-5.0.1.jar:?]
	at com.google.inject.internal.InternalFactoryToProviderAdapter.get(InternalFactoryToProviderAdapter.java:45) [guice-5.0.1.jar:?]
	at com.google.inject.internal.SingleParameterInjector.inject(SingleParameterInjector.java:40) [guice-5.0.1.jar:?]
	at com.google.inject.internal.SingleParameterInjector.getAll(SingleParameterInjector.java:60) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ConstructorInjector.provision(ConstructorInjector.java:113) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ConstructorInjector.construct(ConstructorInjector.java:91) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ConstructorBindingImpl$Factory.get(ConstructorBindingImpl.java:296) [guice-5.0.1.jar:?]
	at com.google.inject.internal.BoundProviderFactory.get(BoundProviderFactory.java:58) [guice-5.0.1.jar:?]
	at com.google.inject.internal.SingleParameterInjector.inject(SingleParameterInjector.java:40) [guice-5.0.1.jar:?]
	at com.google.inject.internal.SingleParameterInjector.getAll(SingleParameterInjector.java:60) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ConstructorInjector.provision(ConstructorInjector.java:113) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ConstructorInjector.construct(ConstructorInjector.java:91) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ConstructorBindingImpl$Factory.get(ConstructorBindingImpl.java:296) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ProviderToInternalFactoryAdapter.get(ProviderToInternalFactoryAdapter.java:40) [guice-5.0.1.jar:?]
	at com.google.inject.internal.SingletonScope$1.get(SingletonScope.java:169) [guice-5.0.1.jar:?]
	at com.google.inject.internal.InternalFactoryToProviderAdapter.get(InternalFactoryToProviderAdapter.java:45) [guice-5.0.1.jar:?]
	at com.google.inject.internal.SingleParameterInjector.inject(SingleParameterInjector.java:40) [guice-5.0.1.jar:?]
	at com.google.inject.internal.SingleParameterInjector.getAll(SingleParameterInjector.java:60) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ConstructorInjector.provision(ConstructorInjector.java:113) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ConstructorInjector.construct(ConstructorInjector.java:91) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ConstructorBindingImpl$Factory.get(ConstructorBindingImpl.java:296) [guice-5.0.1.jar:?]
	at com.google.inject.internal.FactoryProxy.get(FactoryProxy.java:60) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ProviderToInternalFactoryAdapter.get(ProviderToInternalFactoryAdapter.java:40) [guice-5.0.1.jar:?]
	at com.google.inject.internal.SingletonScope$1.get(SingletonScope.java:169) [guice-5.0.1.jar:?]
	at com.google.inject.internal.InternalFactoryToProviderAdapter.get(InternalFactoryToProviderAdapter.java:45) [guice-5.0.1.jar:?]
	at com.google.inject.internal.SingleParameterInjector.inject(SingleParameterInjector.java:40) [guice-5.0.1.jar:?]
	at com.google.inject.internal.SingleParameterInjector.getAll(SingleParameterInjector.java:60) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ConstructorInjector.provision(ConstructorInjector.java:113) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ConstructorInjector.construct(ConstructorInjector.java:91) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ConstructorBindingImpl$Factory.get(ConstructorBindingImpl.java:296) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ProviderToInternalFactoryAdapter.get(ProviderToInternalFactoryAdapter.java:40) [guice-5.0.1.jar:?]
	at com.google.inject.internal.SingletonScope$1.get(SingletonScope.java:169) [guice-5.0.1.jar:?]
	at com.google.inject.internal.InternalFactoryToProviderAdapter.get(InternalFactoryToProviderAdapter.java:45) [guice-5.0.1.jar:?]
	at com.google.inject.internal.SingleParameterInjector.inject(SingleParameterInjector.java:40) [guice-5.0.1.jar:?]
	at com.google.inject.internal.SingleParameterInjector.getAll(SingleParameterInjector.java:60) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ConstructorInjector.provision(ConstructorInjector.java:113) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ConstructorInjector.construct(ConstructorInjector.java:91) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ConstructorBindingImpl$Factory.get(ConstructorBindingImpl.java:296) [guice-5.0.1.jar:?]
	at com.google.inject.internal.FactoryProxy.get(FactoryProxy.java:60) [guice-5.0.1.jar:?]
	at com.google.inject.internal.SingleParameterInjector.inject(SingleParameterInjector.java:40) [guice-5.0.1.jar:?]
	at com.google.inject.internal.SingleParameterInjector.getAll(SingleParameterInjector.java:60) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ConstructorInjector.provision(ConstructorInjector.java:113) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ConstructorInjector.construct(ConstructorInjector.java:91) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ConstructorBindingImpl$Factory.get(ConstructorBindingImpl.java:296) [guice-5.0.1.jar:?]
	at com.google.inject.internal.FactoryProxy.get(FactoryProxy.java:60) [guice-5.0.1.jar:?]
	at com.google.inject.internal.SingleParameterInjector.inject(SingleParameterInjector.java:40) [guice-5.0.1.jar:?]
	at com.google.inject.internal.SingleParameterInjector.getAll(SingleParameterInjector.java:60) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ConstructorInjector.provision(ConstructorInjector.java:113) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ConstructorInjector.construct(ConstructorInjector.java:91) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ConstructorBindingImpl$Factory.get(ConstructorBindingImpl.java:296) [guice-5.0.1.jar:?]
	at com.google.inject.internal.FactoryProxy.get(FactoryProxy.java:60) [guice-5.0.1.jar:?]
	at com.google.inject.internal.SingleParameterInjector.inject(SingleParameterInjector.java:40) [guice-5.0.1.jar:?]
	at com.google.inject.internal.RealMultibinder$RealMultibinderProvider.doProvision(RealMultibinder.java:206) [guice-5.0.1.jar:?]
	at com.google.inject.internal.RealMultibinder$RealMultibinderProvider.doProvision(RealMultibinder.java:159) [guice-5.0.1.jar:?]
	at com.google.inject.internal.InternalProviderInstanceBindingImpl$Factory.get(InternalProviderInstanceBindingImpl.java:113) [guice-5.0.1.jar:?]
	at com.google.inject.internal.SingleParameterInjector.inject(SingleParameterInjector.java:40) [guice-5.0.1.jar:?]
	at com.google.inject.internal.SingleParameterInjector.getAll(SingleParameterInjector.java:60) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ConstructorInjector.provision(ConstructorInjector.java:113) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ConstructorInjector.construct(ConstructorInjector.java:91) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ConstructorBindingImpl$Factory.get(ConstructorBindingImpl.java:296) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ProviderToInternalFactoryAdapter.get(ProviderToInternalFactoryAdapter.java:40) [guice-5.0.1.jar:?]
	at com.google.inject.internal.SingletonScope$1.get(SingletonScope.java:169) [guice-5.0.1.jar:?]
	at com.google.inject.internal.InternalFactoryToProviderAdapter.get(InternalFactoryToProviderAdapter.java:45) [guice-5.0.1.jar:?]
	at com.google.inject.internal.FactoryProxy.get(FactoryProxy.java:60) [guice-5.0.1.jar:?]
	at com.google.inject.internal.SingleParameterInjector.inject(SingleParameterInjector.java:40) [guice-5.0.1.jar:?]
	at com.google.inject.internal.RealMultibinder$RealMultibinderProvider.doProvision(RealMultibinder.java:206) [guice-5.0.1.jar:?]
	at com.google.inject.internal.RealMultibinder$RealMultibinderProvider.doProvision(RealMultibinder.java:159) [guice-5.0.1.jar:?]
	at com.google.inject.internal.InternalProviderInstanceBindingImpl$Factory.get(InternalProviderInstanceBindingImpl.java:113) [guice-5.0.1.jar:?]
	at com.google.inject.internal.SingleFieldInjector.inject(SingleFieldInjector.java:50) [guice-5.0.1.jar:?]
	at com.google.inject.internal.MembersInjectorImpl.injectMembers(MembersInjectorImpl.java:146) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ConstructorInjector.provision(ConstructorInjector.java:124) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ConstructorInjector.construct(ConstructorInjector.java:91) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ConstructorBindingImpl$Factory.get(ConstructorBindingImpl.java:296) [guice-5.0.1.jar:?]
	at com.google.inject.internal.BoundProviderFactory.get(BoundProviderFactory.java:58) [guice-5.0.1.jar:?]
	at com.google.inject.internal.ProviderToInternalFactoryAdapter.get(ProviderToInternalFactoryAdapter.java:40) [guice-5.0.1.jar:?]
	at com.google.inject.internal.SingletonScope$1.get(SingletonScope.java:169) [guice-5.0.1.jar:?]
	at com.google.inject.internal.InternalFactoryToProviderAdapter.get(InternalFactoryToProviderAdapter.java:45) [guice-5.0.1.jar:?]
	at com.google.inject.internal.InternalInjectorCreator.loadEagerSingletons(InternalInjectorCreator.java:213) [guice-5.0.1.jar:?]
	at com.google.inject.internal.InternalInjectorCreator.injectDynamically(InternalInjectorCreator.java:186) [guice-5.0.1.jar:?]
	at com.google.inject.internal.InternalInjectorCreator.build(InternalInjectorCreator.java:113) [guice-5.0.1.jar:?]
	at com.google.inject.Guice.createInjector(Guice.java:87) [guice-5.0.1.jar:?]
	at org.graylog2.shared.bindings.GuiceInjectorHolder.createInjector(GuiceInjectorHolder.java:34) [classes/:?]
	at org.graylog2.bootstrap.CmdLineTool.setupInjector(CmdLineTool.java:408) [classes/:?]
	at org.graylog2.bootstrap.CmdLineTool.run(CmdLineTool.java:230) [classes/:?]
	at org.graylog2.bootstrap.Main.main(Main.java:45) [classes/:?]
Caused by: java.net.ConnectException: Connection refused (Connection refused)
	at java.net.PlainSocketImpl.socketConnect(Native Method) ~[?:1.8.0_265]
	at java.net.AbstractPlainSocketImpl.doConnect(AbstractPlainSocketImpl.java:350) ~[?:1.8.0_265]
	at java.net.AbstractPlainSocketImpl.connectToAddress(AbstractPlainSocketImpl.java:206) ~[?:1.8.0_265]
	at java.net.AbstractPlainSocketImpl.connect(AbstractPlainSocketImpl.java:188) ~[?:1.8.0_265]
	at java.net.SocksSocketImpl.connect(SocksSocketImpl.java:392) ~[?:1.8.0_265]
	at java.net.Socket.connect(Socket.java:607) ~[?:1.8.0_265]
	at okhttp3.internal.platform.Platform.connectSocket(Platform.java:130) ~[okhttp-3.14.6.jar:?]
	at okhttp3.internal.connection.RealConnection.connectSocket(RealConnection.java:263) ~[okhttp-3.14.6.jar:?]
	... 132 more
```

</details>

The complete exception can still be retrieved at runtime by switching the log level to `debug`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.