### PR TITLE
Always define first search query as active query when loading view.

### DIFF
--- a/graylog2-web-interface/src/views/stores/ViewStore.ts
+++ b/graylog2-web-interface/src/views/stores/ViewStore.ts
@@ -157,7 +157,7 @@ export const ViewStore: ViewStoreType = singletonStore(
       /* Select selected query (activeQuery) or first query in view (for now).
          Selected query might become a property on the view later. */
       const queries = view.state.keySeq().toList();
-      const firstQueryId = queries.first();
+      const firstQueryId = view?.search?.queries?.first()?.id ?? queries.first();
       const selectedQuery = this.activeQuery && queries.find((id) => (id === this.activeQuery)) ? this.activeQuery : firstQueryId;
 
       this.selectQuery(selectedQuery);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

With this change we are defining the active query based on `view.search.queries` instead on `view.state`.
This way we can ensure that the active query (responsible for the active dashboard page) is always the first query.

Fixes https://github.com/Graylog2/graylog2-server/issues/10787

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

