### PR TITLE
Updated UPGRADING.rst for new Elasticsearch behavior: retry connecting on startup

### DIFF
--- a/UPGRADING.rst
+++ b/UPGRADING.rst
@@ -20,8 +20,11 @@ Changes to the Elasticsearch Support
 When you have version-probing for the used Elasticsearch version enabled, and Graylog starts up but can not
 connect to ES, the startup stopped immediately with v4.0 and prior. Starting from 4.1 the default behaviour is,
 that Graylog retries connecting with a delay until it can connect to Elasticsearch. See the Elasticsearch
-configuration page for details.
+configuration_ for details.
 
+.. _configuration: https://docs.graylog.org/en/4.1/pages/configuration/elasticsearch.html
+
+Configuration options: ``elasticsearch_version_probe_attempts`` and ``elasticsearch_version_probe_delay``.
 
 Configuration file changes
 --------------------------

--- a/UPGRADING.rst
+++ b/UPGRADING.rst
@@ -13,6 +13,16 @@ Upgrading to Graylog 4.1.x
 Breaking Changes
 ================
 
+
+Changes to the Elasticsearch Support
+------------------------------------
+
+When you have version-probing for the used Elasticsearch version enabled, and Graylog starts up but can not
+connect to ES, the startup stopped immediately with v4.0 and prior. Starting from 4.1 the default behaviour is,
+that Graylog retries connecting with a delay until it can connect to Elasticsearch. See the Elasticsearch
+configuration page for details.
+
+
 Configuration file changes
 --------------------------
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added a description for the changed default behavior with Elasticsearch on startup: now it retries in a given interval until a connection can be made if version probe is enabled.

## Motivation and Context
Doc was missing in the already merged PR

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

