### PR TITLE
Update Prometheus exporter default port

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/metrics/prometheus/PrometheusExporterConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog/metrics/prometheus/PrometheusExporterConfiguration.java
@@ -36,11 +36,9 @@ public class PrometheusExporterConfiguration {
     public static final String MAPPING_FILE_REFRESH_INTERVAL = PREFIX + "mapping_file_refresh_interval";
 
     private static String DEFAULT_BIND_ADDRESS_HOST = "127.0.0.1";
-    // TODO: Grab a default port from https://github.com/prometheus/prometheus/wiki/Default-port-allocations once
-    //       we have working code and link to the repository or the documentation.
-    //       Check if we really want this or if we consider this a private reporter and should choose a default port
-    //       outside of the "official" Prometheus exporter range.
-    private static int DEFAULT_BIND_ADDRESS_PORT = 9832;
+    // The default port has been added to the Prometheus default port allocation wiki page:
+    // https://github.com/prometheus/prometheus/wiki/Default-port-allocations
+    private static int DEFAULT_BIND_ADDRESS_PORT = 9833;
 
     @Parameter(value = ENABLED, required = true)
     private boolean enabled = false;

--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -705,8 +705,8 @@ proxied_requests_thread_pool_size = 32
 #prometheus_exporter_enabled = false
 
 # IP address and port for the Prometheus exporter HTTP server.
-# Default: 127.0.0.1:9832
-#prometheus_exporter_bind_address = 127.0.0.1:9832
+# Default: 127.0.0.1:9833
+#prometheus_exporter_bind_address = 127.0.0.1:9833
 
 # Path to the Prometheus exporter core mapping file. If this option is enabled, the full built-in core mapping is
 # replaced with the mappings in this file.


### PR DESCRIPTION
The previous port has been grabbed by someone else in the meantime. The
new port has been added to the Prometheus default port allocations wiki
page now.