### PR TITLE
Introducing `hasErrors` flag and prevent showing search result if set.

### DIFF
--- a/graylog2-web-interface/src/views/components/Search.tsx
+++ b/graylog2-web-interface/src/views/components/Search.tsx
@@ -229,11 +229,9 @@ const Search = ({ location }: Props) => {
                                 {!focusingWidget && <QueryBar />}
                               </IfDashboard>
                             </IfInteractive>
-                            {!hasErrors && (
                             <HighlightMessageInQuery>
-                              <SearchResult />
+                              <SearchResult hasErrors={hasErrors} />
                             </HighlightMessageInQuery>
-                            )}
                           </SearchArea>
                         </GridContainer>
                       </HighlightingRulesProvider>

--- a/graylog2-web-interface/src/views/components/SearchResult.tsx
+++ b/graylog2-web-interface/src/views/components/SearchResult.tsx
@@ -20,15 +20,12 @@ import styled, { css } from 'styled-components';
 
 import Spinner from 'components/common/Spinner';
 import Query from 'views/components/Query';
-import connect from 'stores/connect';
+import connect, { useStore } from 'stores/connect';
 import { SearchStore } from 'views/stores/SearchStore';
 import { CurrentViewStateStore } from 'views/stores/CurrentViewStateStore';
 import { ViewMetadataStore } from 'views/stores/ViewMetadataStore';
 import { WidgetStore } from 'views/stores/WidgetStore';
 import { SearchLoadingStateStore } from 'views/stores/SearchLoadingStateStore';
-import type { QueryId } from 'views/logic/queries/Query';
-import ViewState from 'views/logic/views/ViewState';
-import TSearchResult from 'views/logic/SearchResult';
 import FieldTypesContext from 'views/components/contexts/FieldTypesContext';
 import LoadingIndicator from 'components/common/LoadingIndicator';
 import { Row, Col } from 'components/graylog';
@@ -56,18 +53,12 @@ const SearchLoadingIndicator = connect(
 
 const QueryWithWidgets = connect(Query, { widgets: WidgetStore });
 
-type Props = {
-  queryId: QueryId,
-  searches: TSearchResult,
-  viewState: {
-    state: ViewState,
-    activeQuery: QueryId,
-  },
-};
-
-const SearchResult = React.memo(({ queryId, searches, viewState }: Props) => {
+const SearchResult = React.memo(() => {
   const fieldTypes = useContext(FieldTypesContext);
   const { focusedWidget } = useContext(WidgetFocusContext);
+  const searches = useStore(SearchStore, ({ result, widgetMapping }) => ({ result, widgetMapping }));
+  const queryId = useStore(ViewMetadataStore, (viewMetadataStore) => viewMetadataStore.activeQuery);
+  const viewState = useStore(CurrentViewStateStore);
 
   if (!fieldTypes) {
     return <Spinner />;
@@ -101,12 +92,4 @@ const SearchResult = React.memo(({ queryId, searches, viewState }: Props) => {
   );
 });
 
-export default connect(SearchResult, {
-  searches: SearchStore,
-  viewMetadata: ViewMetadataStore,
-  viewState: CurrentViewStateStore,
-}, (props) => ({
-  ...props,
-  searches: { result: props.searches.result, widgetMapping: props.searches.widgetMapping },
-  queryId: props.viewMetadata.activeQuery,
-}));
+export default SearchResult;

--- a/graylog2-web-interface/src/views/components/SearchResult.tsx
+++ b/graylog2-web-interface/src/views/components/SearchResult.tsx
@@ -53,7 +53,11 @@ const SearchLoadingIndicator = connect(
 
 const QueryWithWidgets = connect(Query, { widgets: WidgetStore });
 
-const SearchResult = React.memo(() => {
+type Props = {
+  hasErrors: boolean,
+};
+
+const SearchResult = React.memo(({ hasErrors }: Props) => {
   const fieldTypes = useContext(FieldTypesContext);
   const { focusedWidget } = useContext(WidgetFocusContext);
   const searches = useStore(SearchStore, ({ result, widgetMapping }) => ({ result, widgetMapping }));
@@ -80,7 +84,7 @@ const SearchResult = React.memo(() => {
                       results={currentResults}
                       positions={positions}
                       widgetMapping={widgetMapping} />
-  ) : <Spinner />;
+  ) : hasErrors ? null : <Spinner />;
 
   return (
     <StyledRow $hasFocusedWidget={hasFocusedWidget}>

--- a/graylog2-web-interface/src/views/components/messagelist/HighlightMessageInQuery.test.tsx
+++ b/graylog2-web-interface/src/views/components/messagelist/HighlightMessageInQuery.test.tsx
@@ -15,51 +15,46 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import { asMock } from 'helpers/mocking';
+
+import useQuery from 'routing/useQuery';
 
 import _HighlightMessageInQuery from './HighlightMessageInQuery';
 
 import HighlightMessageContext from '../contexts/HighlightMessageContext';
 
-// eslint-disable-next-line react/prop-types
-jest.mock('routing/withLocation', () => (Component) => ({ query, ...rest }) => <Component location={{ query }} {...rest} />);
+jest.mock('routing/useQuery');
 
 const HighlightMessageInQuery = _HighlightMessageInQuery as React.ComponentType<React.ComponentProps<typeof _HighlightMessageInQuery> & { query?: any }>;
 
 describe('HighlightMessageInQuery', () => {
   const TestComponent = () => (
-    <HighlightMessageContext.Consumer>
-      {(messageId) => <span>{messageId}</span>}
-    </HighlightMessageContext.Consumer>
+    <HighlightMessageInQuery>
+      <HighlightMessageContext.Consumer>
+        {(messageId) => (messageId ? <span>Message Id: {messageId}</span> : <span>No message is highlighted</span>)}
+      </HighlightMessageContext.Consumer>
+    </HighlightMessageInQuery>
   );
 
-  it('should render component for empty query', () => {
-    const { container } = render((
-      <HighlightMessageInQuery query={undefined}>
-        <TestComponent />
-      </HighlightMessageInQuery>
-    ));
+  it('should render component for empty query', async () => {
+    asMock(useQuery).mockReturnValue(undefined);
+    render(<TestComponent />);
 
-    expect(container).not.toBeNull();
+    await screen.findByText('No message is highlighted');
   });
 
-  it('should render component for query without message id', () => {
-    const { container } = render((
-      <HighlightMessageInQuery query={{}}>
-        <TestComponent />
-      </HighlightMessageInQuery>
-    ));
+  it('should render component for query without message id', async () => {
+    asMock(useQuery).mockReturnValue({});
+    render(<TestComponent />);
 
-    expect(container).not.toBeNull();
+    await screen.findByText('No message is highlighted');
   });
 
-  it('should pass message id from query to children', () => {
-    const { getByText } = render((
-      <HighlightMessageInQuery query={{ highlightMessage: 'foobar' }}>
-        <TestComponent />
-      </HighlightMessageInQuery>
-    ));
+  it('should pass message id from query to children', async () => {
+    asMock(useQuery).mockReturnValue({ highlightMessage: 'foobar' });
+    render(<TestComponent />);
 
-    expect(getByText('foobar')).not.toBeNull();
+    await screen.findByText('Message Id: foobar');
   });
 });

--- a/graylog2-web-interface/src/views/components/messagelist/HighlightMessageInQuery.tsx
+++ b/graylog2-web-interface/src/views/components/messagelist/HighlightMessageInQuery.tsx
@@ -16,28 +16,23 @@
  */
 import * as React from 'react';
 
-import withLocation from 'routing/withLocation';
-import type { Location } from 'routing/withLocation';
+import useQuery from 'routing/useQuery';
 
 import HighlightMessageContext from '../contexts/HighlightMessageContext';
 
 type Props = {
   children: React.ReactElement,
-  location: Location,
 };
 
-const emptyLocation = { query: undefined, pathname: undefined, search: undefined };
+const HighlightMessageInQuery = ({ children }: Props) => {
+  const query = useQuery();
+  const { highlightMessage } = query ?? {};
 
-const HighlightMessageInQuery = ({ children, location: { query = {} } = emptyLocation }: Props) => {
-  const { highlightMessage } = query;
-
-  return (
-    <HighlightMessageContext.Provider value={String(highlightMessage)}>
+  return highlightMessage ? (
+    <HighlightMessageContext.Provider value={highlightMessage.toString()}>
       {children}
     </HighlightMessageContext.Provider>
-  );
+  ) : children;
 };
 
-HighlightMessageInQuery.propTypes = {};
-
-export default withLocation(HighlightMessageInQuery);
+export default HighlightMessageInQuery;

--- a/graylog2-web-interface/src/views/logic/hooks/SearchRefreshCondition.ts
+++ b/graylog2-web-interface/src/views/logic/hooks/SearchRefreshCondition.ts
@@ -19,4 +19,4 @@ import SearchMetadata from 'views/logic/search/SearchMetadata';
 import View from 'views/logic/views/View';
 
 export type SearchRefreshConditionArguments = { view: View, searchMetadata: SearchMetadata, executionState: SearchExecutionState };
-export type SearchRefreshCondition = (SearchRefreshConditionArguments) => boolean;
+export type SearchRefreshCondition = (args: SearchRefreshConditionArguments) => boolean;

--- a/graylog2-web-interface/src/views/stores/ViewMetadataStore.ts
+++ b/graylog2-web-interface/src/views/stores/ViewMetadataStore.ts
@@ -19,11 +19,12 @@ import { isEqual } from 'lodash';
 
 import type { Store } from 'stores/StoreTypes';
 import { singletonStore } from 'views/logic/singleton';
+import { QueryId } from 'views/logic/queries/Query';
 
 import { ViewStore } from './ViewStore';
 
 export type ViewMetaData = {
-  activeQuery: string,
+  activeQuery: QueryId,
   description: string,
   id: string,
   summary: string,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is avoiding rendering the `SearchResult` component if the `hasErrors` flag is set. This flag is introduced in this PR and is set by the function which handles the response of the search parsing call.  This can be used e.g. to avoid showing the rendering result when there are undeclared parameters present.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.