### PR TITLE
NO_LIMIT was 0 pre 4.x and is now -1 in Legacy API

### DIFF
--- a/UPGRADING.rst
+++ b/UPGRADING.rst
@@ -13,18 +13,10 @@ Upgrading to Graylog 4.1.x
 Breaking Changes
 ================
 
-For the following legacy-API endpoints, one of the underlying search-methods (``Searches#scroll``) has been tagged as ``@deprecated``.
-+-----------------------------------------------+-----------------------------+
-| Endpoint                                      | Description                 |
-+===============================================+=============================+
-| ``/search/universal/absolute*``               | Legacy API endpoint         |
-| ``/search/universal/keyword*``                | Legacy API endpoint         |
-| ``/search/universal/relative*``               | Legacy API endpoint         |
-+-----------------------------------------------+-----------------------------+
-
-The reason is, that internally ``NO_LIMIT`` has been changed to ``-1`` instead of ``0``, so we had to introduce a
-fix to the ``limit`` parameter to keep the legacy-API consistent for users.
-
+The limit parameter in the legacy search api (``/search/universal/(absolute|keyword|relative)``) semantics has changed
+to fix an inconsistency introduced in ``4.0``: prior to ``4.0``, ``0`` meant "no limit", with ``4.0`` this changed to ``-1``
+and ``0`` for "empty result". With 4.1 this has been fixed to work again like in the past but the underlying
+``Searches#scroll`` method has been tagged as ``@deprecated`` now, too.
 
 Changes to the Elasticsearch Support
 ------------------------------------

--- a/UPGRADING.rst
+++ b/UPGRADING.rst
@@ -13,7 +13,7 @@ Upgrading to Graylog 4.1.x
 Breaking Changes
 ================
 
-For the following legacy-API endpoints, some of the underlying search-methods have been tagged as ``@deprecated``.
+For the following legacy-API endpoints, one of the underlying search-methods (``Searches#scroll``) has been tagged as ``@deprecated``.
 +-----------------------------------------------+-----------------------------+
 | Endpoint                                      | Description                 |
 +===============================================+=============================+
@@ -22,8 +22,8 @@ For the following legacy-API endpoints, some of the underlying search-methods ha
 | ``/search/universal/relative*``               | Legacy API endpoint         |
 +-----------------------------------------------+-----------------------------+
 
-The reason is, that internally the ``NO_LIMIT`` has been changed to ``-1`` instead of ``0``, so we had to introduce a
-fix to keep the legacy-API consistent for users.
+The reason is, that internally ``NO_LIMIT`` has been changed to ``-1`` instead of ``0``, so we had to introduce a
+fix to the ``limit`` parameter to keep the legacy-API consistent for users.
 
 
 Changes to the Elasticsearch Support

--- a/UPGRADING.rst
+++ b/UPGRADING.rst
@@ -13,6 +13,18 @@ Upgrading to Graylog 4.1.x
 Breaking Changes
 ================
 
+For the following legacy-API endpoints, some of the underlying search-methods have been tagged as ``@deprecated``.
++-----------------------------------------------+-----------------------------+
+| Endpoint                                      | Description                 |
++===============================================+=============================+
+| ``/search/universal/absolute*``               | Legacy API endpoint         |
+| ``/search/universal/keyword*``                | Legacy API endpoint         |
+| ``/search/universal/relative*``               | Legacy API endpoint         |
++-----------------------------------------------+-----------------------------+
+
+The reason is, that internally the ``NO_LIMIT`` has been changed to ``-1`` instead of ``0``, so we had to introduce a
+fix to keep the legacy-API consistent for users.
+
 
 Changes to the Elasticsearch Support
 ------------------------------------

--- a/graylog2-server/src/main/java/org/graylog2/indexer/searches/Searches.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/searches/Searches.java
@@ -120,7 +120,8 @@ public class Searches {
                 .sorting(sorting)
                 .indices(indexWildcards);
 
-        scrollCommandBuilder = limit != ScrollCommand.NO_LIMIT ? scrollCommandBuilder.limit(limit) : scrollCommandBuilder;
+        // limit > 0 instead of ScrollCommand.NO_LIMIT is a fix for #9817, the caller of this method are only in the legacy-API
+        scrollCommandBuilder = limit > 0 ? scrollCommandBuilder.limit(limit) : scrollCommandBuilder;
         scrollCommandBuilder = batchSize != ScrollCommand.NO_BATCHSIZE ? scrollCommandBuilder.batchSize(batchSize) : scrollCommandBuilder;
 
         final ScrollResult result = searchesAdapter.scroll(scrollCommandBuilder.build());

--- a/graylog2-server/src/main/java/org/graylog2/indexer/searches/Searches.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/searches/Searches.java
@@ -103,6 +103,7 @@ public class Searches {
         return result;
     }
 
+    @Deprecated
     public ScrollResult scroll(String query, TimeRange range, int limit, int offset, List<String> fields, String filter, int batchSize) {
         final Set<String> affectedIndices = determineAffectedIndices(range, filter);
         final Set<String> indexWildcards = indexSetRegistry.getForIndices(affectedIndices).stream()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Pre 4.x, a limit of `0` was interpreted as `no_limit` in the legacy-API. This changed in the background to `-1` for other functionality in 4.0

For the legacy-API, this PR changes the semantics back.

For the following legacy-API endpoints, some of the underlying search-methods have been tagged as ``@deprecated``.

``/search/universal/absolute*`` 
``/search/universal/keyword*``     
``/search/universal/relative*`` 

## Motivation and Context
fixes #9817 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

