### PR TITLE
Adjust widget focus and pagination z-index to fix stacking problem.

### DIFF
--- a/graylog2-web-interface/src/components/common/Pagination.tsx
+++ b/graylog2-web-interface/src/components/common/Pagination.tsx
@@ -64,6 +64,7 @@ const StyledBootstrapPagination = styled(BootstrapPagination)(({ theme }: { them
           color: ${theme.utils.contrastingColor(theme.colors.variant.lightest.info)};
           background-color: ${theme.colors.variant.lightest.info};
           border-color: ${theme.colors.variant.lighter.info};
+          z-index: 1;
         }
       }
 

--- a/graylog2-web-interface/src/components/common/__snapshots__/Pagination.test.jsx.snap
+++ b/graylog2-web-interface/src/components/common/__snapshots__/Pagination.test.jsx.snap
@@ -32,6 +32,7 @@ exports[`<Pagination /> should display Pagination 1`] = `
   color: rgb(76,77,78);
   background-color: #eff2f8;
   border-color: #bdc8e4;
+  z-index: 1;
 }
 
 .c0.pagination > li.disabled > a,

--- a/graylog2-web-interface/src/views/components/WidgetContainer.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetContainer.tsx
@@ -43,7 +43,7 @@ const WidgetContainer = ({ children, className, isFocused, style, ...rest }: Pro
       ...containerStyle,
       height: '100%',
       width: '100%',
-      zIndex: 1,
+      zIndex: 2,
       top: 0,
       left: 0,
     };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Before this change it was possible that the active item of the message
table pagination is still visible when focusing a different widget.
This change is fixing the problem by slightly increasing the widget
focus container and reducing the pagination z-index.

Fixes: https://github.com/Graylog2/graylog2-server/issues/10793

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

