### PR TITLE
Update bouncycastle to version 1.69

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
         <apache-httpclient.version>4.5.13</apache-httpclient.version>
         <auto-value.version>1.7.4</auto-value.version>
         <auto-value-javabean.version>2.5.2</auto-value-javabean.version>
-        <bouncycastle.version>1.64</bouncycastle.version>
+        <bouncycastle.version>1.69</bouncycastle.version>
         <caffeine.version>2.8.1</caffeine.version>
         <cef-parser.version>0.0.1.10</cef-parser.version>
         <commons-codec.version>1.14</commons-codec.version>


### PR DESCRIPTION
This bumps our bouncycastle dependencies to the most recent version.

Prevents downgrading of transitive bouncycastle dependencies e.g. in https://github.com/Graylog2/graylog-plugin-enterprise/pull/2278.



