### PR TITLE
Removing not needed spacings in data table and message table widget.

### DIFF
--- a/graylog2-web-interface/src/views/components/datatable/MessagesTable.jsx
+++ b/graylog2-web-interface/src/views/components/datatable/MessagesTable.jsx
@@ -22,17 +22,14 @@ import chroma from 'chroma-js';
 import { Table } from 'components/graylog';
 
 const MessagesContainer = styled.div`
-  padding-right: 13px;
   width: 100%;
 `;
 
 const StyledTable = styled(Table)(({ theme }) => css`
   position: relative;
   font-size: ${theme.fonts.size.small};
-  margin-top: 15px;
-  margin-bottom: 60px;
+  margin: 0;
   border-collapse: collapse;
-  padding-left: 13px;
   width: 100%;
   word-break: break-all;
 
@@ -43,7 +40,6 @@ const StyledTable = styled(Table)(({ theme }) => css`
   td,
   th {
     position: relative;
-    left: 13px;
   }
 
   > thead th {

--- a/graylog2-web-interface/src/views/components/widgets/MessageTable.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageTable.tsx
@@ -39,10 +39,8 @@ import InteractiveContext from '../contexts/InteractiveContext';
 const Table = styled.table(({ theme }) => css`
   position: relative;
   font-size: ${theme.fonts.size.small};
-  margin-top: 0;
-  margin-bottom: 60px;
+  margin: 0;
   border-collapse: collapse;
-  padding-left: 13px;
   width: 100%;
   word-break: break-all;
 
@@ -50,7 +48,6 @@ const Table = styled.table(({ theme }) => css`
     td,
     th {
       position: relative;
-      left: 13px;
     }
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Before this change the message table and data table widget had some not need spacings.
Removing these spacings unifies the styling with other widgets and for different browser.

Before: 

![image](https://user-images.githubusercontent.com/46300478/121377859-fcb9ed80-c942-11eb-89ea-d3e81e121f97.png)


After:

![image](https://user-images.githubusercontent.com/46300478/121377742-e449d300-c942-11eb-8c78-ab141172a08f.png)


Fixes https://github.com/Graylog2/graylog2-server/issues/7429
