### PR TITLE
Fix closing dashboard tabs.

### DIFF
--- a/graylog2-web-interface/src/views/components/AdaptableQueryTabs.tsx
+++ b/graylog2-web-interface/src/views/components/AdaptableQueryTabs.tsx
@@ -186,6 +186,7 @@ const AdaptableQueryTabs = ({ maxWidth, queries, titles, selectedQueryId, onRemo
                     id={id}
                     onClose={() => onRemove(id)}
                     openEditModal={openTitleEditModal}
+                    allowsClosing={queries.size > 1}
                     title={title} />
       );
 

--- a/graylog2-web-interface/src/views/components/QueryBar.test.tsx
+++ b/graylog2-web-interface/src/views/components/QueryBar.test.tsx
@@ -1,0 +1,67 @@
+import * as React from 'react';
+import * as Immutable from 'immutable';
+import { fireEvent, render, screen, waitFor, within } from 'wrappedTestingLibrary';
+import { MockStore } from 'helpers/mocking';
+
+import QueryBar from 'views/components/QueryBar';
+import { ViewActions } from 'views/stores/ViewStore';
+
+jest.mock('react-sizeme', () => ({
+  SizeMe: ({ children: fn }) => fn({ size: { width: 1024, height: 768 } }),
+}));
+
+jest.mock('views/stores/ViewStore', () => ({
+  ViewActions: {
+    selectQuery: jest.fn(() => Promise.resolve()),
+    search: jest.fn(() => Promise.resolve()),
+  },
+  ViewStore: MockStore(['getInitialState', () => ({ view: {} })]),
+}));
+
+jest.mock('views/stores/ViewStatesStore', () => ({
+  ViewStatesActions: {
+    remove: jest.fn(() => Promise.resolve()),
+  },
+  ViewStatesStore: MockStore(['getInitialState', () => new Map()]),
+}));
+
+const queries = Immutable.OrderedSet(['foo', 'bar', 'baz']);
+const queryTitles = Immutable.Map({
+  foo: 'First Query',
+  bar: 'Second Query',
+  baz: 'Third Query',
+});
+
+const viewMetadata = {
+  id: 'viewId',
+  title: 'Some view',
+  description: 'Hey There!',
+  summary: 'Very helpful summary',
+  activeQuery: 'bar',
+};
+
+describe('QueryBar', () => {
+  it('renders existing tabs', async () => {
+    render(<QueryBar queries={queries} queryTitles={queryTitles} viewMetadata={viewMetadata} />);
+
+    await screen.findByRole('button', { name: 'First Query' });
+    await screen.findByRole('button', { name: 'Second Query' });
+    await screen.findByRole('button', { name: 'Third Query' });
+  });
+
+  it('allows closing current tab', async () => {
+    render(<QueryBar queries={queries} queryTitles={queryTitles} viewMetadata={viewMetadata} />);
+
+    const currentTab = await screen.findByRole('button', { name: 'Second Query' });
+
+    const dropdown = await within(currentTab).findByTestId('query-action-dropdown');
+
+    fireEvent.click(dropdown);
+
+    const closeButton = await screen.findByRole('menuitem', { name: 'Close' });
+
+    fireEvent.click(closeButton);
+
+    await waitFor(() => expect(ViewActions.selectQuery).toHaveBeenCalledWith('foo'));
+  });
+});

--- a/graylog2-web-interface/src/views/components/QueryBar.test.tsx
+++ b/graylog2-web-interface/src/views/components/QueryBar.test.tsx
@@ -49,6 +49,16 @@ describe('QueryBar', () => {
     await screen.findByRole('button', { name: 'Third Query' });
   });
 
+  it('allows changing tab', async () => {
+    render(<QueryBar queries={queries} queryTitles={queryTitles} viewMetadata={viewMetadata} />);
+
+    const nextTab = await screen.findByRole('button', { name: 'Third Query' });
+
+    fireEvent.click(nextTab);
+
+    await waitFor(() => expect(ViewActions.selectQuery).toHaveBeenCalledWith('baz'));
+  });
+
   it('allows closing current tab', async () => {
     render(<QueryBar queries={queries} queryTitles={queryTitles} viewMetadata={viewMetadata} />);
 
@@ -63,5 +73,6 @@ describe('QueryBar', () => {
     fireEvent.click(closeButton);
 
     await waitFor(() => expect(ViewActions.selectQuery).toHaveBeenCalledWith('foo'));
+    await waitFor(() => expect(ViewActions.search).toHaveBeenCalled());
   });
 });

--- a/graylog2-web-interface/src/views/components/QueryBar.test.tsx
+++ b/graylog2-web-interface/src/views/components/QueryBar.test.tsx
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 import * as React from 'react';
 import * as Immutable from 'immutable';
 import { fireEvent, render, screen, waitFor, within } from 'wrappedTestingLibrary';

--- a/graylog2-web-interface/src/views/components/QueryBar.tsx
+++ b/graylog2-web-interface/src/views/components/QueryBar.tsx
@@ -14,7 +14,8 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import React from 'react';
+import * as React from 'react';
+import { useCallback } from 'react';
 import PropTypes from 'prop-types';
 import * as Immutable from 'immutable';
 import * as ImmutablePropTypes from 'react-immutable-proptypes';
@@ -67,15 +68,15 @@ type Props = {
 
 const QueryBar = ({ queries, queryTitles, viewMetadata }: Props) => {
   const { activeQuery } = viewMetadata;
-  const selectQueryAndExecute = (queryId) => onSelectQuery(queryId);
+  const onRemove = useCallback((queryId) => onCloseTab(queryId, activeQuery, queries), [activeQuery, queries]);
 
   return (
     <QueryTabs queries={queries}
                selectedQueryId={activeQuery}
                titles={queryTitles}
-               onSelect={selectQueryAndExecute}
+               onSelect={onSelectQuery}
                onTitleChange={onTitleChange}
-               onRemove={(queryId) => onCloseTab(queryId, activeQuery, queries)} />
+               onRemove={onRemove} />
   );
 };
 

--- a/graylog2-web-interface/src/views/components/QueryBar.tsx
+++ b/graylog2-web-interface/src/views/components/QueryBar.tsx
@@ -37,7 +37,7 @@ const onTitleChange = (queryId, newTitle) => TitlesActions.set('tab', 'title', n
 
 const onSelectQuery = (queryId) => (queryId === 'new' ? NewQueryActionHandler() : ViewActions.selectQuery(queryId));
 
-const onCloseTab = (queryId, currentQuery, queries) => {
+const onCloseTab = (queryId: string, currentQuery: string, queries: Immutable.OrderedSet<string>) => {
   if (queries.size === 1) {
     return Promise.resolve();
   }
@@ -45,9 +45,11 @@ const onCloseTab = (queryId, currentQuery, queries) => {
   let promise;
 
   if (queryId === currentQuery) {
-    const currentQueryIdIndex = queries.indexOf(queryId);
+    const indexedQueryIds = queries.toIndexedSeq();
+    const currentQueryIdIndex = indexedQueryIds.indexOf(queryId);
     const newQueryIdIndex = Math.min(0, currentQueryIdIndex - 1);
-    const newQuery = queries.remove(queryId).get(newQueryIdIndex);
+    const newQuery = indexedQueryIds.filter((currentQueryId) => (currentQueryId !== queryId))
+      .get(newQueryIdIndex);
 
     promise = ViewActions.selectQuery(newQuery);
   } else {

--- a/graylog2-web-interface/src/views/components/queries/QueryTitle.tsx
+++ b/graylog2-web-interface/src/views/components/queries/QueryTitle.tsx
@@ -31,6 +31,7 @@ const TitleWrap = styled.span<{ active: boolean }>(({ active }) => css`
 
 type Props = {
   active: boolean,
+  allowsClosing?: boolean,
   id: QueryId,
   onClose: () => Promise<void> | Promise<ViewState>,
   openEditModal: (string) => void,
@@ -44,9 +45,14 @@ type State = {
 
 class QueryTitle extends React.Component<Props, State> {
   static propTypes = {
+    allowsClosing: PropTypes.bool,
     onClose: PropTypes.func.isRequired,
     title: PropTypes.string.isRequired,
     openEditModal: PropTypes.func.isRequired,
+  };
+
+  static defaultProps = {
+    allowsClosing: true,
   };
 
   constructor(props: Props) {
@@ -75,7 +81,7 @@ class QueryTitle extends React.Component<Props, State> {
 
   render() {
     const { editing, title } = this.state;
-    const { active, id, openEditModal } = this.props;
+    const { active, allowsClosing, id, openEditModal } = this.props;
     const isActive = !editing && active;
 
     return (
@@ -89,7 +95,7 @@ class QueryTitle extends React.Component<Props, State> {
             <MenuItem onSelect={() => this._onDuplicate(id)}>Duplicate</MenuItem>
             <MenuItem onSelect={() => openEditModal(title)}>Edit Title</MenuItem>
             <MenuItem divider />
-            <MenuItem onSelect={this._onClose}>Close</MenuItem>
+            <MenuItem onSelect={this._onClose} disabled={!allowsClosing}>Close</MenuItem>
           </QueryActionDropdown>
         )}
       </>


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

In #10739, the queries/query id structures were changed to ordered sets.  Unfortunately, this change was not reflected in the code that handles closing dashboard tabs, so it called `indexOf` which is not present on an ordered set.

This change is now fixing this by converting the set of indices to an indexed sequence before calling `indexOf`. In addition, it disables the menu item to close a dashboard tab if there is only a single dashboard tab present.

Fixes #10834.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.