### PR TITLE
Do not set time range when selecting `Configure Ranges` option in `RangePresetDropdown`.

### DIFF
--- a/graylog2-web-interface/src/views/components/searchbar/RangePresetDropdown.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/RangePresetDropdown.test.tsx
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import { fireEvent, render, screen } from 'wrappedTestingLibrary';
+import * as React from 'react';
+import MockStore from 'helpers/mocking/StoreMock';
+import { viewsManager } from 'fixtures/users';
+import mockSearchClusterConfig from 'fixtures/searchClusterConfig';
+
+import CurrentUserContext from 'contexts/CurrentUserContext';
+
+import RangePresetDropdown from './RangePresetDropdown';
+
+jest.mock('stores/configurations/ConfigurationsStore', () => ({
+  ConfigurationsStore: MockStore(),
+}));
+
+jest.mock('views/stores/SearchConfigStore', () => ({
+  SearchConfigActions: {
+    refresh: jest.fn(() => Promise.resolve()),
+  },
+  SearchConfigStore: {
+    listen: () => jest.fn(),
+    getInitialState: () => ({ searchesClusterConfig: mockSearchClusterConfig }),
+  },
+}));
+
+describe('RangePresetDropdown', () => {
+  type SUTProps = Partial<React.ComponentProps<typeof RangePresetDropdown>>;
+
+  const currentUser = {
+    ...viewsManager,
+    permissions: ['*'],
+  };
+
+  const SUTRangePresetDropdown = (props: SUTProps) => (
+    <CurrentUserContext.Provider value={currentUser}>
+      <RangePresetDropdown {...props} />
+    </CurrentUserContext.Provider>
+  );
+
+  it('should not call onChange prop when selecting "Configure Ranges" option.', async () => {
+    const onSelectOption = jest.fn();
+    render(<SUTRangePresetDropdown onChange={onSelectOption} />);
+
+    const timeRangeButton = screen.getByLabelText('Open time range preset select');
+    fireEvent.click(timeRangeButton);
+    const rangePresetOption = await screen.findByText('Configure Ranges');
+    fireEvent.click(rangePresetOption);
+
+    expect(onSelectOption).not.toHaveBeenCalled();
+  });
+});

--- a/graylog2-web-interface/src/views/components/searchbar/RangePresetDropdown.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/RangePresetDropdown.tsx
@@ -78,6 +78,12 @@ const RangePresetDropdown = ({ disabled, onChange, onToggle, className, displayT
     options = (<MenuItem eventKey="300" disabled>Loading...</MenuItem>);
   }
 
+  const _onChange = (range) => {
+    if (range !== null && range !== undefined) {
+      onChange(parseInt(range, 10));
+    }
+  };
+
   return (
     <DropdownButton title={title}
                     id="relative-timerange-selector"
@@ -85,7 +91,7 @@ const RangePresetDropdown = ({ disabled, onChange, onToggle, className, displayT
                     bsSize={bsSize}
                     className={className}
                     onToggle={onToggle}
-                    onSelect={onChange}>
+                    onSelect={_onChange}>
       {header && (
         <MenuItem header>{header}</MenuItem>
       )}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


Before this change we called the `onChange` prop of the `RangePresetDropdown` when selecting the `Configure Ranges` link, which is part of the dropdown. As a result we defined:
- an invalid time range for the search bar form when selecting a relative range preset.
- the range "0 Days" for a range in the date time picker.

With this change we are only opening the configuration page when clicking on `Configure Ranges`.

Fixes #10835

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

