### PR TITLE
Do not hide legends for pie charts

### DIFF
--- a/graylog2-web-interface/src/views/components/visualizations/PlotLegend.test.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/PlotLegend.test.tsx
@@ -49,7 +49,7 @@ const columnPivots = [Pivot.create('field1', 'unknown')];
 const config = AggregationWidgetConfig.builder().series([Series.forFunction('count')]).columnPivots(columnPivots).build();
 
 // eslint-disable-next-line react/require-default-props
-const SUT = ({ chartDataProp = chartData, plotConfig = config }: { chartDataProp?: Array<{ name: string, }>, plotConfig?: AggregationWidgetConfig }) => (
+const SUT = ({ chartDataProp = chartData, plotConfig = config, neverHide = false }: { chartDataProp?: Array<{ name: string, }>, plotConfig?: AggregationWidgetConfig, neverHide?: boolean }) => (
   <WidgetFocusContext.Provider value={{
     focusedWidget: undefined,
     setWidgetFocusing: jest.fn(),
@@ -58,7 +58,7 @@ const SUT = ({ chartDataProp = chartData, plotConfig = config }: { chartDataProp
     setWidgetEditing: jest.fn(),
   }}>
     <ChartColorContext.Provider value={{ colors, setColor }}>
-      <PlotLegend config={plotConfig} chartData={chartDataProp}>
+      <PlotLegend config={plotConfig} chartData={chartDataProp} neverHide={neverHide}>
         <div>Plot</div>
       </PlotLegend>
     </ChartColorContext.Provider>
@@ -108,7 +108,7 @@ describe('PlotLegend', () => {
     await screen.findByText('name11');
   });
 
-  it('should hide with a single values', async () => {
+  it('should hide with a single value', async () => {
     const plotConfig = AggregationWidgetConfig.builder().series([Series.forFunction('count')]).build();
     render(<SUT chartDataProp={[{ name: 'name1' }]} plotConfig={plotConfig} />);
 
@@ -122,5 +122,12 @@ describe('PlotLegend', () => {
     fireEvent.click(value);
 
     expect(screen.queryByText('Actions')).not.toBeInTheDocument();
+  });
+
+  it('should not hide with a single value if configured', async () => {
+    const plotConfig = AggregationWidgetConfig.builder().series([Series.forFunction('count')]).build();
+    render(<SUT chartDataProp={[{ name: 'name1' }]} plotConfig={plotConfig} neverHide />);
+
+    expect(screen.queryByText('name1')).toBeInTheDocument();
   });
 });

--- a/graylog2-web-interface/src/views/components/visualizations/PlotLegend.test.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/PlotLegend.test.tsx
@@ -49,7 +49,7 @@ const columnPivots = [Pivot.create('field1', 'unknown')];
 const config = AggregationWidgetConfig.builder().series([Series.forFunction('count')]).columnPivots(columnPivots).build();
 
 // eslint-disable-next-line react/require-default-props
-const SUT = ({ chartDataProp = chartData, plotConfig = config, neverHide = false }: { chartDataProp?: Array<{ name: string, }>, plotConfig?: AggregationWidgetConfig, neverHide?: boolean }) => (
+const SUT = ({ chartDataProp = chartData, plotConfig = config, isPieChart = false }: { chartDataProp?: Array<{ name: string, }>, plotConfig?: AggregationWidgetConfig, isPieChart?: boolean }) => (
   <WidgetFocusContext.Provider value={{
     focusedWidget: undefined,
     setWidgetFocusing: jest.fn(),
@@ -58,7 +58,7 @@ const SUT = ({ chartDataProp = chartData, plotConfig = config, neverHide = false
     setWidgetEditing: jest.fn(),
   }}>
     <ChartColorContext.Provider value={{ colors, setColor }}>
-      <PlotLegend config={plotConfig} chartData={chartDataProp} neverHide={neverHide}>
+      <PlotLegend config={plotConfig} chartData={chartDataProp} isPieChart={isPieChart}>
         <div>Plot</div>
       </PlotLegend>
     </ChartColorContext.Provider>
@@ -126,8 +126,8 @@ describe('PlotLegend', () => {
 
   it('should not hide with a single value if configured', async () => {
     const plotConfig = AggregationWidgetConfig.builder().series([Series.forFunction('count')]).build();
-    render(<SUT chartDataProp={[{ name: 'name1' }]} plotConfig={plotConfig} neverHide />);
+    render(<SUT chartDataProp={[{ name: 'name1' }]} plotConfig={plotConfig} isPieChart />);
 
-    expect(screen.queryByText('name1')).toBeInTheDocument();
+    screen.findByText('name1');
   });
 });

--- a/graylog2-web-interface/src/views/components/visualizations/PlotLegend.test.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/PlotLegend.test.tsx
@@ -49,7 +49,7 @@ const columnPivots = [Pivot.create('field1', 'unknown')];
 const config = AggregationWidgetConfig.builder().series([Series.forFunction('count')]).columnPivots(columnPivots).build();
 
 // eslint-disable-next-line react/require-default-props
-const SUT = ({ chartDataProp = chartData, plotConfig = config, isPieChart = false }: { chartDataProp?: Array<{ name: string, }>, plotConfig?: AggregationWidgetConfig, isPieChart?: boolean }) => (
+const SUT = ({ chartDataProp = chartData, plotConfig = config, neverHide = false }: { chartDataProp?: Array<{ name: string, }>, plotConfig?: AggregationWidgetConfig, neverHide?: boolean }) => (
   <WidgetFocusContext.Provider value={{
     focusedWidget: undefined,
     setWidgetFocusing: jest.fn(),
@@ -58,7 +58,7 @@ const SUT = ({ chartDataProp = chartData, plotConfig = config, isPieChart = fals
     setWidgetEditing: jest.fn(),
   }}>
     <ChartColorContext.Provider value={{ colors, setColor }}>
-      <PlotLegend config={plotConfig} chartData={chartDataProp} isPieChart={isPieChart}>
+      <PlotLegend config={plotConfig} chartData={chartDataProp} neverHide={neverHide}>
         <div>Plot</div>
       </PlotLegend>
     </ChartColorContext.Provider>
@@ -126,7 +126,7 @@ describe('PlotLegend', () => {
 
   it('should not hide with a single value if configured', async () => {
     const plotConfig = AggregationWidgetConfig.builder().series([Series.forFunction('count')]).build();
-    render(<SUT chartDataProp={[{ name: 'name1' }]} plotConfig={plotConfig} isPieChart />);
+    render(<SUT chartDataProp={[{ name: 'name1' }]} plotConfig={plotConfig} neverHide />);
 
     screen.findByText('name1');
   });

--- a/graylog2-web-interface/src/views/components/visualizations/PlotLegend.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/PlotLegend.tsx
@@ -82,6 +82,7 @@ type Props = {
   config: AggregationWidgetConfig,
   chartData: any,
   labelMapper?: (data: Array<any>) => Array<string> | undefined | null,
+  neverHide?: boolean,
 };
 
 type ColorPickerConfig = {
@@ -93,7 +94,7 @@ const defaultLabelMapper = (data: Array<{ name: string }>) => data.map(({ name }
 
 const isLabelAFunction = (label: string, series: Series) => series.function === label || series.config.name === label;
 
-const PlotLegend = ({ children, config, chartData, labelMapper = defaultLabelMapper }: Props) => {
+const PlotLegend = ({ children, config, chartData, labelMapper = defaultLabelMapper, neverHide }: Props) => {
   const [colorPickerConfig, setColorPickerConfig] = useState<ColorPickerConfig | undefined>();
   const { columnPivots, series } = config;
   const labels: Array<string> = labelMapper(chartData);
@@ -149,7 +150,7 @@ const PlotLegend = ({ children, config, chartData, labelMapper = defaultLabelMap
     setColorPickerConfig(undefined);
   }, [setColor]);
 
-  if ((!focusedWidget || !focusedWidget.editing) && series.length <= 1 && columnPivots.length <= 0) {
+  if (!neverHide && (!focusedWidget || !focusedWidget.editing) && series.length <= 1 && columnPivots.length <= 0) {
     return <>{children}</>;
   }
 
@@ -207,6 +208,7 @@ const PlotLegend = ({ children, config, chartData, labelMapper = defaultLabelMap
 
 PlotLegend.defaultProps = {
   labelMapper: defaultLabelMapper,
+  neverHide: false,
 };
 
 export default PlotLegend;

--- a/graylog2-web-interface/src/views/components/visualizations/PlotLegend.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/PlotLegend.tsx
@@ -82,7 +82,7 @@ type Props = {
   config: AggregationWidgetConfig,
   chartData: any,
   labelMapper?: (data: Array<any>) => Array<string> | undefined | null,
-  neverHide?: boolean,
+  isPieChart?: boolean,
 };
 
 type ColorPickerConfig = {
@@ -94,9 +94,9 @@ const defaultLabelMapper = (data: Array<{ name: string }>) => data.map(({ name }
 
 const isLabelAFunction = (label: string, series: Series) => series.function === label || series.config.name === label;
 
-const PlotLegend = ({ children, config, chartData, labelMapper = defaultLabelMapper, neverHide }: Props) => {
+const PlotLegend = ({ children, config, chartData, labelMapper = defaultLabelMapper, isPieChart }: Props) => {
   const [colorPickerConfig, setColorPickerConfig] = useState<ColorPickerConfig | undefined>();
-  const { columnPivots, series } = config;
+  const { rowPivots, columnPivots, series } = config;
   const labels: Array<string> = labelMapper(chartData);
   const { activeQuery } = useStore(CurrentViewStateStore);
   const { colors, setColor } = useContext(ChartColorContext);
@@ -150,7 +150,7 @@ const PlotLegend = ({ children, config, chartData, labelMapper = defaultLabelMap
     setColorPickerConfig(undefined);
   }, [setColor]);
 
-  if (!neverHide && (!focusedWidget || !focusedWidget.editing) && series.length <= 1 && columnPivots.length <= 0) {
+  if (!isPieChart && (!focusedWidget || !focusedWidget.editing) && series.length <= 1 && columnPivots.length <= 0) {
     return <>{children}</>;
   }
 
@@ -160,6 +160,8 @@ const PlotLegend = ({ children, config, chartData, labelMapper = defaultLabelMap
 
     if (columnPivots.length === 1 && series.length === 1 && !isLabelAFunction(value, series[0])) {
       val = (<Value type={FieldType.Unknown} value={value} field={columnPivots[0].field} queryId={activeQuery}>{value}</Value>);
+    } else if (isPieChart && rowPivots.length === 1) {
+      val = (<Value type={FieldType.Unknown} value={value} field={rowPivots[0].field} queryId={activeQuery}>{value}</Value>);
     }
 
     return (
@@ -208,7 +210,7 @@ const PlotLegend = ({ children, config, chartData, labelMapper = defaultLabelMap
 
 PlotLegend.defaultProps = {
   labelMapper: defaultLabelMapper,
-  neverHide: false,
+  isPieChart: false,
 };
 
 export default PlotLegend;

--- a/graylog2-web-interface/src/views/components/visualizations/pie/PieVisualization.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/pie/PieVisualization.tsx
@@ -85,7 +85,7 @@ const PieVisualization = makeVisualization(({ config, data }: VisualizationCompo
   const transformedData = chartData(config, data.chart || Object.values(data)[0], 'pie', _generateSeries);
 
   return (
-    <PlotLegend config={config} chartData={transformedData} labelMapper={labelMapper}>
+    <PlotLegend config={config} chartData={transformedData} labelMapper={labelMapper} neverHide>
       <GenericPlot chartData={transformedData}
                    layout={{ showlegend: false }}
                    getChartColor={getChartColor}

--- a/graylog2-web-interface/src/views/components/visualizations/pie/PieVisualization.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/pie/PieVisualization.tsx
@@ -85,7 +85,7 @@ const PieVisualization = makeVisualization(({ config, data }: VisualizationCompo
   const transformedData = chartData(config, data.chart || Object.values(data)[0], 'pie', _generateSeries);
 
   return (
-    <PlotLegend config={config} chartData={transformedData} labelMapper={labelMapper} neverHide>
+    <PlotLegend config={config} chartData={transformedData} labelMapper={labelMapper} isPieChart>
       <GenericPlot chartData={transformedData}
                    layout={{ showlegend: false }}
                    getChartColor={getChartColor}

--- a/graylog2-web-interface/src/views/components/visualizations/pie/PieVisualization.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/pie/PieVisualization.tsx
@@ -85,7 +85,7 @@ const PieVisualization = makeVisualization(({ config, data }: VisualizationCompo
   const transformedData = chartData(config, data.chart || Object.values(data)[0], 'pie', _generateSeries);
 
   return (
-    <PlotLegend config={config} chartData={transformedData} labelMapper={labelMapper} isPieChart>
+    <PlotLegend config={config} chartData={transformedData} labelMapper={labelMapper} neverHide>
       <GenericPlot chartData={transformedData}
                    layout={{ showlegend: false }}
                    getChartColor={getChartColor}


### PR DESCRIPTION
## Motivation
Prior to this change, we wanted to hide the legend if only one label
was presented to the user. The evaluation of that state did not take
into account that the pie chat needs to always show the labels.

## Description
This change will add a neverHide flag to the PlotLegend component and
that flag will be used by the PieChart component.

This PR also adds field value actions for the pie chart legend.
![image](https://user-images.githubusercontent.com/46300478/122052464-04b3da80-cde6-11eb-83d5-543bf2f6fe78.png)


Fixes #10837
Refs https://github.com/Graylog2/graylog2-server/issues/6612

## How Has This Been Tested?
- Create a Pie Chart with top values widget and see that the Legend is presented
- The histogram still does not show the legend

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)