### PR TITLE
Do not render column roll-up label as value action in PlotLegend

### DIFF
--- a/graylog2-web-interface/src/views/components/visualizations/PlotLegend.test.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/PlotLegend.test.tsx
@@ -78,7 +78,7 @@ describe('PlotLegend', () => {
     await screen.findAllByLabelText('Color Hint');
   });
 
-  it('should set a color when clicking on the color hing', async () => {
+  it('should set a color when clicking on the color hint', async () => {
     render(<SUT />);
     const colorHints = await screen.findAllByLabelText('Color Hint');
     fireEvent.click(colorHints[0]);
@@ -113,5 +113,15 @@ describe('PlotLegend', () => {
     render(<SUT chartDataProp={[{ name: 'name1' }]} plotConfig={plotConfig} />);
 
     expect(screen.queryByText('name1')).not.toBeInTheDocument();
+  });
+
+  it('should not add value action menu for series', async () => {
+    const plotConfig = config.toBuilder().series([Series.forFunction('count')]).build();
+    render(<SUT chartDataProp={[{ name: 'name1' }, { name: 'count' }]} plotConfig={plotConfig} />);
+
+    const value = await screen.findByText('count');
+    fireEvent.click(value);
+
+    expect(screen.queryByText('Actions')).not.toBeInTheDocument();
   });
 });

--- a/graylog2-web-interface/src/views/components/visualizations/PlotLegend.test.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/PlotLegend.test.tsx
@@ -46,7 +46,7 @@ const chartData = [
   { name: 'name3' },
 ];
 const columnPivots = [Pivot.create('field1', 'unknown')];
-const config = AggregationWidgetConfig.builder().columnPivots(columnPivots).build();
+const config = AggregationWidgetConfig.builder().series([Series.forFunction('count')]).columnPivots(columnPivots).build();
 
 // eslint-disable-next-line react/require-default-props
 const SUT = ({ chartDataProp = chartData, plotConfig = config }: { chartDataProp?: Array<{ name: string, }>, plotConfig?: AggregationWidgetConfig }) => (
@@ -116,8 +116,7 @@ describe('PlotLegend', () => {
   });
 
   it('should not add value action menu for series', async () => {
-    const plotConfig = config.toBuilder().series([Series.forFunction('count')]).build();
-    render(<SUT chartDataProp={[{ name: 'name1' }, { name: 'count' }]} plotConfig={plotConfig} />);
+    render(<SUT chartDataProp={[{ name: 'name1' }, { name: 'count' }]} />);
 
     const value = await screen.findByText('count');
     fireEvent.click(value);

--- a/graylog2-web-interface/src/views/components/visualizations/PlotLegend.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/PlotLegend.tsx
@@ -30,6 +30,7 @@ import FieldType from 'views/logic/fieldtypes/FieldType';
 import { colors as defaultColors } from 'views/components/visualizations/Colors';
 import { EVENT_COLOR, eventsDisplayName } from 'views/logic/searchtypes/events/EventHandler';
 import WidgetFocusContext from 'views/components/contexts/WidgetFocusContext';
+import Series from 'views/logic/aggregationbuilder/Series';
 
 const ColorHint = styled.div(({ color }) => `
   cursor: pointer;
@@ -89,6 +90,8 @@ type ColorPickerConfig = {
 };
 
 const defaultLabelMapper = (data: Array<{ name: string }>) => data.map(({ name }) => name);
+
+const isLabelAFunction = (label: string, series: Series) => series.function === label || series.config.name === label;
 
 const PlotLegend = ({ children, config, chartData, labelMapper = defaultLabelMapper }: Props) => {
   const [colorPickerConfig, setColorPickerConfig] = useState<ColorPickerConfig | undefined>();
@@ -154,7 +157,7 @@ const PlotLegend = ({ children, config, chartData, labelMapper = defaultLabelMap
     const defaultColor = value === eventsDisplayName ? EVENT_COLOR : undefined;
     let val: React.ReactNode = value;
 
-    if (columnPivots.length === 1) {
+    if (columnPivots.length === 1 && series.length === 1 && !isLabelAFunction(value, series[0])) {
       val = (<Value type={FieldType.Unknown} value={value} field={columnPivots[0].field} queryId={activeQuery}>{value}</Value>);
     }
 


### PR DESCRIPTION
## Motivation
Prior to this change, the Plot legend would render the column roll-up
label as Value action and with that the user would get a menu offered
which would not really make sense.

## Description
This change will try to find out if the label it renders is a series
function and will not render it with Value Actions.

## Fixes also
This fixes also a problem that when multiple series where selected by
the user the value actions did got presented even though they were
broken.

## Known Issue
If the series function will be renamed to a value which exists in the
chart as a value, the value is not clickable and the plot legend will
only display the label one time (as does plotly renders the it).

Fixes #10840

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

