### PR TITLE
Heatmap: Clear min and max on auto scale use

### DIFF
--- a/graylog2-web-interface/src/views/components/visualizations/heatmap/bindings.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/heatmap/bindings.tsx
@@ -65,8 +65,12 @@ const heatmap: VisualizationType<HeatmapVisualizationConfig, HeatMapVisualizatio
     fromConfig: ({ autoScale, colorScale, reverseScale, defaultValue, useSmallestAsDefault, zMax, zMin }: HeatmapVisualizationConfig) => ({
       autoScale, colorScale, reverseScale, defaultValue, useSmallestAsDefault, zMax, zMin,
     }),
-    toConfig: ({ autoScale = false, colorScale, reverseScale = false, useSmallestAsDefault, zMax, zMin, defaultValue }: HeatMapVisualizationConfigFormValues) => HeatmapVisualizationConfig
-      .create(colorScale, reverseScale, autoScale, zMin, zMax, useSmallestAsDefault, defaultValue),
+    toConfig: ({ autoScale = false, colorScale, reverseScale = false, useSmallestAsDefault, zMax, zMin, defaultValue }: HeatMapVisualizationConfigFormValues) => {
+      const [finalZMin, finalZMax] = autoScale ? [undefined, undefined] : [zMin, zMax];
+
+      return HeatmapVisualizationConfig
+        .create(colorScale, reverseScale, autoScale, finalZMin, finalZMax, useSmallestAsDefault, defaultValue);
+    },
     createConfig: () => ({ colorScale: 'Viridis', autoScale: true }),
     fields: [{
       name: 'colorScale',


### PR DESCRIPTION
## Motivation
Prior to this change, if the user switched back from using min and max
values to auto scale the auto scale setting was ignored and instead min
and max were still used.

That is because plolty does not know of a auto scale option but only the
absense of min and max.

## Description
This change will clear the values min and max when auto scale is used.

## How Has This Been Tested?
- Edit a heatmap to use min and max instaed of auto scale
- switched back to auto scale
- 
- profit

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

