### PR TITLE
Decorator action menu cut off

### DIFF
--- a/graylog2-web-interface/src/views/components/messagelist/decorators/DecoratorSummary.jsx
+++ b/graylog2-web-interface/src/views/components/messagelist/decorators/DecoratorSummary.jsx
@@ -112,7 +112,7 @@ class DecoratorSummary extends React.Component {
     const { decorator } = this.props;
 
     return (
-      <DropdownButton id={`decorator-${decorator.id}-actions`} bsStyle="default" bsSize="xsmall" title="Actions" pullRight>
+      <DropdownButton id={`decorator-${decorator.id}-actions`} bsStyle="default" bsSize="xsmall" title="Actions">
         <MenuItem onSelect={this._handleEditClick}>Edit</MenuItem>
         <MenuItem divider />
         <MenuItem onSelect={this._handleDeleteClick}>Delete</MenuItem>


### PR DESCRIPTION
## Motivation
Prior to this change, the decorator action menu was cut off to the left
side in the Message Table edit modus. The problem exists since we
display the edit modus in focus mode.

## Description
This change will remove the `pullRight` prop from the drop down
component to let the menu open up to the right side.

## Screenshot
![Graylog (11)](https://user-images.githubusercontent.com/448763/122024084-682f0f80-cdc8-11eb-9b14-5ab46ea163a5.png)

Fixes #10841

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
