### PR TITLE
Fixing minor styling/theming issues in decorator configuration.

### DIFF
--- a/graylog2-web-interface/src/views/components/messagelist/decorators/AddDecoratorButton.jsx
+++ b/graylog2-web-interface/src/views/components/messagelist/decorators/AddDecoratorButton.jsx
@@ -17,7 +17,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import jQuery from 'jquery';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import ObjectID from 'bson-objectid';
 
 import { ConfigurationForm } from 'components/configurationforms';
@@ -27,20 +27,21 @@ import { Select } from 'components/common';
 import InlineForm from './InlineForm';
 import PopoverHelp from './PopoverHelp';
 
+// eslint-disable-next-line import/no-webpack-loader-syntax
 import DecoratorStyles from '!style!css!./decoratorStyles.css';
 
-const ConfigurationFormContainer = styled.div`
+const ConfigurationFormContainer = styled.div(({ theme }) => css`
   margin-bottom: 10px;
   margin-top: 10px;
   margin-left: 5px;
   display: inline-block;
   border-style: solid;
-  border-color: lightgray;
+  border-color: ${theme.colors.gray[80]};
   border-radius: 5px;
   border-width: 1px;
   padding: 10px;
-  background: white;
-`;
+  background: ${theme.colors.background};
+`);
 
 class AddDecoratorButton extends React.Component {
   static propTypes = {

--- a/graylog2-web-interface/src/views/components/messagelist/decorators/DecoratorSummary.jsx
+++ b/graylog2-web-interface/src/views/components/messagelist/decorators/DecoratorSummary.jsx
@@ -20,9 +20,9 @@ import React from 'react';
 import { DropdownButton, MenuItem } from 'components/graylog';
 import { ConfigurationForm, ConfigurationWell } from 'components/configurationforms';
 
-// eslint-disable-next-line import/no-webpack-loader-syntax
 import InlineForm from './InlineForm';
 
+// eslint-disable-next-line import/no-webpack-loader-syntax
 import DecoratorStyles from '!style!css!./decoratorStyles.css';
 
 class DecoratorSummary extends React.Component {

--- a/graylog2-web-interface/src/views/components/messagelist/decorators/PopoverHelp.tsx
+++ b/graylog2-web-interface/src/views/components/messagelist/decorators/PopoverHelp.tsx
@@ -39,11 +39,9 @@ const PopoverHelp = () => {
   );
 
   return (
-    <div className={DecoratorStyles.helpLinkContainer}>
-      <OverlayTrigger trigger="click" rootClose placement="right" overlay={popoverHelp}>
-        <Button bsStyle="link" className={DecoratorStyles.helpLink}>What are message decorators?</Button>
-      </OverlayTrigger>
-    </div>
+    <OverlayTrigger trigger="click" rootClose placement="right" overlay={popoverHelp}>
+      <Button bsStyle="link" className={DecoratorStyles.helpLink}>What are message decorators?</Button>
+    </OverlayTrigger>
   );
 };
 

--- a/graylog2-web-interface/src/views/components/messagelist/decorators/decoratorStyles.css
+++ b/graylog2-web-interface/src/views/components/messagelist/decorators/decoratorStyles.css
@@ -28,10 +28,6 @@
     font-size: 1rem; /* theme.fonts.size.body */
 }
 
-:local(.helpLinkContainer) {
-    height: 20px;
-}
-
 :local(.decoratorListContainer) {
     display: inline-block;
     overflow: visible;


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This change is fixing minor styling/theming issues in the decorator configuration components. When adding a decorator, the configuration box was not themed properly, resulting in poor contrast if the dark theme is active. The help box was misaligned, resulting in being cut off.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

Before:

![before-decorators-1](https://user-images.githubusercontent.com/41929/122044677-0f1da680-cddd-11eb-9dd1-f0a35d60a0ba.png)
![before-decorators-2](https://user-images.githubusercontent.com/41929/122044683-11800080-cddd-11eb-92bc-530b3f06cdc2.png)

After:

![after-decorators-1](https://user-images.githubusercontent.com/41929/122044692-15138780-cddd-11eb-811c-71783896d8c9.png)

Fixes: https://github.com/Graylog2/graylog2-server/issues/10553

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.