### PR TITLE
Fixing deletion of all groupings of an aggregation.

### DIFF
--- a/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.groupBy.test.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.groupBy.test.tsx
@@ -172,6 +172,30 @@ describe('AggregationWizard', () => {
     await screen.findByText('timestamp');
   });
 
+  it('should remove all groupings', async () => {
+    const pivot = Pivot.create('took_ms', 'values', { limit: 15 });
+    const config = widgetConfig
+      .toBuilder()
+      .rowPivots([pivot])
+      .build();
+    const onChangeMock = jest.fn();
+    renderSUT({ config, onChange: onChangeMock });
+
+    const removeGroupingElementButton = screen.getByRole('button', { name: 'Remove Grouping' });
+    userEvent.click(removeGroupingElementButton);
+
+    await submitWidgetConfigForm();
+
+    const updatedConfig = widgetConfig
+      .toBuilder()
+      .rowPivots([])
+      .build();
+
+    await waitFor(() => expect(onChangeMock).toHaveBeenCalledTimes(1));
+
+    expect(onChangeMock).toHaveBeenCalledWith(updatedConfig);
+  });
+
   it('should display group by section even if config has no pivots', () => {
     const config = widgetConfig
       .toBuilder()

--- a/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.metric.test.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.metric.test.tsx
@@ -231,7 +231,7 @@ describe('AggregationWizard', () => {
     expect(onChangeMock).toHaveBeenCalledWith(updatedConfig);
   });
 
-  it('should remove metric', async () => {
+  it('should remove all metrics', async () => {
     const onChangeMock = jest.fn();
     const config = widgetConfig
       .toBuilder()

--- a/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.sort.test.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.sort.test.tsx
@@ -214,7 +214,7 @@ describe('AggregationWizard', () => {
     await waitFor(() => expect(expect(applyButton).toBeDisabled()));
   });
 
-  it('should remove sort', async () => {
+  it('should remove all sorts', async () => {
     const onChangeMock = jest.fn();
     const config = widgetConfig
       .toBuilder()

--- a/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/GroupByElement.test.ts
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/GroupByElement.test.ts
@@ -128,7 +128,7 @@ describe('GroupByElement', () => {
 
       const result = onRemove(0, values);
 
-      expect(result.groupBy).toStrictEqual(undefined);
+      expect(result.groupBy).toStrictEqual({ columnRollup: true, groupings: [] });
     });
 
     it('should remove nothing if index is not contained', () => {

--- a/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/GroupByElement.ts
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/aggregationElements/GroupByElement.ts
@@ -165,10 +165,6 @@ const groupingToPivot = (grouping: GroupByFormValues) => {
 };
 
 const groupByToConfig = (groupBy: WidgetConfigFormValues['groupBy'], config: AggregationWidgetConfigBuilder) => {
-  if (!groupBy) {
-    return config;
-  }
-
   const rowPivots = groupBy.groupings.filter((grouping) => grouping.direction === 'row').map(groupingToPivot);
   const columnPivots = groupBy.groupings.filter((grouping) => grouping.direction === 'column').map(groupingToPivot);
   const { columnRollup } = groupBy;
@@ -207,12 +203,6 @@ const GroupByElement: AggregationElement = {
   onRemove: ((index, formValues) => {
     const newFormValues = { ...formValues };
     const newGroupings = formValues.groupBy?.groupings.filter((value, i) => (index !== i));
-
-    if (isEmpty(newGroupings)) {
-      delete newFormValues.groupBy;
-
-      return newFormValues;
-    }
 
     return ({
       ...newFormValues,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

As described in https://github.com/Graylog2/graylog2-server/issues/10858 it is currently not possible to remove all groupings of an aggregation element. This error occurred because we removed the `goupby` key of the `WidgetConfigForm` state when removing all groupings. We are only considering aggregation element changes on submit when its key exists in the form state.

I thought about a solution which ensures we are not having a similar problem in the future, e.g. when adding an aggregation element. But I could not find a good one, since I prefer to only consider aggregation element changes when their key exists in the form sate. Currently we can just ensure this error is not occurring for our existing aggregation elements, by writing a unit test for each one.

Fixes https://github.com/Graylog2/graylog2-server/issues/10858

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

