### PR TITLE
Always close system menu when selecting link in system menu dropdown.

### DIFF
--- a/graylog2-web-interface/src/util/conditional/HideOnCloud.test.tsx
+++ b/graylog2-web-interface/src/util/conditional/HideOnCloud.test.tsx
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import asMock from 'helpers/mocking/AsMock';
+import { render, screen } from 'wrappedTestingLibrary';
+import userEvent from '@testing-library/user-event';
+
+import AppConfig from 'util/AppConfig';
+
+import HideOnCloud from './HideOnCloud';
+
+jest.mock('util/AppConfig', () => ({
+  isCloud: jest.fn(() => false),
+}));
+
+describe('HideOnCloud', () => {
+  it('does not display children on cloud', () => {
+    asMock(AppConfig.isCloud).mockReturnValue(true);
+
+    render(<HideOnCloud>The Content</HideOnCloud>);
+
+    expect(screen.queryByText('The Content')).not.toBeInTheDocument();
+  });
+
+  it('displays children when not on cloud', () => {
+    asMock(AppConfig.isCloud).mockReturnValue(false);
+
+    render(<HideOnCloud>The Content</HideOnCloud>);
+
+    expect(screen.getByText('The Content')).toBeInTheDocument();
+  });
+
+  it('forwards props to its children', () => {
+    const onClick = jest.fn();
+    asMock(AppConfig.isCloud).mockReturnValue(false);
+
+    render(<HideOnCloud onClick={onClick}><button type="button">Click Me!</button></HideOnCloud>);
+
+    const childrenButton = screen.getByText('Click Me!');
+    userEvent.click(childrenButton);
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/graylog2-web-interface/src/util/conditional/HideOnCloud.tsx
+++ b/graylog2-web-interface/src/util/conditional/HideOnCloud.tsx
@@ -18,13 +18,18 @@ import * as React from 'react';
 
 import AppConfig from '../AppConfig';
 
-// eslint-disable-next-line react/prop-types
-const HideOnCloud: React.FunctionComponent = ({ children }) => {
+const HideOnCloud = ({ children, ...rest }) => {
   if (AppConfig.isCloud()) {
     return <></>;
   }
 
-  return <>{children}</>;
+  return React.Children.map(children, (child) => {
+    if (React.isValidElement(child)) {
+      return React.cloneElement(child, rest);
+    }
+
+    return child;
+  });
 };
 
 export default HideOnCloud;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

We recently wrapped some menu items in the system menu dropdown with the `HideOnCloud` component.
One side effect was that we no longer closed the dropdown when selecting any wrapped menu item.

The reason:
When defining a child for the `react-bootstrap` component `NavDropdown`, the child automatically receives props like `active`, `onKeyDown`, `onSelect`. By wrapping a menu item in the system menu drop down with `HideOnCloud`, the component `HideOnCloud` receives these props, but not its children.

This PR is fixing the bug by forwarding the props.

Fixes: https://github.com/Graylog2/graylog2-server/issues/10830

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
