### PR TITLE
Fixing trend calculation in numeric vis if previous value is 0.

### DIFF
--- a/graylog2-web-interface/src/views/components/visualizations/number/Trend.test.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/number/Trend.test.tsx
@@ -77,7 +77,7 @@ describe('Trend', () => {
   it('shows adequate results if previous value is NaN', async () => {
     renderTrend({ current: 23, previous: NaN });
 
-    expect(await findTrend()).toEqual('');
+    expect(await findTrend()).toEqual('-- / --');
   });
 
   it('shows adequate results if current value is 0', async () => {
@@ -89,7 +89,7 @@ describe('Trend', () => {
   it('shows adequate results if current value is NaN', async () => {
     renderTrend({ current: NaN, previous: 42 });
 
-    expect(await findTrend()).toEqual('');
+    expect(await findTrend()).toEqual('-- / --');
   });
 
   describe('renders background according to values and trend preference', () => {

--- a/graylog2-web-interface/src/views/components/visualizations/number/Trend.test.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/number/Trend.test.tsx
@@ -25,41 +25,71 @@ const renderTrend = ({
   trendPreference = 'NEUTRAL',
 }: Partial<React.ComponentProps<typeof Trend>> = {}) => render(<Trend current={current} previous={previous} trendPreference={trendPreference} />);
 
+const findTrend = async () => {
+  const trend = await screen.findByTestId('trend-value');
+
+  return trend.innerHTML;
+};
+
 describe('Trend', () => {
   it('shows absolute delta', async () => {
     renderTrend({ previous: 23 });
 
-    await screen.findByText(/\+19/);
+    expect(await findTrend()).toMatch(/\+19/);
   });
 
   it('shows relative delta as percentage', async () => {
     renderTrend({ previous: 23 });
 
-    await screen.findByText(/\+82.61%/);
+    expect(await findTrend()).toMatch(/\+82.61%/);
   });
 
   it('shows absolute delta if values are equal', async () => {
     renderTrend();
 
-    await screen.findByText(/\+0/);
+    expect(await findTrend()).toMatch(/\+0/);
   });
 
   it('shows relative delta as percentage if values are equal', async () => {
     renderTrend();
 
-    await screen.findByText(/\+0%/);
+    expect(await findTrend()).toMatch(/\+0%/);
   });
 
   it('shows negative absolute delta', async () => {
     renderTrend({ current: 23 });
 
-    await screen.findByText(/-19/);
+    expect(await findTrend()).toMatch(/-19/);
   });
 
   it('shows negative relative delta as percentage', async () => {
     renderTrend({ current: 23 });
 
-    await screen.findByText(/-45.24%/);
+    expect(await findTrend()).toMatch(/-45.24%/);
+  });
+
+  it('shows adequate results if previous value is 0', async () => {
+    renderTrend({ current: 23, previous: 0 });
+
+    expect(await findTrend()).toMatch(/\+23/);
+  });
+
+  it('shows adequate results if previous value is NaN', async () => {
+    renderTrend({ current: 23, previous: NaN });
+
+    expect(await findTrend()).toEqual('');
+  });
+
+  it('shows adequate results if current value is 0', async () => {
+    renderTrend({ current: 0, previous: 42 });
+
+    expect(await findTrend()).toMatch(/-42 \/ -100%/);
+  });
+
+  it('shows adequate results if current value is NaN', async () => {
+    renderTrend({ current: NaN, previous: 42 });
+
+    expect(await findTrend()).toEqual('');
   });
 
   describe('renders background according to values and trend preference', () => {

--- a/graylog2-web-interface/src/views/components/visualizations/number/Trend.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/number/Trend.tsx
@@ -86,17 +86,39 @@ const _trendIcon = (delta: number) => (delta === 0
     ? 'arrow-circle-up'
     : 'arrow-circle-down');
 
+const diff = (current: number | undefined, previous: number | undefined): [number, number] => {
+  if (typeof current === 'number' && typeof previous === 'number') {
+    const difference = current - previous;
+    const differencePercent = difference / previous;
+
+    return [difference, differencePercent];
+  }
+
+  return [NaN, NaN];
+};
+
 const Trend = React.forwardRef<HTMLSpanElement, Props>(({ current, previous, trendPreference }: Props, ref) => {
-  const difference = previous ? current - previous : NaN;
-  const differencePercent = previous ? difference / previous : NaN;
+  const [difference, differencePercent] = diff(current, previous);
 
   const backgroundTrend = _trendDirection(difference, trendPreference);
   const trendIcon = _trendIcon(difference);
 
+  const trendStrings = [];
+
+  if (Number.isFinite(difference)) {
+    trendStrings.push(numeral(difference).format('+0,0[.]0[000]'));
+  }
+
+  if (Number.isFinite(differencePercent)) {
+    trendStrings.push(numeral(differencePercent).format('+0[.]0[0]%'));
+  }
+
+  const trend = trendStrings.join(' / ');
+
   return (
     <Background trend={backgroundTrend} data-testid="trend-background">
       <TextContainer trend={backgroundTrend} ref={ref}>
-        <StyledIcon name={trendIcon} trend={backgroundTrend} data-testid="trend-icon" /> {numeral(difference).format('+0,0[.]0[000]')} / {numeral(differencePercent).format('+0[.]0[0]%')}
+        <StyledIcon name={trendIcon} trend={backgroundTrend} data-testid="trend-icon" /> <span data-testid="trend-value">{trend}</span>
       </TextContainer>
     </Background>
   );

--- a/graylog2-web-interface/src/views/components/visualizations/number/Trend.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/number/Trend.tsx
@@ -103,22 +103,13 @@ const Trend = React.forwardRef<HTMLSpanElement, Props>(({ current, previous, tre
   const backgroundTrend = _trendDirection(difference, trendPreference);
   const trendIcon = _trendIcon(difference);
 
-  const trendStrings = [];
-
-  if (Number.isFinite(difference)) {
-    trendStrings.push(numeral(difference).format('+0,0[.]0[000]'));
-  }
-
-  if (Number.isFinite(differencePercent)) {
-    trendStrings.push(numeral(differencePercent).format('+0[.]0[0]%'));
-  }
-
-  const trend = trendStrings.join(' / ');
+  const absoluteDifference = Number.isFinite(difference) ? numeral(difference).format('+0,0[.]0[000]') : '--';
+  const relativeDifference = Number.isFinite(differencePercent) ? numeral(differencePercent).format('+0[.]0[0]%') : '--';
 
   return (
     <Background trend={backgroundTrend} data-testid="trend-background">
       <TextContainer trend={backgroundTrend} ref={ref}>
-        <StyledIcon name={trendIcon} trend={backgroundTrend} data-testid="trend-icon" /> <span data-testid="trend-value">{trend}</span>
+        <StyledIcon name={trendIcon} trend={backgroundTrend} data-testid="trend-icon" /> <span data-testid="trend-value" title={`Previous value: ${previous}`}>{absoluteDifference} / {relativeDifference}</span>
       </TextContainer>
     </Background>
   );


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Prior to this PR, if the value of the previous time range used for trend calculation returns a value of `0`, the trend was shown as `+0 / +0%`, due to a wrong check in the calculation (it checks if `previous` is set, but does a simple truthyness check which fails if `previous === 0`).

This PR fixes this and also adds conditional rendering of absolute and relative trend parts depending on if difference / difference in percent are finite or not. In addition, a tooltip is added that show the absolute previous value.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

Before:
![trend-before](https://user-images.githubusercontent.com/41929/122179171-8ad42d80-ce87-11eb-86a3-2902c79c7655.png)

After:
![image](https://user-images.githubusercontent.com/41929/122180615-dfc47380-ce88-11eb-9855-8c1b3504dc1e.png)
(relative trend is left out if `previous` is `0`, because the difference in percent results in `NaN`)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.