### PR TITLE
Always update all widgets after unfocusing

### DIFF
--- a/graylog2-web-interface/src/views/components/contexts/WidgetFocusProvider.test.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/WidgetFocusProvider.test.tsx
@@ -177,7 +177,7 @@ describe('WidgetFocusProvider', () => {
     expect(mockHistoryReplace).toBeCalledWith('');
   });
 
-  it('should not trigger search execution when not leaving widget editing', async () => {
+  it('should trigger search execution when not leaving widget focus mode', async () => {
     useLocation.mockReturnValue({
       pathname: '',
       search: '',
@@ -187,6 +187,6 @@ describe('WidgetFocusProvider', () => {
 
     renderSUT(consume);
 
-    expect(SearchActions.executeWithCurrentState).not.toHaveBeenCalled();
+    expect(SearchActions.executeWithCurrentState).toHaveBeenCalledTimes(1);
   });
 });

--- a/graylog2-web-interface/src/views/components/contexts/WidgetFocusProvider.test.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/WidgetFocusProvider.test.tsx
@@ -65,7 +65,9 @@ describe('WidgetFocusProvider', () => {
 
   it('should update url on widget focus', () => {
     let contextValue;
-    const consume = (value) => { contextValue = value; };
+    const consume = (value) => {
+      contextValue = value;
+    };
 
     renderSUT(consume);
 
@@ -81,7 +83,9 @@ describe('WidgetFocusProvider', () => {
     });
 
     let contextValue;
-    const consume = (value) => { contextValue = value; };
+    const consume = (value) => {
+      contextValue = value;
+    };
     renderSUT(consume);
 
     contextValue.unsetWidgetFocusing();
@@ -96,15 +100,19 @@ describe('WidgetFocusProvider', () => {
     });
 
     let contextValue;
-    const consume = (value) => { contextValue = value; };
+    const consume = (value) => {
+      contextValue = value;
+    };
     renderSUT(consume);
 
-    expect(contextValue.focusedWidget).toEqual({ id: 'widget-id', focusing: true, editing: false });
+    expect(contextValue.focusedWidget).toEqual({id: 'widget-id', focusing: true, editing: false});
   });
 
   it('should update url on widget edit', () => {
     let contextValue;
-    const consume = (value) => { contextValue = value; };
+    const consume = (value) => {
+      contextValue = value;
+    };
     renderSUT(consume);
 
     contextValue.setWidgetEditing('widget-id');
@@ -119,7 +127,9 @@ describe('WidgetFocusProvider', () => {
     });
 
     let contextValue;
-    const consume = (value) => { contextValue = value; };
+    const consume = (value) => {
+      contextValue = value;
+    };
 
     renderSUT(consume);
 
@@ -135,10 +145,12 @@ describe('WidgetFocusProvider', () => {
     });
 
     let contextValue;
-    const consume = (value) => { contextValue = value; };
+    const consume = (value) => {
+      contextValue = value;
+    };
     renderSUT(consume);
 
-    expect(contextValue.focusedWidget).toEqual({ id: 'widget-id', editing: true, focusing: true });
+    expect(contextValue.focusedWidget).toEqual({id: 'widget-id', editing: true, focusing: true});
   });
 
   it('should not remove focus query param on widget edit', () => {
@@ -148,7 +160,9 @@ describe('WidgetFocusProvider', () => {
     });
 
     let contextValue;
-    const consume = (value) => { contextValue = value; };
+    const consume = (value) => {
+      contextValue = value;
+    };
     renderSUT(consume);
 
     contextValue.setWidgetEditing('widget-id');
@@ -169,7 +183,9 @@ describe('WidgetFocusProvider', () => {
     });
 
     let contextValue;
-    const consume = (value) => { contextValue = value; };
+    const consume = (value) => {
+      contextValue = value;
+    };
     renderSUT(consume);
 
     expect(contextValue.focusedWidget).toBe(undefined);
@@ -177,7 +193,7 @@ describe('WidgetFocusProvider', () => {
     expect(mockHistoryReplace).toBeCalledWith('');
   });
 
-  it('should trigger search execution when not leaving widget focus mode', async () => {
+  it('should not trigger search execution when no focus mode was requested', async () => {
     useLocation.mockReturnValue({
       pathname: '',
       search: '',
@@ -187,6 +203,6 @@ describe('WidgetFocusProvider', () => {
 
     renderSUT(consume);
 
-    expect(SearchActions.executeWithCurrentState).toHaveBeenCalledTimes(1);
+    expect(SearchActions.executeWithCurrentState).not.toHaveBeenCalled();
   });
 });

--- a/graylog2-web-interface/src/views/components/contexts/WidgetFocusProvider.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/WidgetFocusProvider.tsx
@@ -84,10 +84,7 @@ const useSyncStateWithQueryParams = ({ focusedWidget, focusUriParams, setFocused
       setFocusedWidget(nextFocusedWidget);
       const filter = nextFocusedWidget?.id ? [nextFocusedWidget.id] : null;
       SearchActions.setWidgetsToSearch(filter);
-
-      if (focusedWidget?.editing && filter === null) {
-        SearchActions.executeWithCurrentState();
-      }
+      SearchActions.executeWithCurrentState();
     }
   }, [focusedWidget, setFocusedWidget, widgets, focusUriParams]);
 };

--- a/graylog2-web-interface/src/views/components/contexts/WidgetFocusProvider.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/WidgetFocusProvider.tsx
@@ -84,7 +84,10 @@ const useSyncStateWithQueryParams = ({ focusedWidget, focusUriParams, setFocused
       setFocusedWidget(nextFocusedWidget);
       const filter = nextFocusedWidget?.id ? [nextFocusedWidget.id] : null;
       SearchActions.setWidgetsToSearch(filter);
-      SearchActions.executeWithCurrentState();
+
+      if (focusedWidget?.focusing && filter === null) {
+        SearchActions.executeWithCurrentState();
+      }
     }
   }, [focusedWidget, setFocusedWidget, widgets, focusUriParams]);
 };


### PR DESCRIPTION
## Motivation
Prior to this change, we did only update all searches after we left the
focus mode from editing. But when we switched a message table to a log
view and unfocused the log view other widgets were not part of the newly
generated search result.

## Description
This change will update all widgets after leaving the unfocusing mode.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Fixes https://github.com/Graylog2/graylog-plugin-enterprise/issues/2359