### PR TITLE
Generate new search when only `trend` setting is changed.

### DIFF
--- a/graylog2-web-interface/src/stores/__tests__/EqualityCheck.fixtures.ts
+++ b/graylog2-web-interface/src/stores/__tests__/EqualityCheck.fixtures.ts
@@ -16,6 +16,12 @@
  */
 import { List, Map } from 'immutable';
 
+import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
+import NumberVisualization from 'views/components/visualizations/number/NumberVisualization';
+import NumberVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/NumberVisualizationConfig';
+import BarVisualization from 'views/components/visualizations/bar/BarVisualization';
+import BarVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/BarVisualizationConfig';
+
 type MixedMapsAndObjects = { [key: string]: Map<string, { [key: string]: Map<string, number> }> };
 
 export const mapWithObject = (): Map<string, { [key: string]: number }> => Map({ foo: { bar: 42 } });
@@ -43,3 +49,21 @@ export class NonValueClass {
     this.value = value;
   }
 }
+
+export const numericVisualizationWithTrend = () => AggregationWidgetConfig.builder()
+  .visualization(NumberVisualization.type)
+  .visualizationConfig(NumberVisualizationConfig.create(true))
+  .build();
+export const numericVisualizationWithoutTrend = () => AggregationWidgetConfig.builder()
+  .visualization(NumberVisualization.type)
+  .visualizationConfig(NumberVisualizationConfig.create())
+  .build();
+
+export const barChartWithGrouping = () => AggregationWidgetConfig.builder()
+  .visualization(BarVisualization.type)
+  .visualizationConfig(BarVisualizationConfig.create('group'))
+  .build();
+export const barChartWithStacking = () => AggregationWidgetConfig.builder()
+  .visualization(BarVisualization.type)
+  .visualizationConfig(BarVisualizationConfig.create('stack'))
+  .build();

--- a/graylog2-web-interface/src/views/logic/aggregationbuilder/AggregationWidgetConfig.ts
+++ b/graylog2-web-interface/src/views/logic/aggregationbuilder/AggregationWidgetConfig.ts
@@ -186,7 +186,7 @@ export default class AggregationWidgetConfig extends WidgetConfig {
 
   equalsForSearch(other: any) {
     if (other instanceof AggregationWidgetConfig) {
-      return ['rowPivots', 'columnPivots', 'series', 'sort', 'rollup', 'eventAnnotation']
+      return ['rowPivots', 'columnPivots', 'series', 'sort', 'rollup', 'eventAnnotation', 'visualizationConfig']
         .every((key) => isEqualForSearch(this[key], other[key]));
     }
 

--- a/graylog2-web-interface/src/views/logic/aggregationbuilder/visualizations/NumberVisualizationConfig.ts
+++ b/graylog2-web-interface/src/views/logic/aggregationbuilder/visualizations/NumberVisualizationConfig.ts
@@ -75,6 +75,10 @@ export default class NumberVisualizationConfig extends VisualizationConfig {
     };
   }
 
+  equalsForSearch(other: any) {
+    return other && 'trend' in other && other.trend === this.trend;
+  }
+
   static fromJSON(type: string, value: NumberVisualizationConfigJSON) {
     const { trend, trend_preference: trendPreference } = value;
 

--- a/graylog2-web-interface/src/views/logic/aggregationbuilder/visualizations/VisualizationConfig.ts
+++ b/graylog2-web-interface/src/views/logic/aggregationbuilder/visualizations/VisualizationConfig.ts
@@ -39,6 +39,11 @@ export default class VisualizationConfig {
     throw new Error('Must not be called on abstract class!');
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars,class-methods-use-this
+  equalsForSearch(other: any) {
+    return true;
+  }
+
   static __registrations: { [key: string]: DeserializesVisualizationConfig } = {};
 
   static registerSubtype(type: string, implementingClass: DeserializesVisualizationConfig) {

--- a/graylog2-web-interface/src/views/stores/isEqualForSearch.test.tsx
+++ b/graylog2-web-interface/src/views/stores/isEqualForSearch.test.tsx
@@ -25,6 +25,10 @@ import {
   AlwaysEqual,
   NeverEqual,
   NonValueClass,
+  numericVisualizationWithTrend,
+  numericVisualizationWithoutTrend,
+  barChartWithGrouping,
+  barChartWithStacking,
 } from 'stores/__tests__/EqualityCheck.fixtures';
 
 import isEqualForSearch from './isEqualForSearch';
@@ -79,5 +83,7 @@ describe('isEqualForSearch', () => {
     ${objectWithMap()}       | ${objectWithMap()}       | ${true}   | ${'objects containing immutable maps'}
     ${arrayOfMaps()}         | ${arrayOfMaps()}         | ${true}   | ${'arrays containing immutable maps'}
     ${mixedMapsAndObjects()} | ${mixedMapsAndObjects()} | ${true}   | ${'nested immutable maps and objects'}
+    ${numericVisualizationWithTrend()} | ${numericVisualizationWithoutTrend()} | ${false} | ${'numeric visualization with/without trend'}
+    ${barChartWithGrouping()} | ${barChartWithStacking()} | ${true} | ${'bar charts with different modes'}
   `('compares $description and returns $result', verifyIsEqualForSearch);
 });


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Prior to this PR, when enabling only the boolean `trend` setting of a numeric visualization and nothing else, we did not generate a new search and the `trend` search type was not retrieved. This lead to empty trending information. The root cause of this was that we generally leave out the `visualization` and `visualizationConfig` keys of an aggregation config when determining equality to decide if we need a new search or not.

This change is now implementing `equalsForSearch` methods in the `VisualizationConfig` classes (defaulting to return `true`, as visualization configs should generally not need to generate a new search) and in `NumberVisualizationConfig` (returning a boolean depending on the presence and value of the `trend` setting of both configs). Also, the `visualizationConfig` key is added to the checked attributes. This leads to generating a new search when the `trend` setting is flipped.

The issue can be easily reproduced:

  - start a new search/dashboard
  - create a `Message Count` predefined aggregation
  - edit it
  - toggle only(!) the `trend` setting and apply it
  - see that trending information is empty (`-- / --`)


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

Before:
![before-trend-change](https://user-images.githubusercontent.com/41929/122196945-0047fa00-ce98-11eb-8205-f576571fb399.gif)

After:
![after-trend-change](https://user-images.githubusercontent.com/41929/122196759-cb3ba780-ce97-11eb-9b89-be3e45419eed.gif)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.