### PR TITLE
Disable automatic rebasing for dependency update PRs.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,7 @@ updates:
   open-pull-requests-limit: 10
   labels:
   - dependencies
+  rebase-strategy: "disabled"
 - package-ecosystem: npm
   directory: "/graylog2-web-interface/packages/graylog-web-plugin"
   schedule:
@@ -23,6 +24,7 @@ updates:
     versions:
     - ">= 1.a"
     - "< 2"
+  rebase-strategy: "disabled"
 - package-ecosystem: npm
   directory: "/graylog2-web-interface"
   schedule:
@@ -37,6 +39,7 @@ updates:
     versions:
     - ">= 4.a"
     - "< 5"
+  rebase-strategy: "disabled"
 - package-ecosystem: npm
   directory: "/graylog2-web-interface/packages/eslint-config-graylog"
   schedule:
@@ -46,6 +49,7 @@ updates:
   open-pull-requests-limit: 10
   labels:
   - dependencies
+  rebase-strategy: "disabled"
 - package-ecosystem: npm
   directory: "/graylog2-web-interface/packages/jest-preset-graylog"
   schedule:
@@ -55,3 +59,4 @@ updates:
   open-pull-requests-limit: 10
   labels:
   - dependencies
+  rebase-strategy: "disabled"


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This change is disabling automatic rebasing for dependabot's update PRs.  The motivation for this is to reduce the number of running builds on our CI due to rebased PRs, whenever one of the package management configuration files are touched. Most of these rebases are unnecessary, especially for PRs which take longer to review.

In order to trigger a rebase manually for PRs, a simple

```
@dependabot rebase
```

as a PR comment is enough.