### PR TITLE
Enabling security updates for stable branch.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,6 @@
 version: 2
 updates:
+# default branch: enabling all dependency updates
 - package-ecosystem: maven
   directory: "/"
   schedule:
@@ -59,4 +60,61 @@ updates:
   open-pull-requests-limit: 10
   labels:
   - dependencies
+  rebase-strategy: "disabled"
+  
+# stable branch, enabling only security updates by setting PR limit to 0 (security updates will still go through)
+- package-ecosystem: maven
+  directory: "/"
+  target-branch: "4.0"
+  schedule:
+    interval: daily
+    time: "02:00"
+    timezone: "Europe/Berlin"
+  open-pull-requests-limit: 0
+  labels:
+  - security
+  rebase-strategy: "disabled"
+- package-ecosystem: npm
+  directory: "/graylog2-web-interface/packages/graylog-web-plugin"
+  target-branch: "4.0"
+  schedule:
+    interval: daily
+    time: "02:00"
+    timezone: "Europe/Berlin"
+  open-pull-requests-limit: 0
+  labels:
+  - security
+  rebase-strategy: "disabled"
+- package-ecosystem: npm
+  directory: "/graylog2-web-interface"
+  target-branch: "4.0"
+  schedule:
+    interval: daily
+    time: "02:00"
+    timezone: "Europe/Berlin"
+  open-pull-requests-limit: 0
+  labels:
+  - security
+  rebase-strategy: "disabled"
+- package-ecosystem: npm
+  directory: "/graylog2-web-interface/packages/eslint-config-graylog"
+  target-branch: "4.0"
+  schedule:
+    interval: daily
+    time: "02:00"
+    timezone: "Europe/Berlin"
+  open-pull-requests-limit: 0
+  labels:
+  - security
+  rebase-strategy: "disabled"
+- package-ecosystem: npm
+  directory: "/graylog2-web-interface/packages/jest-preset-graylog"
+  target-branch: "4.0"
+  schedule:
+    interval: daily
+    time: "02:00"
+    timezone: "Europe/Berlin"
+  open-pull-requests-limit: 0
+  labels:
+  - security
   rebase-strategy: "disabled"


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is extending our dependabot config to include the last stable branches,  so security update PRs are generated, but no general dependency update PRs. The entries for the stable branch contain essentially the same configuration as for the default branch, but with a different target branch, a `security` label and a PR limit of `0`. This limit affects dependency update PRs, but security updates are not counted against it.