### PR TITLE
Add cluster wide Loggers endpoint

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterLoggersResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterLoggersResource.java
@@ -96,4 +96,16 @@ public class ClusterLoggersResource extends ProxiedResource {
 
         remoteLoggersResource.setSubsystemLoggerLevel(subsystemTitle, level).execute();
     }
+
+    @PUT
+    @Timed
+    @Path("/{loggerName}/level/{level}")
+    @ApiOperation(value = "Set the loglevel of a single logger",
+            notes = "Provided level is falling back to DEBUG if it does not exist")
+    @NoAuditEvent("proxy resource, audit event will be emitted on target nodes")
+    public Map<String, CallResult<Void>> setClusterSingleLoggerLevel(
+            @ApiParam(name = "loggerName", required = true) @PathParam("loggerName") @NotEmpty String loggerName,
+            @ApiParam(name = "level", required = true) @PathParam("level") @NotEmpty String level) throws NodeNotFoundException, IOException {
+        return requestOnAllNodes(createRemoteInterfaceProvider(RemoteLoggersResource.class), client -> client.setSingleLoggerLevel(loggerName, level));
+    }
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/logs/RemoteLoggersResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/logs/RemoteLoggersResource.java
@@ -35,7 +35,7 @@ public interface RemoteLoggersResource {
     Call<Void> setSubsystemLoggerLevel(@Path("subsystem") String subsystemTitle, @Path("level") String level);
 
     @PUT("system/loggers/{loggerName}/level/{level}")
-    Call<Void> setSingleLoggerLevel(String loggerName, String level);
+    Call<Void> setSingleLoggerLevel(@Path("loggerName") String loggerName, @Path("level") String level);
 
     @GET("system/loggers/messages/recent")
     Call<LogMessagesSummary> messages(int limit, String level);


### PR DESCRIPTION
We currently only support changing entire subsystems on the entire cluster.

For debugging specific problems it might help to change the loglevel
of classes under a certain package name.
E.g.:

`$ http --json --auth admin:admin put https://172.16.1.1:9000/api/cluster/system/loggers/org.graylog.plugins.events/level/DEBUG  X-Requested-By:httpie`

