### PR TITLE
Always normalize dashboard widget time range correctly when updating widget.

### DIFF
--- a/graylog2-web-interface/src/views/components/WidgetQueryControls.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetQueryControls.tsx
@@ -43,7 +43,7 @@ import TimeRangeInput from './searchbar/TimeRangeInput';
 import StreamsFilter from './searchbar/StreamsFilter';
 import SearchButton from './searchbar/SearchButton';
 import QueryInput from './searchbar/AsyncQueryInput';
-import SearchBarForm from './searchbar/SearchBarForm';
+import SearchBarForm, { normalizeSearchBarFormValues } from './searchbar/SearchBarForm';
 import WidgetQueryOverride from './WidgetQueryOverride';
 
 const SecondRow = styled.div`
@@ -91,7 +91,9 @@ const useBindApplySearchControlsChanges = (formRef) => {
         const { dirty, values, isValid } = formRef.current;
 
         if (dirty && isValid) {
-          return updateWidgetSearchControls(newWidget, values);
+          const normalizedFormValues = normalizeSearchBarFormValues(values);
+
+          return updateWidgetSearchControls(newWidget, normalizedFormValues);
         }
       }
 

--- a/graylog2-web-interface/src/views/components/searchbar/SearchBarForm.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/SearchBarForm.tsx
@@ -43,15 +43,19 @@ const StyledForm = styled(Form)`
 
 const _isFunction = (children: Props['children']): children is (props: FormikProps<SearchBarFormValues>) => React.ReactElement => isFunction(children);
 
+export const normalizeSearchBarFormValues = ({ timerange, streams, queryString }) => {
+  const newTimeRange = onSubmittingTimerange(timerange);
+
+  return {
+    timerange: newTimeRange,
+    streams,
+    queryString,
+  };
+};
+
 const SearchBarForm = ({ initialValues, limitDuration, onSubmit, children, validateOnMount, formRef }: Props) => {
   const _onSubmit = useCallback(({ timerange, streams, queryString }) => {
-    const newTimeRange = onSubmittingTimerange(timerange);
-
-    return onSubmit({
-      timerange: newTimeRange,
-      streams,
-      queryString,
-    });
+    return onSubmit(normalizeSearchBarFormValues({ timerange, streams, queryString }));
   }, [onSubmit]);
   const { timerange, streams, queryString } = initialValues;
   const initialTimeRange = onInitializingTimerange(timerange);

--- a/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TimeRangeLivePreview.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TimeRangeLivePreview.tsx
@@ -130,7 +130,7 @@ const TimeRangeLivePreview = ({ timerange }: Props) => {
   }, [isValid, timerange]);
 
   return (
-    <PreviewWrapper>
+    <PreviewWrapper data-testid="time-range-live-preview">
       <FromWrapper>
         <Title>From</Title>
         <Date title={`Dates Formatted as [${DateTime.Formats.TIMESTAMP}]`}>{from}</Date>

--- a/graylog2-web-interface/src/views/components/widgets/Widget.aggregations.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/Widget.aggregations.test.tsx
@@ -47,7 +47,7 @@ import FieldTypesContext from '../contexts/FieldTypesContext';
 import ViewTypeContext from '../contexts/ViewTypeContext';
 
 const testTimeout = applyTimeoutMultiplier(30000);
-const mockedUnixTime = 1577836800000; // 2020-01-01 00:00:00.00
+const mockedUnixTime = 1577836800000; // 2020-01-01 00:00:00.000
 
 jest.mock('./WidgetHeader', () => 'widget-header');
 jest.mock('./WidgetColorContext', () => ({ children }) => children);

--- a/graylog2-web-interface/src/views/components/widgets/Widget.aggregations.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/Widget.aggregations.test.tsx
@@ -117,7 +117,6 @@ describe('Aggregation Widget', () => {
 
   beforeEach(() => {
     Date.now = jest.fn(() => mockedUnixTime);
-    jest.useFakeTimers('modern').setSystemTime(mockedUnixTime);
     ViewStore.getInitialState = jest.fn(() => viewStoreState);
   });
 
@@ -125,7 +124,6 @@ describe('Aggregation Widget', () => {
     jest.clearAllMocks();
     jest.resetModules();
     Date.now = originalDateNow;
-    jest.useRealTimers();
   });
 
   type AggregationWidgetProps = Partial<WidgetComponentProps> & {

--- a/graylog2-web-interface/src/views/components/widgets/Widget.aggregations.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/Widget.aggregations.test.tsx
@@ -16,7 +16,7 @@
  */
 import React from 'react';
 import * as Immutable from 'immutable';
-import { render, waitFor, fireEvent, screen } from 'wrappedTestingLibrary';
+import { render, waitFor, fireEvent, screen, within } from 'wrappedTestingLibrary';
 import mockAction from 'helpers/mocking/MockAction';
 import { PluginManifest, PluginStore } from 'graylog-web-plugin/plugin';
 import MockStore from 'helpers/mocking/StoreMock';
@@ -105,12 +105,14 @@ describe('Aggregation Widget', () => {
   };
 
   beforeEach(() => {
+    jest.useFakeTimers('modern').setSystemTime(new Date('2020-01-01').getTime());
     ViewStore.getInitialState = jest.fn(() => viewStoreState);
   });
 
   afterEach(() => {
     jest.clearAllMocks();
     jest.resetModules();
+    jest.useRealTimers();
   });
 
   type AggregationWidgetProps = Partial<WidgetComponentProps> & {
@@ -151,7 +153,7 @@ describe('Aggregation Widget', () => {
   const findWidgetConfigSubmitButton = () => screen.findByRole('button', { name: 'Update Preview' });
 
   describe('on a dashboard', () => {
-    it('should update not submitted widget search controls and aggregation elements changes when clicking on "Apply Changes"', async () => {
+    it('should apply not submitted widget search controls and aggregation elements changes when clicking on "Apply Changes"', async () => {
       const newSeries = Series.create('count').toBuilder().config(SeriesConfig.empty().toBuilder().name('Metric name').build()).build();
       const updatedConfig = dataTableWidget.config
         .toBuilder()
@@ -196,8 +198,44 @@ describe('Aggregation Widget', () => {
     }, testTimeout);
   });
 
+  it('should apply not submitted widget time range changes in correct format when clicking on "Apply Changes"', async () => {
+    const updatedWidget = dataTableWidget
+      .toBuilder()
+      .timerange({
+        from: '2019-12-31T23:55:00.000Z',
+        to: '2020-01-01T00:00:00.000Z',
+        type: 'absolute',
+      })
+      .build();
+
+    render(<AggregationWidget editing viewType={View.Type.Dashboard} />);
+
+    // Change widget time range
+    const timeRangeDropdownButton = screen.getByLabelText('Open Time Range Selector');
+    userEvent.click(timeRangeDropdownButton);
+
+    const absoluteTabButton = await screen.findByRole('tab', { name: /absolute/i });
+    userEvent.click(absoluteTabButton);
+
+    await screen.findByText(/2020-01-01 00:55:00.000/i);
+
+    const applyTimeRangeChangesButton = screen.getByRole('button', { name: 'Apply' });
+    userEvent.click(applyTimeRangeChangesButton);
+
+    const timeRangeDisplay = screen.getByLabelText('Search Time Range, Opens Time Range Selector On Click');
+    await within(timeRangeDisplay).findByText('2020-01-01 00:55:00.000');
+
+    // Submit all changes
+    const saveButton = screen.getByText('Apply Changes');
+    fireEvent.click(saveButton);
+
+    await waitFor(() => expect(WidgetActions.update).toHaveBeenCalledTimes(1));
+
+    expect(WidgetActions.update).toHaveBeenCalledWith(expect.any(String), updatedWidget);
+  }, testTimeout);
+
   describe('on a search', () => {
-    it('should update not submitted aggregation elements changes when clicking on "Apply Changes"', async () => {
+    it('should apply not submitted aggregation elements changes when clicking on "Apply Changes"', async () => {
       const newSeries = Series.create('count').toBuilder().config(SeriesConfig.empty().toBuilder().name('Metric name').build()).build();
       const updatedConfig = dataTableWidget.config
         .toBuilder()

--- a/graylog2-web-interface/src/views/components/widgets/Widget.aggregations.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/Widget.aggregations.test.tsx
@@ -196,43 +196,44 @@ describe('Aggregation Widget', () => {
 
       expect(WidgetActions.update).toHaveBeenCalledWith(expect.any(String), updatedWidget);
     }, testTimeout);
+
+    it('should apply not submitted widget time range changes in correct format when clicking on "Apply Changes"', async () => {
+      const updatedWidget = dataTableWidget
+        .toBuilder()
+        .timerange({
+          from: '2019-12-31T23:55:00.000Z',
+          to: '2020-01-01T00:00:00.000Z',
+          type: 'absolute',
+        })
+        .build();
+
+      render(<AggregationWidget editing viewType={View.Type.Dashboard} />);
+
+      // Change widget time range
+      const timeRangeDropdownButton = screen.getByLabelText('Open Time Range Selector');
+      userEvent.click(timeRangeDropdownButton);
+
+      const absoluteTabButton = await screen.findByRole('tab', { name: /absolute/i });
+      userEvent.click(absoluteTabButton);
+
+      const timeRangeLivePreview = screen.getByTestId('time-range-live-preview');
+      await within(timeRangeLivePreview).findByText(/2020-01-01 00:55:00\.000/i);
+
+      const applyTimeRangeChangesButton = screen.getByRole('button', { name: 'Apply' });
+      userEvent.click(applyTimeRangeChangesButton);
+
+      const timeRangeDisplay = screen.getByLabelText('Search Time Range, Opens Time Range Selector On Click');
+      await within(timeRangeDisplay).findByText('2020-01-01 00:55:00.000');
+
+      // Submit all changes
+      const saveButton = screen.getByText('Apply Changes');
+      fireEvent.click(saveButton);
+
+      await waitFor(() => expect(WidgetActions.update).toHaveBeenCalledTimes(1));
+
+      expect(WidgetActions.update).toHaveBeenCalledWith(expect.any(String), updatedWidget);
+    }, testTimeout);
   });
-
-  it('should apply not submitted widget time range changes in correct format when clicking on "Apply Changes"', async () => {
-    const updatedWidget = dataTableWidget
-      .toBuilder()
-      .timerange({
-        from: '2019-12-31T23:55:00.000Z',
-        to: '2020-01-01T00:00:00.000Z',
-        type: 'absolute',
-      })
-      .build();
-
-    render(<AggregationWidget editing viewType={View.Type.Dashboard} />);
-
-    // Change widget time range
-    const timeRangeDropdownButton = screen.getByLabelText('Open Time Range Selector');
-    userEvent.click(timeRangeDropdownButton);
-
-    const absoluteTabButton = await screen.findByRole('tab', { name: /absolute/i });
-    userEvent.click(absoluteTabButton);
-
-    await screen.findByText(/2020-01-01 00:55:00.000/i);
-
-    const applyTimeRangeChangesButton = screen.getByRole('button', { name: 'Apply' });
-    userEvent.click(applyTimeRangeChangesButton);
-
-    const timeRangeDisplay = screen.getByLabelText('Search Time Range, Opens Time Range Selector On Click');
-    await within(timeRangeDisplay).findByText('2020-01-01 00:55:00.000');
-
-    // Submit all changes
-    const saveButton = screen.getByText('Apply Changes');
-    fireEvent.click(saveButton);
-
-    await waitFor(() => expect(WidgetActions.update).toHaveBeenCalledTimes(1));
-
-    expect(WidgetActions.update).toHaveBeenCalledWith(expect.any(String), updatedWidget);
-  }, testTimeout);
 
   describe('on a search', () => {
     it('should apply not submitted aggregation elements changes when clicking on "Apply Changes"', async () => {

--- a/graylog2-web-interface/src/views/components/widgets/Widget.aggregations.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/Widget.aggregations.test.tsx
@@ -113,17 +113,15 @@ describe('Aggregation Widget', () => {
     dirty: false,
   };
 
-  const originalDateNow = Date.now;
-
   beforeEach(() => {
-    Date.now = jest.fn(() => mockedUnixTime);
+    jest.useFakeTimers('modern').setSystemTime(mockedUnixTime);
     ViewStore.getInitialState = jest.fn(() => viewStoreState);
   });
 
   afterEach(() => {
     jest.clearAllMocks();
     jest.resetModules();
-    Date.now = originalDateNow;
+    jest.useRealTimers();
   });
 
   type AggregationWidgetProps = Partial<WidgetComponentProps> & {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

As described in https://github.com/Graylog2/graylog2-server/issues/10885 there is currently a bug, when updating the time range of a dashboard widget by using the "Apply Changes" button. This bug does not occur when a user applies the time range changes, by executing the search first.

The bug occurred because we were not normalizing the widget time range correctly. This PR by always normalizing the dashboard widget time range, no matter if the changes are being applied by clicking on the search or "Apply Changes" button.

Fixes: https://github.com/Graylog2/graylog2-server/issues/10885

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.