### PR TITLE
Adjusting to changed error messages in ES7 for flood stage/missing alias target

### DIFF
--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/MessagesAdapterES7.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/MessagesAdapterES7.java
@@ -64,6 +64,9 @@ public class MessagesAdapterES7 implements MessagesAdapter {
     static final String UNAVAILABLE_SHARDS_EXCEPTION = "unavailable_shards_exception";
     static final String PRIMARY_SHARD_NOT_ACTIVE_REASON = "primary shard is not active";
 
+    static final String ILLEGAL_ARGUMENT_EXCEPTION = "illegal_argument_exception";
+    static final String NO_WRITE_INDEX_DEFINED_FOR_ALIAS = "no write index is defined for alias";
+
     private final ElasticsearchClient client;
     private final Meter invalidTimestampMeter;
     private final ChunkedBulkIndexer chunkedBulkIndexer;
@@ -230,6 +233,9 @@ public class MessagesAdapterES7 implements MessagesAdapter {
                     return Messages.IndexingError.ErrorType.IndexBlocked;
             case UNAVAILABLE_SHARDS_EXCEPTION:
                 if (exception.reason().contains(PRIMARY_SHARD_NOT_ACTIVE_REASON))
+                    return Messages.IndexingError.ErrorType.IndexBlocked;
+            case ILLEGAL_ARGUMENT_EXCEPTION:
+                if (exception.reason().contains(NO_WRITE_INDEX_DEFINED_FOR_ALIAS))
                     return Messages.IndexingError.ErrorType.IndexBlocked;
             default: return Messages.IndexingError.ErrorType.Unknown;
         }

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/MessagesAdapterES7.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/MessagesAdapterES7.java
@@ -60,6 +60,7 @@ public class MessagesAdapterES7 implements MessagesAdapter {
     static final String INDEX_BLOCK_ERROR = "cluster_block_exception";
     static final String MAPPER_PARSING_EXCEPTION = "mapper_parsing_exception";
     static final String INDEX_BLOCK_REASON = "blocked by: [TOO_MANY_REQUESTS/12/index read-only / allow delete (api)";
+    static final String FLOOD_STAGE_WATERMARK = "blocked by: [TOO_MANY_REQUESTS/12/disk usage exceeded flood-stage watermark";
     static final String UNAVAILABLE_SHARDS_EXCEPTION = "unavailable_shards_exception";
     static final String PRIMARY_SHARD_NOT_ACTIVE_REASON = "primary shard is not active";
 
@@ -224,8 +225,12 @@ public class MessagesAdapterES7 implements MessagesAdapter {
         final ParsedElasticsearchException exception = ParsedElasticsearchException.from(item.getFailureMessage());
         switch (exception.type()) {
             case MAPPER_PARSING_EXCEPTION: return Messages.IndexingError.ErrorType.MappingError;
-            case INDEX_BLOCK_ERROR: if (exception.reason().contains(INDEX_BLOCK_REASON)) return Messages.IndexingError.ErrorType.IndexBlocked;
-            case UNAVAILABLE_SHARDS_EXCEPTION: if (exception.reason().contains(PRIMARY_SHARD_NOT_ACTIVE_REASON)) return Messages.IndexingError.ErrorType.IndexBlocked;
+            case INDEX_BLOCK_ERROR:
+                if (exception.reason().contains(INDEX_BLOCK_REASON) || exception.reason().contains(FLOOD_STAGE_WATERMARK))
+                    return Messages.IndexingError.ErrorType.IndexBlocked;
+            case UNAVAILABLE_SHARDS_EXCEPTION:
+                if (exception.reason().contains(PRIMARY_SHARD_NOT_ACTIVE_REASON))
+                    return Messages.IndexingError.ErrorType.IndexBlocked;
             default: return Messages.IndexingError.ErrorType.Unknown;
         }
     }

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/testing/ElasticsearchInstanceES7.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/testing/ElasticsearchInstanceES7.java
@@ -35,7 +35,7 @@ import java.net.URI;
 
 public class ElasticsearchInstanceES7 extends ElasticsearchInstance {
     private static final Logger LOG = LoggerFactory.getLogger(ElasticsearchInstanceES7.class);
-    private static final String ES_VERSION = "7.8.0";
+    private static final String ES_VERSION = "7.10.1";
 
     private final RestHighLevelClient restHighLevelClient;
     private final ElasticsearchClient elasticsearchClient;

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/testing/ElasticsearchInstanceES7.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/testing/ElasticsearchInstanceES7.java
@@ -35,7 +35,7 @@ import java.net.URI;
 
 public class ElasticsearchInstanceES7 extends ElasticsearchInstance {
     private static final Logger LOG = LoggerFactory.getLogger(ElasticsearchInstanceES7.class);
-    private static final String ES_VERSION = "7.10.1";
+    private static final String ES_VERSION = "7.10.2";
 
     private final RestHighLevelClient restHighLevelClient;
     private final ElasticsearchClient elasticsearchClient;


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Between ES 7.8.0 and 7.10.1, the error messages returned by the server for these case:

  - a message cannot be ingested to an index because the index/cluster is in flood stage
  - a message cannot be ingested to an alias, because the alias is missing a target

have changed. Therefore our error checking code does not identify these cases as being retriable, resulting in message loss.

This PR addresses these cases and adds the changed error messages in addition to the previous ones in order to support both versions.

This circumstance could have been detected if our integration tests would have used newer versions of ES for testing. Therefore, the ES version for the tests was bumped. In the future, we should complete our plans to run integration tests against a matrix of versions, including earliest and latest version.

Fixes #10887.

Note: There are additional cornes cases during flood stage when an index is rotated/the deflector is cycled (either manually or automatically). While this works, it currently generates quite some noise in the logs looking ugly, because a lot of exceptions are thrown in different places. The indices/deflectors are cleaned up successfully after the ES cluster was recovered though, therefore this was not cleaned up at this stage, because of the risk of accidental regressions. It will be cleaned up after the release to maintain a readable log during these situations.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Manual testing using this procedure:

  - Triggering flood stage by decreasing disk watermark thresholds for ES
  - Ingesting one or more messages
  - Resetting disk watermask tresholds
  - Waiting for ES to reset index blocks automatically
  - Check if messages have been ingested and ingestion continues

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.