### PR TITLE
Releasing objects retained by RawMessageEvents

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/shared/buffers/DirectMessageHandler.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/buffers/DirectMessageHandler.java
@@ -42,7 +42,7 @@ class DirectMessageHandler implements WorkHandler<RawMessageEvent> {
             processingStatusRecorder.updateIngestReceiveTime(rawMessage.getTimestamp());
         }
         // clear out for gc and to avoid promoting the raw message event to a tenured gen
-        event.setRawMessage(null);
+        event.clear();
     }
 
 

--- a/graylog2-server/src/main/java/org/graylog2/shared/buffers/JournallingMessageHandler.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/buffers/JournallingMessageHandler.java
@@ -67,11 +67,14 @@ public class JournallingMessageHandler implements EventHandler<RawMessageEvent> 
             // call the update on the recorder service for every message. (less contention)
             processingStatusRecorder.updateIngestReceiveTime(metricsFilter.getLatestReceiveTime());
 
-            // Clear the batch list after transforming it with the Converter because the fields of the RawMessageEvent
-            // objects in there have been set to null and cannot be used anymore.
-            batch.clear();
-
             messageQueueWriter.write(entries);
+
+            // Release objects for GC
+            batch.stream()
+                    .filter(Objects::nonNull)
+                    .forEach(RawMessageEvent::clear);
+
+            batch.clear();
         }
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/shared/buffers/RawMessageEvent.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/buffers/RawMessageEvent.java
@@ -96,4 +96,11 @@ public class RawMessageEvent {
         final ByteBuffer wrap = ByteBuffer.wrap(messageIdBytes);
         return new UUID(wrap.asLongBuffer().get(0), wrap.asLongBuffer().get(1));
     }
+
+    public void clear() {
+        this.rawMessage = null;
+        this.encodedRawMessage = null;
+        this.messageIdBytes = null;
+        this.messageTimestamp = null;
+    }
 }


### PR DESCRIPTION
Even though the input ring buffer is capped, the unreleased references occupy memory which could be used otherwise. The fix covers both scenarios: with and without journalling. 