### PR TITLE
Fixing floating of `ListGroupItem`s in `ListGroup`.

### DIFF
--- a/graylog2-web-interface/src/components/common/ControlledTableListHeader.jsx
+++ b/graylog2-web-interface/src/components/common/ControlledTableListHeader.jsx
@@ -34,8 +34,8 @@ const StyledListGroupItem = styled(ListGroupItem)(({ theme }) => css`
 `);
 
 const HeaderWrapper = styled.div`
-  margin: 10px 0;
-  min-height: 20px;
+  padding: 10px 0;
+  min-height: 40px;
 `;
 
 const ControlledTableListHeader = createReactClass({

--- a/graylog2-web-interface/src/components/graylog/ListGroupItem.jsx
+++ b/graylog2-web-interface/src/components/graylog/ListGroupItem.jsx
@@ -20,9 +20,8 @@ import PropTypes from 'prop-types';
 // eslint-disable-next-line no-restricted-imports
 import { ListGroupItem as BootstrapListGroupItem } from 'react-bootstrap';
 
-const RefContainer = styled.div(({ theme }) => `
-  display: inline-block;
-  width: 100%;
+const RefContainer = styled.span(({ theme }) => `
+  display: block;
   border: 1px solid ${theme.colors.variant.lighter.default};
   margin-bottom: -1px;
 


### PR DESCRIPTION
**Please note this PR needs a backport for 4.1**

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

In the past we had to adjust the structure of our `ListGroupItem` component, to be able to easily create a reference.
This resulted in a UI bug in the saved searches list and comparable lists. https://github.com/Graylog2/graylog2-server/pull/10809. Although we fixed this bug, the bugfix introduced another UI problem for lists like the content packs overview.

Before:
![image](https://user-images.githubusercontent.com/46300478/122563355-66718000-d044-11eb-8e61-ea0f7fe383c5.png)

This PR is adjusting the `ListGroupItem` styling in a way that works for all different list types. After:

![image](https://user-images.githubusercontent.com/46300478/122563441-8012c780-d044-11eb-878c-feef6007d0d5.png)

Fixes: https://github.com/Graylog2/graylog2-server/issues/10884

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I tested the different list types with chrome, safari and firefox.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)