### PR TITLE
Fixing shared entities overview filter for saved searches. (Backport of #10880 for 4.0)

### DIFF
--- a/graylog2-web-interface/src/components/permissions/SharedEntitiesOverview/SharedEntitiesFilter.jsx
+++ b/graylog2-web-interface/src/components/permissions/SharedEntitiesOverview/SharedEntitiesFilter.jsx
@@ -83,7 +83,7 @@ const SharedEntitiesFilter = ({ onSearch, onFilter }: Props) => (
         <StyledSelect inputId="capability-select"
                       onChange={(capability) => onFilter('capability', capability)}
                       options={capabilityOptions}
-                      placeholder="Filter capabilies" />
+                      placeholder="Filter capabilities" />
       </SelectWrapper>
     </Filters>
   </>

--- a/graylog2-web-interface/src/logic/permissions/mocked.js
+++ b/graylog2-web-interface/src/logic/permissions/mocked.js
@@ -68,7 +68,7 @@ const searchPaginatedEntitySharesResponse = (page: number, perPage: number, quer
 const availableEntityTypes = {
   stream: 'Stream',
   dashboard: 'Dashboard',
-  saved_search: 'Saved Search',
+  search: 'Saved Search',
   event_definition: 'Event Definition',
 };
 


### PR DESCRIPTION
_This is a backport of #10880 for 4.0._

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Before this change we provided the wrong query parameter value when
filtering the shared entities overview by saved searches.
As a result the API response was always empty, when applying this filter.

Refs: https://github.com/Graylog2/graylog2-server/issues/10878

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
