### PR TITLE
Include `IntersectionObserver` polyfill in `eslint-config-graylog` polyfill list.

### DIFF
--- a/graylog2-web-interface/packages/eslint-config-graylog/index.js
+++ b/graylog2-web-interface/packages/eslint-config-graylog/index.js
@@ -153,8 +153,9 @@ module.exports = {
       },
     },
     polyfills: [
-      'Promise',
       'fetch',
+      'IntersectionObserver',
+      'Promise',
     ],
   },
 };

--- a/graylog2-web-interface/src/polyfill.js
+++ b/graylog2-web-interface/src/polyfill.js
@@ -14,6 +14,10 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
+
+// When adding a polyfill it is probably necessary to extend the polyfill list in the eslint-config-graylog package.
+// Otherwise ESLint does not know about the polyfill and throws a warning because of the compat/compat rule.
+
 import 'core-js';
 import 'regenerator-runtime/runtime';
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR adds the `IntersectionObserver` polyfill to the polyfill list of the `eslint-config-graylog` package. Without this change ESLint does not know about the `IntersectionObserver` polyfill and throws a warning, because of the [compat/compat](https://github.com/amilajack/eslint-plugin-compat/blob/master/docs/rules/compat.md) rule.
