### PR TITLE
Mock moment time zone for all tests.

### DIFF
--- a/graylog2-web-interface/packages/jest-preset-graylog/jest-preset.js
+++ b/graylog2-web-interface/packages/jest-preset-graylog/jest-preset.js
@@ -26,6 +26,7 @@ module.exports = {
     require.resolve('./lib/setup-files/mock-FetchProvider.js'),
     require.resolve('./lib/setup-files/mock-Version.js'),
     require.resolve('./lib/setup-files/mock-IntersectionObserver.js'),
+    require.resolve('./lib/setup-files/mock-moment-timezone.js'),
     require.resolve('./lib/setup-files/console-warnings-fail-tests.js'),
     'jest-canvas-mock',
   ],

--- a/graylog2-web-interface/packages/jest-preset-graylog/src/setup-files/mock-moment-timezone.js
+++ b/graylog2-web-interface/packages/jest-preset-graylog/src/setup-files/mock-moment-timezone.js
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+
+const mockRootTimeZone = 'America/Chicago';
+
+jest.mock('moment-timezone', () => {
+  const momentMock = jest.requireActual('moment-timezone');
+  momentMock.tz.setDefault(mockRootTimeZone);
+  momentMock.tz.guess = () => mockRootTimeZone;
+
+  return momentMock;
+});

--- a/graylog2-web-interface/src/views/components/widgets/Widget.aggregations.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/Widget.aggregations.test.tsx
@@ -52,14 +52,6 @@ const mockedUnixTime = 1577836800000; // 2020-01-01 00:00:00.000
 jest.mock('./WidgetHeader', () => 'widget-header');
 jest.mock('./WidgetColorContext', () => ({ children }) => children);
 
-jest.mock('moment-timezone', () => {
-  const momentMock = jest.requireActual('moment-timezone');
-  momentMock.tz.setDefault('UTC');
-  momentMock.tz.guess = () => 'UTC';
-
-  return momentMock;
-});
-
 jest.mock('views/stores/FieldTypesStore', () => ({
   FieldTypesStore: MockStore(['getInitialState', () => ({ all: {}, queryFields: {} })]),
 }));
@@ -207,6 +199,7 @@ describe('Aggregation Widget', () => {
     }, testTimeout);
 
     it('should apply not submitted widget time range changes in correct format when clicking on "Apply Changes"', async () => {
+      // Displayed times are based on time zone defined in moment-timezone mock.
       const updatedWidget = dataTableWidget
         .toBuilder()
         .timerange({
@@ -226,13 +219,13 @@ describe('Aggregation Widget', () => {
       userEvent.click(absoluteTabButton);
 
       const timeRangeLivePreview = screen.getByTestId('time-range-live-preview');
-      await within(timeRangeLivePreview).findByText(/2020-01-01 00:00:00\.000/i);
+      await within(timeRangeLivePreview).findByText('2019-12-31 18:00:00.000');
 
       const applyTimeRangeChangesButton = screen.getByRole('button', { name: 'Apply' });
       userEvent.click(applyTimeRangeChangesButton);
 
       const timeRangeDisplay = screen.getByLabelText('Search Time Range, Opens Time Range Selector On Click');
-      await within(timeRangeDisplay).findByText('2020-01-01 00:00:00.000');
+      await within(timeRangeDisplay).findByText('2019-12-31 18:00:00.000');
 
       // Submit all changes
       const saveButton = screen.getByText('Apply Changes');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Before this change it was possible that `moment.tz.guess()` returns a different time zone, when running the frontend tests, depending the environment (e.g. local dev environment vs. GitHub actions).

To avoid this problem in the future we are now mocking the moment time zone for all tests.
