### PR TITLE
Configure more dynamic default menu placement for `Select` component.

### DIFF
--- a/graylog2-web-interface/src/components/common/Select.tsx
+++ b/graylog2-web-interface/src/components/common/Select.tsx
@@ -358,7 +358,7 @@ class Select extends React.Component<Props, State> {
     value: undefined,
     valueKey: 'value',
     valueRenderer: undefined,
-    menuPlacement: 'bottom',
+    menuPlacement: 'auto',
     maxMenuHeight: 300,
   };
 

--- a/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/FieldSelect.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/FieldSelect.tsx
@@ -52,7 +52,6 @@ const FieldSelect = ({ name, id, error, clearable, value, onChange, label, ariaL
               aria-label={ariaLabel}
               size="small"
               menuPortalTarget={document.body}
-              menuPlacement="auto"
               onChange={(newValue) => onChange({ target: { name, value: newValue } })} />
     </Input>
 

--- a/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/Metric.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/Metric.tsx
@@ -64,7 +64,6 @@ const Metric = ({ index }: Props) => {
                     aria-label="Select a function"
                     size="small"
                     menuPortalTarget={document.body}
-                    menuPlacement="auto"
                     onChange={(newValue) => {
                       onChange({ target: { name, value: newValue } });
                     }} />
@@ -98,7 +97,6 @@ const Metric = ({ index }: Props) => {
                       aria-label="Select percentile"
                       size="small"
                       menuPortalTarget={document.body}
-                      menuPlacement="auto"
                       onChange={(newValue) => onChange({ target: { name, value: newValue } })} />
             </Input>
           )}

--- a/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/Sort.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/Sort.tsx
@@ -89,7 +89,6 @@ const Sort = React.memo(({ index }: Props) => {
                       aria-label="Select field for sorting"
                       size="small"
                       menuPortalTarget={document.body}
-                      menuPlacement="auto"
                       onChange={(newValue: Option['value']) => {
                         const option = options[newValue];
                         setFieldValue(`sort.${index}.type`, option.type);
@@ -114,7 +113,6 @@ const Sort = React.memo(({ index }: Props) => {
                     value={value}
                     size="small"
                     menuPortalTarget={document.body}
-                    menuPlacement="auto"
                     onChange={(newValue) => {
                       onChange({ target: { name, value: newValue } });
                     }} />

--- a/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/VisualizationConfiguration.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/VisualizationConfiguration.tsx
@@ -89,7 +89,6 @@ const VisualizationConfiguration = () => {
                     name={name}
                     value={value}
                     menuPortalTarget={document.body}
-                    menuPlacement="auto"
                     onChange={(newValue) => {
                       if (newValue !== value) {
                         setNewVisualizationType(newValue);

--- a/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/configurationFields/SelectField.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/elementConfiguration/configurationFields/SelectField.tsx
@@ -51,7 +51,6 @@ const SelectField = ({ name, field, title, error, value, onChange }: FieldCompon
               name={name}
               value={value}
               size="small"
-              menuPlacement="auto"
               menuPortalTarget={document.body}
               onChange={(newValue) => onChange(createEvent(name, newValue))} />
     </Input>


### PR DESCRIPTION
**Please note:  This PR needs to be merged together with https://github.com/Graylog2/graylog-plugin-enterprise/pull/2399**

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

With this PR we are changing the default for the `menuPlacement` prop of the common `Select` component from `bottom` to `auto`. When a select menu can not be displayed at the bottom of a select, because of the browser window height, it will be display at the top instead.

Before (opening menu creates a scroll bar):
![image](https://user-images.githubusercontent.com/46300478/122773648-cf593200-d2a8-11eb-8f8e-99a5a82b03fa.png)

After: 
![image](https://user-images.githubusercontent.com/46300478/122773319-8e611d80-d2a8-11eb-83c4-042334648d44.png)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested with different use cases.


/jenkins-pr-deps https://github.com/Graylog2/graylog-plugin-enterprise/pull/2399