### PR TITLE
Improve error logging for auth service connection test

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/security/authservice/test/AuthServiceBackendTestService.java
+++ b/graylog2-server/src/main/java/org/graylog/security/authservice/test/AuthServiceBackendTestService.java
@@ -37,13 +37,16 @@ public class AuthServiceBackendTestService {
     }
 
     public AuthServiceBackendTestResult testConnection(AuthServiceBackendTestRequest request) {
-        final Optional<AuthServiceBackend> backend = createNewBackend(request);
+        try {
+            final Optional<AuthServiceBackend> backend = createNewBackend(request);
 
-        if (backend.isPresent()) {
-            return backend.get().testConnection(getExistingBackendConfig(request).orElse(null));
+            if (backend.isPresent()) {
+                return backend.get().testConnection(getExistingBackendConfig(request).orElse(null));
+            }
+            return AuthServiceBackendTestResult.createFailure("Unknown authentication service type: " + request.backendConfiguration().config().type());
+        } catch (Exception e) {
+            return AuthServiceBackendTestResult.createFailure("Failed with error: " + e.getMessage());
         }
-
-        return AuthServiceBackendTestResult.createFailure("Unknown authentication service type: " + request.backendConfiguration().config().type());
     }
 
     public AuthServiceBackendTestResult testLogin(AuthServiceBackendTestRequest request) {


### PR DESCRIPTION
Provide a user-friendly error message when testing the connection to an auth service backend.
Avoid logging an exception, when the service is merely misconfigured.

This is related to PR [enterprise/2403](https://github.com/Graylog2/graylog-plugin-enterprise/pull/2403)