### PR TITLE
Always display widget title in line with drag handle and widget actions.

### DIFF
--- a/graylog2-web-interface/src/views/components/common/EditableTitle.tsx
+++ b/graylog2-web-interface/src/views/components/common/EditableTitle.tsx
@@ -23,7 +23,6 @@ import styles from './EditableTitle.css';
 const StyledStaticSpan = styled.span(({ theme }) => css`
   border: 1px solid ${theme.colors.global.contentBackground};
   font-size: ${theme.fonts.size.large};
-  display: inline-block;
 `);
 
 const StyledInput = styled.input(({ theme }) => css`


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Before this change it was that the widget header elements are displayed in three rows, depending on the widget title length.
With this change we ensure that all elements are displayed "inline".

Before:
![image](https://user-images.githubusercontent.com/46300478/122917381-413f8300-d35e-11eb-85fe-16e1b57ba808.png)

After: 
![image](https://user-images.githubusercontent.com/46300478/122917153-fa518d80-d35d-11eb-9fe9-378bd6b079f4.png)
