### PR TITLE
Display widget edit action as action icon instead of menu item in widget actions dropdown.

### DIFF
--- a/graylog2-web-interface/src/views/components/widgets/WidgetActionsMenu.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/WidgetActionsMenu.tsx
@@ -172,20 +172,21 @@ const WidgetActionsMenu = ({
         )}
         {!isFocused && (
           <>
-            <IconButton name="expand-arrows-alt"
-                        title="Focus this widget"
-                        onClick={() => setWidgetFocusing(widget.id)} />
             <WidgetHorizontalStretch widgetId={widget.id}
                                      widgetType={widget.type}
                                      onStretch={onPositionsChange}
                                      position={position} />
+            <IconButton name="expand-arrows-alt"
+                        title="Focus this widget"
+                        onClick={() => setWidgetFocusing(widget.id)} />
           </>
         )}
 
+        <IconButton name="edit"
+                    title="Edit"
+                    onClick={toggleEdit} />
+
         <WidgetActionDropdown>
-          <MenuItem onSelect={toggleEdit}>
-            Edit
-          </MenuItem>
           <MenuItem onSelect={onDuplicate}>
             Duplicate
           </MenuItem>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

With this PR we are changing the placement of the widget edit action. The widget edit action is now a widget action icon instead of a menu item in the widget action menu. This way the user needs less clicks to edit a widget.

We are also changing the position of the widget stretch icon, mainly to keep the placement of most other icons consistent when focusing a widget (and hiding the stretch icon).

Before:
![image](https://user-images.githubusercontent.com/46300478/123095004-db223100-d42d-11eb-87a5-56876bb105c9.png)


After:
![image](https://user-images.githubusercontent.com/46300478/123093248-bfb62680-d42b-11eb-9a55-401a1e3f500a.png)
