### PR TITLE
Display info for undeclared parameters in event definitions filter step only if user has `lookuptables:read` permission.

### DIFF
--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterForm.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterForm.jsx
@@ -66,7 +66,7 @@ class FilterForm extends React.Component {
   );
 
   _parseQuery = lodash.debounce((queryString) => {
-    if (!this._userCanViewLookupTables) {
+    if (!this._userCanViewLookupTables()) {
       return;
     }
 
@@ -122,11 +122,9 @@ class FilterForm extends React.Component {
   }
 
   componentDidMount() {
-    if (!this._userCanViewLookupTables) {
-      return;
+    if (this._userCanViewLookupTables()) {
+      LookupTablesActions.searchPaginated(1, 0, undefined, false);
     }
-
-    LookupTablesActions.searchPaginated(1, 0, undefined, false);
   }
 
   propagateChange = (key, value) => {
@@ -228,7 +226,7 @@ class FilterForm extends React.Component {
       return onChange('config', newConfig);
     };
 
-    if (!this._userCanViewLookupTables) {
+    if (!this._userCanViewLookupTables()) {
       return (
         <Alert bsStyle="info">
           Only Admins are able to declare Query Parameters from Lookup Tables.

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterForm.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterForm.jsx
@@ -44,11 +44,6 @@ export const TIME_UNITS = ['HOURS', 'MINUTES', 'SECONDS'];
 const LOOKUP_PERMISSIONS = [
   'lookuptables:read',
 ];
-const PREVIEW_PERMISSIONS = [
-  'streams:read',
-  'extendedsearch:create',
-  'extendedsearch:use',
-];
 
 class FilterForm extends React.Component {
   formatStreamIds = lodash.memoize(
@@ -73,7 +68,7 @@ class FilterForm extends React.Component {
   _parseQuery = lodash.debounce((queryString) => {
     const { currentUser } = this.props;
 
-    if (!isPermitted(currentUser.permissions, PREVIEW_PERMISSIONS)) {
+    if (!isPermitted(currentUser.permissions, LOOKUP_PERMISSIONS)) {
       return;
     }
 

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterForm.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterForm.jsx
@@ -66,9 +66,7 @@ class FilterForm extends React.Component {
   );
 
   _parseQuery = lodash.debounce((queryString) => {
-    const { currentUser } = this.props;
-
-    if (!isPermitted(currentUser.permissions, LOOKUP_PERMISSIONS)) {
+    if (!this._userCanViewLookupTables) {
       return;
     }
 
@@ -124,9 +122,7 @@ class FilterForm extends React.Component {
   }
 
   componentDidMount() {
-    const { currentUser } = this.props;
-
-    if (!isPermitted(currentUser.permissions, LOOKUP_PERMISSIONS)) {
+    if (!this._userCanViewLookupTables) {
       return;
     }
 
@@ -139,6 +135,12 @@ class FilterForm extends React.Component {
 
     config[key] = value;
     onChange('config', config);
+  };
+
+  _userCanViewLookupTables = () => {
+    const { currentUser } = this.props;
+
+    return !isPermitted(currentUser.permissions, LOOKUP_PERMISSIONS);
   };
 
   _syncParamsWithQuery = (paramsInQuery) => {
@@ -225,6 +227,14 @@ class FilterForm extends React.Component {
 
       return onChange('config', newConfig);
     };
+
+    if (!this._userCanViewLookupTables) {
+      return (
+        <Alert bsStyle="info">
+          Only Admins are able to declare Query Parameters from Lookup Tables.
+        </Alert>
+      );
+    }
 
     const parameterButtons = queryParameters.map((queryParam) => {
       return (

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterForm.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterForm.jsx
@@ -135,12 +135,6 @@ class FilterForm extends React.Component {
     onChange('config', config);
   };
 
-  _userCanViewLookupTables = () => {
-    const { currentUser } = this.props;
-
-    return !isPermitted(currentUser.permissions, LOOKUP_PERMISSIONS);
-  };
-
   _syncParamsWithQuery = (paramsInQuery) => {
     const { eventDefinition, onChange } = this.props;
     const config = lodash.cloneDeep(eventDefinition.config);
@@ -173,6 +167,12 @@ class FilterForm extends React.Component {
 
     config.query_parameters = keptParameters.concat(newParameters);
     onChange('config', config);
+  };
+
+  _userCanViewLookupTables = () => {
+    const { currentUser } = this.props;
+
+    return isPermitted(currentUser.permissions, LOOKUP_PERMISSIONS);
   };
 
   _buildNewParameter = (name) => {

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterForm.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterForm.jsx
@@ -229,7 +229,7 @@ class FilterForm extends React.Component {
     if (!this._userCanViewLookupTables()) {
       return (
         <Alert bsStyle="info">
-          Only Admins are able to declare Query Parameters from Lookup Tables.
+          This account lacks permission to declare Query Parameters from Lookup Tables.
         </Alert>
       );
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

With this PR we are adjusting the permissions check for the undeclared parameters info in the event definitions filter step.
The undeclared parameters info appears, when the filter search query contains an undeclared parameter:

![image](https://user-images.githubusercontent.com/46300478/123283890-16932d00-d50c-11eb-845b-98d32a443511.png)


Before this change we only displayed this info for users with the following permissions:
```
[
  'streams:read',
  'extendedsearch:create',
  'extendedsearch:use',
];
```

The `extendedsearch` permissions are legacy view permissions which are no longer supported. Related issue: https://github.com/Graylog2/graylog2-server/issues/9904. This did not caused a bug, because only admin users were (and are) able to define query parameters.

Because these query parameters are only usable, when a user has access to lookup tables, we are now:
- only displaying the undeclared parameter info when a user has the following permissions: `lookuptables:read`
- are displaying an info that only admin users are able to declare parameters, when a user does not have this permission. Admins are currently the only users with this permission.