### PR TITLE
Removing legacy usage view permissions `extendedsearch:use` and `view:use` in the frontend.

### DIFF
--- a/graylog2-web-interface/src/views/Permissions.js
+++ b/graylog2-web-interface/src/views/Permissions.js
@@ -14,10 +14,8 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
+
+// eslint-disable-next-line import/prefer-default-export
 export const View = {
-  Use: 'view:use',
   Edit: (id) => `view:edit:${id}`,
-};
-export const ExtendedSearch = {
-  Use: 'extendedsearch:use',
 };

--- a/graylog2-web-interface/src/views/bindings.tsx
+++ b/graylog2-web-interface/src/views/bindings.tsx
@@ -21,7 +21,6 @@ import { PluginExports } from 'graylog-web-plugin/plugin';
 import Routes from 'routing/Routes';
 import App from 'routing/App';
 import AppConfig from 'util/AppConfig';
-import * as Permissions from 'views/Permissions';
 import { MessageListHandler } from 'views/logic/searchtypes/messages';
 import { MessageList } from 'views/components/widgets';
 import AddToTableActionHandler from 'views/logic/fieldactions/AddToTableActionHandler';
@@ -128,9 +127,9 @@ const exports: PluginExports = {
     { path: showSearchPath, component: ShowViewPage, parentComponent: App },
     { path: `${Routes.unqualified.stream_search(':streamId')}/new`, component: NewSearchRedirectPage, parentComponent: null },
     { path: Routes.unqualified.stream_search(':streamId'), component: StreamSearchPage, parentComponent: App },
-    { path: extendedSearchPath, component: NewSearchPage, permissions: Permissions.ExtendedSearch.Use, parentComponent: App },
+    { path: extendedSearchPath, component: NewSearchPage, parentComponent: App },
 
-    { path: viewsPath, component: ViewManagementPage, permissions: Permissions.View.Use },
+    { path: viewsPath, component: ViewManagementPage },
     { path: showViewsPath, component: ShowViewPage, parentComponent: App },
   ],
   enterpriseWidgets: [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

As described in https://github.com/Graylog2/graylog2-server/issues/9904 we migrated the legacy views permissions defined in https://github.com/Graylog2/graylog2-server/blob/master/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/LegacyViewsPermissions.java but some of them still exist in the frontend code.

With this PR we are removing the legacy views permissions. There are still some legacy permissions in `event-definition-types/FilterForm` which will be removed with https://github.com/Graylog2/graylog2-server/pull/10933

Fixes: https://github.com/Graylog2/graylog2-server/issues/9904