### PR TITLE
Set default value for matchingType in StreamDTO

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/streams/StreamDTO.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/StreamDTO.java
@@ -19,23 +19,22 @@ package org.graylog2.streams;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
 import org.bson.types.ObjectId;
 import org.graylog.autovalue.WithBeanGetter;
+import org.graylog2.plugin.streams.Stream;
 import org.graylog2.plugin.streams.StreamRule;
 import org.graylog2.rest.models.alarmcallbacks.requests.AlertReceivers;
 import org.graylog2.rest.models.streams.alerts.AlertConditionSummary;
-import org.graylog2.rest.models.system.outputs.responses.OutputSummary;
 
 import javax.annotation.Nullable;
 import java.util.Collection;
-import java.util.Collections;
-
-import static com.google.common.base.MoreObjects.firstNonNull;
 
 @AutoValue
 @WithBeanGetter
 @JsonAutoDetect
+@JsonDeserialize(builder = StreamDTO.Builder.class)
 public abstract class StreamDTO {
     public static final String FIELD_ID = "_id";
     public static final String FIELD_TITLE = "title";
@@ -108,45 +107,18 @@ public abstract class StreamDTO {
 
     public abstract Builder toBuilder();
 
-    @JsonCreator
-    public static StreamDTO create(@JsonProperty(FIELD_ID) String id,
-                                   @JsonProperty(FIELD_CREATOR_USER_ID) String creatorUserId,
-                                   @JsonProperty(FIELD_OUTPUTS) @Nullable Collection<ObjectId> outputs,
-                                   @JsonProperty(FIELD_MATCHING_TYPE) String matchingType,
-                                   @JsonProperty(FIELD_DESCRIPTION) @Nullable String description,
-                                   @JsonProperty(FIELD_CREATED_AT) String createdAt,
-                                   @JsonProperty(FIELD_DISABLED) boolean disabled,
-                                   @JsonProperty(FIELD_RULES) @Nullable Collection<StreamRule> rules,
-                                   @JsonProperty(EMBEDDED_ALERT_CONDITIONS) @Nullable Collection<AlertConditionSummary> alertConditions,
-                                   @JsonProperty(FIELD_ALERT_RECEIVERS) @Nullable AlertReceivers alertReceivers,
-                                   @JsonProperty(FIELD_TITLE) String title,
-                                   @JsonProperty(FIELD_CONTENT_PACK) @Nullable String contentPack,
-                                   @JsonProperty(FIELD_DEFAULT_STREAM) @Nullable Boolean isDefault,
-                                   @JsonProperty(FIELD_REMOVE_MATCHES_FROM_DEFAULT_STREAM) @Nullable Boolean removeMatchesFromDefaultStream,
-                                   @JsonProperty(FIELD_INDEX_SET_ID) String indexSetId) {
-        return new AutoValue_StreamDTO(
-                id,
-                creatorUserId,
-                outputs,
-                matchingType,
-                description,
-                createdAt,
-                rules,
-                disabled,
-                alertConditions,
-                alertReceivers,
-                title,
-                contentPack,
-                firstNonNull(isDefault, false),
-                firstNonNull(removeMatchesFromDefaultStream, false),
-                indexSetId);
+    static Builder builder() {
+        return Builder.create();
     }
 
     @AutoValue.Builder
     public abstract static class Builder {
         @JsonCreator
         public static Builder create() {
-            return new AutoValue_StreamDTO.Builder();
+            return new AutoValue_StreamDTO.Builder()
+                    .matchingType(Stream.MatchingType.AND.toString())
+                    .isDefault(false)
+                    .removeMatchesFromDefaultStream(false);
         }
 
         @JsonProperty(FIELD_ID)


### PR DESCRIPTION
Streams have a `matching_type` field, which got introduced in version `1.2.0` with https://github.com/Graylog2/graylog2-server/commit/a7bac4a1f05c823fd4c8487eeb0116319d35cfae. 

Streams which have been created before that wouldn't have that field set in MongoDB. This is gracefully handled by adding a default value, when the field is missing.

When pagination was added to the streams page in version `4.0.0` it wasn't considered that very old records could have the field missing. This would break the "streams" page.

This PR aims at fixing that by setting a default value for `matching_type` when de-serializing a stream from MongoDB for pagination.

Fixes #10514 