### PR TITLE
Add allowed_auxiliary_paths to default server.conf file

### DIFF
--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -723,3 +723,9 @@ proxied_requests_thread_pool_size = 32
 # Configures the refresh interval for the monitored Prometheus exporter mapping files.
 # Default: 60s
 #prometheus_exporter_mapping_file_refresh_interval = 60s
+
+# Optional allowed paths for Graylog data files. If provided, certain operations in Graylog will only be permitted
+# if the data file(s) are located in the specified paths (for example, with the CSV File lookup adapter).
+# All subdirectories of indicated paths are allowed by default. This Provides an additional layer of security,
+# and allows administrators to control where in the file system Graylog users can select files from.
+#allowed_auxiliary_paths = /etc/graylog/data-files,/etc/custom-allowed-path


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add a sample configuration for the `allowed_auxiliary_paths` configuration property in the default `graylog.conf` file, which was originally added in https://github.com/Graylog2/graylog2-server/pull/10244

Documentation has also been provided in https://github.com/Graylog2/documentation/pull/1185.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This configuration property was discussed yesterday in the context of investigating a Cloud-related issue. I thought that it would be good to provide a sample configuration and documentation for this property, so that others can see a description for the property and an example for how to configure it.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
No testing needed. Just static file changes in the default `graylog.conf`, which are commented out. 
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [*] My code follows the code style of this project.
- [*] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

