### PR TITLE
Only restrict TLS to secure ciphers with TLS1.2 or greater

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/beats/BeatsTransport.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/beats/BeatsTransport.java
@@ -19,6 +19,7 @@ package org.graylog.plugins.beats;
 import com.google.inject.assistedinject.Assisted;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.EventLoopGroup;
+import org.graylog2.configuration.TLSProtocolsConfiguration;
 import org.graylog2.inputs.transports.NettyTransportConfiguration;
 import org.graylog2.inputs.transports.netty.EventLoopGroupFactory;
 import org.graylog2.plugin.LocalMetricRegistry;
@@ -44,8 +45,8 @@ public class BeatsTransport extends AbstractTcpTransport {
                           NettyTransportConfiguration nettyTransportConfiguration,
                           ThroughputCounter throughputCounter,
                           LocalMetricRegistry localRegistry,
-                          org.graylog2.Configuration graylogConfiguration) {
-        super(configuration, throughputCounter, localRegistry, eventLoopGroup, eventLoopGroupFactory, nettyTransportConfiguration, graylogConfiguration);
+                          TLSProtocolsConfiguration tlsConfiguration) {
+        super(configuration, throughputCounter, localRegistry, eventLoopGroup, eventLoopGroupFactory, nettyTransportConfiguration, tlsConfiguration);
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog/security/authservice/ldap/UnboundLDAPConnector.java
+++ b/graylog2-server/src/main/java/org/graylog/security/authservice/ldap/UnboundLDAPConnector.java
@@ -39,6 +39,7 @@ import com.unboundid.ldap.sdk.extensions.StartTLSExtendedRequest;
 import com.unboundid.util.Base64;
 import com.unboundid.util.LDAPTestUtils;
 import com.unboundid.util.ssl.SSLUtil;
+import org.graylog2.configuration.TLSProtocolsConfiguration;
 import org.graylog2.security.TrustAllX509TrustManager;
 import org.graylog2.security.TrustManagerProvider;
 import org.graylog2.security.encryption.EncryptedValue;
@@ -74,18 +75,18 @@ public class UnboundLDAPConnector {
     private static final String OBJECT_CLASS_ATTRIBUTE = "objectClass";
 
     private final int connectionTimeout;
-    private final Set<String> enabledTlsProtocols;
+    private final TLSProtocolsConfiguration tlsConfiguration;
     private final TrustManagerProvider trustManagerProvider;
     private final EncryptedValueService encryptedValueService;
     private final int requestTimeoutSeconds;
 
     @Inject
     public UnboundLDAPConnector(@Named("ldap_connection_timeout") int connectionTimeout,
-                                @Named("enabled_tls_protocols") Set<String> enabledTlsProtocols,
+                                TLSProtocolsConfiguration tlsConfiguration,
                                 TrustManagerProvider trustManagerProvider,
                                 EncryptedValueService encryptedValueService) {
         this.connectionTimeout = connectionTimeout; // TODO: Make configurable per backend
-        this.enabledTlsProtocols = enabledTlsProtocols;
+        this.tlsConfiguration = tlsConfiguration;
         this.trustManagerProvider = trustManagerProvider;
         this.encryptedValueService = encryptedValueService;
         this.requestTimeoutSeconds = 60; // TODO: Make configurable per backend
@@ -107,7 +108,7 @@ public class UnboundLDAPConnector {
         StartTLSExtendedRequest startTLSRequest = null;
         SocketFactory socketFactory = null;
         if (ldapConfig.transportSecurity() != LDAPTransportSecurity.NONE) {
-            SSLUtil.setEnabledSSLProtocols(enabledTlsProtocols);
+            SSLUtil.setEnabledSSLProtocols(tlsConfiguration.getEnabledTlsProtocols());
 
             final SSLUtil sslUtil;
             if (ldapConfig.verifyCertificates()) {

--- a/graylog2-server/src/main/java/org/graylog2/Configuration.java
+++ b/graylog2-server/src/main/java/org/graylog2/Configuration.java
@@ -158,6 +158,10 @@ public class Configuration extends BaseConfiguration {
     @Parameter(value = "deactivated_builtin_authentication_providers", converter = StringSetConverter.class)
     private Set<String> deactivatedBuiltinAuthenticationProviders = Collections.emptySet();
 
+    // This is needed for backwards compatibility. The setting in TLSProtocolsConfiguration should be used instead.
+    @Parameter(value = "enabled_tls_protocols", converter = StringSetConverter.class)
+    public Set<String> enabledTlsProtocols = null;
+
     @Parameter(value = "is_cloud")
     private boolean isCloud = false;
 

--- a/graylog2-server/src/main/java/org/graylog2/Configuration.java
+++ b/graylog2-server/src/main/java/org/graylog2/Configuration.java
@@ -29,7 +29,6 @@ import com.github.joschi.jadconfig.validators.PositiveLongValidator;
 import com.github.joschi.jadconfig.validators.StringNotBlankValidator;
 import org.graylog2.plugin.BaseConfiguration;
 import org.graylog2.security.realm.RootAccountRealm;
-import org.graylog2.shared.security.tls.DefaultTLSProtocolProvider;
 import org.graylog2.utilities.IPSubnetConverter;
 import org.graylog2.utilities.IpSubnet;
 import org.joda.time.DateTimeZone;
@@ -158,9 +157,6 @@ public class Configuration extends BaseConfiguration {
 
     @Parameter(value = "deactivated_builtin_authentication_providers", converter = StringSetConverter.class)
     private Set<String> deactivatedBuiltinAuthenticationProviders = Collections.emptySet();
-
-    @Parameter(value = "enabled_tls_protocols", converter = StringSetConverter.class)
-    private Set<String> enabledTlsProtocols = DefaultTLSProtocolProvider.getDefaultSupportedTlsProtocols();
 
     @Parameter(value = "is_cloud")
     private boolean isCloud = false;
@@ -322,10 +318,6 @@ public class Configuration extends BaseConfiguration {
 
     public Set<String> getDeactivatedBuiltinAuthenticationProviders() {
         return deactivatedBuiltinAuthenticationProviders;
-    }
-
-    public Set<String> getEnabledTlsProtocols() {
-        return enabledTlsProtocols;
     }
 
     @ValidatorMethod

--- a/graylog2-server/src/main/java/org/graylog2/Configuration.java
+++ b/graylog2-server/src/main/java/org/graylog2/Configuration.java
@@ -160,7 +160,7 @@ public class Configuration extends BaseConfiguration {
 
     // This is needed for backwards compatibility. The setting in TLSProtocolsConfiguration should be used instead.
     @Parameter(value = "enabled_tls_protocols", converter = StringSetConverter.class)
-    public Set<String> enabledTlsProtocols = null;
+    private Set<String> enabledTlsProtocols = null;
 
     @Parameter(value = "is_cloud")
     private boolean isCloud = false;
@@ -322,6 +322,14 @@ public class Configuration extends BaseConfiguration {
 
     public Set<String> getDeactivatedBuiltinAuthenticationProviders() {
         return deactivatedBuiltinAuthenticationProviders;
+    }
+
+    /**
+     * This is needed for backwards compatibility. The setting in TLSProtocolsConfiguration should be used instead.
+     */
+    @Deprecated
+    public Set<String> getEnabledTlsProtocols() {
+        return enabledTlsProtocols;
     }
 
     @ValidatorMethod

--- a/graylog2-server/src/main/java/org/graylog2/bootstrap/CmdLineTool.java
+++ b/graylog2-server/src/main/java/org/graylog2/bootstrap/CmdLineTool.java
@@ -184,7 +184,7 @@ public abstract class CmdLineTool implements CliCommand {
         // Only restrict ciphers if insecure TLS protocols are explicitly enabled.
         // c.f. https://github.com/Graylog2/graylog2-server/issues/10944
         final Set<String> tlsProtocols = configuration.getConfiguredTlsProtocols();
-        if (tlsProtocols == null || !(tlsProtocols.isEmpty() || tlsProtocols.contains("TLSv1") || tlsProtocols.contains("TLSv1.1") || tlsProtocols.contains("TLSv1.0"))) {
+        if (tlsProtocols == null || !(tlsProtocols.isEmpty() || tlsProtocols.contains("TLSv1") || tlsProtocols.contains("TLSv1.1"))) {
             // Weirdly this is not a System property
             Security.setProperty("jdk.tls.disabledAlgorithms", "CBC,3DES");
         }

--- a/graylog2-server/src/main/java/org/graylog2/bootstrap/CmdLineTool.java
+++ b/graylog2-server/src/main/java/org/graylog2/bootstrap/CmdLineTool.java
@@ -211,6 +211,7 @@ public abstract class CmdLineTool implements CliCommand {
         installConfigRepositories();
         installCommandConfig();
 
+        beforeStart();
         beforeStart(parseAndGetTLSConfiguration());
 
         processConfiguration(jadConfig);

--- a/graylog2-server/src/main/java/org/graylog2/bootstrap/ServerBootstrap.java
+++ b/graylog2-server/src/main/java/org/graylog2/bootstrap/ServerBootstrap.java
@@ -22,8 +22,10 @@ import com.google.common.util.concurrent.ServiceManager;
 import com.google.inject.Injector;
 import com.google.inject.Module;
 import com.google.inject.ProvisionException;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.graylog2.audit.AuditActor;
 import org.graylog2.audit.AuditEventSender;
+import org.graylog2.configuration.TLSProtocolsConfiguration;
 import org.graylog2.plugin.BaseConfiguration;
 import org.graylog2.plugin.ServerStatus;
 import org.graylog2.plugin.Tools;
@@ -50,8 +52,10 @@ import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
+import java.security.Security;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
@@ -84,15 +88,44 @@ public abstract class ServerBootstrap extends CmdLineTool {
     }
 
     @Override
-    protected void beforeStart() {
-        super.beforeStart();
+    protected void beforeStart(TLSProtocolsConfiguration configuration) {
+        super.beforeStart(configuration);
 
         // Do not use a PID file if the user requested not to
         if (!isNoPidFile()) {
             savePidFile(getPidFile());
         }
+        // This needs to run before the first SSLContext is instantiated,
+        // because it sets up the default SSLAlgorithmConstraints
+        applySecuritySettings(configuration);
+
         // Set these early in the startup because netty's NativeLibraryUtil uses a static initializer
         setNettyNativeDefaults();
+    }
+
+    private static void applySecuritySettings(TLSProtocolsConfiguration configuration) {
+        // Disable insecure TLS parameters and algorithms by default.
+        // Prevent attacks like LOGJAM, LUCKY13, et al.
+        setSystemPropertyIfEmpty("jdk.tls.ephemeralDHKeySize", "2048");
+        setSystemPropertyIfEmpty("jdk.tls.rejectClientInitiatedRenegotiation", "true");
+
+        // Only restrict ciphers if insecure TLS protocols are explicitly enabled.
+        // c.f. https://github.com/Graylog2/graylog2-server/issues/10944
+        final Set<String> tlsProtocols = configuration.getConfiguredTlsProtocols();
+        if (tlsProtocols == null || !(tlsProtocols.isEmpty() || tlsProtocols.contains("TLSv1") || tlsProtocols.contains("TLSv1.1") || tlsProtocols.contains("TLSv1.0"))) {
+            // Weirdly this is not a System property
+            Security.setProperty("jdk.tls.disabledAlgorithms", "CBC,3DES");
+        }
+
+        // Explicitly register Bouncy Castle as security provider.
+        // This allows us to use more key formats than with JCE
+        Security.addProvider(new BouncyCastleProvider());
+    }
+
+    private static void setSystemPropertyIfEmpty(String key, String value) {
+        if (System.getProperty(key) == null) {
+            System.setProperty(key, value);
+        }
     }
 
     private void setNettyNativeDefaults() {

--- a/graylog2-server/src/main/java/org/graylog2/commands/Server.java
+++ b/graylog2-server/src/main/java/org/graylog2/commands/Server.java
@@ -63,6 +63,7 @@ import org.graylog2.configuration.ElasticsearchConfiguration;
 import org.graylog2.configuration.EmailConfiguration;
 import org.graylog2.configuration.HttpConfiguration;
 import org.graylog2.configuration.MongoDbConfiguration;
+import org.graylog2.configuration.TLSProtocolsConfiguration;
 import org.graylog2.configuration.VersionCheckConfiguration;
 import org.graylog2.contentpacks.ContentPacksModule;
 import org.graylog2.decorators.DecoratorBindings;
@@ -119,6 +120,7 @@ public class Server extends ServerBootstrap {
     private final JobSchedulerConfiguration jobSchedulerConfiguration = new JobSchedulerConfiguration();
     private final FreeEnterpriseConfiguration freeEnterpriseConfiguration = new FreeEnterpriseConfiguration();
     private final PrometheusExporterConfiguration prometheusExporterConfiguration = new PrometheusExporterConfiguration();
+    private final TLSProtocolsConfiguration tlsConfiguration = new TLSProtocolsConfiguration();
 
     public Server() {
         super("server", configuration);
@@ -190,7 +192,8 @@ public class Server extends ServerBootstrap {
                 processingStatusConfig,
                 jobSchedulerConfiguration,
                 freeEnterpriseConfiguration,
-                prometheusExporterConfiguration);
+                prometheusExporterConfiguration,
+                tlsConfiguration);
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/configuration/TLSProtocolsConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/TLSProtocolsConfiguration.java
@@ -62,16 +62,12 @@ public class TLSProtocolsConfiguration {
      * If it's not configured (null and the default) return a secure set of supported TLS protocols.
      */
     public Set<String> getEnabledTlsProtocols() {
-        return getEnabledTlsProtocols(enabledTlsProtocols);
-    }
-
-    public static Set<String> getEnabledTlsProtocols(Set<String> configuredTlsProtocols) {
-        if (configuredTlsProtocols != null) {
-            if (configuredTlsProtocols.isEmpty()) {
-                return DefaultTLSProtocolProvider.getSupportedTlsProtocols();
+        if (enabledTlsProtocols != null) {
+            if (enabledTlsProtocols.isEmpty()) {
+                return DefaultTLSProtocolProvider.getAllSupportedTlsProtocols();
             }
-            return configuredTlsProtocols;
+            return enabledTlsProtocols;
         }
-        return DefaultTLSProtocolProvider.getDefaultSupportedTlsProtocols();
+        return DefaultTLSProtocolProvider.getSecureTLSProtocols();
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/configuration/TLSProtocolsConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/TLSProtocolsConfiguration.java
@@ -1,0 +1,41 @@
+package org.graylog2.configuration;
+
+import com.github.joschi.jadconfig.Parameter;
+import com.github.joschi.jadconfig.converters.StringSetConverter;
+import org.graylog2.shared.security.tls.DefaultTLSProtocolProvider;
+
+import java.util.Set;
+
+/**
+ * Configuration bean for enabled TLS protocols.
+ *
+ * This was extracted to a separate configuration bean
+ * so that it can be parsed in the early server startup phase individually.
+ * Parsing the entire server configuration might trigger the initialization of the default SSLContext,
+ * which needs to happen after a `jdk.tls.disabledAlgorithms` setting is applied.
+ */
+public class TLSProtocolsConfiguration {
+    @Parameter(value = "enabled_tls_protocols", converter = StringSetConverter.class)
+    private Set<String> enabledTlsProtocols = null;
+
+    public Set<String> getConfiguredTlsProtocols() {
+        return enabledTlsProtocols;
+    }
+
+    /**
+     * Retrieve the enabled TLS protocols setting.
+     * @return
+     * If the setting is explicitly configured (not null) return that.
+     * If it's configured to an empty set, return all supported protocols by the JVM.
+     * If it's not configured (null and the default) return a secure set of supported TLS protocols.
+     */
+    public Set<String> getEnabledTlsProtocols() {
+        if (enabledTlsProtocols != null) {
+            if (enabledTlsProtocols.isEmpty()) {
+                return DefaultTLSProtocolProvider.getSupportedTlsProtocols();
+            }
+            return enabledTlsProtocols;
+        }
+        return DefaultTLSProtocolProvider.getDefaultSupportedTlsProtocols();
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/configuration/TLSProtocolsConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/TLSProtocolsConfiguration.java
@@ -20,6 +20,7 @@ import com.github.joschi.jadconfig.Parameter;
 import com.github.joschi.jadconfig.converters.StringSetConverter;
 import org.graylog2.shared.security.tls.DefaultTLSProtocolProvider;
 
+import javax.annotation.Nullable;
 import java.util.Set;
 
 /**
@@ -34,6 +35,21 @@ public class TLSProtocolsConfiguration {
     @Parameter(value = "enabled_tls_protocols", converter = StringSetConverter.class)
     private Set<String> enabledTlsProtocols = null;
 
+    public TLSProtocolsConfiguration() {
+    }
+
+    /**
+     * Used to transfer this setting from {@link org.graylog2.Configuration}
+     */
+    public TLSProtocolsConfiguration(Set<String> enabledTlsProtocols) {
+        this.enabledTlsProtocols = enabledTlsProtocols;
+    }
+
+    /**
+     * Used to access the plain configuration value.
+     * In most cases you'd want to use {@link TLSProtocolsConfiguration#getEnabledTlsProtocols()}
+     */
+    @Nullable
     public Set<String> getConfiguredTlsProtocols() {
         return enabledTlsProtocols;
     }
@@ -46,11 +62,15 @@ public class TLSProtocolsConfiguration {
      * If it's not configured (null and the default) return a secure set of supported TLS protocols.
      */
     public Set<String> getEnabledTlsProtocols() {
-        if (enabledTlsProtocols != null) {
-            if (enabledTlsProtocols.isEmpty()) {
+        return getEnabledTlsProtocols(enabledTlsProtocols);
+    }
+
+    public static Set<String> getEnabledTlsProtocols(Set<String> configuredTlsProtocols) {
+        if (configuredTlsProtocols != null) {
+            if (configuredTlsProtocols.isEmpty()) {
                 return DefaultTLSProtocolProvider.getSupportedTlsProtocols();
             }
-            return enabledTlsProtocols;
+            return configuredTlsProtocols;
         }
         return DefaultTLSProtocolProvider.getDefaultSupportedTlsProtocols();
     }

--- a/graylog2-server/src/main/java/org/graylog2/configuration/TLSProtocolsConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/TLSProtocolsConfiguration.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog2.configuration;
 
 import com.github.joschi.jadconfig.Parameter;

--- a/graylog2-server/src/main/java/org/graylog2/inputs/transports/HttpTransport.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/transports/HttpTransport.java
@@ -26,6 +26,7 @@ import io.netty.handler.codec.http.HttpObjectAggregator;
 import io.netty.handler.codec.http.HttpRequestDecoder;
 import io.netty.handler.codec.http.HttpResponseEncoder;
 import io.netty.handler.timeout.ReadTimeoutHandler;
+import org.graylog2.configuration.TLSProtocolsConfiguration;
 import org.graylog2.inputs.transports.netty.EventLoopGroupFactory;
 import org.graylog2.inputs.transports.netty.HttpHandler;
 import org.graylog2.plugin.LocalMetricRegistry;
@@ -66,14 +67,14 @@ public class HttpTransport extends AbstractTcpTransport {
                          NettyTransportConfiguration nettyTransportConfiguration,
                          ThroughputCounter throughputCounter,
                          LocalMetricRegistry localRegistry,
-                         org.graylog2.Configuration graylogConfiguration) {
+                         TLSProtocolsConfiguration tlsConfiguration) {
         super(configuration,
               throughputCounter,
               localRegistry,
               eventLoopGroup,
               eventLoopGroupFactory,
               nettyTransportConfiguration,
-              graylogConfiguration);
+              tlsConfiguration);
 
         enableCors = configuration.getBoolean(CK_ENABLE_CORS);
 

--- a/graylog2-server/src/main/java/org/graylog2/inputs/transports/SyslogTcpTransport.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/transports/SyslogTcpTransport.java
@@ -20,6 +20,7 @@ import com.google.inject.assistedinject.Assisted;
 import com.google.inject.assistedinject.AssistedInject;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.EventLoopGroup;
+import org.graylog2.configuration.TLSProtocolsConfiguration;
 import org.graylog2.inputs.syslog.tcp.SyslogTCPFramingRouterHandler;
 import org.graylog2.inputs.transports.netty.EventLoopGroupFactory;
 import org.graylog2.plugin.LocalMetricRegistry;
@@ -41,14 +42,14 @@ public class SyslogTcpTransport extends TcpTransport {
                               NettyTransportConfiguration nettyTransportConfiguration,
                               ThroughputCounter throughputCounter,
                               LocalMetricRegistry localRegistry,
-                              org.graylog2.Configuration graylogConfiguration) {
+                              TLSProtocolsConfiguration tlsConfiguration) {
         super(configuration,
                 eventLoopGroup,
                 eventLoopGroupFactory,
                 nettyTransportConfiguration,
                 throughputCounter,
                 localRegistry,
-                graylogConfiguration);
+                tlsConfiguration);
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/inputs/transports/TcpTransport.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/transports/TcpTransport.java
@@ -21,6 +21,7 @@ import com.google.inject.assistedinject.AssistedInject;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.EventLoopGroup;
+import org.graylog2.configuration.TLSProtocolsConfiguration;
 import org.graylog2.inputs.transports.netty.EventLoopGroupFactory;
 import org.graylog2.inputs.transports.netty.LenientDelimiterBasedFrameDecoder;
 import org.graylog2.plugin.LocalMetricRegistry;
@@ -57,8 +58,8 @@ public class TcpTransport extends AbstractTcpTransport {
                         NettyTransportConfiguration nettyTransportConfiguration,
                         ThroughputCounter throughputCounter,
                         LocalMetricRegistry localRegistry,
-                        org.graylog2.Configuration graylogConfiguration) {
-        super(configuration, throughputCounter, localRegistry, eventLoopGroup, eventLoopGroupFactory, nettyTransportConfiguration, graylogConfiguration);
+                        TLSProtocolsConfiguration tlsConfiguration) {
+        super(configuration, throughputCounter, localRegistry, eventLoopGroup, eventLoopGroupFactory, nettyTransportConfiguration, tlsConfiguration);
 
         final boolean nulDelimiter = configuration.getBoolean(CK_USE_NULL_DELIMITER);
         this.delimiter = nulDelimiter ? nulDelimiter() : lineDelimiter();

--- a/graylog2-server/src/main/java/org/graylog2/plugin/inputs/transports/AbstractTcpTransport.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/inputs/transports/AbstractTcpTransport.java
@@ -42,6 +42,7 @@ import io.netty.handler.ssl.util.SelfSignedCertificate;
 import io.netty.util.concurrent.GlobalEventExecutor;
 import org.bouncycastle.operator.OperatorCreationException;
 import org.bouncycastle.pkcs.PKCSException;
+import org.graylog2.configuration.TLSProtocolsConfiguration;
 import org.graylog2.inputs.transports.NettyTransportConfiguration;
 import org.graylog2.inputs.transports.netty.ByteBufMessageAggregationHandler;
 import org.graylog2.inputs.transports.netty.ChannelRegistrationHandler;
@@ -120,7 +121,7 @@ public abstract class AbstractTcpTransport extends NettyTransport {
     protected final Configuration configuration;
     protected final EventLoopGroup parentEventLoopGroup;
     private final NettyTransportConfiguration nettyTransportConfiguration;
-    private final org.graylog2.Configuration graylogConfiguration;
+    private final TLSProtocolsConfiguration tlsConfiguration;
     private final AtomicReference<Channel> channelReference;
 
     private final boolean tlsEnable;
@@ -142,12 +143,12 @@ public abstract class AbstractTcpTransport extends NettyTransport {
             EventLoopGroup parentEventLoopGroup,
             EventLoopGroupFactory eventLoopGroupFactory,
             NettyTransportConfiguration nettyTransportConfiguration,
-            org.graylog2.Configuration graylogConfiguration) {
+            TLSProtocolsConfiguration tlsConfiguration) {
         super(configuration, eventLoopGroupFactory, throughputCounter, localRegistry);
         this.configuration = configuration;
         this.parentEventLoopGroup = parentEventLoopGroup;
         this.nettyTransportConfiguration = nettyTransportConfiguration;
-        this.graylogConfiguration = graylogConfiguration;
+        this.tlsConfiguration = tlsConfiguration;
         this.channelReference = new AtomicReference<>();
         this.childChannels = new DefaultChannelGroup(GlobalEventExecutor.INSTANCE);
 
@@ -349,8 +350,8 @@ public abstract class AbstractTcpTransport extends NettyTransport {
                         .sslProvider(tlsProvider)
                         .clientAuth(clientAuth)
                         .trustManager(clientAuthCerts);
-                if (!graylogConfiguration.getEnabledTlsProtocols().isEmpty()) {
-                    sslContext.protocols(graylogConfiguration.getEnabledTlsProtocols());
+                if (!tlsConfiguration.getEnabledTlsProtocols().isEmpty()) {
+                    sslContext.protocols(tlsConfiguration.getEnabledTlsProtocols());
                 }
                 if (tlsProvider.equals(SslProvider.OPENSSL)) {
                     // Netty tcnative does not adhere jdk.tls.disabledAlgorithms: https://github.com/netty/netty-tcnative/issues/530

--- a/graylog2-server/src/main/java/org/graylog2/plugin/inputs/transports/AbstractTcpTransport.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/inputs/transports/AbstractTcpTransport.java
@@ -365,9 +365,11 @@ public abstract class AbstractTcpTransport extends NettyTransport {
                         .trustManager(clientAuthCerts);
                 sslContext.protocols(enabledTLSProtocols);
                 if (tlsProvider.equals(SslProvider.OPENSSL)) {
-                    // Netty tcnative does not adhere jdk.tls.disabledAlgorithms: https://github.com/netty/netty-tcnative/issues/530
-                    // We need to build our own cipher list
-                    sslContext.ciphers(secureDefaultCiphers.get());
+                    if (!enabledTLSProtocols.contains("TLSv1") && !enabledTLSProtocols.contains("TLSv1.1")) {
+                        // Netty tcnative does not adhere jdk.tls.disabledAlgorithms: https://github.com/netty/netty-tcnative/issues/530
+                        // We need to build our own cipher list
+                        sslContext.ciphers(secureDefaultCiphers.get());
+                    }
                 }
 
                 // TODO: Use byte buffer allocator of channel

--- a/graylog2-server/src/main/java/org/graylog2/plugin/inputs/transports/AbstractTcpTransport.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/inputs/transports/AbstractTcpTransport.java
@@ -146,7 +146,7 @@ public abstract class AbstractTcpTransport extends NettyTransport {
             NettyTransportConfiguration nettyTransportConfiguration,
             org.graylog2.Configuration graylogConfiguration) {
             this(configuration, throughputCounter, localRegistry, parentEventLoopGroup, eventLoopGroupFactory,
-                    nettyTransportConfiguration, new TLSProtocolsConfiguration(graylogConfiguration.enabledTlsProtocols));
+                    nettyTransportConfiguration, new TLSProtocolsConfiguration(graylogConfiguration.getEnabledTlsProtocols()));
     }
 
     public AbstractTcpTransport(

--- a/graylog2-server/src/main/java/org/graylog2/shared/initializers/JerseyService.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/initializers/JerseyService.java
@@ -41,6 +41,7 @@ import org.graylog2.Configuration;
 import org.graylog2.audit.PluginAuditEventTypes;
 import org.graylog2.audit.jersey.AuditEventModelProcessor;
 import org.graylog2.configuration.HttpConfiguration;
+import org.graylog2.configuration.TLSProtocolsConfiguration;
 import org.graylog2.jersey.PrefixAddingModelProcessor;
 import org.graylog2.plugin.inject.Graylog2Module;
 import org.graylog2.plugin.rest.PluginRestResource;
@@ -115,6 +116,7 @@ public class JerseyService extends AbstractIdleService {
     private final ObjectMapper objectMapper;
     private final MetricRegistry metricRegistry;
     private final ErrorPageGenerator errorPageGenerator;
+    private final TLSProtocolsConfiguration tlsConfiguration;
 
     private HttpServer apiHttpServer = null;
 
@@ -129,7 +131,8 @@ public class JerseyService extends AbstractIdleService {
                          Set<PluginAuditEventTypes> pluginAuditEventTypes,
                          ObjectMapper objectMapper,
                          MetricRegistry metricRegistry,
-                         ErrorPageGenerator errorPageGenerator) {
+                         ErrorPageGenerator errorPageGenerator,
+                         TLSProtocolsConfiguration tlsConfiguration) {
         this.configuration = requireNonNull(configuration, "configuration");
         this.graylogConfiguration = graylogConfiguration;
         this.dynamicFeatures = requireNonNull(dynamicFeatures, "dynamicFeatures");
@@ -142,6 +145,7 @@ public class JerseyService extends AbstractIdleService {
         this.objectMapper = requireNonNull(objectMapper, "objectMapper");
         this.metricRegistry = requireNonNull(metricRegistry, "metricRegistry");
         this.errorPageGenerator = requireNonNull(errorPageGenerator, "errorPageGenerator");
+        this.tlsConfiguration = requireNonNull(tlsConfiguration);
     }
 
     @Override
@@ -354,9 +358,7 @@ public class JerseyService extends AbstractIdleService {
 
         final SSLContext sslContext = sslContextConfigurator.createSSLContext(true);
         final SSLEngineConfigurator sslEngineConfigurator = new SSLEngineConfigurator(sslContext, false, false, false);
-        if (!graylogConfiguration.getEnabledTlsProtocols().isEmpty()) {
-            sslEngineConfigurator.setEnabledProtocols(graylogConfiguration.getEnabledTlsProtocols().toArray(new String[0]));
-        }
+        sslEngineConfigurator.setEnabledProtocols(tlsConfiguration.getEnabledTlsProtocols().toArray(new String[0]));
         return sslEngineConfigurator;
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/shared/security/tls/DefaultTLSProtocolProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/security/tls/DefaultTLSProtocolProvider.java
@@ -23,35 +23,38 @@ import org.slf4j.LoggerFactory;
 
 import javax.net.ssl.SSLContext;
 import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 public abstract class DefaultTLSProtocolProvider {
     // Defaults to TLS protocols that are currently considered secure
-    private static final Set<String> DEFAULT_TLS_PROTOCOLS = ImmutableSet.of("TLSv1.2", "TLSv1.3");
+    private static final Set<String> SECURE_TLS_PROTOCOLS = ImmutableSet.of("TLSv1.2", "TLSv1.3");
 
     private static final Logger LOG = LoggerFactory.getLogger(DefaultTLSProtocolProvider.class);
     private static Set<String> defaultSupportedTlsProtocols = null;
 
-    public synchronized static Set<String> getDefaultSupportedTlsProtocols() {
+    public synchronized static Set<String> getSecureTLSProtocols() {
         if (defaultSupportedTlsProtocols != null) {
             return defaultSupportedTlsProtocols;
         }
 
-        final Set<String> tlsProtocols = Sets.newHashSet(DEFAULT_TLS_PROTOCOLS);
-        final Set<String> supportedProtocols = getSupportedTlsProtocols();
+        final Set<String> tlsProtocols = Sets.newHashSet(SECURE_TLS_PROTOCOLS);
+        final Set<String> supportedProtocols = getAllSupportedTlsProtocols();
         if (tlsProtocols.retainAll(supportedProtocols)) {
-            LOG.warn("JRE doesn't support all default TLS protocols. Changing <{}> to <{}>", DEFAULT_TLS_PROTOCOLS, tlsProtocols);
+            LOG.warn("JRE doesn't support all default TLS protocols. Changing <{}> to <{}>", SECURE_TLS_PROTOCOLS, tlsProtocols);
         }
         defaultSupportedTlsProtocols = tlsProtocols;
         return defaultSupportedTlsProtocols;
     }
 
-    public synchronized static Set<String> getSupportedTlsProtocols() {
+    public static Set<String> getAllSupportedTlsProtocols() {
         try {
-            return ImmutableSet.copyOf(SSLContext.getDefault().createSSLEngine().getSupportedProtocols());
+            // Drop SSLv3, as it's not supported by OpenSSL anymore
+            return Arrays.stream(SSLContext.getDefault().createSSLEngine().getSupportedProtocols()).filter(p -> !p.equals("SSLv3")).collect(Collectors.toSet());
         } catch (NoSuchAlgorithmException e) {
-            LOG.error("Failed to detect supported TLS protocols. Keeping default <{}>", DEFAULT_TLS_PROTOCOLS, e);
-            return DEFAULT_TLS_PROTOCOLS;
+            LOG.error("Failed to detect supported TLS protocols. Keeping default <{}>", SECURE_TLS_PROTOCOLS, e);
+            return SECURE_TLS_PROTOCOLS;
         }
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/shared/security/tls/DefaultTLSProtocolProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/security/tls/DefaultTLSProtocolProvider.java
@@ -38,16 +38,20 @@ public abstract class DefaultTLSProtocolProvider {
         }
 
         final Set<String> tlsProtocols = Sets.newHashSet(DEFAULT_TLS_PROTOCOLS);
+        final Set<String> supportedProtocols = getSupportedTlsProtocols();
+        if (tlsProtocols.retainAll(supportedProtocols)) {
+            LOG.warn("JRE doesn't support all default TLS protocols. Changing <{}> to <{}>", DEFAULT_TLS_PROTOCOLS, tlsProtocols);
+        }
+        defaultSupportedTlsProtocols = tlsProtocols;
+        return defaultSupportedTlsProtocols;
+    }
+
+    public synchronized static Set<String> getSupportedTlsProtocols() {
         try {
-            final Set<String> supportedProtocols = ImmutableSet.copyOf(SSLContext.getDefault().createSSLEngine().getSupportedProtocols());
-            if (tlsProtocols.retainAll(supportedProtocols)) {
-                LOG.warn("JRE doesn't support all default TLS protocols. Changing <{}> to <{}>", DEFAULT_TLS_PROTOCOLS, tlsProtocols);
-            }
-            defaultSupportedTlsProtocols = tlsProtocols;
+            return ImmutableSet.copyOf(SSLContext.getDefault().createSSLEngine().getSupportedProtocols());
         } catch (NoSuchAlgorithmException e) {
             LOG.error("Failed to detect supported TLS protocols. Keeping default <{}>", DEFAULT_TLS_PROTOCOLS, e);
-            defaultSupportedTlsProtocols = DEFAULT_TLS_PROTOCOLS;
+            return DEFAULT_TLS_PROTOCOLS;
         }
-        return defaultSupportedTlsProtocols;
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/shared/security/tls/DefaultTLSProtocolProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/security/tls/DefaultTLSProtocolProvider.java
@@ -27,7 +27,7 @@ import java.util.Set;
 
 public abstract class DefaultTLSProtocolProvider {
     // Defaults to TLS protocols that are currently considered secure
-    public static final Set<String> DEFAULT_TLS_PROTOCOLS = ImmutableSet.of("TLSv1.2", "TLSv1.3");
+    private static final Set<String> DEFAULT_TLS_PROTOCOLS = ImmutableSet.of("TLSv1.2", "TLSv1.3");
 
     private static final Logger LOG = LoggerFactory.getLogger(DefaultTLSProtocolProvider.class);
     private static Set<String> defaultSupportedTlsProtocols = null;

--- a/graylog2-server/src/test/java/org/graylog/plugins/beats/BeatsTransportTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/beats/BeatsTransportTest.java
@@ -17,6 +17,7 @@
 package org.graylog.plugins.beats;
 
 import io.netty.channel.nio.NioEventLoopGroup;
+import org.graylog2.configuration.TLSProtocolsConfiguration;
 import org.graylog2.inputs.transports.NettyTransportConfiguration;
 import org.graylog2.inputs.transports.netty.EventLoopGroupFactory;
 import org.graylog2.plugin.LocalMetricRegistry;
@@ -41,7 +42,7 @@ public class BeatsTransportTest {
     private NioEventLoopGroup eventLoopGroup;
 
     @Mock
-    private org.graylog2.Configuration graylogConfiguration;
+    private TLSProtocolsConfiguration tlsConfiguration;
 
     @Before
     public void setUp() {
@@ -64,7 +65,7 @@ public class BeatsTransportTest {
                 nettyTransportConfiguration,
                 new ThroughputCounter(eventLoopGroup),
                 new LocalMetricRegistry(),
-                graylogConfiguration
+                tlsConfiguration
         );
 
         final MessageInput input = mock(MessageInput.class);

--- a/graylog2-server/src/test/java/org/graylog/security/authservice/ldap/UnboundLDAPConnectorTest.java
+++ b/graylog2-server/src/test/java/org/graylog/security/authservice/ldap/UnboundLDAPConnectorTest.java
@@ -34,6 +34,7 @@ import org.apache.directory.server.core.partition.impl.avl.AvlPartition;
 import org.apache.directory.server.ldap.LdapServer;
 import org.graylog.testing.ldap.LDAPTestUtils;
 import org.graylog2.ApacheDirectoryTestServiceFactory;
+import org.graylog2.configuration.TLSProtocolsConfiguration;
 import org.graylog2.security.TrustManagerProvider;
 import org.graylog2.security.encryption.EncryptedValue;
 import org.graylog2.security.encryption.EncryptedValueService;
@@ -108,7 +109,7 @@ public class UnboundLDAPConnectorTest extends AbstractLdapTestUnit {
                 .serverList(ImmutableList.of(unreachableServer, ldapServer))
                 .build();
 
-        connector = new UnboundLDAPConnector(10000, ENABLED_TLS_PROTOCOLS, mock(TrustManagerProvider.class), encryptedValueService);
+        connector = new UnboundLDAPConnector(10000, new TLSProtocolsConfiguration(), mock(TrustManagerProvider.class), encryptedValueService);
         connection = connector.connect(connectorConfig);
     }
 

--- a/graylog2-server/src/test/java/org/graylog/security/authservice/ldap/UnboundLDAPConnectorTestTLSIT.java
+++ b/graylog2-server/src/test/java/org/graylog/security/authservice/ldap/UnboundLDAPConnectorTestTLSIT.java
@@ -22,10 +22,10 @@ import com.unboundid.ldap.sdk.LDAPException;
 import org.assertj.core.api.Assertions;
 import org.graylog.testing.ldap.LDAPTestUtils;
 import org.graylog.testing.ldap.OpenLDAPContainer;
+import org.graylog2.configuration.TLSProtocolsConfiguration;
 import org.graylog2.security.DefaultX509TrustManager;
 import org.graylog2.security.TrustManagerProvider;
 import org.graylog2.security.encryption.EncryptedValueService;
-import org.graylog2.shared.security.tls.DefaultTLSProtocolProvider;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.junit.jupiter.Container;
@@ -69,7 +69,7 @@ public class UnboundLDAPConnectorTestTLSIT {
 
         mockTrustManagerWithSystemKeystore();
 
-        this.ldapConnector = new UnboundLDAPConnector(DEFAULT_TIMEOUT, DefaultTLSProtocolProvider.getDefaultSupportedTlsProtocols(), trustManagerProvider, encryptedValueService);
+        this.ldapConnector = new UnboundLDAPConnector(DEFAULT_TIMEOUT, new TLSProtocolsConfiguration(), trustManagerProvider, encryptedValueService);
     }
 
     @Test

--- a/graylog2-server/src/test/java/org/graylog2/plugin/inputs/transports/AbstractTcpTransportTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/plugin/inputs/transports/AbstractTcpTransportTest.java
@@ -24,6 +24,7 @@ import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.handler.logging.LoggingHandler;
+import org.graylog2.configuration.TLSProtocolsConfiguration;
 import org.graylog2.inputs.transports.NettyTransportConfiguration;
 import org.graylog2.inputs.transports.netty.EventLoopGroupFactory;
 import org.graylog2.plugin.LocalMetricRegistry;
@@ -70,7 +71,7 @@ public class AbstractTcpTransportTest {
     private MessageInput input;
 
     @Mock
-    private org.graylog2.Configuration graylogConfiguration;
+    private TLSProtocolsConfiguration tlsConfiguration;
 
     private ThroughputCounter throughputCounter;
     private LocalMetricRegistry localRegistry;
@@ -100,7 +101,7 @@ public class AbstractTcpTransportTest {
         );
 
         final AbstractTcpTransport transport = new AbstractTcpTransport(
-                configuration, throughputCounter, localRegistry, eventLoopGroup, eventLoopGroupFactory, nettyTransportConfiguration, graylogConfiguration) {
+                configuration, throughputCounter, localRegistry, eventLoopGroup, eventLoopGroupFactory, nettyTransportConfiguration, tlsConfiguration) {
         };
         final MessageInput input = mock(MessageInput.class);
         assertThat(transport.getChildChannelHandlers(input)).containsKey("tls");
@@ -119,7 +120,7 @@ public class AbstractTcpTransportTest {
         );
 
         final AbstractTcpTransport transport = new AbstractTcpTransport(
-            configuration, throughputCounter, localRegistry, eventLoopGroup, eventLoopGroupFactory, nettyTransportConfiguration, graylogConfiguration) {};
+            configuration, throughputCounter, localRegistry, eventLoopGroup, eventLoopGroupFactory, nettyTransportConfiguration, tlsConfiguration) {};
 
         expectedException.expect(IllegalStateException.class);
         expectedException.expectMessage("Couldn't write to temporary directory: " + tmpDir.getAbsolutePath());
@@ -141,7 +142,7 @@ public class AbstractTcpTransportTest {
         );
 
         final AbstractTcpTransport transport = new AbstractTcpTransport(
-            configuration, throughputCounter, localRegistry, eventLoopGroup, eventLoopGroupFactory, nettyTransportConfiguration, graylogConfiguration) {};
+            configuration, throughputCounter, localRegistry, eventLoopGroup, eventLoopGroupFactory, nettyTransportConfiguration, tlsConfiguration) {};
 
         expectedException.expect(IllegalStateException.class);
         expectedException.expectMessage("Couldn't write to temporary directory: " + tmpDir.getAbsolutePath());
@@ -162,7 +163,7 @@ public class AbstractTcpTransportTest {
         );
 
         final AbstractTcpTransport transport = new AbstractTcpTransport(
-            configuration, throughputCounter, localRegistry, eventLoopGroup, eventLoopGroupFactory, nettyTransportConfiguration, graylogConfiguration) {};
+            configuration, throughputCounter, localRegistry, eventLoopGroup, eventLoopGroupFactory, nettyTransportConfiguration, tlsConfiguration) {};
 
         expectedException.expect(IllegalStateException.class);
         expectedException.expectMessage("Couldn't write to temporary directory: " + file.getAbsolutePath());
@@ -177,7 +178,7 @@ public class AbstractTcpTransportTest {
                 "bind_address", "127.0.0.1",
                 "port", 0));
         final AbstractTcpTransport transport = new AbstractTcpTransport(
-                configuration, throughputCounter, localRegistry, eventLoopGroup, eventLoopGroupFactory, nettyTransportConfiguration, graylogConfiguration) {
+                configuration, throughputCounter, localRegistry, eventLoopGroup, eventLoopGroupFactory, nettyTransportConfiguration, tlsConfiguration) {
         };
         transport.launch(input);
 
@@ -209,7 +210,7 @@ public class AbstractTcpTransportTest {
                 "bind_address", "127.0.0.1",
                 "port", 0));
         final AbstractTcpTransport transport = new AbstractTcpTransport(
-                configuration, throughputCounter, localRegistry, eventLoopGroup, eventLoopGroupFactory, nettyTransportConfiguration, graylogConfiguration) {
+                configuration, throughputCounter, localRegistry, eventLoopGroup, eventLoopGroupFactory, nettyTransportConfiguration, tlsConfiguration) {
         };
         transport.launch(input);
 


### PR DESCRIPTION
The changes made in #10653 also apply to cases where Graylog
uses TLS as a client.

This makes it impossible to create TLS connections
to legacy software that is only supporting old and insecure ciphers.
Most prominently ES 6.8.x

This changes gives the user the possiblity to re-enable old cipher
suites by changing our default and allowing TLS protocols < 1.2.

This can be done with the `enabled_tls_protocols` setting.
E.g. by setting `enabled_tls_protocols=TLSv1.1, TLSv1.2`

This change had to introduce a separate configuration bean,
to avoid triggering anything that might initialize the default SSLContext.
As for example would the MongoDBConfiguration.validat() method do.

Fixes #10944

/jenkins-pr-deps  Graylog2/graylog-plugin-enterprise#2427,Graylog2/graylog-plugin-enterprise-integrations#584
