### PR TITLE
Missing Forwarder gRPC server-side metrics

### DIFF
--- a/graylog2-server/src/main/resources/prometheus-exporter.yml
+++ b/graylog2-server/src/main/resources/prometheus-exporter.yml
@@ -1200,12 +1200,12 @@ metric_mappings:
     match_pattern: "org.graylog2.traffic.system-output-traffic"
 
   - metric_name: "forwarder_grpc_method_invocations"
-    match_pattern: "org.graylog.plugins.cloud.forwarder.grpc.ServerMetricsInterceptor.method.org.graylog.cloud.forwarder.*.invocations"
+    match_pattern: "org.graylog.plugins.forwarder.grpc.ServerMetricsInterceptor.method.org.graylog.cloud.forwarder.*.invocations"
     wildcard_extract_labels:
       - "method"
 
   - metric_name: "forwarder_grpc_method_executionTime"
-    match_pattern: "org.graylog.plugins.cloud.forwarder.grpc.ServerMetricsInterceptor.method.org.graylog.cloud.forwarder.*.executionTime"
+    match_pattern: "org.graylog.plugins.forwarder.grpc.ServerMetricsInterceptor.method.org.graylog.cloud.forwarder.*.executionTime"
     wildcard_extract_labels:
       - "method"
 
@@ -1242,103 +1242,3 @@ metric_mappings:
     additional_labels:
       success: "false"
       type: "graylog"
-
-  - metric_name: "input_buffer_thread_factory"
-    match_pattern: "org.graylog.cloud.forwarder.input.JournalWritingInputBuffer.thread-factory.created"
-    additional_labels:
-      type: "created"
-
-  - metric_name: "input_buffer_thread_factory"
-    match_pattern: "org.graylog.cloud.forwarder.input.JournalWritingInputBuffer.thread-factory.running"
-    additional_labels:
-      type: "running"
-
-  - metric_name: "input_buffer_thread_factory"
-    match_pattern: "org.graylog.cloud.forwarder.input.JournalWritingInputBuffer.thread-factory.terminated"
-    additional_labels:
-      type: "terminated"
-
-  - metric_name: "process_buffer_thread_factory"
-    match_pattern: "org.graylog.cloud.forwarder.processing.ForwarderProcessBuffer.thread-factory.created"
-    additional_labels:
-      type: "created"
-
-  - metric_name: "process_buffer_thread_factory"
-    match_pattern: "org.graylog.cloud.forwarder.processing.ForwarderProcessBuffer.thread-factory.running"
-    additional_labels:
-      type: "running"
-
-  - metric_name: "process_buffer_thread_factory"
-    match_pattern: "org.graylog.cloud.forwarder.processing.ForwarderProcessBuffer.thread-factory.terminated"
-    additional_labels:
-      type: "terminated"
-
-  - metric_name: "buffer_incoming_messages"
-    match_pattern: "org.graylog.cloud.forwarder.input.JournalWritingInputBuffer.incomingMessages"
-    additional_labels:
-      type: "input"
-
-  - metric_name: "buffer_incoming_messages"
-    match_pattern: "org.graylog.cloud.forwarder.processing.ForwarderProcessBuffer.incomingMessages"
-    additional_labels:
-      type: "process"
-
-  - metric_name: "process_buffer_decode_time"
-    match_pattern: "org.graylog.cloud.forwarder.processing.ForwarderProcessBuffer.decodeTime"
-
-  - metric_name: "process_buffer_parse_time"
-    match_pattern: "org.graylog.cloud.forwarder.processing.ForwarderProcessBuffer.parseTime"
-
-  - metric_name: "buffer_processor_incoming_messages"
-    match_pattern: "org.graylog.cloud.forwarder.processing.ForwarderProcessBufferProcessor.incomingMessages"
-
-  - metric_name: "buffer_processor_outgoing_messages"
-    match_pattern: "org.graylog.cloud.forwarder.processing.ForwarderProcessBufferProcessor.outgoingMessages"
-
-  - metric_name: "buffer_processor_process_time"
-    match_pattern: "org.graylog.cloud.forwarder.processing.ForwarderProcessBufferProcessor.processTime"
-
-  - metric_name: "journal_reader_read_blocked"
-    match_pattern: "org.graylog.cloud.forwarder.processing.ForwarderJournalReader.readBlocked"
-
-  - metric_name: "journal_reader_read_messages"
-    match_pattern: "org.graylog.cloud.forwarder.processing.ForwarderJournalReader.readMessages"
-
-  - metric_name: "journal_reader_requested_read_count"
-    match_pattern: "org.graylog.cloud.forwarder.processing.ForwarderJournalReader.requestedReadCount"
-
-  - metric_name: "batch_sender_sending_threads"
-    match_pattern: "org.graylog.cloud.forwarder.grpc.messaging.BatchSender.sendingThreads.max"
-    additional_labels:
-      type: "max"
-
-  - metric_name: "batch_sender_sending_threads"
-    match_pattern: "org.graylog.cloud.forwarder.grpc.messaging.BatchSender.sendingThreads.busy"
-    additional_labels:
-      type: "busy"
-
-  - metric_name: "batch_sender_batch_size"
-    match_pattern: "org.graylog.cloud.forwarder.grpc.messaging.BatchSender.batchSize.bytes"
-    additional_labels:
-      unit: "bytes"
-
-  - metric_name: "batch_sender_batch_size"
-    match_pattern: "org.graylog.cloud.forwarder.grpc.messaging.BatchSender.batchSize.messages"
-    additional_labels:
-      unit: "messages"
-
-  - metric_name: "batch_sender_batches_sent"
-    match_pattern: "org.graylog.cloud.forwarder.grpc.messaging.BatchSender.batchesSent"
-
-  - metric_name: "batch_sender_message_serialization_time"
-    match_pattern: "org.graylog.cloud.forwarder.grpc.messaging.BatchSender.messageSerializationTime"
-
-  - metric_name: "grpc_method_invocations"
-    match_pattern: "org.graylog.cloud.forwarder.grpc.ClientMetricsInterceptor.method.org.graylog.cloud.forwarder.*.invocations"
-    wildcard_extract_labels:
-      - "method"
-
-  - metric_name: "grpc_method_executionTime"
-    match_pattern: "org.graylog.cloud.forwarder.grpc.ClientMetricsInterceptor.method.org.graylog.cloud.forwarder.*.executionTime"
-    wildcard_extract_labels:
-      - "method"


### PR DESCRIPTION
While coping with https://github.com/Graylog2/forwarder/issues/32 it turned out that the Forwarder gRPC server-side metrics are declared with a wrong package name resulting into having no metrics for the gRPC calls. This PR addresses this issue and also removes irrelevant Forwarder client-side metrics.