### PR TITLE
Issue 10552 dashboard page context

### DIFF
--- a/graylog2-web-interface/src/views/components/QueryBar.test.tsx
+++ b/graylog2-web-interface/src/views/components/QueryBar.test.tsx
@@ -21,6 +21,7 @@ import { MockStore } from 'helpers/mocking';
 
 import QueryBar from 'views/components/QueryBar';
 import { ViewActions } from 'views/stores/ViewStore';
+import DashboardPageContext from 'views/components/contexts/DashboardPageContext';
 
 jest.mock('react-sizeme', () => ({
   SizeMe: ({ children: fn }) => fn({ size: { width: 1024, height: 768 } }),
@@ -76,7 +77,17 @@ describe('QueryBar', () => {
   });
 
   it('allows closing current tab', async () => {
-    render(<QueryBar queries={queries} queryTitles={queryTitles} viewMetadata={viewMetadata} />);
+    const setDashboard = jest.fn();
+
+    render(
+      <DashboardPageContext.Provider value={{
+        setDashboardPage: setDashboard,
+        unsetDashboardPage: jest.fn(),
+        dashboardPage: undefined,
+      }}>
+        <QueryBar queries={queries} queryTitles={queryTitles} viewMetadata={viewMetadata} />
+      </DashboardPageContext.Provider>,
+    );
 
     const currentTab = await screen.findByRole('button', { name: 'Second Query' });
 
@@ -88,7 +99,7 @@ describe('QueryBar', () => {
 
     fireEvent.click(closeButton);
 
-    await waitFor(() => expect(ViewActions.selectQuery).toHaveBeenCalledWith('foo'));
+    await waitFor(() => expect(setDashboard).toHaveBeenCalled());
     await waitFor(() => expect(ViewActions.search).toHaveBeenCalled());
   });
 });

--- a/graylog2-web-interface/src/views/components/QueryBar.tsx
+++ b/graylog2-web-interface/src/views/components/QueryBar.tsx
@@ -15,7 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { useCallback, useContext } from 'react';
+import { useCallback, useContext, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import * as Immutable from 'immutable';
 import * as ImmutablePropTypes from 'react-immutable-proptypes';
@@ -69,7 +69,13 @@ type Props = {
 
 const QueryBar = ({ queries, queryTitles, viewMetadata }: Props) => {
   const { activeQuery } = viewMetadata;
-  const { setDashboardPage } = useContext(DashboardPageContext);
+  const { setDashboardPage, dashboardPage } = useContext(DashboardPageContext);
+
+  useEffect(() => {
+    if (dashboardPage && activeQuery !== dashboardPage) {
+      ViewActions.selectQuery(dashboardPage);
+    }
+  }, [activeQuery, dashboardPage]);
 
   const onSelectPage = useCallback((pageId) => {
     setDashboardPage(pageId);

--- a/graylog2-web-interface/src/views/components/QueryBar.tsx
+++ b/graylog2-web-interface/src/views/components/QueryBar.tsx
@@ -37,9 +37,7 @@ import QueryTabs from './QueryTabs';
 
 const onTitleChange = (queryId, newTitle) => TitlesActions.set('tab', 'title', newTitle);
 
-const onSelectQuery = (queryId) => (queryId === 'new' ? NewQueryActionHandler() : ViewActions.selectQuery(queryId));
-
-const onCloseTab = (queryId: string, currentQuery: string, queries: Immutable.OrderedSet<string>, setDashboardPage: (page: string | undefined) => void) => {
+const onCloseTab = (queryId: string, currentQuery: string, queries: Immutable.OrderedSet<string>, setDashboardPage: (page: string) => void) => {
   if (queries.size === 1) {
     return Promise.resolve();
   }
@@ -68,9 +66,17 @@ const QueryBar = ({ queries, queryTitles, viewMetadata }: Props) => {
   const { setDashboardPage } = useContext(DashboardPageContext);
 
   const onSelectPage = useCallback((pageId) => {
+    if (pageId === 'new') {
+      return NewQueryActionHandler().then((newPage) => {
+        setDashboardPage(newPage.id);
+
+        return newPage;
+      });
+    }
+
     setDashboardPage(pageId);
 
-    return onSelectQuery(pageId);
+    return ViewActions.selectQuery(pageId);
   }, [setDashboardPage]);
 
   const onRemove = useCallback((queryId) => onCloseTab(queryId, activeQuery, queries, setDashboardPage), [activeQuery, queries, setDashboardPage]);

--- a/graylog2-web-interface/src/views/components/QueryBar.tsx
+++ b/graylog2-web-interface/src/views/components/QueryBar.tsx
@@ -15,7 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { useCallback } from 'react';
+import { useCallback, useContext } from 'react';
 import PropTypes from 'prop-types';
 import * as Immutable from 'immutable';
 import * as ImmutablePropTypes from 'react-immutable-proptypes';
@@ -31,6 +31,7 @@ import { QueryTitlesStore } from 'views/stores/QueryTitlesStore';
 import { ViewMetaData, ViewMetadataStore } from 'views/stores/ViewMetadataStore';
 import { ViewStatesActions } from 'views/stores/ViewStatesStore';
 import { QueryId } from 'views/logic/queries/Query';
+import DashboardPageContext from 'views/components/contexts/DashboardPageContext';
 
 import QueryTabs from './QueryTabs';
 
@@ -68,13 +69,21 @@ type Props = {
 
 const QueryBar = ({ queries, queryTitles, viewMetadata }: Props) => {
   const { activeQuery } = viewMetadata;
+  const { setDashboardPage } = useContext(DashboardPageContext);
+
+  const onSelectPage = useCallback((pageId) => {
+    setDashboardPage(pageId);
+
+    return onSelectQuery(pageId);
+  }, [setDashboardPage]);
+
   const onRemove = useCallback((queryId) => onCloseTab(queryId, activeQuery, queries), [activeQuery, queries]);
 
   return (
     <QueryTabs queries={queries}
                selectedQueryId={activeQuery}
                titles={queryTitles}
-               onSelect={onSelectQuery}
+               onSelect={onSelectPage}
                onTitleChange={onTitleChange}
                onRemove={onRemove} />
   );

--- a/graylog2-web-interface/src/views/components/QueryTabs.tsx
+++ b/graylog2-web-interface/src/views/components/QueryTabs.tsx
@@ -55,7 +55,7 @@ const QueryTabs = ({ onRemove, onSelect, onTitleChange, queries, selectedQueryId
                                 onSelect={onSelect}
                                 queryTitleEditModal={queryTitleEditModal}
                                 onTitleChange={onTitleChange} />
-          ) : null)}
+          ) : <div />)}
         </SizeMe>
 
         {/*

--- a/graylog2-web-interface/src/views/components/Search.tsx
+++ b/graylog2-web-interface/src/views/components/Search.tsx
@@ -62,7 +62,6 @@ import WidgetFocusProvider from 'views/components/contexts/WidgetFocusProvider';
 import WidgetFocusContext from 'views/components/contexts/WidgetFocusContext';
 import SearchExecutionState from 'views/logic/search/SearchExecutionState';
 import { RefluxActions } from 'stores/StoreTypes';
-import DashboardPageContextProvider from 'views/components/contexts/DashboardPageContextProvider';
 
 const GridContainer = styled.div<{ interactive: boolean }>(({ interactive }) => {
   return interactive ? css`
@@ -193,7 +192,6 @@ const Search = ({ location }: Props) => {
   }, []);
 
   return (
-    <DashboardPageContextProvider>
     <WidgetFocusProvider>
       <WidgetFocusContext.Consumer>
         {({ focusedWidget: { focusing: focusingWidget, editing: editingWidget } = { focusing: false, editing: false } }) => (
@@ -246,7 +244,6 @@ const Search = ({ location }: Props) => {
         )}
       </WidgetFocusContext.Consumer>
     </WidgetFocusProvider>
-    </DashboardPageContextProvider>
   );
 };
 

--- a/graylog2-web-interface/src/views/components/Search.tsx
+++ b/graylog2-web-interface/src/views/components/Search.tsx
@@ -62,6 +62,7 @@ import WidgetFocusProvider from 'views/components/contexts/WidgetFocusProvider';
 import WidgetFocusContext from 'views/components/contexts/WidgetFocusContext';
 import SearchExecutionState from 'views/logic/search/SearchExecutionState';
 import { RefluxActions } from 'stores/StoreTypes';
+import DashboardPageContextProvider from 'views/components/contexts/DashboardPageContextProvider';
 
 const GridContainer = styled.div<{ interactive: boolean }>(({ interactive }) => {
   return interactive ? css`
@@ -192,6 +193,7 @@ const Search = ({ location }: Props) => {
   }, []);
 
   return (
+    <DashboardPageContextProvider>
     <WidgetFocusProvider>
       <WidgetFocusContext.Consumer>
         {({ focusedWidget: { focusing: focusingWidget, editing: editingWidget } = { focusing: false, editing: false } }) => (
@@ -244,6 +246,7 @@ const Search = ({ location }: Props) => {
         )}
       </WidgetFocusContext.Consumer>
     </WidgetFocusProvider>
+    </DashboardPageContextProvider>
   );
 };
 

--- a/graylog2-web-interface/src/views/components/contexts/DashboardPageContext.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/DashboardPageContext.tsx
@@ -30,6 +30,6 @@ const defaultContext = {
   unsetDashboardPage: () => undefined,
 };
 
-const DashboardPage = React.createContext<DashboardPageContextType>(defaultContext);
+const DashboardPageContext = React.createContext<DashboardPageContextType>(defaultContext);
 
-export default singleton('contexts.DashboardPage', () => DashboardPage);
+export default singleton('contexts.DashboardPage', () => DashboardPageContext);

--- a/graylog2-web-interface/src/views/components/contexts/DashboardPageContext.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/DashboardPageContext.tsx
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+
+import { singleton } from 'views/logic/singleton';
+
+export type DashboardPageContextType = {
+  dashboardPage: string,
+  setDashboardPage: (pageId: string) => void,
+  unsetDashboardPage: () => void,
+};
+
+const defaultContext = {
+  dashboardPage: undefined,
+  setDashboardPage: () => undefined,
+  unsetDashboardPage: () => undefined,
+};
+
+const DashboardPage = React.createContext<DashboardPageContextType>(defaultContext);
+
+export default singleton('contexts.DashboardPage', () => DashboardPage);

--- a/graylog2-web-interface/src/views/components/contexts/DashboardPageContextProvider.test.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/DashboardPageContextProvider.test.tsx
@@ -1,0 +1,133 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import { render } from 'wrappedTestingLibrary';
+import { useLocation } from 'react-router-dom';
+import { asMock } from 'helpers/mocking';
+
+import DashboardPageContext from './DashboardPageContext';
+import DashboardPageContextProvider from './DashboardPageContextProvider';
+
+const mockHistoryReplace = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual<{}>('react-router-dom'),
+  useHistory: () => ({
+    replace: mockHistoryReplace,
+  }),
+  useLocation: jest.fn(() => ({
+    pathname: '',
+    search: '',
+  })),
+}));
+
+jest.mock('views/stores/ViewStatesStore', () => ({
+  ViewStatesStore: {
+    getInitialState: jest.fn(() => ({
+      has: jest.fn((pageId) => pageId === 'page-id' || pageId === 'page2-id'),
+    })),
+    listen: jest.fn(),
+  },
+}));
+
+describe('DashboardPageContextProvider', () => {
+  beforeEach(() => {
+    asMock(useLocation).mockReturnValue({
+      pathname: '',
+      search: '',
+    });
+  });
+
+  const renderSUT = (consume) => render(
+    <DashboardPageContextProvider>
+      <DashboardPageContext.Consumer>
+        {consume}
+      </DashboardPageContext.Consumer>
+    </DashboardPageContextProvider>,
+  );
+
+  it('should update url on page set', () => {
+    let contextValue;
+
+    const consume = (value) => {
+      contextValue = value;
+    };
+
+    renderSUT(consume);
+
+    contextValue.setDashboardPage('page-id');
+
+    expect(mockHistoryReplace).toBeCalledWith('?page=page-id');
+  });
+
+  it('should update url on page change', () => {
+    asMock(useLocation).mockReturnValueOnce({
+      pathname: '',
+      search: '?page=page2-id',
+    });
+
+    let contextValue;
+
+    const consume = (value) => {
+      contextValue = value;
+    };
+
+    renderSUT(consume);
+
+    contextValue.setDashboardPage('page-id');
+
+    expect(mockHistoryReplace).toBeCalledWith('?page=page-id');
+  });
+
+  it('should unset a page from url', () => {
+    asMock(useLocation).mockReturnValueOnce({
+      pathname: '',
+      search: '?page=page-id',
+    });
+
+    let contextValue;
+
+    const consume = (value) => {
+      contextValue = value;
+    };
+
+    renderSUT(consume);
+
+    contextValue.unsetDashboardPage();
+
+    expect(mockHistoryReplace).toBeCalledWith('');
+  });
+
+  it('should not set to an unknown page', () => {
+    asMock(useLocation).mockReturnValueOnce({
+      pathname: '',
+      search: '?page=page-id',
+    });
+
+    let contextValue;
+
+    const consume = (value) => {
+      contextValue = value;
+    };
+
+    renderSUT(consume);
+
+    contextValue.setDashboardPage('new');
+
+    expect(mockHistoryReplace).toBeCalledWith('');
+  });
+});

--- a/graylog2-web-interface/src/views/components/contexts/DashboardPageContextProvider.test.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/DashboardPageContextProvider.test.tsx
@@ -25,7 +25,7 @@ import DashboardPageContextProvider from './DashboardPageContextProvider';
 const mockHistoryReplace = jest.fn();
 
 jest.mock('react-router-dom', () => ({
-  ...jest.requireActual<{}>('react-router-dom'),
+  ...jest.requireActual('react-router-dom'),
   useHistory: () => ({
     replace: mockHistoryReplace,
   }),

--- a/graylog2-web-interface/src/views/components/contexts/DashboardPageContextProvider.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/DashboardPageContextProvider.tsx
@@ -32,13 +32,10 @@ const _updateQueryParams = (
   newPage: string | undefined,
   query: string,
 ) => {
-  let baseUri = _clearURI(query);
+  const baseUri = _clearURI(query);
+  const newUri = baseUri.setSearch('page', newPage);
 
-  if (newPage && newPage !== 'new') {
-    baseUri = baseUri.setSearch('page', newPage);
-  }
-
-  return baseUri.toString();
+  return newUri.toString();
 };
 
 const useSyncStateWithQueryParams = ({ dashboardPage, uriParams, setDashboardPage, states }) => {

--- a/graylog2-web-interface/src/views/components/contexts/DashboardPageContextProvider.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/DashboardPageContextProvider.tsx
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import { useState, useEffect, useMemo, useCallback } from 'react';
+import { useLocation, useHistory } from 'react-router-dom';
+import URI from 'urijs';
+
+import useQuery from 'routing/useQuery';
+import DashboardPageContext from 'views/components/contexts/DashboardPageContext';
+
+const _clearURI = (query) => new URI(query)
+  .removeSearch('page');
+
+const _updateQueryParams = (
+  newPage: string | undefined,
+  query: string,
+) => {
+  let baseUri = _clearURI(query);
+
+  if (newPage) {
+    baseUri = baseUri.setSearch('page', newPage);
+  }
+
+  return baseUri.toString();
+};
+
+const useSyncStateWithQueryParams = ({ dashboardPage, uriParams, setDashboardPage }) => {
+  useEffect(() => {
+    const nextPage = uriParams.page;
+
+    if (nextPage !== dashboardPage) {
+      setDashboardPage(dashboardPage);
+    }
+  }, [uriParams.page, dashboardPage, setDashboardPage]);
+};
+
+const useCleanupQueryParams = ({ uriParams, query, history }) => {
+  useEffect(() => {
+    if (uriParams?.page === undefined) {
+      const baseURI = _clearURI(query);
+
+      history.replace(baseURI.toString());
+    }
+  }, [query, history, uriParams?.page]);
+};
+
+const DashboardPageContextProvider = ({ children }: { children: React.ReactNode }): React.ReactElement => {
+  const { search, pathname } = useLocation();
+  const query = pathname + search;
+  const history = useHistory();
+  const [dashboardPage, setDashboardPage] = useState<string | undefined>();
+  const params = useQuery();
+  const uriParams = useMemo(() => ({
+    page: params.page,
+  }), [params]);
+
+  useSyncStateWithQueryParams({ dashboardPage, uriParams, setDashboardPage });
+  useCleanupQueryParams({ uriParams, query, history });
+
+  const updatePageParams = useCallback((newPage: string | undefined) => {
+    const newUri = _updateQueryParams(newPage, query);
+
+    history.replace(newUri);
+  }, [history, query]);
+
+  const setDashboardPageParam = (nextPage) => updatePageParams(nextPage);
+  const unSetDashboardPageParam = () => updatePageParams(undefined);
+
+  return (
+    <DashboardPageContext.Provider value={{
+      setDashboardPage: setDashboardPageParam,
+      unsetDashboardPage: unSetDashboardPageParam,
+      dashboardPage: dashboardPage,
+    }}>
+      {children}
+    </DashboardPageContext.Provider>
+  );
+};
+
+export default DashboardPageContextProvider;

--- a/graylog2-web-interface/src/views/components/contexts/DashboardPageContextProvider.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/DashboardPageContextProvider.tsx
@@ -43,7 +43,7 @@ const useSyncStateWithQueryParams = ({ dashboardPage, uriParams, setDashboardPag
     const nextPage = uriParams.page;
 
     if (nextPage !== dashboardPage) {
-      setDashboardPage(dashboardPage);
+      setDashboardPage(nextPage);
     }
   }, [uriParams.page, dashboardPage, setDashboardPage]);
 };

--- a/graylog2-web-interface/src/views/components/contexts/DashboardPageContextProvider.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/DashboardPageContextProvider.tsx
@@ -41,17 +41,17 @@ const _updateQueryParams = (
   return baseUri.toString();
 };
 
-const useSyncStateWithQueryParams = ({ dashboardPage, uriParams, setDashboardPage, pageIds }) => {
+const useSyncStateWithQueryParams = ({ dashboardPage, uriParams, setDashboardPage, states }) => {
   useEffect(() => {
     const nextPage = uriParams.page;
 
-    if (!pageIds.includes(nextPage)) {
+    if (!states.has(nextPage)) {
       setDashboardPage(undefined);
     } else if (nextPage !== dashboardPage) {
       setDashboardPage(nextPage);
       ViewActions.selectQuery(nextPage);
     }
-  }, [uriParams.page, dashboardPage, setDashboardPage, pageIds]);
+  }, [uriParams.page, dashboardPage, setDashboardPage, states]);
 };
 
 const useCleanupQueryParams = ({ uriParams, query, history }) => {
@@ -66,7 +66,6 @@ const useCleanupQueryParams = ({ uriParams, query, history }) => {
 
 const DashboardPageContextProvider = ({ children }: { children: React.ReactNode }): React.ReactElement => {
   const states = useStore(ViewStatesStore);
-  const pageIds = states.keySeq();
   const { search, pathname } = useLocation();
   const query = pathname + search;
   const history = useHistory();
@@ -76,7 +75,7 @@ const DashboardPageContextProvider = ({ children }: { children: React.ReactNode 
     page: params.page,
   }), [params]);
 
-  useSyncStateWithQueryParams({ dashboardPage, uriParams, setDashboardPage, pageIds });
+  useSyncStateWithQueryParams({ dashboardPage, uriParams, setDashboardPage, states });
   useCleanupQueryParams({ uriParams, query, history });
 
   const updatePageParams = useCallback((newPage: string | undefined) => {

--- a/graylog2-web-interface/src/views/components/contexts/DashboardPageContextProvider.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/DashboardPageContextProvider.tsx
@@ -33,9 +33,12 @@ const _updateQueryParams = (
   query: string,
 ) => {
   const baseUri = _clearURI(query);
-  const newUri = baseUri.setSearch('page', newPage);
 
-  return newUri.toString();
+  if (newPage) {
+    return baseUri.setSearch('page', newPage).toString();
+  }
+
+  return baseUri.toString();
 };
 
 const useSyncStateWithQueryParams = ({ dashboardPage, uriParams, setDashboardPage, states }) => {

--- a/graylog2-web-interface/src/views/components/contexts/WidgetFocusProvider.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/WidgetFocusProvider.tsx
@@ -25,9 +25,9 @@ import { useStore } from 'stores/connect';
 import useQuery from 'routing/useQuery';
 import { WidgetStore } from 'views/stores/WidgetStore';
 import { SearchActions } from 'views/stores/SearchStore';
+import { ViewMetadataStore } from 'views/stores/ViewMetadataStore';
 
 import WidgetFocusContext, { FocusContextState } from './WidgetFocusContext';
-import { ViewMetadataStore } from 'views/stores/ViewMetadataStore';
 
 type WidgetFocusRequest = {
   id: string,

--- a/graylog2-web-interface/src/views/components/contexts/WidgetFocusProvider.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/WidgetFocusProvider.tsx
@@ -27,6 +27,7 @@ import { WidgetStore } from 'views/stores/WidgetStore';
 import { SearchActions } from 'views/stores/SearchStore';
 
 import WidgetFocusContext, { FocusContextState } from './WidgetFocusContext';
+import { ViewMetadataStore } from 'views/stores/ViewMetadataStore';
 
 type WidgetFocusRequest = {
   id: string,
@@ -94,7 +95,7 @@ const useSyncStateWithQueryParams = ({ focusedWidget, focusUriParams, setFocused
 
 const useCleanupQueryParams = ({ focusUriParams, widgets, query, history }) => {
   useEffect(() => {
-    if ((focusUriParams?.id && !widgets.has(focusUriParams.id)) || (focusUriParams?.id === undefined)) {
+    if ((focusUriParams?.id && !widgets.has(focusUriParams.id) && focusUriParams.isPageShown) || (focusUriParams?.id === undefined)) {
       const baseURI = _clearURI(query);
 
       history.replace(baseURI.toString());
@@ -108,12 +109,14 @@ const WidgetFocusProvider = ({ children }: { children: React.ReactNode }): React
   const history = useHistory();
   const [focusedWidget, setFocusedWidget] = useState<FocusContextState | undefined>();
   const widgets = useStore(WidgetStore);
+  const { activeQuery } = useStore(ViewMetadataStore);
   const params = useQuery();
   const focusUriParams = useMemo(() => ({
     editing: params.editing === 'true',
     focusing: params.focusing === 'true',
     id: params.focusedId,
-  }), [params.editing, params.focusing, params.focusedId]);
+    isPageShown: !params.page || params.page === activeQuery,
+  }), [params.editing, params.focusing, params.focusedId, params.page, activeQuery]);
 
   useSyncStateWithQueryParams({ focusedWidget, setFocusedWidget, widgets, focusUriParams });
 

--- a/graylog2-web-interface/src/views/components/queries/QueryTitle.tsx
+++ b/graylog2-web-interface/src/views/components/queries/QueryTitle.tsx
@@ -15,6 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
+import { useEffect, useState, useCallback, useContext } from 'react';
 import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
 
@@ -22,6 +23,8 @@ import { MenuItem } from 'components/graylog';
 import { QueriesActions } from 'views/stores/QueriesStore';
 import type { QueryId } from 'views/logic/queries/Query';
 import ViewState from 'views/logic/views/ViewState';
+import { QueriesList } from 'views/actions/QueriesActions';
+import DashboardPageContext from 'views/components/contexts/DashboardPageContext';
 
 import QueryActionDropdown from './QueryActionDropdown';
 
@@ -38,69 +41,45 @@ type Props = {
   title: string,
 };
 
-type State = {
-  editing: boolean,
-  title: string,
+const QueryTitle = ({ active, allowsClosing, id, onClose, openEditModal, title }: Props) => {
+  const [titleValue, setTitleValue] = useState(title);
+  const { setDashboardPage } = useContext(DashboardPageContext);
+
+  useEffect(() => {
+    setTitleValue(title);
+  }, [title]);
+
+  const _onDuplicate = useCallback(() => QueriesActions.duplicate(id).then(
+    (queryList: QueriesList) => setDashboardPage(queryList.keySeq().last()),
+  ), [id, setDashboardPage]);
+
+  return (
+    <>
+      <TitleWrap aria-label={titleValue} active={active}>
+        {titleValue}
+      </TitleWrap>
+
+      {active && (
+        <QueryActionDropdown>
+          <MenuItem onSelect={() => _onDuplicate()}>Duplicate</MenuItem>
+          <MenuItem onSelect={() => openEditModal(titleValue)}>Edit Title</MenuItem>
+          <MenuItem divider />
+          <MenuItem onSelect={onClose} disabled={!allowsClosing}>Close</MenuItem>
+        </QueryActionDropdown>
+      )}
+    </>
+  );
 };
 
-class QueryTitle extends React.Component<Props, State> {
-  static propTypes = {
-    allowsClosing: PropTypes.bool,
-    onClose: PropTypes.func.isRequired,
-    title: PropTypes.string.isRequired,
-    openEditModal: PropTypes.func.isRequired,
-  };
+QueryTitle.propTypes = {
+  allowsClosing: PropTypes.bool,
+  onClose: PropTypes.func.isRequired,
+  title: PropTypes.string.isRequired,
+  openEditModal: PropTypes.func.isRequired,
+};
 
-  static defaultProps = {
-    allowsClosing: true,
-  };
-
-  constructor(props: Props) {
-    super(props);
-
-    this.state = {
-      editing: false,
-      title: props.title,
-    };
-  }
-
-  UNSAFE_componentWillReceiveProps(nextProps: Props) {
-    /** TODO: Replace componentWillReceiveProps
-     * https://reactjs.org/blog/2018/06/07/you-probably-dont-need-derived-state.html#anti-pattern-unconditionally-copying-props-to-state
-     */
-    this.setState({ title: nextProps.title });
-  }
-
-  _onClose = () => {
-    const { onClose } = this.props;
-
-    onClose();
-  };
-
-  _onDuplicate = (id: QueryId) => QueriesActions.duplicate(id);
-
-  render() {
-    const { editing, title } = this.state;
-    const { active, allowsClosing, id, openEditModal } = this.props;
-    const isActive = !editing && active;
-
-    return (
-      <>
-        <TitleWrap aria-label={title} active={isActive}>
-          {title}
-        </TitleWrap>
-
-        {isActive && (
-          <QueryActionDropdown>
-            <MenuItem onSelect={() => this._onDuplicate(id)}>Duplicate</MenuItem>
-            <MenuItem onSelect={() => openEditModal(title)}>Edit Title</MenuItem>
-            <MenuItem divider />
-            <MenuItem onSelect={this._onClose} disabled={!allowsClosing}>Close</MenuItem>
-          </QueryActionDropdown>
-        )}
-      </>
-    );
-  }
-}
+QueryTitle.defaultProps = {
+  allowsClosing: true,
+};
 
 export default QueryTitle;

--- a/graylog2-web-interface/src/views/pages/NewSearchPage.test.tsx
+++ b/graylog2-web-interface/src/views/pages/NewSearchPage.test.tsx
@@ -41,6 +41,13 @@ jest.mock('routing/withLocation', () => (x) => x);
 jest.mock('views/components/Search', () => jest.fn(() => <div>Extended search page</div>));
 jest.mock('views/stores/SearchStore');
 
+jest.mock('views/stores/ViewStatesStore', () => ({
+  ViewStatesStore: {
+    listen: jest.fn(),
+    getInitialState: jest.fn(() => ({ has: jest.fn(() => false) })),
+  },
+}));
+
 jest.mock('views/stores/ViewStore', () => ({
   ViewActions: { create: jest.fn(() => Promise.resolve({ view: mockView })) },
 }));

--- a/graylog2-web-interface/src/views/pages/SearchPage.tsx
+++ b/graylog2-web-interface/src/views/pages/SearchPage.tsx
@@ -21,6 +21,7 @@ import NewViewLoaderContext from 'views/logic/NewViewLoaderContext';
 import Search from 'views/components/Search';
 import { loadNewView as defaultLoadNewView, loadView as defaultLoadView } from 'views/logic/views/Actions';
 import IfUserHasAccessToAnyStream from 'views/components/IfUserHasAccessToAnyStream';
+import DashboardPageContextProvider from 'views/components/contexts/DashboardPageContextProvider';
 
 type Props = {
   loadNewView?: () => unknown,
@@ -28,13 +29,15 @@ type Props = {
 };
 
 const SearchPage = ({ loadNewView = defaultLoadNewView, loadView = defaultLoadView }: Props) => (
-  <NewViewLoaderContext.Provider value={loadNewView}>
-    <ViewLoaderContext.Provider value={loadView}>
-      <IfUserHasAccessToAnyStream>
-        <Search />
-      </IfUserHasAccessToAnyStream>
-    </ViewLoaderContext.Provider>
-  </NewViewLoaderContext.Provider>
+  <DashboardPageContextProvider>
+    <NewViewLoaderContext.Provider value={loadNewView}>
+      <ViewLoaderContext.Provider value={loadView}>
+        <IfUserHasAccessToAnyStream>
+          <Search />
+        </IfUserHasAccessToAnyStream>
+      </ViewLoaderContext.Provider>
+    </NewViewLoaderContext.Provider>
+  </DashboardPageContextProvider>
 );
 
 SearchPage.defaultProps = {

--- a/graylog2-web-interface/src/views/pages/StreamSearchPage.test.tsx
+++ b/graylog2-web-interface/src/views/pages/StreamSearchPage.test.tsx
@@ -40,6 +40,13 @@ const mockView = View.create()
 jest.mock('views/components/Search', () => jest.fn(() => <div>Extended search page</div>));
 jest.mock('views/stores/SearchStore', () => ({ SearchActions: {} }));
 
+jest.mock('views/stores/ViewStatesStore', () => ({
+  ViewStatesStore: {
+    listen: jest.fn(),
+    getInitialState: jest.fn(() => ({ has: jest.fn(() => false) })),
+  },
+}));
+
 jest.mock('views/stores/ViewStore', () => ({
   ViewActions: {
     create: jest.fn(() => Promise.resolve({ view: mockView })),

--- a/graylog2-web-interface/src/views/stores/QueriesStore.ts
+++ b/graylog2-web-interface/src/views/stores/QueriesStore.ts
@@ -76,7 +76,9 @@ export const QueriesStore: QueriesStoreType = singletonStore(
     duplicate(queryId: QueryId) {
       const newQuery = this.queries.get(queryId).toBuilder().newId().build();
       const promise: Promise<QueriesList> = ViewStatesActions.duplicate(queryId)
-        .then((newViewState) => QueriesActions.create(newQuery, newViewState));
+        .then((newViewState) => {
+          return QueriesActions.create(newQuery, newViewState);
+        });
 
       QueriesActions.duplicate.promise(promise);
 

--- a/graylog2-web-interface/src/views/stores/ViewStore.ts
+++ b/graylog2-web-interface/src/views/stores/ViewStore.ts
@@ -136,7 +136,13 @@ export const ViewStore: ViewStoreType = singletonStore(
       this.view = view;
       this.activeQuery = query.id;
 
-      const promise = (isModified ? ViewActions.search(view.search) : Promise.resolve(view)).then(() => this._trigger());
+      const promise = (isModified ? ViewActions.search(view.search) : Promise.resolve(view)).then(
+        () => {
+          this._trigger();
+
+          return Immutable.OrderedMap<QueryId, Query>(newSearch.queries.map((q) => [q.id, q]).toArray());
+        },
+      );
 
       QueriesActions.create.promise(promise);
     },


### PR DESCRIPTION
## Description
Implement context which updates the URL of the browser when changing the page of a Dashboard.

## Motivation and Context
A user wants to be able to send a dashboard with a certain page tab open to a colleague.

## Also
Fixes #10552  

## Note
I stumbled into a problem here when `SizeMe` returned undefined. We checked if `SizeMe` is returning a value and if not did not render the children but instead returned `null`. This did not seem to work any longer. But when returning `<div />` instead everything is turning out fine.
The assumption is, that since we return `null` there will be no rerendering. :man_shrugging: 

## How Has This Been Tested?
- Switch pages
- Create new Page
- Close Page
- Focus a widget in a 2nd page and reload

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)