### PR TITLE
Removed double call with ES6: check for Index Template

### DIFF
--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/IndicesAdapterES6.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/IndicesAdapterES6.java
@@ -204,9 +204,6 @@ public class IndicesAdapterES6 implements IndicesAdapter {
                 .settings(settings)
                 .build();
 
-        // Make sure our index template exists before creating an index!
-        ensureIndexTemplate(templateName, template);
-
         final JestResult jestResult;
         try {
             jestResult = jestClient.execute(request);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The call to `ensureIndexTemplate` is removed in `IndicesAdapterES6.create()`

## Motivation and Context
The call has been removed because it's a double call, it's also called in `create` in `Indices.class`. 


## How Has This Been Tested?
Manual check that it's actually called twice before removal and only called once after removal.
I also checked the ES7 implementation for comparison.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

