### PR TITLE
Deprecate shutting a node down via the API

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterSystemShutdownResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterSystemShutdownResource.java
@@ -17,9 +17,6 @@
 package org.graylog2.rest.resources.cluster;
 
 import com.codahale.metrics.annotation.Timed;
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiParam;
 import org.apache.shiro.authz.annotation.RequiresAuthentication;
 import org.graylog2.audit.AuditEventTypes;
 import org.graylog2.audit.jersey.AuditEvent;
@@ -49,10 +46,14 @@ import java.util.concurrent.ExecutorService;
 import static javax.ws.rs.core.Response.Status.ACCEPTED;
 import static javax.ws.rs.core.Response.Status.BAD_GATEWAY;
 
+/**
+ * @deprecated Shutting down nodes using an API request is discouraged in favor of using a service manager to
+ *         control the server process.
+ */
 @RequiresAuthentication
-@Api(value = "Cluster/Shutdown", description = "Shutdown gracefully nodes in cluster")
 @Path("/cluster/{nodeId}/shutdown")
 @Produces(MediaType.APPLICATION_JSON)
+@Deprecated
 public class ClusterSystemShutdownResource extends ProxiedResource {
     private static final Logger LOG = LoggerFactory.getLogger(ClusterSystemShutdownResource.class);
 
@@ -66,12 +67,12 @@ public class ClusterSystemShutdownResource extends ProxiedResource {
 
     @POST
     @Timed
-    @ApiOperation(value = "Shutdown node gracefully.",
-            notes = "Attempts to process all buffered and cached messages before exiting, " +
-                    "shuts down inputs first to make sure that no new messages are accepted.")
     @AuditEvent(type = AuditEventTypes.NODE_SHUTDOWN_INITIATE)
-    public void shutdown(@ApiParam(name = "nodeId", value = "The id of the node to shutdown.", required = true)
-                         @PathParam("nodeId") String nodeId) throws IOException, NodeNotFoundException {
+    public void shutdown(@PathParam("nodeId") String nodeId) throws IOException, NodeNotFoundException {
+        LOG.warn(
+                "Deprecated API endpoint /cluster/{nodeId}/shutdown was called. Shutting down nodes via the API is " +
+                        "discouraged in favor of using a service manager to control the server process.");
+
         final Node targetNode = nodeService.byNodeId(nodeId);
 
         RemoteSystemShutdownResource remoteSystemShutdownResource = remoteInterfaceProvider.get(targetNode,

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/RemoteSystemShutdownResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/RemoteSystemShutdownResource.java
@@ -19,6 +19,7 @@ package org.graylog2.rest.resources.system;
 import retrofit2.Call;
 import retrofit2.http.POST;
 
+@Deprecated
 public interface RemoteSystemShutdownResource {
     @POST("system/shutdown/shutdown")
     Call<Void> shutdown();

--- a/graylog2-server/src/main/java/org/graylog2/shared/security/RestPermissions.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/security/RestPermissions.java
@@ -109,7 +109,7 @@ public class RestPermissions implements PluginPermissions {
     public static final String METRICS_READ = "metrics:read";
     public static final String METRICS_READALL = "metrics:readall";
     public static final String METRICS_READHISTORY = "metrics:readhistory";
-    public static final String NODE_SHUTDOWN = "node:shutdown";
+    @Deprecated public static final String NODE_SHUTDOWN = "node:shutdown";
     public static final String NOTIFICATIONS_DELETE = "notifications:delete";
     public static final String NOTIFICATIONS_READ = "notifications:read";
     public static final String OUTPUTS_CREATE = "outputs:create";


### PR DESCRIPTION
Deprecates the API endpoints used to shut down a node.
- Adds deprecation annotations to discourage usage in the code
- Removes Swagger annotations to hide the endpoints in the API browser
- Logs a warning when the endpoints are called
- Returns a warning message in the API response where applicable

Refs #10668