### PR TITLE
Provide default if no visualization config was provided for Heatmap

### DIFF
--- a/graylog2-web-interface/src/views/components/visualizations/heatmap/bindings.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/heatmap/bindings.tsx
@@ -62,7 +62,7 @@ const heatmap: VisualizationType<HeatmapVisualizationConfig, HeatMapVisualizatio
   displayName: 'Heatmap',
   component: HeatmapVisualization,
   config: {
-    fromConfig: ({ autoScale, colorScale, reverseScale, defaultValue, useSmallestAsDefault, zMax, zMin }: HeatmapVisualizationConfig) => ({
+    fromConfig: ({ autoScale, colorScale, reverseScale, defaultValue, useSmallestAsDefault, zMax, zMin }: HeatmapVisualizationConfig = HeatmapVisualizationConfig.empty()) => ({
       autoScale, colorScale, reverseScale, defaultValue, useSmallestAsDefault, zMax, zMin,
     }),
     toConfig: ({ autoScale = false, colorScale, reverseScale = false, useSmallestAsDefault, zMax, zMin, defaultValue }: HeatMapVisualizationConfigFormValues) => {


### PR DESCRIPTION
## Motivation
Prior to this change, some user expierenced problems with heat maps when
the heat map did not have a visualization config.

## Description
This change will provide a default if no visualization config was
persisted.

Fixes #10928
Fixes #10967