### PR TITLE
Fix issue with duplicate Jackson JSON modules

### DIFF
--- a/graylog2-server/pom.xml
+++ b/graylog2-server/pom.xml
@@ -260,10 +260,6 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.media</groupId>
-            <artifactId>jersey-media-json-jackson</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.jersey.media</groupId>
             <artifactId>jersey-media-multipart</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
This removes the jersey-media-json-jackson dependency to avoid duplicate
registration of two Jackson JSON modules for Jersey.

We currently run into problems in some setups where HTTP requests
use com.fasterxml.jackson.jaxrs.base.ProviderBase on deserialization of
the request and
org.glassfish.jersey.jackson.internal.jackson.jaxrs.base.ProviderBase on
serialization of the response.

See #10906 for example. In this specific issue the "pretty=true" flag
to prettify the JSON response didn't work on some nodes but worked on
others. Here on the way in the com.fasterxml.jackson.jaxrs.cfg.ObjectWriterInjector
was modified to enable pretty printing but when serializing the
response the code was querying
org.glassfish.jersey.jackson.internal.jackson.jaxrs.cfg.ObjectWriterInjector
and found that the pretty printer was not enabled.

This issue showed up on some nodes only probably because of some kind of
random ordering of the registered modules within Jersey.

We only need to remove the jersey-media-json-jackson dependency and
don't have to modify anything else because this module was auto detected
by Jersey.

Fixes #10906

(cherry picked from commit f3b815401128e88a9949b933d9115bd4771a4c41)