### PR TITLE
Make LookupTableService database independent 

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/debug/Debug.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/debug/Debug.java
@@ -30,7 +30,7 @@ public class Debug extends AbstractFunction<Void> {
 
     public static final String NAME = "debug";
 
-    Debug() {
+    public Debug() {
         valueParam = ParameterDescriptor.object("value").description("The value to print in the graylog-server log.").build();
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/lookup/LookupModule.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/LookupModule.java
@@ -24,6 +24,7 @@ import org.graylog2.lookup.adapters.DnsLookupDataAdapter;
 import org.graylog2.lookup.adapters.HTTPJSONPathDataAdapter;
 import org.graylog2.lookup.caches.CaffeineLookupCache;
 import org.graylog2.lookup.caches.NullCache;
+import org.graylog2.lookup.db.DBLookupTableConfigService;
 import org.graylog2.plugin.inject.Graylog2Module;
 import org.graylog2.system.urlwhitelist.UrlWhitelistNotificationService;
 import org.graylog2.system.urlwhitelist.UrlWhitelistService;
@@ -41,6 +42,7 @@ public class LookupModule extends Graylog2Module {
         binder().bind(UrlWhitelistNotificationService.class).in(Scopes.SINGLETON);
         binder().bind(AllowedAuxiliaryPathChecker.class).in(Scopes.SINGLETON);
 
+        bind(LookupTableConfigService.class).to(DBLookupTableConfigService.class).asEagerSingleton();
         serviceBinder().addBinding().to(LookupTableService.class).asEagerSingleton();
 
         installLookupCache(NullCache.NAME,

--- a/graylog2-server/src/main/java/org/graylog2/lookup/LookupTableConfigService.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/LookupTableConfigService.java
@@ -1,0 +1,75 @@
+package org.graylog2.lookup;
+
+import org.graylog2.lookup.dto.CacheDto;
+import org.graylog2.lookup.dto.DataAdapterDto;
+import org.graylog2.lookup.dto.LookupTableDto;
+
+import java.util.Collection;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Abstracts the configuration retrieval for {@link LookupTableService}.
+ */
+public interface LookupTableConfigService {
+    /**
+     * Returns the lookup table config for the given ID.
+     *
+     * @param id lookup table ID
+     * @return Filled optional with the lookup table config or an empty optional if the lookup table doesn't exist
+     */
+    Optional<LookupTableDto> getTable(String id);
+
+    /**
+     * Returns all existing lookup table config objects.
+     *
+     * @return collection of lookup table config objects
+     */
+    Collection<LookupTableDto> loadAllTables();
+
+    /**
+     * Returns all lookup table config objets that use the given data adapter IDs.
+     *
+     * @param ids data adapter IDs
+     * @return collection of lookup table config objects
+     */
+    Collection<LookupTableDto> findTablesForDataAdapterIds(Set<String> ids);
+
+    /**
+     * Returns all lookup table config objets that use the given cache IDs.
+     *
+     * @param ids cache IDs
+     * @return collection of lookup table config objects
+     */
+    Collection<LookupTableDto> findTablesForCacheIds(Set<String> ids);
+
+    /**
+     * Returns all existing lookup data adapter config objects.
+     *
+     * @return collection of lookup data adapter config objects
+     */
+    Collection<DataAdapterDto> loadAllDataAdapters();
+
+    /**
+     * Returns all lookup data adapter config objects for the given IDs.
+     *
+     * @param ids data dapter IDs
+     * @return collection of lookup data adapter config objects
+     */
+    Collection<DataAdapterDto> findDataAdaptersForIds(Set<String> ids);
+
+    /**
+     * Returns all existing lookup cache config objects.
+     *
+     * @return collection of lookup cache config objects
+     */
+    Collection<CacheDto> loadAllCaches();
+
+    /**
+     * Returns all lookup cache config objects for the given IDs.
+     *
+     * @param ids cache IDs
+     * @return collection of lookup data adapter config objects
+     */
+    Collection<CacheDto> findCachesForIds(Set<String> ids);
+}

--- a/graylog2-server/src/main/java/org/graylog2/lookup/LookupTableConfigService.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/LookupTableConfigService.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog2.lookup;
 
 import org.graylog2.lookup.dto.CacheDto;

--- a/graylog2-server/src/main/java/org/graylog2/lookup/LookupTableService.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/LookupTableService.java
@@ -23,9 +23,6 @@ import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
 import com.google.common.util.concurrent.AbstractIdleService;
 import com.google.common.util.concurrent.Service;
-import org.graylog2.lookup.db.DBCacheService;
-import org.graylog2.lookup.db.DBDataAdapterService;
-import org.graylog2.lookup.db.DBLookupTableService;
 import org.graylog2.lookup.dto.CacheDto;
 import org.graylog2.lookup.dto.DataAdapterDto;
 import org.graylog2.lookup.dto.LookupTableDto;
@@ -79,10 +76,7 @@ import static org.graylog2.utilities.ObjectUtils.objectId;
 public class LookupTableService extends AbstractIdleService {
     private static final Logger LOG = LoggerFactory.getLogger(LookupTableService.class);
 
-    private DBDataAdapterService dbAdapters;
-    private final DBCacheService dbCaches;
-    private final DBLookupTableService dbTables;
-
+    private final LookupTableConfigService configService;
     private final Map<String, LookupCache.Factory> cacheFactories;
     private final Map<String, LookupDataAdapter.Factory> adapterFactories;
     private final Map<String, LookupDataAdapter.Factory2> adapterFactories2;
@@ -99,17 +93,13 @@ public class LookupTableService extends AbstractIdleService {
     private final ConcurrentMap<String, LookupCache> liveCaches = new ConcurrentHashMap<>();
 
     @Inject
-    public LookupTableService(DBDataAdapterService dbAdapters,
-                              DBCacheService dbCaches,
-                              DBLookupTableService dbTables,
+    public LookupTableService(LookupTableConfigService configService,
                               Map<String, LookupCache.Factory> cacheFactories,
                               Map<String, LookupDataAdapter.Factory> adapterFactories,
                               Map<String, LookupDataAdapter.Factory2> adapterFactories2,
                               @Named("daemonScheduler") ScheduledExecutorService scheduler,
                               EventBus eventBus) {
-        this.dbAdapters = dbAdapters;
-        this.dbCaches = dbCaches;
-        this.dbTables = dbTables;
+        this.configService = configService;
         this.cacheFactories = cacheFactories;
         this.adapterFactories = adapterFactories;
         this.adapterFactories2 = adapterFactories2;
@@ -177,7 +167,8 @@ public class LookupTableService extends AbstractIdleService {
         private final Consumer<LookupDataAdapter> replacedAdapterConsumer;
 
         public DataAdapterListener(DataAdapterDto dto, LookupDataAdapter adapter, CountDownLatch latch) {
-            this(dto, adapter, latch, replacedAdapter -> {});
+            this(dto, adapter, latch, replacedAdapter -> {
+            });
         }
 
         public DataAdapterListener(DataAdapterDto dto,
@@ -220,7 +211,8 @@ public class LookupTableService extends AbstractIdleService {
         private final Consumer<LookupCache> replacedCacheConsumer;
 
         public CacheListener(CacheDto dto, LookupCache cache, CountDownLatch latch) {
-            this(dto, cache, latch, replacedCache -> {});
+            this(dto, cache, latch, replacedCache -> {
+            });
         }
 
         public CacheListener(CacheDto dto,
@@ -264,13 +256,13 @@ public class LookupTableService extends AbstractIdleService {
             // then we retrieve the old one so we can safely stop it later
             // then we build a new lookup table instance with the new adapter instance
             // last we can remove the old lookup table instance and stop the original adapter
-            final Collection<LookupTableDto> tablesToUpdate = dbTables.findByDataAdapterIds(updated.ids());
+            final Collection<LookupTableDto> tablesToUpdate = configService.findTablesForDataAdapterIds(updated.ids());
 
             // collect old adapter instances
             final ImmutableSet.Builder<LookupDataAdapter> existingAdapters = ImmutableSet.builder();
 
             // create new adapter and lookup table instances
-            final Map<DataAdapterDto, LookupDataAdapter> newAdapters = createAdapters(dbAdapters.findByIds(updated.ids()));
+            final Map<DataAdapterDto, LookupDataAdapter> newAdapters = createAdapters(configService.findDataAdaptersForIds(updated.ids()));
 
             final CountDownLatch runningLatch = new CountDownLatch(newAdapters.size());
 
@@ -308,13 +300,13 @@ public class LookupTableService extends AbstractIdleService {
             // then we retrieve the old one so we can safely stop it later
             // then we build a new lookup table instance with the new cache instance
             // last we can remove the old lookup table instance and stop the original cache
-            final Collection<LookupTableDto> tablesToUpdate = dbTables.findByCacheIds(updated.ids());
+            final Collection<LookupTableDto> tablesToUpdate = configService.findTablesForCacheIds(updated.ids());
 
             // collect old cache instances
             final ImmutableSet.Builder<LookupCache> existingCaches = ImmutableSet.builder();
 
             // create new cache and lookup table instances
-            final Map<CacheDto, LookupCache> newCaches = createCaches(dbCaches.findByIds(updated.ids()));
+            final Map<CacheDto, LookupCache> newCaches = createCaches(configService.findCachesForIds(updated.ids()));
             final CountDownLatch runningLatch = new CountDownLatch(newCaches.size());
 
             newCaches.forEach((cacheDto, cache) -> {
@@ -358,7 +350,7 @@ public class LookupTableService extends AbstractIdleService {
     public void handleLookupTableUpdate(LookupTablesUpdated updated) {
         scheduler.schedule(() -> {
             // load the DTO, and recreate the table
-            updated.lookupTableIds().forEach(id -> dbTables.get(id).map(this::createLookupTable));
+            updated.lookupTableIds().forEach(id -> configService.getTable(id).map(this::createLookupTable));
         }, 0, TimeUnit.SECONDS);
     }
 
@@ -368,7 +360,7 @@ public class LookupTableService extends AbstractIdleService {
     }
 
     private CountDownLatch createAndStartAdapters() {
-        final Map<DataAdapterDto, LookupDataAdapter> adapters = createAdapters(dbAdapters.findAll());
+        final Map<DataAdapterDto, LookupDataAdapter> adapters = createAdapters(configService.loadAllDataAdapters());
         final CountDownLatch latch = new CountDownLatch(toIntExact(adapters.size()));
 
         adapters.forEach((dto, adapter) -> {
@@ -415,7 +407,7 @@ public class LookupTableService extends AbstractIdleService {
     }
 
     private CountDownLatch createAndStartCaches() {
-        final Map<CacheDto, LookupCache> caches = createCaches(dbCaches.findAll());
+        final Map<CacheDto, LookupCache> caches = createCaches(configService.loadAllCaches());
         final CountDownLatch latch = new CountDownLatch(toIntExact(caches.size()));
 
         caches.forEach((cacheDto, lookupCache) -> {
@@ -455,7 +447,7 @@ public class LookupTableService extends AbstractIdleService {
 
     private void createLookupTables() {
         try {
-            dbTables.forEach(dto -> {
+            configService.loadAllTables().forEach(dto -> {
                 try {
                     createLookupTable(dto);
                 } catch (Exception e) {
@@ -549,7 +541,7 @@ public class LookupTableService extends AbstractIdleService {
         } else {
             try {
                 // Do a more expensive DB lookup as fallback (live tables might not be populated yet)
-                return dbTables.get(name).isPresent();
+                return configService.getTable(name).isPresent();
             } catch (Exception e) {
                 LOG.error("Couldn't load lookup table <{}> from database", name, e);
                 return false;

--- a/graylog2-server/src/main/java/org/graylog2/lookup/db/DBLookupTableConfigService.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/db/DBLookupTableConfigService.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog2.lookup.db;
 
 import org.graylog2.lookup.LookupTableConfigService;

--- a/graylog2-server/src/main/java/org/graylog2/lookup/db/DBLookupTableConfigService.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/db/DBLookupTableConfigService.java
@@ -1,0 +1,68 @@
+package org.graylog2.lookup.db;
+
+import org.graylog2.lookup.LookupTableConfigService;
+import org.graylog2.lookup.dto.CacheDto;
+import org.graylog2.lookup.dto.DataAdapterDto;
+import org.graylog2.lookup.dto.LookupTableDto;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.util.Collection;
+import java.util.Optional;
+import java.util.Set;
+
+@Singleton
+public class DBLookupTableConfigService implements LookupTableConfigService {
+    private final DBDataAdapterService dbAdapters;
+    private final DBCacheService dbCaches;
+    private final DBLookupTableService dbTables;
+
+    @Inject
+    public DBLookupTableConfigService(DBDataAdapterService dbAdapters,
+                                      DBCacheService dbCaches,
+                                      DBLookupTableService dbTables) {
+        this.dbAdapters = dbAdapters;
+        this.dbCaches = dbCaches;
+        this.dbTables = dbTables;
+    }
+
+    @Override
+    public Optional<LookupTableDto> getTable(String id) {
+        return dbTables.get(id);
+    }
+
+    @Override
+    public Collection<LookupTableDto> loadAllTables() {
+        return dbTables.findAll();
+    }
+
+    @Override
+    public Collection<LookupTableDto> findTablesForDataAdapterIds(Set<String> ids) {
+        return dbTables.findByDataAdapterIds(ids);
+    }
+
+    @Override
+    public Collection<LookupTableDto> findTablesForCacheIds(Set<String> ids) {
+        return dbTables.findByCacheIds(ids);
+    }
+
+    @Override
+    public Collection<DataAdapterDto> loadAllDataAdapters() {
+        return dbAdapters.findAll();
+    }
+
+    @Override
+    public Collection<DataAdapterDto> findDataAdaptersForIds(Set<String> ids) {
+        return dbAdapters.findByIds(ids);
+    }
+
+    @Override
+    public Collection<CacheDto> loadAllCaches() {
+        return dbCaches.findAll();
+    }
+
+    @Override
+    public Collection<CacheDto> findCachesForIds(Set<String> ids) {
+        return dbCaches.findByIds(ids);
+    }
+}


### PR DESCRIPTION
Create a `LookupTableConfigService` interface and use it in `LookupTableService` to make it possible to create a `LookupTableService` instance that doesn't depend on the database.

Also make the constructor in the `Debug` pipeline function public to allow the creation of custom instances.
