### PR TITLE
Add new hook to CopyWidgetToDashboard

### DIFF
--- a/graylog2-web-interface/src/views/logic/views/CopyWidgetToDashboard.ts
+++ b/graylog2-web-interface/src/views/logic/views/CopyWidgetToDashboard.ts
@@ -15,6 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import { List, Map } from 'immutable';
+import { PluginStore } from 'graylog-web-plugin/plugin';
 
 import Widget from 'views/logic/widgets/Widget';
 import View from 'views/logic/views/View';
@@ -27,6 +28,8 @@ import UpdateSearchForWidgets from './UpdateSearchForWidgets';
 import FindWidgetAndQueryIdInView from './FindWidgetAndQueryIdInView';
 
 type QueryId = string;
+
+export type CopyWidgetToDashboardHook = (widgetId: string, search: View, dashboard: View) => View;
 
 const _newPositionsMap = (oldPosition, widgetPositions, widget, widgets) => {
   const widgetPositionsMap = oldPosition ? {
@@ -75,6 +78,8 @@ const CopyWidgetToDashboard = (widgetId: string, search: View, dashboard: View):
     return undefined;
   }
 
+  const copyHooks = PluginStore.exports('views.hooks.copyWidgetToDashboard') || [];
+
   const queryMap: Map<QueryId, Query> = Map(search.search.queries.map((q) => [q.id, q]));
   const match: [Widget, QueryId] | undefined | null = FindWidgetAndQueryIdInView(widgetId, search);
 
@@ -98,7 +103,9 @@ const CopyWidgetToDashboard = (widgetId: string, search: View, dashboard: View):
       .streams(streams)
       .build();
 
-    return UpdateSearchForWidgets(_addWidgetToDashboard(dashboardWidget, dashboard, oldPositions, title));
+    const updatedView = UpdateSearchForWidgets(_addWidgetToDashboard(dashboardWidget, dashboard, oldPositions, title));
+
+    return copyHooks.reduce((previousDashboard, copyHook) => copyHook(widgetId, search, previousDashboard), updatedView);
   }
 
   return undefined;

--- a/graylog2-web-interface/src/views/types.d.ts
+++ b/graylog2-web-interface/src/views/types.d.ts
@@ -39,6 +39,7 @@ import {
 } from 'views/components/aggregationwizard';
 import VisualizationConfig from 'views/logic/aggregationbuilder/visualizations/VisualizationConfig';
 import { TimeRange } from 'views/logic/queries/Query';
+import { CopyWidgetToDashboardHook } from 'views/logic/views/CopyWidgetToDashboard';
 
 interface EditWidgetComponentProps<Config extends WidgetConfig = WidgetConfig> {
   children: React.ReactNode,
@@ -196,6 +197,7 @@ declare module 'graylog-web-plugin/plugin' {
     'views.hooks.executingView'?: Array<ViewHook>,
     'views.hooks.loadingView'?: Array<ViewHook>,
     'views.hooks.searchRefresh'?: Array<SearchRefreshCondition>;
+    'views.hooks.copyWidgetToDashboard'?: Array<CopyWidgetToDashboardHook>;
     'views.overrides.widgetEdit'?: Array<React.ComponentType<OverrideProps>>;
     'views.widgets.actions'?: Array<WidgetActionType>;
     'views.requires.provided'?: Array<string>;


### PR DESCRIPTION
## Motivation
Prior to this change, there was no way to copy plugin information of a
widget to a dashboard, when copying the widget.

## Description
This change will add a new hook which provides the possibility to copy
additional things for the widget to a dashboard.

## How Has This Been Tested?
- Create widget in a Search with a parameter
- Copy this widget to a Dashboard

Fixes:  #10846

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
