### PR TITLE
Do not set 'to' when setting TimeRange to 'All Time'

### DIFF
--- a/graylog2-web-interface/src/views/logic/queries/IsAllMessagesRange.ts
+++ b/graylog2-web-interface/src/views/logic/queries/IsAllMessagesRange.ts
@@ -20,7 +20,7 @@ import { isTypeRelativeWithEnd, isTypeRelativeWithStartOnly } from 'views/typeGu
 import { TimeRange } from 'views/logic/queries/Query';
 
 const isAllMessagesRange = (timeRange: TimeRange) => {
-  return (isTypeRelativeWithEnd(timeRange) && timeRange.from === RELATIVE_ALL_TIME && !timeRange.to) || (isTypeRelativeWithStartOnly(timeRange) && timeRange.range === RELATIVE_ALL_TIME);
+  return (isTypeRelativeWithEnd(timeRange) && timeRange.from === RELATIVE_ALL_TIME) || (isTypeRelativeWithStartOnly(timeRange) && timeRange.range === RELATIVE_ALL_TIME);
 };
 
 export default isAllMessagesRange;


### PR DESCRIPTION
## Motivation
Prior to this change, the backend raised an error if a user switch the
timerange from 'from -> to' to 'All time' since 'to' was still send to
the server, which the server refuesed to accept.

## Description
This change will change the check where the submitted timerange is
checked to be 'All Time'
Before we did not see the timerange as 'All Time' if 'to' was still set,
but to would have been unset AFTER it acknowleged the time range a s
'All Time'.

Fixes #10920.

## How Has This Been Tested?
- set timerange with from and to
- checked 'All time'
- applied the settings
- started a search

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
