### PR TITLE
Fix returning count of saved searches list

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/ViewSummaryService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/ViewSummaryService.java
@@ -24,9 +24,7 @@ import org.graylog2.search.SearchQuery;
 import org.mongojack.DBQuery;
 
 import javax.inject.Inject;
-import java.util.ArrayList;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -45,11 +43,7 @@ public class ViewSummaryService extends PaginatedDbService<ViewSummaryDTO> {
                                                    String sortField,
                                                    int page,
                                                    int perPage) {
-        final PaginatedList<ViewSummaryDTO> viewsList = findPaginatedWithQueryFilterAndSort(query, filter, getSortBuilder(order, sortField), page, perPage);
-        return viewsList.stream()
-                .collect(Collectors.toCollection(() -> viewsList.grandTotal()
-                        .map(grandTotal -> new PaginatedList<ViewSummaryDTO>(new ArrayList<>(viewsList.size()), viewsList.pagination().total(), page, perPage, grandTotal))
-                        .orElseGet(() -> new PaginatedList<>(new ArrayList<>(viewsList.size()), viewsList.pagination().total(), page, perPage))));
+        return findPaginatedWithQueryFilterAndSort(query, filter, getSortBuilder(order, sortField), page, perPage);
     }
 
     public PaginatedList<ViewSummaryDTO> searchPaginatedByType(ViewDTO.Type type,

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/ViewSummaryService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/ViewSummaryService.java
@@ -37,15 +37,6 @@ public class ViewSummaryService extends PaginatedDbService<ViewSummaryDTO> {
         super(mongoConnection, mapper, ViewSummaryDTO.class, COLLECTION_NAME);
     }
 
-    private PaginatedList<ViewSummaryDTO> searchPaginated(DBQuery.Query query,
-                                                          Predicate<ViewSummaryDTO> filter,
-                                                          String order,
-                                                          String sortField,
-                                                          int page,
-                                                          int perPage) {
-        return findPaginatedWithQueryFilterAndSort(query, filter, getSortBuilder(order, sortField), page, perPage);
-    }
-
     private PaginatedList<ViewSummaryDTO> searchPaginatedWithGrandTotal(DBQuery.Query query,
                                                    Predicate<ViewSummaryDTO> filter,
                                                    String order,

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/ViewSummaryService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/ViewSummaryService.java
@@ -38,12 +38,22 @@ public class ViewSummaryService extends PaginatedDbService<ViewSummaryDTO> {
     }
 
     private PaginatedList<ViewSummaryDTO> searchPaginated(DBQuery.Query query,
+                                                          Predicate<ViewSummaryDTO> filter,
+                                                          String order,
+                                                          String sortField,
+                                                          int page,
+                                                          int perPage) {
+        return findPaginatedWithQueryFilterAndSort(query, filter, getSortBuilder(order, sortField), page, perPage);
+    }
+
+    private PaginatedList<ViewSummaryDTO> searchPaginatedWithGrandTotal(DBQuery.Query query,
                                                    Predicate<ViewSummaryDTO> filter,
                                                    String order,
                                                    String sortField,
+                                                   DBQuery.Query grandTotalQuery,
                                                    int page,
                                                    int perPage) {
-        return findPaginatedWithQueryFilterAndSort(query, filter, getSortBuilder(order, sortField), page, perPage);
+        return findPaginatedWithQueryFilterAndSortWithGrandTotal(query, filter, getSortBuilder(order, sortField), grandTotalQuery, page, perPage);
     }
 
     public PaginatedList<ViewSummaryDTO> searchPaginatedByType(ViewDTO.Type type,
@@ -54,7 +64,7 @@ public class ViewSummaryService extends PaginatedDbService<ViewSummaryDTO> {
                                                         int page,
                                                         int perPage) {
         checkNotNull(sortField);
-        return searchPaginated(
+        return searchPaginatedWithGrandTotal(
                 DBQuery.and(
                         DBQuery.or(DBQuery.is(ViewDTO.FIELD_TYPE, type), DBQuery.notExists(ViewDTO.FIELD_TYPE)),
                         query.toDBQuery()
@@ -62,6 +72,7 @@ public class ViewSummaryService extends PaginatedDbService<ViewSummaryDTO> {
                 filter,
                 order,
                 sortField,
+                DBQuery.or(DBQuery.is(ViewDTO.FIELD_TYPE, type), DBQuery.notExists(ViewDTO.FIELD_TYPE)),
                 page,
                 perPage
         );

--- a/graylog2-server/src/main/java/org/graylog2/database/PaginatedDbService.java
+++ b/graylog2-server/src/main/java/org/graylog2/database/PaginatedDbService.java
@@ -153,6 +153,22 @@ public abstract class PaginatedDbService<DTO> {
                                                                      DBSort.SortBuilder sort,
                                                                      int page,
                                                                      int perPage) {
+        return findPaginatedWithQueryFilterAndSortWithGrandTotal(
+                query,
+                filter,
+                sort,
+                DBQuery.empty(),
+                page,
+                perPage);
+    }
+
+
+    protected PaginatedList<DTO> findPaginatedWithQueryFilterAndSortWithGrandTotal(DBQuery.Query query,
+                                                                     Predicate<DTO> filter,
+                                                                     DBSort.SortBuilder sort,
+                                                                     DBQuery.Query grandTotalQuery,
+                                                                     int page,
+                                                                     int perPage) {
         // Calculate the total amount of items matching the query/filter, but before pagination
         final long total;
         try (final Stream<DTO> cursor = streamQueryWithSort(query, sort)) {
@@ -166,7 +182,7 @@ public abstract class PaginatedDbService<DTO> {
                 filteredResultStream = filteredResultStream.skip(perPage * Math.max(0, page - 1)).limit(perPage);
             }
 
-            final long grandTotal = db.count();
+            final long grandTotal = db.getCount(grandTotalQuery);
 
             return new PaginatedList<>(filteredResultStream.collect(Collectors.toList()), Math.toIntExact(total), page, perPage, grandTotal);
         }

--- a/graylog2-server/src/main/java/org/graylog2/database/PaginatedList.java
+++ b/graylog2-server/src/main/java/org/graylog2/database/PaginatedList.java
@@ -33,8 +33,9 @@ public class PaginatedList<E> extends ForwardingList<E> {
 
     private final List<E> delegate;
 
-    private final PaginationInfo paginationInfo;
-
+    private final int total;
+    private final int page;
+    private final int perPage;
     private final Long grandTotal;
 
     /**
@@ -58,7 +59,9 @@ public class PaginatedList<E> extends ForwardingList<E> {
      */
     public PaginatedList(@Nonnull List<E> delegate, int total, int page, int perPage, Long grandTotal) {
         this.delegate = delegate;
-        this.paginationInfo = PaginationInfo.create(total, delegate.size(), page, perPage);
+        this.total = total;
+        this.page = page;
+        this.perPage = perPage;
         this.grandTotal = grandTotal;
     }
 
@@ -68,7 +71,7 @@ public class PaginatedList<E> extends ForwardingList<E> {
     }
 
     public PaginationInfo pagination() {
-        return paginationInfo;
+        return PaginationInfo.create(total, delegate.size(), page, perPage);
     }
 
     public Optional<Long> grandTotal() {


### PR DESCRIPTION
## Motivation
Prior to this change, when returning the list of saved searches the
pagination info always had a count of zero.

## Description
This change will remove the seemingly unnecessary construction of
PagianationList with empty arrays.

## How Has This Been Tested?
- Use the saved searches end point and check the pagination info

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Backport
Needs backport to 4.1