### PR TITLE
Also exclude outputs from search dependencies (#11023)

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/security/entities/EntityDependencyResolver.java
+++ b/graylog2-server/src/main/java/org/graylog/security/entities/EntityDependencyResolver.java
@@ -47,6 +47,7 @@ public class EntityDependencyResolver {
     // Some dependencies can be ignored.
     // E.g. To view a stream with a custom output, a user does not need output permissions
     private static final Map<GRNType, Set<ModelType>> IGNORED_DEPENDENCIES = ImmutableMap.<GRNType, Set<ModelType>>builder()
+            .put(GRNTypes.SEARCH, ImmutableSet.of(ModelTypes.OUTPUT_V1))
             .put(GRNTypes.STREAM, ImmutableSet.of(ModelTypes.OUTPUT_V1))
             .put(GRNTypes.DASHBOARD, ImmutableSet.of(ModelTypes.OUTPUT_V1))
             .build();


### PR DESCRIPTION
A search can reference a stream, which can reference an output.
We don't care for these permissions when sharing a search.

Fixes #11021

(cherry picked from commit 83d352046122d31c076f2f7ee6cb98b00c51f27b)

