### PR TITLE
Fix returning count and grand_total of views

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/ViewService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/ViewService.java
@@ -82,8 +82,8 @@ public class ViewService extends PaginatedDbService<ViewDTO> {
         return viewsList.stream()
                 .map(this::requirementsForView)
                 .collect(Collectors.toCollection(() -> viewsList.grandTotal()
-                        .map(grandTotal -> new PaginatedList<ViewDTO>(new ArrayList<>(viewsList.size()), viewsList.pagination().total(), page, perPage, viewsList.size(), grandTotal))
-                        .orElseGet(() -> new PaginatedList<>(new ArrayList<>(viewsList.size()), viewsList.pagination().total(), page, perPage, viewsList.size()))));
+                        .map(grandTotal -> new PaginatedList<ViewDTO>(new ArrayList<>(viewsList.size()), viewsList.pagination().total(), page, perPage, grandTotal))
+                        .orElseGet(() -> new PaginatedList<>(new ArrayList<>(viewsList.size()), viewsList.pagination().total(), page, perPage))));
     }
 
     public PaginatedList<ViewDTO> searchPaginated(SearchQuery query,

--- a/graylog2-server/src/main/java/org/graylog2/database/PaginatedDbService.java
+++ b/graylog2-server/src/main/java/org/graylog2/database/PaginatedDbService.java
@@ -153,6 +153,24 @@ public abstract class PaginatedDbService<DTO> {
                                                                      DBSort.SortBuilder sort,
                                                                      int page,
                                                                      int perPage) {
+        return findPaginatedWithQueryFilterAndSortWithGrandTotalQuery(
+                query,
+                filter,
+                sort,
+                DBQuery.empty(),
+                page,
+                perPage
+        );
+
+    }
+
+    protected PaginatedList<DTO> findPaginatedWithQueryFilterAndSortWithGrandTotalQuery(DBQuery.Query query,
+                                                                                        Predicate<DTO> filter,
+                                                                                        DBSort.SortBuilder sort,
+                                                                                        DBQuery.Query grandTotalQuery,
+                                                                                        int page,
+                                                                                        int perPage) {
+
         // Calculate the total amount of items matching the query/filter, but before pagination
         final long total;
         try (final Stream<DTO> cursor = streamQueryWithSort(query, sort)) {
@@ -166,7 +184,7 @@ public abstract class PaginatedDbService<DTO> {
                 filteredResultStream = filteredResultStream.skip(perPage * Math.max(0, page - 1)).limit(perPage);
             }
 
-            final long grandTotal = db.count();
+            final long grandTotal = db.getCount(grandTotalQuery);
 
             return new PaginatedList<>(filteredResultStream.collect(Collectors.toList()), Math.toIntExact(total), page, perPage, grandTotal);
         }

--- a/graylog2-server/src/main/java/org/graylog2/database/PaginatedList.java
+++ b/graylog2-server/src/main/java/org/graylog2/database/PaginatedList.java
@@ -39,26 +39,38 @@ public class PaginatedList<E> extends ForwardingList<E> {
 
     /**
      * Creates a PaginatedList
+     *
      * @param delegate the actual entries
-     * @param total the count of all entries (ignoring pagination)
-     * @param page  the page this PaginatedList represents
-     * @param perPage the size limit for each page
+     * @param total    the count of all entries (ignoring pagination)
+     * @param page     the page this PaginatedList represents
+     * @param perPage  the size limit for each page
      */
     public PaginatedList(@Nonnull List<E> delegate, int total, int page, int perPage) {
         this(delegate, total, page, perPage, null);
     }
 
+    public PaginatedList(@Nonnull List<E> delegate, int total, int page, int perPage, int count) {
+        this(delegate, total, page, perPage, count, null);
+    }
+
     /**
      * Creates a PaginatedList
-     * @param delegate the actual entries
-     * @param total the count of all entries (ignoring pagination)
-     * @param page  the page this PaginatedList represents
-     * @param perPage the size limit for each page
+     *
+     * @param delegate   the actual entries
+     * @param total      the count of all entries (ignoring pagination)
+     * @param page       the page this PaginatedList represents
+     * @param perPage    the size limit for each page
      * @param grandTotal the count of all entries (ignoring query filters and pagination)
      */
     public PaginatedList(@Nonnull List<E> delegate, int total, int page, int perPage, Long grandTotal) {
         this.delegate = delegate;
         this.paginationInfo = PaginationInfo.create(total, delegate.size(), page, perPage);
+        this.grandTotal = grandTotal;
+    }
+
+    public PaginatedList(@Nonnull List<E> delegate, int total, int page, int perPage, int count, Long grandTotal) {
+        this.delegate = delegate;
+        this.paginationInfo = PaginationInfo.create(total, count, page, perPage);
         this.grandTotal = grandTotal;
     }
 
@@ -77,8 +89,12 @@ public class PaginatedList<E> extends ForwardingList<E> {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof PaginatedList)) return false;
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof PaginatedList)) {
+            return false;
+        }
         PaginatedList<?> that = (PaginatedList<?>) o;
         return Objects.equals(pagination(), that.pagination()) &&
                 Objects.equals(delegate(), that.delegate()) &&

--- a/graylog2-server/src/main/java/org/graylog2/database/PaginatedList.java
+++ b/graylog2-server/src/main/java/org/graylog2/database/PaginatedList.java
@@ -33,8 +33,9 @@ public class PaginatedList<E> extends ForwardingList<E> {
 
     private final List<E> delegate;
 
-    private final PaginationInfo paginationInfo;
-
+    private final int total;
+    private final int page;
+    private final int perPage;
     private final Long grandTotal;
 
     /**
@@ -49,10 +50,6 @@ public class PaginatedList<E> extends ForwardingList<E> {
         this(delegate, total, page, perPage, null);
     }
 
-    public PaginatedList(@Nonnull List<E> delegate, int total, int page, int perPage, int count) {
-        this(delegate, total, page, perPage, count, null);
-    }
-
     /**
      * Creates a PaginatedList
      *
@@ -64,13 +61,9 @@ public class PaginatedList<E> extends ForwardingList<E> {
      */
     public PaginatedList(@Nonnull List<E> delegate, int total, int page, int perPage, Long grandTotal) {
         this.delegate = delegate;
-        this.paginationInfo = PaginationInfo.create(total, delegate.size(), page, perPage);
-        this.grandTotal = grandTotal;
-    }
-
-    public PaginatedList(@Nonnull List<E> delegate, int total, int page, int perPage, int count, Long grandTotal) {
-        this.delegate = delegate;
-        this.paginationInfo = PaginationInfo.create(total, count, page, perPage);
+        this.total = total;
+        this.page = page;
+        this.perPage = perPage;
         this.grandTotal = grandTotal;
     }
 
@@ -80,7 +73,7 @@ public class PaginatedList<E> extends ForwardingList<E> {
     }
 
     public PaginationInfo pagination() {
-        return paginationInfo;
+        return PaginationInfo.create(total, delegate.size(), page, perPage);
     }
 
     public Optional<Long> grandTotal() {


### PR DESCRIPTION
## Motivation
Prior to this change, when returning the list of saved searches
or dashboards the pagination info always had a count of zero
and the combined result of dashboards and saved searches count in
grand_total.

## Description
This PR will slightly change the pagination api so grand total also can
have a DBQuery which will be based on the type (search / dashboard) and
will initiate the newly created PaginatedList with the correct count.

## How Has This Been Tested?
- Retrive a list of saved searches and check the count and grand total
- Same for dashboards

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
