### PR TITLE
Fix retrying indexing when connection failed to elastic search 7

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/messages/Messages.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/messages/Messages.java
@@ -53,6 +53,8 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
+import static org.graylog2.shared.utilities.ExceptionUtils.getRootCause;
+
 @Singleton
 public class Messages {
     public interface IndexingListener {
@@ -78,7 +80,7 @@ public class Messages {
     @SuppressWarnings("UnstableApiUsage")
     private RetryerBuilder<List<IndexingError>> createBulkRequestRetryerBuilder() {
         return RetryerBuilder.<List<IndexingError>>newBuilder()
-                .retryIfException(t -> t instanceof IOException || t instanceof InvalidWriteTargetException || t.getCause().getCause() instanceof IOException)
+                .retryIfException(t -> t instanceof IOException || getRootCause(t) instanceof IOException || t instanceof InvalidWriteTargetException)
                 .withWaitStrategy(WaitStrategies.exponentialWait(MAX_WAIT_TIME.getQuantity(), MAX_WAIT_TIME.getUnit()))
                 .withRetryListener(new RetryListener() {
                     @Override

--- a/graylog2-server/src/main/java/org/graylog2/indexer/messages/Messages.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/messages/Messages.java
@@ -78,7 +78,7 @@ public class Messages {
     @SuppressWarnings("UnstableApiUsage")
     private RetryerBuilder<List<IndexingError>> createBulkRequestRetryerBuilder() {
         return RetryerBuilder.<List<IndexingError>>newBuilder()
-                .retryIfException(t -> t instanceof IOException || t instanceof InvalidWriteTargetException)
+                .retryIfException(t -> t instanceof IOException || t instanceof InvalidWriteTargetException || t.getCause().getCause() instanceof IOException)
                 .withWaitStrategy(WaitStrategies.exponentialWait(MAX_WAIT_TIME.getQuantity(), MAX_WAIT_TIME.getUnit()))
                 .withRetryListener(new RetryListener() {
                     @Override


### PR DESCRIPTION
## Motivation
Prior to this change, the creation of an bulk request retryer failed
with an exception if the connection to elasitc search 7 could not be
established. Since the Exection was wrapped in a new elastsic search
execption.

## Description
This change will check if the error which causes the retryer to be
executed is an IOException and  will not raise a new execption, but
instead retries in configured time.

## How Has This Been Tested?
- Switch off elastic search
- check the error messages 

Fixes #11045

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Backport
Needs backport to 4.1

