### PR TITLE
Zero count for saved searches list

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/ViewService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/ViewService.java
@@ -66,11 +66,13 @@ public class ViewService extends PaginatedDbService<ViewDTO> {
 
     private PaginatedList<ViewDTO> searchPaginated(DBQuery.Query query,
                                                    Predicate<ViewDTO> filter,
+                                                   DBQuery.Query grandTotalQuery,
                                                    String order,
                                                    String sortField,
                                                    int page,
                                                    int perPage) {
-        final PaginatedList<ViewDTO> viewsList = findPaginatedWithQueryFilterAndSort(query, filter, getSortBuilder(order, sortField), page, perPage);
+        final PaginatedList<ViewDTO> viewsList = findPaginatedWithQueryFilterAndSortWithGrandTotalQuery(
+                query, filter, getSortBuilder(order, sortField), grandTotalQuery, page, perPage);
         return viewsList.stream()
                 .map(this::requirementsForView)
                 .collect(Collectors.toCollection(() -> viewsList.grandTotal()
@@ -84,7 +86,7 @@ public class ViewService extends PaginatedDbService<ViewDTO> {
                                                   String sortField,
                                                   int page,
                                                   int perPage) {
-        return searchPaginated(query.toDBQuery(), filter, order, sortField, page, perPage);
+        return searchPaginated(query.toDBQuery(), filter, DBQuery.empty(), order, sortField, page, perPage);
     }
 
     public PaginatedList<ViewDTO> searchPaginatedByType(ViewDTO.Type type,
@@ -101,6 +103,7 @@ public class ViewService extends PaginatedDbService<ViewDTO> {
                         query.toDBQuery()
                 ),
                 filter,
+                DBQuery.or(DBQuery.is(ViewDTO.FIELD_TYPE, type), DBQuery.notExists(ViewDTO.FIELD_TYPE)),
                 order,
                 sortField,
                 page,

--- a/graylog2-server/src/main/java/org/graylog2/database/PaginatedDbService.java
+++ b/graylog2-server/src/main/java/org/graylog2/database/PaginatedDbService.java
@@ -153,6 +153,23 @@ public abstract class PaginatedDbService<DTO> {
                                                                      DBSort.SortBuilder sort,
                                                                      int page,
                                                                      int perPage) {
+        return findPaginatedWithQueryFilterAndSortWithGrandTotalQuery(
+                query,
+                filter,
+                sort,
+                DBQuery.empty(),
+                page,
+                perPage
+        );
+    }
+
+    protected PaginatedList<DTO> findPaginatedWithQueryFilterAndSortWithGrandTotalQuery(DBQuery.Query query,
+                                                                                        Predicate<DTO> filter,
+                                                                                        DBSort.SortBuilder sort,
+                                                                                        DBQuery.Query grandTotalQuery,
+                                                                                        int page,
+                                                                                        int perPage) {
+
         // Calculate the total amount of items matching the query/filter, but before pagination
         final long total;
         try (final Stream<DTO> cursor = streamQueryWithSort(query, sort)) {
@@ -166,7 +183,7 @@ public abstract class PaginatedDbService<DTO> {
                 filteredResultStream = filteredResultStream.skip(perPage * Math.max(0, page - 1)).limit(perPage);
             }
 
-            final long grandTotal = db.count();
+            final long grandTotal = db.getCount(grandTotalQuery);
 
             return new PaginatedList<>(filteredResultStream.collect(Collectors.toList()), Math.toIntExact(total), page, perPage, grandTotal);
         }


### PR DESCRIPTION
## Motivation
Prior to this change, when returning the list of saved searches the
pagination info always had a count of zero.

## Description
This change will remove the seemingly unnecessary construction of
PagianationList with empty arrays.

## Also
Fix calculation of grand_total for dashboard and saved searches

## How Has This Been Tested?
- Retrieve List of dashboards and saved searches and check for correct count and grand total.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)