### PR TITLE
Create random http message timestamps early

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/inputs/random/generators/FakeHttpRawMessageGenerator.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/random/generators/FakeHttpRawMessageGenerator.java
@@ -94,6 +94,7 @@ public class FakeHttpRawMessageGenerator {
         generatorState.isSlowRequest = RANDOM.nextInt(500) == 1;
         generatorState.userId = ((UserId) getWeighted(USER_IDS)).getId();
         generatorState.resource = ((Resource) getWeighted(GET_RESOURCES)).getResource();
+        generatorState.timeStamp = Tools.nowUTC();
 
         if (methodProb <= 85) {
             generatorState.method = GET;
@@ -163,10 +164,10 @@ public class FakeHttpRawMessageGenerator {
                 .build();
     }
 
-    private static Message createMessage(GeneratorState state, int httpCode, Resource resource, int tookMs, DateTime ingestTime) {
-        final Message msg = new Message(shortMessage(ingestTime, state.method, state.resource, httpCode, tookMs), state.source, Tools.nowUTC());
+    private static Message createMessage(GeneratorState state, int httpCode, Resource resource, int tookMs) {
+        final Message msg = new Message(shortMessage(state.timeStamp, state.method, state.resource, httpCode, tookMs), state.source, state.timeStamp);
         msg.addField("sequence_nr", state.msgSequenceNr);
-        msg.addFields(ingestTimeFields(ingestTime));
+        msg.addFields(ingestTimeFields(state.timeStamp));
         msg.addFields(resourceFields(resource));
         msg.addField("ticks", System.nanoTime());
         msg.addField("http_method", state.method.name());
@@ -191,11 +192,10 @@ public class FakeHttpRawMessageGenerator {
             msBase = 400;
         }
 
-        final DateTime ingestTime = Tools.nowUTC();
         final Resource resource = RESOURCE_MAP.get(state.resource);
         final int tookMs = rateDeviation(msBase, deviation, rand);
 
-        return createMessage(state, code, resource, tookMs, ingestTime);
+        return createMessage(state, code, resource, tookMs);
     }
 
 
@@ -213,11 +213,10 @@ public class FakeHttpRawMessageGenerator {
             msBase = 400;
         }
 
-        final DateTime ingestTime = Tools.nowUTC();
         final Resource resource = RESOURCE_MAP.get(state.resource);
         final int tookMs = rateDeviation(msBase, deviation, rand);
 
-        return createMessage(state, code, resource, tookMs, ingestTime);
+        return createMessage(state, code, resource, tookMs);
     }
 
     private static Message simulatePUT(GeneratorState state, Random rand) {
@@ -234,11 +233,10 @@ public class FakeHttpRawMessageGenerator {
             msBase = 400;
         }
 
-        final DateTime ingestTime = Tools.nowUTC();
         final Resource resource = RESOURCE_MAP.get(state.resource);
         final int tookMs = rateDeviation(msBase, deviation, rand);
 
-        return createMessage(state, code, resource, tookMs, ingestTime);
+        return createMessage(state, code, resource, tookMs);
     }
 
     private static Message simulateDELETE(GeneratorState state, Random rand) {
@@ -255,11 +253,10 @@ public class FakeHttpRawMessageGenerator {
             msBase = 400;
         }
 
-        final DateTime ingestTime = Tools.nowUTC();
         final Resource resource = RESOURCE_MAP.get(state.resource);
         final int tookMs = rateDeviation(msBase, deviation, rand);
 
-        return createMessage(state, code, resource, tookMs, ingestTime);
+        return createMessage(state, code, resource, tookMs);
     }
 
     private static abstract class Weighted {
@@ -331,6 +328,7 @@ public class FakeHttpRawMessageGenerator {
         public boolean isSlowRequest;
         public int userId;
         public String resource;
+        public DateTime timeStamp;
 
         public enum Method {
             GET, POST, DELETE, PUT


### PR DESCRIPTION
This change moves the timestamp creation for the random http message
generator to an earlier point in the processing stack.

Previously the timestamp was created _after_ the message was read from
the journal.
When testing situations where we want to make sure we don't lose any
messages, it is desirable to have messages as a continous flow which is easliy visible
in the histogram.

This change moves the timestamp into the GeneratorState which is
created _before_ the message is written into the disk journal.

This way we don't get a spike of messages with the same timestamp, if
they are read from a bigger disk journal backlog.

Before:
![image](https://user-images.githubusercontent.com/3034831/126636431-9033d7fe-6d35-4387-8474-089a8fc275c9.png)

After:
![image](https://user-images.githubusercontent.com/3034831/126637143-1b6dcddc-948d-4c7e-81cb-b881d882e964.png)
