### PR TITLE
Lazily compute page info for PaginatedList

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/database/PaginatedList.java
+++ b/graylog2-server/src/main/java/org/graylog2/database/PaginatedList.java
@@ -33,8 +33,9 @@ public class PaginatedList<E> extends ForwardingList<E> {
 
     private final List<E> delegate;
 
-    private final PaginationInfo paginationInfo;
-
+    private final int total;
+    private final int page;
+    private final int perPage;
     private final Long grandTotal;
 
     /**
@@ -58,7 +59,9 @@ public class PaginatedList<E> extends ForwardingList<E> {
      */
     public PaginatedList(@Nonnull List<E> delegate, int total, int page, int perPage, Long grandTotal) {
         this.delegate = delegate;
-        this.paginationInfo = PaginationInfo.create(total, delegate.size(), page, perPage);
+        this.total = total;
+        this.page = page;
+        this.perPage = perPage;
         this.grandTotal = grandTotal;
     }
 
@@ -68,7 +71,7 @@ public class PaginatedList<E> extends ForwardingList<E> {
     }
 
     public PaginationInfo pagination() {
-        return paginationInfo;
+        return PaginationInfo.create(total, delegate.size(), page, perPage);
     }
 
     public Optional<Long> grandTotal() {


### PR DESCRIPTION
## Motivation
Before the change the PaginatedList was storing the pagination info on
creation. But the size of the list could alter later on without updating
the page info.

## Description
This change will now create the pageinfo on access which will lead to a
fresh count number.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


