### PR TITLE
Reimplement #10277: some JARs may not exist in a certain manifest

### DIFF
--- a/graylog2-server/src/test/java/org/graylog/testing/completebackend/DefaultPluginJarsProvider.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/completebackend/DefaultPluginJarsProvider.java
@@ -37,12 +37,8 @@ public class DefaultPluginJarsProvider implements PluginJarsProvider {
                         "graylog-storage-elasticsearch6-" + projectVersion + ".jar"),
                 Paths.get(reposDir, "graylog2-server/graylog-storage-elasticsearch7/target",
                         "graylog-storage-elasticsearch7-" + projectVersion + ".jar"),
-                Paths.get(reposDir, "graylog-plugin-aws/target",
-                        "graylog-plugin-aws-" + projectVersion + ".jar"),
                 Paths.get(reposDir, "graylog-plugin-threatintel/target",
                         "graylog-plugin-threatintel-" + projectVersion + ".jar"),
-                Paths.get(reposDir, "graylog-plugin-collector/target",
-                        "graylog-plugin-collector-" + projectVersion + ".jar")
         );
     }
 

--- a/graylog2-server/src/test/java/org/graylog/testing/completebackend/DefaultPluginJarsProvider.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/completebackend/DefaultPluginJarsProvider.java
@@ -37,8 +37,12 @@ public class DefaultPluginJarsProvider implements PluginJarsProvider {
                         "graylog-storage-elasticsearch6-" + projectVersion + ".jar"),
                 Paths.get(reposDir, "graylog2-server/graylog-storage-elasticsearch7/target",
                         "graylog-storage-elasticsearch7-" + projectVersion + ".jar"),
+                Paths.get(reposDir, "graylog-plugin-aws/target",
+                        "graylog-plugin-aws-" + projectVersion + ".jar"),
                 Paths.get(reposDir, "graylog-plugin-threatintel/target",
                         "graylog-plugin-threatintel-" + projectVersion + ".jar"),
+                Paths.get(reposDir, "graylog-plugin-collector/target",
+                        "graylog-plugin-collector-" + projectVersion + ".jar")
         );
     }
 

--- a/graylog2-server/src/test/java/org/graylog/testing/graylognode/NodeContainerFactory.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/graylognode/NodeContainerFactory.java
@@ -118,8 +118,8 @@ public class NodeContainerFactory {
                 .withStartupTimeout(Duration.of(120, SECONDS));
 
         pluginJars.forEach(hostPath -> {
-            final Path containerPath = Paths.get(graylogHome, "plugin", hostPath.getFileName().toString());
-            if (Files.exists(containerPath)) {
+            if (Files.exists(hostPath)) {
+                final Path containerPath = Paths.get(graylogHome, "plugin", hostPath.getFileName().toString());
                 container.addFileSystemBind(hostPath.toString(), containerPath.toString(), BindMode.READ_ONLY);
             }
         });

--- a/graylog2-server/src/test/java/org/graylog/testing/graylognode/NodeContainerFactory.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/graylognode/NodeContainerFactory.java
@@ -29,6 +29,7 @@ import org.testcontainers.images.builder.ImageFromDockerfile;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
@@ -118,7 +119,9 @@ public class NodeContainerFactory {
 
         pluginJars.forEach(hostPath -> {
             final Path containerPath = Paths.get(graylogHome, "plugin", hostPath.getFileName().toString());
-            container.addFileSystemBind(hostPath.toString(), containerPath.toString(), BindMode.READ_ONLY);
+            if (Files.exists(containerPath)) {
+                container.addFileSystemBind(hostPath.toString(), containerPath.toString(), BindMode.READ_ONLY);
+            }
         });
 
         container.start();


### PR DESCRIPTION
Some JARs may not exist in a certain environment. Trying to mount these causes problems for the Jenkins Workspace. 
Refer to https://github.com/Graylog2/graylog2-server/pull/10277 for the details and how we initially solved this on the Cloud branch. 

Now that Cloud and Master branches have merged, we achieve the same result by simply ignoring any non-existant JARs (rather than having a Cloud-specific configuration).