### PR TITLE
Reimplement #10277: some JARs may not exist in a certain manifest

### DIFF
--- a/graylog2-server/src/test/java/org/graylog/testing/graylognode/NodeContainerFactory.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/graylognode/NodeContainerFactory.java
@@ -29,6 +29,7 @@ import org.testcontainers.images.builder.ImageFromDockerfile;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
@@ -117,8 +118,10 @@ public class NodeContainerFactory {
                 .withStartupTimeout(Duration.of(120, SECONDS));
 
         pluginJars.forEach(hostPath -> {
-            final Path containerPath = Paths.get(graylogHome, "plugin", hostPath.getFileName().toString());
-            container.addFileSystemBind(hostPath.toString(), containerPath.toString(), BindMode.READ_ONLY);
+            if (Files.exists(hostPath)) {
+                final Path containerPath = Paths.get(graylogHome, "plugin", hostPath.getFileName().toString());
+                container.addFileSystemBind(hostPath.toString(), containerPath.toString(), BindMode.READ_ONLY);
+            }
         });
 
         container.start();


### PR DESCRIPTION
* Reimplement #10277: some JARs may not exist in a certain manifest

* Use correct path in docker container

* Undo unintentionally committed change

(cherry picked from commit 3ea2d9c4c394b21c9bfc51620206a9dd3649916b)