### PR TITLE
Add config option for message table widget to control display of message summaries.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/widgets/messagelist/MessageListConfigDTO.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/widgets/messagelist/MessageListConfigDTO.java
@@ -27,6 +27,7 @@ import org.graylog.plugins.views.search.views.widgets.aggregation.sort.SortConfi
 import org.graylog2.decorators.Decorator;
 import org.graylog2.decorators.DecoratorImpl;
 
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -38,6 +39,7 @@ public abstract class MessageListConfigDTO implements WidgetConfigDTO {
     public static final String NAME = "messages";
     private static final String FIELD_FIELDS = "fields";
     private static final String FIELD_SHOW_MESSAGE_ROW = "show_message_row";
+    private static final String FIELD_SHOW_SUMMARY_ROW = "show_summary_row";
     private static final String FIELD_DECORATORS = "decorators";
     private static final String FIELD_SORT = "sort";
 
@@ -46,6 +48,10 @@ public abstract class MessageListConfigDTO implements WidgetConfigDTO {
 
     @JsonProperty(FIELD_SHOW_MESSAGE_ROW)
     public abstract boolean showMessageRow();
+
+    @JsonProperty(FIELD_SHOW_SUMMARY_ROW)
+    @Nullable
+    public abstract Boolean showSummaryRow();
 
     @JsonProperty(FIELD_DECORATORS)
     public abstract List<Decorator> decorators();
@@ -61,6 +67,10 @@ public abstract class MessageListConfigDTO implements WidgetConfigDTO {
         @JsonProperty(FIELD_SHOW_MESSAGE_ROW)
         public abstract Builder showMessageRow(boolean showMessageRow);
 
+        @JsonProperty(FIELD_SHOW_SUMMARY_ROW)
+        @Nullable
+        public abstract Builder showSummaryRow(Boolean showSummaryRow);
+
         @JsonProperty(FIELD_DECORATORS)
         public Builder _decorators(List<DecoratorImpl> decorators) {
             return decorators(new ArrayList<>(decorators));
@@ -75,6 +85,7 @@ public abstract class MessageListConfigDTO implements WidgetConfigDTO {
         @JsonCreator
         public static Builder builder() {
             return new AutoValue_MessageListConfigDTO.Builder()
+                    .showSummaryRow(true)
                     .decorators(Collections.emptyList())
                     .sort(Collections.emptyList());
         }

--- a/graylog2-web-interface/src/views/components/export/ExportModal.test.tsx
+++ b/graylog2-web-interface/src/views/components/export/ExportModal.test.tsx
@@ -168,7 +168,7 @@ describe('ExportModal', () => {
   });
 
   it('initial fields should not contain the message field if message list config showMessageRow is false', async () => {
-    const widgetConfig = new MessagesWidgetConfig(['level', 'http_method'], false, [], []);
+    const widgetConfig = new MessagesWidgetConfig(['level', 'http_method'], false, false, [], []);
     const widgetWithoutMessageRow = messagesWidget().toBuilder().config(widgetConfig).build();
     const viewStateMap: ViewStateMap = Immutable.Map({
       'query-id-1': stateWithOneWidget(messagesWidget()).toBuilder()

--- a/graylog2-web-interface/src/views/components/export/Fixtures.ts
+++ b/graylog2-web-interface/src/views/components/export/Fixtures.ts
@@ -43,7 +43,7 @@ const queries = [
   Query.builder().id('query-id-1').searchTypes([searchType]).build(),
 ];
 const currentSort = new SortConfig(SortConfig.PIVOT_TYPE, 'level', Direction.Descending);
-const config = new MessagesWidgetConfig(['level', 'http_method'], true, [], [currentSort]);
+const config = new MessagesWidgetConfig(['level', 'http_method'], true, true, [], [currentSort]);
 
 export const messagesWidget = (id: string = 'widget-id-1') => MessagesWidget.builder()
   .id(id)

--- a/graylog2-web-interface/src/views/components/messagelist/MessageTableEntry.test.tsx
+++ b/graylog2-web-interface/src/views/components/messagelist/MessageTableEntry.test.tsx
@@ -77,6 +77,7 @@ describe('MessageTableEntry', () => {
                              toggleDetail={() => {}}
                              fields={Immutable.List()}
                              message={message}
+                             showSummaryRow
                              selectedFields={Immutable.OrderedSet(['message'])}
                              expanded={false} />
         </table>,

--- a/graylog2-web-interface/src/views/components/messagelist/MessageTableEntry.tsx
+++ b/graylog2-web-interface/src/views/components/messagelist/MessageTableEntry.tsx
@@ -110,6 +110,7 @@ type Props = {
   message: Message,
   selectedFields?: Immutable.OrderedSet<string>,
   showMessageRow?: boolean,
+  showSummaryRow?: boolean,
   toggleDetail: (string) => void,
 };
 
@@ -127,7 +128,8 @@ const MessageTableEntry = ({
   fields,
   highlightMessage = '',
   message,
-  showMessageRow = false,
+  showMessageRow,
+  showSummaryRow,
   selectedFields = Immutable.OrderedSet<string>(),
   toggleDetail,
 }: Props) => {
@@ -185,7 +187,11 @@ const MessageTableEntry = ({
         </MessageRow>
       )}
 
-      <MessageSummaryRow onClick={_toggleDetail} colSpanFixup={colSpanFixup} message={message} />
+      {showSummaryRow && (
+        <MessageSummaryRow onClick={_toggleDetail}
+                           colSpanFixup={colSpanFixup}
+                           message={message} />
+      )}
 
       {expanded && (
         <MessageDetailRow>
@@ -224,6 +230,7 @@ MessageTableEntry.propTypes = {
   // @ts-ignore
   selectedFields: PropTypes.instanceOf(Immutable.OrderedSet),
   showMessageRow: PropTypes.bool,
+  showSummaryRow: PropTypes.bool,
   toggleDetail: PropTypes.func.isRequired,
 };
 
@@ -232,6 +239,7 @@ MessageTableEntry.defaultProps = {
   highlightMessage: undefined,
   selectedFields: Immutable.OrderedSet(),
   showMessageRow: false,
+  showSummaryRow: false,
 };
 
 export default MessageTableEntry;

--- a/graylog2-web-interface/src/views/components/widgets/EditMessageList.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/EditMessageList.tsx
@@ -56,6 +56,12 @@ const _onShowMessageRowChanged = (config, onChange) => {
   return onChange(newConfig);
 };
 
+const _onShowSummaryRow = (config, onChange) => {
+  const newConfig = config.toBuilder().showSummaryRow(!config.showSummaryRow).build();
+
+  return onChange(newConfig);
+};
+
 const _onSortChange = (sort: $PropertyType<AggregationWidgetConfig, 'sort'>, config, onChange) => {
   const newConfig = config.toBuilder().sort(sort).build();
 
@@ -84,6 +90,9 @@ const EditMessageList = ({ children, config, fields, onChange }: EditWidgetCompo
                        value={selectedFieldsForSelect} />
           <Checkbox checked={config.showMessageRow} onChange={() => _onShowMessageRowChanged(config, onChange)}>
             Show message in new row
+          </Checkbox>
+          <Checkbox checked={config.showSummaryRow} onChange={() => _onShowSummaryRow(config, onChange)}>
+            Show message summary
           </Checkbox>
         </DescriptionBox>
         <DescriptionBox description="Sorting">

--- a/graylog2-web-interface/src/views/components/widgets/EditMessageList.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/EditMessageList.tsx
@@ -30,6 +30,7 @@ import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationW
 import MessagesWidgetConfig from 'views/logic/widgets/MessagesWidgetConfig';
 import DescriptionBox from 'views/components/aggregationbuilder/DescriptionBox';
 import DecoratorSidebar from 'views/components/messagelist/decorators/DecoratorSidebar';
+import { HoverForHelp } from 'components/common';
 
 const FullHeightRow = styled(Row)`
   height: 100%;
@@ -41,6 +42,13 @@ const FullHeightCol = styled(Col)`
   height: 100%;
   padding-bottom: 10px;
   overflow: auto;
+`;
+
+const SummaryCheckbox = styled(Checkbox)`
+  label {
+    display: flex;
+    justify-content: space-between;
+  }
 `;
 
 const _onFieldSelectionChanged = (fields, config, onChange) => {
@@ -91,9 +99,12 @@ const EditMessageList = ({ children, config, fields, onChange }: EditWidgetCompo
           <Checkbox checked={config.showMessageRow} onChange={() => _onShowMessageRowChanged(config, onChange)}>
             Show message in new row
           </Checkbox>
-          <Checkbox checked={config.showSummaryRow} onChange={() => _onShowSummaryRow(config, onChange)}>
+          <SummaryCheckbox checked={config.showSummaryRow} onChange={() => _onShowSummaryRow(config, onChange)}>
             Show message summary
-          </Checkbox>
+            <HoverForHelp title="Message Summary">
+              Display a summary of the most relevant information of a message, based on the message event type.
+            </HoverForHelp>
+          </SummaryCheckbox>
         </DescriptionBox>
         <DescriptionBox description="Sorting">
           <FieldSortSelect fields={fields} sort={sort} onChange={(data) => _onSortChange(data, config, onChange)} />

--- a/graylog2-web-interface/src/views/components/widgets/FieldSortIcon.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/FieldSortIcon.test.tsx
@@ -25,7 +25,7 @@ import FieldSortIcon from './FieldSortIcon';
 
 describe('FieldSortIcon', () => {
   const currentSort = new SortConfig(SortConfig.PIVOT_TYPE, 'timestamp', Direction.Descending);
-  const config = new MessagesWidgetConfig(['timestamp', 'source'], true, [], [currentSort]);
+  const config = new MessagesWidgetConfig(['timestamp', 'source'], true, true, [], [currentSort]);
 
   it('should set descending sort on click, if field sort is not defined', () => {
     const onSortChangeStub = jest.fn(() => Promise.resolve());
@@ -55,9 +55,9 @@ describe('FieldSortIcon', () => {
     expect(onSortChangeStub).toHaveBeenCalledWith(expectedSort);
   });
 
-  it('should set ascending sort on click, if field sort is descending', () => {
+  it('should set descending sort on click, if field sort is descending', () => {
     const initialSort = new SortConfig(SortConfig.PIVOT_TYPE, 'source', Direction.Ascending);
-    const initialConfig = new MessagesWidgetConfig(['timestamp', 'source'], true, [], [initialSort]);
+    const initialConfig = new MessagesWidgetConfig(['timestamp', 'source'], true, true, [], [initialSort]);
     const onSortChangeStub = jest.fn(() => Promise.resolve());
 
     const { getByTestId } = render(<FieldSortIcon config={initialConfig} fieldName="source" onSortChange={onSortChangeStub} setLoadingState={() => {}} />);

--- a/graylog2-web-interface/src/views/components/widgets/MessageTable.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageTable.tsx
@@ -222,6 +222,7 @@ class MessageTable extends React.Component<Props, State> {
                     <MessageTableEntry fields={fields}
                                        message={message}
                                        showMessageRow={config && config.showMessageRow}
+                                       showSummaryRow={config && config.showSummaryRow}
                                        selectedFields={selectedFields}
                                        expanded={expandedMessages.contains(messageKey)}
                                        toggleDetail={this._toggleMessageDetail}

--- a/graylog2-web-interface/src/views/logic/Widgets.ts
+++ b/graylog2-web-interface/src/views/logic/Widgets.ts
@@ -72,6 +72,7 @@ export const allMessagesTable = (id: string = uuid(), decorators: Array<Decorato
   .config(MessageWidgetConfig.builder()
     .fields(DEFAULT_MESSAGE_FIELDS)
     .showMessageRow(true)
+    .showSummaryRow(true)
     .decorators(decorators)
     .build())
   .build();

--- a/graylog2-web-interface/src/views/logic/fieldactions/AddMessageTableActionHandler.ts
+++ b/graylog2-web-interface/src/views/logic/fieldactions/AddMessageTableActionHandler.ts
@@ -20,5 +20,14 @@ import { DEFAULT_MESSAGE_FIELDS } from 'views/Constants';
 import MessagesWidget from '../widgets/MessagesWidget';
 import MessagesWidgetConfig from '../widgets/MessagesWidgetConfig';
 
-export default () => WidgetActions.create(MessagesWidget.builder().newId()
-  .config(MessagesWidgetConfig.builder().fields(DEFAULT_MESSAGE_FIELDS).showMessageRow(true).build()).build());
+export default () => WidgetActions.create(
+  MessagesWidget.builder()
+    .newId()
+    .config(
+      MessagesWidgetConfig.builder()
+        .fields(DEFAULT_MESSAGE_FIELDS)
+        .showMessageRow(true)
+        .showSummaryRow(true)
+        .build(),
+    ).build(),
+);

--- a/graylog2-web-interface/src/views/logic/widgets/MessagesWidgetConfig.ts
+++ b/graylog2-web-interface/src/views/logic/widgets/MessagesWidgetConfig.ts
@@ -38,6 +38,7 @@ type InternalState = {
   fields: Array<string>,
   sort: Array<SortConfig>,
   showMessageRow: boolean,
+  showSummaryRow: boolean,
 };
 
 export type MessagesWidgetConfigJSON = {
@@ -45,6 +46,7 @@ export type MessagesWidgetConfigJSON = {
   fields: Array<string>,
   sort: Array<SortConfigJson>,
   show_message_row: boolean,
+  show_summary_row: boolean,
 };
 
 export const defaultSortDirection = Direction.Descending;
@@ -53,9 +55,9 @@ export const defaultSort = [new SortConfig(SortConfig.PIVOT_TYPE, TIMESTAMP_FIEL
 export default class MessagesWidgetConfig extends WidgetConfig {
   _value: InternalState;
 
-  constructor(fields: Array<string>, showMessageRow: boolean, decorators: Array<Decorator>, sort: Array<SortConfig>) {
+  constructor(fields: Array<string>, showMessageRow: boolean, showSummaryRow: boolean, decorators: Array<Decorator>, sort: Array<SortConfig>) {
     super();
-    this._value = { decorators, fields: fields.slice(0), showMessageRow, sort: sort && sort.length > 0 ? sort : defaultSort };
+    this._value = { decorators, fields: fields.slice(0), showMessageRow, showSummaryRow, sort: sort && sort.length > 0 ? sort : defaultSort };
   }
 
   get decorators() {
@@ -74,18 +76,23 @@ export default class MessagesWidgetConfig extends WidgetConfig {
     return this._value.showMessageRow;
   }
 
+  get showSummaryRow() {
+    return this._value.showSummaryRow;
+  }
+
   toBuilder() {
     // eslint-disable-next-line @typescript-eslint/no-use-before-define
     return new Builder(Immutable.Map((this._value)));
   }
 
   toJSON() {
-    const { decorators, fields, showMessageRow, sort } = this._value;
+    const { decorators, fields, showMessageRow, showSummaryRow, sort } = this._value;
 
     return {
       decorators,
       fields,
       show_message_row: showMessageRow,
+      show_summary_row: showSummaryRow,
       sort,
     };
   }
@@ -95,7 +102,8 @@ export default class MessagesWidgetConfig extends WidgetConfig {
       && isDeepEqual(this.decorators, other.decorators)
       && isDeepEqual(this.fields, other.fields)
       && isDeepEqual(this.sort, other.sort)
-      && this.showMessageRow === other.showMessageRow;
+      && this.showMessageRow === other.showMessageRow
+      && this.showSummaryRow === other.showSummaryRow;
   }
 
   equalsForSearch(other: any): boolean {
@@ -114,9 +122,9 @@ export default class MessagesWidgetConfig extends WidgetConfig {
   }
 
   static fromJSON(value: MessagesWidgetConfigJSON) {
-    const { decorators, show_message_row, fields, sort } = value;
+    const { decorators, show_message_row, show_summary_row, fields, sort } = value;
 
-    return new MessagesWidgetConfig(fields, show_message_row, decorators, sort.map(SortConfig.fromJSON));
+    return new MessagesWidgetConfig(fields, show_message_row, show_summary_row, decorators, sort.map(SortConfig.fromJSON));
   }
 }
 
@@ -141,13 +149,17 @@ class Builder {
     return new Builder(this.value.set('showMessageRow', value));
   }
 
+  showSummaryRow(value: boolean) {
+    return new Builder(this.value.set('showSummaryRow', value));
+  }
+
   sort(sorts: Array<SortConfig>) {
     return new Builder(this.value.set('sort', sorts));
   }
 
   build() {
-    const { decorators, fields, showMessageRow, sort } = this.value.toObject();
+    const { decorators, fields, showMessageRow, showSummaryRow, sort } = this.value.toObject();
 
-    return new MessagesWidgetConfig(fields, showMessageRow, decorators, sort);
+    return new MessagesWidgetConfig(fields, showMessageRow, showSummaryRow, decorators, sort);
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Recently we implemented message summaries for messages in the message table widget https://github.com/Graylog2/graylog2-server/pull/11058. With this PR we are extending the message table widget config to make this option configurable. This way users can control if messages in the message table widget should also display a summary.

Similar to the message summary row we are now displaying checkbox in the message table widget edit mode, which allows controlling this option.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

Fixes #11042 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

