### PR TITLE
Add "match pass" guard for pipeline stages

### DIFF
--- a/graylog2-server/src/main/antlr4/org/graylog/plugins/pipelineprocessor/parser/RuleLang.g4
+++ b/graylog2-server/src/main/antlr4/org/graylog/plugins/pipelineprocessor/parser/RuleLang.g4
@@ -55,7 +55,7 @@ pipelineDeclaration
     ;
 
 stageDeclaration
-    :   Stage stage=Integer Match modifier=(All|Either)
+    :   Stage stage=Integer Match modifier=(All|Either|Pass)
         ruleRef*
     ;
 
@@ -125,6 +125,7 @@ literal
 
 All : A L L;
 Either: E I T H E R;
+Pass: P A S S;
 And : A N D | '&&';
 Or: O R | '||';
 Not: N O T | '!';

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/ast/Stage.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/ast/Stage.java
@@ -28,6 +28,10 @@ import static com.codahale.metrics.MetricRegistry.name;
 
 @AutoValue
 public abstract class Stage implements Comparable<Stage> {
+    public enum Match {
+        ALL, EITHER, PASS
+    }
+
     private List<Rule> rules;
     // not an autovalue property, because it introduces a cycle in hashCode() and we have no way of excluding it
     private transient Pipeline pipeline;
@@ -35,7 +39,9 @@ public abstract class Stage implements Comparable<Stage> {
     private transient String meterName;
 
     public abstract int stage();
-    public abstract boolean matchAll();
+
+    public abstract Match match();
+
     public abstract List<String> ruleReferences();
 
     public List<Rule> getRules() {
@@ -100,7 +106,7 @@ public abstract class Stage implements Comparable<Stage> {
 
         public abstract Builder stage(int stageNumber);
 
-        public abstract Builder matchAll(boolean mustMatchAll);
+        public abstract Builder match(Match match);
 
         public abstract Builder ruleReferences(List<String> ruleRefs);
     }

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/parser/PipelineRuleParser.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/parser/PipelineRuleParser.java
@@ -93,6 +93,7 @@ import javax.inject.Inject;
 import java.util.ArrayDeque;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -989,8 +990,12 @@ public class PipelineRuleParser {
                     parseContext.addError(new SyntaxError(null, stageToken.getLine(), stageToken.getCharPositionInLine(), "", null));
                     return;
                 }
-                final boolean isAllModifier = modifier.getText().equalsIgnoreCase("all");
-                stageBuilder.matchAll(isAllModifier);
+                try {
+                    stageBuilder.match(Stage.Match.valueOf(modifier.getText().toUpperCase(Locale.ROOT)));
+                } catch (IllegalArgumentException e) {
+                    parseContext.addError(new SyntaxError(null, stageToken.getLine(), stageToken.getCharPositionInLine(), "", null));
+                    return;
+                }
 
                 final List<String> ruleRefs = stage.ruleRef().stream()
                         .map(ruleRefContext -> {

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/processors/PipelineInterpreter.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/processors/PipelineInterpreter.java
@@ -289,7 +289,7 @@ public class PipelineInterpreter implements MessageProcessor {
         log.debug("[{}] evaluating rule conditions in stage {}: match {}",
                 msgId,
                 stage.stage(),
-                stage.matchAll() ? "all" : "either");
+                stage.match());
 
         // TODO the message should be decorated to allow layering changes and isolate stages
         final EvaluationContext context = new EvaluationContext(message);
@@ -325,17 +325,18 @@ public class PipelineInterpreter implements MessageProcessor {
         // OR
         // any rule could match, but at least one had to,
         // record that it is ok to proceed with the pipeline
-        final boolean matchAllSuccess = stage.matchAll() && allRulesMatched;
-        final boolean matchEitherSuccess = !stage.matchAll() && anyRulesMatched;
-        if (matchAllSuccess || matchEitherSuccess) {
+        final boolean matchAllSuccess = Stage.Match.ALL == stage.match() && allRulesMatched;
+        final boolean matchEitherSuccess = Stage.Match.EITHER == stage.match() && anyRulesMatched;
+        final boolean matchIsPass = Stage.Match.PASS == stage.match();
+        if (matchAllSuccess || matchEitherSuccess || matchIsPass) {
             interpreterListener.continuePipelineExecution(pipeline, stage);
             log.debug("[{}] stage {} for pipeline `{}` required match: {}, ok to proceed with next stage",
-                    msgId, stage.stage(), pipeline.name(), stage.matchAll() ? "all" : "either");
+                    msgId, stage.stage(), pipeline.name(), stage.match());
         } else {
             // no longer execute stages from this pipeline, the guard prevents it
             interpreterListener.stopPipelineExecution(pipeline, stage);
             log.debug("[{}] stage {} for pipeline `{}` required match: {}, NOT ok to proceed with next stage",
-                    msgId, stage.stage(), pipeline.name(), stage.matchAll() ? "all" : "either");
+                    msgId, stage.stage(), pipeline.name(), stage.match());
             pipelinesToSkip.add(pipeline);
         }
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/rest/PipelineResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/rest/PipelineResource.java
@@ -23,7 +23,6 @@ import io.swagger.annotations.ApiParam;
 import org.apache.shiro.authz.annotation.RequiresAuthentication;
 import org.apache.shiro.authz.annotation.RequiresPermissions;
 import org.graylog.plugins.pipelineprocessor.ast.Pipeline;
-import org.graylog.plugins.pipelineprocessor.ast.Rule;
 import org.graylog.plugins.pipelineprocessor.audit.PipelineProcessorAuditEventTypes;
 import org.graylog.plugins.pipelineprocessor.db.PipelineDao;
 import org.graylog.plugins.pipelineprocessor.db.PipelineService;
@@ -118,7 +117,7 @@ public class PipelineResource extends RestResource implements PluginRestResource
                 .stages(pipeline.stages().stream()
                         .map(stage -> StageSource.create(
                                 stage.stage(),
-                                stage.matchAll(),
+                                stage.match(),
                                 stage.ruleReferences()))
                         .collect(Collectors.toList()))
                 .createdAt(now)

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/rest/PipelineSource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/rest/PipelineSource.java
@@ -107,7 +107,7 @@ public abstract class PipelineSource {
         final List<StageSource> stageSources = (pipeline == null) ? Collections.emptyList() :
                 pipeline.stages().stream()
                         .map(stage -> StageSource.builder()
-                                .matchAll(stage.matchAll())
+                                .match(stage.match())
                                 .rules(stage.ruleReferences())
                                 .stage(stage.stage())
                                 .build())

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/rest/StageSource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/rest/StageSource.java
@@ -20,7 +20,9 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
+import org.graylog.plugins.pipelineprocessor.ast.Stage;
 
+import javax.annotation.Nullable;
 import javax.validation.constraints.Min;
 import java.util.List;
 
@@ -31,19 +33,19 @@ public abstract class StageSource {
     @JsonProperty("stage")
     public abstract int stage();
 
-    @JsonProperty("match_all")
-    public abstract boolean matchAll();
+    @JsonProperty("match")
+    public abstract Stage.Match match();
 
     @JsonProperty("rules")
     public abstract List<String> rules();
 
     @JsonCreator
     public static StageSource create(@JsonProperty("stage") @Min(0) int stage,
-                                     @JsonProperty("match_all") boolean matchAll,
+                                     @JsonProperty("match") @Nullable Stage.Match match,
                                      @JsonProperty("rules") List<String> rules) {
         return builder()
                 .stage(stage)
-                .matchAll(matchAll)
+                .match(match)
                 .rules(rules)
                 .build();
     }
@@ -60,7 +62,7 @@ public abstract class StageSource {
 
         public abstract Builder stage(int stageNumber);
 
-        public abstract Builder matchAll(boolean mustMatchAll);
+        public abstract Builder match(Stage.Match match);
 
         public abstract Builder rules(List<String> ruleRefs);
     }

--- a/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/parser/PipelineRuleParserTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/parser/PipelineRuleParserTest.java
@@ -291,11 +291,11 @@ public class PipelineRuleParserTest extends BaseParserTest {
         final Stage stage1 = pipeline.stages().first();
         final Stage stage2 = pipeline.stages().last();
 
-        assertEquals(true, stage1.matchAll());
+        assertEquals(Stage.Match.ALL, stage1.match());
         assertEquals(1, stage1.stage());
         assertArrayEquals(new Object[]{"check_ip_whitelist", "cisco_device"}, stage1.ruleReferences().toArray());
 
-        assertEquals(false, stage2.matchAll());
+        assertEquals(Stage.Match.EITHER, stage2.match());
         assertEquals(2, stage2.stage());
         assertArrayEquals(new Object[]{"parse_cisco_time", "extract_src_dest", "normalize_src_dest", "lookup_ips", "resolve_ips"},
                 stage2.ruleReferences().toArray());

--- a/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/processors/PipelineInterpreterTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/processors/PipelineInterpreterTest.java
@@ -246,6 +246,66 @@ public class PipelineInterpreterTest {
         assertThat(actualMessage.hasField("foobar")).isFalse();
     }
 
+    public void testMatchPassContinuesIfOneRuleMatched() {
+        final RuleService ruleService = mock(MongoDbRuleService.class);
+        when(ruleService.loadAll()).thenReturn(ImmutableList.of(RULE_TRUE, RULE_FALSE, RULE_ADD_FOOBAR));
+
+        final PipelineService pipelineService = mock(MongoDbPipelineService.class);
+        when(pipelineService.loadAll()).thenReturn(Collections.singleton(
+                PipelineDao.create("p1", "title", "description",
+                        "pipeline \"pipeline\"\n" +
+                                "stage 0 match pass\n" +
+                                "    rule \"true\";\n" +
+                                "    rule \"false\";\n" +
+                                "stage 1 match pass\n" +
+                                "    rule \"add_foobar\";\n" +
+                                "end\n",
+                        Tools.nowUTC(),
+                        null)
+        ));
+
+        final Map<String, Function<?>> functions = ImmutableMap.of(SetField.NAME, new SetField());
+        final PipelineInterpreter interpreter = createPipelineInterpreter(ruleService, pipelineService, functions);
+
+        final Messages processed = interpreter.process(messageInDefaultStream("message", "test"));
+
+        final List<Message> messages = ImmutableList.copyOf(processed);
+        assertThat(messages).hasSize(1);
+
+        final Message actualMessage = messages.get(0);
+        assertThat(actualMessage.getFieldAs(String.class, "foobar")).isEqualTo("covfefe");
+    }
+
+    @Test
+    public void testMatchPassContinuesIfNoRuleMatched() {
+        final RuleService ruleService = mock(MongoDbRuleService.class);
+        when(ruleService.loadAll()).thenReturn(ImmutableList.of(RULE_TRUE, RULE_FALSE, RULE_ADD_FOOBAR));
+
+        final PipelineService pipelineService = mock(MongoDbPipelineService.class);
+        when(pipelineService.loadAll()).thenReturn(Collections.singleton(
+                PipelineDao.create("p1", "title", "description",
+                        "pipeline \"pipeline\"\n" +
+                                "stage 0 match pass\n" +
+                                "    rule \"false\";\n" +
+                                "stage 1 match pass\n" +
+                                "    rule \"add_foobar\";\n" +
+                                "end\n",
+                        Tools.nowUTC(),
+                        null)
+        ));
+
+        final Map<String, Function<?>> functions = ImmutableMap.of(SetField.NAME, new SetField());
+        final PipelineInterpreter interpreter = createPipelineInterpreter(ruleService, pipelineService, functions);
+
+        final Messages processed = interpreter.process(messageInDefaultStream("message", "test"));
+
+        final List<Message> messages = ImmutableList.copyOf(processed);
+        assertThat(messages).hasSize(1);
+
+        final Message actualMessage = messages.get(0);
+        assertThat(actualMessage.getFieldAs(String.class, "foobar")).isEqualTo("covfefe");
+    }
+
     @SuppressForbidden("Allow using default thread factory")
     private PipelineInterpreter createPipelineInterpreter(RuleService ruleService, PipelineService pipelineService, Map<String, Function<?>> functions) {
         final RuleMetricsConfigService ruleMetricsConfigService = mock(RuleMetricsConfigService.class);

--- a/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/processors/PipelineInterpreterTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/processors/PipelineInterpreterTest.java
@@ -246,6 +246,7 @@ public class PipelineInterpreterTest {
         assertThat(actualMessage.hasField("foobar")).isFalse();
     }
 
+    @Test
     public void testMatchPassContinuesIfOneRuleMatched() {
         final RuleService ruleService = mock(MongoDbRuleService.class);
         when(ruleService.loadAll()).thenReturn(ImmutableList.of(RULE_TRUE, RULE_FALSE, RULE_ADD_FOOBAR));

--- a/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/processors/StageIteratorTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/processors/StageIteratorTest.java
@@ -53,8 +53,8 @@ public class StageIteratorTest {
                 ImmutableSet.of(Pipeline.builder()
                                         .name("hallo")
                                         .stages(of(Stage.builder()
-                                                           .stage(0)
-                                                           .matchAll(true)
+                                                .stage(0)
+                                                .match(Stage.Match.ALL)
                                                            .ruleReferences(Collections.emptyList())
                                                            .build()))
                                         .build());
@@ -73,15 +73,15 @@ public class StageIteratorTest {
                 ImmutableSet.of(Pipeline.builder()
                                         .name("hallo")
                                         .stages(of(Stage.builder()
-                                                           .stage(0)
-                                                           .matchAll(true)
-                                                           .ruleReferences(Collections.emptyList())
-                                                           .build(),
-                                                   Stage.builder()
-                                                           .stage(10)
-                                                           .matchAll(true)
-                                                           .ruleReferences(Collections.emptyList())
-                                                           .build()
+                                                        .stage(0)
+                                                        .match(Stage.Match.ALL)
+                                                        .ruleReferences(Collections.emptyList())
+                                                        .build(),
+                                                Stage.builder()
+                                                        .stage(10)
+                                                        .match(Stage.Match.ALL)
+                                                        .ruleReferences(Collections.emptyList())
+                                                        .build()
                                         )).build());
         final StageIterator iterator = new StageIterator(input);
         //noinspection unchecked
@@ -99,37 +99,37 @@ public class StageIteratorTest {
     public void multiplePipelines() {
         final ImmutableSortedSet<Stage> stages1 =
                 of(Stage.builder()
-                           .stage(0)
-                           .matchAll(true)
-                           .ruleReferences(Collections.emptyList())
-                           .build(),
-                   Stage.builder()
-                           .stage(10)
-                           .matchAll(true)
-                           .ruleReferences(Collections.emptyList())
-                           .build()
+                                .stage(0)
+                                .match(Stage.Match.ALL)
+                                .ruleReferences(Collections.emptyList())
+                                .build(),
+                        Stage.builder()
+                                .stage(10)
+                                .match(Stage.Match.ALL)
+                                .ruleReferences(Collections.emptyList())
+                                .build()
                 );
         final ImmutableSortedSet<Stage> stages2 =
                 of(Stage.builder()
-                           .stage(-1)
-                           .matchAll(true)
-                           .ruleReferences(Collections.emptyList())
-                           .build(),
-                   Stage.builder()
-                           .stage(4)
-                           .matchAll(true)
-                           .ruleReferences(Collections.emptyList())
-                           .build(),
-                   Stage.builder()
-                           .stage(11)
-                           .matchAll(true)
-                           .ruleReferences(Collections.emptyList())
-                           .build()
+                                .stage(-1)
+                                .match(Stage.Match.ALL)
+                                .ruleReferences(Collections.emptyList())
+                                .build(),
+                        Stage.builder()
+                                .stage(4)
+                                .match(Stage.Match.ALL)
+                                .ruleReferences(Collections.emptyList())
+                                .build(),
+                        Stage.builder()
+                                .stage(11)
+                                .match(Stage.Match.ALL)
+                                .ruleReferences(Collections.emptyList())
+                                .build()
                 );
         final ImmutableSortedSet<Stage> stages3 =
                 of(Stage.builder()
-                           .stage(0)
-                           .matchAll(true)
+                        .stage(0)
+                        .match(Stage.Match.ALL)
                            .ruleReferences(Collections.emptyList())
                            .build());
 

--- a/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/rest/PipelineResourceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/rest/PipelineResourceTest.java
@@ -74,11 +74,11 @@ public class PipelineResourceTest {
                 Stage.builder()
                         .stage(0)
                         .ruleReferences(ImmutableList.of("geo loc of dev", "open source dev"))
-                        .matchAll(false)
+                        .match(Stage.Match.EITHER)
                         .build()
         );
         final List<StageSource> expectedStages = ImmutableList.of(
-                StageSource.create(0, false, ImmutableList.of(
+                StageSource.create(0, Stage.Match.EITHER, ImmutableList.of(
                         "geo loc of dev", "open source dev"
                 ))
         );

--- a/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/rest/PipelineSourceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/rest/PipelineSourceTest.java
@@ -18,6 +18,7 @@ package org.graylog.plugins.pipelineprocessor.rest;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.graylog.plugins.pipelineprocessor.ast.Stage;
 import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
@@ -32,7 +33,7 @@ public class PipelineSourceTest {
 
     @Test
     public void testSerialization() throws Exception {
-        final StageSource stageSource = StageSource.create(23, true, Collections.singletonList("some-rule"));
+        final StageSource stageSource = StageSource.create(23, Stage.Match.ALL, Collections.singletonList("some-rule"));
         final PipelineSource pipelineSource = PipelineSource.create(
                 "id",
                 "title",
@@ -55,7 +56,7 @@ public class PipelineSourceTest {
 
         final JsonNode stageNode = json.path("stages").get(0);
         assertThat(stageNode.path("stage").asInt()).isEqualTo(23);
-        assertThat(stageNode.path("match_all").asBoolean()).isTrue();
+        assertThat(stageNode.path("match").asText()).isEqualTo("ALL");
         assertThat(stageNode.path("rules").isArray()).isTrue();
         assertThat(stageNode.path("rules")).hasSize(1);
         assertThat(stageNode.path("rules").get(0).asText()).isEqualTo("some-rule");
@@ -70,7 +71,7 @@ public class PipelineSourceTest {
                 + "\"source\":\"source\","
                 + "\"created_at\":\"2017-07-04T15:00:00.000Z\","
                 + "\"modified_at\":\"2017-07-04T15:00:00.000Z\","
-                + "\"stages\":[{\"stage\":23,\"match_all\":true,\"rules\":[\"some-rule\"]}]"
+                + "\"stages\":[{\"stage\":23,\"match\":\"ALL\",\"rules\":[\"some-rule\"]}]"
                 + "}";
 
         final PipelineSource pipelineSource = objectMapper.readValue(json, PipelineSource.class);
@@ -82,6 +83,6 @@ public class PipelineSourceTest {
         assertThat(pipelineSource.modifiedAt()).isEqualTo(new DateTime(2017, 7, 4, 15, 0, DateTimeZone.UTC));
         assertThat(pipelineSource.stages())
                 .hasSize(1)
-                .containsOnly(StageSource.create(23, true, Collections.singletonList("some-rule")));
+                .containsOnly(StageSource.create(23, Stage.Match.ALL, Collections.singletonList("some-rule")));
     }
 }

--- a/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/rest/StageSourceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/rest/StageSourceTest.java
@@ -18,6 +18,7 @@ package org.graylog.plugins.pipelineprocessor.rest;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.graylog.plugins.pipelineprocessor.ast.Stage;
 import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
 import org.junit.Test;
 
@@ -30,11 +31,11 @@ public class StageSourceTest {
 
     @Test
     public void testSerialization() throws Exception {
-        final StageSource stageSource = StageSource.create(23, true, Collections.singletonList("some-rule"));
+        final StageSource stageSource = StageSource.create(23, Stage.Match.ALL, Collections.singletonList("some-rule"));
         final JsonNode json = objectMapper.convertValue(stageSource, JsonNode.class);
 
         assertThat(json.path("stage").asInt()).isEqualTo(23);
-        assertThat(json.path("match_all").asBoolean()).isTrue();
+        assertThat(json.path("match").asText()).isEqualTo("ALL");
         assertThat(json.path("rules").isArray()).isTrue();
         assertThat(json.path("rules")).hasSize(1);
         assertThat(json.path("rules").get(0).asText()).isEqualTo("some-rule");
@@ -42,10 +43,10 @@ public class StageSourceTest {
 
     @Test
     public void testDeserialization() throws Exception {
-        final String json = "{\"stage\":23,\"match_all\":true,\"rules\":[\"some-rule\"]}";
+        final String json = "{\"stage\":23,\"match\":\"ALL\",\"rules\":[\"some-rule\"]}";
         final StageSource stageSource = objectMapper.readValue(json, StageSource.class);
         assertThat(stageSource.stage()).isEqualTo(23);
-        assertThat(stageSource.matchAll()).isTrue();
+        assertThat(stageSource.match()).isEqualTo(Stage.Match.ALL);
         assertThat(stageSource.rules())
                 .hasSize(1)
                 .containsOnly("some-rule");

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/PipelineFacadeTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/PipelineFacadeTest.java
@@ -268,7 +268,7 @@ public class PipelineFacadeTest {
     public void resolveEntityDescriptor() {
         final Stage stage = Stage.builder()
                 .stage(0)
-                .matchAll(false)
+                .match(Stage.Match.EITHER)
                 .ruleReferences(Collections.singletonList("no-op"))
                 .build();
         final Pipeline pipeline = Pipeline.builder()
@@ -347,7 +347,7 @@ public class PipelineFacadeTest {
     public void resolve() {
         final Stage stage = Stage.builder()
                 .stage(0)
-                .matchAll(false)
+                .match(Stage.Match.EITHER)
                 .ruleReferences(ImmutableList.of("debug", "no-op"))
                 .build();
 

--- a/graylog2-web-interface/src/components/pipelines/Stage.tsx
+++ b/graylog2-web-interface/src/components/pipelines/Stage.tsx
@@ -59,9 +59,26 @@ const Stage = ({ stage, pipeline, isLastStage, onUpdate, onDelete }: Props) => {
   if (isLastStage) {
     description = 'There are no further stages in this pipeline. Once rules in this stage are applied, the pipeline will have finished processing.';
   } else {
+    let matchText;
+
+    switch (stage.match) {
+      case 'ALL':
+        matchText = 'all rules';
+        break;
+      case 'EITHER':
+        matchText = 'at least one rule';
+        break;
+      case 'PASS':
+        matchText = 'none or more rules';
+        break;
+      default:
+        matchText = 'UNKNOWN';
+        break;
+    }
+
     description = (
       <span>
-        Messages satisfying <strong>{stage.match_all ? 'all rules' : 'at least one rule'}</strong>{' '}
+        Messages satisfying <strong>{matchText}</strong>{' '}
         in this stage, will continue to the next stage.
       </span>
     );

--- a/graylog2-web-interface/src/components/pipelines/StageForm.tsx
+++ b/graylog2-web-interface/src/components/pipelines/StageForm.tsx
@@ -130,19 +130,27 @@ const StageForm = ({ pipeline, stage, create, save }: Props) => {
 
           <Input type="radio"
                  id="match_all"
-                 name="match_all"
-                 value="true"
+                 name="match"
+                 value="ALL"
                  label="All rules on this stage match the message"
                  onChange={_onChange}
-                 checked={nextStage.match_all} />
+                 checked={nextStage.match === 'ALL'} />
 
           <Input type="radio"
                  id="match_any"
-                 name="match_all"
-                 value="false"
+                 name="match"
+                 value="EITHER"
                  label="At least one of the rules on this stage matches the message"
                  onChange={_onChange}
-                 checked={!nextStage.match_all} />
+                 checked={nextStage.match === 'EITHER'} />
+
+          <Input type="radio"
+                 id="match_pass"
+                 name="match"
+                 value="PASS"
+                 label="None or more rules on this stage match"
+                 onChange={_onChange}
+                 checked={nextStage.match === 'PASS'} />
 
           <Input id="stage-rules-select"
                  label="Stage rules"
@@ -169,7 +177,7 @@ StageForm.defaultProps = {
   create: false,
   stage: {
     stage: 0,
-    match_all: false,
+    match: 'EITHER',
     rules: [],
   },
 };

--- a/graylog2-web-interface/src/logic/pipelines/SourceGenerator.js
+++ b/graylog2-web-interface/src/logic/pipelines/SourceGenerator.js
@@ -19,7 +19,7 @@ const SourceGenerator = {
     let source = `pipeline "${pipeline.title}"\n`;
 
     pipeline.stages.forEach((stage) => {
-      source += `stage ${stage.stage} match ${stage.match_all ? 'all' : 'either'}\n`;
+      source += `stage ${stage.stage} match ${stage.match.toLowerCase()}\n`;
 
       stage.rules.forEach((rule) => {
         source += `rule "${rule}"\n`;

--- a/graylog2-web-interface/src/stores/pipelines/PipelinesStore.ts
+++ b/graylog2-web-interface/src/stores/pipelines/PipelinesStore.ts
@@ -37,7 +37,7 @@ export type PipelineType = {
 
 export type StageType = {
   stage: number,
-  match_all: boolean,
+  match: string,
   rules: [string],
 };
 


### PR DESCRIPTION
This allows users to define a stage with the following to make sure the
next stage is executed even when no rule in the declared stage matches.

```
pipeline "title"
stage 0 match pass
  rule "test-1"
stage 1 match all
  rule "test-2"
end
```

If the "test-1" rule in stage 0 doesn't match, the pipeline interpreter
will still execute  stage 1.