### PR TITLE
WIP: Store more detailed failure context on Messages

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/failure/FailureSubmissionService.java
+++ b/graylog2-server/src/main/java/org/graylog/failure/FailureSubmissionService.java
@@ -16,6 +16,7 @@
  */
 package org.graylog.failure;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.graylog2.indexer.messages.Indexable;
 import org.graylog2.indexer.messages.Messages.IndexingError;
 import org.graylog2.plugin.Message;
@@ -23,6 +24,7 @@ import org.graylog2.shared.utilities.ExceptionUtils;
 
 import javax.inject.Inject;
 import java.util.Collection;
+import java.util.List;
 import java.util.stream.Collectors;
 
 public class FailureSubmissionService {
@@ -64,6 +66,25 @@ public class FailureSubmissionService {
             message.setFilterOut(true);
         }
         submitProcessingFailure(message, failureContext, ExceptionUtils.getShortenedStackTrace(e));
+    }
+
+    public void handleProcessingErrors(Message message) {
+        final List<Pair<String, Object>> processingErrors = message.getProcessingErrors();
+
+        final Pair<String, String> reduced = processingErrors.stream().map((pair) -> {
+            String formatedError;
+
+                    if (pair.getRight() instanceof Exception) {
+                        final Throwable rootCause = ExceptionUtils.getRootCause((Throwable) pair.getRight());
+                        formatedError =
+
+                    } else if (pair.getRight() instanceof String) {
+                        return Pair.of(pair.getLeft(), pair.getRight());
+                    }// else { // TODO
+
+                    return Pair.of(pair.getLeft(), formatedError);
+                })
+                .reduce(Pair.of("", ""), (acc, pair) -> Pair.of("", "")));
     }
 
     public void handleProcessingFailure(Message message, String failureContext) {

--- a/graylog2-server/src/main/java/org/graylog2/inputs/extractors/JsonExtractor.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/extractors/JsonExtractor.java
@@ -27,7 +27,6 @@ import org.graylog2.ConfigurationException;
 import org.graylog2.jackson.TypeReferences;
 import org.graylog2.plugin.inputs.Converter;
 import org.graylog2.plugin.inputs.Extractor;
-import org.graylog2.shared.utilities.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -98,7 +97,7 @@ public class JsonExtractor extends Extractor {
         try {
             extractedJson = extractJson(value);
         } catch (IOException e) {
-            return new Result[]{new Result(null, null, -1, -1, ExceptionUtils.getShortenedStackTrace(e))};
+            return new Result[]{new Result(null, null, -1, -1, e)};
         }
         final List<Result> results = new ArrayList<>(extractedJson.size());
         for (Map.Entry<String, Object> entry : extractedJson.entrySet()) {

--- a/graylog2-server/src/main/java/org/graylog2/plugin/Message.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/Message.java
@@ -30,6 +30,7 @@ import com.google.common.collect.Iterators;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.common.net.InetAddresses;
+import org.apache.commons.lang3.tuple.Pair;
 import org.graylog2.indexer.IndexSet;
 import org.graylog2.indexer.messages.Indexable;
 import org.graylog2.plugin.streams.Stream;
@@ -279,9 +280,12 @@ public class Message implements Messages, Indexable {
 
     private ArrayList<Recording> recordings;
 
+    private List<Pair<String, Object>> processingErrors = new ArrayList<>(2);
+
     private com.codahale.metrics.Counter sizeCounter = new com.codahale.metrics.Counter();
 
     private static final IdentityHashMap<Class<?>, Integer> classSizes = Maps.newIdentityHashMap();
+
     static {
         classSizes.put(byte.class, 1);
         classSizes.put(Byte.class, 1);
@@ -524,6 +528,22 @@ public class Message implements Messages, Indexable {
         } else {
             addField(FIELD_GL2_PROCESSING_ERROR, error);
         }
+    }
+
+    public void addProcessingError(final String context, String error) {
+        processingErrors.add(Pair.of(context, error));
+    }
+
+    public void addProcessingException(final String context, Exception exception) {
+        processingErrors.add(Pair.of(context, exception));
+    }
+
+    public boolean hasProcessingErrors() {
+        return !processingErrors.isEmpty();
+    }
+
+    public List<Pair<String, Object>> getProcessingErrors() {
+        return processingErrors;
     }
 
     private void addRequiredField(final String key, final Object value) {

--- a/graylog2-server/src/main/java/org/graylog2/plugin/inputs/Extractor.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/inputs/Extractor.java
@@ -213,8 +213,9 @@ public abstract class Extractor implements EmbeddedPersistable {
 
             try (final Timer.Context ignored2 = executionTimer.time()) {
                 final Result[] results = run(field);
-                if (results != null && results.length == 1 && results[0].errorString != null) {
-                    msg.addProcessingError(results[0].errorString);
+                if (results != null && results.length == 1 && results[0].exception != null) {
+                    final String error = "Could not apply extractor \"" + getTitle() + "\" (id=" + getId() + ") ";
+                    msg.addProcessingException(error, results[0].exception);
                 } else if (results == null || results.length == 0 || Arrays.stream(results).anyMatch(result -> result.getValue() == null)) {
                     return;
                 } else if (results.length == 1 && results[0].target == null) {
@@ -428,7 +429,7 @@ public abstract class Extractor implements EmbeddedPersistable {
         private final String target;
         private final int beginIndex;
         private final int endIndex;
-        private final String errorString;
+        private final Exception exception;
 
         public Result(String value, int beginIndex, int endIndex) {
             this(value, null, beginIndex, endIndex);
@@ -438,12 +439,12 @@ public abstract class Extractor implements EmbeddedPersistable {
             this(value, target, beginIndex, endIndex, null);
         }
 
-        public Result(Object value, String target, int beginIndex, int endIndex, String errorString) {
+        public Result(Object value, String target, int beginIndex, int endIndex, Exception exception) {
             this.value = value;
             this.target = target;
             this.beginIndex = beginIndex;
             this.endIndex = endIndex;
-            this.errorString = errorString;
+            this.exception = exception;
         }
 
         public Object getValue() {
@@ -462,10 +463,6 @@ public abstract class Extractor implements EmbeddedPersistable {
             return endIndex;
         }
 
-        public String getErrorString() {
-            return errorString;
-        }
-
         @Override
         public boolean equals(Object o) {
             if (this == o) {
@@ -479,12 +476,12 @@ public abstract class Extractor implements EmbeddedPersistable {
                     Objects.equals(endIndex, result.endIndex) &&
                     Objects.equals(value, result.value) &&
                     Objects.equals(target, result.target) &&
-                    Objects.equals(errorString, result.errorString);
+                    Objects.equals(exception, result.exception);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(value, target, beginIndex, endIndex, errorString);
+            return Objects.hash(value, target, beginIndex, endIndex, exception);
         }
 
         @Override
@@ -494,7 +491,7 @@ public abstract class Extractor implements EmbeddedPersistable {
                     .add("target", target)
                     .add("beginIndex", beginIndex)
                     .add("endIndex", endIndex)
-                    .add("errorString", errorString)
+                    .add("errorString", exception)
                     .toString();
         }
     }

--- a/graylog2-server/src/main/java/org/graylog2/shared/buffers/processors/ProcessBufferProcessor.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/buffers/processors/ProcessBufferProcessor.java
@@ -165,7 +165,8 @@ public class ProcessBufferProcessor implements WorkHandler<MessageEvent> {
             message.setProcessingTime(Tools.nowUTC());
             processingStatusRecorder.updatePostProcessingReceiveTime(message.getReceiveTime());
 
-            if (message.hasField(Message.FIELD_GL2_PROCESSING_ERROR)) {
+//          if (message.hasField(Message.FIELD_GL2_PROCESSING_ERROR)) {
+            if (message.hasProcessingErrors()) {
                 failureSubmissionService.handleProcessingFailure(message, "process-buffer-processor");
                 if (!message.getFilterOut()) {
                     outputBuffer.insertBlocking(message);


### PR DESCRIPTION
The goal of this PR is to have a dedicated failure_cause
which for processing errors, would always be an Exception class.

The message of the rootCause can be extracted when
the failure is submitted

Multiple erros on a single message will need to be
split up into multiple ProcessingFailure objects.

