### PR TITLE
Exclude non-data nodes from ES floodgate checks

### DIFF
--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/ClusterAdapterES6.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/ClusterAdapterES6.java
@@ -102,13 +102,14 @@ public class ClusterAdapterES6 implements ClusterAdapter {
 
     @Override
     public Set<NodeDiskUsageStats> diskUsageStats() {
-        final JsonNode nodes = catNodes("name", "host", "ip", "diskUsed", "diskTotal","diskUsedPercent");
+        final JsonNode nodes = catNodes("name", "role", "host", "ip", "diskUsed", "diskTotal", "diskUsedPercent");
         final ImmutableSet.Builder<NodeDiskUsageStats> setBuilder = ImmutableSet.builder();
         for (JsonNode jsonElement : nodes) {
             if (jsonElement.isObject()) {
                 setBuilder.add(
                         NodeDiskUsageStats.create(
                                 jsonElement.path("name").asText(),
+                                jsonElement.path("role").asText(),
                                 jsonElement.path("ip").asText(),
                                 jsonElement.path("host").asText(null),
                                 jsonElement.path("diskUsed").asText(),

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/ClusterAdapterES7.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/ClusterAdapterES7.java
@@ -111,7 +111,7 @@ public class ClusterAdapterES7 implements ClusterAdapter {
     public Set<NodeDiskUsageStats> diskUsageStats() {
         final List<NodeResponse> result = nodes();
         return result.stream()
-                .map(node -> NodeDiskUsageStats.create(node.name(), node.ip(), node.host(), node.diskUsed(), node.diskTotal(), node.diskUsedPercent()))
+                .map(node -> NodeDiskUsageStats.create(node.name(), node.role(), node.ip(), node.host(), node.diskUsed(), node.diskTotal(), node.diskUsedPercent()))
                 .collect(Collectors.toSet());
     }
 

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/cat/CatApi.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/cat/CatApi.java
@@ -46,7 +46,7 @@ public class CatApi {
 
     public List<NodeResponse> nodes() {
         final Request request = request("GET", "nodes");
-        request.addParameter("h", "id,name,host,ip,fileDescriptorMax,diskUsed,diskTotal,diskUsedPercent");
+        request.addParameter("h", "id,name,role,host,ip,fileDescriptorMax,diskUsed,diskTotal,diskUsedPercent");
         request.addParameter("full_id", "true");
         return perform(request, new TypeReference<List<NodeResponse>>() {}, "Unable to retrieve nodes list");
     }

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/cat/NodeResponse.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/cat/NodeResponse.java
@@ -30,6 +30,8 @@ public abstract class NodeResponse {
 
     public abstract String name();
 
+    public abstract String role();
+
     @Nullable
     public abstract String host();
 
@@ -46,6 +48,7 @@ public abstract class NodeResponse {
     @JsonCreator
     public static NodeResponse create(@JsonProperty("id") String id,
                                       @JsonProperty("name") String name,
+                                      @JsonProperty("role") String role,
                                       @JsonProperty("host") @Nullable String host,
                                       @JsonProperty("ip") String ip,
                                       @JsonProperty("diskUsed") String diskUsed,
@@ -55,6 +58,7 @@ public abstract class NodeResponse {
         return new AutoValue_NodeResponse(
                 id,
                 name,
+                role,
                 host,
                 ip,
                 diskUsed,

--- a/graylog2-server/src/main/java/org/graylog2/indexer/cluster/health/NodeDiskUsageStats.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/cluster/health/NodeDiskUsageStats.java
@@ -19,12 +19,15 @@ package org.graylog2.indexer.cluster.health;
 import com.google.auto.value.AutoValue;
 
 import javax.annotation.Nullable;
+import java.util.EnumSet;
 
 @AutoValue
 public abstract class NodeDiskUsageStats {
     public static final double DEFAULT_DISK_USED_PERCENT = -1D;
 
     public abstract String name();
+
+    public abstract EnumSet<NodeRole> roles();
 
     public abstract String ip();
 
@@ -39,12 +42,13 @@ public abstract class NodeDiskUsageStats {
 
     public abstract Double diskUsedPercent();
 
-    public static NodeDiskUsageStats create(String name, String ip, @Nullable String host, String diskUsedString, String diskTotalString, Double diskUsedPercent) {
+    public static NodeDiskUsageStats create(String name, String roles, String ip, @Nullable String host, String diskUsedString, String diskTotalString, Double diskUsedPercent) {
         ByteSize diskTotal = SIUnitParser.parseBytesSizeValue(diskTotalString);
         ByteSize diskUsed = SIUnitParser.parseBytesSizeValue(diskUsedString);
         ByteSize diskAvailable = () -> diskTotal.getBytes() - diskUsed.getBytes();
         return new AutoValue_NodeDiskUsageStats(
                 name,
+                NodeRole.parseSymbolString(roles),
                 ip,
                 host,
                 diskTotal,

--- a/graylog2-server/src/main/java/org/graylog2/indexer/cluster/health/NodeRole.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/cluster/health/NodeRole.java
@@ -27,33 +27,38 @@ import java.util.stream.Stream;
 
 public enum NodeRole {
 
-    COLD('c'),
-    DATA('d'),
-    FROZEN('f'),
-    HOT('h'),
-    INGEST('i'),
-    MACHINE_LEARNING('l'),
-    MASTER_ELIGIBLE('m'),
-    REMOTE_CLUSTER_CLIENT('r'),
-    CONTENT('s'),
-    TRANSFORM('t'),
-    VOTING_ONLY('v'),
-    WARM('w'),
-    COORDINATING_ONLY('-');
+    COORDINATING_ONLY('-', false),
+    DATA('d', true),
+    DATA_COLD('c', true),
+    DATA_CONTENT('s', true),
+    DATA_HOT('h', true),
+    DATA_WARM('w', true),
+    FROZEN('f', true),
+    INGEST('i', false),
+    MACHINE_LEARNING('l', false),
+    MASTER_ELIGIBLE('m', false),
+    REMOTE_CLUSTER_CLIENT('r', false),
+    TRANSFORM('t', false),
+    VOTING_ONLY('v', false);
 
     private static final Logger log = LoggerFactory.getLogger(NodeRole.class);
 
     private final int symbol;
-
+    private final boolean holdsData;
     private static final Map<Integer, NodeRole> symbolToRole = Stream.of(NodeRole.values())
             .collect(Collectors.toMap(NodeRole::getSymbol, r -> r));
 
-    NodeRole(int symbol) {
+    NodeRole(int symbol, boolean holdsData) {
         this.symbol = symbol;
+        this.holdsData = holdsData;
     }
 
     public int getSymbol() {
         return symbol;
+    }
+
+    public boolean holdsData() {
+        return holdsData;
     }
 
     public static EnumSet<NodeRole> parseSymbolString(String symbols) {

--- a/graylog2-server/src/main/java/org/graylog2/indexer/cluster/health/NodeRole.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/cluster/health/NodeRole.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.indexer.cluster.health;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.EnumSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public enum NodeRole {
+
+    COLD('c'),
+    DATA('d'),
+    FROZEN('f'),
+    HOT('h'),
+    INGEST('i'),
+    MACHINE_LEARNING('l'),
+    MASTER_ELIGIBLE('m'),
+    REMOTE_CLUSTER_CLIENT('r'),
+    CONTENT('s'),
+    TRANSFORM('t'),
+    VOTING_ONLY('v'),
+    WARM('w'),
+    COORDINATING_ONLY('-');
+
+    private static final Logger log = LoggerFactory.getLogger(NodeRole.class);
+
+    private final int symbol;
+
+    private static final Map<Integer, NodeRole> symbolToRole = Stream.of(NodeRole.values())
+            .collect(Collectors.toMap(NodeRole::getSymbol, r -> r));
+
+    NodeRole(int symbol) {
+        this.symbol = symbol;
+    }
+
+    public int getSymbol() {
+        return symbol;
+    }
+
+    public static EnumSet<NodeRole> parseSymbolString(String symbols) {
+        final EnumSet<NodeRole> roles = symbols.chars().boxed()
+                .map(symbol -> {
+                    final NodeRole role = symbolToRole.get(symbol);
+                    if (role == null) {
+                        log.warn("Unknown ES node role <{}>.", (char) symbol.intValue());
+                    }
+                    return role;
+                })
+                .filter(Objects::nonNull)
+                .collect(Collectors.toCollection(() -> EnumSet.noneOf(NodeRole.class)));
+        log.debug("Parsed node roles <{}> out of symbol string <{}>.", roles, symbols);
+
+        return roles;
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/indexer/cluster/health/NodeDiskUsageStatsTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/cluster/health/NodeDiskUsageStatsTest.java
@@ -28,6 +28,7 @@ public class NodeDiskUsageStatsTest {
     public void createWithValidValues() {
         nodeDiskUsageStats = NodeDiskUsageStats.create(
                 "name",
+                "mdi",
                 "0.0.0.0",
                 "myelasticnode.graylog.org",
                 "1gb",
@@ -46,6 +47,7 @@ public class NodeDiskUsageStatsTest {
     public void hostCanBeNull() {
         nodeDiskUsageStats = NodeDiskUsageStats.create(
                 "name",
+                "mdi",
                 "0.0.0.0",
                 null,
                 "1mb",
@@ -59,6 +61,7 @@ public class NodeDiskUsageStatsTest {
     public void diskAvailabileIsCorrect() {
         nodeDiskUsageStats = NodeDiskUsageStats.create(
                 "name",
+                "mdi",
                 "0.0.0.0",
                 null,
                 "1gb",

--- a/graylog2-server/src/test/java/org/graylog2/indexer/cluster/health/NodeRoleTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/cluster/health/NodeRoleTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.indexer.cluster.health;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.graylog2.indexer.cluster.health.NodeRole.DATA;
+import static org.graylog2.indexer.cluster.health.NodeRole.INGEST;
+import static org.graylog2.indexer.cluster.health.NodeRole.MASTER_ELIGIBLE;
+
+public class NodeRoleTest {
+    @Test
+    public void parse() {
+        assertThat(NodeRole.parseSymbolString("dim")).containsExactly(DATA, INGEST,
+                MASTER_ELIGIBLE);
+    }
+
+    @Test
+    public void parseUnknown() {
+        assertThat(NodeRole.parseSymbolString("d\u00c4")).containsExactly(DATA);
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fetches an ES node's roles along with its stats and uses the roles to filter nodes when issuing low diskspace warnings.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #11074 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* Used https://www.elastic.co/guide/en/elasticsearch/reference/7.10/docker.html#docker-compose-file to start a multi-node cluster.
* Modified the docker-compose file to alter node roles
* Changed cluster settings during runtime with
```
$ curl -X PUT "localhost:9200/_cluster/settings?pretty" -H 'Content-Type: application/json' -d'
{
  "transient" : {
    "cluster.routing.allocation.disk.watermark.low" : "1%"
  }
}
'
```
* Observed watermark notifications in Graylog for the nodes holding data.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [z] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

