### PR TITLE
Fixing streams overview query handling (backport of #11100 for 4.1)

### DIFF
--- a/graylog2-web-interface/src/stores/streams/StreamsStore.ts
+++ b/graylog2-web-interface/src/stores/streams/StreamsStore.ts
@@ -123,17 +123,26 @@ const StreamsStore = singletonStore('Streams', () => Reflux.createStore({
 
     const promise = fetch('GET', qualifyUrl(url))
       .then((response: PaginatedResponse) => {
-        const pagination = {
-          count: response.pagination.count,
-          total: response.pagination.total,
-          page: response.pagination.page,
-          perPage: response.pagination.per_page,
-          query: response.pagination.query,
-        };
+        const {
+          streams,
+          query,
+          pagination: {
+            count,
+            total,
+            page,
+            per_page: perPage,
+          }
+        } = response;
 
         return {
-          streams: response.streams,
-          pagination,
+          streams,
+          pagination: {
+            count,
+            total,
+            page,
+            perPage,
+            query,
+          },
         };
       })
       .catch((errorThrown) => {

--- a/graylog2-web-interface/src/stores/streams/StreamsStore.ts
+++ b/graylog2-web-interface/src/stores/streams/StreamsStore.ts
@@ -118,8 +118,8 @@ const StreamsStore = singletonStore('Streams', () => Reflux.createStore({
 
   callbacks: [],
 
-  searchPaginated(page, perPage, query) {
-    const url = PaginationURL(ApiRoutes.StreamsApiController.paginated().url, page, perPage, query);
+  searchPaginated(newPage, newPerPage, newQuery) {
+    const url = PaginationURL(ApiRoutes.StreamsApiController.paginated().url, newPage, newPerPage, newQuery);
 
     const promise = fetch('GET', qualifyUrl(url))
       .then((response: PaginatedResponse) => {
@@ -131,7 +131,7 @@ const StreamsStore = singletonStore('Streams', () => Reflux.createStore({
             total,
             page,
             per_page: perPage,
-          }
+          },
         } = response;
 
         return {

--- a/graylog2-web-interface/src/stores/streams/StreamsStore.ts
+++ b/graylog2-web-interface/src/stores/streams/StreamsStore.ts
@@ -108,8 +108,8 @@ type PaginatedResponse = {
     total: number,
     page: number,
     per_page: number,
-    query: string,
   },
+  query: string,
   streams: Array<Stream>,
 };
 


### PR DESCRIPTION
**This is a backport of https://github.com/Graylog2/graylog2-server/pull/11100 for 4.1**

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

As described in #11091 using the stream overview pagination will reset the search. This bug occurred because we are updating the list state based on the response of the streams request. Unfortunately we were not extracting the query properly from the response.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

