### PR TITLE
Meaningful failure content

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/failure/DefaultFailureHandler.java
+++ b/graylog2-server/src/main/java/org/graylog/failure/DefaultFailureHandler.java
@@ -39,11 +39,11 @@ public class DefaultFailureHandler implements FailureHandler {
     public void handle(FailureBatch failureBatch) {
         failureBatch.getFailures().forEach(failure ->
                 indexFailureService.saveWithoutValidation(new IndexFailureImpl(ImmutableMap.<String, Object>builder()
-                    .put("letter_id", failure.failedMessageId())
+                    .put("letter_id", failure.failedMessage().getMessageId())
                     .put("index", failure.targetIndex())
                     .put("type", failure.failureType().toString())
-                    .put("message", failure.errorMessage())
-                    .put("timestamp", failure.timestamp())
+                    .put("message", failure.failureDetails())
+                    .put("timestamp", failure.failedMessage().getTimestamp())
                     .build())));
     }
 

--- a/graylog2-server/src/main/java/org/graylog/failure/Failure.java
+++ b/graylog2-server/src/main/java/org/graylog/failure/Failure.java
@@ -18,7 +18,6 @@ package org.graylog.failure;
 
 
 import org.graylog2.indexer.messages.Indexable;
-import org.graylog2.plugin.Message;
 import org.joda.time.DateTime;
 
 import javax.annotation.Nullable;
@@ -35,12 +34,28 @@ public interface Failure {
     FailureType failureType();
 
     /**
-     * Returns an id of a failed message. The id is represented
-     * by a value of the {@link Message#FIELD_GL2_MESSAGE_ID} field
-     *
-     * TODO: currently it's false for processing failures !!!
+     * Returns a cause of this failure
      */
-    String failedMessageId();
+    FailureCause failureCause();
+
+    /**
+     * Returns a brief description of this failure, which
+     * is supposed to answer the following 2 questions:
+     *      1) WHAT has happened?
+     *      2) WHICH component has caused it?
+     */
+    String message();
+
+    /**
+     * Returns further failure details, which are supposed
+     * to answer the question "WHY this failure has happened?"
+     */
+    String failureDetails();
+
+    /**
+     * Returns a timestamp of this failure
+     */
+    DateTime failureTimestamp();
 
     /**
      * Returns a failed message
@@ -55,20 +70,6 @@ public interface Failure {
     @Nullable
     String targetIndex();
 
-    /**
-     * Returns a subcategory of this failure
-     */
-    String errorType();
-
-    /**
-     * Returns a detailed error message
-     */
-    String errorMessage();
-
-    /**
-     * Returns a timestamp of the failed message
-     */
-    DateTime timestamp();
 
     /**
      * Returns true if the failed message must

--- a/graylog2-server/src/main/java/org/graylog/failure/FailureCause.java
+++ b/graylog2-server/src/main/java/org/graylog/failure/FailureCause.java
@@ -1,0 +1,5 @@
+package org.graylog.failure;
+
+public interface FailureCause {
+    String label();
+}

--- a/graylog2-server/src/main/java/org/graylog/failure/FailureCause.java
+++ b/graylog2-server/src/main/java/org/graylog/failure/FailureCause.java
@@ -16,6 +16,9 @@
  */
 package org.graylog.failure;
 
+/**
+ * A tag-like label representing a failure cause
+ */
 public interface FailureCause {
     String label();
 }

--- a/graylog2-server/src/main/java/org/graylog/failure/FailureCause.java
+++ b/graylog2-server/src/main/java/org/graylog/failure/FailureCause.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog.failure;
 
 public interface FailureCause {

--- a/graylog2-server/src/main/java/org/graylog/failure/FailureSubmissionQueue.java
+++ b/graylog2-server/src/main/java/org/graylog/failure/FailureSubmissionQueue.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.failure;
+
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricRegistry;
+import org.graylog2.Configuration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import static com.codahale.metrics.MetricRegistry.name;
+
+/**
+ * A blocking FIFO queue accepting failure batches for further handling.
+ * It should be used as an entry point for failure producers.
+ *
+ * The service was introduced for 2 essential reasons:
+ *  1. To control pressure on the failure handling framework.
+ *  2. To decouple failure producers from failure consumers.
+ *
+ * The capacity of the underlying queue is controlled by `failure_handling_queue_capacity` configuration
+ * property. By default its value is 1000.
+ */
+@Singleton
+public class FailureSubmissionQueue {
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    private final BlockingQueue<FailureBatch> queue;
+    private final Configuration configuration;
+    private final Meter submittedFailureBatches;
+    private final Meter submittedFailures;
+    private final Meter consumedFailureBatches;
+    private final Meter consumedFailures;
+
+    @Inject
+    public FailureSubmissionQueue(Configuration configuration,
+                                  MetricRegistry metricRegistry) {
+        this.queue = new LinkedBlockingQueue<>(configuration.getFailureHandlingQueueCapacity());
+        this.configuration = configuration;
+        this.submittedFailureBatches = metricRegistry.meter(name(FailureSubmissionQueue.class, "submittedFailureBatches"));
+        this.submittedFailures = metricRegistry.meter(name(FailureSubmissionQueue.class, "submittedFailures"));
+        this.consumedFailureBatches = metricRegistry.meter(name(FailureSubmissionQueue.class, "consumedFailureBatches"));
+        this.consumedFailures = metricRegistry.meter(name(FailureSubmissionQueue.class, "consumedFailures"));
+    }
+
+    /**
+     * Submits a failure batch for handling. If the underlying queue is full,
+     * the call will block until the queue is ready to accept new batches.
+     */
+    public void submitBlocking(FailureBatch batch) throws InterruptedException {
+        queue.put(batch);
+
+        if (queueSize() == configuration.getFailureHandlingQueueCapacity()) {
+            logger.debug("The queue is full! Current capacity: {}", configuration.getFailureHandlingQueueCapacity());
+        }
+
+        submittedFailureBatches.mark();
+        submittedFailures.mark(batch.size());
+    }
+
+    /**
+     * Logs current submission/consumption stats.
+     */
+    void logStats(String tag) {
+        logger.info("[{}] Total number of submitted batches: {} ({} failures), total number of consumed batches: {} ({} failures)",
+                tag,
+                submittedFailureBatches.getCount(), submittedFailures.getCount(),
+                consumedFailureBatches.getCount(), consumedFailures.getCount());
+    }
+
+    /**
+     * @return one batch from the queue. If the queue is empty,
+     * waits for a batch to become available.
+     */
+    FailureBatch consumeBlocking() throws InterruptedException {
+        final FailureBatch fb = queue.take();
+        consumedFailureBatches.mark();
+        consumedFailures.mark(fb.size());
+        return fb;
+    }
+
+
+    /**
+     * @return one batch from the queue. If the queue is empty,
+     * waits for the specified period of time for a batch to become available,
+     * otherwise returns null.
+     */
+    @Nullable
+    FailureBatch consumeBlockingWithTimeout(long timeoutInMs) throws InterruptedException {
+        final FailureBatch fb = queue.poll(timeoutInMs, TimeUnit.MILLISECONDS);
+        if (fb != null) {
+            consumedFailureBatches.mark();
+            consumedFailures.mark(fb.size());
+        }
+        return fb;
+    }
+
+    /**
+     * @return the current amount of failure batches in the queue.
+     */
+    int queueSize() {
+        return queue.size();
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/failure/FailureSubmissionService.java
+++ b/graylog2-server/src/main/java/org/graylog/failure/FailureSubmissionService.java
@@ -1,126 +1,123 @@
-/*
- * Copyright (C) 2020 Graylog, Inc.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the Server Side Public License, version 1,
- * as published by MongoDB, Inc.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * Server Side Public License for more details.
- *
- * You should have received a copy of the Server Side Public License
- * along with this program. If not, see
- * <http://www.mongodb.com/licensing/server-side-public-license>.
- */
 package org.graylog.failure;
 
-import com.codahale.metrics.Meter;
-import com.codahale.metrics.MetricRegistry;
-import org.graylog2.Configuration;
+import com.google.common.collect.ImmutableList;
+import org.apache.commons.lang3.StringUtils;
+import org.graylog2.indexer.messages.Messages;
+import org.graylog2.plugin.Message;
+import org.graylog2.plugin.Tools;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.TimeUnit;
+import java.util.Collection;
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.Collectors;
 
-import static com.codahale.metrics.MetricRegistry.name;
-
-/**
- * A blocking FIFO queue accepting failure batches for further handling.
- * It should be used as an entry point for failure producers.
- *
- * The service was introduced for 2 essential reasons:
- *  1. To control pressure on the failure handling framework.
- *  2. To decouple failure producers from failure consumers.
- *
- * The capacity of the underlying queue is controlled by `failure_handling_queue_capacity` configuration
- * property. By default its value is 1000.
- */
 @Singleton
 public class FailureSubmissionService {
 
     private final Logger logger = LoggerFactory.getLogger(getClass());
 
-    private final BlockingQueue<FailureBatch> queue;
-    private final Configuration configuration;
-    private final Meter submittedFailureBatches;
-    private final Meter submittedFailures;
-    private final Meter consumedFailureBatches;
-    private final Meter consumedFailures;
+    private final FailureSubmissionQueue failureSubmissionQueue;
+    private final FailureHandlingConfiguration failureHandlingConfiguration;
 
     @Inject
-    public FailureSubmissionService(Configuration configuration,
-                                    MetricRegistry metricRegistry) {
-        this.queue = new LinkedBlockingQueue<>(configuration.getFailureHandlingQueueCapacity());
-        this.configuration = configuration;
-        this.submittedFailureBatches = metricRegistry.meter(name(FailureSubmissionService.class, "submittedFailureBatches"));
-        this.submittedFailures = metricRegistry.meter(name(FailureSubmissionService.class, "submittedFailures"));
-        this.consumedFailureBatches = metricRegistry.meter(name(FailureSubmissionService.class, "consumedFailureBatches"));
-        this.consumedFailures = metricRegistry.meter(name(FailureSubmissionService.class, "consumedFailures"));
+    public FailureSubmissionService(
+            FailureSubmissionQueue failureSubmissionQueue,
+            FailureHandlingConfiguration failureHandlingConfiguration) {
+        this.failureSubmissionQueue = failureSubmissionQueue;
+        this.failureHandlingConfiguration = failureHandlingConfiguration;
     }
 
-    /**
-     * Submits a failure batch for handling. If the underlying queue is full,
-     * the call will block until the queue is ready to accept new batches.
-     */
-    public void submitBlocking(FailureBatch batch) throws InterruptedException {
-        queue.put(batch);
 
-        if (queueSize() == configuration.getFailureHandlingQueueCapacity()) {
-            logger.debug("The queue is full! Current capacity: {}", configuration.getFailureHandlingQueueCapacity());
+    public boolean submitUnknownProcessingError(Message message, String details) {
+        return submitProcessingErrorsInternal(message, ImmutableList.of(new Message.ProcessingError(
+                ProcessingFailureCause.UNKNOWN,
+                "Encountered an unrecognizable processing error",
+                details)));
+    }
+
+    public boolean submitProcessingErrors(Message message) {
+        return submitProcessingErrorsInternal(message, message.processingErrors());
+    }
+
+    private boolean submitProcessingErrorsInternal(Message message, List<Message.ProcessingError> processingErrors) {
+        if (!failureHandlingConfiguration.submitProcessingFailures()) {
+            // We don't handle processing errors
+            return true;
+        }
+        if (processingErrors.isEmpty()) {
+            return true;
+        }
+        if (!failureHandlingConfiguration.keepFailedMessageDuplicate()) {
+            message.setFilterOut(true);
         }
 
-        submittedFailureBatches.mark();
-        submittedFailures.mark(batch.size());
+        processingErrors.forEach(pe -> submitProcessingFailure(message, pe));
+
+        return !message.getFilterOut();
     }
 
-    /**
-     * Logs current submission/consumption stats.
-     */
-    void logStats(String tag) {
-        logger.info("[{}] Total number of submitted batches: {} ({} failures), total number of consumed batches: {} ({} failures)",
-                tag,
-                submittedFailureBatches.getCount(), submittedFailures.getCount(),
-                consumedFailureBatches.getCount(), consumedFailures.getCount());
-    }
+    private void submitProcessingFailure(Message failedMessage, Message.ProcessingError processingError) {
+        try {
+            // If we store the regular message, the acknowledgement happens in the output path
+            final boolean needsAcknowledgement = !failureHandlingConfiguration.keepFailedMessageDuplicate();
 
-    /**
-     * @return one batch from the queue. If the queue is empty,
-     * waits for a batch to become available.
-     */
-    FailureBatch consumeBlocking() throws InterruptedException {
-        final FailureBatch fb = queue.take();
-        consumedFailureBatches.mark();
-        consumedFailures.mark(fb.size());
-        return fb;
-    }
+            final String message;
 
+            if (StringUtils.isBlank(failedMessage.getMessageId())) {
+                message = String.format(Locale.ENGLISH,
+                        "Failed to process a message with unknown id. %s",
+                        processingError.getMessage());
+            } else {
+                message = String.format(Locale.ENGLISH,
+                        "Failed to process message with id '%s'. %s",
+                        failedMessage.getMessageId(),
+                        processingError.getMessage());
+            }
 
-    /**
-     * @return one batch from the queue. If the queue is empty,
-     * waits for the specified period of time for a batch to become available,
-     * otherwise returns null.
-     */
-    @Nullable
-    FailureBatch consumeBlockingWithTimeout(long timeoutInMs) throws InterruptedException {
-        final FailureBatch fb = queue.poll(timeoutInMs, TimeUnit.MILLISECONDS);
-        if (fb != null) {
-            consumedFailureBatches.mark();
-            consumedFailures.mark(fb.size());
+            final ProcessingFailure processingFailure = new ProcessingFailure(
+                    processingError.getCause(),
+                    message,
+                    processingError.getDetails(),
+                    Tools.nowUTC(),
+                    failedMessage,
+                    needsAcknowledgement);
+
+            failureSubmissionQueue.submitBlocking(FailureBatch.processingFailureBatch(processingFailure));
+        } catch (InterruptedException ignored) {
+            logger.warn("Failed to submit a processing failure for failure handling. The thread has been interrupted!");
+            Thread.currentThread().interrupt();
         }
-        return fb;
     }
 
-    /**
-     * @return the current amount of failure batches in the queue.
-     */
-    int queueSize() {
-        return queue.size();
+    public void submitIndexingErrors(Collection<Messages.IndexingError> indexingErrors) {
+        try {
+            failureSubmissionQueue.submitBlocking(FailureBatch.indexingFailureBatch(
+                    indexingErrors.stream()
+                            .map(this::fromIndexingError)
+                            .collect(Collectors.toList())));
+
+        } catch (InterruptedException ignored) {
+            logger.warn("Failed to submit {} indexing errors for failure handling. The thread has been interrupted!",
+                    indexingErrors.size());
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private IndexingFailure fromIndexingError(Messages.IndexingError indexingError) {
+        return new IndexingFailure(
+                indexingError.errorType() == Messages.IndexingError.ErrorType.MappingError ?
+                        IndexingFailureCause.MappingError : IndexingFailureCause.UNKNOWN,
+                String.format(Locale.ENGLISH,
+                        "Failed to index message with id '%s' targeting '%s'",
+                        indexingError.message().getMessageId(), indexingError.index()),
+                indexingError.errorMessage(),
+                Tools.nowUTC(),
+                indexingError.message(),
+                indexingError.index()
+        );
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/failure/FailureSubmissionService.java
+++ b/graylog2-server/src/main/java/org/graylog/failure/FailureSubmissionService.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog.failure;
 
 import com.google.common.collect.ImmutableList;

--- a/graylog2-server/src/main/java/org/graylog/failure/IndexingFailure.java
+++ b/graylog2-server/src/main/java/org/graylog/failure/IndexingFailure.java
@@ -16,6 +16,7 @@
  */
 package org.graylog.failure;
 
+import com.google.common.base.Objects;
 import org.graylog2.indexer.messages.Indexable;
 import org.joda.time.DateTime;
 
@@ -23,25 +24,26 @@ import javax.annotation.Nullable;
 
 public class IndexingFailure implements Failure {
 
-    private final String failedMessageId;
-    private final String targetIndex;
-    private final String errorType;
-    private final String errorMessage;
-    private final DateTime timestamp;
+    private final FailureCause failureCause;
+    private final String message;
+    private final String failureDetails;
+    private final DateTime failureTimestamp;
     private final Indexable failedMessage;
+    private final String targetIndex;
 
-    public IndexingFailure(String failedMessageId,
-                           String targetIndex,
-                           String errorType,
-                           String errorMessage,
-                           DateTime timestamp,
-                           Indexable failedMessage) {
-        this.failedMessageId = failedMessageId;
-        this.targetIndex = targetIndex;
-        this.errorType = errorType;
-        this.errorMessage = errorMessage;
-        this.timestamp = timestamp;
+    public IndexingFailure(
+            FailureCause failureCause,
+            String message,
+            String failureDetails,
+            DateTime failureTimestamp,
+            Indexable failedMessage,
+            String targetIndex) {
+        this.failureCause = failureCause;
+        this.message = message;
+        this.failureDetails = failureDetails;
+        this.failureTimestamp = failureTimestamp;
         this.failedMessage = failedMessage;
+        this.targetIndex = targetIndex;
     }
 
     @Override
@@ -50,8 +52,28 @@ public class IndexingFailure implements Failure {
     }
 
     @Override
-    public String failedMessageId() {
-        return failedMessageId;
+    public FailureCause failureCause() {
+        return failureCause;
+    }
+
+    @Override
+    public String message() {
+        return message;
+    }
+
+    @Override
+    public String failureDetails() {
+        return failureDetails;
+    }
+
+    @Override
+    public DateTime failureTimestamp() {
+        return failureTimestamp;
+    }
+
+    @Override
+    public Indexable failedMessage() {
+        return failedMessage;
     }
 
     @Nullable
@@ -61,27 +83,25 @@ public class IndexingFailure implements Failure {
     }
 
     @Override
-    public String errorType() {
-        return errorType;
-    }
-
-    @Override
-    public String errorMessage() {
-        return errorMessage;
-    }
-
-    @Override
-    public DateTime timestamp() {
-        return timestamp;
-    }
-
-    @Override
-    public Indexable failedMessage() {
-        return failedMessage;
-    }
-
-    @Override
     public boolean requiresAcknowledgement() {
         return false;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        final IndexingFailure that = (IndexingFailure) o;
+        return Objects.equal(failureCause, that.failureCause)
+                && Objects.equal(message, that.message)
+                && Objects.equal(failureDetails, that.failureDetails)
+                && Objects.equal(failureTimestamp, that.failureTimestamp)
+                && Objects.equal(failedMessage, that.failedMessage)
+                && Objects.equal(targetIndex, that.targetIndex);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(failureCause, message, failureDetails, failureTimestamp, failedMessage, targetIndex);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/failure/IndexingFailureCause.java
+++ b/graylog2-server/src/main/java/org/graylog/failure/IndexingFailureCause.java
@@ -1,0 +1,16 @@
+package org.graylog.failure;
+
+public enum IndexingFailureCause implements FailureCause {
+    MappingError("MappingError"),
+    UNKNOWN("UNKNOWN");
+
+    private final String label;
+
+    IndexingFailureCause(String label) {
+        this.label = label;
+    }
+
+    public String label() {
+        return label;
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/failure/IndexingFailureCause.java
+++ b/graylog2-server/src/main/java/org/graylog/failure/IndexingFailureCause.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog.failure;
 
 public enum IndexingFailureCause implements FailureCause {

--- a/graylog2-server/src/main/java/org/graylog/failure/ProcessingFailure.java
+++ b/graylog2-server/src/main/java/org/graylog/failure/ProcessingFailure.java
@@ -24,23 +24,24 @@ import javax.annotation.Nullable;
 
 public class ProcessingFailure implements Failure {
 
-    private final String failedMessageId;
-    private final String errorType;
-    private final String errorMessage;
-    private final DateTime timestamp;
+    private final FailureCause failureCause;
+    private final String message;
+    private final String failureDetails;
+    private final DateTime failureTimestamp;
     private final Indexable failedMessage;
     private final boolean requiresAcknowledgement;
 
-    public ProcessingFailure(String failedMessageId,
-                             String errorType,
-                             String errorMessage,
-                             DateTime timestamp,
-                             Indexable failedMessage,
-                             boolean requiresAcknowledgement) {
-        this.failedMessageId = failedMessageId;
-        this.errorType = errorType;
-        this.errorMessage = errorMessage;
-        this.timestamp = timestamp;
+    public ProcessingFailure(
+            FailureCause failureCause,
+            String message,
+            String failureDetails,
+            DateTime failureTimestamp,
+            Indexable failedMessage,
+            boolean requiresAcknowledgement) {
+        this.failureCause = failureCause;
+        this.message = message;
+        this.failureDetails = failureDetails;
+        this.failureTimestamp = failureTimestamp;
         this.failedMessage = failedMessage;
         this.requiresAcknowledgement = requiresAcknowledgement;
     }
@@ -51,34 +52,34 @@ public class ProcessingFailure implements Failure {
     }
 
     @Override
-    public String failedMessageId() {
-        return failedMessageId;
+    public FailureCause failureCause() {
+        return failureCause;
+    }
+
+    @Override
+    public String message() {
+        return message;
+    }
+
+    @Override
+    public String failureDetails() {
+        return failureDetails;
+    }
+
+    @Override
+    public DateTime failureTimestamp() {
+        return failureTimestamp;
+    }
+
+    @Override
+    public Indexable failedMessage() {
+        return failedMessage;
     }
 
     @Nullable
     @Override
     public String targetIndex() {
         return null;
-    }
-
-    @Override
-    public String errorType() {
-        return errorType;
-    }
-
-    @Override
-    public String errorMessage() {
-        return errorMessage;
-    }
-
-    @Override
-    public DateTime timestamp() {
-        return timestamp;
-    }
-
-    @Override
-    public Indexable failedMessage() {
-        return failedMessage;
     }
 
     @Override
@@ -91,16 +92,16 @@ public class ProcessingFailure implements Failure {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         final ProcessingFailure that = (ProcessingFailure) o;
-        return Objects.equal(failedMessageId, that.failedMessageId)
-                && Objects.equal(errorType, that.errorType)
-                && Objects.equal(errorMessage, that.errorMessage)
-                && Objects.equal(timestamp, that.timestamp)
-                && Objects.equal(failedMessage, that.failedMessage)
-                && Objects.equal(requiresAcknowledgement, that.requiresAcknowledgement);
+        return requiresAcknowledgement == that.requiresAcknowledgement
+                && Objects.equal(failureCause, that.failureCause)
+                && Objects.equal(message, that.message)
+                && Objects.equal(failureDetails, that.failureDetails)
+                && Objects.equal(failureTimestamp, that.failureTimestamp)
+                && Objects.equal(failedMessage, that.failedMessage);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(failedMessageId, errorType, errorMessage, timestamp, failedMessage, requiresAcknowledgement);
+        return Objects.hashCode(failureCause, message, failureDetails, failureTimestamp, failedMessage, requiresAcknowledgement);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/failure/ProcessingFailureCause.java
+++ b/graylog2-server/src/main/java/org/graylog/failure/ProcessingFailureCause.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog.failure;
 
 public enum ProcessingFailureCause implements FailureCause {

--- a/graylog2-server/src/main/java/org/graylog/failure/ProcessingFailureCause.java
+++ b/graylog2-server/src/main/java/org/graylog/failure/ProcessingFailureCause.java
@@ -1,0 +1,18 @@
+package org.graylog.failure;
+
+public enum ProcessingFailureCause implements FailureCause {
+    RuleStatementEvaluationError("RuleStatementEvaluationError"),
+    RuleConditionEvaluationError("RuleConditionEvaluationError"),
+    UNKNOWN("UNKNOWN"),
+    ;
+
+    private final String label;
+
+    ProcessingFailureCause(String label) {
+        this.label = label;
+    }
+
+    public String label() {
+        return label;
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/plugin/Message.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/Message.java
@@ -425,7 +425,7 @@ public class Message implements Messages, Indexable {
             obj.put(FIELD_GL2_PROCESSING_ERROR,
                     processingErrors.stream()
                             .map(ProcessingError::getDetails)
-                            .collect(Collectors.joining(",")));
+                            .collect(Collectors.joining(", ")));
         }
 
         final Object timestampValue = getField(FIELD_TIMESTAMP);
@@ -914,16 +914,13 @@ public class Message implements Messages, Indexable {
     }
 
     /**
-     * Appends another processing error. After being done with processing, all errors
-     * are joined into one string and stored in {@link org.graylog2.plugin.Message.FIELD_GL2_PROCESSING_ERROR}
+     * Appends another processing error.
      *
      * @param processingError another processing error to be appended.
      *                        Must not be null.
-     * @return this message
      */
-    public Message addProcessingError(@Nonnull ProcessingError processingError) {
+    public void addProcessingError(@Nonnull ProcessingError processingError) {
         processingErrors.add(processingError);
-        return this;
     }
 
     /**

--- a/graylog2-server/src/main/java/org/graylog2/plugin/Message.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/Message.java
@@ -21,7 +21,9 @@ import com.eaio.uuid.UUID;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
+import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
@@ -29,6 +31,7 @@ import com.google.common.collect.Iterators;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.common.net.InetAddresses;
+import org.graylog.failure.FailureCause;
 import org.graylog2.indexer.IndexSet;
 import org.graylog2.indexer.messages.Indexable;
 import org.graylog2.plugin.streams.Stream;
@@ -60,6 +63,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import static com.google.common.base.Predicates.equalTo;
 import static com.google.common.base.Predicates.not;
@@ -280,6 +284,8 @@ public class Message implements Messages, Indexable {
 
     private com.codahale.metrics.Counter sizeCounter = new com.codahale.metrics.Counter();
 
+    private List<ProcessingError> processingErrors = new ArrayList<>();
+
     private static final IdentityHashMap<Class<?>, Integer> classSizes = Maps.newIdentityHashMap();
     static {
         classSizes.put(byte.class, 1);
@@ -414,6 +420,13 @@ public class Message implements Messages, Indexable {
         obj.put(FIELD_SOURCE, getSource());
         obj.put(FIELD_STREAMS, getStreamIds());
         obj.put(FIELD_GL2_ACCOUNTED_MESSAGE_SIZE, getSize());
+
+        if (!processingErrors.isEmpty()) {
+            obj.put(FIELD_GL2_PROCESSING_ERROR,
+                    processingErrors.stream()
+                            .map(ProcessingError::getDetails)
+                            .collect(Collectors.joining(",")));
+        }
 
         final Object timestampValue = getField(FIELD_TIMESTAMP);
         DateTime dateTime;
@@ -900,6 +913,26 @@ public class Message implements Messages, Indexable {
         return !serverStatus.getDetailedMessageRecordingStrategy().shouldRecord(this);
     }
 
+    /**
+     * Appends another processing error. After being done with processing, all errors
+     * are joined into one string and stored in {@link org.graylog2.plugin.Message.FIELD_GL2_PROCESSING_ERROR}
+     *
+     * @param processingError another processing error to be appended.
+     *                        Must not be null.
+     * @return this message
+     */
+    public Message addProcessingError(@Nonnull ProcessingError processingError) {
+        processingErrors.add(processingError);
+        return this;
+    }
+
+    /**
+     * Returns a list of submitted processing errors
+     */
+    public List<ProcessingError> processingErrors() {
+        return ImmutableList.copyOf(processingErrors);
+    }
+
     @Override
     @Nonnull
     public Iterator<Message> iterator() {
@@ -955,6 +988,49 @@ public class Message implements Messages, Indexable {
         @Override
         public String apply(final Message input) {
             return input.getId();
+        }
+    }
+
+    public static class ProcessingError {
+
+        private final FailureCause cause;
+        private final String message;
+        private final String details;
+
+        public ProcessingError(@Nonnull FailureCause cause,
+                               @Nonnull String message,
+                               @Nonnull String details) {
+            this.cause = cause;
+            this.message = message;
+            this.details = details;
+        }
+
+        @Nonnull
+        public FailureCause getCause() {
+            return cause;
+        }
+
+        @Nonnull
+        public String getMessage() {
+            return message;
+        }
+
+        @Nonnull
+        public String getDetails() {
+            return details;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            final ProcessingError that = (ProcessingError) o;
+            return Objects.equal(cause, that.cause) && Objects.equal(message, that.message) && Objects.equal(details, that.details);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(cause, message, details);
         }
     }
 }

--- a/graylog2-server/src/test/java/org/graylog/failure/FailureBatchTest.java
+++ b/graylog2-server/src/test/java/org/graylog/failure/FailureBatchTest.java
@@ -16,14 +16,12 @@
  */
 package org.graylog.failure;
 
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
+import org.graylog2.plugin.Tools;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.shaded.com.google.common.collect.ImmutableList;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
@@ -122,22 +120,22 @@ public class FailureBatchTest {
 
     private IndexingFailure createIndexingFailure() {
         return new IndexingFailure(
-                UUID.randomUUID().toString(), "target-index", "error-type", "error-message",
-                DateTime.now(DateTimeZone.UTC), null
+                IndexingFailureCause.MappingError, "Mapping Failed", "Cannot cast String to Double",
+                Tools.nowUTC(), null, "target-index"
         );
     }
 
     private ProcessingFailure createProcessingFailure() {
         return new ProcessingFailure(
-                UUID.randomUUID().toString(), "error-type", "error-message",
-                DateTime.now(DateTimeZone.UTC), null,
+                ProcessingFailureCause.UNKNOWN, "failure-cause", "failure-details",
+                Tools.nowUTC(), null,
                 true);
     }
 }
 
 class CustomIndexingFailure extends IndexingFailure {
     CustomIndexingFailure() {
-        super(UUID.randomUUID().toString(), "target-index", "error-type", "error-message",
-                DateTime.now(DateTimeZone.UTC), null);
+        super(IndexingFailureCause.UNKNOWN, "Mapping Failed", "Cannot cast String to Double",
+                Tools.nowUTC(), null, "target-index");
     }
 }

--- a/graylog2-server/src/test/java/org/graylog/failure/FailureSubmissionQueueTest.java
+++ b/graylog2-server/src/test/java/org/graylog/failure/FailureSubmissionQueueTest.java
@@ -23,7 +23,6 @@ import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.junit.Test;
 
-import java.util.UUID;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -32,7 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class FailureSubmissionServiceTest {
+public class FailureSubmissionQueueTest {
 
     private final Configuration configuration = mock(Configuration.class);
 
@@ -48,7 +47,7 @@ public class FailureSubmissionServiceTest {
         //given
         when(configuration.getFailureHandlingQueueCapacity()).thenReturn(1000);
 
-        final FailureSubmissionService underTest = new FailureSubmissionService(configuration, metricRegistry);
+        final FailureSubmissionQueue underTest = new FailureSubmissionQueue(configuration, metricRegistry);
 
         final ProcessingFailure prcFailure1 = createProcessingFailure();
         final ProcessingFailure prcFailure2 = createProcessingFailure();
@@ -68,7 +67,7 @@ public class FailureSubmissionServiceTest {
         //given
         when(configuration.getFailureHandlingQueueCapacity()).thenReturn(2);
 
-        final FailureSubmissionService underTest = new FailureSubmissionService(configuration, metricRegistry);
+        final FailureSubmissionQueue underTest = new FailureSubmissionQueue(configuration, metricRegistry);
 
         final ProcessingFailure prcFailure1 = createProcessingFailure();
         final ProcessingFailure prcFailure2 = createProcessingFailure();
@@ -104,7 +103,7 @@ public class FailureSubmissionServiceTest {
         //given
         when(configuration.getFailureHandlingQueueCapacity()).thenReturn(2);
 
-        final FailureSubmissionService underTest = new FailureSubmissionService(configuration, metricRegistry);
+        final FailureSubmissionQueue underTest = new FailureSubmissionQueue(configuration, metricRegistry);
 
         final ProcessingFailure prcFailure1 = createProcessingFailure();
 
@@ -131,7 +130,7 @@ public class FailureSubmissionServiceTest {
         //given
         when(configuration.getFailureHandlingQueueCapacity()).thenReturn(2);
 
-        final FailureSubmissionService underTest = new FailureSubmissionService(configuration, metricRegistry);
+        final FailureSubmissionQueue underTest = new FailureSubmissionQueue(configuration, metricRegistry);
 
         final ProcessingFailure prcFailure1 = createProcessingFailure();
 
@@ -158,7 +157,7 @@ public class FailureSubmissionServiceTest {
         //given
         when(configuration.getFailureHandlingQueueCapacity()).thenReturn(2);
 
-        final FailureSubmissionService underTest = new FailureSubmissionService(configuration, metricRegistry);
+        final FailureSubmissionQueue underTest = new FailureSubmissionQueue(configuration, metricRegistry);
 
         final ProcessingFailure prcFailure1 = createProcessingFailure();
 
@@ -179,7 +178,7 @@ public class FailureSubmissionServiceTest {
 
     private ProcessingFailure createProcessingFailure() {
         return new ProcessingFailure(
-                UUID.randomUUID().toString(), "error-type", "error-message",
+                ProcessingFailureCause.UNKNOWN, "message", "details",
                 DateTime.now(DateTimeZone.UTC), null,
                 true);
     }

--- a/graylog2-server/src/test/java/org/graylog/failure/FailureSubmissionServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/failure/FailureSubmissionServiceTest.java
@@ -1,0 +1,294 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.failure;
+
+import org.graylog2.indexer.messages.Messages;
+import org.graylog2.plugin.Message;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.testcontainers.shaded.com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+public class FailureSubmissionServiceTest {
+
+    private final FailureSubmissionQueue failureSubmissionQueue = Mockito.mock(FailureSubmissionQueue.class);
+    private final FailureHandlingConfiguration failureHandlingConfiguration = Mockito.mock(FailureHandlingConfiguration.class);
+    private final FailureSubmissionService underTest = new FailureSubmissionService(failureSubmissionQueue, failureHandlingConfiguration);
+
+    private final ArgumentCaptor<FailureBatch> failureBatchCaptor = ArgumentCaptor.forClass(FailureBatch.class);
+
+    @Test
+    public void submitIndexingErrors_allIndexingErrorsTransformedAndSubmittedToFailureQueue() throws Exception {
+        // given
+        final Message msg1 = Mockito.mock(Message.class);
+        when(msg1.getMessageId()).thenReturn("msg-1");
+        final Message msg2 = Mockito.mock(Message.class);
+        when(msg2.getMessageId()).thenReturn("msg-2");
+
+        final List<Messages.IndexingError> indexingErrors = ImmutableList.of(
+                Messages.IndexingError.create(msg1, "index-1", Messages.IndexingError.ErrorType.MappingError, "Error"),
+                Messages.IndexingError.create(msg2, "index-2", Messages.IndexingError.ErrorType.Unknown, "Error2")
+        );
+
+        // when
+        underTest.submitIndexingErrors(indexingErrors);
+
+        // then
+        verify(failureSubmissionQueue, times(1)).submitBlocking(failureBatchCaptor.capture());
+
+        assertThat(failureBatchCaptor.getValue()).satisfies(fb -> {
+            assertThat(fb.containsIndexingFailures()).isTrue();
+            assertThat(fb.size()).isEqualTo(2);
+
+            assertThat(fb.getFailures().get(0)).satisfies(indexingFailure -> {
+                assertThat(indexingFailure.failureType()).isEqualTo(FailureType.INDEXING);
+                assertThat(indexingFailure.failureCause().label()).isEqualTo("MappingError");
+                assertThat(indexingFailure.message()).isEqualTo("Failed to index message with id 'msg-1' targeting 'index-1'");
+                assertThat(indexingFailure.failureDetails()).isEqualTo("Error");
+                assertThat(indexingFailure.failureTimestamp()).isNotNull();
+                assertThat(indexingFailure.failedMessage()).isEqualTo(msg1);
+                assertThat(indexingFailure.targetIndex()).isEqualTo("index-1");
+                assertThat(indexingFailure.requiresAcknowledgement()).isFalse();
+            });
+
+            assertThat(fb.getFailures().get(1)).satisfies(indexingFailure -> {
+                assertThat(indexingFailure.failureType()).isEqualTo(FailureType.INDEXING);
+                assertThat(indexingFailure.failureCause().label()).isEqualTo("UNKNOWN");
+                assertThat(indexingFailure.message()).isEqualTo("Failed to index message with id 'msg-2' targeting 'index-2'");
+                assertThat(indexingFailure.failureDetails()).isEqualTo("Error2");
+                assertThat(indexingFailure.failureTimestamp()).isNotNull();
+                assertThat(indexingFailure.failedMessage()).isEqualTo(msg2);
+                assertThat(indexingFailure.targetIndex()).isEqualTo("index-2");
+                assertThat(indexingFailure.requiresAcknowledgement()).isFalse();
+            });
+        });
+    }
+
+
+    @Test
+    public void submitProcessingErrors_allProcessingErrorsSubmittedToQueueAndMessageNotFilteredOut_ifSubmissionEnabledAndDuplicatesAreKept() throws Exception {
+        // given
+        final Message msg = Mockito.mock(Message.class);
+        when(msg.getMessageId()).thenReturn("msg-x");
+
+        when(msg.processingErrors()).thenReturn(ImmutableList.of(
+                new Message.ProcessingError(() -> "Cause 1", "Message 1", "Details 1"),
+                new Message.ProcessingError(() -> "Cause 2", "Message 2", "Details 2")
+        ));
+
+        when(failureHandlingConfiguration.submitProcessingFailures()).thenReturn(true);
+        when(failureHandlingConfiguration.keepFailedMessageDuplicate()).thenReturn(true);
+
+        // when
+        final boolean notFilterOut = underTest.submitProcessingErrors(msg);
+
+        // then
+
+        assertThat(notFilterOut).isTrue();
+
+        verify(failureSubmissionQueue, times(2)).submitBlocking(failureBatchCaptor.capture());
+
+        assertThat(failureBatchCaptor.getAllValues().get(0)).satisfies(fb -> {
+            assertThat(fb.containsProcessingFailures()).isTrue();
+            assertThat(fb.size()).isEqualTo(1);
+
+            assertThat(fb.getFailures().get(0)).satisfies(processingFailure -> {
+                assertThat(processingFailure.failureType()).isEqualTo(FailureType.PROCESSING);
+                assertThat(processingFailure.failureCause().label()).isEqualTo("Cause 1");
+                assertThat(processingFailure.message()).isEqualTo("Failed to process message with id 'msg-x': Message 1");
+                assertThat(processingFailure.failureDetails()).isEqualTo("Details 1");
+                assertThat(processingFailure.failureTimestamp()).isNotNull();
+                assertThat(processingFailure.failedMessage()).isEqualTo(msg);
+                assertThat(processingFailure.targetIndex()).isNull();
+                assertThat(processingFailure.requiresAcknowledgement()).isFalse();
+            });
+        });
+
+        assertThat(failureBatchCaptor.getAllValues().get(1)).satisfies(fb -> {
+            assertThat(fb.containsProcessingFailures()).isTrue();
+            assertThat(fb.size()).isEqualTo(1);
+
+            assertThat(fb.getFailures().get(0)).satisfies(processingFailure -> {
+                assertThat(processingFailure.failureType()).isEqualTo(FailureType.PROCESSING);
+                assertThat(processingFailure.failureCause().label()).isEqualTo("Cause 2");
+                assertThat(processingFailure.message()).isEqualTo("Failed to process message with id 'msg-x': Message 2");
+                assertThat(processingFailure.failureDetails()).isEqualTo("Details 2");
+                assertThat(processingFailure.failureTimestamp()).isNotNull();
+                assertThat(processingFailure.failedMessage()).isEqualTo(msg);
+                assertThat(processingFailure.targetIndex()).isNull();
+                assertThat(processingFailure.requiresAcknowledgement()).isFalse();
+            });
+        });
+    }
+
+
+    @Test
+    public void submitProcessingErrors_nothingSubmittedAndMessageNotFilteredOut_ifSubmissionDisabledAndDuplicatesAreKept() throws Exception {
+        // given
+        final Message msg = Mockito.mock(Message.class);
+        when(msg.getMessageId()).thenReturn("msg-x");
+
+        when(msg.processingErrors()).thenReturn(ImmutableList.of(
+                new Message.ProcessingError(() -> "Cause 1", "Message 1", "Details 1"),
+                new Message.ProcessingError(() -> "Cause 2", "Message 2", "Details 2")
+        ));
+
+        when(failureHandlingConfiguration.submitProcessingFailures()).thenReturn(false);
+        when(failureHandlingConfiguration.keepFailedMessageDuplicate()).thenReturn(true);
+
+        // when
+        final boolean notFilterOut = underTest.submitProcessingErrors(msg);
+
+        // then
+
+        assertThat(notFilterOut).isTrue();
+
+        verifyNoInteractions(failureSubmissionQueue);
+    }
+
+    @Test
+    public void submitProcessingErrors_nothingSubmittedAndMessageNotFilteredOut_ifSubmissionDisabledAndDuplicatesAreNotKept() throws Exception {
+        // given
+        final Message msg = Mockito.mock(Message.class);
+        when(msg.getMessageId()).thenReturn("msg-x");
+
+        when(msg.processingErrors()).thenReturn(ImmutableList.of(
+                new Message.ProcessingError(() -> "Cause 1", "Message 1", "Details 1"),
+                new Message.ProcessingError(() -> "Cause 2", "Message 2", "Details 2")
+        ));
+
+        when(failureHandlingConfiguration.submitProcessingFailures()).thenReturn(false);
+        when(failureHandlingConfiguration.keepFailedMessageDuplicate()).thenReturn(false);
+
+        // when
+        final boolean notFilterOut = underTest.submitProcessingErrors(msg);
+
+        // then
+
+        assertThat(notFilterOut).isTrue();
+
+        verifyNoInteractions(failureSubmissionQueue);
+    }
+
+    @Test
+    public void submitProcessingErrors_nothingSubmittedAndMessageNotFilteredOut_ifMessageHasNoErrors() throws Exception {
+        // given
+        final Message msg = Mockito.mock(Message.class);
+        when(msg.getMessageId()).thenReturn("msg-x");
+
+        when(msg.processingErrors()).thenReturn(ImmutableList.of());
+
+        when(failureHandlingConfiguration.submitProcessingFailures()).thenReturn(true);
+        when(failureHandlingConfiguration.keepFailedMessageDuplicate()).thenReturn(false);
+
+        // when
+        final boolean notFilterOut = underTest.submitProcessingErrors(msg);
+
+        // then
+
+        assertThat(notFilterOut).isTrue();
+
+        verifyNoInteractions(failureSubmissionQueue);
+    }
+
+
+    @Test
+    public void submitProcessingErrors_processingErrorSubmittedToQueueAndMessageFilteredOut_ifSubmissionEnabledAndDuplicatesAreNotKept() throws Exception {
+        // given
+        final Message msg = Mockito.mock(Message.class);
+        when(msg.getMessageId()).thenReturn("msg-x");
+
+        when(msg.processingErrors()).thenReturn(ImmutableList.of(
+                new Message.ProcessingError(() -> "Cause", "Message", "Details")
+        ));
+
+        when(failureHandlingConfiguration.submitProcessingFailures()).thenReturn(true);
+        when(failureHandlingConfiguration.keepFailedMessageDuplicate()).thenReturn(false);
+
+        // when
+        final boolean notFilterOut = underTest.submitProcessingErrors(msg);
+
+        // then
+
+        assertThat(notFilterOut).isFalse();
+
+        verify(msg).setFilterOut(true);
+
+        verify(failureSubmissionQueue, times(1)).submitBlocking(failureBatchCaptor.capture());
+
+        assertThat(failureBatchCaptor.getValue()).satisfies(fb -> {
+            assertThat(fb.containsProcessingFailures()).isTrue();
+            assertThat(fb.size()).isEqualTo(1);
+
+            assertThat(fb.getFailures().get(0)).satisfies(processingFailure -> {
+                assertThat(processingFailure.failureType()).isEqualTo(FailureType.PROCESSING);
+                assertThat(processingFailure.failureCause().label()).isEqualTo("Cause");
+                assertThat(processingFailure.message()).isEqualTo("Failed to process message with id 'msg-x': Message");
+                assertThat(processingFailure.failureDetails()).isEqualTo("Details");
+                assertThat(processingFailure.failureTimestamp()).isNotNull();
+                assertThat(processingFailure.failedMessage()).isEqualTo(msg);
+                assertThat(processingFailure.targetIndex()).isNull();
+                assertThat(processingFailure.requiresAcknowledgement()).isTrue();
+            });
+        });
+    }
+
+    @Test
+    public void submitUnknownProcessingError_unknownProcessingErrorSubmittedToQueue() throws Exception {
+        // given
+        final Message msg = Mockito.mock(Message.class);
+
+        when(msg.processingErrors()).thenReturn(ImmutableList.of());
+
+        when(failureHandlingConfiguration.submitProcessingFailures()).thenReturn(true);
+        when(failureHandlingConfiguration.keepFailedMessageDuplicate()).thenReturn(true);
+
+        // when
+        final boolean notFilterOut = underTest.submitUnknownProcessingError(msg, "Details of the unknown error!");
+
+        // then
+
+        assertThat(notFilterOut).isTrue();
+
+        verify(failureSubmissionQueue, times(1)).submitBlocking(failureBatchCaptor.capture());
+
+        assertThat(failureBatchCaptor.getValue()).satisfies(fb -> {
+            assertThat(fb.containsProcessingFailures()).isTrue();
+            assertThat(fb.size()).isEqualTo(1);
+
+            assertThat(fb.getFailures().get(0)).satisfies(processingFailure -> {
+                assertThat(processingFailure.failureType()).isEqualTo(FailureType.PROCESSING);
+                assertThat(processingFailure.failureCause().label()).isEqualTo("UNKNOWN");
+                assertThat(processingFailure.message()).isEqualTo("Failed to process a message with unknown id: Encountered an unrecognizable processing error");
+                assertThat(processingFailure.failureDetails()).isEqualTo("Details of the unknown error!");
+                assertThat(processingFailure.failureTimestamp()).isNotNull();
+                assertThat(processingFailure.failedMessage()).isEqualTo(msg);
+                assertThat(processingFailure.targetIndex()).isNull();
+                assertThat(processingFailure.requiresAcknowledgement()).isFalse();
+            });
+        });
+
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/processors/PipelineInterpreterTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/processors/PipelineInterpreterTest.java
@@ -22,10 +22,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.eventbus.EventBus;
-import org.graylog.failure.FailureBatch;
-import org.graylog.failure.FailureHandlingConfiguration;
-import org.graylog.failure.FailureSubmissionService;
-import org.graylog.failure.ProcessingFailure;
 import org.graylog.plugins.pipelineprocessor.ast.Pipeline;
 import org.graylog.plugins.pipelineprocessor.ast.Rule;
 import org.graylog.plugins.pipelineprocessor.ast.functions.Function;
@@ -42,17 +38,14 @@ import org.graylog.plugins.pipelineprocessor.db.memory.InMemoryRuleService;
 import org.graylog.plugins.pipelineprocessor.db.mongodb.MongoDbPipelineService;
 import org.graylog.plugins.pipelineprocessor.db.mongodb.MongoDbPipelineStreamConnectionsService;
 import org.graylog.plugins.pipelineprocessor.db.mongodb.MongoDbRuleService;
-import org.graylog.plugins.pipelineprocessor.functions.conversion.LongConversion;
 import org.graylog.plugins.pipelineprocessor.functions.conversion.StringConversion;
 import org.graylog.plugins.pipelineprocessor.functions.messages.CreateMessage;
-import org.graylog.plugins.pipelineprocessor.functions.messages.DropMessage;
 import org.graylog.plugins.pipelineprocessor.functions.messages.SetField;
 import org.graylog.plugins.pipelineprocessor.parser.FunctionRegistry;
 import org.graylog.plugins.pipelineprocessor.parser.PipelineRuleParser;
 import org.graylog.plugins.pipelineprocessor.rest.PipelineConnections;
 import org.graylog2.events.ClusterEventBus;
 import org.graylog2.plugin.Message;
-import org.graylog2.plugin.MessageCollection;
 import org.graylog2.plugin.Messages;
 import org.graylog2.plugin.Tools;
 import org.graylog2.plugin.streams.Stream;
@@ -68,13 +61,9 @@ import java.util.concurrent.Executors;
 
 import static com.codahale.metrics.MetricRegistry.name;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.graylog2.plugin.Message.FIELD_GL2_PROCESSING_ERROR;
 import static org.graylog2.plugin.streams.Stream.DEFAULT_STREAM_ID;
 import static org.junit.Assert.assertEquals;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 public class PipelineInterpreterTest {
@@ -95,29 +84,6 @@ public class PipelineInterpreterTest {
                     "  set_field(\"foobar\", \"covfefe\");\n" +
                     "end", null, null);
 
-    private static final RuleDao RULE_WITH_RUNTIME_EXCEPTION = RuleDao.create("problematic_rule", "problematic_rule", "problematic_rule",
-            "rule \"problematic_rule\"\n" +
-                    "when true\n" +
-                    "then\n" +
-                    "  set_field(\"num\", $message.num / $message.num);\n" +
-                    "end", null, null);
-
-    private static final RuleDao DROP_RULE = RuleDao.create("drop_rule", "drop_rule", "drop_rule",
-            "rule \"drop_rule\"\n" +
-                    "when true\n" +
-                    "then\n" +
-                    "  drop_message();\n" +
-                    "end", null, null);
-
-    private static final Map<String, Function<?>> FUNCTIONS = ImmutableMap.of(
-            SetField.NAME, new SetField(),
-            LongConversion.NAME, new LongConversion(),
-            DropMessage.NAME, new DropMessage());
-
-    private final RuleService ruleService = mock(MongoDbRuleService.class);
-    private final PipelineService pipelineService = mock(MongoDbPipelineService.class);
-    private final FailureSubmissionService failureSubmissionService = mock(FailureSubmissionService.class);
-    private final FailureHandlingConfiguration failureHandlingConfiguration = mock(FailureHandlingConfiguration.class);
     private final MessageQueueAcknowledger messageQueueAcknowledger = mock(MessageQueueAcknowledger.class);
 
     @Test
@@ -306,9 +272,7 @@ public class PipelineInterpreterTest {
         return new PipelineInterpreter(
                 messageQueueAcknowledger,
                 new MetricRegistry(),
-                stateUpdater,
-                failureSubmissionService,
-                failureHandlingConfiguration);
+                stateUpdater);
     }
 
     @Test
@@ -363,9 +327,7 @@ public class PipelineInterpreterTest {
         final PipelineInterpreter interpreter = new PipelineInterpreter(
                 mock(MessageQueueAcknowledger.class),
                 metricRegistry,
-                stateUpdater,
-                mock(FailureSubmissionService.class),
-                mock(FailureHandlingConfiguration.class));
+                stateUpdater);
 
         interpreter.process(messageInDefaultStream("", ""));
 
@@ -409,171 +371,6 @@ public class PipelineInterpreterTest {
         assertThat(meters.get(name(Rule.class, "abc", "cde", "0", "failed")).getCount()).isEqualTo(0L);
         assertThat(meters.get(name(Rule.class, "abc", "cde", "1", "failed")).getCount()).isEqualTo(0L);
 
-    }
-
-    @Test
-    public void process_failureNotSubmitted_whenMessageDropped() throws Exception {
-        // given
-        when(ruleService.loadAll()).thenReturn(ImmutableList.of(RULE_WITH_RUNTIME_EXCEPTION, DROP_RULE));
-
-        when(pipelineService.loadAll()).thenReturn(Collections.singleton(
-                PipelineDao.create("p1", "title", "description",
-                        "pipeline \"pipeline\"\n" +
-                                "stage 0 match all\n" +
-                                "    rule \"drop_rule\";\n" +
-                                "    rule \"problematic_rule\";\n" +
-                                "end\n",
-                        Tools.nowUTC(),
-                        null)
-        ));
-
-        when(failureHandlingConfiguration.submitProcessingFailures()).thenReturn(true);
-        when(failureHandlingConfiguration.keepFailedMessageDuplicate()).thenReturn(true);
-
-        final PipelineInterpreter interpreter = createPipelineInterpreter(ruleService, pipelineService, FUNCTIONS);
-
-        // when
-        final List<Message> processed = extractMessagesFromMessageCollection(interpreter.process(messageWithNumField()));
-
-        // then
-        assertThat(ImmutableList.copyOf(processed))
-                .hasSize(1)
-                .hasOnlyOneElementSatisfying(m -> {
-                    assertThat(m.hasField(FIELD_GL2_PROCESSING_ERROR)).isTrue();
-                    assertThat(m.getFilterOut()).isTrue();
-                });
-
-        verifyNoInteractions(failureSubmissionService);
-        verify(messageQueueAcknowledger).acknowledge(processed.get(0));
-    }
-
-    @Test
-    public void process_failureSbmittedAndMessageAcknowledgedLaterAndNotFilteredOut_whenMessageNotDroppedAndConfiguredToSubmitAndConfiguredToKeepDuplicate() throws Exception {
-        // given
-        when(ruleService.loadAll()).thenReturn(ImmutableList.of(RULE_WITH_RUNTIME_EXCEPTION));
-
-        when(pipelineService.loadAll()).thenReturn(Collections.singleton(
-                PipelineDao.create("p1", "title", "description",
-                        "pipeline \"pipeline\"\n" +
-                                "stage 0 match all\n" +
-                                "    rule \"problematic_rule\";\n" +
-                                "end\n",
-                        Tools.nowUTC(),
-                        null)
-        ));
-
-        when(failureHandlingConfiguration.submitProcessingFailures()).thenReturn(true);
-        when(failureHandlingConfiguration.keepFailedMessageDuplicate()).thenReturn(true);
-
-        final PipelineInterpreter interpreter = createPipelineInterpreter(ruleService, pipelineService, FUNCTIONS);
-
-        // when
-        final List<Message> processed = extractMessagesFromMessageCollection(interpreter.process(messageWithNumField()));
-        final Message processedMessage = processed.get(0);
-
-        // then
-        assertThat(ImmutableList.copyOf(processed))
-                .hasSize(1)
-                .hasOnlyOneElementSatisfying(m -> {
-                    assertThat(m.hasField(FIELD_GL2_PROCESSING_ERROR)).isTrue();
-                    assertThat(m.getFilterOut()).isFalse();
-                });
-
-        verify(failureSubmissionService).submitBlocking(eq(FailureBatch.processingFailureBatch(
-                new ProcessingFailure(processedMessage.getId(), "pipeline-processor",
-                        processedMessage.getField(FIELD_GL2_PROCESSING_ERROR).toString(),
-                        processedMessage.getTimestamp(), processedMessage, false))));
-
-        // this only checks for calls directly made from the PipelineInterpreter
-        verifyNoInteractions(messageQueueAcknowledger);
-    }
-
-    @Test
-    public void process_failureNotSubmittedAndMessageAcknowledgedLaterAndNotFilteredOut_whenMessageNotDroppedAndConfiguredNotToSubmit() throws Exception {
-        // given
-        when(ruleService.loadAll()).thenReturn(ImmutableList.of(RULE_WITH_RUNTIME_EXCEPTION));
-
-        when(pipelineService.loadAll()).thenReturn(Collections.singleton(
-                PipelineDao.create("p1", "title", "description",
-                        "pipeline \"pipeline\"\n" +
-                                "stage 0 match all\n" +
-                                "    rule \"problematic_rule\";\n" +
-                                "end\n",
-                        Tools.nowUTC(),
-                        null)
-        ));
-
-        when(failureHandlingConfiguration.submitProcessingFailures()).thenReturn(false);
-
-        final PipelineInterpreter interpreter = createPipelineInterpreter(ruleService, pipelineService, FUNCTIONS);
-
-        // when
-        final List<Message> processed = extractMessagesFromMessageCollection(interpreter.process(messageWithNumField()));
-        final Message processedMessage = processed.get(0);
-
-        // then
-        assertThat(ImmutableList.copyOf(processed))
-                .hasSize(1)
-                .hasOnlyOneElementSatisfying(m -> {
-                    assertThat(m.hasField(FIELD_GL2_PROCESSING_ERROR)).isTrue();
-                    assertThat(processedMessage.getFilterOut()).isFalse();
-                });
-
-        verifyNoInteractions(failureSubmissionService);
-        // this only checks for calls directly made from the PipelineInterpreter
-        verifyNoInteractions(messageQueueAcknowledger);
-    }
-
-    @Test
-    public void process_failureSubmittedAndMessageAcknowledgedLaterAndFilteredOut_whenMessageNotDroppedAndConfiguredToSubmitAndConfiguredToKeepNoDuplicate() throws Exception {
-        // given
-        when(ruleService.loadAll()).thenReturn(ImmutableList.of(RULE_WITH_RUNTIME_EXCEPTION));
-
-        when(pipelineService.loadAll()).thenReturn(Collections.singleton(
-                PipelineDao.create("p1", "title", "description",
-                        "pipeline \"pipeline\"\n" +
-                                "stage 0 match all\n" +
-                                "    rule \"problematic_rule\";\n" +
-                                "end\n",
-                        Tools.nowUTC(),
-                        null)
-        ));
-
-        when(failureHandlingConfiguration.submitProcessingFailures()).thenReturn(true);
-        when(failureHandlingConfiguration.keepFailedMessageDuplicate()).thenReturn(false);
-
-        final PipelineInterpreter interpreter = createPipelineInterpreter(ruleService, pipelineService, FUNCTIONS);
-
-        // when
-        final List<Message> processed = extractMessagesFromMessageCollection(interpreter.process(messageWithNumField()));
-        final Message processedMessage = processed.get(0);
-
-        // then
-        assertThat(ImmutableList.copyOf(processed))
-                .hasSize(1)
-                .hasOnlyOneElementSatisfying(m -> {
-                    assertThat(m.hasField(FIELD_GL2_PROCESSING_ERROR)).isTrue();
-                    assertThat(processedMessage.getFilterOut()).isTrue();
-                });
-
-        verify(failureSubmissionService).submitBlocking(eq(FailureBatch.processingFailureBatch(
-                new ProcessingFailure(processedMessage.getId(), "pipeline-processor",
-                        processedMessage.getField(FIELD_GL2_PROCESSING_ERROR).toString(),
-                        processedMessage.getTimestamp(), processedMessage, true))));
-
-        // this only checks for calls directly made from the PipelineInterpreter
-        verifyNoInteractions(messageQueueAcknowledger);
-    }
-
-
-    private Message messageWithNumField() {
-        final Message msg = messageInDefaultStream("message", "test");
-        msg.addField("num", new Integer(5));
-        return msg;
-    }
-
-    private List<Message> extractMessagesFromMessageCollection(Messages messages) {
-        return ((MessageCollection) messages).source();
     }
 
     private Message messageInDefaultStream(String message, String source) {

--- a/graylog2-server/src/test/java/org/graylog2/indexer/messages/MessagesBulkIndexRetryingTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/messages/MessagesBulkIndexRetryingTest.java
@@ -16,7 +16,6 @@
  */
 package org.graylog2.indexer.messages;
 
-import com.codahale.metrics.MetricRegistry;
 import com.google.common.collect.ImmutableList;
 import org.graylog.failure.FailureSubmissionService;
 import org.graylog2.Configuration;
@@ -50,14 +49,13 @@ class MessagesBulkIndexRetryingTest {
     private final ProcessingStatusRecorder processingStatusRecorder = mock(ProcessingStatusRecorder.class);
     private final Configuration conf = mock(Configuration.class);
 
-    private FailureSubmissionService failureSubmissionService;
     private Messages messages;
 
     @BeforeEach
     void setUp() {
         when(conf.getFailureHandlingQueueCapacity()).thenReturn(1000);
-        this.failureSubmissionService = new FailureSubmissionService(conf, new MetricRegistry());
-        this.messages = new Messages(trafficAccounting, messagesAdapter, processingStatusRecorder, failureSubmissionService);
+        this.messages = new Messages(trafficAccounting, messagesAdapter, processingStatusRecorder,
+                mock(FailureSubmissionService.class));
     }
 
     @Test

--- a/graylog2-server/src/test/java/org/graylog2/indexer/messages/MessagesIT.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/messages/MessagesIT.java
@@ -22,7 +22,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import joptsimple.internal.Strings;
-import org.graylog.failure.FailureBatch;
 import org.graylog.failure.FailureSubmissionService;
 import org.graylog.testing.elasticsearch.ElasticsearchBaseTest;
 import org.graylog2.indexer.IndexSet;
@@ -59,7 +58,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -187,7 +186,7 @@ public abstract class MessagesIT extends ElasticsearchBaseTest {
 
         assertThat(failedItems).hasSize(1);
 
-        verify(failureSubmissionService).submitBlocking(any(FailureBatch.class));
+        verify(failureSubmissionService).submitIndexingErrors(argThat(arg -> arg.size() == 1));
     }
 
     @Test


### PR DESCRIPTION
As discussed with the team:

1. One processing error should be associated with one failure. All processing errors are collected via `Message#addProcessingError` and handled later in `ProcessBufferProcessor`.
2. As for now we focus on the pipeline processing errors only.
3. The list of the failure fields is refined and their content reviewed.

[graylog-plugin-enterprise/issue-2127] Storing indexing/processing failures

