### PR TITLE
Clear grants when user is deleted

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/bindings/ServerBindings.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/ServerBindings.java
@@ -80,6 +80,7 @@ import org.graylog2.system.jobs.SystemJobFactory;
 import org.graylog2.system.jobs.SystemJobManager;
 import org.graylog2.system.shutdown.GracefulShutdown;
 import org.graylog2.system.stats.ClusterStatsModule;
+import org.graylog2.users.GrantsCleanupListener;
 import org.graylog2.users.RoleService;
 import org.graylog2.users.RoleServiceImpl;
 import org.graylog2.users.StartPageCleanupListener;
@@ -193,6 +194,7 @@ public class ServerBindings extends Graylog2Module {
         bind(LocalDebugEventListener.class).asEagerSingleton();
         bind(ClusterDebugEventListener.class).asEagerSingleton();
         bind(StartPageCleanupListener.class).asEagerSingleton();
+        bind(GrantsCleanupListener.class).asEagerSingleton();
     }
 
     private void bindSearchResponseDecorators() {

--- a/graylog2-server/src/main/java/org/graylog2/security/UserSessionTerminationService.java
+++ b/graylog2-server/src/main/java/org/graylog2/security/UserSessionTerminationService.java
@@ -63,6 +63,8 @@ public class UserSessionTerminationService extends AbstractIdleService {
     private static final Logger LOG = LoggerFactory.getLogger(UserSessionTerminationService.class);
 
     // Sessions should be terminated when a user's account status is one of the following
+    // (Note: the DELETED status is not yet used throughout Graylog and won't be set for any user atm.
+    // But it will probably be used in the future to mark user accounts as deleted instead of purging them from the DB.)
     private static final EnumSet<User.AccountStatus> SESSION_TERMINATION_STATUS = EnumSet.of(
             User.AccountStatus.DELETED,
             User.AccountStatus.DISABLED

--- a/graylog2-server/src/main/java/org/graylog2/users/GrantsCleanupListener.java
+++ b/graylog2-server/src/main/java/org/graylog2/users/GrantsCleanupListener.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.users;
+
+import com.google.common.collect.Sets;
+import com.google.common.eventbus.EventBus;
+import com.google.common.eventbus.Subscribe;
+import org.graylog.grn.GRN;
+import org.graylog.grn.GRNRegistry;
+import org.graylog.grn.GRNTypes;
+import org.graylog.security.DBGrantService;
+import org.graylog.security.GrantDTO;
+import org.graylog2.users.events.UserDeletedEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Listens for {@link UserDeletedEvent}s to remove orphaned grants from the DB. It will go through all grants present
+ * in the DB, not just the grants for the user mentioned in the delete event to remove any leftover grants for users
+ * which don't exist anymore.
+ */
+@Singleton
+public class GrantsCleanupListener {
+    private static final Logger log = LoggerFactory.getLogger(GrantsCleanupListener.class);
+
+    private final DBGrantService grantService;
+    private final PaginatedUserService userService;
+    private final GRNRegistry grnRegistry;
+
+    @Inject
+    public GrantsCleanupListener(EventBus eventBus, DBGrantService grantService, PaginatedUserService userService,
+                                 GRNRegistry grnRegistry) {
+        this.grantService = grantService;
+        this.userService = userService;
+        this.grnRegistry = grnRegistry;
+        eventBus.register(this);
+    }
+
+    @Subscribe
+    public void handleUserDeletedEvent(UserDeletedEvent event) {
+        final Set<GRN> grantees;
+        try (final Stream<GrantDTO> grantStream = grantService.streamAll()) {
+            grantees = grantStream
+                    .map(GrantDTO::grantee)
+                    .filter(grantee -> grantee.grnType().equals(GRNTypes.USER))
+                    .collect(Collectors.toSet());
+        }
+
+        final Set<GRN> users;
+        try (final Stream<UserOverviewDTO> userStream = userService.streamAll()) {
+            users = userStream
+                    .map(user -> grnRegistry.newGRN(GRNTypes.USER.type(), user.id()))
+                    .collect(Collectors.toSet());
+        }
+
+        final Sets.SetView<GRN> removedGrantees = Sets.difference(grantees, users);
+
+        if (!removedGrantees.isEmpty()) {
+            log.debug("Clearing grants for {} grantees ({}).", removedGrantees.size(), removedGrantees);
+            removedGrantees.forEach(grantService::deleteForGrantee);
+        }
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/users/GrantsCleanupListenerTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/users/GrantsCleanupListenerTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.users;
+
+import com.google.common.eventbus.EventBus;
+import org.graylog.grn.GRNRegistry;
+import org.graylog.grn.GRNTypes;
+import org.graylog.security.Capability;
+import org.graylog.security.DBGrantService;
+import org.graylog.security.GrantDTO;
+import org.graylog2.users.events.UserDeletedEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.stream.Stream;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class GrantsCleanupListenerTest {
+
+    @Mock
+    DBGrantService grantService;
+
+    @Mock
+    PaginatedUserService userService;
+
+    GRNRegistry grnRegistry = GRNRegistry.createWithBuiltinTypes();
+    GrantsCleanupListener cleanupListener;
+
+    private final UserOverviewDTO userA = UserOverviewDTO.builder()
+            .id("a")
+            .username("a@graylog.local")
+            .email("a@graylog.local")
+            .build();
+
+    private final GrantDTO grantUserA = GrantDTO.of(
+            grnRegistry.newGRN(GRNTypes.USER, "a"), Capability.VIEW, grnRegistry.newGRN(GRNTypes.DASHBOARD, "d"));
+    private final GrantDTO grantUserB = GrantDTO.of(
+            grnRegistry.newGRN(GRNTypes.USER, "b"), Capability.VIEW, grnRegistry.newGRN(GRNTypes.DASHBOARD, "d"));
+    private final GrantDTO grantTeam = GrantDTO.of(
+            grnRegistry.newGRN(GRNTypes.TEAM, "t"), Capability.VIEW, grnRegistry.newGRN(GRNTypes.DASHBOARD, "d"));
+
+    @BeforeEach
+    void setUp() {
+        cleanupListener = new GrantsCleanupListener(mock(EventBus.class), grantService, userService, grnRegistry);
+    }
+
+    @Test
+    void noGrants() {
+        when(userService.streamAll()).thenReturn(Stream.of(userA));
+        when(grantService.streamAll()).thenReturn(Stream.empty());
+
+        cleanupListener.handleUserDeletedEvent(mock(UserDeletedEvent.class));
+
+        verify(grantService, never()).deleteForGrantee(any());
+    }
+
+    @Test
+    void userRemoved() {
+        when(userService.streamAll()).thenReturn(Stream.of(userA));
+        when(grantService.streamAll()).thenReturn(Stream.of(grantUserA, grantUserB, grantTeam));
+
+        cleanupListener.handleUserDeletedEvent(mock(UserDeletedEvent.class));
+
+        verify(grantService).deleteForGrantee(grnRegistry.newGRN(GRNTypes.USER, "b"));
+        verifyNoMoreInteractions(grantService);
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Upon deletion of a user, clears all grants for users which are not present in the DB anymore.

We scanning the complete grants table and remove all grants that are orphaned. This way we keep a clean grants table even if previously some grants have been missed before. This saves us from writing an additional migration.

I considered using raw mongodb queries and some batching to reduce the number of queries but I think we are fine using the higher level APIs to query for users and delete the grants.

I wouldn't expect any systems with user/grant numbers at such a high level that this could become a problem.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#10385 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Smoke test by creating grants for users/teams and checking which grants get removed when a user is deleted.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

