### PR TITLE
Include current user in `ActionContext`.

### DIFF
--- a/graylog2-web-interface/src/views/components/Search.test.tsx
+++ b/graylog2-web-interface/src/views/components/Search.test.tsx
@@ -36,10 +36,15 @@ import CurrentViewTypeProvider from 'views/components/views/CurrentViewTypeProvi
 import ViewTypeContext from 'views/components/contexts/ViewTypeContext';
 import { SearchExecutionResult } from 'views/actions/SearchActions';
 import WindowLeaveMessage from 'views/components/common/WindowLeaveMessage';
+import MockSearchPageLayoutProvider from 'views/components/contexts/SearchPageLayoutProvider';
 
 import Search from './Search';
 
 import { useSyncWithQueryParameters } from '../hooks/SyncWithQueryParameters';
+
+jest.mock('views/components/contexts/SearchPageLayoutProvider', () => jest.fn(
+  jest.requireActual('views/components/contexts/SearchPageLayoutProvider').default,
+));
 
 jest.mock('util/History');
 jest.mock('components/layout/Footer', () => mockComponent('Footer'));
@@ -288,6 +293,10 @@ describe('Search', () => {
   });
 
   it('changing current query in view does not trigger search execution', async () => {
+    const MockTest = <div>Test</div>;
+
+    asMock(MockSearchPageLayoutProvider).mockReturnValue(MockTest);
+
     render(<SimpleSearch />);
 
     asMock(SearchActions.execute).mockClear();

--- a/graylog2-web-interface/src/views/components/Search.tsx
+++ b/graylog2-web-interface/src/views/components/Search.tsx
@@ -22,7 +22,7 @@ import styled, { css } from 'styled-components';
 import PageContentLayout from 'components/layout/PageContentLayout';
 import withLocation from 'routing/withLocation';
 import type { Location } from 'routing/withLocation';
-import connect from 'stores/connect';
+import connect, { useStore } from 'stores/connect';
 import Sidebar from 'views/components/sidebar/Sidebar';
 import WithSearchStatus from 'views/components/WithSearchStatus';
 import SearchResult from 'views/components/SearchResult';
@@ -64,6 +64,7 @@ import SearchExecutionState from 'views/logic/search/SearchExecutionState';
 import { RefluxActions } from 'stores/StoreTypes';
 import MessageEventTypesProvider from 'views/components/contexts/MessageEventTypesProvider';
 import FieldAndValueActionsProvider from 'views/components/contexts/FieldAndValueActionsProvider';
+import CurrentUserContext from 'contexts/CurrentUserContext';
 
 const GridContainer = styled.div<{ interactive: boolean }>(({ interactive }) => {
   return interactive ? css`
@@ -141,11 +142,17 @@ const _refreshIfNotUndeclared = (searchRefreshHooks: Array<SearchRefreshConditio
 const SearchBarWithStatus = WithSearchStatus(SearchBar);
 const DashboardSearchBarWithStatus = WithSearchStatus(DashboardSearchBar);
 
-const ViewAdditionalContextProvider = connect(
-  AdditionalContext.Provider,
-  { view: ViewStore, configs: SearchConfigStore },
-  ({ view, configs: { searchesClusterConfig } }) => ({ value: { view: view.view, analysisDisabledFields: searchesClusterConfig?.analysis_disabled_fields } } as { value: object}),
-);
+const ViewAdditionalContextProvider = ({ children }: { children: React.ReactNode }) => {
+  const { view } = useStore(ViewStore);
+  const { searchesClusterConfig } = useStore(SearchConfigStore) ?? {};
+  const currentUser = useContext(CurrentUserContext);
+
+  return (
+    <AdditionalContext.Provider value={{ view, analysisDisabledFields: searchesClusterConfig.analysis_disabled_fields, currentUser }}>
+      {children}
+    </AdditionalContext.Provider>
+  );
+};
 
 ViewAdditionalContextProvider.displayName = 'ViewAdditionalContextProvider';
 

--- a/graylog2-web-interface/src/views/components/Search.tsx
+++ b/graylog2-web-interface/src/views/components/Search.tsx
@@ -148,7 +148,7 @@ const ViewAdditionalContextProvider = ({ children }: { children: React.ReactNode
   const currentUser = useContext(CurrentUserContext);
 
   return (
-    <AdditionalContext.Provider value={{ view, analysisDisabledFields: searchesClusterConfig.analysis_disabled_fields, currentUser }}>
+    <AdditionalContext.Provider value={{ view, analysisDisabledFields: searchesClusterConfig?.analysis_disabled_fields, currentUser }}>
       {children}
     </AdditionalContext.Provider>
   );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

With this PR we are including the current user in the `ActionContext`. We are currently using the `ActionContext` for example when we check if a value action should be displayed. By including the current user, we can consider the user permissions in these checks.

We already have a `CurrentUserContext` which provides the user, but I preferred to extend the `ActionContext`, this way we do not have to add the current user manually, whenever we check e.g. if a value action should be displayed.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

