### PR TITLE
Display Tooltips by default

### DIFF
--- a/graylog2-web-interface/src/components/events/events/Events.jsx
+++ b/graylog2-web-interface/src/components/events/events/Events.jsx
@@ -143,7 +143,7 @@ class Events extends React.Component {
 
     return (
       <>
-        <OverlayTrigger placement="top" overlay={tooltip}>
+        <OverlayTrigger placement="top" trigger={['hover', 'click', 'focus']} overlay={tooltip}>
           <EventsIcon name={icon} fixedWidth className={style} />
         </OverlayTrigger>
       </>

--- a/graylog2-web-interface/src/components/graylog/Tooltip.jsx
+++ b/graylog2-web-interface/src/components/graylog/Tooltip.jsx
@@ -135,7 +135,7 @@ Tooltip.defaultProps = {
   positionLeft: undefined,
   arrowOffsetTop: undefined,
   arrowOffsetLeft: undefined,
-  show: false,
+  show: true,
 };
 
 /** @component */


### PR DESCRIPTION
The `Tooltip` component offers a `show` prop that will decide if the tooltip is rendered or not, with a default value of `false`. However, when introducing that prop and its default value we did not update all usages of the component, which use `OverlayTrigger` to decide when to display or hide the `Tooltip`, and therefore they expect the `Tooltip` to be visible as default when rendered.

This PR changes the default value of `show` to `true`, ensurig `Tooltip`s are shown by default but still having the possibility of hiding a `Tooltip` with a prop if needed.

Fixes #10975