### PR TITLE
Creating shared component for lookup table parameter form components.

### DIFF
--- a/graylog2-web-interface/src/actions/lookup-tables/LookupTablesActions.js
+++ b/graylog2-web-interface/src/actions/lookup-tables/LookupTablesActions.js
@@ -18,7 +18,7 @@ import Reflux from 'reflux';
 
 import { singletonActions } from 'views/logic/singleton';
 
-const LookupTablesActions = singletonActions('LookupTable', () => Reflux.createActions({
+const LookupTablesActions = singletonActions('LookupTables', () => Reflux.createActions({
   searchPaginated: { asyncResult: true },
   reloadPage: { asyncResult: true },
   get: { asyncResult: true },

--- a/graylog2-web-interface/src/actions/lookup-tables/LookupTablesActions.js
+++ b/graylog2-web-interface/src/actions/lookup-tables/LookupTablesActions.js
@@ -16,7 +16,9 @@
  */
 import Reflux from 'reflux';
 
-const LookupTablesActions = Reflux.createActions({
+import { singletonActions } from 'views/logic/singleton';
+
+const LookupTablesActions = singletonActions('LookupTable', () => Reflux.createActions({
   searchPaginated: { asyncResult: true },
   reloadPage: { asyncResult: true },
   get: { asyncResult: true },
@@ -28,6 +30,6 @@ const LookupTablesActions = Reflux.createActions({
   purgeKey: { asyncResult: true },
   purgeAll: { asyncResult: true },
   validate: { asyncResult: true },
-});
+}));
 
 export default LookupTablesActions;

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/EditQueryParameterModal.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/EditQueryParameterModal.jsx
@@ -21,7 +21,6 @@ import React from 'react';
 import LookupTableParameterEdit from 'components/lookup-table-parameters/LookupTableParameterEdit';
 import { Button } from 'components/graylog';
 import { BootstrapModalForm } from 'components/bootstrap';
-import LookupTableParameter from 'views/logic/parameters/LookupTableParameter';
 
 class EditQueryParameterModal extends React.Component {
   static propTypes = {

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/EditQueryParameterModal.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/EditQueryParameterModal.jsx
@@ -17,22 +17,11 @@
 import PropTypes from 'prop-types';
 import lodash from 'lodash';
 import React from 'react';
-import styled from 'styled-components';
 
-import { Button, Panel, ControlLabel, FormGroup, HelpBlock } from 'components/graylog';
-import { BootstrapModalForm, Input } from 'components/bootstrap';
-import { Select } from 'components/common';
-import * as FormsUtils from 'util/FormsUtils';
-import { naturalSortIgnoreCase } from 'util/SortUtils';
-
-const StyledPanel = styled(Panel)`
-  margin-top: 20px;
-`;
-
-const StyledInlineCode = styled('code')`
-  margin: 0 0.25em;
-  white-space: nowrap;
-`;
+import LookupTableParameterEdit from 'components/lookup-table-parameters/LookupTableParameterEdit';
+import { Button } from 'components/graylog';
+import { BootstrapModalForm } from 'components/bootstrap';
+import LookupTableParameter from 'views/logic/parameters/LookupTableParameter';
 
 class EditQueryParameterModal extends React.Component {
   static propTypes = {
@@ -48,7 +37,7 @@ class EditQueryParameterModal extends React.Component {
     const { queryParameter } = this.props;
 
     this.state = {
-      queryParameter: lodash.cloneDeep(queryParameter),
+      queryParameter,
       validation: {},
     };
   }
@@ -71,7 +60,7 @@ class EditQueryParameterModal extends React.Component {
   _cleanState = () => {
     const { queryParameter } = this.props;
 
-    this.setState({ queryParameter: lodash.cloneDeep(queryParameter) });
+    this.setState({ queryParameter });
   }
 
   propagateChanges = () => {
@@ -85,35 +74,22 @@ class EditQueryParameterModal extends React.Component {
       throw new Error(`Query parameter "${queryParameter.name}" not found`);
     }
 
-    queryParameters[index] = lodash.omit(queryParameter, 'embryonic');
+    queryParameters[index] = lodash.omit(queryParameter.toJSON(), 'embryonic');
     onChange('config', config);
   };
 
   handleParameterChange = (key, value) => {
     const { queryParameter } = this.state;
-    const nextQueryParameter = { ...queryParameter, [key]: value };
+    const nextQueryParameter = queryParameter.toBuilder()[key](value).build();
 
     this.setState({ queryParameter: nextQueryParameter });
-  };
-
-  handleSelectChange = (key) => {
-    return (nextLookupTable) => {
-      this.handleParameterChange(key, nextLookupTable);
-    };
-  };
-
-  handleChange = (event) => {
-    const { name } = event.target;
-    const value = FormsUtils.getValueFromInput(event.target);
-
-    this.handleParameterChange(name, value);
   };
 
   _validate = (queryParameter) => {
     const newValidation = {};
 
-    if (!queryParameter.lookup_table) {
-      newValidation.lookup_table = 'Cannot be empty';
+    if (!queryParameter.lookupTable) {
+      newValidation.lookupTable = 'Cannot be empty';
     }
 
     if (!queryParameter.key) {
@@ -125,20 +101,14 @@ class EditQueryParameterModal extends React.Component {
     return lodash.isEmpty(newValidation);
   };
 
-  formatLookupTables = (lookupTables) => {
-    if (!lookupTables) {
-      return [];
-    }
-
-    return lookupTables
-      .sort((lt1, lt2) => naturalSortIgnoreCase(lt1.title, lt2.title))
-      .map((table) => ({ label: table.title, value: table.name }));
-  };
-
   render() {
     const { lookupTables } = this.props;
     const { queryParameter, validation } = this.state;
-    const parameterSyntax = `$${queryParameter.name}$`;
+
+    const validationState = {
+      lookupTable: validation.lookupTable ? ['error', validation.lookupTable] : undefined,
+      key: validation.key ? ['error', validation.key] : undefined,
+    };
 
     return (
       <>
@@ -153,63 +123,11 @@ class EditQueryParameterModal extends React.Component {
                             onSubmitForm={this._saved}
                             onModalClose={this._cleanState}
                             submitButtonText="Save">
-
-          <FormGroup controlId="lookup-provider-table" validationState={validation.lookup_table ? 'error' : null}>
-            <ControlLabel>Select Lookup Table</ControlLabel>
-            <Select name="query-param-table-name"
-                    placeholder="Select Lookup Table"
-                    onChange={this.handleSelectChange('lookup_table')}
-                    options={this.formatLookupTables(lookupTables)}
-                    value={queryParameter.lookup_table}
-                    autoFocus
-                    clearable={false}
-                    required />
-            <HelpBlock>
-              {validation.lookup_table || 'Select the Lookup Table Graylog should use to get the values.'}
-            </HelpBlock>
-          </FormGroup>
-          <Input type="text"
-                 id={`key-${queryParameter.name}`}
-                 label="Lookup Table Key"
-                 name="key"
-                 defaultValue={queryParameter.key}
-                 onChange={this.handleChange}
-                 bsStyle={validation.key ? 'error' : null}
-                 help={validation.key ? validation.key : 'Select the Lookup Table Key'}
-                 spellCheck={false}
-                 required />
-          <Input id={`default-value-${queryParameter.name}`}
-                 type="text"
-                 name="default_value"
-                 label="Default Value"
-                 help="Select a default value in case the lookup result is empty"
-                 defaultValue={queryParameter.default_value}
-                 spellCheck={false}
-                 onChange={this.handleChange} />
-          <StyledPanel header="How to use">
-            <h5>General Usage</h5>
-            <p>
-              After declaring it, the parameter
-              <StyledInlineCode>{parameterSyntax}</StyledInlineCode>
-              in your query, will be replaced with the list of results from the lookup table.
-              The list of results will be presented in the form of a Lucene BooleanQuery. E.g.:
-              <StyledInlineCode>(&quot;foo&quot; OR &quot;bar&quot; OR &quot;baz&quot;)</StyledInlineCode>
-            </p>
-            <h5>Behaviour on empty lookup result list</h5>
-            <p>
-              The event definition query is only executed if a value for the parameter is present.
-              If the lookup result is empty, the execution will be skipped and treated as if the <i>Search Query</i> found
-              no messages. If an execution is desired a <i>Default Value</i> that yields the desired search result
-              needs to be provided. For example, (depending on the use case) a wildcard like
-              <StyledInlineCode>*</StyledInlineCode>
-              can be a meaningful Default Value.
-            </p>
-            <h5>Limitations</h5>
-            <p>
-              Please note that maximum number of supported results is 1024. If the lookup table returns
-              more results, the event definition is not executed.
-            </p>
-          </StyledPanel>
+          <LookupTableParameterEdit validationState={validationState}
+                                    identifier={queryParameter.name}
+                                    parameter={queryParameter}
+                                    onChange={this.handleParameterChange}
+                                    lookupTables={lookupTables} />
         </BootstrapModalForm>
       </>
     );

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterForm.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterForm.jsx
@@ -31,7 +31,7 @@ import { naturalSortIgnoreCase } from 'util/SortUtils';
 import * as FormsUtils from 'util/FormsUtils';
 import CombinedProvider from 'injection/CombinedProvider';
 import { SearchMetadataActions } from 'views/stores/SearchMetadataStore';
-import PermissionsMixin from 'util/PermissionsMixin';
+import { isPermitted } from 'util/PermissionsMixin';
 import LookupTableParameter from 'views/logic/parameters/LookupTableParameter';
 
 import EditQueryParameterModal from '../event-definition-form/EditQueryParameterModal';
@@ -73,7 +73,7 @@ class FilterForm extends React.Component {
   _parseQuery = lodash.debounce((queryString) => {
     const { currentUser } = this.props;
 
-    if (!PermissionsMixin.isPermitted(currentUser.permissions, PREVIEW_PERMISSIONS)) {
+    if (!isPermitted(currentUser.permissions, PREVIEW_PERMISSIONS)) {
       return;
     }
 
@@ -131,7 +131,7 @@ class FilterForm extends React.Component {
   componentDidMount() {
     const { currentUser } = this.props;
 
-    if (!PermissionsMixin.isPermitted(currentUser.permissions, LOOKUP_PERMISSIONS)) {
+    if (!isPermitted(currentUser.permissions, LOOKUP_PERMISSIONS)) {
       return;
     }
 

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterForm.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterForm.jsx
@@ -32,6 +32,7 @@ import * as FormsUtils from 'util/FormsUtils';
 import CombinedProvider from 'injection/CombinedProvider';
 import { SearchMetadataActions } from 'views/stores/SearchMetadataStore';
 import PermissionsMixin from 'util/PermissionsMixin';
+import LookupTableParameter from 'views/logic/parameters/LookupTableParameter';
 
 import EditQueryParameterModal from '../event-definition-form/EditQueryParameterModal';
 import commonStyles from '../common/commonStyles.css';
@@ -226,9 +227,9 @@ class FilterForm extends React.Component {
     const parameterButtons = queryParameters.map((queryParam) => {
       return (
         <EditQueryParameterModal key={queryParam.name}
-                                 queryParameter={queryParam}
+                                 queryParameter={LookupTableParameter.fromJSON(queryParam)}
                                  eventDefinition={eventDefinition}
-                                 lookupTables={lookupTables.tables || []}
+                                 lookupTables={lookupTables.tables}
                                  validation={validation}
                                  onChange={onChange} />
       );

--- a/graylog2-web-interface/src/components/lookup-table-parameters/LookupTableParameterEdit.tsx
+++ b/graylog2-web-interface/src/components/lookup-table-parameters/LookupTableParameterEdit.tsx
@@ -136,7 +136,7 @@ const LookupTableParameterEdit = ({
             <h5>Limitations</h5>
             <p>
               Please note that maximum number of supported results is 1024. If the lookup table returns
-              more results, the event definition is not executed.
+              more results, the query is not executed.
             </p>
           </Panel.Body>
         </Panel.Collapse>

--- a/graylog2-web-interface/src/components/lookup-table-parameters/LookupTableParameterEdit.tsx
+++ b/graylog2-web-interface/src/components/lookup-table-parameters/LookupTableParameterEdit.tsx
@@ -19,7 +19,7 @@ import styled from 'styled-components';
 
 import { Panel } from 'components/graylog';
 import { Input } from 'components/bootstrap';
-import { Select } from 'components/common';
+import Select from 'components/common/Select';
 import { naturalSortIgnoreCase } from 'util/SortUtils';
 import Spinner from 'components/common/Spinner';
 

--- a/graylog2-web-interface/src/components/lookup-table-parameters/LookupTableParameterEdit.tsx
+++ b/graylog2-web-interface/src/components/lookup-table-parameters/LookupTableParameterEdit.tsx
@@ -1,0 +1,154 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import styled from 'styled-components';
+
+import { Panel } from 'components/graylog';
+import { Input } from 'components/bootstrap';
+import { Select } from 'components/common';
+import { naturalSortIgnoreCase } from 'util/SortUtils';
+import Spinner from 'components/common/Spinner';
+
+import type { LookupTable } from '../lookup-tables/types';
+
+const StyledInlineCode = styled('code')`
+  margin: 0 0.25em;
+  white-space: nowrap;
+`;
+
+type Props = {
+  onChange: (fieldName: string, value: string) => void
+  lookupTables: Array<LookupTable>
+  identifier: string | number,
+  defaultExpandHelp?: boolean,
+  parameter?: {
+    lookupTable?: string,
+    key?: string,
+    defaultValue?: string
+    name?: string,
+  },
+  validationState?: {
+    lookupTable?: [string, string],
+    key?: [string, string],
+  }
+};
+
+const LookupTableParameterEdit = ({
+  validationState,
+  onChange,
+  lookupTables,
+  identifier,
+  parameter,
+  defaultExpandHelp,
+}: Props) => {
+  const { lookupTable, key: tableKey, defaultValue, name } = parameter;
+  const parameterSyntax = `$${name}$`;
+
+  const _handleChange = (fieldName: string) => (value) => {
+    onChange(fieldName, value);
+  };
+
+  const _handleInputChange = (attributeName: string) => ({ target: { value } }: React.ChangeEvent<HTMLInputElement>) => _handleChange(attributeName)(value);
+
+  if (!lookupTables) {
+    return <Spinner text="Loading lookup tables" />;
+  }
+
+  const lookupTableOptions = lookupTables.sort((lt1, lt2) => naturalSortIgnoreCase(lt1.title, lt2.title))
+    .map((table) => ({ label: table.title, value: table.name }));
+
+  return (
+    <>
+      <Input id={`lookup-table-parameter-table-${identifier}`}
+             name="query-param-table-name"
+             label="Lookup Table"
+             bsStyle={validationState?.lookupTable?.[0]}
+             error={validationState?.lookupTable?.[1]}
+             help="Select the lookup table Graylog should use to get the values.">
+        <Select placeholder="Select lookup table"
+                inputProps={{ 'aria-label': 'Select lookup table' }}
+                onChange={_handleChange('lookupTable')}
+                options={lookupTableOptions}
+                value={lookupTable}
+                autoFocus
+                clearable={false}
+                required />
+      </Input>
+      <Input type="text"
+             id={`lookup-table-parameter-key-${identifier}`}
+             label="Lookup Table Key"
+             name="key"
+             defaultValue={tableKey}
+             onChange={_handleInputChange('key')}
+             bsStyle={validationState?.key?.[0]}
+             help="Select the lookup table key"
+             error={validationState?.key?.[0] === 'error' ? validationState?.key?.[1] : undefined}
+             spellCheck={false}
+             required />
+      <Input id={`lookup-table-parameter-default-value-${identifier}`}
+             type="text"
+             name="defaultValue"
+             label="Default Value"
+             help="Select a default value in case the lookup result is empty"
+             defaultValue={defaultValue}
+             spellCheck={false}
+             onChange={_handleInputChange('defaultValue')} />
+
+      <Panel id="lookup-table-parameter-help" defaultExpanded={defaultExpandHelp}>
+        <Panel.Heading>
+          <Panel.Title toggle>
+            How to use lookup table parameters
+          </Panel.Title>
+        </Panel.Heading>
+        <Panel.Collapse>
+          <Panel.Body>
+            <h5>General Usage</h5>
+            <p>
+              After declaring it, the parameter
+              <StyledInlineCode>{parameterSyntax}</StyledInlineCode>
+              in your query, will be replaced with the list of results from the lookup table.
+              The list of results will be presented in the form of a Lucene BooleanQuery. E.g.:
+              <StyledInlineCode>(&quot;foo&quot; OR &quot;bar&quot; OR &quot;baz&quot;)</StyledInlineCode>
+            </p>
+            <h5>Behaviour on empty lookup result list</h5>
+            <p>
+              The event definition query is only executed if a value for the parameter is present.
+              If the lookup result is empty, the execution will be skipped and treated as if the <i>Search Query</i> found
+              no messages. If an execution is desired a <i>Default Value</i> that yields the desired search result
+              needs to be provided. For example, (depending on the use case) a wildcard like
+              <StyledInlineCode>*</StyledInlineCode>
+              can be a meaningful Default Value.
+            </p>
+            <h5>Limitations</h5>
+            <p>
+              Please note that maximum number of supported results is 1024. If the lookup table returns
+              more results, the event definition is not executed.
+            </p>
+          </Panel.Body>
+        </Panel.Collapse>
+      </Panel>
+    </>
+  );
+};
+
+LookupTableParameterEdit.defaultProps = {
+  parameter: {},
+  validationState: {},
+  defaultExpandHelp: true,
+};
+
+export default LookupTableParameterEdit;

--- a/graylog2-web-interface/src/components/lookup-tables/types.ts
+++ b/graylog2-web-interface/src/components/lookup-tables/types.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+
+export type LookupTable = {
+  cache_id: string,
+  data_adapter_id: string,
+  default_multi_value: string,
+  default_multi_value_type: string,
+  default_single_value: string,
+  default_single_value_type: string,
+  description: string,
+  id: string,
+  name: string,
+  title: string,
+}

--- a/graylog2-web-interface/src/stores/lookup-tables/LookupTablesStore.js
+++ b/graylog2-web-interface/src/stores/lookup-tables/LookupTablesStore.js
@@ -21,8 +21,7 @@ import PaginationURL from 'util/PaginationURL';
 import { qualifyUrl } from 'util/URLUtils';
 import fetch from 'logic/rest/FetchProvider';
 import LookupTablesActions from 'actions/lookup-tables/LookupTablesActions';
-
-import { singletonStore } from '../../views/logic/singleton';
+import { singletonStore } from 'views/logic/singleton';
 
 const LookupTablesStore = singletonStore('LookupTables', () => Reflux.createStore({
   listenables: [LookupTablesActions],

--- a/graylog2-web-interface/src/stores/lookup-tables/LookupTablesStore.js
+++ b/graylog2-web-interface/src/stores/lookup-tables/LookupTablesStore.js
@@ -20,11 +20,9 @@ import UserNotification from 'util/UserNotification';
 import PaginationURL from 'util/PaginationURL';
 import { qualifyUrl } from 'util/URLUtils';
 import fetch from 'logic/rest/FetchProvider';
-import ActionsProvider from 'injection/ActionsProvider';
+import LookupTablesActions from 'actions/lookup-tables/LookupTablesActions';
 
 import { singletonStore } from '../../views/logic/singleton';
-
-const LookupTablesActions = ActionsProvider.getActions('LookupTables');
 
 const LookupTablesStore = singletonStore('LookupTables', () => Reflux.createStore({
   listenables: [LookupTablesActions],

--- a/graylog2-web-interface/src/stores/lookup-tables/LookupTablesStore.js
+++ b/graylog2-web-interface/src/stores/lookup-tables/LookupTablesStore.js
@@ -22,9 +22,11 @@ import { qualifyUrl } from 'util/URLUtils';
 import fetch from 'logic/rest/FetchProvider';
 import ActionsProvider from 'injection/ActionsProvider';
 
+import { singletonStore } from '../../views/logic/singleton';
+
 const LookupTablesActions = ActionsProvider.getActions('LookupTables');
 
-const LookupTablesStore = Reflux.createStore({
+const LookupTablesStore = singletonStore('LookupTables', () => Reflux.createStore({
   listenables: [LookupTablesActions],
   pagination: {
     page: 1,
@@ -274,6 +276,7 @@ const LookupTablesStore = Reflux.createStore({
   _urlClusterWise(path) {
     return qualifyUrl(`/cluster/system/lookup/${path}`);
   },
-});
+}));
 
+export { LookupTablesStore, LookupTablesActions };
 export default LookupTablesStore;

--- a/graylog2-web-interface/src/views/components/WithSearchStatus.tsx
+++ b/graylog2-web-interface/src/views/components/WithSearchStatus.tsx
@@ -26,7 +26,7 @@ import { SearchesConfig } from 'components/search/SearchConfig';
 
 const _disableSearch = (undeclaredParameters, parameterBindings, usedParameters) => {
   const bindingsMap = getParameterBindingsAsMap(parameterBindings);
-  const missingValues = usedParameters.filter((param) => param.needsBinding || !param.optional).map((p) => bindingsMap.get(p.name)).filter((value) => !trim(value));
+  const missingValues = usedParameters.filter((param) => (param.needsBinding && !param.optional)).map((p) => bindingsMap.get(p.name)).filter((value) => !trim(value));
 
   return undeclaredParameters.size > 0 || missingValues.size > 0;
 };

--- a/graylog2-web-interface/src/views/components/WithSearchStatus.tsx
+++ b/graylog2-web-interface/src/views/components/WithSearchStatus.tsx
@@ -26,7 +26,7 @@ import { SearchesConfig } from 'components/search/SearchConfig';
 
 const _disableSearch = (undeclaredParameters, parameterBindings, usedParameters) => {
   const bindingsMap = getParameterBindingsAsMap(parameterBindings);
-  const missingValues = usedParameters.map((p) => bindingsMap.get(p.name)).filter((value) => !trim(value));
+  const missingValues = usedParameters.filter((param) => param.needsBinding || !param.optional).map((p) => bindingsMap.get(p.name)).filter((value) => !trim(value));
 
   return undeclaredParameters.size > 0 || missingValues.size > 0;
 };

--- a/graylog2-web-interface/src/views/logic/parameters/LookupTableParameter.ts
+++ b/graylog2-web-interface/src/views/logic/parameters/LookupTableParameter.ts
@@ -20,7 +20,6 @@ import * as Immutable from 'immutable';
 import Parameter from 'views/logic/parameters/Parameter';
 
 import type { ParameterJson } from './Parameter';
-import ParameterBinding from './ParameterBinding';
 
 type InternalBuilderState = Immutable.Map<string, any>;
 
@@ -43,7 +42,7 @@ export default class LookupTableParameter extends Parameter {
   static Builder: typeof Builder;
 
   constructor(name: string, title: string, description: string, dataType: string, defaultValue: any, optional: boolean, lookupTable: string, key: string) {
-    super(LookupTableParameter.type, name, title, description, dataType, defaultValue, optional, ParameterBinding.empty());
+    super(LookupTableParameter.type, name, title, description, dataType, defaultValue, optional);
     this._value2 = { lookupTable, key };
   }
 
@@ -53,11 +52,11 @@ export default class LookupTableParameter extends Parameter {
 
   // eslint-disable-next-line @typescript-eslint/no-use-before-define
   toBuilder(): Builder {
-    const { type, name, title, description, dataType, defaultValue, optional, binding } = this._value;
+    const { type, name, title, description, dataType, defaultValue, optional } = this._value;
     const { lookupTable, key } = this._value2;
 
     // eslint-disable-next-line @typescript-eslint/no-use-before-define
-    return new Builder(Immutable.Map({ type, name, title, description, dataType, defaultValue, optional, binding, lookupTable, key }));
+    return new Builder(Immutable.Map({ type, name, title, description, dataType, defaultValue, optional, lookupTable, key }));
   }
 
   // screw you eslint, using param.constructor.needsBinding() is ugly

--- a/graylog2-web-interface/src/views/logic/search/Search.ts
+++ b/graylog2-web-interface/src/views/logic/search/Search.ts
@@ -68,7 +68,7 @@ export default class Search {
 
   get requiredParameters(): Immutable.Set<Parameter> {
     return this.parameters
-      .filter((p) => (!p.defaultValue && (!p.optional || p.needsBinding))).toSet();
+      .filter((p) => (!p.defaultValue && (!p.optional && p.needsBinding))).toSet();
   }
 
   // eslint-disable-next-line @typescript-eslint/no-use-before-define

--- a/graylog2-web-interface/src/views/logic/search/Search.ts
+++ b/graylog2-web-interface/src/views/logic/search/Search.ts
@@ -68,7 +68,7 @@ export default class Search {
 
   get requiredParameters(): Immutable.Set<Parameter> {
     return this.parameters
-      .filter((p) => (!p.optional && !p.defaultValue)).toSet();
+      .filter((p) => (!p.defaultValue && (!p.optional || p.needsBinding))).toSet();
   }
 
   // eslint-disable-next-line @typescript-eslint/no-use-before-define

--- a/graylog2-web-interface/test/fixtures/lookupTables.ts
+++ b/graylog2-web-interface/test/fixtures/lookupTables.ts
@@ -15,6 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 
+// eslint-disable-next-line import/prefer-default-export
 export const createLookupTable = (index = 1, overrides = {}) => ({
   cache_id: 'cache-id',
   content_pack: null,

--- a/graylog2-web-interface/test/fixtures/lookupTables.ts
+++ b/graylog2-web-interface/test/fixtures/lookupTables.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+
+export const createLookupTable = (index = 1, overrides = {}) => ({
+  cache_id: 'cache-id',
+  content_pack: null,
+  data_adapter_id: 'data-adapter-id',
+  default_multi_value: '',
+  default_multi_value_type: 'NULL',
+  default_single_value: '',
+  default_single_value_type: 'NULL',
+  description: `Description lookup-table-${index}`,
+  id: `lookup-table-id-${index}`,
+  name: `lookup-table-name-${index}`,
+  title: `Lookup Table Title ${index}`,
+  ...overrides,
+});

--- a/graylog2-web-interface/test/fixtures/parameters.ts
+++ b/graylog2-web-interface/test/fixtures/parameters.ts
@@ -17,4 +17,5 @@
 
 import ValueParameter from 'views/logic/parameters/ValueParameter';
 
+// eslint-disable-next-line import/prefer-default-export
 export const valueParameter = ValueParameter.create('paraemterName', 'Parameter Title', '', 'any', undefined, false);

--- a/graylog2-web-interface/test/fixtures/parameters.ts
+++ b/graylog2-web-interface/test/fixtures/parameters.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+
+import ValueParameter from 'views/logic/parameters/ValueParameter';
+
+export const valueParameter = ValueParameter.create('paraemterName', 'Parameter Title', '', 'any', undefined, false);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

With this PR we are creating a shared component for the lookup table parameter form components, to improve their reusability.
Currently we are using this component e.g. in the event definition form. While the  new `LookupTableEdit` component expects to receive a `LookupTableParameter` class, we are using JSON for the parameter inside the event definition form and had to adjust the code accordingly.

We are also implementing some smaller changes for lookup table parameter. We are:
-  no longer creating an empty binding when creating a lookup table parameter, since this parameter type has no binding.
- improving the parts which check if the lookup table parameter binding is required.
- creating fixtures for value parameters and lookup tables.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

