### PR TITLE
Display Tooltips by default (#11130)

### DIFF
--- a/graylog2-web-interface/src/components/events/events/Events.jsx
+++ b/graylog2-web-interface/src/components/events/events/Events.jsx
@@ -143,7 +143,7 @@ class Events extends React.Component {
 
     return (
       <>
-        <OverlayTrigger placement="top" overlay={tooltip}>
+        <OverlayTrigger placement="top" trigger={['hover', 'click', 'focus']} overlay={tooltip}>
           <EventsIcon name={icon} fixedWidth className={style} />
         </OverlayTrigger>
       </>

--- a/graylog2-web-interface/src/components/graylog/Tooltip.jsx
+++ b/graylog2-web-interface/src/components/graylog/Tooltip.jsx
@@ -135,7 +135,7 @@ Tooltip.defaultProps = {
   positionLeft: undefined,
   arrowOffsetTop: undefined,
   arrowOffsetLeft: undefined,
-  show: false,
+  show: true,
 };
 
 /** @component */


### PR DESCRIPTION
Backport of https://github.com/Graylog2/graylog2-server/pull/11130 for 4.1.

* Show Tooltips by default

The `Tooltip` component offers a `show` prop that will decide if the
tooltip is rendered or not. At the moment we always use `Tooltip` with
`OverlayTrigger`, so the tooltip will already be displayed conditionally
and we expect that it will be rendered by default (or so do most of our
usages of the component).

This change reverses the default value for the `show` prop, so it is
still possible to hide a Tooltip if needed, but by default it will be
displayed on screen.

Fixes #10975

* Display event priority tooltip on hover and focus

(cherry picked from commit d2d2dbb5a2637f590809489270e53473dcc72041)
