### PR TITLE
Fixing resolving alias target for index sets with plus in prefix on ES6.

### DIFF
--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/IndicesAdapterES6.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/IndicesAdapterES6.java
@@ -179,7 +179,7 @@ public class IndicesAdapterES6 implements IndicesAdapter {
     @Override
     public Set<String> resolveAlias(String alias) {
         final GetSingleAlias request = new GetSingleAlias.Builder()
-                .alias(alias)
+                .alias(uncheckedURLEncode(alias))
                 .build();
         try {
             final JestResult jestResult = JestUtils.execute(jestClient, request, () -> "Couldn't collect indices for alias " + alias);

--- a/graylog2-server/src/test/java/org/graylog2/indexer/indices/IndicesIT.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/indices/IndicesIT.java
@@ -467,4 +467,16 @@ public abstract class IndicesIT extends ElasticsearchBaseTest {
 
         assertThat(indices.aliasTarget("graylog_alias_*")).contains(index);
     }
+
+    @Test
+    public void aliasTargetSupportsIndicesWithPlusInName() {
+        final String prefixWithPlus = "index+set_";
+        final String index = client().createRandomIndex(prefixWithPlus);
+        final String alias = prefixWithPlus + "deflector";
+        assertThat(indices.aliasTarget(alias)).isEmpty();
+
+        client().addAliasMapping(index, alias);
+
+        assertThat(indices.aliasTarget(prefixWithPlus + "*")).contains(index);
+    }
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

**Note:** This needs a backport to `4.0` and `4.1`.

Prior to this PR, we fixed a couple of issues related to index sets with a plus in their names (or any other character that requires special URL encoding) in #10392. One additional source of error was not found, which prevents resolving the deflector alias to the current index name on ES6.

This error leads to index cycling not working, due to receiving `null` for the current deflector target and passing that as the old index to the cycle alias method, which constructs an ES-command which atomically removes the old alias mapping and creates the new one. Due to the alias target which needs to be removed, the overall command fails, resulting in the complete index cycling to fail.

This change is now applying proper URL encoding in the `resolveAlias` method, resulting in the current target being properly resolved and index cycling to succeed.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.