### PR TITLE
Improving typing of field/value action contexts.

### DIFF
--- a/graylog2-web-interface/src/views/bindings.fieldActions.test.tsx
+++ b/graylog2-web-interface/src/views/bindings.fieldActions.test.tsx
@@ -17,6 +17,7 @@
 import MockStore from 'helpers/mocking/StoreMock';
 
 import FieldType, { FieldTypes, Properties } from 'views/logic/fieldtypes/FieldType';
+import { ActionDefinition } from 'views/components/actions/ActionHandler';
 
 import bindings from './bindings';
 
@@ -39,7 +40,7 @@ describe('Views bindings field actions', () => {
     contexts: {},
     type: FieldType.Unknown,
   };
-  const findAction = (type: string) => fieldActions.find((binding) => binding.type === type);
+  const findAction = (type: string): ActionDefinition<{ analysisDisabledFields?: Array<string> }> => fieldActions.find((binding) => binding.type === type);
 
   describe('Aggregate', () => {
     const action = findAction('aggregate');

--- a/graylog2-web-interface/src/views/bindings.valueActions.test.tsx
+++ b/graylog2-web-interface/src/views/bindings.valueActions.test.tsx
@@ -17,6 +17,7 @@
 import MockStore from 'helpers/mocking/StoreMock';
 
 import FieldType, { FieldTypes, Properties } from 'views/logic/fieldtypes/FieldType';
+import { ActionDefinition } from 'views/components/actions/ActionHandler';
 
 import bindings from './bindings';
 
@@ -41,7 +42,7 @@ describe('Views bindings value actions', () => {
     },
     type: FieldType.Unknown,
   };
-  const findAction = (type) => valueActions.find((binding) => binding.type === type);
+  const findAction = (type): ActionDefinition<{}> => valueActions.find((binding) => binding.type === type);
 
   describe('CreateExtractor', () => {
     const action = findAction('create-extractor');

--- a/graylog2-web-interface/src/views/components/actions/Action.test.tsx
+++ b/graylog2-web-interface/src/views/components/actions/Action.test.tsx
@@ -18,6 +18,7 @@ import * as React from 'react';
 import { render, screen } from 'wrappedTestingLibrary';
 import userEvent from '@testing-library/user-event';
 import { createSimpleExternalValueAction } from 'fixtures/externalValueActions';
+import { ActionContexts } from 'views/types';
 
 import FieldAndValueActionsContext, { FieldAndValueActionsContextType } from 'views/components/contexts/FieldAndValueActionsContext';
 import FieldType from 'views/logic/fieldtypes/FieldType';
@@ -32,7 +33,7 @@ describe('Action', () => {
     field: 'field1',
     value: 'field-value',
     type: new FieldType('string', [], []),
-    contexts: {},
+    contexts: {} as ActionContexts,
   };
 
   type Props = Partial<React.ComponentProps<typeof Action>> & {

--- a/graylog2-web-interface/src/views/components/actions/ActionHandler.test.tsx
+++ b/graylog2-web-interface/src/views/components/actions/ActionHandler.test.tsx
@@ -20,11 +20,7 @@ import { mount } from 'wrappedEnzyme';
 import FieldType from 'views/logic/fieldtypes/FieldType';
 
 import { createHandlerFor } from './ActionHandler';
-import type {
-  ActionComponentProps,
-  ActionComponents, ActionDefinition,
-  ActionHandler,
-} from './ActionHandler';
+import type { ActionComponentProps, ActionComponents, ActionDefinition } from './ActionHandler';
 
 describe('ActionHandler', () => {
   it('returns the handler for a function-based definition', () => {
@@ -43,13 +39,13 @@ describe('ActionHandler', () => {
   it('generates a handler from a component-based definition', () => {
     const setState = jest.fn();
     const setActionComponents = jest.fn((fn) => setState(fn({})));
-    const actionDefinition: ActionDefinition = {
+    const actionDefinition: ActionDefinition<{}> = {
       type: 'dummy-action',
       title: 'A Dummy Action',
       component: () => <div>Hello world!</div>,
       resetFocus: false,
     };
-    const handler: ActionHandler = createHandlerFor(actionDefinition, setActionComponents);
+    const handler = createHandlerFor(actionDefinition, setActionComponents);
 
     expect(handler).toBeDefined();
 
@@ -76,13 +72,13 @@ describe('ActionHandler', () => {
   it('supplied onClose removes component from state', () => {
     const setState = jest.fn();
     const setActionComponents = jest.fn((fn) => setState(fn({})));
-    const actionDefinition: ActionDefinition = {
+    const actionDefinition: ActionDefinition<{}> = {
       type: 'dummy-action',
       title: 'A Dummy Action',
       component: () => <div>Hello world!</div>,
       resetFocus: false,
     };
-    const handler: ActionHandler = createHandlerFor(actionDefinition, setActionComponents);
+    const handler = createHandlerFor(actionDefinition, setActionComponents);
 
     return handler({ queryId: 'foo', field: 'bar', value: 42, type: FieldType.Unknown, contexts: {} })
       .then(() => {

--- a/graylog2-web-interface/src/views/components/actions/ActionHandler.tsx
+++ b/graylog2-web-interface/src/views/components/actions/ActionHandler.tsx
@@ -16,9 +16,9 @@
  */
 import * as React from 'react';
 import uuid from 'uuid/v4';
+import { ActionContexts } from 'views/types';
 
 import type { FieldName, FieldValue } from 'views/logic/fieldtypes/FieldType';
-import type { ActionContexts } from 'views/logic/ActionContext';
 import type { QueryId } from 'views/logic/queries/Query';
 import FieldType from 'views/logic/fieldtypes/FieldType';
 
@@ -36,35 +36,35 @@ export type ActionComponents = { [key: string]: React.ReactElement<ActionCompone
 
 export type SetActionComponents = (fn: (component: ActionComponents) => ActionComponents) => void;
 
-export type ActionHandlerArguments = {
+export type ActionHandlerArguments<Contexts = ActionContexts> = {
   queryId: QueryId,
   field: FieldName,
   value?: FieldValue,
   type: FieldType,
-  contexts: ActionContexts,
+  contexts: Contexts,
 };
 
-export type ActionHandler = (args: ActionHandlerArguments) => Promise<unknown>;
-export type ActionHandlerCondition = (args: ActionHandlerArguments) => boolean;
+export type ActionHandler<Contexts> = (args: ActionHandlerArguments<Contexts>) => Promise<unknown>;
+export type ActionHandlerCondition<Contexts> = (args: ActionHandlerArguments<Contexts>) => boolean;
 
-export type ActionHandlerConditions = {
-  isEnabled?: ActionHandlerCondition,
-  isHidden?: ActionHandlerCondition,
+export type ActionHandlerConditions<Contexts> = {
+  isEnabled?: ActionHandlerCondition<Contexts>,
+  isHidden?: ActionHandlerCondition<Contexts>,
 };
 
-export type HandlerAction = {
+export type HandlerAction<Contexts> = {
   type: string,
   title: string,
   component?: ActionComponentType,
-  handler?: ActionHandler,
+  handler?: ActionHandler<Contexts>,
   resetFocus: boolean,
-  linkTarget?: (args: ActionHandlerArguments) => string,
+  linkTarget?: (args: ActionHandlerArguments<Contexts>) => string,
 };
 
-export type ActionDefinition = HandlerAction & ActionHandlerConditions;
+export type ActionDefinition<Contexts = ActionContexts> = HandlerAction<Contexts> & ActionHandlerConditions<Contexts>;
 
 // eslint-disable-next-line import/prefer-default-export
-export function createHandlerFor(action: ActionDefinition, setActionComponents: SetActionComponents): ActionHandler {
+export function createHandlerFor<T>(action: ActionDefinition<T>, setActionComponents: SetActionComponents): ActionHandler<T> {
   if (action.handler) {
     return action.handler;
   }

--- a/graylog2-web-interface/src/views/components/messagelist/Highlight.test.tsx
+++ b/graylog2-web-interface/src/views/components/messagelist/Highlight.test.tsx
@@ -18,10 +18,11 @@ import React from 'react';
 import { render } from 'wrappedTestingLibrary';
 
 import { AdditionalContext } from 'views/logic/ActionContext';
+import { Message } from 'views/components/messagelist/Types';
 
 import Highlight from './Highlight';
 
-const messageFor = (ranges) => ({ highlight_ranges: ranges });
+const messageFor = (ranges) => ({ highlight_ranges: ranges } as Message);
 
 const hasBrokenUpText = (text) => (content, node) => {
   const hasText = (currentNode) => currentNode.textContent === text;

--- a/graylog2-web-interface/src/views/logic/ActionContext.tsx
+++ b/graylog2-web-interface/src/views/logic/ActionContext.tsx
@@ -15,14 +15,13 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
+import type { ActionContexts } from 'views/types';
 
-export type ActionContexts = { [key: string]: any };
-
-const ActionContext = React.createContext<ActionContexts>({});
+const ActionContext = React.createContext<ActionContexts>({} as ActionContexts);
 
 type Props = {
   children: React.ReactNode,
-  value: ActionContexts;
+  value: Partial<ActionContexts>;
 };
 
 const AdditionalContext = {

--- a/graylog2-web-interface/src/views/logic/fieldactions/AddMessageCountActionHandler.ts
+++ b/graylog2-web-interface/src/views/logic/fieldactions/AddMessageCountActionHandler.ts
@@ -22,7 +22,7 @@ import Series from 'views/logic/aggregationbuilder/Series';
 import SeriesConfig from 'views/logic/aggregationbuilder/SeriesConfig';
 import type { ActionHandler } from 'views/components/actions/ActionHandler';
 
-const AddMessageCountActionHandler: ActionHandler = async () => {
+const AddMessageCountActionHandler: ActionHandler<{}> = async () => {
   const series = Series.forFunction('count()')
     .toBuilder()
     .config(new SeriesConfig('Message Count'))

--- a/graylog2-web-interface/src/views/logic/fieldactions/AddToAllTablesActionHandler.ts
+++ b/graylog2-web-interface/src/views/logic/fieldactions/AddToAllTablesActionHandler.ts
@@ -17,7 +17,7 @@
 import { WidgetStore, WidgetActions } from 'views/stores/WidgetStore';
 import type { FieldActionHandler } from 'views/logic/fieldactions/FieldActionHandler';
 
-const AddToAllTablesActionHandler: FieldActionHandler = ({ field }) => {
+const AddToAllTablesActionHandler: FieldActionHandler<{}> = ({ field }) => {
   const widgets = WidgetStore.getInitialState();
   const newWidgets = widgets.map((widget) => {
     if (widget.type.toUpperCase() === 'MESSAGES') {

--- a/graylog2-web-interface/src/views/logic/fieldactions/AddToTableActionHandler.ts
+++ b/graylog2-web-interface/src/views/logic/fieldactions/AddToTableActionHandler.ts
@@ -17,8 +17,11 @@
 import { WidgetActions } from 'views/stores/WidgetStore';
 import MessagesWidget from 'views/logic/widgets/MessagesWidget';
 import type { FieldActionHandler, FieldActionHandlerCondition } from 'views/logic/fieldactions/FieldActionHandler';
+import Widget from 'views/logic/widgets/Widget';
 
-const AddToTableActionHandler: FieldActionHandler = ({ field, contexts: { widget } }) => {
+type Contexts = { widget: Widget };
+
+const AddToTableActionHandler: FieldActionHandler<Contexts> = ({ field, contexts: { widget } }) => {
   const newFields = [].concat(widget.config.fields, [field]);
   const newConfig = widget.config.toBuilder()
     .fields(newFields)
@@ -27,7 +30,7 @@ const AddToTableActionHandler: FieldActionHandler = ({ field, contexts: { widget
   return WidgetActions.updateConfig(widget.id, newConfig);
 };
 
-const isEnabled: FieldActionHandlerCondition = ({ contexts: { widget }, field }) => {
+const isEnabled: FieldActionHandlerCondition<Contexts> = ({ contexts: { widget }, field }) => {
   if (MessagesWidget.isMessagesWidget(widget) && widget.config) {
     const fields = widget.config.fields || [];
 
@@ -38,7 +41,7 @@ const isEnabled: FieldActionHandlerCondition = ({ contexts: { widget }, field })
 };
 
 /* Hide AddToTableHandler in the sidebar */
-const isHidden: FieldActionHandlerCondition = ({ contexts: { widget } }) => !widget;
+const isHidden: FieldActionHandlerCondition<Contexts> = ({ contexts: { widget } }) => !widget;
 
 AddToTableActionHandler.isEnabled = isEnabled;
 AddToTableActionHandler.isHidden = isHidden;

--- a/graylog2-web-interface/src/views/logic/fieldactions/AggregateActionHandler.ts
+++ b/graylog2-web-interface/src/views/logic/fieldactions/AggregateActionHandler.ts
@@ -25,7 +25,7 @@ import DataTable from 'views/components/datatable/DataTable';
 import type { FieldActionHandler } from './FieldActionHandler';
 import duplicateCommonWidgetSettings from './DuplicateCommonWidgetSettings';
 
-const AggregateActionHandler: FieldActionHandler = ({ field, type, contexts: { widget = Widget.empty() } }) => {
+const AggregateActionHandler: FieldActionHandler<{ widget?: Widget }> = ({ field, type, contexts: { widget = Widget.empty() } }) => {
   const newWidgetBuilder = AggregationWidget.builder()
     .newId()
     .config(AggregationWidgetConfig.builder()

--- a/graylog2-web-interface/src/views/logic/fieldactions/ChartActionHandler.ts
+++ b/graylog2-web-interface/src/views/logic/fieldactions/ChartActionHandler.ts
@@ -54,7 +54,7 @@ const fieldTypeFor = (fieldName: string, queryId: string): FieldType => {
   return mapping.type;
 };
 
-const ChartActionHandler: FieldActionHandler = ({ queryId, field, contexts: { widget: origWidget = Widget.empty() } }) => {
+const ChartActionHandler: FieldActionHandler<{ widget?: Widget }> = ({ queryId, field, contexts: { widget: origWidget = Widget.empty() } }) => {
   const series = isFunction(field) ? Series.forFunction(field) : Series.forFunction(`avg(${field})`);
   const config = AggregationWidgetConfig.builder()
     .rowPivots([pivotForField(TIMESTAMP_FIELD, fieldTypeFor(TIMESTAMP_FIELD, queryId))])

--- a/graylog2-web-interface/src/views/logic/fieldactions/FieldActionHandler.ts
+++ b/graylog2-web-interface/src/views/logic/fieldactions/FieldActionHandler.ts
@@ -14,12 +14,14 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
+import { ActionContexts } from 'views/types';
+
 import type {
   ActionHandler,
   ActionHandlerArguments,
   ActionHandlerConditions,
 } from 'views/components/actions/ActionHandler';
 
-export type FieldActionHandlerCondition = (args: ActionHandlerArguments) => boolean;
+export type FieldActionHandlerCondition<Contexts = ActionContexts> = (args: ActionHandlerArguments<Contexts>) => boolean;
 
-export type FieldActionHandler = ActionHandler & ActionHandlerConditions;
+export type FieldActionHandler<Contexts = ActionContexts> = ActionHandler<Contexts> & ActionHandlerConditions<Contexts>;

--- a/graylog2-web-interface/src/views/logic/fieldactions/FieldStatisticsHandler.ts
+++ b/graylog2-web-interface/src/views/logic/fieldactions/FieldStatisticsHandler.ts
@@ -27,7 +27,7 @@ import duplicateCommonWidgetSettings from './DuplicateCommonWidgetSettings';
 const NUMERIC_FIELD_SERIES = ['count', 'sum', 'avg', 'min', 'max', 'stddev', 'variance', 'card', 'percentile'];
 const NONNUMERIC_FIELD_SERIES = ['count', 'card'];
 
-const handler: FieldActionHandler = ({ field, type, contexts: { widget: origWidget = Widget.empty() } }) => {
+const handler: FieldActionHandler<{ widget?: Widget }> = ({ field, type, contexts: { widget: origWidget = Widget.empty() } }) => {
   const series = ((type && type.isNumeric()) ? NUMERIC_FIELD_SERIES : NONNUMERIC_FIELD_SERIES)
     .map((f) => {
       if (f === 'percentile') {

--- a/graylog2-web-interface/src/views/logic/fieldactions/RemoveFromAllTablesActionHandler.ts
+++ b/graylog2-web-interface/src/views/logic/fieldactions/RemoveFromAllTablesActionHandler.ts
@@ -17,7 +17,7 @@
 import { WidgetStore, WidgetActions } from 'views/stores/WidgetStore';
 import type { FieldActionHandler } from 'views/logic/fieldactions/FieldActionHandler';
 
-const RemoveFromAllTablesActionHandler: FieldActionHandler = ({ field }) => {
+const RemoveFromAllTablesActionHandler: FieldActionHandler<{}> = ({ field }) => {
   const widgets = WidgetStore.getInitialState();
   const newWidgets = widgets.map((widget) => {
     if (widget.type.toUpperCase() === 'MESSAGES') {

--- a/graylog2-web-interface/src/views/logic/fieldactions/RemoveFromTableActionHandler.ts
+++ b/graylog2-web-interface/src/views/logic/fieldactions/RemoveFromTableActionHandler.ts
@@ -16,10 +16,13 @@
  */
 import { WidgetActions } from 'views/stores/WidgetStore';
 import MessagesWidget from 'views/logic/widgets/MessagesWidget';
+import Widget from 'views/logic/widgets/Widget';
 
 import type { FieldActionHandlerCondition, FieldActionHandler } from './FieldActionHandler';
 
-const RemoveFromTableActionHandler: FieldActionHandler = ({ field, contexts: { widget } }) => {
+type Contexts = { widget: Widget };
+
+const RemoveFromTableActionHandler: FieldActionHandler<Contexts> = ({ field, contexts: { widget } }) => {
   const newFields = widget.config.fields.filter((f) => (f !== field));
   const newConfig = widget.config.toBuilder()
     .fields(newFields)
@@ -28,7 +31,7 @@ const RemoveFromTableActionHandler: FieldActionHandler = ({ field, contexts: { w
   return WidgetActions.updateConfig(widget.id, newConfig);
 };
 
-const isEnabled: FieldActionHandlerCondition = ({ contexts: { widget }, field }) => {
+const isEnabled: FieldActionHandlerCondition<Contexts> = ({ contexts: { widget }, field }) => {
   if (MessagesWidget.isMessagesWidget(widget) && widget.config) {
     const fields = widget.config.fields || [];
 
@@ -39,7 +42,7 @@ const isEnabled: FieldActionHandlerCondition = ({ contexts: { widget }, field })
 };
 
 /* Hide RemoveFromTableHandler in the sidebar */
-const isHidden: FieldActionHandlerCondition = ({ contexts: { widget } }): boolean => !widget;
+const isHidden: FieldActionHandlerCondition<Contexts> = ({ contexts: { widget } }): boolean => !widget;
 
 RemoveFromTableActionHandler.isEnabled = isEnabled;
 RemoveFromTableActionHandler.isHidden = isHidden;

--- a/graylog2-web-interface/src/views/logic/valueactions/AddToQueryHandler.ts
+++ b/graylog2-web-interface/src/views/logic/valueactions/AddToQueryHandler.ts
@@ -38,7 +38,7 @@ export default class AddToQueryHandler extends QueryManipulationHandler {
     return addToQuery(oldQuery, fieldPredicate);
   };
 
-  handle: ActionHandler = ({ queryId, field, value = '', type }) => {
+  handle: ActionHandler<{}> = ({ queryId, field, value = '', type }) => {
     const oldQuery = this.currentQueryString(queryId);
     const newQuery = this.formatNewQuery(oldQuery, field, value, type);
 

--- a/graylog2-web-interface/src/views/logic/valueactions/ExcludeFromQueryHandler.ts
+++ b/graylog2-web-interface/src/views/logic/valueactions/ExcludeFromQueryHandler.ts
@@ -26,7 +26,7 @@ export default class ExcludeFromQueryHandler extends QueryManipulationHandler {
     return addToQuery(oldQuery, fieldPredicate);
   };
 
-  handle: ActionHandler = ({ queryId, field, value }) => {
+  handle: ActionHandler<{}> = ({ queryId, field, value }) => {
     const oldQuery = this.currentQueryString(queryId);
     const newQuery = this.formatNewQuery(oldQuery, field, value);
 

--- a/graylog2-web-interface/src/views/logic/valueactions/HighlightValueHandler.ts
+++ b/graylog2-web-interface/src/views/logic/valueactions/HighlightValueHandler.ts
@@ -34,7 +34,7 @@ const HighlightValueHandler: ValueActionHandler = ({ field, value }) => {
   );
 };
 
-const isEnabled: ActionHandlerCondition = ({ field, value }) => {
+const isEnabled: ActionHandlerCondition<{}> = ({ field, value }) => {
   const highlightingRules = HighlightingRulesStore.getInitialState();
 
   return highlightingRules.find(({ field: f, value: v }) => (field === f && value === v)) === undefined;

--- a/graylog2-web-interface/src/views/logic/valueactions/ShowDocumentsHandler.test.ts
+++ b/graylog2-web-interface/src/views/logic/valueactions/ShowDocumentsHandler.test.ts
@@ -65,7 +65,7 @@ describe('ShowDocumentsHandler', () => {
   });
 
   it('adds a new message widget for an empty value path', () => {
-    return ShowDocumentsHandler({ queryId, field, value: 42, type: FieldType.Unknown, contexts: { widget: widget, valuePath: [] } })
+    return ShowDocumentsHandler({ queryId, field, value: 42, type: FieldType.Unknown, contexts: { widget, valuePath: [] } })
       .then(() => {
         expect(WidgetActions.create).toHaveBeenCalled();
 
@@ -76,7 +76,7 @@ describe('ShowDocumentsHandler', () => {
   });
 
   it('adds the given value path as widget filter for new message widget', () => {
-    return ShowDocumentsHandler({ queryId, field, value: 42, type: FieldType.Unknown, contexts: { widget: widget, valuePath: [{ bar: 42 }, { [field]: 'Hello!' }] } })
+    return ShowDocumentsHandler({ queryId, field, value: 42, type: FieldType.Unknown, contexts: { widget, valuePath: [{ bar: 42 }, { [field]: 'Hello!' }] } })
       .then(() => {
         expect(WidgetActions.create).toHaveBeenCalled();
 

--- a/graylog2-web-interface/src/views/logic/valueactions/ShowDocumentsHandler.ts
+++ b/graylog2-web-interface/src/views/logic/valueactions/ShowDocumentsHandler.ts
@@ -18,7 +18,6 @@ import { DEFAULT_MESSAGE_FIELDS } from 'views/Constants';
 import { WidgetActions } from 'views/stores/WidgetStore';
 import { escape, addToQuery } from 'views/logic/queries/QueryHelper';
 import TitleTypes from 'views/stores/TitleTypes';
-import { ActionHandlerArguments } from 'views/components/actions/ActionHandler';
 
 import type { ValueActionHandler, ValuePath } from './ValueActionHandler';
 
@@ -46,7 +45,7 @@ const extractFieldsFromValuePath = (valuePath: ValuePath): Array<string> => {
     .reduce((prev, cur) => (prev.includes(cur) ? prev : [...prev, cur]), []);
 };
 
-const ShowDocumentsHandler: ValueActionHandler = ({ contexts: { valuePath, widget } }: ActionHandlerArguments & Arguments) => {
+const ShowDocumentsHandler: ValueActionHandler<Contexts> = ({ contexts: { valuePath, widget } }: Arguments) => {
   const mergedObject = valuePath.reduce((elem, acc) => ({
     ...acc,
     ...elem,

--- a/graylog2-web-interface/src/views/logic/valueactions/ValueActionHandler.ts
+++ b/graylog2-web-interface/src/views/logic/valueactions/ValueActionHandler.ts
@@ -14,8 +14,10 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
+import { ActionContexts } from 'views/types';
+
 import type { ActionHandler, ActionHandlerConditions } from 'views/components/actions/ActionHandler';
 
 export type ValuePath = Array<{ [key: string]: any }>;
 
-export type ValueActionHandler = ActionHandler & ActionHandlerConditions;
+export type ValueActionHandler<Contexts = ActionContexts> = ActionHandler<Contexts> & ActionHandlerConditions<Contexts>;

--- a/graylog2-web-interface/src/views/types.d.ts
+++ b/graylog2-web-interface/src/views/types.d.ts
@@ -40,6 +40,10 @@ import {
 import VisualizationConfig from 'views/logic/aggregationbuilder/visualizations/VisualizationConfig';
 import { TimeRange } from 'views/logic/queries/Query';
 import { CopyWidgetToDashboardHook } from 'views/logic/views/CopyWidgetToDashboard';
+import View from 'views/logic/views/View';
+import User from 'logic/users/User';
+import { Message } from 'views/components/messagelist/Types';
+import { ValuePath } from 'views/logic/valueactions/ValueActionHandler';
 
 import type { MessageEventTypes } from './types/messageEventTypes';
 
@@ -180,6 +184,15 @@ export type MessageResult = {
 export interface SearchTypeResultTypes {
   generic: SearchTypeResult,
   messages: MessageResult,
+}
+
+export interface ActionContexts {
+  view: View,
+  analysisDisabledFields: Array<string>,
+  currentUser: User,
+  widget: Widget,
+  message: Message,
+  valuePath: ValuePath,
 }
 
 export type SearchTypeResults = { [id: string]: SearchTypeResultTypes[keyof SearchTypeResultTypes] };

--- a/graylog2-web-interface/test/fixtures/externalValueActions.ts
+++ b/graylog2-web-interface/test/fixtures/externalValueActions.ts
@@ -18,7 +18,7 @@
 import { ActionDefinition } from 'views/components/actions/ActionHandler';
 
 // eslint-disable-next-line import/prefer-default-export
-export const createSimpleExternalValueAction = (overrides: Partial<ActionDefinition> = {}): ActionDefinition => ({
+export const createSimpleExternalValueAction = (overrides: Partial<ActionDefinition> = {}): ActionDefinition<{}> => ({
   type: 'http-get',
   title: 'Pivot to example.org',
   isHidden: ({ field }) => !['field1'].includes(field),


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is a followup to #11126. During review the weak typing of the `ActionContexts` type became apparent. It consisted of an indexer signature with an `any` type for its contents, resulting in the lack of types for all consumers of it.

This PR is attempting to change this by turning it into an explicitly typed interface, declared in the `views/types` module. An `interface` is used instead of a `type` to allow declaration merging. This makes it possible to extend the `ActionContexts` type through plugins.

Existing field/value actions/handlers are being adjusted accordingly.  A couple of types (`ActionHandler`, `ActionHandlerCondition`, ...) are made generic, with the generic type declaring the type of the context provided. This allows us to narrow down the context type to the context used in the specific handler, simplifying the construction of tests.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.