### PR TITLE
Provide default stage for new pipeline

### DIFF
--- a/graylog2-web-interface/src/logic/pipelines/SourceGenerator.js
+++ b/graylog2-web-interface/src/logic/pipelines/SourceGenerator.js
@@ -19,7 +19,7 @@ const SourceGenerator = {
     let source = `pipeline "${pipeline.title}"\n`;
 
     pipeline.stages.forEach((stage) => {
-      source += `stage ${stage.stage} match ${stage.match.toLowerCase()}\n`;
+      source += `stage ${stage.stage} match ${stage.match?.toLowerCase() || 'all'}\n`;
 
       stage.rules.forEach((rule) => {
         source += `rule "${rule}"\n`;

--- a/graylog2-web-interface/src/logic/pipelines/SourceGenerator.js
+++ b/graylog2-web-interface/src/logic/pipelines/SourceGenerator.js
@@ -19,7 +19,7 @@ const SourceGenerator = {
     let source = `pipeline "${pipeline.title}"\n`;
 
     pipeline.stages.forEach((stage) => {
-      source += `stage ${stage.stage} match ${stage.match?.toLowerCase() || 'all'}\n`;
+      source += `stage ${stage.stage} match ${stage.match?.toLowerCase() || 'either'}\n`;
 
       stage.rules.forEach((rule) => {
         source += `rule "${rule}"\n`;


### PR DESCRIPTION
## Motivation
Prior to this change, the creation of pipelines was broken
since we did not check if a stage actually exists.

## Description
This change will check if a stage exists and otherwise will
fallback to 'all'.

Fixes #11141

## How Has This Been Tested?
- Created a new pipeline
- Edited the newly created pipeline

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
