### PR TITLE
Add metadata field and accessors on Graylog Message object

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/plugin/Message.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/Message.java
@@ -196,20 +196,20 @@ public class Message implements Messages, Indexable {
     private static final char KEY_REPLACEMENT_CHAR = '_';
 
     private static final ImmutableSet<String> GRAYLOG_FIELDS = ImmutableSet.of(
-            FIELD_GL2_ACCOUNTED_MESSAGE_SIZE,
-            FIELD_GL2_ORIGINAL_TIMESTAMP,
-            FIELD_GL2_PROCESSING_ERROR,
-            FIELD_GL2_PROCESSING_TIMESTAMP,
-            FIELD_GL2_RECEIVE_TIMESTAMP,
-            FIELD_GL2_REMOTE_HOSTNAME,
-            FIELD_GL2_REMOTE_IP,
-            FIELD_GL2_REMOTE_PORT,
-            FIELD_GL2_SOURCE_COLLECTOR,
-            FIELD_GL2_SOURCE_COLLECTOR_INPUT,
-            FIELD_GL2_SOURCE_INPUT,
-            FIELD_GL2_SOURCE_NODE,
-            FIELD_GL2_SOURCE_RADIO,
-            FIELD_GL2_SOURCE_RADIO_INPUT
+        FIELD_GL2_ACCOUNTED_MESSAGE_SIZE,
+        FIELD_GL2_ORIGINAL_TIMESTAMP,
+        FIELD_GL2_PROCESSING_ERROR,
+        FIELD_GL2_PROCESSING_TIMESTAMP,
+        FIELD_GL2_RECEIVE_TIMESTAMP,
+        FIELD_GL2_REMOTE_HOSTNAME,
+        FIELD_GL2_REMOTE_IP,
+        FIELD_GL2_REMOTE_PORT,
+        FIELD_GL2_SOURCE_COLLECTOR,
+        FIELD_GL2_SOURCE_COLLECTOR_INPUT,
+        FIELD_GL2_SOURCE_INPUT,
+        FIELD_GL2_SOURCE_NODE,
+        FIELD_GL2_SOURCE_RADIO,
+        FIELD_GL2_SOURCE_RADIO_INPUT
     );
 
     // Graylog Illuminate Fields
@@ -222,41 +222,41 @@ public class Message implements Messages, Indexable {
     );
 
     private static final ImmutableSet<String> CORE_MESSAGE_FIELDS = ImmutableSet.of(
-            FIELD_MESSAGE,
-            FIELD_SOURCE,
-            FIELD_TIMESTAMP
+        FIELD_MESSAGE,
+        FIELD_SOURCE,
+        FIELD_TIMESTAMP
     );
 
     private static final ImmutableSet<String> ES_FIELDS = ImmutableSet.of(
-            // ElasticSearch fields.
-            FIELD_ID,
-            "_ttl",
-            "_source",
-            "_all",
-            "_index",
-            "_type",
-            "_score"
+        // ElasticSearch fields.
+        FIELD_ID,
+        "_ttl",
+        "_source",
+        "_all",
+        "_index",
+        "_type",
+        "_score"
     );
 
     public static final ImmutableSet<String> RESERVED_SETTABLE_FIELDS = new ImmutableSet.Builder<String>()
-            .addAll(GRAYLOG_FIELDS)
-            .addAll(CORE_MESSAGE_FIELDS)
-            .build();
+        .addAll(GRAYLOG_FIELDS)
+        .addAll(CORE_MESSAGE_FIELDS)
+        .build();
 
     public static final ImmutableSet<String> RESERVED_FIELDS = new ImmutableSet.Builder<String>()
-            .addAll(RESERVED_SETTABLE_FIELDS)
-            .addAll(ES_FIELDS)
-            .build();
+        .addAll(RESERVED_SETTABLE_FIELDS)
+        .addAll(ES_FIELDS)
+        .build();
 
     public static final ImmutableSet<String> FILTERED_FIELDS = new ImmutableSet.Builder<String>()
-            .addAll(GRAYLOG_FIELDS)
-            .addAll(ES_FIELDS)
-            .add(FIELD_STREAMS)
-            .add(FIELD_FULL_MESSAGE)
-            .build();
+        .addAll(GRAYLOG_FIELDS)
+        .addAll(ES_FIELDS)
+        .add(FIELD_STREAMS)
+        .add(FIELD_FULL_MESSAGE)
+        .build();
 
     private static final ImmutableSet<String> REQUIRED_FIELDS = ImmutableSet.of(
-            FIELD_MESSAGE, FIELD_ID
+        FIELD_MESSAGE, FIELD_ID
     );
 
     @Deprecated
@@ -290,7 +290,6 @@ public class Message implements Messages, Indexable {
     private com.codahale.metrics.Counter sizeCounter = new com.codahale.metrics.Counter();
 
     private static final IdentityHashMap<Class<?>, Integer> classSizes = Maps.newIdentityHashMap();
-
     static {
         classSizes.put(byte.class, 1);
         classSizes.put(Byte.class, 1);
@@ -400,7 +399,7 @@ public class Message implements Messages, Indexable {
                     obj.put(newKey, value);
                 } else {
                     LOG.warn("Keys must not contain a \".\" character! Ignoring field \"{}\"=\"{}\" in message [{}] - Unable to replace \".\" with a \"{}\" because of key conflict: \"{}\"=\"{}\"",
-                            key, value, getId(), KEY_REPLACEMENT_CHAR, newKey, obj.get(newKey));
+                        key, value, getId(), KEY_REPLACEMENT_CHAR, newKey, obj.get(newKey));
                     LOG.debug("Full message with \".\" in message key: {}", this);
                 }
             } else {
@@ -409,7 +408,7 @@ public class Message implements Messages, Indexable {
                     // Deliberate warning duplicates because the key with the "." might be transformed before reaching
                     // the duplicate original key with a "_". Otherwise we would silently overwrite the transformed key.
                     LOG.warn("Keys must not contain a \".\" character! Ignoring field \"{}\"=\"{}\" in message [{}] - Unable to replace \".\" with a \"{}\" because of key conflict: \"{}\"=\"{}\"",
-                            newKey, fields.get(newKey), getId(), KEY_REPLACEMENT_CHAR, key, value);
+                        newKey, fields.get(newKey), getId(), KEY_REPLACEMENT_CHAR, key, value);
                     LOG.debug("Full message with \".\" in message key: {}", this);
                 }
                 obj.put(key, value);
@@ -919,7 +918,6 @@ public class Message implements Messages, Indexable {
         static Timing timing(String name, long elapsedNanos) {
             return new Timing(name, elapsedNanos);
         }
-
         public static Message.Counter counter(String name, int counter) {
             return new Counter(name, counter);
         }

--- a/graylog2-server/src/main/java/org/graylog2/plugin/Message.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/Message.java
@@ -975,6 +975,7 @@ public class Message implements Messages, Indexable {
         if (metadata == null) {
             metadata = new HashMap<>();
         }
+        metadata.put(key, value);
     }
 
     /**
@@ -982,8 +983,26 @@ public class Message implements Messages, Indexable {
      *
      * @param key The string key for the metadata entry.
      */
+    @Nullable
     public Object getMetadataValue(String key) {
+        if (metadata == null) {
+            return null;
+        }
         return metadata.get(key);
+    }
+
+    /**
+     * Get the metadata value for the specified key. If not present, then return the default value.
+     *
+     * @param key The string key for the metadata entry.
+     */
+    @Nullable
+    public Object getMetadataValue(String key, Object defaultValue) {
+        if (metadata == null) {
+            return null;
+        }
+        final Object value = metadata.get(key);
+        return value != null ? value : defaultValue;
     }
 
     /**

--- a/graylog2-server/src/main/java/org/graylog2/plugin/Message.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/Message.java
@@ -281,7 +281,7 @@ public class Message implements Messages, Indexable {
     private ArrayList<Recording> recordings;
 
     /**
-     * A metadata map for storing custom-defined attributes that need to accompany the message throughout the Graylog
+     * A metadata map for storing custom-defined attributes that need to accompany the message throughout the
      * processing lifecycle. The value is intentionally not initialized by default, to avoid allocating unneeded
      * memory for messages that don't need to use metadata.
      */

--- a/graylog2-server/src/main/java/org/graylog2/plugin/Message.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/Message.java
@@ -999,7 +999,7 @@ public class Message implements Messages, Indexable {
     @Nullable
     public Object getMetadataValue(String key, Object defaultValue) {
         if (metadata == null) {
-            return null;
+            return defaultValue;
         }
         final Object value = metadata.get(key);
         return value != null ? value : defaultValue;

--- a/graylog2-server/src/test/java/org/graylog2/plugin/MessageTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/plugin/MessageTest.java
@@ -649,13 +649,24 @@ public class MessageTest {
         // Set and get value.
         message.setMetadata("stateKey", 10L);
         assertThat(message.getMetadataValue("stateKey")).isEqualTo(10L);
-        assertThat(message.getMetadataValue("stateKey", "default")).isEqualTo(10L);
-        assertThat(message.getMetadataValue("badKey", "default")).isEqualTo("default");
 
         // Test value removal.
         message.removeMetadata("badKey");
         assertThat(message.getMetadataValue("stateKey")).isEqualTo(10L);
         message.removeMetadata("stateKey");
         assertThat(message.getMetadataValue("stateKey")).isNull();
+    }
+
+    @Test
+    public void testMetadataDefault() throws NoSuchFieldException, IllegalAccessException {
+        final Message message = new Message("message", "source", Tools.nowUTC());
+
+        // Verify that appropriate default value is returned for uninitialized metadata.
+        assertThat(message.getMetadataValue("stateKey", "default")).isEqualTo("default");
+
+        // Set value, and confirm appropriate default is still returned.
+        message.setMetadata("stateKey", 10L);
+        assertThat(message.getMetadataValue("badKey", "default")).isEqualTo("default");
+        assertThat(message.getMetadataValue("stateKey", "default")).isEqualTo(10L);
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/plugin/MessageTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/plugin/MessageTest.java
@@ -662,7 +662,7 @@ public class MessageTest {
         final Message message = new Message("message", "source", Tools.nowUTC());
 
         // Verify that appropriate default value is returned for uninitialized metadata.
-        assertThat(message.getMetadataValue("stateKey", "default")).isEqualTo("default");
+        assertThat(message.getMetadataValue("nonExistentKey", "default")).isEqualTo("default");
 
         // Set value, and confirm appropriate default is still returned.
         message.setMetadata("stateKey", 10L);

--- a/graylog2-server/src/test/java/org/graylog2/plugin/MessageTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/plugin/MessageTest.java
@@ -38,7 +38,6 @@ import org.junit.Test;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
-import java.lang.reflect.Field;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -641,16 +640,22 @@ public class MessageTest {
     }
 
     @Test
-    public void testSetMessageState() throws NoSuchFieldException, IllegalAccessException {
+    public void testMetadata() throws NoSuchFieldException, IllegalAccessException {
         final Message message = new Message("message", "source", Tools.nowUTC());
-        final Field stateMap = Message.class.getDeclaredField("metadata");
-        assertNull(stateMap.get(message));
+
+        // Ensure an exception is not thrown for an uninitialized metadata map.
+        assertThat(message.getMetadataValue("stateKey")).isNull();
+
+        // Set and get value.
         message.setMetadata("stateKey", 10L);
-        assertNotNull(stateMap.get(message));
-        assertEquals(10L, message.getMetadataValue("stateKey"));
+        assertThat(message.getMetadataValue("stateKey")).isEqualTo(10L);
+        assertThat(message.getMetadataValue("stateKey", "default")).isEqualTo(10L);
+        assertThat(message.getMetadataValue("badKey", "default")).isEqualTo("default");
+
+        // Test value removal.
         message.removeMetadata("badKey");
-        assertEquals(10L, message.getMetadataValue("stateKey"));
+        assertThat(message.getMetadataValue("stateKey")).isEqualTo(10L);
         message.removeMetadata("stateKey");
-        assertNull(message.getMetadataValue("stateKey"));
+        assertThat(message.getMetadataValue("stateKey")).isNull();
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/plugin/MessageTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/plugin/MessageTest.java
@@ -353,13 +353,13 @@ public class MessageTest {
         final DateTime dateTime = new DateTime(2015, 9, 8, 0, 0, DateTimeZone.UTC);
 
         message.addField(Message.FIELD_TIMESTAMP,
-                dateTime.toDate());
+                         dateTime.toDate());
 
         final Map<String, Object> elasticSearchObject = message.toElasticSearchObject(objectMapper, invalidTimestampMeter);
         final Object esTimestampFormatted = elasticSearchObject.get(Message.FIELD_TIMESTAMP);
 
         assertEquals("Setting message timestamp as java.util.Date results in correct format for elasticsearch",
-                Tools.buildElasticSearchTimeFormat(dateTime), esTimestampFormatted);
+                     Tools.buildElasticSearchTimeFormat(dateTime), esTimestampFormatted);
     }
 
     @Test


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds a new `metadata` field on the Graylog `Message` object to allow data to be stored in the message, that will accompany the message throughout the processing lifecycle. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In certain feature cases, it can be useful to store state within the message object in Graylog.  Previously, this was only possible to add metadata to messages within explicit fields on the message. This previous approach was less desirable, since fields are intended to be eventually stored in search indices, so careful handling was needed to ensure the field metadata data is not indexed.

With this new approach, the metadata field (which is `null` by default) can be set, retrieved, and cleared through accessor methods (`message.setMetadata()`, `message.getMetadataValue()`, `message.removeMetadata()`)

See https://github.com/Graylog2/graylog-plugin-enterprise/issues/2590 for additional details on the initial motivation for the change.

Closes https://github.com/Graylog2/graylog-plugin-enterprise/issues/2590

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested to verify that Graylog pipelines still process messages successfully, and also verified that messages are indexed properly.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

