### PR TITLE
Fix counts in ViewService

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/ViewService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/ViewService.java
@@ -30,6 +30,7 @@ import org.mongojack.DBQuery;
 import org.mongojack.WriteResult;
 
 import javax.inject.Inject;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.Set;
@@ -70,7 +71,12 @@ public class ViewService extends PaginatedDbService<ViewDTO> {
                                                    DBQuery.Query grandTotalQuery,
                                                    int page,
                                                    int perPage) {
-        return findPaginatedWithQueryFilterAndSortWithGrandTotal(query, filter, getSortBuilder(order, sortField), grandTotalQuery, page, perPage);
+        final PaginatedList<ViewDTO> viewsList = findPaginatedWithQueryFilterAndSortWithGrandTotal(query, filter, getSortBuilder(order, sortField), grandTotalQuery, page, perPage);
+        return viewsList.stream()
+                .map(this::requirementsForView)
+                .collect(Collectors.toCollection(() -> viewsList.grandTotal()
+                        .map(grandTotal -> new PaginatedList<ViewDTO>(new ArrayList<>(viewsList.size()), viewsList.pagination().total(), page, perPage, grandTotal))
+                        .orElseGet(() -> new PaginatedList<>(new ArrayList<>(viewsList.size()), viewsList.pagination().total(), page, perPage))));
     }
 
     public PaginatedList<ViewDTO> searchPaginated(SearchQuery query,


### PR DESCRIPTION
## Motivation
see #11020 for initial motivation and description

## Description
An error was found in ViewSummaryService calculating counts. ViewSummaryService originated as a copy from ViewService - which consequently suffered from the same error.

## How Has This Been Tested?
- Use the API endpoints for dashboards & cluster-stats that execute the modified searches

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Backport
Needs backport to 4.1 (see #11151)