### PR TITLE
Failure queue metrics

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/failure/FailureSubmissionQueue.java
+++ b/graylog2-server/src/main/java/org/graylog/failure/FailureSubmissionQueue.java
@@ -60,7 +60,7 @@ public class FailureSubmissionQueue {
         this.queue = new LinkedBlockingQueue<>(configuration.getFailureHandlingQueueCapacity());
         this.configuration = configuration;
 
-            this.submittedFailureBatches = metricRegistry.meter(name(FailureSubmissionQueue.class, "submittedFailureBatches"));
+        this.submittedFailureBatches = metricRegistry.meter(name(FailureSubmissionQueue.class, "submittedFailureBatches"));
         this.submittedFailures = metricRegistry.meter(name(FailureSubmissionQueue.class, "submittedFailures"));
         this.consumedFailureBatches = metricRegistry.meter(name(FailureSubmissionQueue.class, "consumedFailureBatches"));
         this.consumedFailures = metricRegistry.meter(name(FailureSubmissionQueue.class, "consumedFailures"));

--- a/graylog2-server/src/main/resources/prometheus-exporter.yml
+++ b/graylog2-server/src/main/resources/prometheus-exporter.yml
@@ -979,8 +979,14 @@ metric_mappings:
   - metric_name: "elasticsearch_output_writes"
     match_pattern: "org.graylog2.outputs.ElasticSearchOutput.writes"
 
-  - metric_name: "elasticsearch_output_queue_size"
-    match_pattern: "org.graylog2.periodical.IndexFailuresPeriodical.queueSize"
+  - metric_name: "failure_queue_size"
+    match_pattern: "org.graylog.failure.FailureSubmissionQueue.queueSize"
+
+  - metric_name: "failure_queue_submitted_failures"
+    match_pattern: "org.graylog.failure.FailureSubmissionQueue.submittedFailures"
+
+  - metric_name: "failure_queue_consumed_failures"
+    match_pattern: "org.graylog.failure.FailureSubmissionQueue.consumedFailures"
 
   - metric_name: "mongodb_auth_cache_manager_evictions"
     match_pattern: "org.graylog2.security.MongoDbAuthorizationCacheManager.cache.evictions"


### PR DESCRIPTION
Migrated the `IndexFailuresPeriodical` size metric. The change is not
backward-compatible (it was decided to rename the metric, since the old
name doesn't represent the actual nature of that metric).

Also 2 more metrics were exposed to monitor performance of
failure handling (`failure_queue_submitted_failures` vs
`failure_queue_consumed_failures`)

[graylog-plugin-enterprise/issue-2127] Storing indexing/processing failures