### PR TITLE
Fixing resolving alias target for index sets with plus in prefix on ES6 in 4.0 (backport of #11142)

### DIFF
--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/IndicesAdapterES6.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/IndicesAdapterES6.java
@@ -66,6 +66,7 @@ import org.graylog.shaded.elasticsearch5.org.elasticsearch.search.aggregations.b
 import org.graylog.shaded.elasticsearch5.org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.graylog.shaded.elasticsearch5.org.elasticsearch.search.sort.FieldSortBuilder;
 import org.graylog.shaded.elasticsearch5.org.elasticsearch.search.sort.SortBuilders;
+import org.graylog.storage.elasticsearch6.indices.GetSingleAlias;
 import org.graylog.storage.elasticsearch6.jest.JestUtils;
 import org.graylog2.indexer.ElasticsearchException;
 import org.graylog2.indexer.IndexMapping;
@@ -91,6 +92,7 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -176,28 +178,20 @@ public class IndicesAdapterES6 implements IndicesAdapter {
 
     @Override
     public Set<String> resolveAlias(String alias) {
-        // TODO: This is basically getting all indices and later we filter out the alias we want to check for.
-        //       This can be done in a more efficient way by either using the /_cat/aliases/<alias-name> API or
-        //       the regular /_alias/<alias-name> API.
-        final GetAliases request = new GetAliases.Builder().build();
-        final JestResult jestResult = JestUtils.execute(jestClient, request, () -> "Couldn't collect indices for alias " + alias);
+        final GetSingleAlias request = new GetSingleAlias.Builder()
+                .alias(uncheckedURLEncode(alias))
+                .build();
+        try {
+            final JestResult jestResult = JestUtils.execute(jestClient, request, () -> "Couldn't collect indices for alias " + alias);
 
-        // The ES return value of this has an awkward format: The first key of the hash is the target index. Thanks.
-        final ImmutableSet.Builder<String> indicesBuilder = ImmutableSet.builder();
-        final Iterator<Map.Entry<String, JsonNode>> it = jestResult.getJsonObject().fields();
-        while (it.hasNext()) {
-            Map.Entry<String, JsonNode> entry = it.next();
-            final String indexName = entry.getKey();
-            Optional.of(entry.getValue())
-                    .map(json -> json.path("aliases"))
-                    .map(JsonNode::fields)
-                    .map(ImmutableList::copyOf)
-                    .filter(aliases -> !aliases.isEmpty())
-                    .filter(aliases -> aliases.stream().anyMatch(aliasEntry -> aliasEntry.getKey().equals(uncheckedURLEncode(alias))))
-                    .ifPresent(x -> indicesBuilder.add(indexName));
+            // The ES return value of this has an awkward format: The first key of the hash is the target index. Thanks.
+            return ImmutableSet.copyOf(jestResult.getJsonObject().fieldNames());
+        } catch (ElasticsearchException e) {
+            if (e.getMessage().startsWith("Couldn't collect indices for alias ")) {
+                return Collections.emptySet();
+            }
+            throw e;
         }
-
-        return indicesBuilder.build();
     }
 
     @Override

--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/IndicesAdapterES6.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/IndicesAdapterES6.java
@@ -176,7 +176,6 @@ public class IndicesAdapterES6 implements IndicesAdapter {
 
     @Override
     public Set<String> resolveAlias(String alias) {
-<<<<<<< HEAD
         // TODO: This is basically getting all indices and later we filter out the alias we want to check for.
         //       This can be done in a more efficient way by either using the /_cat/aliases/<alias-name> API or
         //       the regular /_alias/<alias-name> API.
@@ -194,23 +193,8 @@ public class IndicesAdapterES6 implements IndicesAdapter {
                     .map(JsonNode::fields)
                     .map(ImmutableList::copyOf)
                     .filter(aliases -> !aliases.isEmpty())
-                    .filter(aliases -> aliases.stream().anyMatch(aliasEntry -> aliasEntry.getKey().equals(alias)))
+                    .filter(aliases -> aliases.stream().anyMatch(aliasEntry -> aliasEntry.getKey().equals(uncheckedURLEncode(alias))))
                     .ifPresent(x -> indicesBuilder.add(indexName));
-=======
-        final GetSingleAlias request = new GetSingleAlias.Builder()
-                .alias(uncheckedURLEncode(alias))
-                .build();
-        try {
-            final JestResult jestResult = JestUtils.execute(jestClient, request, () -> "Couldn't collect indices for alias " + alias);
-
-            // The ES return value of this has an awkward format: The first key of the hash is the target index. Thanks.
-            return ImmutableSet.copyOf(jestResult.getJsonObject().fieldNames());
-        } catch (ElasticsearchException e) {
-            if (e.getMessage().startsWith("Couldn't collect indices for alias ")) {
-                return Collections.emptySet();
-            }
-            throw e;
->>>>>>> 4f9e8a2a82... Fixing resolving alias target for index sets with plus in prefix on ES6. (#11142)
         }
 
         return indicesBuilder.build();

--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/IndicesAdapterES6.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/IndicesAdapterES6.java
@@ -176,6 +176,7 @@ public class IndicesAdapterES6 implements IndicesAdapter {
 
     @Override
     public Set<String> resolveAlias(String alias) {
+<<<<<<< HEAD
         // TODO: This is basically getting all indices and later we filter out the alias we want to check for.
         //       This can be done in a more efficient way by either using the /_cat/aliases/<alias-name> API or
         //       the regular /_alias/<alias-name> API.
@@ -195,6 +196,21 @@ public class IndicesAdapterES6 implements IndicesAdapter {
                     .filter(aliases -> !aliases.isEmpty())
                     .filter(aliases -> aliases.stream().anyMatch(aliasEntry -> aliasEntry.getKey().equals(alias)))
                     .ifPresent(x -> indicesBuilder.add(indexName));
+=======
+        final GetSingleAlias request = new GetSingleAlias.Builder()
+                .alias(uncheckedURLEncode(alias))
+                .build();
+        try {
+            final JestResult jestResult = JestUtils.execute(jestClient, request, () -> "Couldn't collect indices for alias " + alias);
+
+            // The ES return value of this has an awkward format: The first key of the hash is the target index. Thanks.
+            return ImmutableSet.copyOf(jestResult.getJsonObject().fieldNames());
+        } catch (ElasticsearchException e) {
+            if (e.getMessage().startsWith("Couldn't collect indices for alias ")) {
+                return Collections.emptySet();
+            }
+            throw e;
+>>>>>>> 4f9e8a2a82... Fixing resolving alias target for index sets with plus in prefix on ES6. (#11142)
         }
 
         return indicesBuilder.build();

--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/indices/GetSingleAlias.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/indices/GetSingleAlias.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.storage.elasticsearch6.indices;
+
+import io.searchbox.action.AbstractMultiIndexActionBuilder;
+import io.searchbox.action.GenericResultAbstractAction;
+
+public class GetSingleAlias extends GenericResultAbstractAction {
+    private final String alias;
+
+    protected GetSingleAlias(Builder builder) {
+        super(builder);
+        this.alias = builder.alias;
+        setURI(buildURI());
+    }
+
+    @Override
+    public String getRestMethodName() {
+        return "GET";
+    }
+
+    @Override
+    protected String buildURI() {
+        return super.buildURI() + "/_alias/" + this.alias;
+    }
+
+    public static class Builder extends AbstractMultiIndexActionBuilder<GetSingleAlias, Builder> {
+        private String alias;
+
+        public Builder alias(String alias) {
+            this.alias = alias;
+            return this;
+        }
+
+        @Override
+        public GetSingleAlias build() {
+            return new GetSingleAlias(this);
+        }
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
@@ -151,6 +151,10 @@ public class Indices {
         return indices.stream().findFirst();
     }
 
+    public Set<String> aliasTargets(String alias) {
+        return indicesAdapter.resolveAlias(alias);
+    }
+
     public void ensureIndexTemplate(IndexSet indexSet) {
         final IndexSetConfig indexSetConfig = indexSet.getConfig();
         final String templateName = indexSetConfig.indexTemplateName();
@@ -253,9 +257,9 @@ public class Indices {
     }
 
     public boolean isReopened(String indexName) {
-        final Optional<String> aliasTarget = aliasTarget(indexName + REOPENED_ALIAS_SUFFIX);
+        final Set<String> aliasTarget = aliasTargets(indexName + REOPENED_ALIAS_SUFFIX);
 
-        return aliasTarget.map(target -> target.equals(indexName)).orElse(false);
+        return !aliasTarget.isEmpty();
     }
 
     public Map<String, Boolean> areReopened(Collection<String> indices) {

--- a/graylog2-server/src/test/java/org/graylog2/indexer/indices/IndicesIT.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/indices/IndicesIT.java
@@ -449,4 +449,27 @@ public abstract class IndicesIT extends ElasticsearchBaseTest {
 
         indices.optimizeIndex("graylog_0", 1, Duration.minutes(1));
     }
+
+    @Test
+    public void aliasTargetReturnsListOfTargetsGivenAliasIsPointingToWithWildcards() {
+        final String index = client().createRandomIndex("indices_it_");
+        final String alias = "graylog_alias_target";
+        assertThat(indices.aliasTarget(alias)).isEmpty();
+
+        client().addAliasMapping(index, alias);
+
+        assertThat(indices.aliasTarget("graylog_alias_*")).contains(index);
+    }
+
+    @Test
+    public void aliasTargetSupportsIndicesWithPlusInName() {
+        final String prefixWithPlus = "index+set_";
+        final String index = client().createRandomIndex(prefixWithPlus);
+        final String alias = prefixWithPlus + "deflector";
+        assertThat(indices.aliasTarget(alias)).isEmpty();
+
+        client().addAliasMapping(index, alias);
+
+        assertThat(indices.aliasTarget(prefixWithPlus + "*")).contains(index);
+    }
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

**Note:** backport from #11142, also backports #10757, verified that #10544 has been backported

Prior to this PR, we fixed a couple of issues related to index sets with a plus in their names (or any other character that requires special URL encoding) in #10392. One additional source of error was not found, which prevents resolving the deflector alias to the current index name on ES6.

This error leads to index cycling not working, due to receiving `null` for the current deflector target and passing that as the old index to the cycle alias method, which constructs an ES-command which atomically removes the old alias mapping and creates the new one. Due to the alias target which needs to be removed, the overall command fails, resulting in the complete index cycling to fail.

This change is now applying proper URL encoding in the `resolveAlias` method, resulting in the current target being properly resolved and index cycling to succeed.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.