### PR TITLE
Assign page titles dynamically instead of setting them during render.

### DIFF
--- a/graylog2-web-interface/src/views/components/AdaptableQueryTabs.tsx
+++ b/graylog2-web-interface/src/views/components/AdaptableQueryTabs.tsx
@@ -160,7 +160,7 @@ const adjustTabsVisibility = (maxWidth, lockedTab, setLockedTab) => {
   }
 };
 
-const AdaptableQueryTabs = ({ maxWidth, queries, titles, selectedQueryId, onRemove, onSelect, queryTitleEditModal, onTitleChange }: Props) => {
+const AdaptableQueryTabs = ({ maxWidth, queries, titles, selectedQueryId, onRemove, onSelect, queryTitleEditModal }: Props) => {
   const [openedMore, setOpenedMore] = useState<boolean>(false);
   const [lockedTab, setLockedTab] = useState<QueryId>();
 
@@ -169,18 +169,14 @@ const AdaptableQueryTabs = ({ maxWidth, queries, titles, selectedQueryId, onRemo
     const menuItems = [];
     const lockedItems = [];
 
-    queries.forEach((id) => {
+    queries.keySeq().forEach((id, idx) => {
       const openTitleEditModal = (activeQueryTitle: string) => {
         if (queryTitleEditModal) {
           queryTitleEditModal.current.open(activeQueryTitle);
         }
       };
 
-      if (!titles.has(id) && lockedTab !== id && selectedQueryId === id) {
-        onTitleChange(id, `Page#${queries.size}`).then(() => setLockedTab(id));
-      }
-
-      const title = titles.get(id, `Page#${queries.size}`);
+      const title = titles.get(id, `Page#${idx + 1}`);
       const tabTitle = (
         <QueryTitle active={id === selectedQueryId}
                     id={id}
@@ -225,7 +221,7 @@ const AdaptableQueryTabs = ({ maxWidth, queries, titles, selectedQueryId, onRemo
     });
 
     return { navItems, menuItems, lockedItems };
-  }, [lockedTab, onRemove, onSelect, onTitleChange, queries, queryTitleEditModal, selectedQueryId, titles]);
+  }, [lockedTab, onRemove, onSelect, queries, queryTitleEditModal, selectedQueryId, titles]);
 
   useEffect(() => {
     adjustTabsVisibility(maxWidth, lockedTab, setLockedTab);
@@ -272,7 +268,6 @@ AdaptableQueryTabs.propTypes = {
     PropTypes.func,
     PropTypes.shape({ current: PropTypes.object }),
   ]).isRequired,
-  onTitleChange: PropTypes.func.isRequired,
 };
 
 export default AdaptableQueryTabs;

--- a/graylog2-web-interface/src/views/components/common/WindowLeaveMessage.tsx
+++ b/graylog2-web-interface/src/views/components/common/WindowLeaveMessage.tsx
@@ -17,22 +17,19 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import connect from 'stores/connect';
+import { useStore } from 'stores/connect';
 import ConfirmLeaveDialog from 'components/common/ConfirmLeaveDialog';
 import { ViewStore } from 'views/stores/ViewStore';
 
-type Props = {
-  dirty: boolean,
+const WindowLeaveMessage = () => {
+  const dirty = useStore(ViewStore, ({ dirty }) => dirty);
+  return dirty
+    ? <ConfirmLeaveDialog question="Are you sure you want to leave the page? Any unsaved changes will be lost."/>
+    : null;
 };
-
-const WindowLeaveMessage = ({ dirty }: Props) => (dirty
-  ? (
-    <ConfirmLeaveDialog question="Are you sure you want to leave the page? Any unsaved changes will be lost." />
-  )
-  : null);
 
 WindowLeaveMessage.propTypes = {
   dirty: PropTypes.bool.isRequired,
 };
 
-export default connect(WindowLeaveMessage, { view: ViewStore }, ({ view }) => ({ dirty: view.dirty }));
+export default WindowLeaveMessage

--- a/graylog2-web-interface/src/views/components/common/WindowLeaveMessage.tsx
+++ b/graylog2-web-interface/src/views/components/common/WindowLeaveMessage.tsx
@@ -15,21 +15,17 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import React from 'react';
-import PropTypes from 'prop-types';
 
 import { useStore } from 'stores/connect';
 import ConfirmLeaveDialog from 'components/common/ConfirmLeaveDialog';
 import { ViewStore } from 'views/stores/ViewStore';
 
 const WindowLeaveMessage = () => {
-  const dirty = useStore(ViewStore, ({ dirty }) => dirty);
+  const dirty = useStore(ViewStore, (state) => state.dirty);
+
   return dirty
-    ? <ConfirmLeaveDialog question="Are you sure you want to leave the page? Any unsaved changes will be lost."/>
+    ? <ConfirmLeaveDialog question="Are you sure you want to leave the page? Any unsaved changes will be lost." />
     : null;
 };
 
-WindowLeaveMessage.propTypes = {
-  dirty: PropTypes.bool.isRequired,
-};
-
-export default WindowLeaveMessage
+export default WindowLeaveMessage;


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Prior to this change, the tab/page titles were set during render in some cases. This results in a newly loaded existing dashboard being flagged as dirty immediately.

This change is now assigning page names based on the index in the queries list instead of setting the title explicitly.
    
Fixes #11156.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.