### PR TITLE
Allow null message queue ids

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/shared/messageq/AbstractMessageQueueAcknowledger.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/messageq/AbstractMessageQueueAcknowledger.java
@@ -1,0 +1,53 @@
+package org.graylog2.shared.messageq;
+
+import org.graylog2.plugin.Message;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+public abstract class AbstractMessageQueueAcknowledger<T> implements MessageQueueAcknowledger {
+    private static final Logger log = LoggerFactory.getLogger(AbstractMessageQueueAcknowledger.class);
+
+    protected final Class<T> queueIdClass;
+    protected final Metrics metrics;
+
+    public AbstractMessageQueueAcknowledger(Class<T> queueIdClass, Metrics metrics) {
+        this.queueIdClass = queueIdClass;
+        this.metrics = metrics;
+    }
+
+    @Override
+    public void acknowledge(Object queueId) {
+        if (isValidMessageQueueId(queueId)) {
+            //noinspection unchecked
+            doAcknowledge((T) queueId);
+            metrics.acknowledgedMessages().mark();
+        }
+    }
+
+    @Override
+    public void acknowledge(Message message) {
+        acknowledge(message.getMessageQueueId());
+    }
+
+    @Override
+    public void acknowledge(List<Message> messages) {
+        messages.forEach(message -> acknowledge(message.getMessageQueueId()));
+    }
+
+    protected abstract void doAcknowledge(T queueId);
+
+    protected boolean isValidMessageQueueId(Object object) {
+        if (queueIdClass.isInstance(object)) {
+            return true;
+        }
+        // null is not valid, but it's also not an error condition because we might be dealing with a synthetic message
+        // e.g. from the "create_message" pipeline function
+        if (object != null) {
+            log.error("{} is unable to acknowledge message. Expected <{}> to be of type <{}>, but found <{}>.",
+                    getClass().getSimpleName(), object, queueIdClass.getSimpleName(), object.getClass().getSimpleName());
+        }
+        return false;
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/shared/messageq/AbstractMessageQueueAcknowledger.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/messageq/AbstractMessageQueueAcknowledger.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog2.shared.messageq;
 
 import org.graylog2.plugin.Message;

--- a/graylog2-server/src/main/java/org/graylog2/shared/messageq/MessageQueueAcknowledger.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/messageq/MessageQueueAcknowledger.java
@@ -21,6 +21,7 @@ import com.codahale.metrics.MetricRegistry;
 import com.google.auto.value.AutoValue;
 import org.graylog2.plugin.Message;
 
+import javax.annotation.Nullable;
 import javax.inject.Inject;
 import java.util.List;
 
@@ -28,7 +29,7 @@ import static com.codahale.metrics.MetricRegistry.name;
 
 public interface MessageQueueAcknowledger {
 
-    void acknowledge(Object messageQueueId);
+    void acknowledge(@Nullable Object messageQueueId);
 
     void acknowledge(Message message);
 

--- a/graylog2-server/src/test/java/org/graylog2/shared/messageq/localkafka/LocalKafkaMessageQueueAcknowledgerTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/shared/messageq/localkafka/LocalKafkaMessageQueueAcknowledgerTest.java
@@ -1,0 +1,82 @@
+package org.graylog2.shared.messageq.localkafka;
+
+import com.google.common.collect.ImmutableList;
+import org.graylog2.plugin.Message;
+import org.graylog2.shared.journal.LocalKafkaJournal;
+import org.graylog2.shared.messageq.MessageQueueAcknowledger;
+import org.joda.time.DateTime;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+@ExtendWith(MockitoExtension.class)
+public class LocalKafkaMessageQueueAcknowledgerTest {
+
+    @Mock
+    LocalKafkaJournal kafkaJournal;
+
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    MessageQueueAcknowledger.Metrics metrics;
+
+    @InjectMocks
+    LocalKafkaMessageQueueAcknowledger acknowledger;
+
+    @Test
+    void acknowledgeOffset() {
+        acknowledger.acknowledge(1L);
+        verify(kafkaJournal).markJournalOffsetCommitted(1L);
+    }
+
+    @Test
+    void acknowledgeNullOffset() {
+        acknowledger.acknowledge((Long) null);
+        verifyNoMoreInteractions(kafkaJournal);
+    }
+
+    @Test
+    void acknowledgeMessage() {
+        final Message message = new Message("message", "source", DateTime.now());
+        message.setMessageQueueId(1L);
+        acknowledger.acknowledge(message);
+        verify(kafkaJournal).markJournalOffsetCommitted(1L);
+    }
+
+    @Test
+    void acknowledgeMessageWithoutMessageQueueId() {
+        final Message message = new Message("message", "source", DateTime.now());
+        acknowledger.acknowledge(message);
+        verifyNoMoreInteractions(kafkaJournal);
+    }
+
+    @Test
+    void acknowledgeMessageWithWrongTypeOfMessageQueueId() {
+        final Message message = new Message("message", "source", DateTime.now());
+        message.setMessageQueueId("foo");
+        acknowledger.acknowledge(message);
+        verifyNoMoreInteractions(kafkaJournal);
+    }
+
+    @Test
+    void acknowledgeMessages() {
+        final Message firstMessage = new Message("message", "source", DateTime.now());
+        firstMessage.setMessageQueueId(1L);
+
+        final Message nullOffsetMessage = new Message("message", "source", DateTime.now());
+
+        final Message secondMessage = new Message("message", "source", DateTime.now());
+        secondMessage.setMessageQueueId(2L);
+
+        final Message wrongOffsetTypeMessage = new Message("message", "source", DateTime.now());
+        wrongOffsetTypeMessage.setMessageQueueId("foo");
+
+        acknowledger.acknowledge(ImmutableList.of(firstMessage, nullOffsetMessage, secondMessage, wrongOffsetTypeMessage));
+
+        verify(kafkaJournal).markJournalOffsetCommitted(2L);
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/shared/messageq/localkafka/LocalKafkaMessageQueueAcknowledgerTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/shared/messageq/localkafka/LocalKafkaMessageQueueAcknowledgerTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog2.shared.messageq.localkafka;
 
 import com.google.common.collect.ImmutableList;

--- a/graylog2-server/src/test/java/org/graylog2/shared/messageq/localkafka/LocalKafkaMessageQueueAcknowledgerTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/shared/messageq/localkafka/LocalKafkaMessageQueueAcknowledgerTest.java
@@ -28,6 +28,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import static org.joda.time.DateTimeZone.UTC;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
@@ -57,7 +58,7 @@ public class LocalKafkaMessageQueueAcknowledgerTest {
 
     @Test
     void acknowledgeMessage() {
-        final Message message = new Message("message", "source", DateTime.now());
+        final Message message = new Message("message", "source", DateTime.now(UTC));
         message.setMessageQueueId(1L);
         acknowledger.acknowledge(message);
         verify(kafkaJournal).markJournalOffsetCommitted(1L);
@@ -65,14 +66,14 @@ public class LocalKafkaMessageQueueAcknowledgerTest {
 
     @Test
     void acknowledgeMessageWithoutMessageQueueId() {
-        final Message message = new Message("message", "source", DateTime.now());
+        final Message message = new Message("message", "source", DateTime.now(UTC));
         acknowledger.acknowledge(message);
         verifyNoMoreInteractions(kafkaJournal);
     }
 
     @Test
     void acknowledgeMessageWithWrongTypeOfMessageQueueId() {
-        final Message message = new Message("message", "source", DateTime.now());
+        final Message message = new Message("message", "source", DateTime.now(UTC));
         message.setMessageQueueId("foo");
         acknowledger.acknowledge(message);
         verifyNoMoreInteractions(kafkaJournal);
@@ -80,15 +81,15 @@ public class LocalKafkaMessageQueueAcknowledgerTest {
 
     @Test
     void acknowledgeMessages() {
-        final Message firstMessage = new Message("message", "source", DateTime.now());
+        final Message firstMessage = new Message("message", "source", DateTime.now(UTC));
         firstMessage.setMessageQueueId(1L);
 
-        final Message nullOffsetMessage = new Message("message", "source", DateTime.now());
+        final Message nullOffsetMessage = new Message("message", "source", DateTime.now(UTC));
 
-        final Message secondMessage = new Message("message", "source", DateTime.now());
+        final Message secondMessage = new Message("message", "source", DateTime.now(UTC));
         secondMessage.setMessageQueueId(2L);
 
-        final Message wrongOffsetTypeMessage = new Message("message", "source", DateTime.now());
+        final Message wrongOffsetTypeMessage = new Message("message", "source", DateTime.now(UTC));
         wrongOffsetTypeMessage.setMessageQueueId("foo");
 
         acknowledger.acknowledge(ImmutableList.of(firstMessage, nullOffsetMessage, secondMessage, wrongOffsetTypeMessage));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
A message queue ID may be `null` if the message is not originating from the message queue but was generated during processing, e.g. as part of a pipeline rule.

To fix this for all message queues at once, a new `AbstractMessageQueueAcknowledger` class has been added which implementations can derive from.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #11143

Also see https://github.com/Graylog2/graylog-plugin-cloud/pull/963

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manual smoke test with disk based journal and Kafka journal (cloud).

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

