### PR TITLE
No failure handling loops

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/failure/FailureSubmissionQueue.java
+++ b/graylog2-server/src/main/java/org/graylog/failure/FailureSubmissionQueue.java
@@ -43,7 +43,7 @@ import static com.codahale.metrics.MetricRegistry.name;
  * The capacity of the underlying queue is controlled by {@link org.graylog2.Configuration#failureHandlingQueueCapacity}
  */
 @Singleton
-public class FailureSubmissionQueue {
+class FailureSubmissionQueue {
 
     private final Logger logger = LoggerFactory.getLogger(getClass());
 
@@ -55,7 +55,7 @@ public class FailureSubmissionQueue {
     private final Meter consumedFailures;
 
     @Inject
-    public FailureSubmissionQueue(Configuration configuration,
+    FailureSubmissionQueue(Configuration configuration,
                                   MetricRegistry metricRegistry) {
         this.queue = new LinkedBlockingQueue<>(configuration.getFailureHandlingQueueCapacity());
         this.configuration = configuration;
@@ -73,7 +73,7 @@ public class FailureSubmissionQueue {
      * Submits a failure batch for handling. If the underlying queue is full,
      * the call will block until the queue is ready to accept new batches.
      */
-    public void submitBlocking(FailureBatch batch) throws InterruptedException {
+    void submitBlocking(FailureBatch batch) throws InterruptedException {
         queue.put(batch);
 
         if (queueSize() == configuration.getFailureHandlingQueueCapacity()) {

--- a/graylog2-server/src/main/java/org/graylog/failure/FailureSubmissionService.java
+++ b/graylog2-server/src/main/java/org/graylog/failure/FailureSubmissionService.java
@@ -88,6 +88,12 @@ public class FailureSubmissionService {
             // We don't handle processing errors
             return true;
         }
+
+        if (!message.supportsFailureHandling()) {
+            logger.warn("Submitted a message with processing errors, which doesn't support failure handling!");
+            return true;
+        }
+
         if (processingErrors.isEmpty()) {
             return true;
         }
@@ -139,10 +145,22 @@ public class FailureSubmissionService {
      */
     public void submitIndexingErrors(Collection<Messages.IndexingError> indexingErrors) {
         try {
-            failureSubmissionQueue.submitBlocking(FailureBatch.indexingFailureBatch(
+            final FailureBatch fb = FailureBatch.indexingFailureBatch(
                     indexingErrors.stream()
+                            .filter(ie -> {
+                                if (!ie.message().supportsFailureHandling()) {
+                                    logger.warn("Submitted a message with indexing errors, which doesn't support failure handling!");
+                                    return false;
+                                } else {
+                                    return true;
+                                }
+                            })
                             .map(this::fromIndexingError)
-                            .collect(Collectors.toList())));
+                            .collect(Collectors.toList()));
+
+            if (fb.size() > 0) {
+                failureSubmissionQueue.submitBlocking(fb);
+            }
 
         } catch (InterruptedException ignored) {
             logger.warn("Failed to submit {} indexing errors for failure handling. The thread has been interrupted!",

--- a/graylog2-server/src/main/java/org/graylog2/indexer/messages/Indexable.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/messages/Indexable.java
@@ -42,4 +42,13 @@ public interface Indexable {
     DateTime getReceiveTime();
     Map<String, Object> toElasticSearchObject(ObjectMapper objectMapper,@Nonnull final Meter invalidTimestampMeter);
     DateTime getTimestamp();
+
+    /**
+     * Guides the failure handling framework when deciding whether this particular
+     * message should be accepted for the further failure processing. By default
+     * disabled for all messages.
+     */
+    default boolean supportsFailureHandling() {
+        return false;
+    }
 }

--- a/graylog2-server/src/main/java/org/graylog2/plugin/Message.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/Message.java
@@ -939,6 +939,11 @@ public class Message implements Messages, Indexable {
         return Iterators.singletonIterator(this);
     }
 
+    @Override
+    public boolean supportsFailureHandling() {
+        return true;
+    }
+
     public static abstract class Recording {
         static Timing timing(String name, long elapsedNanos) {
             return new Timing(name, elapsedNanos);


### PR DESCRIPTION
To avoid scenarios in which we try to handle a failed failure in a loop, 
another guiding property was added to the `Indexable` interface to indicate
whether a concrete `Indexable` should be picked by the failure handling
framework in case of exception.