### PR TITLE
/system/cluster/traffic: Support dots in nodeId field name

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/plugin/system/NodeId.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/system/NodeId.java
@@ -93,6 +93,14 @@ public class NodeId {
         return id;
     }
 
+    public String toEscapedString() {
+        return id.replace("\\", "\\\\").replace("$", "\\u0024").replace(".", "\\u002e");
+    }
+
+    public String toUnescapedString() {
+        return id.replace("\\u002e", ".").replace("\\u0024", "$").replace("\\\\", "\\");
+    }
+
     /**
      * Generate an "anonymized" node ID for use with external services. Currently it just hashes the actual node ID
      * using SHA-256.

--- a/graylog2-server/src/main/java/org/graylog2/system/traffic/TrafficCounterService.java
+++ b/graylog2-server/src/main/java/org/graylog2/system/traffic/TrafficCounterService.java
@@ -71,14 +71,16 @@ public class TrafficCounterService {
             LOG.debug("Updating traffic for node {} at {}:  in/decoded/out {}/{}/{} bytes",
                     nodeId.toString(), dayBucket, inLastMinute, decodedLastMinute, outLastMinute);
         }
+
+        final String escapedNodeId = nodeId.toEscapedString();
         final WriteResult<TrafficDto, ObjectId> update = db.update(DBQuery.is("bucket", dayBucket),
                 // sigh DBUpdate.inc only takes integers, but we have a long.
                 new DBUpdate.Builder()
-                        .addOperation("$inc", "input." + nodeId.toString(),
+                        .addOperation("$inc", "input." + escapedNodeId,
                                 new SingleUpdateOperationValue(false, false, inLastMinute))
-                        .addOperation("$inc", "output." + nodeId.toString(),
+                        .addOperation("$inc", "output." + escapedNodeId,
                                 new SingleUpdateOperationValue(false, false, outLastMinute))
-                        .addOperation("$inc", "decoded." + nodeId.toString(),
+                        .addOperation("$inc", "decoded." + escapedNodeId,
                                 new SingleUpdateOperationValue(false, false, decodedLastMinute)),
                 true, false);
         if (update.getN() == 0) {

--- a/graylog2-server/src/main/java/org/graylog2/system/traffic/TrafficCounterService.java
+++ b/graylog2-server/src/main/java/org/graylog2/system/traffic/TrafficCounterService.java
@@ -115,6 +115,10 @@ public class TrafficCounterService {
                 decodedHistogram = aggregateToDaily(decodedHistogram);
             }
             return TrafficHistogram.create(from, to, inputHistogram, outputHistogram, decodedHistogram);
+        } catch (Exception e) {
+            // TODO: remove this diagnostic logging after fixing https://github.com/Graylog2/graylog2-server/issues/9559
+            LOG.error("Unable to load traffic data range {} to {}", from, to);
+            throw e;
         }
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/system/traffic/TrafficCounterService.java
+++ b/graylog2-server/src/main/java/org/graylog2/system/traffic/TrafficCounterService.java
@@ -69,11 +69,11 @@ public class TrafficCounterService {
 
         if (LOG.isDebugEnabled()) {
             LOG.debug("Updating traffic for node {} at {}:  in/decoded/out {}/{}/{} bytes",
-                    nodeId.toString(), dayBucket, inLastMinute, decodedLastMinute, outLastMinute);
+                    nodeId, dayBucket, inLastMinute, decodedLastMinute, outLastMinute);
         }
 
         final String escapedNodeId = nodeId.toEscapedString();
-        final WriteResult<TrafficDto, ObjectId> update = db.update(DBQuery.is("bucket", dayBucket),
+        final WriteResult<TrafficDto, ObjectId> update = db.update(DBQuery.is(BUCKET, dayBucket),
                 // sigh DBUpdate.inc only takes integers, but we have a long.
                 new DBUpdate.Builder()
                         .addOperation("$inc", "input." + escapedNodeId,
@@ -117,10 +117,6 @@ public class TrafficCounterService {
                 decodedHistogram = aggregateToDaily(decodedHistogram);
             }
             return TrafficHistogram.create(from, to, inputHistogram, outputHistogram, decodedHistogram);
-        } catch (Exception e) {
-            // TODO: remove this diagnostic logging after fixing https://github.com/Graylog2/graylog2-server/issues/9559
-            LOG.error("Unable to load traffic data range {} to {}", from, to);
-            throw e;
         }
     }
 


### PR DESCRIPTION
This addresses #9559: Mongo will save field names with embedded dot characters, but it cannot properly update or retrieve them. As a result, retrieving traffic metrics may lead to an IOException.

Solution: escape the problematic characters "$" and "." when saving the field name. 
At this time we do not ever retrieve and expose the field name; but an unescape method is provided in case we do.

As of version 5.0, Mongo also has [built-in support](https://docs.mongodb.com/manual/core/dot-dollar-considerations/#field-names-with-periods--.--and-dollar-signs----) for this issue; however, MongoJack library only supports versions up to 4.x.