### PR TITLE
new Pipeline Rule: Check for a value in a StringList in a key in a LookupTable

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ProcessorFunctionsModule.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ProcessorFunctionsModule.java
@@ -81,9 +81,10 @@ import org.graylog.plugins.pipelineprocessor.functions.lookup.Lookup;
 import org.graylog.plugins.pipelineprocessor.functions.lookup.LookupAddStringList;
 import org.graylog.plugins.pipelineprocessor.functions.lookup.LookupClearKey;
 import org.graylog.plugins.pipelineprocessor.functions.lookup.LookupRemoveStringList;
+import org.graylog.plugins.pipelineprocessor.functions.lookup.LookupSetStringList;
 import org.graylog.plugins.pipelineprocessor.functions.lookup.LookupSetValue;
 import org.graylog.plugins.pipelineprocessor.functions.lookup.LookupStringList;
-import org.graylog.plugins.pipelineprocessor.functions.lookup.LookupSetStringList;
+import org.graylog.plugins.pipelineprocessor.functions.lookup.LookupStringListContains;
 import org.graylog.plugins.pipelineprocessor.functions.lookup.LookupValue;
 import org.graylog.plugins.pipelineprocessor.functions.messages.CloneMessage;
 import org.graylog.plugins.pipelineprocessor.functions.messages.CreateMessage;
@@ -267,6 +268,7 @@ public class ProcessorFunctionsModule extends PluginModule {
         addMessageProcessorFunction(LookupSetStringList.NAME, LookupSetStringList.class);
         addMessageProcessorFunction(LookupAddStringList.NAME, LookupAddStringList.class);
         addMessageProcessorFunction(LookupRemoveStringList.NAME, LookupRemoveStringList.class);
+        addMessageProcessorFunction(LookupStringListContains.NAME, LookupStringListContains.class);
 
         // Debug
         addMessageProcessorFunction(Debug.NAME, Debug.class);

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/lookup/LookupStringListContains.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/lookup/LookupStringListContains.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.pipelineprocessor.functions.lookup;
+
+import com.google.inject.Inject;
+import org.graylog.plugins.pipelineprocessor.EvaluationContext;
+import org.graylog.plugins.pipelineprocessor.ast.functions.AbstractFunction;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionArgs;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionDescriptor;
+import org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor;
+import org.graylog2.lookup.LookupTableService;
+import org.graylog2.plugin.lookup.LookupResult;
+
+import static org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor.object;
+import static org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor.string;
+
+public class LookupStringListContains extends AbstractFunction<Boolean> {
+
+    public static final String NAME = "lookup_string_list_contains";
+
+    private final ParameterDescriptor<String, LookupTableService.Function> lookupTableParam;
+    private final ParameterDescriptor<Object, Object> keyParam;
+    private final ParameterDescriptor<Object, Object> valueParam;
+
+    @Inject
+    public LookupStringListContains(LookupTableService lookupTableService) {
+        lookupTableParam = string("lookup_table", LookupTableService.Function.class)
+                .description("The existing lookup table to use to lookup the given key")
+                .transform(tableName -> lookupTableService.newBuilder().lookupTable(tableName).build())
+                .build();
+        keyParam = object("key")
+                .description("The key to lookup in the table")
+                .build();
+        valueParam = object("value")
+                .description("The value to lookup in the list referenced by the key")
+                .build();
+    }
+
+    @Override
+    public Boolean evaluate(FunctionArgs args, EvaluationContext context) {
+        Object value = valueParam.required(args, context);
+        if (value == null) {
+            return false;
+        }
+        Object key = keyParam.required(args, context);
+        if (key == null) {
+            return false;
+        }
+        LookupTableService.Function table = lookupTableParam.required(args, context);
+        if (table == null) {
+            return false;
+        }
+        LookupResult result = table.lookup(key);
+        if (result == null || result.isEmpty()) {
+            return false;
+        }
+        return result.stringListValue().contains(value);
+    }
+
+    @Override
+    public FunctionDescriptor<Boolean> descriptor() {
+        //noinspection unchecked
+        return FunctionDescriptor.<Boolean>builder()
+                .name(NAME)
+                .description("Looks up a value in the string list referenced by the key in the named lookup table.")
+                .params(lookupTableParam, keyParam, valueParam)
+                .returnType(Boolean.class)
+                .build();
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adding a new pipeline rule.

## Motivation and Context
If you have a key in a lookup-table that contains a list of strings (e.g. ip-addresses), I found no solution to check for containment of an IP from e.g. a message-field.
Adding this method makes it usable for watchlists just like the existing lookup for events/alerts.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

