### PR TITLE
Migrate PipelineInterpreter.State to standalone class

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/PipelineProcessorModule.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/PipelineProcessorModule.java
@@ -21,6 +21,7 @@ import org.graylog.plugins.pipelineprocessor.audit.PipelineProcessorAuditEventTy
 import org.graylog.plugins.pipelineprocessor.functions.ProcessorFunctionsModule;
 import org.graylog.plugins.pipelineprocessor.periodical.LegacyDefaultStreamMigration;
 import org.graylog.plugins.pipelineprocessor.processors.PipelineInterpreter;
+import org.graylog.plugins.pipelineprocessor.processors.PipelineInterpreterState;
 import org.graylog.plugins.pipelineprocessor.rest.PipelineConnectionsResource;
 import org.graylog.plugins.pipelineprocessor.rest.PipelineResource;
 import org.graylog.plugins.pipelineprocessor.rest.PipelineRestPermissions;
@@ -47,7 +48,7 @@ public class PipelineProcessorModule extends PluginModule {
                 PipelineProcessorMessageDecorator.class,
                 PipelineProcessorMessageDecorator.Factory.class);
 
-        install(new FactoryModuleBuilder().build(PipelineInterpreter.State.Factory.class));
+        install(new FactoryModuleBuilder().build(PipelineInterpreterState.Factory.class));
 
         addAuditEventTypes(PipelineProcessorAuditEventTypes.class);
     }

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/processors/ConfigurationStateUpdater.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/processors/ConfigurationStateUpdater.java
@@ -66,11 +66,11 @@ public class ConfigurationStateUpdater {
     private final MetricRegistry metricRegistry;
     private final ScheduledExecutorService scheduler;
     private final EventBus serverEventBus;
-    private final PipelineInterpreter.State.Factory stateFactory;
+    private final PipelineInterpreterState.Factory stateFactory;
     /**
      * non-null if the update has successfully loaded a state
      */
-    private final AtomicReference<PipelineInterpreter.State> latestState = new AtomicReference<>();
+    private final AtomicReference<PipelineInterpreterState> latestState = new AtomicReference<>();
 
     @Inject
     public ConfigurationStateUpdater(RuleService ruleService,
@@ -81,7 +81,7 @@ public class ConfigurationStateUpdater {
                                      MetricRegistry metricRegistry,
                                      @Named("daemonScheduler") ScheduledExecutorService scheduler,
                                      EventBus serverEventBus,
-                                     PipelineInterpreter.State.Factory stateFactory) {
+                                     PipelineInterpreterState.Factory stateFactory) {
         this.ruleService = ruleService;
         this.pipelineService = pipelineService;
         this.pipelineStreamConnectionsService = pipelineStreamConnectionsService;
@@ -100,7 +100,7 @@ public class ConfigurationStateUpdater {
 
     // only the singleton instance should mutate itself, others are welcome to reload a new state, but we don't
     // currently allow direct global state updates from external sources (if you need to, send an event on the bus instead)
-    private synchronized PipelineInterpreter.State reloadAndSave() {
+    private synchronized PipelineInterpreterState reloadAndSave() {
         // read all rules and parse them
         Map<String, Rule> ruleNameMap = Maps.newHashMap();
         ruleService.loadAll().forEach(ruleDao -> {
@@ -140,7 +140,7 @@ public class ConfigurationStateUpdater {
         ImmutableSetMultimap<String, Pipeline> streamPipelineConnections = ImmutableSetMultimap.copyOf(connections);
 
         final RuleMetricsConfigDto ruleMetricsConfig = ruleMetricsConfigService.get();
-        final PipelineInterpreter.State newState = stateFactory.newState(currentPipelines, streamPipelineConnections, ruleMetricsConfig);
+        final PipelineInterpreterState newState = stateFactory.newState(currentPipelines, streamPipelineConnections, ruleMetricsConfig);
         latestState.set(newState);
         return newState;
     }
@@ -152,7 +152,7 @@ public class ConfigurationStateUpdater {
      *
      * @return the currently loaded state of the updater
      */
-    public PipelineInterpreter.State getLatestState() {
+    public PipelineInterpreterState getLatestState() {
         return latestState.get();
     }
 
@@ -212,7 +212,7 @@ public class ConfigurationStateUpdater {
     }
 
     @Subscribe
-    public void handlePipelineStateChange(PipelineInterpreter.State event) {
+    public void handlePipelineStateChange(PipelineInterpreterState event) {
         log.debug("Pipeline interpreter state got updated");
     }
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/processors/PipelineInterpreterState.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/processors/PipelineInterpreterState.java
@@ -1,0 +1,98 @@
+package org.graylog.plugins.pipelineprocessor.processors;
+
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSetMultimap;
+import com.google.inject.assistedinject.Assisted;
+import com.google.inject.assistedinject.AssistedInject;
+import org.graylog.plugins.pipelineprocessor.ast.Pipeline;
+import org.graylog.plugins.pipelineprocessor.db.RuleMetricsConfigDto;
+import org.graylog2.metrics.CacheStatsSet;
+import org.graylog2.shared.metrics.MetricUtils;
+import org.graylog2.shared.utilities.ExceptionUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+import javax.inject.Named;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+
+import static com.codahale.metrics.MetricRegistry.name;
+
+public class PipelineInterpreterState {
+    private static final Logger LOG = LoggerFactory.getLogger(PipelineInterpreterState.class);
+    public static final String STAGE_CACHE_METRIC_SUFFIX = "stage-cache";
+
+    private final ImmutableMap<String, Pipeline> currentPipelines;
+    private final ImmutableSetMultimap<String, Pipeline> streamPipelineConnections;
+    private final LoadingCache<Set<Pipeline>, StageIterator.Configuration> cache;
+    private final boolean cachedIterators;
+    private final RuleMetricsConfigDto ruleMetricsConfig;
+
+    @AssistedInject
+    public PipelineInterpreterState(@Assisted ImmutableMap<String, Pipeline> currentPipelines,
+                                    @Assisted ImmutableSetMultimap<String, Pipeline> streamPipelineConnections,
+                                    @Assisted RuleMetricsConfigDto ruleMetricsConfig,
+                                    MetricRegistry metricRegistry,
+                                    @Named("processbuffer_processors") int processorCount,
+                                    @Named("cached_stageiterators") boolean cachedIterators) {
+        this.currentPipelines = currentPipelines;
+        this.streamPipelineConnections = streamPipelineConnections;
+        this.cachedIterators = cachedIterators;
+        this.ruleMetricsConfig = ruleMetricsConfig;
+
+        cache = CacheBuilder.newBuilder()
+                .concurrencyLevel(processorCount)
+                .recordStats()
+                .build(new CacheLoader<Set<Pipeline>, StageIterator.Configuration>() {
+                    @Override
+                    public StageIterator.Configuration load(@Nonnull Set<Pipeline> pipelines) {
+                        return new StageIterator.Configuration(pipelines);
+                    }
+                });
+
+        // we have to remove the metrics, because otherwise we leak references to the cache (and the register call with throw)
+        metricRegistry.removeMatching((name, metric) -> name.startsWith(getStageCacheMetricName()));
+        MetricUtils.safelyRegisterAll(metricRegistry, new CacheStatsSet(getStageCacheMetricName(), cache));
+    }
+
+    public String getStageCacheMetricName() {
+        return name(PipelineInterpreter.class, STAGE_CACHE_METRIC_SUFFIX);
+    }
+
+    public ImmutableMap<String, Pipeline> getCurrentPipelines() {
+        return currentPipelines;
+    }
+
+    public ImmutableSetMultimap<String, Pipeline> getStreamPipelineConnections() {
+        return streamPipelineConnections;
+    }
+
+    public boolean enableRuleMetrics() {
+        return ruleMetricsConfig.metricsEnabled();
+    }
+
+    public StageIterator getStageIterator(Set<Pipeline> pipelines) {
+        try {
+            if (cachedIterators) {
+                return new StageIterator(cache.get(pipelines));
+            } else {
+                return new StageIterator(pipelines);
+            }
+        } catch (ExecutionException e) {
+            LOG.error("Unable to get StageIterator from cache, this should not happen.", ExceptionUtils.getRootCause(e));
+            return new StageIterator(pipelines);
+        }
+    }
+
+
+    public interface Factory {
+        PipelineInterpreterState newState(ImmutableMap<String, Pipeline> currentPipelines,
+                                          ImmutableSetMultimap<String, Pipeline> streamPipelineConnections,
+                                          RuleMetricsConfigDto ruleMetricsConfig);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/processors/PipelineInterpreterState.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/processors/PipelineInterpreterState.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog.plugins.pipelineprocessor.processors;
 
 import com.codahale.metrics.MetricRegistry;

--- a/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/processors/PipelineInterpreterTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/processors/PipelineInterpreterTest.java
@@ -326,7 +326,7 @@ public class PipelineInterpreterTest {
                 new MetricRegistry(),
                 Executors.newScheduledThreadPool(1),
                 mock(EventBus.class),
-                (currentPipelines, streamPipelineConnections, ruleMetricsConfig) -> new PipelineInterpreter.State(currentPipelines, streamPipelineConnections, ruleMetricsConfig, new MetricRegistry(), 1, true)
+                (currentPipelines, streamPipelineConnections, ruleMetricsConfig) -> new PipelineInterpreterState(currentPipelines, streamPipelineConnections, ruleMetricsConfig, new MetricRegistry(), 1, true)
         );
         return new PipelineInterpreter(
                 mock(MessageQueueAcknowledger.class),
@@ -382,7 +382,7 @@ public class PipelineInterpreterTest {
                 metricRegistry,
                 Executors.newScheduledThreadPool(1),
                 mock(EventBus.class),
-                (currentPipelines, streamPipelineConnections, ruleMetricsConfig) -> new PipelineInterpreter.State(currentPipelines, streamPipelineConnections, ruleMetricsConfig, new MetricRegistry(), 1, true)
+                (currentPipelines, streamPipelineConnections, ruleMetricsConfig) -> new PipelineInterpreterState(currentPipelines, streamPipelineConnections, ruleMetricsConfig, new MetricRegistry(), 1, true)
         );
         final PipelineInterpreter interpreter = new PipelineInterpreter(
                 mock(MessageQueueAcknowledger.class),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Migrate the `PipelineInterpreter.State` class to a standalone class, so that the new Illuminate implementation can extend it, and override the metric name.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The new Illuminate Processing functionality needs to use certain core Graylog server components and extend them. The `PipelineInterpreter.State` is one such component that is needed, which must be adjusted in order to be usable in Illuminate processing code without errors. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested basic pipeline processing in Graylog to ensure that the new standalone `PipelineInterpreterState` class works as expected.

## API Change
Note that this is a breaking API change, `PipelineInterpreter.State` is being moved to it's own class. If any third party code had referenced that class with the old name and location, it would break. We should ensure this change is only included in the major 4.2 release (currently planned)

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

/jenkins-pr-deps Graylog2/graylog-plugin-enterprise-integrations#608 Graylog2/graylog-plugin-enterprise#2641