### PR TITLE
Shorten widget titles with ellipsis when overflowing available space.

### DIFF
--- a/graylog2-web-interface/src/views/components/common/EditableTitle.tsx
+++ b/graylog2-web-interface/src/views/components/common/EditableTitle.tsx
@@ -26,6 +26,7 @@ const StyledStaticSpan = styled.span(({ theme }) => css`
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
+  min-width: 20px;
 `);
 
 const StyledInput = styled.input(({ theme }) => css`

--- a/graylog2-web-interface/src/views/components/common/EditableTitle.tsx
+++ b/graylog2-web-interface/src/views/components/common/EditableTitle.tsx
@@ -26,7 +26,6 @@ const StyledStaticSpan = styled.span(({ theme }) => css`
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
-  min-width: 20px;
 `);
 
 const StyledInput = styled.input(({ theme }) => css`

--- a/graylog2-web-interface/src/views/components/common/EditableTitle.tsx
+++ b/graylog2-web-interface/src/views/components/common/EditableTitle.tsx
@@ -125,6 +125,6 @@ export default class EditableTitle extends React.Component<Props, State> {
                        onChange={this._onChange} />
         </form>
       </span>
-    ) : <StyledStaticSpan onDoubleClick={this._toggleEditing} title="Double click the title to edit it.">{value}</StyledStaticSpan>;
+    ) : <StyledStaticSpan onDoubleClick={this._toggleEditing} title={`${value} - Double click the title to edit it.`}>{value}</StyledStaticSpan>;
   }
 }

--- a/graylog2-web-interface/src/views/components/common/EditableTitle.tsx
+++ b/graylog2-web-interface/src/views/components/common/EditableTitle.tsx
@@ -23,6 +23,9 @@ import styles from './EditableTitle.css';
 const StyledStaticSpan = styled.span(({ theme }) => css`
   border: 1px solid ${theme.colors.global.contentBackground};
   font-size: ${theme.fonts.size.large};
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
 `);
 
 const StyledInput = styled.input(({ theme }) => css`

--- a/graylog2-web-interface/src/views/components/widgets/WidgetHeader.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/WidgetHeader.tsx
@@ -33,6 +33,7 @@ const Container = styled.div(({ theme }) => css`
   margin-bottom: 5px;
   display: grid;
   grid-template-columns: max-content auto max-content;
+  align-items: center;
 `);
 
 const WidgetDragHandle = styled(Icon)`

--- a/graylog2-web-interface/src/views/components/widgets/WidgetHeader.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/WidgetHeader.tsx
@@ -16,7 +16,7 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import styled, { css } from 'styled-components';
+import styled, { css, DefaultTheme } from 'styled-components';
 
 import { Spinner, Icon } from 'components/common';
 import EditableTitle from 'views/components/common/EditableTitle';
@@ -27,12 +27,12 @@ const LoadingSpinner = styled(Spinner)`
   margin-left: 10px;
 `;
 
-const Container = styled.div(({ theme }) => css`
+const Container = styled.div(({ theme, $hideDragHandle }: {theme: DefaultTheme, $hideDragHandle: boolean }) => css`
   font-size: ${theme.fonts.size.large};
   text-overflow: ellipsis;
   margin-bottom: 5px;
   display: grid;
-  grid-template-columns: max-content auto max-content;
+  grid-template-columns: ${$hideDragHandle ? 'minmax(20px, auto) max-content' : 'max-content minmax(20px, auto) max-content'};
   align-items: center;
 `);
 
@@ -55,7 +55,7 @@ type Props = {
 };
 
 const WidgetHeader = ({ children, onRename, hideDragHandle, title, loading }: Props) => (
-  <Container>
+  <Container $hideDragHandle={hideDragHandle}>
     {hideDragHandle || <WidgetDragHandle name="bars" className="widget-drag-handle" />}
     <EditableTitle key={title} disabled={!onRename} value={title} onChange={onRename} />
     {loading && <LoadingSpinner text="" delay={0} />}

--- a/graylog2-web-interface/src/views/components/widgets/WidgetHeader.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/WidgetHeader.tsx
@@ -31,6 +31,8 @@ const Container = styled.div(({ theme }) => css`
   font-size: ${theme.fonts.size.large};
   text-overflow: ellipsis;
   margin-bottom: 5px;
+  display: grid;
+  grid-template-columns: max-content auto max-content;
 `);
 
 const WidgetDragHandle = styled(Icon)`


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Prior to this change, a widget's title was always shown in full, even when there was not enough space, leading to unwanted line breaks and even taking over space of the actual visualization.

This change is now implementing shortening of the widget's title and adding an ellipsis when the available space is exceeded.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

Before:

![image](https://user-images.githubusercontent.com/41929/129915299-cb6b4f27-816c-45e9-b23d-7f789baa8024.png)


After:

![image](https://user-images.githubusercontent.com/41929/129915162-27d0c476-2d33-4e11-93c7-8e52c20937f7.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.