### PR TITLE
Reduce margin between widget actions.

### DIFF
--- a/graylog2-web-interface/src/views/components/widgets/WidgetActionsMenu.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/WidgetActionsMenu.tsx
@@ -48,12 +48,8 @@ import WidgetFocusContext from '../contexts/WidgetFocusContext';
 import WidgetContext from '../contexts/WidgetContext';
 
 const Container = styled.div`
-  > * {
-    margin-right: 5px;
-
-    :last-child {
-      margin-right: 0;
-    }
+  > *:not(:last-child) {
+    margin-right: 2px;
   }
 `;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

With this PR we are reducing the margin between widget actions.

Before: 
![image](https://user-images.githubusercontent.com/46300478/130059020-6824e40d-186f-4280-bec5-b6f0da014497.png)

After: 
![image](https://user-images.githubusercontent.com/46300478/130059043-297a51d1-ed09-432e-8be7-09fd4be5679f.png)

It looks slightly better and the widget title receives more space, which is especially beneficial for small widgets.