### PR TITLE
Handling rule condition evaluation exceptions

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/EvaluationContext.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/EvaluationContext.java
@@ -139,6 +139,12 @@ public class EvaluationContext {
         return evalErrors == null ? Collections.emptyList() : Collections.unmodifiableList(evalErrors);
     }
 
+    @Nullable
+    public EvalError lastEvaluationError() {
+        return evalErrors == null || evalErrors.isEmpty() ? null
+                : evalErrors.get(evalErrors.size() - 1);
+    }
+
     public static class TypedValue {
         private final Class type;
         private final Object value;

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/ast/expressions/Expression.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/ast/expressions/Expression.java
@@ -18,16 +18,11 @@ package org.graylog.plugins.pipelineprocessor.ast.expressions;
 
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Maps;
-
 import org.antlr.v4.runtime.Token;
 import org.graylog.plugins.pipelineprocessor.EvaluationContext;
-import org.graylog.plugins.pipelineprocessor.ast.exceptions.FunctionEvaluationException;
-
-import java.util.Map;
 
 import javax.annotation.Nullable;
-
-import static org.graylog2.shared.utilities.ExceptionUtils.getRootCause;
+import java.util.Map;
 
 public interface Expression {
 
@@ -39,13 +34,8 @@ public interface Expression {
     default Object evaluate(EvaluationContext context) {
         try {
             return evaluateUnsafe(context);
-        } catch (FunctionEvaluationException fee) {
-            context.addEvaluationError(fee.getStartToken().getLine(),
-                                       fee.getStartToken().getCharPositionInLine(),
-                                       fee.getFunctionExpression().getFunction().descriptor(),
-                                       getRootCause(fee));
         } catch (Exception e) {
-            context.addEvaluationError(getStartToken().getLine(), getStartToken().getCharPositionInLine(), null, getRootCause(e));
+            context.onEvaluationException(e, this);
         }
         return null;
     }

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/processors/PipelineInterpreter.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/processors/PipelineInterpreter.java
@@ -411,7 +411,7 @@ public class PipelineInterpreter implements MessageProcessor {
                                           EvaluationContext context,
                                           List<Rule> rulesToRun, InterpreterListener interpreterListener) {
         interpreterListener.evaluateRule(rule, pipeline);
-        boolean matched;
+        final boolean matched;
         final LogicalExpression logicalExpression = rule.when();
         try {
             matched = logicalExpression.evaluateBool(context);

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/processors/PipelineInterpreter.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/processors/PipelineInterpreter.java
@@ -431,8 +431,6 @@ public class PipelineInterpreter implements MessageProcessor {
                     lastEvalError.toString()
             ));
 
-            log.debug("Encountered evaluation error during condition, skipping rule actions: {}", lastEvalError);
-
             interpreterListener.failEvaluateRule(rule, pipeline);
 
             return false;

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/processors/PipelineInterpreter.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/processors/PipelineInterpreter.java
@@ -411,24 +411,20 @@ public class PipelineInterpreter implements MessageProcessor {
                                           EvaluationContext context,
                                           List<Rule> rulesToRun, InterpreterListener interpreterListener) {
         interpreterListener.evaluateRule(rule, pipeline);
-        boolean matched = false;
+        boolean matched;
         final LogicalExpression logicalExpression = rule.when();
-        boolean caughtEvaluationException = false;
         try {
             matched = logicalExpression.evaluateBool(context);
         } catch (Exception e) {
-            context.onEvaluationException(e, logicalExpression);
-            caughtEvaluationException = true;
-        }
 
-        if (caughtEvaluationException) {
-            final EvaluationContext.EvalError lastEvalError = context.lastEvaluationError();
+            context.onEvaluationException(e, logicalExpression);
+
             message.addProcessingError(new Message.ProcessingError(
                     ProcessingFailureCause.RuleConditionEvaluationError,
                     String.format(Locale.ENGLISH,
                             "Error evaluating condition for rule <%s/%s> (pipeline <%s/%s>)",
                             rule.name(), rule.id(), pipeline.name(), pipeline.id()),
-                    lastEvalError.toString()
+                    context.lastEvaluationError().toString()
             ));
 
             interpreterListener.failEvaluateRule(rule, pipeline);

--- a/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/processors/PipelineInterpreterTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/processors/PipelineInterpreterTest.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.eventbus.EventBus;
+import org.graylog.failure.ProcessingFailureCause;
 import org.graylog.plugins.pipelineprocessor.ast.Pipeline;
 import org.graylog.plugins.pipelineprocessor.ast.Rule;
 import org.graylog.plugins.pipelineprocessor.ast.functions.Function;
@@ -38,20 +39,24 @@ import org.graylog.plugins.pipelineprocessor.db.memory.InMemoryRuleService;
 import org.graylog.plugins.pipelineprocessor.db.mongodb.MongoDbPipelineService;
 import org.graylog.plugins.pipelineprocessor.db.mongodb.MongoDbPipelineStreamConnectionsService;
 import org.graylog.plugins.pipelineprocessor.db.mongodb.MongoDbRuleService;
+import org.graylog.plugins.pipelineprocessor.functions.conversion.DoubleConversion;
 import org.graylog.plugins.pipelineprocessor.functions.conversion.StringConversion;
 import org.graylog.plugins.pipelineprocessor.functions.messages.CreateMessage;
+import org.graylog.plugins.pipelineprocessor.functions.messages.HasField;
 import org.graylog.plugins.pipelineprocessor.functions.messages.SetField;
 import org.graylog.plugins.pipelineprocessor.parser.FunctionRegistry;
 import org.graylog.plugins.pipelineprocessor.parser.PipelineRuleParser;
 import org.graylog.plugins.pipelineprocessor.rest.PipelineConnections;
 import org.graylog2.events.ClusterEventBus;
 import org.graylog2.plugin.Message;
+import org.graylog2.plugin.MessageCollection;
 import org.graylog2.plugin.Messages;
 import org.graylog2.plugin.Tools;
 import org.graylog2.plugin.streams.Stream;
 import org.graylog2.shared.SuppressForbidden;
 import org.graylog2.shared.messageq.MessageQueueAcknowledger;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import java.util.Collections;
 import java.util.List;
@@ -85,6 +90,9 @@ public class PipelineInterpreterTest {
                     "end", null, null);
 
     private final MessageQueueAcknowledger messageQueueAcknowledger = mock(MessageQueueAcknowledger.class);
+
+    private final RuleService ruleService = Mockito.mock(RuleService.class);
+    private final PipelineService pipelineService = Mockito.mock(PipelineService.class);
 
     @Test
     public void testCreateMessage() {
@@ -432,6 +440,148 @@ public class PipelineInterpreterTest {
         assertThat(meters.get(name(Rule.class, "abc", "cde", "0", "failed")).getCount()).isEqualTo(0L);
         assertThat(meters.get(name(Rule.class, "abc", "cde", "1", "failed")).getCount()).isEqualTo(0L);
 
+    }
+
+    @Test
+    public void process_ruleConditionEvaluationErrorConvertedIntoMessageProcessingError() throws Exception {
+        // given
+        when(ruleService.loadAll()).thenReturn(ImmutableList.of(RuleDao.create("broken_condition", "broken_condition",
+                "broken_condition",
+                "rule \"broken_condition\"\n" +
+                        "when\n" +
+                        "    to_double($message.num * $message.num) > 0.0\n" +
+                        "then\n" +
+                        "    set_field(\"num_sqr\", $message.num * $message.num);\n" +
+                        "end", null, null)));
+
+        when(pipelineService.loadAll()).thenReturn(Collections.singleton(
+                PipelineDao.create("p1", "title", "description",
+                        "pipeline \"pipeline\"\n" +
+                                "stage 0 match all\n" +
+                                "    rule \"broken_condition\";\n" +
+                                "end\n",
+                        Tools.nowUTC(),
+                        null)
+        ));
+
+
+        final PipelineInterpreter interpreter = createPipelineInterpreter(ruleService, pipelineService, ImmutableMap.of(
+                SetField.NAME, new SetField(),
+                DoubleConversion.NAME, new DoubleConversion())
+        );
+
+        // when
+        final List<Message> processed = extractMessagesFromMessageCollection(interpreter.process(messageWithNumField("ABC")));
+
+        // then
+        assertThat(processed)
+                .hasSize(1)
+                .hasOnlyOneElementSatisfying(m -> {
+                    assertThat(m.processingErrors())
+                            .hasSize(1)
+                            .hasOnlyOneElementSatisfying(pe -> {
+                                assertThat(pe.getCause()).isEqualTo(ProcessingFailureCause.RuleConditionEvaluationError);
+                                assertThat(pe.getMessage()).isEqualTo("Error evaluating condition for rule <broken_condition/broken_condition> (pipeline <pipeline/p1>)");
+                                assertThat(pe.getDetails()).isEqualTo("In call to function 'to_double' at 3:4 an exception was thrown: java.lang.String cannot be cast to java.lang.Double");
+                            });
+                });
+    }
+
+    @Test
+    public void process_ruleStatementEvaluationErrorConvertedIntoMessageProcessingError() throws Exception {
+        // given
+        when(ruleService.loadAll()).thenReturn(ImmutableList.of(RuleDao.create("broken_statement", "broken_statement",
+                "broken_statement",
+                "rule \"broken_statement\"\n" +
+                        "when\n" +
+                        "    has_field(\"num\")\n" +
+                        "then\n" +
+                        "    set_field(\"num_sqr\", $message.num * $message.num);\n" +
+                        "end", null, null)));
+
+        when(pipelineService.loadAll()).thenReturn(Collections.singleton(
+                PipelineDao.create("p1", "title", "description",
+                        "pipeline \"pipeline\"\n" +
+                                "stage 0 match all\n" +
+                                "    rule \"broken_statement\";\n" +
+                                "end\n",
+                        Tools.nowUTC(),
+                        null)
+        ));
+
+
+        final PipelineInterpreter interpreter = createPipelineInterpreter(ruleService, pipelineService, ImmutableMap.of(
+                SetField.NAME, new SetField(),
+                DoubleConversion.NAME, new DoubleConversion(),
+                HasField.NAME, new HasField()
+                ));
+
+        // when
+        final List<Message> processed = extractMessagesFromMessageCollection(interpreter.process(messageWithNumField(new Long(1))));
+
+        // then
+        assertThat(processed)
+                .hasSize(1)
+                .hasOnlyOneElementSatisfying(m -> {
+                    assertThat(m.processingErrors())
+                            .hasSize(1)
+                            .hasOnlyOneElementSatisfying(pe -> {
+                                assertThat(pe.getCause()).isEqualTo(ProcessingFailureCause.RuleStatementEvaluationError);
+                                assertThat(pe.getMessage()).isEqualTo("Error evaluating action for rule <broken_statement/broken_statement> (pipeline <pipeline/p1>)");
+                                assertThat(pe.getDetails()).isEqualTo("In call to function 'set_field' at 5:4 an exception was thrown: java.lang.Long cannot be cast to java.lang.Double");
+                            });
+                });
+    }
+
+    @Test
+    public void process_noEvaluationErrorsResultIntoNoMessageProcessingErrors() throws Exception {
+        // given
+        when(ruleService.loadAll()).thenReturn(ImmutableList.of(RuleDao.create("valid_rule", "valid_rule",
+                "valid_rule",
+                "rule \"valid_rule\"\n" +
+                        "when\n" +
+                        "    has_field(\"num\")\n" +
+                        "then\n" +
+                        "    set_field(\"num_sqr\", to_double($message.num) * to_double($message.num));\n" +
+                        "end", null, null)));
+
+        when(pipelineService.loadAll()).thenReturn(Collections.singleton(
+                PipelineDao.create("p1", "title", "description",
+                        "pipeline \"pipeline\"\n" +
+                                "stage 0 match all\n" +
+                                "    rule \"valid_rule\";\n" +
+                                "end\n",
+                        Tools.nowUTC(),
+                        null)
+        ));
+
+
+        final PipelineInterpreter interpreter = createPipelineInterpreter(ruleService, pipelineService, ImmutableMap.of(
+                SetField.NAME, new SetField(),
+                DoubleConversion.NAME, new DoubleConversion(),
+                HasField.NAME, new HasField()
+        ));
+
+        // when
+        final List<Message> processed = extractMessagesFromMessageCollection(interpreter.process(messageWithNumField(new Long(5))));
+
+        // then
+        assertThat(processed)
+                .hasSize(1)
+                .hasOnlyOneElementSatisfying(m -> {
+                    assertThat(m.processingErrors()).isEmpty();
+                    assertThat(m.getField("num_sqr")).isEqualTo(new Double(25.0));
+                });
+    }
+
+    private Message messageWithNumField(Object numValue) {
+        final Message msg = messageInDefaultStream("message", "test");
+        msg.addField("num", numValue);
+        return msg;
+    }
+
+    private List<Message> extractMessagesFromMessageCollection(Messages messages) {
+        return ((MessageCollection) messages).source();
     }
 
     private Message messageInDefaultStream(String message, String source) {


### PR DESCRIPTION
For "historical" reasons `NumericExpression` and `LogicalExpression` both
bypass the concept of "override `evaluateUnsafe` - call `evaluate`" (which
is by default implemented within `Expression`), what in its turn leads to
evaluation exceptions being **_propagated_**, instead of being converted to an
evaluation error and stored in `EvaluationContext#evalErrors`.

This fix "duplicates" the evaluation exception handling logic for
LogicalExpression(s), so that those errors become discoverable by the
failure handling framework.

To trigger a rule condition evaluation error for a rule below send a message 
with a string value inside the `randomLong` field:
```
rule "Broken Condition"
when
    to_double($message.randomLong * $message.randomLong) > 0.0
then
    set_field("randomLong_sqr", $message.randomLong * $message.randomLong);
end
```

[graylog-plugin-enterprise/issue-2127] Storing indexing/processing failures

