### PR TITLE
Fix warning about receive buffer size

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/inputs/transports/UdpTransport.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/transports/UdpTransport.java
@@ -105,6 +105,7 @@ public class UdpTransport extends NettyTransport {
         return handlers;
     }
 
+    @Override
     protected LinkedHashMap<String, Callable<? extends ChannelHandler>> getChildChannelHandlers(final MessageInput input) {
         final LinkedHashMap<String, Callable<? extends ChannelHandler>> handlerList = new LinkedHashMap<>(getCustomChildChannelHandlers(input));
 
@@ -201,8 +202,8 @@ public class UdpTransport extends NettyTransport {
 
                 final DatagramChannelConfig channelConfig = (DatagramChannelConfig) channel.config();
                 final int receiveBufferSize = channelConfig.getReceiveBufferSize();
-                if (receiveBufferSize != expectedRecvBufferSize) {
-                    LOG.warn("receiveBufferSize (SO_RCVBUF) for input {} (channel {}) should be {} but is {}.",
+                if (receiveBufferSize < expectedRecvBufferSize) {
+                    LOG.warn("receiveBufferSize (SO_RCVBUF) for input {} (channel {}) should be >= {} but is {}.",
                             input, channel, expectedRecvBufferSize, receiveBufferSize);
                 }
             } else {

--- a/graylog2-server/src/main/java/org/graylog2/plugin/inputs/transports/AbstractTcpTransport.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/inputs/transports/AbstractTcpTransport.java
@@ -476,8 +476,8 @@ public abstract class AbstractTcpTransport extends NettyTransport {
 
                 final ServerSocketChannelConfig channelConfig = (ServerSocketChannelConfig) channel.config();
                 final int receiveBufferSize = channelConfig.getReceiveBufferSize();
-                if (receiveBufferSize != expectedRecvBufferSize) {
-                    LOG.warn("receiveBufferSize (SO_RCVBUF) for input {} (channel {}) should be {} but is {}.",
+                if (receiveBufferSize < expectedRecvBufferSize) {
+                    LOG.warn("receiveBufferSize (SO_RCVBUF) for input {} (channel {}) should be >= {} but is {}.",
                             input, channel, expectedRecvBufferSize, receiveBufferSize);
                 }
             } else {


### PR DESCRIPTION
We were previously warning when the receive buffer size reported
by netty wasn't exactly matching the receive buffer size that was
configured. However, as the OS can choose to overprovision the buffer,
we shouldn't warn if the reported buffer size is exceeding the expected
buffer size.

With this change, we are only warning when the reported buffer size is
smaller than what we were expecting, as this is the problematic case
worth warning the user about.

Fixes #7720