### PR TITLE
Add description for `globalContextProviders` in plugin store.

### DIFF
--- a/graylog2-web-interface/src/@types/graylog-web-plugin/index.d.ts
+++ b/graylog2-web-interface/src/@types/graylog-web-plugin/index.d.ts
@@ -88,6 +88,8 @@ declare module 'graylog-web-plugin/plugin' {
     navigation?: Array<PluginNavigation>;
     navigationItems?: Array<PluginNavigationItems>;
     globalNotifications?: Array<GlobalNotification>
+    // Global context providers can be useful, when you want to fetch and process data once
+    // and provide its value for all components in your plugin.
     globalContextProviders?: Array<React.ComponentType>,
     routes?: Array<PluginRoute>;
     pages?: PluginPages;

--- a/graylog2-web-interface/src/@types/graylog-web-plugin/index.d.ts
+++ b/graylog2-web-interface/src/@types/graylog-web-plugin/index.d.ts
@@ -88,8 +88,8 @@ declare module 'graylog-web-plugin/plugin' {
     navigation?: Array<PluginNavigation>;
     navigationItems?: Array<PluginNavigationItems>;
     globalNotifications?: Array<GlobalNotification>
-    // Global context providers can be useful, when you want to fetch and process data once
-    // and provide its value for all components in your plugin.
+    // Global context providers allow to fetch and process data once
+    // and provide the result for all components in your plugin.
     globalContextProviders?: Array<React.ComponentType>,
     routes?: Array<PluginRoute>;
     pages?: PluginPages;

--- a/graylog2-web-interface/src/routing/GlobalContextProviders.tsx
+++ b/graylog2-web-interface/src/routing/GlobalContextProviders.tsx
@@ -34,7 +34,7 @@ const GlobalContextProviders = ({ children }: Props) => {
     <ErrorBoundary FallbackComponent={() => nestedChildren}>
       <GlobalContextProvider>
         {nestedChildren}
-      </GlobalContextProvider>;
+      </GlobalContextProvider>
     </ErrorBoundary>
   ), children);
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

With https://github.com/Graylog2/graylog2-server/pull/11164 we introduced plugable global context providers. This PR is adding a description for the plugin store export. We are also removing a not needed character which got added with the referenced PR.