### PR TITLE
Lazy initialize processingErrors list

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/failure/DefaultFailureHandler.java
+++ b/graylog2-server/src/main/java/org/graylog/failure/DefaultFailureHandler.java
@@ -39,12 +39,12 @@ public class DefaultFailureHandler implements FailureHandler {
     public void handle(FailureBatch failureBatch) {
         failureBatch.getFailures().forEach(failure ->
                 indexFailureService.saveWithoutValidation(new IndexFailureImpl(ImmutableMap.<String, Object>builder()
-                    .put("letter_id", failure.failedMessage().getMessageId())
-                    .put("index", failure.targetIndex())
-                    .put("type", failure.failureType().toString())
-                    .put("message", failure.failureDetails())
-                    .put("timestamp", failure.failedMessage().getTimestamp())
-                    .build())));
+                        .put("letter_id", failure.failedMessage().getId())
+                        .put("index", failure.targetIndex())
+                        .put("type", failure.failureType().toString())
+                        .put("message", failure.failureDetails())
+                        .put("timestamp", failure.failedMessage().getTimestamp())
+                        .build())));
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/plugin/Message.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/Message.java
@@ -293,7 +293,7 @@ public class Message implements Messages, Indexable {
 
     private com.codahale.metrics.Counter sizeCounter = new com.codahale.metrics.Counter();
 
-    private List<ProcessingError> processingErrors = new ArrayList<>();
+    private List<ProcessingError> processingErrors;
 
     private static final IdentityHashMap<Class<?>, Integer> classSizes = Maps.newIdentityHashMap();
 
@@ -432,7 +432,7 @@ public class Message implements Messages, Indexable {
         obj.put(FIELD_STREAMS, getStreamIds());
         obj.put(FIELD_GL2_ACCOUNTED_MESSAGE_SIZE, getSize());
 
-        if (!processingErrors.isEmpty()) {
+        if (processingErrors != null && !processingErrors.isEmpty()) {
             obj.put(FIELD_GL2_PROCESSING_ERROR,
                     processingErrors.stream()
                             .map(ProcessingError::getDetails)
@@ -931,6 +931,9 @@ public class Message implements Messages, Indexable {
      *                        Must not be null.
      */
     public void addProcessingError(@Nonnull ProcessingError processingError) {
+        if (processingErrors == null) {
+            processingErrors = new ArrayList<>();
+        }
         processingErrors.add(processingError);
     }
 
@@ -938,6 +941,9 @@ public class Message implements Messages, Indexable {
      * Returns a list of submitted processing errors
      */
     public List<ProcessingError> processingErrors() {
+        if (processingErrors == null) {
+            return ImmutableList.of();
+        }
         return ImmutableList.copyOf(processingErrors);
     }
 

--- a/graylog2-server/src/test/java/org/graylog/failure/DefaultFailureHandlerTest.java
+++ b/graylog2-server/src/test/java/org/graylog/failure/DefaultFailureHandlerTest.java
@@ -61,11 +61,11 @@ public class DefaultFailureHandlerTest {
         final DateTime ts = DateTime.now(DateTimeZone.UTC);
 
         final Indexable indexable1 = mock(Indexable.class);
-        when(indexable1.getMessageId()).thenReturn("msg-1");
+        when(indexable1.getId()).thenReturn("msg-1");
         when(indexable1.getTimestamp()).thenReturn(ts);
 
         final Indexable indexable2 = mock(Indexable.class);
-        when(indexable2.getMessageId()).thenReturn("msg-2");
+        when(indexable2.getId()).thenReturn("msg-2");
         when(indexable2.getTimestamp()).thenReturn(ts);
 
         final IndexingFailure indexingFailure1 = new IndexingFailure(


### PR DESCRIPTION
Processing errors should still be rare cases in regular message
processing. Better save the memory for messages without errors.

