### PR TITLE
Configure `target` directory as default for `jest-junit` output.

### DIFF
--- a/graylog2-web-interface/package.json
+++ b/graylog2-web-interface/package.json
@@ -41,9 +41,6 @@
       "<rootDir>/test/configure-testing-library.js"
     ]
   },
-  "jest-junit": {
-    "outputDirectory": "target"
-  },
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^1.2.28",
     "@fortawesome/free-brands-svg-icons": "^5.13.0",

--- a/graylog2-web-interface/packages/jest-preset-graylog/jest-preset.js
+++ b/graylog2-web-interface/packages/jest-preset-graylog/jest-preset.js
@@ -56,5 +56,12 @@ module.exports = {
     '.fixtures.[jt]s$',
   ],
   testTimeout: applyTimeoutMultiplier(5000),
-  reporters: ['default', 'jest-junit'],
+  reporters: [
+    'default',
+    [
+      'jest-junit', {
+        outputDirectory: 'target',
+      },
+    ],
+  ],
 };


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

With #10435 we installed and configured `jest-junit` for frontend test reporting. Since we configured the jest reporters in the `jest-preset-graylog` we are also generating a `junit.xml` when running  `yarn test` in a plugin. which includes this package. 

With this PR we are using the `target` dir for the `junit.xml` by default.