### PR TITLE
Fix race condition in message details related to uninitialized nodes store.

### DIFF
--- a/graylog2-web-interface/src/stores/nodes/NodesStore.ts
+++ b/graylog2-web-interface/src/stores/nodes/NodesStore.ts
@@ -99,7 +99,7 @@ const NodesStore = Reflux.createStore<NodesStoreState>({
   },
 
   getNode(nodeId) {
-    return this.nodes[nodeId];
+    return this.nodes?.[nodeId];
   },
 
   _clusterId() {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

**Note:** This needs a backport to `4.1`.

This change fixes an issue that occurs when immediately expanding the
message details of an arbitrary message on the search page. This is
caused by the `MessageDetail` calling `isLocalNode`, which is currently
an alias for `NodesStore.getNode()`. If the nodes store was not
initialized (has not retrieved an initial nodes list) before this,
`NodesStore.getNode` throws an exception as it is accessing
`this.nodes[id]`.

Fixes #11089.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Manually tested. It is pretty easy to reproduce the initial error as
described in #11089 by loading the search page and clicking the mouse
button repeatedly during loading in a place where a message row will
appear. Doing this, will lead to the message table widget showing the
exception that was thrown. Applying this change results in me being
unable to reproduce the reported issue.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.