### PR TITLE
Index Mapping update operation

### DIFF
--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/IndicesAdapterES6.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/IndicesAdapterES6.java
@@ -53,6 +53,7 @@ import io.searchbox.indices.aliases.AliasMapping;
 import io.searchbox.indices.aliases.GetAliases;
 import io.searchbox.indices.aliases.ModifyAliases;
 import io.searchbox.indices.aliases.RemoveAliasMapping;
+import io.searchbox.indices.mapping.PutMapping;
 import io.searchbox.indices.settings.GetSettings;
 import io.searchbox.indices.settings.UpdateSettings;
 import io.searchbox.indices.template.DeleteTemplate;
@@ -85,6 +86,7 @@ import org.joda.time.DateTimeZone;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nonnull;
 import javax.inject.Inject;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
@@ -209,6 +211,25 @@ public class IndicesAdapterES6 implements IndicesAdapter {
             jestResult = jestClient.execute(request);
         } catch (IOException e) {
             throw new ElasticsearchException("Couldn't create index " + indexName, e);
+        }
+
+        if (!jestResult.isSucceeded()){
+            throw new ElasticsearchException(jestResult.getErrorMessage());
+        }
+    }
+
+    @Override
+    public void updateIndexMapping(@Nonnull String indexName,
+                                   @Nonnull String mappingType,
+                                   @Nonnull Map<String, Object> mapping) {
+
+        final PutMapping request = new PutMapping.Builder(indexName, mappingType, mapping).build();
+
+        final JestResult jestResult;
+        try {
+            jestResult = jestClient.execute(request);
+        } catch (IOException e) {
+            throw new ElasticsearchException("Couldn't update index mapping " + indexName + "/" + mappingType, e);
         }
 
         if (!jestResult.isSucceeded()){

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/IndicesAdapterES7.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/IndicesAdapterES7.java
@@ -42,6 +42,7 @@ import org.graylog.shaded.elasticsearch7.org.elasticsearch.client.indices.CloseI
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.client.indices.CreateIndexRequest;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.client.indices.DeleteAliasRequest;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.client.indices.PutIndexTemplateRequest;
+import org.graylog.shaded.elasticsearch7.org.elasticsearch.client.indices.PutMappingRequest;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.cluster.metadata.AliasMetadata;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.common.unit.TimeValue;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.index.query.QueryBuilders;
@@ -72,6 +73,7 @@ import org.joda.time.DateTimeZone;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nonnull;
 import javax.inject.Inject;
 import java.util.Arrays;
 import java.util.Collection;
@@ -150,6 +152,18 @@ public class IndicesAdapterES7 implements IndicesAdapter {
 
         client.execute((c, requestOptions) -> c.indices().create(request, requestOptions),
                 "Unable to create index " + index);
+    }
+
+    @Override
+    public void updateIndexMapping(@Nonnull String indexName,
+                                   @Nonnull String mappingType,
+                                   @Nonnull Map<String, Object> mapping) {
+
+        final PutMappingRequest request = new PutMappingRequest(indexName)
+                .source(mapping);
+
+        client.execute((c, requestOptions) -> c.indices().putMapping(request, requestOptions),
+                "Unable to update index mapping " + indexName);
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/indexer/indices/IndicesAdapter.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indices/IndicesAdapter.java
@@ -22,6 +22,7 @@ import org.graylog2.indexer.indices.stats.IndexStatistics;
 import org.graylog2.indexer.searches.IndexRangeStats;
 import org.joda.time.DateTime;
 
+import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
@@ -38,6 +39,14 @@ public interface IndicesAdapter {
     Set<String> resolveAlias(String alias);
 
     void create(String indexName, IndexSettings indexSettings, String templateName, Map<String, Object> template);
+
+    /**
+     * Add fields to an existing index or to change search only settings of existing fields
+     * @param indexName existing index name
+     * @param mappingType target mapping type (e.g. message). Not relevant for ES7+ (will be simply ignored).
+     * @param mapping field mappings
+     */
+    void updateIndexMapping(@Nonnull String indexName, @Nonnull String mappingType, @Nonnull Map<String, Object> mapping);
 
     boolean ensureIndexTemplate(String templateName, Map<String, Object> template);
 


### PR DESCRIPTION
## Description
This PR introduces a new method to facilitate index mapping update

## Motivation and Context
Closes https://github.com/Graylog2/graylog-plugin-enterprise/issues/2626

## Example
```java
indices.updateIndexMapping("test-0", "message",
                ImmutableMap.of("properties", 
                        ImmutableMap.of(
                                "new_field", ImmutableMap.of("type", "keyword"),
                                "new_alias", ImmutableMap.of("type", "alias", "path", "some_old_field"))
                ));
```

## Links

- https://www.elastic.co/guide/en/elasticsearch/reference/6.8/indices-put-mapping.html
- https://www.elastic.co/guide/en/elasticsearch/reference/7.14/indices-put-mapping.html