### PR TITLE
Consolidate rows retrieval for charts and improve its typing.

### DIFF
--- a/graylog2-web-interface/src/views/components/aggregationbuilder/AggregationBuilder.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/AggregationBuilder.tsx
@@ -43,9 +43,11 @@ type EventResult = {
   name: 'events',
 };
 
+type VisualizationResult = { [key: string]: Rows } & { events?: Events };
+
 export type VisualizationComponentProps = {
   config: AggregationWidgetConfig,
-  data: { [key: string]: Rows } & { events?: Events },
+  data: VisualizationResult,
   editing?: boolean,
   effectiveTimerange: AbsoluteTimeRange,
   fields: FieldTypeMappingsList,
@@ -58,6 +60,8 @@ export type VisualizationComponentProps = {
 export type VisualizationComponent<T extends string> =
   { type: T, propTypes?: any }
   & React.ComponentType<VisualizationComponentProps>;
+
+export const retrieveChartData = (data: VisualizationResult): Rows => data.chart ?? data[Object.keys(data).filter((name) => name !== 'events')[0]];
 
 export const makeVisualization = <T extends string>(component: React.ComponentType<VisualizationComponentProps>, type: T): VisualizationComponent<T> => {
   const visualizationComponent = component as VisualizationComponent<T>;

--- a/graylog2-web-interface/src/views/components/datatable/DataTable.tsx
+++ b/graylog2-web-interface/src/views/components/datatable/DataTable.tsx
@@ -36,7 +36,7 @@ import styles from './DataTable.css';
 
 import RenderCompletionCallback from '../widgets/RenderCompletionCallback';
 import type { VisualizationComponentProps } from '../aggregationbuilder/AggregationBuilder';
-import { makeVisualization } from '../aggregationbuilder/AggregationBuilder';
+import { makeVisualization, retrieveChartData } from '../aggregationbuilder/AggregationBuilder';
 
 type Props = VisualizationComponentProps & {
   config: AggregationWidgetConfig,
@@ -94,7 +94,7 @@ const DataTable = ({ config, currentView, data, fields }: Props) => {
   useEffect(onRenderComplete, [onRenderComplete]);
 
   const { columnPivots, rowPivots, series, rollup } = config;
-  const rows = (data.chart ?? Object.values(data)[0] ?? []) as Rows;
+  const rows = retrieveChartData(data);
 
   const rowFieldNames = rowPivots.map<string>((pivot) => pivot.field);
   const columnFieldNames = columnPivots.map((pivot) => pivot.field);

--- a/graylog2-web-interface/src/views/components/datatable/DataTable.tsx
+++ b/graylog2-web-interface/src/views/components/datatable/DataTable.tsx
@@ -94,7 +94,7 @@ const DataTable = ({ config, currentView, data, fields }: Props) => {
   useEffect(onRenderComplete, [onRenderComplete]);
 
   const { columnPivots, rowPivots, series, rollup } = config;
-  const rows = retrieveChartData(data);
+  const rows = retrieveChartData(data) ?? [];
 
   const rowFieldNames = rowPivots.map<string>((pivot) => pivot.field);
   const columnFieldNames = columnPivots.map((pivot) => pivot.field);

--- a/graylog2-web-interface/src/views/components/visualizations/area/AreaVisualization.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/area/AreaVisualization.tsx
@@ -22,8 +22,7 @@ import toPlotly from 'views/logic/aggregationbuilder/visualizations/Interpolatio
 import type { VisualizationComponentProps } from 'views/components/aggregationbuilder/AggregationBuilder';
 import { AggregationType, AggregationResult } from 'views/components/aggregationbuilder/AggregationBuilderPropTypes';
 import AreaVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/AreaVisualizationConfig';
-import { makeVisualization } from 'views/components/aggregationbuilder/AggregationBuilder';
-import { Rows } from 'views/logic/searchtypes/pivot/PivotHandler';
+import { makeVisualization, retrieveChartData } from 'views/components/aggregationbuilder/AggregationBuilder';
 
 import type { ChartDefinition } from '../ChartData';
 import XYPlot from '../XYPlot';
@@ -55,7 +54,7 @@ const AreaVisualization = makeVisualization(({ config, data, effectiveTimerange,
     line: { shape: toPlotly(interpolation) },
   }), [interpolation]);
 
-  const rows = (data.chart ?? Object.values(data)[0]) as Rows;
+  const rows = retrieveChartData(data);
 
   const chartDataResult = chartData(config, rows, 'scatter', chartGenerator);
   const layout: { shapes?: Shapes } = {};

--- a/graylog2-web-interface/src/views/components/visualizations/bar/BarVisualization.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/bar/BarVisualization.tsx
@@ -21,9 +21,8 @@ import { AggregationType, AggregationResult } from 'views/components/aggregation
 import type { VisualizationComponentProps } from 'views/components/aggregationbuilder/AggregationBuilder';
 import EventHandler, { Shapes } from 'views/logic/searchtypes/events/EventHandler';
 import { DateType } from 'views/logic/aggregationbuilder/Pivot';
-import { makeVisualization } from 'views/components/aggregationbuilder/AggregationBuilder';
+import { makeVisualization, retrieveChartData } from 'views/components/aggregationbuilder/AggregationBuilder';
 import BarVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/BarVisualizationConfig';
-import { Rows } from 'views/logic/searchtypes/pivot/PivotHandler';
 
 import { chartData } from '../ChartData';
 import XYPlot from '../XYPlot';
@@ -92,7 +91,7 @@ const BarVisualization = makeVisualization(({ config, data, effectiveTimerange, 
 
   const _seriesGenerator = (type, name, labels, values): ChartDefinition => ({ type, name, x: labels, y: values, opacity });
 
-  const rows = (data.chart ?? Object.values(data)[0]) as Rows;
+  const rows = retrieveChartData(data);
   const chartDataResult = chartData(config, rows, 'bar', _seriesGenerator);
 
   if (config.eventAnnotation && data.events) {

--- a/graylog2-web-interface/src/views/components/visualizations/heatmap/HeatmapVisualization.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/heatmap/HeatmapVisualization.tsx
@@ -19,9 +19,8 @@ import { values, merge, fill, find, isEmpty, get } from 'lodash';
 
 import { AggregationType, AggregationResult } from 'views/components/aggregationbuilder/AggregationBuilderPropTypes';
 import type { VisualizationComponentProps } from 'views/components/aggregationbuilder/AggregationBuilder';
-import { makeVisualization } from 'views/components/aggregationbuilder/AggregationBuilder';
+import { makeVisualization, retrieveChartData } from 'views/components/aggregationbuilder/AggregationBuilder';
 import HeatmapVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/HeatmapVisualizationConfig';
-import { Rows } from 'views/logic/searchtypes/pivot/PivotHandler';
 
 import type { ChartDefinition, ExtractedSeries } from '../ChartData';
 import GenericPlot from '../GenericPlot';
@@ -131,7 +130,7 @@ const _leafSourceMatcher = ({ source }) => source.endsWith('leaf') && source !==
 
 const HeatmapVisualization = makeVisualization(({ config, data }: VisualizationComponentProps) => {
   const visualizationConfig = (config.visualizationConfig || HeatmapVisualizationConfig.empty()) as HeatmapVisualizationConfig;
-  const rows = (data.chart ?? Object.values(data)[0]) as Rows;
+  const rows = retrieveChartData(data);
   const heatmapData = chartData(config, rows, 'heatmap', _generateSeries(visualizationConfig), _formatSeries(visualizationConfig), _leafSourceMatcher);
   const layout = _chartLayout(heatmapData);
 

--- a/graylog2-web-interface/src/views/components/visualizations/line/LineVisualization.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/line/LineVisualization.tsx
@@ -22,7 +22,7 @@ import type { VisualizationComponentProps } from 'views/components/aggregationbu
 import LineVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/LineVisualizationConfig';
 import toPlotly from 'views/logic/aggregationbuilder/visualizations/Interpolation';
 import EventHandler, { Shapes } from 'views/logic/searchtypes/events/EventHandler';
-import { makeVisualization } from 'views/components/aggregationbuilder/AggregationBuilder';
+import { makeVisualization, retrieveChartData } from 'views/components/aggregationbuilder/AggregationBuilder';
 import { Rows } from 'views/logic/searchtypes/pivot/PivotHandler';
 
 import type { ChartDefinition } from '../ChartData';
@@ -54,7 +54,7 @@ const LineVisualization = makeVisualization(({ config, data, effectiveTimerange,
     line: { shape: toPlotly(interpolation) },
   }), [interpolation]);
 
-  const rows = (data.chart ?? Object.values(data)[0]) as Rows;
+  const rows = retrieveChartData(data);
   const chartDataResult = chartData(config, rows, 'scatter', chartGenerator);
   const layout: { shapes?: Shapes } = {};
 

--- a/graylog2-web-interface/src/views/components/visualizations/line/LineVisualization.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/line/LineVisualization.tsx
@@ -23,7 +23,6 @@ import LineVisualizationConfig from 'views/logic/aggregationbuilder/visualizatio
 import toPlotly from 'views/logic/aggregationbuilder/visualizations/Interpolation';
 import EventHandler, { Shapes } from 'views/logic/searchtypes/events/EventHandler';
 import { makeVisualization, retrieveChartData } from 'views/components/aggregationbuilder/AggregationBuilder';
-import { Rows } from 'views/logic/searchtypes/pivot/PivotHandler';
 
 import type { ChartDefinition } from '../ChartData';
 import { chartData } from '../ChartData';

--- a/graylog2-web-interface/src/views/components/visualizations/number/NumberVisualization.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/number/NumberVisualization.tsx
@@ -28,7 +28,7 @@ import CustomHighlighting from 'views/components/messagelist/CustomHighlighting'
 import RenderCompletionCallback from 'views/components/widgets/RenderCompletionCallback';
 import NumberVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/NumberVisualizationConfig';
 import type { VisualizationComponentProps } from 'views/components/aggregationbuilder/AggregationBuilder';
-import { makeVisualization } from 'views/components/aggregationbuilder/AggregationBuilder';
+import { makeVisualization, retrieveChartData } from 'views/components/aggregationbuilder/AggregationBuilder';
 
 import Trend from './Trend';
 import AutoFontSizer from './AutoFontSizer';
@@ -109,7 +109,7 @@ const NumberVisualization = ({ config, currentView, fields, data }: Props) => {
 
   useEffect(onRenderComplete, [onRenderComplete]);
   const { activeQuery } = currentView;
-  const chartRows = (data.chart ?? Object.values(data)[0]) as Rows;
+  const chartRows = retrieveChartData(data);
   const trendRows = data.trend;
   const { value } = _extractValueAndField(chartRows);
   const { value: previousValue } = _extractValueAndField(trendRows || []);

--- a/graylog2-web-interface/src/views/components/visualizations/pie/PieVisualization.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/pie/PieVisualization.tsx
@@ -19,9 +19,8 @@ import { union } from 'lodash';
 
 import { AggregationType, AggregationResult } from 'views/components/aggregationbuilder/AggregationBuilderPropTypes';
 import type { VisualizationComponentProps } from 'views/components/aggregationbuilder/AggregationBuilder';
-import { makeVisualization } from 'views/components/aggregationbuilder/AggregationBuilder';
+import { makeVisualization, retrieveChartData } from 'views/components/aggregationbuilder/AggregationBuilder';
 import PlotLegend from 'views/components/visualizations/PlotLegend';
-import { Rows } from 'views/logic/searchtypes/pivot/PivotHandler';
 
 import GenericPlot from '../GenericPlot';
 import { chartData } from '../ChartData';
@@ -83,7 +82,7 @@ const labelMapper = (data: Array<{ labels: Array<string>}>) => data.reduce((acc,
 }, []);
 
 const PieVisualization = makeVisualization(({ config, data }: VisualizationComponentProps) => {
-  const rows = (data.chart ?? Object.values(data)[0]) as Rows;
+  const rows = retrieveChartData(data);
   const transformedData = chartData(config, rows, 'pie', _generateSeries);
 
   return (

--- a/graylog2-web-interface/src/views/components/visualizations/scatter/ScatterVisualization.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/scatter/ScatterVisualization.tsx
@@ -20,8 +20,7 @@ import PropTypes from 'prop-types';
 import EventHandler, { Shapes } from 'views/logic/searchtypes/events/EventHandler';
 import { AggregationType, AggregationResult } from 'views/components/aggregationbuilder/AggregationBuilderPropTypes';
 import type { VisualizationComponentProps } from 'views/components/aggregationbuilder/AggregationBuilder';
-import { makeVisualization } from 'views/components/aggregationbuilder/AggregationBuilder';
-import { Rows } from 'views/logic/searchtypes/pivot/PivotHandler';
+import { makeVisualization, retrieveChartData } from 'views/components/aggregationbuilder/AggregationBuilder';
 
 import { chartData } from '../ChartData';
 import XYPlot from '../XYPlot';
@@ -31,7 +30,7 @@ const seriesGenerator = (type, name, labels, values) => ({ type, name, x: labels
 const setChartColor = (chart, colors) => ({ marker: { color: colors.get(chart.name) } });
 
 const ScatterVisualization = makeVisualization(({ config, data, effectiveTimerange, height }: VisualizationComponentProps) => {
-  const rows = (data.chart ?? Object.values(data)[0]) as Rows;
+  const rows = retrieveChartData(data);
   const chartDataResult = chartData(config, rows, 'scatter', seriesGenerator);
   const layout: { shapes?: Shapes } = {};
 

--- a/graylog2-web-interface/src/views/components/visualizations/worldmap/WorldMapVisualization.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/worldmap/WorldMapVisualization.tsx
@@ -23,7 +23,7 @@ import { AggregationType, AggregationResult } from 'views/components/aggregation
 import type { VisualizationComponentProps } from 'views/components/aggregationbuilder/AggregationBuilder';
 import type { Rows } from 'views/logic/searchtypes/pivot/PivotHandler';
 import type Pivot from 'views/logic/aggregationbuilder/Pivot';
-import { makeVisualization } from 'views/components/aggregationbuilder/AggregationBuilder';
+import { makeVisualization, retrieveChartData } from 'views/components/aggregationbuilder/AggregationBuilder';
 
 import MapVisualization from './MapVisualization';
 
@@ -74,7 +74,7 @@ const WorldMapVisualization = makeVisualization(({ config, data, editing, onChan
     _formatSeriesForMap(rowPivots),
   ]);
 
-  const rows = data.chart || Object.values(data)[0];
+  const rows = retrieveChartData(data);
 
   const series = pipeline(rows);
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is doing a minor refactoring for retrieval of the typed charts rows in visualization. Previously, it required some type hints (`as Rows`), which are obsolete now and consolidate the extraction of the `chart` key vs. results stored as `id` keys..

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.