### PR TITLE
Changes to be able to compile with JDK 11

### DIFF
--- a/graylog-plugin-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/graylog-plugin-archetype/src/main/resources/archetype-resources/pom.xml
@@ -54,10 +54,11 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.release>11</maven.compiler.release>
 
-        <!-- Plugins will not be deployed by default - set to `false` if you actually want to deploy it -->
+    <!-- Plugins will not be deployed by default - set to `false` if you actually want to deploy it -->
         <maven.deploy.skip>true</maven.deploy.skip>
 
         <graylog.version>${project.parent.version}</graylog.version>

--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/views/ElasticsearchBackend.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/views/ElasticsearchBackend.java
@@ -112,7 +112,7 @@ public class ElasticsearchBackend implements QueryBackend<ESGeneratedQueryContex
 
         // add the optional root query filters
         generateFilterClause(query.filter(), job, query, results)
-                .map(boolQuery::filter);
+                .ifPresent(boolQuery::filter);
 
         final SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder()
                 .query(boolQuery)

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackend.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackend.java
@@ -112,7 +112,7 @@ public class ElasticsearchBackend implements QueryBackend<ESGeneratedQueryContex
 
         // add the optional root query filters
         generateFilterClause(query.filter(), job, query, results)
-                .map(boolQuery::filter);
+                .ifPresent(boolQuery::filter);
 
         final SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder()
                 .query(boolQuery)

--- a/graylog2-server/src/main/java/org/graylog/events/rest/EventDefinitionsResource.java
+++ b/graylog2-server/src/main/java/org/graylog/events/rest/EventDefinitionsResource.java
@@ -166,8 +166,8 @@ public class EventDefinitionsResource extends RestResource implements PluginRest
                            @ApiParam(name = "JSON Body") EventDefinitionDto dto) {
         checkPermission(RestPermissions.EVENT_DEFINITIONS_EDIT, definitionId);
         checkEventDefinitionPermissions(dto, "update");
-        dbService.get(definitionId)
-                .orElseThrow(() -> new NotFoundException("Event definition <" + definitionId + "> doesn't exist"));
+        if (!dbService.get(definitionId).isPresent())
+            throw new NotFoundException("Event definition <" + definitionId + "> doesn't exist");
 
         final ValidationResult result = dto.validate();
         if (!definitionId.equals(dto.id())) {

--- a/graylog2-server/src/main/java/org/graylog/events/rest/EventNotificationsResource.java
+++ b/graylog2-server/src/main/java/org/graylog/events/rest/EventNotificationsResource.java
@@ -134,8 +134,8 @@ public class EventNotificationsResource extends RestResource implements PluginRe
     public Response update(@ApiParam(name = "notificationId") @PathParam("notificationId") @NotBlank String notificationId,
                                   @ApiParam(name = "JSON Body") NotificationDto dto) {
         checkPermission(RestPermissions.EVENT_NOTIFICATIONS_EDIT, notificationId);
-        dbNotificationService.get(notificationId)
-                .orElseThrow(() -> new NotFoundException("Notification " + notificationId + " doesn't exist"));
+        if (!dbNotificationService.get(notificationId).isPresent())
+            throw new NotFoundException("Notification " + notificationId + " doesn't exist");
 
         if (!notificationId.equals(dto.id())) {
             throw new BadRequestException("Notification IDs don't match");

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/buckets/AutoInterval.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/buckets/AutoInterval.java
@@ -81,7 +81,7 @@ public abstract class AutoInterval implements Interval {
     public DateInterval toDateInterval(TimeRange timerange) {
         //noinspection UnnecessaryBoxing
         final Duration duration = Duration.ofMillis(
-                Math.round(new Double(timerange.getTo().getMillis() - timerange.getFrom().getMillis()) / 1000 * scaling() * 1000)
+                Math.round(Double.valueOf(timerange.getTo().getMillis() - timerange.getFrom().getMillis()) / 1000 * scaling() * 1000)
         );
         return boundaries.get(duration);
     }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/EnterpriseMetadataSummary.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/EnterpriseMetadataSummary.java
@@ -55,6 +55,32 @@ public class EnterpriseMetadataSummary extends PluginMetadataSummary {
 
     @Override
     public boolean equals(Object obj) {
-        return obj instanceof EnterpriseMetadataSummary;
+        if (obj == null) {
+            return false;
+        }
+
+        if (this == obj) {
+            return true;
+        }
+
+        if (obj instanceof EnterpriseMetadataSummary) {
+            EnterpriseMetadataSummary ems = (EnterpriseMetadataSummary) obj;
+            if (ems.name() == this.name()
+                    && ems.author() == this.author()
+                    && ems.url() == this.url()
+                    && ems.version() == this.version()
+                    && ems.description() == this.description()) {
+                return true;
+            } else {
+                return false;
+            }
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return (this.name() + this.author() + this.url() + this.version() + this.description()).hashCode();
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/scheduler/rest/JobSchedulerResource.java
+++ b/graylog2-server/src/main/java/org/graylog/scheduler/rest/JobSchedulerResource.java
@@ -100,8 +100,8 @@ public class JobSchedulerResource extends RestResource implements PluginRestReso
     @AuditEvent(type = JobSchedulerAuditEventTypes.SCHEDULER_JOB_UPDATE)
     public JobDefinitionDto update(@ApiParam(name = "jobDefinitionId") @PathParam("jobDefinitionId") @NotBlank String jobDefinitionId,
                                    JobDefinitionDto dto) {
-        dbJobDefinitionService.get(jobDefinitionId)
-                .orElseThrow(() -> new NotFoundException("Job definition " + jobDefinitionId + " doesn't exist"));
+        if(!dbJobDefinitionService.get(jobDefinitionId).isPresent())
+            throw new NotFoundException("Job definition " + jobDefinitionId + " doesn't exist");
 
         if (!jobDefinitionId.equals(dto.id())) {
             throw new BadRequestException("Job definition IDs don't match");

--- a/graylog2-server/src/main/java/org/graylog/security/authzroles/AuthzRolesResource.java
+++ b/graylog2-server/src/main/java/org/graylog/security/authzroles/AuthzRolesResource.java
@@ -247,7 +247,8 @@ public class AuthzRolesResource extends RestResource {
             if (user == null) {
                 throw new NotFoundException("Cannot find user with name: " + username);
             }
-            authzRolesService.get(roleId).orElseThrow(() -> new NotFoundException("Cannot find role with id: " + roleId));
+            if (!authzRolesService.get(roleId).isPresent())
+                throw new NotFoundException("Cannot find role with id: " + roleId);
             Set<String> roles = user.getRoleIds();
             rolesUpdater.update(roles, roleId);
             user.setRoleIds(roles);

--- a/graylog2-server/src/main/java/org/graylog2/bindings/providers/DefaultSecurityManagerProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/providers/DefaultSecurityManagerProvider.java
@@ -62,7 +62,7 @@ public class DefaultSecurityManagerProvider implements Provider<DefaultSecurityM
         List<Realm> authorizingRealms = new ArrayList<>();
         authorizingRealms.addAll(authorizingOnlyRealms.values());
         // root account realm might be deactivated and won't be present in that case
-        orderedAuthenticatingRealms.getRootAccountRealm().map(authorizingRealms::add);
+        orderedAuthenticatingRealms.getRootAccountRealm().ifPresent(authorizingRealms::add);
 
         final ModularRealmAuthorizer authorizer = new ModularRealmAuthorizer(authorizingRealms);
 

--- a/graylog2-server/src/main/java/org/graylog2/decorators/DecoratorImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/decorators/DecoratorImpl.java
@@ -34,6 +34,7 @@ import java.util.Optional;
 @WithBeanGetter
 @JsonAutoDetect
 @CollectionName("decorators")
+@SuppressWarnings("ComparableType")
 public abstract class DecoratorImpl implements Decorator, Comparable {
     static final String FIELD_ID = "id";
     static final String FIELD_TYPE = "type";

--- a/graylog2-server/src/main/java/org/graylog2/lookup/LookupTableService.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/LookupTableService.java
@@ -352,7 +352,7 @@ public class LookupTableService extends AbstractIdleService {
     public void handleLookupTableUpdate(LookupTablesUpdated updated) {
         scheduler.schedule(() -> {
             // load the DTO, and recreate the table
-            updated.lookupTableIds().forEach(id -> configService.getTable(id).map(this::createLookupTable));
+            updated.lookupTableIds().forEach(id -> configService.getTable(id).ifPresent(this::createLookupTable));
         }, 0, TimeUnit.SECONDS);
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/lookup/adapters/dsvhttp/DSVParser.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/adapters/dsvhttp/DSVParser.java
@@ -57,7 +57,9 @@ public class DSVParser {
 
         if (!keyOnly) {
             //noinspection ResultOfMethodCallIgnored
-            valueColumn.orElseThrow(() -> new IllegalStateException("No value column and not key only parsing specified!"));
+            if (!valueColumn.isPresent()) {
+                throw new IllegalStateException("No value column and not key only parsing specified!");
+            }
         }
 
         if (Strings.isNullOrEmpty(quoteChar)) {

--- a/graylog2-server/src/main/java/org/graylog2/plugin/journal/RawMessage.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/journal/RawMessage.java
@@ -117,7 +117,7 @@ public class RawMessage implements Serializable {
                   .setInputId(sourceInputId)
                   .setId(nodeId.toString())
                   .setType(JournalMessages.SourceNode.Type.SERVER)
-                  .build();
+                  .isInitialized();
     }
 
     public RawMessage(JournalMessage journalMessage, Object messageQueueId) {

--- a/graylog2-server/src/main/java/org/graylog2/rest/models/streams/alerts/requests/CreateConditionRequest.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/streams/alerts/requests/CreateConditionRequest.java
@@ -50,7 +50,11 @@ public abstract class CreateConditionRequest {
     public static CreateConditionRequest create(@JsonProperty("type") @Nullable String type,
                                                 @JsonProperty("title") @Nullable String title,
                                                 @JsonProperty("parameters") Map<String, Object> parameters) {
-        return new AutoValue_CreateConditionRequest(type, title, parameters);
+        return new AutoValue_CreateConditionRequest.Builder()
+                .setType(type)
+                .setTitle(title)
+                .setParameters(parameters)
+                .build();
     }
 
     @AutoValue.Builder

--- a/graylog2-server/src/main/java/org/graylog2/rest/models/system/indexer/responses/ShardRouting.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/system/indexer/responses/ShardRouting.java
@@ -64,7 +64,16 @@ public abstract class ShardRouting {
                                       @JsonProperty("node_name") @Nullable String nodeName,
                                       @JsonProperty("node_hostname") @Nullable String nodeHostname,
                                       @JsonProperty("relocating_to") @Nullable String relocatingTo) {
-        return new AutoValue_ShardRouting(id, state, active, primary, nodeId, nodeName, nodeHostname, relocatingTo);
+        return new AutoValue_ShardRouting.Builder()
+                .id(id)
+                .state(state)
+                .active(active)
+                .primary(primary)
+                .nodeId(nodeId)
+                .nodeName(nodeName)
+                .nodeHostname(nodeHostname)
+                .relocatingTo(relocatingTo)
+                .build();
     }
 
     public static Builder builder() {

--- a/graylog2-server/src/main/java/org/graylog2/security/DefaultX509TrustManager.java
+++ b/graylog2-server/src/main/java/org/graylog2/security/DefaultX509TrustManager.java
@@ -36,6 +36,7 @@ import java.security.cert.X509Certificate;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 public class DefaultX509TrustManager extends X509ExtendedTrustManager {
     private final List<String> hosts;
@@ -133,10 +134,11 @@ public class DefaultX509TrustManager extends X509ExtendedTrustManager {
     }
 
     private void validateHostnames(X509Certificate[] x509Certificates, String s) throws CertificateException {
-        Arrays.stream(x509Certificates)
+        Optional<X509Certificate> cert = Arrays.stream(x509Certificates)
                 .filter(this::certificateMatchesHostname)
-                .findFirst()
-                .orElseThrow(() -> new CertificateException("Presented certificate does not match configured hostname!"));
+                .findFirst();
+        if (!cert.isPresent())
+            throw new CertificateException("Presented certificate does not match configured hostname!");
     }
 
     private boolean certificateMatchesHostname(X509Certificate x509Certificate) {

--- a/graylog2-server/src/main/java/org/graylog2/shared/system/stats/fs/OshiFsProbe.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/system/stats/fs/OshiFsProbe.java
@@ -108,7 +108,7 @@ public class OshiFsProbe implements FsProbe {
                     HWDiskStore diskStore = it.getValue().getB();
                     OSFileStore fileStore = it.getValue().getA();
                     return FsStats.Filesystem.create(it.getKey().toString(), fileStore.getMount(),
-                            Optional.of(fileStore.getLogicalVolume()).orElse(fileStore.getVolume()),
+                            Optional.ofNullable(fileStore.getLogicalVolume()).orElse(fileStore.getVolume()),
                             fileStore.getDescription(), fileStore.getType(), fileStore.getTotalSpace(), fileStore.getUsableSpace(),
                             fileStore.getUsableSpace(), fileStore.getTotalSpace() - fileStore.getUsableSpace(),
                             (short) (((fileStore.getTotalSpace() - fileStore.getUsableSpace()) * 100 / fileStore.getTotalSpace())),

--- a/pom.xml
+++ b/pom.xml
@@ -81,8 +81,9 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.release>11</maven.compiler.release>
         <maven.compiler.useIncrementalCompilation>false</maven.compiler.useIncrementalCompilation>
 
         <!-- Dependencies -->
@@ -235,7 +236,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.7.0</version>
+                    <version>3.8.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -305,7 +306,7 @@
                 <plugin>
                     <groupId>de.thetaphi</groupId>
                     <artifactId>forbiddenapis</artifactId>
-                    <version>2.5</version>
+                    <version>3.1</version>
                 </plugin>
                 <plugin>
                     <groupId>com.github.eirslett</groupId>
@@ -338,29 +339,41 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
+                    <release>11</release>
                     <showWarnings>true</showWarnings>
                     <showDeprecation>true</showDeprecation>
-                    <compilerId>javac-with-errorprone</compilerId>
                     <forceJavacCompilerUse>true</forceJavacCompilerUse>
+                    <fork>true</fork>
                     <compilerArgs>
-                        <arg>-XepDisableWarningsInGeneratedCode</arg>
+                        <arg>-XDcompilePolicy=simple</arg>
+                        <arg>-Xplugin:ErrorProne -XepDisableWarningsInGeneratedCode</arg>
+                        <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
+                        <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</arg>
+                        <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</arg>
+                        <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED</arg>
+                        <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED</arg>
+                        <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED</arg>
+                        <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</arg>
+                        <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</arg>
+                        <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
+                        <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED</arg>
                     </compilerArgs>
                     <annotationProcessors>
                         <annotationProcessor>com.google.auto.value.processor.AutoValueProcessor</annotationProcessor>
                     </annotationProcessors>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>com.google.errorprone</groupId>
+                            <artifactId>error_prone_core</artifactId>
+                            <version>2.9.0</version>
+                        </path>
+                        <path>
+                            <groupId>com.google.auto.value</groupId>
+                            <artifactId>auto-value</artifactId>
+                            <version>1.7.4</version>
+                        </path>
+                    </annotationProcessorPaths>
                 </configuration>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.codehaus.plexus</groupId>
-                        <artifactId>plexus-compiler-javac-errorprone</artifactId>
-                        <version>2.8.4</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>com.google.errorprone</groupId>
-                        <artifactId>error_prone_core</artifactId>
-                        <version>2.3.1</version>
-                    </dependency>
-                </dependencies>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
- Most java code changes are related to new errorprone checks
- Changes to EnterpriseMetadataSummary to properly override equals and hashCode
- Changed new Double, deprecated in JDK 11, to Double.valueOf

<!--- Provide a general summary of your changes in the Title above -->

## Description
Changes necessary to compile the graylog-project, and all sub-projects, with JDK 11.

## Motivation and Context
Since JDK 11 is the latest LTS version, and brings significant performance improvements in many areas, I believe it is too good to pass on the free performance gains.

Please keep in mind I am submitting pull requests to all involved projects below, so the full project can compile and execute properly under JDK 11.

- graylog-project
- graylog2-server
- graylog-plugin-threatintel
- graylog-plugin-integrations
- graylog-plugin-aws

## How Has This Been Tested?
The code changes in itself are minimal.

For my current setup, I compiled and ran all the projects using openjdk 11.0.11 under Ubuntu 20.04. No problems, so far.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

