### PR TITLE
Checking if input node is local asynchronously in message details.

### DIFF
--- a/graylog2-web-interface/src/@types/graylog-web-plugin/index.d.ts
+++ b/graylog2-web-interface/src/@types/graylog-web-plugin/index.d.ts
@@ -15,7 +15,6 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import FetchError from 'logic/errors/FetchError';
-import { NodeInfo } from 'stores/nodes/NodesStore';
 
 interface PluginRoute {
   path: string;
@@ -51,7 +50,7 @@ interface PluginForwarder {
     inputId: string;
     forwarderNodeId: string;
   }>;
-  isLocalNode: (nodeId: string) => NodeInfo;
+  isLocalNode: (nodeId: string) => Promise<boolean>;
   messageLoaders: {
     ForwarderInputDropdown: React.ComponentType<{
       autoLoadMessage?: boolean;

--- a/graylog2-web-interface/src/stores/nodes/NodesStore.ts
+++ b/graylog2-web-interface/src/stores/nodes/NodesStore.ts
@@ -99,7 +99,7 @@ const NodesStore = Reflux.createStore<NodesStoreState>({
   },
 
   getNode(nodeId) {
-    return this.nodes[nodeId];
+    return this.nodes?.[nodeId];
   },
 
   _clusterId() {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This change is a follow-up to #11207. This PR was fixing the symptoms of the underlying issue, but not the reason. Prior to it, we were expecting the nodes list to be present in the `NodesStore`, which does not necessarily have to be the case, depending on timing. Unfortunately, this check was performed synchronously, so there was no way to just wait for the nodes list to arrive before returning a result.

This change is now making the `isLocalNode` check return a `Promise<boolean>` instead, allowing us to wait for the nodes list in case of its absence.

/jenkins-pr-deps Graylog2/graylog-plugin-enterprise#2646

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.