### PR TITLE
Fix exception being thrown for message details if plugin is missing.

### DIFF
--- a/graylog2-web-interface/src/stores/nodes/NodesStore.ts
+++ b/graylog2-web-interface/src/stores/nodes/NodesStore.ts
@@ -41,7 +41,7 @@ type NodesListResponse = {
 };
 
 export type NodesStoreState = {
-  nodes: Array<NodeInfo>;
+  nodes: { [nodeId: string]: NodeInfo };
   clusterId: string;
   nodeCount: number;
 };

--- a/graylog2-web-interface/src/views/components/messagelist/FormatReceivedBy.test.tsx
+++ b/graylog2-web-interface/src/views/components/messagelist/FormatReceivedBy.test.tsx
@@ -1,0 +1,73 @@
+import * as React from 'react';
+import { render, screen, within } from 'wrappedTestingLibrary';
+import * as Immutable from 'immutable';
+import { MockCombinedProvider, MockStore } from 'helpers/mocking';
+import { PluginStore } from 'graylog-web-plugin/plugin';
+
+import { Input } from 'components/messageloaders/Types';
+
+import FormatReceivedBy from './FormatReceivedBy';
+
+jest.mock('injection/CombinedProvider', () => new MockCombinedProvider({
+  Nodes: {
+    NodesStore: MockStore(['getInitialState', () => ({ nodes: { existingNode: { short_node_id: 'foobar', hostname: 'existing.node' } } })]),
+  },
+}));
+
+type ForwarderReceivedByProps = {
+  inputId: string,
+  forwarderNodeId: string,
+};
+
+describe('FormatReceivedBy', () => {
+  it('shows that input is deleted if it is unknown', async () => {
+    render(<FormatReceivedBy inputs={Immutable.Map()} sourceNodeId="foo" sourceInputId="bar" />);
+    await screen.findByText('deleted input');
+  });
+
+  it('shows that node is stopped if it is unknown', async () => {
+    render(<FormatReceivedBy inputs={Immutable.Map()} sourceNodeId="foo" sourceInputId="bar" />);
+    await screen.findByText('stopped node');
+  });
+
+  it('shows input information if present', async () => {
+    const inputs = Immutable.Map<string, Input>({
+      bar: {
+        title: 'My awesome input',
+      },
+    });
+    render(<FormatReceivedBy inputs={inputs} sourceNodeId="foo" sourceInputId="bar" />);
+    await screen.findByText('My awesome input');
+  });
+
+  it('shows node information if present', async () => {
+    render(<FormatReceivedBy inputs={Immutable.Map()} sourceNodeId="existingNode" sourceInputId="bar" />);
+
+    const nodeLink = await screen.findByRole('link', { name: /existing.node/ }) as HTMLAnchorElement;
+
+    expect(nodeLink.href).toEqual('http://localhost/system/nodes/existingNode');
+    expect(within(nodeLink).getByText('foobar')).not.toBeNull();
+  });
+
+  it('allows overriding node information through plugin', async () => {
+    const ForwarderReceivedBy = ({ inputId, forwarderNodeId }: ForwarderReceivedByProps) => <span>Mighty plugin magic: {inputId}/{forwarderNodeId}</span>;
+    const pluginManifest = {
+      exports: {
+        forwarder: [{
+          isLocalNode: () => Promise.resolve(false),
+          ForwarderReceivedBy,
+          messageLoaders: { ForwarderInputDropdown: () => <></> },
+        }],
+      },
+    };
+    PluginStore.register(pluginManifest);
+    const inputs = Immutable.Map<string, Input>({
+      bar: {
+        title: 'My awesome input',
+      },
+    });
+
+    render(<FormatReceivedBy inputs={inputs} sourceNodeId="foo" sourceInputId="bar" />);
+    await screen.findByText('Mighty plugin magic: bar/foo');
+  });
+});

--- a/graylog2-web-interface/src/views/components/messagelist/FormatReceivedBy.test.tsx
+++ b/graylog2-web-interface/src/views/components/messagelist/FormatReceivedBy.test.tsx
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 import * as React from 'react';
 import { render, screen, within } from 'wrappedTestingLibrary';
 import * as Immutable from 'immutable';

--- a/graylog2-web-interface/src/views/components/messagelist/FormatReceivedBy.tsx
+++ b/graylog2-web-interface/src/views/components/messagelist/FormatReceivedBy.tsx
@@ -1,0 +1,57 @@
+import * as React from 'react';
+import { useState, useEffect } from 'react';
+import * as Immutable from 'immutable';
+
+import { Spinner } from 'components/common';
+import NodeName from 'views/components/messagelist/NodeName';
+import { Input } from 'components/messageloaders/Types';
+import usePluginEntities from 'views/logic/usePluginEntities';
+
+type Inputs = Immutable.Map<string, Input>;
+
+const _inputName = (inputs: Inputs, inputId: string) => {
+  // eslint-disable-next-line react/destructuring-assignment
+  const input = inputs.get(inputId);
+
+  return input ? <span style={{ wordBreak: 'break-word' }}>{input.title}</span> : 'deleted input';
+};
+
+const FormatReceivedBy = ({ inputs, sourceInputId, sourceNodeId }: { inputs: Inputs, sourceNodeId: string, sourceInputId: string }) => {
+  const [isLocalNode, setIsLocalNode] = useState<boolean | undefined>();
+
+  const forwarderPlugin = usePluginEntities('forwarder');
+  const ForwarderReceivedBy = forwarderPlugin?.[0]?.ForwarderReceivedBy;
+  const _isLocalNode = forwarderPlugin?.[0]?.isLocalNode;
+
+  useEffect(() => {
+    if (sourceNodeId && _isLocalNode) {
+      _isLocalNode(sourceNodeId).then(setIsLocalNode);
+    } else {
+      setIsLocalNode(true);
+    }
+  }, [sourceNodeId, _isLocalNode]);
+
+  if (!sourceNodeId) {
+    return null;
+  }
+
+  if (isLocalNode === undefined) {
+    return <Spinner />;
+  }
+
+  if (isLocalNode === false) {
+    return <ForwarderReceivedBy inputId={sourceInputId} forwarderNodeId={sourceNodeId} />;
+  }
+
+  return (
+    <div>
+      <dt>Received by</dt>
+      <dd>
+        <em>{_inputName(inputs, sourceInputId)}</em>{' '}
+        on <NodeName nodeId={sourceNodeId} />
+      </dd>
+    </div>
+  );
+};
+
+export default FormatReceivedBy;

--- a/graylog2-web-interface/src/views/components/messagelist/FormatReceivedBy.tsx
+++ b/graylog2-web-interface/src/views/components/messagelist/FormatReceivedBy.tsx
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 import * as React from 'react';
 import { useState, useEffect } from 'react';
 import * as Immutable from 'immutable';

--- a/graylog2-web-interface/src/views/components/messagelist/FormatReceivedBy.tsx
+++ b/graylog2-web-interface/src/views/components/messagelist/FormatReceivedBy.tsx
@@ -25,7 +25,7 @@ const FormatReceivedBy = ({ inputs, sourceInputId, sourceNodeId }: { inputs: Inp
 
   useEffect(() => {
     if (sourceNodeId && _isLocalNode) {
-      _isLocalNode(sourceNodeId).then(setIsLocalNode);
+      _isLocalNode(sourceNodeId).then(setIsLocalNode, () => setIsLocalNode(true));
     } else {
       setIsLocalNode(true);
     }

--- a/graylog2-web-interface/src/views/components/messagelist/MessageDetail.tsx
+++ b/graylog2-web-interface/src/views/components/messagelist/MessageDetail.tsx
@@ -16,9 +16,8 @@
  */
 import PropTypes from 'prop-types';
 import * as React from 'react';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import Immutable from 'immutable';
-import { PluginStore } from 'graylog-web-plugin/plugin';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 
 import { Link } from 'components/graylog/router';
@@ -35,54 +34,11 @@ import CustomPropTypes from 'views/components/CustomPropTypes';
 import { FieldTypeMappingsList } from 'views/stores/FieldTypesStore';
 import { useStore } from 'stores/connect';
 import { SearchConfigStore } from 'views/stores/SearchConfigStore';
+import FormatReceivedBy from 'views/components/messagelist/FormatReceivedBy';
 
-import NodeName from './NodeName';
 import MessageActions from './MessageActions';
 import MessageAugmentations from './MessageAugmentations';
 import MessageMetadata from './MessageMetadata';
-
-const _inputName = (inputs: Props['inputs'], inputId: string) => {
-  // eslint-disable-next-line react/destructuring-assignment
-  const input = inputs.get(inputId);
-
-  return input ? <span style={{ wordBreak: 'break-word' }}>{input.title}</span> : 'deleted input';
-};
-
-const FormatReceivedBy = ({ inputs, sourceInputId, sourceNodeId }: { inputs: Props['inputs'], sourceNodeId: string, sourceInputId: string }) => {
-  const [isLocalNode, setIsLocalNode] = useState<boolean | undefined>();
-
-  const forwarderPlugin = PluginStore.exports('forwarder');
-  const ForwarderReceivedBy = forwarderPlugin?.[0]?.ForwarderReceivedBy;
-  const _isLocalNode = forwarderPlugin?.[0]?.isLocalNode;
-
-  useEffect(() => {
-    if (sourceNodeId) {
-      _isLocalNode(sourceNodeId).then(setIsLocalNode);
-    }
-  }, [sourceNodeId, _isLocalNode]);
-
-  if (!sourceNodeId) {
-    return null;
-  }
-
-  if (isLocalNode === undefined) {
-    return <Spinner />;
-  }
-
-  if (isLocalNode === false) {
-    return <ForwarderReceivedBy inputId={sourceInputId} forwarderNodeId={sourceNodeId} />;
-  }
-
-  return (
-    <div>
-      <dt>Received by</dt>
-      <dd>
-        <em>{_inputName(inputs, sourceInputId)}</em>{' '}
-        on <NodeName nodeId={sourceNodeId} />
-      </dd>
-    </div>
-  );
-};
 
 const _formatMessageTitle = (index, id) => {
   if (index) {

--- a/graylog2-web-interface/src/views/components/messagelist/NodeName.tsx
+++ b/graylog2-web-interface/src/views/components/messagelist/NodeName.tsx
@@ -20,23 +20,19 @@ import PropTypes from 'prop-types';
 import Routes from 'routing/Routes';
 import { Icon } from 'components/common';
 import CombinedProvider from 'injection/CombinedProvider';
-import connect from 'stores/connect';
+import { useStore } from 'stores/connect';
 import { NodesStoreState } from 'stores/nodes/NodesStore';
 import { Store } from 'stores/StoreTypes';
 
-const { NodesStore } = CombinedProvider.get('Nodes');
+const { NodesStore }: { NodesStore: Store<NodesStoreState> } = CombinedProvider.get('Nodes');
 
 type NodeId = string;
-type NodeInfo = {
-  short_node_id: string,
-  hostname: string,
-};
 type Props = {
   nodeId: NodeId,
-  nodes: { [key: string]: NodeInfo },
 };
 
-const NodeName = ({ nodeId, nodes }: Props) => {
+const NodeName = ({ nodeId }: Props) => {
+  const nodes = useStore(NodesStore, (state) => state?.nodes ?? {});
   const node = nodes[nodeId];
 
   if (node) {
@@ -63,4 +59,4 @@ NodeName.propTypes = {
   nodeId: PropTypes.string.isRequired,
 };
 
-export default connect(NodeName, { nodes: NodesStore as Store<NodesStoreState> }, ({ nodes: { nodes = {} } = {} }) => ({ nodes }));
+export default NodeName;


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Prior to this change, #11225 introduced an issue that results in an exception being thrown when no plugin is present implementing the `isLocalNode` function.

This change is now handling the absence of a plugin for it and adds tests.


<!--- Provide a general summary of your changes in the Title above -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.