### PR TITLE
Update forbiddenapis checker from 2.5 to 3.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -305,7 +305,7 @@
                 <plugin>
                     <groupId>de.thetaphi</groupId>
                     <artifactId>forbiddenapis</artifactId>
-                    <version>2.5</version>
+                    <version>3.1</version>
                 </plugin>
                 <plugin>
                     <groupId>com.github.eirslett</groupId>


### PR DESCRIPTION
Our version is quite ancient and doesn't support compiling with Java 11

Changelog: https://github.com/policeman-tools/forbidden-apis/wiki/Changes

