### PR TITLE
Improve re-rendering of widget grid on search page.

### DIFF
--- a/graylog2-web-interface/src/components/common/ReactGridContainer.jsx
+++ b/graylog2-web-interface/src/components/common/ReactGridContainer.jsx
@@ -219,7 +219,7 @@ class ReactGridContainer extends React.Component {
     }
   }
 
-  computeLayout = (positions) => {
+  computeLayout = (positions = {}) => {
     return Object.keys(positions).map((id) => {
       const { col, row, height, width } = positions[id];
 

--- a/graylog2-web-interface/src/routing/AppFacade.tsx
+++ b/graylog2-web-interface/src/routing/AppFacade.tsx
@@ -62,11 +62,7 @@ const AppFacade = () => {
     );
   }
 
-  console.log({ currentUser, server, sessionId });
-
   if (!currentUser) {
-    console.log('Showing loading message');
-
     return <LoadingPage text="We are preparing Graylog for you..." />;
   }
 

--- a/graylog2-web-interface/src/routing/AppFacade.tsx
+++ b/graylog2-web-interface/src/routing/AppFacade.tsx
@@ -62,7 +62,11 @@ const AppFacade = () => {
     );
   }
 
+  console.log({ currentUser, server, sessionId });
+
   if (!currentUser) {
+    console.log('Showing loading message');
+
     return <LoadingPage text="We are preparing Graylog for you..." />;
   }
 

--- a/graylog2-web-interface/src/stores/StoreTypes.ts
+++ b/graylog2-web-interface/src/stores/StoreTypes.ts
@@ -32,3 +32,5 @@ export type Store<State> = {
   listen: (cb: (state: State) => unknown) => () => void;
   getInitialState: () => State;
 };
+
+export type StoreState<R> = R extends Store<infer T> ? T : never;

--- a/graylog2-web-interface/src/views/components/Query.tsx
+++ b/graylog2-web-interface/src/views/components/Query.tsx
@@ -15,18 +15,14 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import Immutable from 'immutable';
 import styled, { css } from 'styled-components';
-import { BackendWidgetPosition } from 'views/types';
 
 import DocsHelper from 'util/DocsHelper';
 import { Jumbotron } from 'components/graylog';
-import { CurrentViewStateActions } from 'views/stores/CurrentViewStateStore';
 import DocumentationLink from 'components/support/DocumentationLink';
 import IfDashboard from 'views/components/dashboard/IfDashboard';
 import IfSearch from 'views/components/search/IfSearch';
 import WidgetGrid from 'views/components/WidgetGrid';
-import WidgetPosition from 'views/logic/widgets/WidgetPosition';
 import { useStore } from 'stores/connect';
 import { WidgetStore } from 'views/stores/WidgetStore';
 
@@ -41,21 +37,10 @@ const StyledJumbotron = styled(Jumbotron)(({ theme }) => css`
   }
 `);
 
-const MAXIMUM_GRID_SIZE = 12;
-
-const _onPositionsChange = (positions: Array<BackendWidgetPosition>) => {
-  const newPositions = Immutable.Map<string, WidgetPosition>(
-    positions.map(({ col, height, row, width, id }) => [id, new WidgetPosition(col, row, height, width >= MAXIMUM_GRID_SIZE ? Infinity : width)]),
-  ).toObject();
-
-  CurrentViewStateActions.widgetPositions(newPositions);
-};
-
 const RenderedWidgetGrid = () => (
   <InteractiveContext.Consumer>
     {(interactive) => (
-      <WidgetGrid locked={!interactive}
-                  onPositionsChange={_onPositionsChange} />
+      <WidgetGrid locked={!interactive} />
     )}
   </InteractiveContext.Consumer>
 );

--- a/graylog2-web-interface/src/views/components/Query.tsx
+++ b/graylog2-web-interface/src/views/components/Query.tsx
@@ -45,7 +45,7 @@ const RenderedWidgetGrid = () => (
   </InteractiveContext.Consumer>
 );
 
-const EmptyDashboardInfo = () => (
+const NoWidgetsInfo = () => (
   <StyledJumbotron>
     <h2>
       <IfDashboard>
@@ -76,14 +76,14 @@ const EmptyDashboardInfo = () => (
   </StyledJumbotron>
 );
 
-const useWidgetCount = () => useStore(WidgetStore, (widgets) => widgets?.size ?? 0);
+const useHasWidgets = () => useStore(WidgetStore, (widgets) => widgets?.size > 0);
 
 const Query = () => {
-  const widgetCount = useWidgetCount();
+  const hasWidgets = useHasWidgets();
 
-  return widgetCount > 0
+  return hasWidgets
     ? <RenderedWidgetGrid />
-    : <EmptyDashboardInfo />;
+    : <NoWidgetsInfo />;
 };
 
 const memoizedQuery = React.memo(Query);

--- a/graylog2-web-interface/src/views/components/Query.tsx
+++ b/graylog2-web-interface/src/views/components/Query.tsx
@@ -26,8 +26,6 @@ import WidgetGrid from 'views/components/WidgetGrid';
 import { useStore } from 'stores/connect';
 import { WidgetStore } from 'views/stores/WidgetStore';
 
-import InteractiveContext from './contexts/InteractiveContext';
-
 const StyledJumbotron = styled(Jumbotron)(({ theme }) => css`
   .container-fluid & {
     border: 1px solid ${theme.colors.gray[80]};
@@ -36,14 +34,6 @@ const StyledJumbotron = styled(Jumbotron)(({ theme }) => css`
     margin-bottom: 0;
   }
 `);
-
-const RenderedWidgetGrid = () => (
-  <InteractiveContext.Consumer>
-    {(interactive) => (
-      <WidgetGrid locked={!interactive} />
-    )}
-  </InteractiveContext.Consumer>
-);
 
 const NoWidgetsInfo = () => (
   <StyledJumbotron>
@@ -82,7 +72,7 @@ const Query = () => {
   const hasWidgets = useHasWidgets();
 
   return hasWidgets
-    ? <RenderedWidgetGrid />
+    ? <WidgetGrid />
     : <NoWidgetsInfo />;
 };
 

--- a/graylog2-web-interface/src/views/components/Query.tsx
+++ b/graylog2-web-interface/src/views/components/Query.tsx
@@ -157,14 +157,13 @@ type Props = {
 
 const Query = ({ fields, results, widgetMapping }: Props) => {
   const widgets = useStore(WidgetStore);
-  const positions = useStore(CurrentViewStateStore, (viewState) => viewState?.state?.widgetPositions);
 
   if (!widgets || widgets.isEmpty()) {
     return <EmptyDashboardInfo />;
   }
 
   return results
-    ? <RenderedWidgetGrid widgetDefs={widgets} widgetMapping={widgetMapping.toJS()} results={results} positions={positions} fields={fields} />
+    ? <RenderedWidgetGrid widgetDefs={widgets} widgetMapping={widgetMapping.toJS()} results={results} fields={fields} />
     : <Spinner />;
 };
 

--- a/graylog2-web-interface/src/views/components/Query.tsx
+++ b/graylog2-web-interface/src/views/components/Query.tsx
@@ -15,7 +15,6 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import PropTypes from 'prop-types';
 import Immutable from 'immutable';
 import styled, { css } from 'styled-components';
 import { BackendWidgetPosition } from 'views/types';
@@ -23,17 +22,11 @@ import { BackendWidgetPosition } from 'views/types';
 import DocsHelper from 'util/DocsHelper';
 import { Jumbotron } from 'components/graylog';
 import { CurrentViewStateActions } from 'views/stores/CurrentViewStateStore';
-import { Spinner } from 'components/common';
-import { widgetDefinition } from 'views/logic/Widgets';
 import DocumentationLink from 'components/support/DocumentationLink';
 import IfDashboard from 'views/components/dashboard/IfDashboard';
 import IfSearch from 'views/components/search/IfSearch';
 import WidgetGrid from 'views/components/WidgetGrid';
 import WidgetPosition from 'views/logic/widgets/WidgetPosition';
-import { FieldTypeMappingsList } from 'views/stores/FieldTypesStore';
-import Widget from 'views/logic/widgets/Widget';
-import QueryResult from 'views/logic/QueryResult';
-import { WidgetMapping } from 'views/logic/views/types';
 import { useStore } from 'stores/connect';
 import { WidgetStore } from 'views/stores/WidgetStore';
 
@@ -58,63 +51,14 @@ const _onPositionsChange = (positions: Array<BackendWidgetPosition>) => {
   CurrentViewStateActions.widgetPositions(newPositions);
 };
 
-const _getDataAndErrors = (widget, widgetMapping, results) => {
-  const { searchTypes } = results;
-  const widgetType = widgetDefinition(widget.type);
-  const dataTransformer = widgetType.searchResultTransformer || ((x) => x);
-  const searchTypeIds = widgetMapping[widget.id] ?? [];
-  const widgetData = searchTypeIds.map((searchTypeId) => searchTypes[searchTypeId]).filter((result) => result);
-  const widgetErrors = results.errors.filter((e) => searchTypeIds.includes(e.searchTypeId));
-  let error;
-
-  const data = dataTransformer(widgetData, widget);
-
-  if (widgetErrors && widgetErrors.length > 0) {
-    error = widgetErrors;
-  }
-
-  if (!widgetData || widgetData.length === 0) {
-    const queryErrors = results.errors.filter((e) => e.type === 'query');
-
-    if (queryErrors.length > 0) {
-      error = error ? [].concat(error, queryErrors) : queryErrors;
-    }
-  }
-
-  return { widgetData: data, error };
-};
-
-type GridProps = {
-  widgetDefs: Immutable.Map<string, Widget>,
-  widgetMapping: { [widgetId: string]: Array<string> },
-  results: QueryResult,
-  fields: FieldTypeMappingsList,
-}
-
-const RenderedWidgetGrid = ({ widgetDefs, widgetMapping, results, fields }: GridProps) => {
-  const data = {};
-  const errors = {};
-
-  // eslint-disable-next-line react/destructuring-assignment
-  widgetDefs.forEach((widget) => {
-    const { widgetData, error } = _getDataAndErrors(widget, widgetMapping, results);
-
-    data[widget.id] = widgetData;
-    errors[widget.id] = error;
-  });
-
-  return (
-    <InteractiveContext.Consumer>
-      {(interactive) => (
-        <WidgetGrid data={data}
-                    errors={errors}
-                    fields={fields}
-                    locked={!interactive}
-                    onPositionsChange={_onPositionsChange} />
-      )}
-    </InteractiveContext.Consumer>
-  );
-};
+const RenderedWidgetGrid = () => (
+  <InteractiveContext.Consumer>
+    {(interactive) => (
+      <WidgetGrid locked={!interactive}
+                  onPositionsChange={_onPositionsChange} />
+    )}
+  </InteractiveContext.Consumer>
+);
 
 const EmptyDashboardInfo = () => (
   <StyledJumbotron>
@@ -147,28 +91,14 @@ const EmptyDashboardInfo = () => (
   </StyledJumbotron>
 );
 
-type Props = {
-  fields: FieldTypeMappingsList,
-  results: QueryResult,
-  widgetMapping: WidgetMapping,
-};
+const useWidgetCount = () => useStore(WidgetStore, (widgets) => widgets?.size ?? 0);
 
-const Query = ({ fields, results, widgetMapping }: Props) => {
-  const widgets = useStore(WidgetStore);
+const Query = () => {
+  const widgetCount = useWidgetCount();
 
-  if (!widgets || widgets.isEmpty()) {
-    return <EmptyDashboardInfo />;
-  }
-
-  return results
-    ? <RenderedWidgetGrid widgetDefs={widgets} widgetMapping={widgetMapping.toJS()} results={results} fields={fields} />
-    : <Spinner />;
-};
-
-Query.propTypes = {
-  fields: PropTypes.object.isRequired,
-  results: PropTypes.object.isRequired,
-  widgetMapping: PropTypes.object.isRequired,
+  return widgetCount > 0
+    ? <RenderedWidgetGrid />
+    : <EmptyDashboardInfo />;
 };
 
 const memoizedQuery = React.memo(Query);

--- a/graylog2-web-interface/src/views/components/Query.tsx
+++ b/graylog2-web-interface/src/views/components/Query.tsx
@@ -22,7 +22,7 @@ import { BackendWidgetPosition } from 'views/types';
 
 import DocsHelper from 'util/DocsHelper';
 import { Jumbotron } from 'components/graylog';
-import { CurrentViewStateActions, CurrentViewStateStore } from 'views/stores/CurrentViewStateStore';
+import { CurrentViewStateActions } from 'views/stores/CurrentViewStateStore';
 import { Spinner } from 'components/common';
 import { widgetDefinition } from 'views/logic/Widgets';
 import DocumentationLink from 'components/support/DocumentationLink';
@@ -88,11 +88,10 @@ type GridProps = {
   widgetDefs: Immutable.Map<string, Widget>,
   widgetMapping: { [widgetId: string]: Array<string> },
   results: QueryResult,
-  positions: { [widgetId: string]: WidgetPosition },
   fields: FieldTypeMappingsList,
 }
 
-const RenderedWidgetGrid = ({ widgetDefs, widgetMapping, results, positions, fields }: GridProps) => {
+const RenderedWidgetGrid = ({ widgetDefs, widgetMapping, results, fields }: GridProps) => {
   const data = {};
   const errors = {};
 
@@ -111,8 +110,7 @@ const RenderedWidgetGrid = ({ widgetDefs, widgetMapping, results, positions, fie
                     errors={errors}
                     fields={fields}
                     locked={!interactive}
-                    onPositionsChange={_onPositionsChange}
-                    positions={positions} />
+                    onPositionsChange={_onPositionsChange} />
       )}
     </InteractiveContext.Consumer>
   );

--- a/graylog2-web-interface/src/views/components/Search.tsx
+++ b/graylog2-web-interface/src/views/components/Search.tsx
@@ -20,8 +20,6 @@ import * as Immutable from 'immutable';
 import styled, { css } from 'styled-components';
 
 import PageContentLayout from 'components/layout/PageContentLayout';
-import withLocation from 'routing/withLocation';
-import type { Location } from 'routing/withLocation';
 import connect, { useStore } from 'stores/connect';
 import Sidebar from 'views/components/sidebar/Sidebar';
 import WithSearchStatus from 'views/components/WithSearchStatus';
@@ -50,8 +48,6 @@ import IfSearch from 'views/components/search/IfSearch';
 import IfInteractive from 'views/components/dashboard/IfInteractive';
 import HighlightMessageInQuery from 'views/components/messagelist/HighlightMessageInQuery';
 import { ViewMetadataStore } from 'views/stores/ViewMetadataStore';
-import bindSearchParamsFromQuery from 'views/hooks/BindSearchParamsFromQuery';
-import { useSyncWithQueryParameters } from 'views/hooks/SyncWithQueryParameters';
 import { AdditionalContext } from 'views/logic/ActionContext';
 import DefaultFieldTypesProvider from 'views/components/contexts/DefaultFieldTypesProvider';
 import InteractiveContext from 'views/components/contexts/InteractiveContext';
@@ -63,6 +59,7 @@ import WidgetFocusContext from 'views/components/contexts/WidgetFocusContext';
 import SearchExecutionState from 'views/logic/search/SearchExecutionState';
 import { RefluxActions } from 'stores/StoreTypes';
 import CurrentUserContext from 'contexts/CurrentUserContext';
+import SynchronizeUrl from 'views/components/SynchronizeUrl';
 
 const GridContainer = styled.div<{ interactive: boolean }>(({ interactive }) => {
   return interactive ? css`
@@ -105,10 +102,6 @@ const ConnectedSidebar = connect(
     results: searches?.result?.forId(viewMetadata.activeQuery),
   }),
 );
-
-type Props = {
-  location: Location,
-};
 
 const _searchRefreshConditionChain = (searchRefreshHooks: Array<SearchRefreshCondition>, state: SearchRefreshConditionArguments) => {
   if (!searchRefreshHooks || searchRefreshHooks.length === 0) {
@@ -168,26 +161,13 @@ const useRefreshSearchOn = (actions: Array<RefluxActions<any>>, refresh: () => P
   }, [refresh]);
 };
 
-const useBindSearchParamsFromQuery = (query: { [key: string]: unknown }) => {
-  useEffect(() => {
-    const { view } = ViewStore.getInitialState();
-
-    bindSearchParamsFromQuery({ view, query, retry: () => Promise.resolve() });
-  }, [query]);
-};
-
-const Search = ({ location }: Props) => {
-  const { pathname, search } = location;
-  const query = `${pathname}${search}`;
+const Search = () => {
   const searchRefreshHooks = usePluginEntities('views.hooks.searchRefresh');
   const [hasErrors, setHasErrors] = useState(false);
   const refreshIfNotUndeclared = useCallback(
     () => _refreshIfNotUndeclared(searchRefreshHooks, SearchExecutionStateStore.getInitialState(), setHasErrors),
     [searchRefreshHooks],
   );
-
-  useBindSearchParamsFromQuery(location.query);
-  useSyncWithQueryParameters(query);
 
   useRefreshSearchOn([SearchActions.refresh, ViewActions.search], refreshIfNotUndeclared);
 
@@ -198,59 +178,62 @@ const Search = ({ location }: Props) => {
   }, []);
 
   return (
-    <WidgetFocusProvider>
-      <WidgetFocusContext.Consumer>
-        {({ focusedWidget: { focusing: focusingWidget, editing: editingWidget } = { focusing: false, editing: false } }) => (
-          <CurrentViewTypeProvider>
-            <IfInteractive>
-              <IfDashboard>
-                <WindowLeaveMessage />
-              </IfDashboard>
-            </IfInteractive>
-            <InteractiveContext.Consumer>
-              {(interactive) => (
-                <SearchPageLayoutProvider>
-                  <DefaultFieldTypesProvider>
-                    <ViewAdditionalContextProvider>
-                      <HighlightingRulesProvider>
-                        <GridContainer id="main-row" interactive={interactive}>
-                          <IfInteractive>
-                            <ConnectedSidebar>
-                              <FieldsOverview />
-                            </ConnectedSidebar>
-                          </IfInteractive>
-                          <SearchArea>
+    <>
+      <SynchronizeUrl />
+      <WidgetFocusProvider>
+        <WidgetFocusContext.Consumer>
+          {({ focusedWidget: { focusing: focusingWidget, editing: editingWidget } = { focusing: false, editing: false } }) => (
+            <CurrentViewTypeProvider>
+              <IfInteractive>
+                <IfDashboard>
+                  <WindowLeaveMessage />
+                </IfDashboard>
+              </IfInteractive>
+              <InteractiveContext.Consumer>
+                {(interactive) => (
+                  <SearchPageLayoutProvider>
+                    <DefaultFieldTypesProvider>
+                      <ViewAdditionalContextProvider>
+                        <HighlightingRulesProvider>
+                          <GridContainer id="main-row" interactive={interactive}>
                             <IfInteractive>
-                              <HeaderElements />
-                              <IfDashboard>
-                                {!editingWidget && <DashboardSearchBarWithStatus onExecute={refreshIfNotUndeclared} />}
-                              </IfDashboard>
-                              <IfSearch>
-                                <SearchBarWithStatus onExecute={refreshIfNotUndeclared} />
-                              </IfSearch>
-
-                              <QueryBarElements />
-
-                              <IfDashboard>
-                                {!focusingWidget && <QueryBar />}
-                              </IfDashboard>
+                              <ConnectedSidebar>
+                                <FieldsOverview />
+                              </ConnectedSidebar>
                             </IfInteractive>
-                            <HighlightMessageInQuery>
-                              <SearchResult hasErrors={hasErrors} />
-                            </HighlightMessageInQuery>
-                          </SearchArea>
-                        </GridContainer>
-                      </HighlightingRulesProvider>
-                    </ViewAdditionalContextProvider>
-                  </DefaultFieldTypesProvider>
-                </SearchPageLayoutProvider>
-              )}
-            </InteractiveContext.Consumer>
-          </CurrentViewTypeProvider>
-        )}
-      </WidgetFocusContext.Consumer>
-    </WidgetFocusProvider>
+                            <SearchArea>
+                              <IfInteractive>
+                                <HeaderElements />
+                                <IfDashboard>
+                                  {!editingWidget && <DashboardSearchBarWithStatus onExecute={refreshIfNotUndeclared} />}
+                                </IfDashboard>
+                                <IfSearch>
+                                  <SearchBarWithStatus onExecute={refreshIfNotUndeclared} />
+                                </IfSearch>
+
+                                <QueryBarElements />
+
+                                <IfDashboard>
+                                  {!focusingWidget && <QueryBar />}
+                                </IfDashboard>
+                              </IfInteractive>
+                              <HighlightMessageInQuery>
+                                <SearchResult hasErrors={hasErrors} />
+                              </HighlightMessageInQuery>
+                            </SearchArea>
+                          </GridContainer>
+                        </HighlightingRulesProvider>
+                      </ViewAdditionalContextProvider>
+                    </DefaultFieldTypesProvider>
+                  </SearchPageLayoutProvider>
+                )}
+              </InteractiveContext.Consumer>
+            </CurrentViewTypeProvider>
+          )}
+        </WidgetFocusContext.Consumer>
+      </WidgetFocusProvider>
+    </>
   );
 };
 
-export default withLocation(Search);
+export default Search;

--- a/graylog2-web-interface/src/views/components/SearchResult.tsx
+++ b/graylog2-web-interface/src/views/components/SearchResult.tsx
@@ -22,7 +22,6 @@ import Spinner from 'components/common/Spinner';
 import Query from 'views/components/Query';
 import { useStore } from 'stores/connect';
 import { SearchStore } from 'views/stores/SearchStore';
-import { CurrentViewStateStore } from 'views/stores/CurrentViewStateStore';
 import { ViewMetadataStore } from 'views/stores/ViewMetadataStore';
 import { SearchLoadingStateStore } from 'views/stores/SearchLoadingStateStore';
 import FieldTypesContext from 'views/components/contexts/FieldTypesContext';
@@ -54,7 +53,6 @@ const SearchResult = React.memo(({ hasErrors }: Props) => {
   const { focusedWidget } = useContext(WidgetFocusContext);
   const searches = useStore(SearchStore, ({ result, widgetMapping }) => ({ result, widgetMapping }));
   const queryId = useStore(ViewMetadataStore, (viewMetadataStore) => viewMetadataStore.activeQuery);
-  const viewState = useStore(CurrentViewStateStore);
 
   if (!fieldTypes) {
     return <Spinner />;
@@ -67,11 +65,9 @@ const SearchResult = React.memo(({ hasErrors }: Props) => {
   const currentResults = searches?.result?.forId(queryId);
 
   const queryFields = fieldTypes.queryFields.get(queryId, fieldTypes.all);
-  const positions = viewState.state?.widgetPositions;
   const content = currentResults ? (
     <Query fields={queryFields}
            results={currentResults}
-           positions={positions}
            widgetMapping={widgetMapping} />
   ) : hasErrors ? null : <Spinner />;
 
@@ -84,5 +80,7 @@ const SearchResult = React.memo(({ hasErrors }: Props) => {
     </StyledRow>
   );
 });
+
+SearchResult.displayName = 'SearchResult';
 
 export default SearchResult;

--- a/graylog2-web-interface/src/views/components/SearchResult.tsx
+++ b/graylog2-web-interface/src/views/components/SearchResult.tsx
@@ -21,7 +21,6 @@ import styled, { css } from 'styled-components';
 import Spinner from 'components/common/Spinner';
 import Query from 'views/components/Query';
 import { useStore } from 'stores/connect';
-import { SearchStore } from 'views/stores/SearchStore';
 import { ViewMetadataStore } from 'views/stores/ViewMetadataStore';
 import { SearchLoadingStateStore } from 'views/stores/SearchLoadingStateStore';
 import FieldTypesContext from 'views/components/contexts/FieldTypesContext';
@@ -51,25 +50,14 @@ type Props = {
 const SearchResult = React.memo(({ hasErrors }: Props) => {
   const fieldTypes = useContext(FieldTypesContext);
   const { focusedWidget } = useContext(WidgetFocusContext);
-  const searches = useStore(SearchStore, ({ result, widgetMapping }) => ({ result, widgetMapping }));
-  const queryId = useStore(ViewMetadataStore, (viewMetadataStore) => viewMetadataStore.activeQuery);
 
   if (!fieldTypes) {
     return <Spinner />;
   }
 
-  const widgetMapping = searches?.widgetMapping;
-
   const hasFocusedWidget = !!focusedWidget?.id;
 
-  const currentResults = searches?.result?.forId(queryId);
-
-  const queryFields = fieldTypes.queryFields.get(queryId, fieldTypes.all);
-  const content = currentResults ? (
-    <Query fields={queryFields}
-           results={currentResults}
-           widgetMapping={widgetMapping} />
-  ) : hasErrors ? null : <Spinner />;
+  const content = hasErrors ? null : <Query />;
 
   return (
     <StyledRow $hasFocusedWidget={hasFocusedWidget}>

--- a/graylog2-web-interface/src/views/components/SearchResult.tsx
+++ b/graylog2-web-interface/src/views/components/SearchResult.tsx
@@ -21,7 +21,6 @@ import styled, { css } from 'styled-components';
 import Spinner from 'components/common/Spinner';
 import Query from 'views/components/Query';
 import { useStore } from 'stores/connect';
-import { ViewMetadataStore } from 'views/stores/ViewMetadataStore';
 import { SearchLoadingStateStore } from 'views/stores/SearchLoadingStateStore';
 import FieldTypesContext from 'views/components/contexts/FieldTypesContext';
 import LoadingIndicator from 'components/common/LoadingIndicator';

--- a/graylog2-web-interface/src/views/components/SearchResult.tsx
+++ b/graylog2-web-interface/src/views/components/SearchResult.tsx
@@ -20,22 +20,15 @@ import styled, { css } from 'styled-components';
 
 import Spinner from 'components/common/Spinner';
 import Query from 'views/components/Query';
-import connect, { useStore } from 'stores/connect';
+import { useStore } from 'stores/connect';
 import { SearchStore } from 'views/stores/SearchStore';
 import { CurrentViewStateStore } from 'views/stores/CurrentViewStateStore';
 import { ViewMetadataStore } from 'views/stores/ViewMetadataStore';
-import { WidgetStore } from 'views/stores/WidgetStore';
 import { SearchLoadingStateStore } from 'views/stores/SearchLoadingStateStore';
 import FieldTypesContext from 'views/components/contexts/FieldTypesContext';
 import LoadingIndicator from 'components/common/LoadingIndicator';
 import { Row, Col } from 'components/graylog';
 import WidgetFocusContext from 'views/components/contexts/WidgetFocusContext';
-
-type IndicatorProps = {
-  searchLoadingState: {
-    isLoading: boolean;
-  };
-};
 
 const StyledRow = styled(Row)(({ $hasFocusedWidget }: { $hasFocusedWidget: boolean }) => css`
   height: ${$hasFocusedWidget ? '100%' : 'auto'};
@@ -46,12 +39,11 @@ const StyledCol = styled(Col)`
   height: 100%;
 `;
 
-const SearchLoadingIndicator = connect(
-  ({ searchLoadingState }: IndicatorProps) => (searchLoadingState.isLoading && <LoadingIndicator text="Updating search results..." />),
-  { searchLoadingState: SearchLoadingStateStore },
-);
+const SearchLoadingIndicator = () => {
+  const searchLoadingState = useStore(SearchLoadingStateStore);
 
-const QueryWithWidgets = connect(Query, { widgets: WidgetStore });
+  return (searchLoadingState.isLoading && <LoadingIndicator text="Updating search results..." />);
+};
 
 type Props = {
   hasErrors: boolean,
@@ -68,20 +60,19 @@ const SearchResult = React.memo(({ hasErrors }: Props) => {
     return <Spinner />;
   }
 
-  const results = searches && searches.result;
-  const widgetMapping = searches && searches.widgetMapping;
+  const widgetMapping = searches?.widgetMapping;
 
   const hasFocusedWidget = !!focusedWidget?.id;
 
-  const currentResults = results ? results.forId(queryId) : undefined;
+  const currentResults = searches?.result?.forId(queryId);
+
   const queryFields = fieldTypes.queryFields.get(queryId, fieldTypes.all);
-  const positions = viewState.state && viewState.state.widgetPositions;
+  const positions = viewState.state?.widgetPositions;
   const content = currentResults ? (
-    <QueryWithWidgets fields={queryFields}
-                      queryId={queryId}
-                      results={currentResults}
-                      positions={positions}
-                      widgetMapping={widgetMapping} />
+    <Query fields={queryFields}
+           results={currentResults}
+           positions={positions}
+           widgetMapping={widgetMapping} />
   ) : hasErrors ? null : <Spinner />;
 
   return (

--- a/graylog2-web-interface/src/views/components/SynchronizeUrl.tsx
+++ b/graylog2-web-interface/src/views/components/SynchronizeUrl.tsx
@@ -1,0 +1,30 @@
+import * as React from 'react';
+import { useEffect } from 'react';
+
+import withLocation, { Location } from 'routing/withLocation';
+import { useSyncWithQueryParameters } from 'views/hooks/SyncWithQueryParameters';
+import { ViewStore } from 'views/stores/ViewStore';
+import bindSearchParamsFromQuery from 'views/hooks/BindSearchParamsFromQuery';
+
+const useBindSearchParamsFromQuery = (query: { [key: string]: unknown }) => {
+  useEffect(() => {
+    const { view } = ViewStore.getInitialState();
+
+    bindSearchParamsFromQuery({ view, query, retry: () => Promise.resolve() });
+  }, [query]);
+};
+
+type Props = {
+  location: Location,
+};
+
+const SynchronizeUrl = ({ location }: Props) => {
+  const { pathname, search } = location;
+  const query = `${pathname}${search}`;
+  useBindSearchParamsFromQuery(location.query);
+  useSyncWithQueryParameters(query);
+
+  return <></>;
+};
+
+export default withLocation(SynchronizeUrl);

--- a/graylog2-web-interface/src/views/components/SynchronizeUrl.tsx
+++ b/graylog2-web-interface/src/views/components/SynchronizeUrl.tsx
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 import * as React from 'react';
 import { useEffect } from 'react';
 

--- a/graylog2-web-interface/src/views/components/WidgetComponent.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetComponent.tsx
@@ -21,7 +21,6 @@ import { BackendWidgetPosition } from 'views/types';
 
 import { AdditionalContext } from 'views/logic/ActionContext';
 import WidgetContext from 'views/components/contexts/WidgetContext';
-import WidgetClass from 'views/logic/widgets/Widget';
 import WidgetPosition from 'views/logic/widgets/WidgetPosition';
 import TFieldTypeMapping from 'views/logic/fieldtypes/FieldTypeMapping';
 import ExportSettingsContextProvider from 'views/components/ExportSettingsContextProvider';
@@ -30,6 +29,7 @@ import View from 'views/logic/views/View';
 import { useStore } from 'stores/connect';
 import { TitlesStore, TitleTypes } from 'views/stores/TitlesStore';
 import defaultTitle from 'views/components/defaultTitle';
+import { WidgetStore } from 'views/stores/WidgetStore';
 
 import { Position, WidgetDataMap, WidgetErrorsMap } from './widgets/WidgetPropTypes';
 import Widget from './widgets/Widget';
@@ -44,7 +44,7 @@ type Props = {
   onPositionsChange: (position: BackendWidgetPosition) => void,
   onWidgetSizeChange: (widgetId?: string, dimensions?: { height: number, width: number }) => void,
   position: WidgetPosition,
-  widget: WidgetClass & { data?: string };
+  widgetId: string,
   widgetDimension: { height: number | null | undefined, width: number | null | undefined },
 };
 
@@ -56,12 +56,12 @@ const WidgetComponent = ({
   onPositionsChange = () => undefined,
   onWidgetSizeChange = () => {},
   position,
-  widget,
+  widgetId,
   widgetDimension: { height, width },
 }: Props) => {
-  const dataKey = widget.data || widget.id;
-  const widgetData = data[dataKey];
-  const widgetErrors = errors[widget.id] || [];
+  const widget = useStore(WidgetStore, (state) => state.get(widgetId));
+  const widgetData = data[widgetId];
+  const widgetErrors = errors[widgetId] || [];
   const viewType = useContext(ViewTypeContext);
   const title = useStore(TitlesStore, (titles) => titles.getIn([TitleTypes.Widget, widget.id], defaultTitle(widget)) as string);
 
@@ -101,7 +101,6 @@ WidgetComponent.propTypes = {
   onPositionsChange: PropTypes.func,
   onWidgetSizeChange: PropTypes.func,
   position: PropTypes.shape(Position).isRequired,
-  widget: PropTypes.object.isRequired,
   widgetDimension: PropTypes.object.isRequired,
 };
 

--- a/graylog2-web-interface/src/views/components/WidgetComponent.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetComponent.tsx
@@ -31,7 +31,6 @@ import { TitlesStore } from 'views/stores/TitlesStore';
 import defaultTitle from 'views/components/defaultTitle';
 import { WidgetStore } from 'views/stores/WidgetStore';
 import TitleTypes from 'views/stores/TitleTypes';
-import useWidgetResults from 'views/components/useWidgetResults';
 
 import { Position } from './widgets/WidgetPropTypes';
 import Widget from './widgets/Widget';
@@ -58,7 +57,6 @@ const WidgetComponent = ({
   widgetDimension: { height, width },
 }: Props) => {
   const widget = useStore(WidgetStore, (state) => state.get(widgetId));
-  const { widgetData, error: widgetErrors = [] } = useWidgetResults(widgetId);
   const viewType = useContext(ViewTypeContext);
   const title = useStore(TitlesStore, (titles) => titles.getIn([TitleTypes.Widget, widget.id], defaultTitle(widget)) as string);
 
@@ -70,9 +68,7 @@ const WidgetComponent = ({
         <AdditionalContext.Provider value={{ widget }}>
           <ExportSettingsContextProvider>
             <WidgetFieldTypesIfDashboard>
-              <Widget data={widgetData as React.ComponentProps<typeof Widget>['data']}
-                      editing={editing}
-                      errors={widgetErrors}
+              <Widget editing={editing}
                       fields={fields}
                       height={height}
                       id={widget.id}

--- a/graylog2-web-interface/src/views/components/WidgetComponent.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetComponent.tsx
@@ -58,7 +58,7 @@ const WidgetComponent = ({
 }: Props) => {
   const widget = useStore(WidgetStore, (state) => state.get(widgetId));
   const viewType = useContext(ViewTypeContext);
-  const title = useStore(TitlesStore, (titles) => titles.getIn([TitleTypes.Widget, widget.id], defaultTitle(widget)) as string);
+  const title = useStore(TitlesStore, (titles) => titles?.getIn([TitleTypes.Widget, widget.id], defaultTitle(widget)) as string);
 
   const WidgetFieldTypesIfDashboard = viewType === View.Type.Dashboard ? WidgetFieldTypesContextProvider : React.Fragment;
 

--- a/graylog2-web-interface/src/views/components/WidgetComponent.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetComponent.tsx
@@ -17,6 +17,7 @@
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import * as Immutable from 'immutable';
+import { BackendWidgetPosition } from 'views/types';
 
 import { AdditionalContext } from 'views/logic/ActionContext';
 import WidgetContext from 'views/components/contexts/WidgetContext';
@@ -26,6 +27,9 @@ import TFieldTypeMapping from 'views/logic/fieldtypes/FieldTypeMapping';
 import ExportSettingsContextProvider from 'views/components/ExportSettingsContextProvider';
 import ViewTypeContext from 'views/components/contexts/ViewTypeContext';
 import View from 'views/logic/views/View';
+import { useStore } from 'stores/connect';
+import { TitlesStore, TitleTypes } from 'views/stores/TitlesStore';
+import defaultTitle from 'views/components/defaultTitle';
 
 import { Position, WidgetDataMap, WidgetErrorsMap } from './widgets/WidgetPropTypes';
 import Widget from './widgets/Widget';
@@ -37,10 +41,9 @@ type Props = {
   editing: boolean,
   errors: { [widgetId: string]: Array<{ description: string }> },
   fields: Immutable.List<TFieldTypeMapping>,
-  onPositionsChange: (position?: WidgetPosition) => void,
+  onPositionsChange: (position: BackendWidgetPosition) => void,
   onWidgetSizeChange: (widgetId?: string, dimensions?: { height: number, width: number }) => void,
   position: WidgetPosition,
-  title: string,
   widget: WidgetClass & { data?: string };
   widgetDimension: { height: number | null | undefined, width: number | null | undefined },
 };
@@ -53,7 +56,6 @@ const WidgetComponent = ({
   onPositionsChange = () => undefined,
   onWidgetSizeChange = () => {},
   position,
-  title,
   widget,
   widgetDimension: { height, width },
 }: Props) => {
@@ -61,6 +63,7 @@ const WidgetComponent = ({
   const widgetData = data[dataKey];
   const widgetErrors = errors[widget.id] || [];
   const viewType = useContext(ViewTypeContext);
+  const title = useStore(TitlesStore, (titles) => titles.getIn([TitleTypes.Widget, widget.id], defaultTitle(widget)) as string);
 
   const WidgetFieldTypesIfDashboard = viewType === View.Type.Dashboard ? WidgetFieldTypesContextProvider : React.Fragment;
 
@@ -98,7 +101,6 @@ WidgetComponent.propTypes = {
   onPositionsChange: PropTypes.func,
   onWidgetSizeChange: PropTypes.func,
   position: PropTypes.shape(Position).isRequired,
-  title: PropTypes.string.isRequired,
   widget: PropTypes.object.isRequired,
   widgetDimension: PropTypes.object.isRequired,
 };

--- a/graylog2-web-interface/src/views/components/WidgetComponent.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetComponent.tsx
@@ -27,9 +27,10 @@ import ExportSettingsContextProvider from 'views/components/ExportSettingsContex
 import ViewTypeContext from 'views/components/contexts/ViewTypeContext';
 import View from 'views/logic/views/View';
 import { useStore } from 'stores/connect';
-import { TitlesStore, TitleTypes } from 'views/stores/TitlesStore';
+import { TitlesStore } from 'views/stores/TitlesStore';
 import defaultTitle from 'views/components/defaultTitle';
 import { WidgetStore } from 'views/stores/WidgetStore';
+import TitleTypes from 'views/stores/TitleTypes';
 
 import { Position, WidgetDataMap, WidgetErrorsMap } from './widgets/WidgetPropTypes';
 import Widget from './widgets/Widget';

--- a/graylog2-web-interface/src/views/components/WidgetComponent.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetComponent.tsx
@@ -41,7 +41,7 @@ type Props = {
   onWidgetSizeChange: (widgetId?: string, dimensions?: { height: number, width: number }) => void,
   position: WidgetPosition,
   title: string,
-  widget: WidgetClass & { data: string };
+  widget: WidgetClass & { data?: string };
   widgetDimension: { height: number | null | undefined, width: number | null | undefined },
 };
 

--- a/graylog2-web-interface/src/views/components/WidgetComponent.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetComponent.tsx
@@ -31,16 +31,15 @@ import { TitlesStore } from 'views/stores/TitlesStore';
 import defaultTitle from 'views/components/defaultTitle';
 import { WidgetStore } from 'views/stores/WidgetStore';
 import TitleTypes from 'views/stores/TitleTypes';
+import useWidgetResults from 'views/components/useWidgetResults';
 
-import { Position, WidgetDataMap, WidgetErrorsMap } from './widgets/WidgetPropTypes';
+import { Position } from './widgets/WidgetPropTypes';
 import Widget from './widgets/Widget';
 import DrilldownContextProvider from './contexts/DrilldownContextProvider';
 import WidgetFieldTypesContextProvider from './contexts/WidgetFieldTypesContextProvider';
 
 type Props = {
-  data: {},
   editing: boolean,
-  errors: { [widgetId: string]: Array<{ description: string }> },
   fields: Immutable.List<TFieldTypeMapping>,
   onPositionsChange: (position: BackendWidgetPosition) => void,
   onWidgetSizeChange: (widgetId?: string, dimensions?: { height: number, width: number }) => void,
@@ -50,9 +49,7 @@ type Props = {
 };
 
 const WidgetComponent = ({
-  data,
   editing,
-  errors,
   fields,
   onPositionsChange = () => undefined,
   onWidgetSizeChange = () => {},
@@ -61,8 +58,7 @@ const WidgetComponent = ({
   widgetDimension: { height, width },
 }: Props) => {
   const widget = useStore(WidgetStore, (state) => state.get(widgetId));
-  const widgetData = data[widgetId];
-  const widgetErrors = errors[widgetId] || [];
+  const { widgetData, error: widgetErrors = [] } = useWidgetResults(widgetId);
   const viewType = useContext(ViewTypeContext);
   const title = useStore(TitlesStore, (titles) => titles.getIn([TitleTypes.Widget, widget.id], defaultTitle(widget)) as string);
 
@@ -74,7 +70,7 @@ const WidgetComponent = ({
         <AdditionalContext.Provider value={{ widget }}>
           <ExportSettingsContextProvider>
             <WidgetFieldTypesIfDashboard>
-              <Widget data={widgetData}
+              <Widget data={widgetData as React.ComponentProps<typeof Widget>['data']}
                       editing={editing}
                       errors={widgetErrors}
                       fields={fields}
@@ -95,9 +91,7 @@ const WidgetComponent = ({
 };
 
 WidgetComponent.propTypes = {
-  data: WidgetDataMap.isRequired,
   editing: PropTypes.bool.isRequired,
-  errors: WidgetErrorsMap.isRequired,
   fields: PropTypes.object.isRequired,
   onPositionsChange: PropTypes.func,
   onWidgetSizeChange: PropTypes.func,

--- a/graylog2-web-interface/src/views/components/WidgetGrid.test.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetGrid.test.tsx
@@ -74,7 +74,6 @@ describe('<WidgetGrid />', () => {
       <WidgetGrid data={{}}
                   errors={{}}
                   onPositionsChange={() => {}}
-                  positions={{}}
                   fields={Immutable.List()} />
     ));
 
@@ -102,7 +101,6 @@ describe('<WidgetGrid />', () => {
 
     const wrapper = mount((
       <WidgetGrid errors={{}}
-                  positions={positions}
                   data={data}
                   fields={Immutable.List()}
                   onPositionsChange={() => {}} />
@@ -131,7 +129,6 @@ describe('<WidgetGrid />', () => {
 
     const wrapper = mount((
       <WidgetGrid errors={{}}
-                  positions={positions}
                   data={data}
                   fields={Immutable.List()}
                   onPositionsChange={() => {}} />

--- a/graylog2-web-interface/src/views/components/WidgetGrid.test.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetGrid.test.tsx
@@ -25,6 +25,7 @@ import Widget from 'views/components/widgets/Widget';
 import _Widget from 'views/logic/widgets/Widget';
 import { WidgetStore } from 'views/stores/WidgetStore';
 import { CurrentViewStateStore } from 'views/stores/CurrentViewStateStore';
+import FieldTypesContext, { FieldTypes } from 'views/components/contexts/FieldTypesContext';
 
 import WidgetGrid from './WidgetGrid';
 
@@ -69,9 +70,15 @@ describe('<WidgetGrid />', () => {
     asMock(WidgetStore.getInitialState).mockReturnValue(Immutable.Map());
   });
 
+  const fieldTypes: FieldTypes = {
+    all: Immutable.List(),
+    queryFields: Immutable.Map(),
+  };
+  const SimpleWidgetGrid = (props) => <FieldTypesContext.Provider value={fieldTypes}><WidgetGrid {...props} /></FieldTypesContext.Provider>;
+
   it('should render with minimal props', () => {
     const wrapper = mount((
-      <WidgetGrid />
+      <SimpleWidgetGrid />
     ));
 
     expect(wrapper).toExist();
@@ -92,12 +99,8 @@ describe('<WidgetGrid />', () => {
       },
     });
 
-    const data = {
-      widget1: [],
-    };
-
     const wrapper = mount((
-      <WidgetGrid />
+      <SimpleWidgetGrid />
     ));
 
     expect(wrapper.find(Widget)).toHaveLength(1);
@@ -118,11 +121,8 @@ describe('<WidgetGrid />', () => {
       },
     });
 
-    const data = {
-    };
-
     const wrapper = mount((
-      <WidgetGrid />
+      <SimpleWidgetGrid />
     ));
 
     expect(wrapper.find(Widget)).toHaveLength(1);

--- a/graylog2-web-interface/src/views/components/WidgetGrid.test.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetGrid.test.tsx
@@ -54,7 +54,6 @@ describe('<WidgetGrid />', () => {
       <WidgetGrid data={{}}
                   errors={{}}
                   onPositionsChange={() => {}}
-                  titles={Immutable.Map()}
                   widgets={{}}
                   fields={Immutable.List()} />
     ));

--- a/graylog2-web-interface/src/views/components/WidgetGrid.test.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetGrid.test.tsx
@@ -71,7 +71,7 @@ describe('<WidgetGrid />', () => {
 
   it('should render with minimal props', () => {
     const wrapper = mount((
-      <WidgetGrid onPositionsChange={() => {}} />
+      <WidgetGrid />
     ));
 
     expect(wrapper).toExist();
@@ -97,7 +97,7 @@ describe('<WidgetGrid />', () => {
     };
 
     const wrapper = mount((
-      <WidgetGrid onPositionsChange={() => {}} />
+      <WidgetGrid />
     ));
 
     expect(wrapper.find(Widget)).toHaveLength(1);
@@ -122,7 +122,7 @@ describe('<WidgetGrid />', () => {
     };
 
     const wrapper = mount((
-      <WidgetGrid onPositionsChange={() => {}} />
+      <WidgetGrid />
     ));
 
     expect(wrapper.find(Widget)).toHaveLength(1);

--- a/graylog2-web-interface/src/views/components/WidgetGrid.test.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetGrid.test.tsx
@@ -74,7 +74,7 @@ describe('<WidgetGrid />', () => {
     all: Immutable.List(),
     queryFields: Immutable.Map(),
   };
-  const SimpleWidgetGrid = (props) => <FieldTypesContext.Provider value={fieldTypes}><WidgetGrid {...props} /></FieldTypesContext.Provider>;
+  const SimpleWidgetGrid = () => <FieldTypesContext.Provider value={fieldTypes}><WidgetGrid /></FieldTypesContext.Provider>;
 
   it('should render with minimal props', () => {
     const wrapper = mount((

--- a/graylog2-web-interface/src/views/components/WidgetGrid.test.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetGrid.test.tsx
@@ -73,15 +73,11 @@ describe('<WidgetGrid />', () => {
       widget1: [],
     };
 
-    const titles = Immutable.Map({
-      widget1: 'A dummy widget',
-    });
     const wrapper = mount((
       <WidgetGrid widgets={widgets}
                   errors={{}}
                   positions={positions}
                   data={data}
-                  titles={titles}
                   fields={Immutable.List()}
                   onPositionsChange={() => {}} />
     ));
@@ -99,15 +95,11 @@ describe('<WidgetGrid />', () => {
     const data = {
     };
 
-    const titles = Immutable.Map({
-      widget1: 'A dummy widget',
-    });
     const wrapper = mount((
       <WidgetGrid widgets={widgets}
                   errors={{}}
                   positions={positions}
                   data={data}
-                  titles={titles}
                   fields={Immutable.List()}
                   onPositionsChange={() => {}} />
     ));

--- a/graylog2-web-interface/src/views/components/WidgetGrid.test.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetGrid.test.tsx
@@ -71,10 +71,7 @@ describe('<WidgetGrid />', () => {
 
   it('should render with minimal props', () => {
     const wrapper = mount((
-      <WidgetGrid data={{}}
-                  errors={{}}
-                  onPositionsChange={() => {}}
-                  fields={Immutable.List()} />
+      <WidgetGrid onPositionsChange={() => {}} />
     ));
 
     expect(wrapper).toExist();
@@ -100,10 +97,7 @@ describe('<WidgetGrid />', () => {
     };
 
     const wrapper = mount((
-      <WidgetGrid errors={{}}
-                  data={data}
-                  fields={Immutable.List()}
-                  onPositionsChange={() => {}} />
+      <WidgetGrid onPositionsChange={() => {}} />
     ));
 
     expect(wrapper.find(Widget)).toHaveLength(1);
@@ -128,10 +122,7 @@ describe('<WidgetGrid />', () => {
     };
 
     const wrapper = mount((
-      <WidgetGrid errors={{}}
-                  data={data}
-                  fields={Immutable.List()}
-                  onPositionsChange={() => {}} />
+      <WidgetGrid onPositionsChange={() => {}} />
     ));
 
     expect(wrapper.find(Widget)).toHaveLength(1);

--- a/graylog2-web-interface/src/views/components/WidgetGrid.test.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetGrid.test.tsx
@@ -14,13 +14,17 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import React from 'react';
-import Immutable from 'immutable';
+import * as React from 'react';
+import * as Immutable from 'immutable';
+import { Map as MockMap } from 'immutable';
 import { mount } from 'wrappedEnzyme';
+import { MockStore, asMock } from 'helpers/mocking';
 
 import WidgetPosition from 'views/logic/widgets/WidgetPosition';
 import Widget from 'views/components/widgets/Widget';
 import _Widget from 'views/logic/widgets/Widget';
+import { WidgetStore } from 'views/stores/WidgetStore';
+import { CurrentViewStateStore } from 'views/stores/CurrentViewStateStore';
 
 import WidgetGrid from './WidgetGrid';
 
@@ -48,13 +52,29 @@ jest.mock('react-sizeme', () => ({
 
 jest.mock('views/components/contexts/WidgetFieldTypesContextProvider', () => ({ children }) => children);
 
+jest.mock('views/stores/WidgetStore', () => ({
+  WidgetStore: MockStore(['getInitialState', jest.fn()]),
+}));
+
+jest.mock('views/stores/CurrentViewStateStore', () => ({
+  CurrentViewStateStore: MockStore(['getInitialState', jest.fn(() => ({ state: { widgetPositions: {} } }))]),
+}));
+
+jest.mock('views/stores/TitlesStore', () => ({
+  TitlesStore: MockStore(['getInitialState', jest.fn(() => MockMap())]),
+}));
+
 describe('<WidgetGrid />', () => {
+  beforeEach(() => {
+    asMock(WidgetStore.getInitialState).mockReturnValue(Immutable.Map());
+  });
+
   it('should render with minimal props', () => {
     const wrapper = mount((
       <WidgetGrid data={{}}
                   errors={{}}
                   onPositionsChange={() => {}}
-                  widgets={{}}
+                  positions={{}}
                   fields={Immutable.List()} />
     ));
 
@@ -65,16 +85,23 @@ describe('<WidgetGrid />', () => {
     const widgets = {
       widget1: _Widget.builder().type('dummy').id('widget1').build(),
     };
+    asMock(WidgetStore.getInitialState).mockReturnValue(Immutable.Map(widgets));
     const positions = {
       widget1: new WidgetPosition(1, 1, 1, 1),
     };
+
+    asMock(CurrentViewStateStore.getInitialState).mockReturnValue({
+      state: {
+        widgetPositions: positions,
+      },
+    });
+
     const data = {
       widget1: [],
     };
 
     const wrapper = mount((
-      <WidgetGrid widgets={widgets}
-                  errors={{}}
+      <WidgetGrid errors={{}}
                   positions={positions}
                   data={data}
                   fields={Immutable.List()}
@@ -88,15 +115,22 @@ describe('<WidgetGrid />', () => {
     const widgets = {
       widget1: _Widget.builder().type('dummy').id('widget1').build(),
     };
+    asMock(WidgetStore.getInitialState).mockReturnValue(Immutable.Map(widgets));
     const positions = {
       widget1: new WidgetPosition(1, 1, 1, 1),
     };
+
+    asMock(CurrentViewStateStore.getInitialState).mockReturnValue({
+      state: {
+        widgetPositions: positions,
+      },
+    });
+
     const data = {
     };
 
     const wrapper = mount((
-      <WidgetGrid widgets={widgets}
-                  errors={{}}
+      <WidgetGrid errors={{}}
                   positions={positions}
                   data={data}
                   fields={Immutable.List()}

--- a/graylog2-web-interface/src/views/components/WidgetGrid.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetGrid.tsx
@@ -16,7 +16,6 @@
  */
 import * as React from 'react';
 import { useState, useContext, useMemo } from 'react';
-import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
 import { SizeMe } from 'react-sizeme';
 import { WidgetPositions, BackendWidgetPosition } from 'views/types';
@@ -30,6 +29,7 @@ import { useStore } from 'stores/connect';
 import { WidgetStore } from 'views/stores/WidgetStore';
 import { CurrentViewStateStore, CurrentViewStateActions } from 'views/stores/CurrentViewStateStore';
 import FieldTypesContext from 'views/components/contexts/FieldTypesContext';
+import InteractiveContext from 'views/components/contexts/InteractiveContext';
 import { ViewMetadataStore } from 'views/stores/ViewMetadataStore';
 
 import WidgetContainer from './WidgetContainer';
@@ -71,10 +71,6 @@ const _onWidgetSizeChange = (
   setWidgetDimensions: (newWidgetDimensions: { [widgetId: string]: WidgetDimensions }) => void,
 ) => (widgetId: string, dimensions: WidgetDimensions) => {
   setWidgetDimensions({ ...widgetDimensions, [widgetId]: dimensions });
-};
-
-type Props = {
-  locked?: boolean,
 };
 
 type WidgetsProps = {
@@ -175,7 +171,8 @@ const onPositionsChange = (newPositions: Array<BackendWidgetPosition>) => {
   CurrentViewStateActions.widgetPositions(widgetPositions);
 };
 
-const WidgetGrid = ({ locked }: Props) => {
+const WidgetGrid = () => {
+  const isInteractive = useContext(InteractiveContext);
   const { focusedWidget } = useContext(WidgetFocusContext);
   const [widgetDimensions, setWidgetDimensions] = useState({});
 
@@ -189,7 +186,7 @@ const WidgetGrid = ({ locked }: Props) => {
   // when its content height results in a scrollbar
   return (
     <DashboardWrap>
-      <Grid locked={locked}
+      <Grid locked={!isInteractive}
             onPositionsChange={onPositionsChange}>
         {widgets.map(({ id: widgetId }) => (
           <WidgetContainer key={widgetId} isFocused={focusedWidget?.id === widgetId && focusedWidget?.focusing}>
@@ -208,14 +205,6 @@ const WidgetGrid = ({ locked }: Props) => {
 };
 
 WidgetGrid.displayName = 'WidgetGrid';
-
-WidgetGrid.propTypes = {
-  locked: PropTypes.bool,
-};
-
-WidgetGrid.defaultProps = {
-  locked: true,
-};
 
 const MemoizedWidgetGrid = React.memo(WidgetGrid);
 

--- a/graylog2-web-interface/src/views/components/WidgetGrid.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetGrid.tsx
@@ -75,7 +75,6 @@ const _onWidgetSizeChange = (
 
 type Props = {
   locked?: boolean,
-  staticWidgets?: React.ReactNode,
   onPositionsChange: (newPositions: Array<BackendWidgetPosition>) => void,
 };
 
@@ -162,11 +161,7 @@ const useQueryFieldTypes = () => {
   return queryFields;
 };
 
-const WidgetGrid = ({
-  staticWidgets,
-  locked,
-  onPositionsChange,
-}: Props) => {
+const WidgetGrid = ({ locked, onPositionsChange }: Props) => {
   const { focusedWidget } = useContext(WidgetFocusContext);
   const [widgetDimensions, setWidgetDimensions] = useState({});
 
@@ -204,7 +199,6 @@ const WidgetGrid = ({
           </WidgetContainer>
         ))}
       </Grid>
-      {staticWidgets}
     </DashboardWrap>
   );
 };
@@ -214,12 +208,10 @@ WidgetGrid.displayName = 'WidgetGrid';
 WidgetGrid.propTypes = {
   locked: PropTypes.bool,
   onPositionsChange: PropTypes.func.isRequired,
-  staticWidgets: PropTypes.arrayOf(PropTypes.node),
 };
 
 WidgetGrid.defaultProps = {
   locked: true,
-  staticWidgets: [],
 };
 
 const MemoizedWidgetGrid = React.memo(WidgetGrid);

--- a/graylog2-web-interface/src/views/components/WidgetGrid.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetGrid.tsx
@@ -154,7 +154,7 @@ const WidgetGrid = ({
     const newPositions = Object.keys(positions).map((id) => {
       const { col, row, height, width } = positions[id];
 
-      return { id: id, col: col, row: row, height: height, width: width };
+      return { id, col, row, height, width };
     });
 
     onPositionsChange([...newPositions, newPosition]);

--- a/graylog2-web-interface/src/views/components/WidgetGrid.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetGrid.tsx
@@ -127,13 +127,17 @@ const generatePositions = (widgets: Array<{ id: string, type: string }>, positio
   .map<[string, WidgetPosition]>(({ id, type }) => [id, positions[id] ?? _defaultDimensions(type)])
   .reduce((prev, [id, position]) => ({ ...prev, [id]: position }), {});
 
-const Grid = ({ children, locked, onPositionsChange }) => {
-  const { focusedWidget } = useContext(WidgetFocusContext);
-
+const useWidgetPositions = () => {
   const initialPositions = useStore(CurrentViewStateStore, (viewState) => viewState?.state?.widgetPositions);
   const widgets = useStore(WidgetStore, (state) => state.map(({ id, type }) => ({ id, type })).toArray());
 
-  const positions = useMemo(() => generatePositions(widgets, initialPositions), [widgets, initialPositions]);
+  return useMemo(() => generatePositions(widgets, initialPositions), [widgets, initialPositions]);
+};
+
+const Grid = ({ children, locked, onPositionsChange }) => {
+  const { focusedWidget } = useContext(WidgetFocusContext);
+
+  const positions = useWidgetPositions();
 
   return (
     <SizeMe monitorWidth refreshRate={100}>
@@ -160,7 +164,6 @@ const WidgetGrid = ({
   errors,
   locked,
   onPositionsChange,
-  positions: propsPositions,
   fields,
 }: Props) => {
   const { focusedWidget } = useContext(WidgetFocusContext);
@@ -168,7 +171,7 @@ const WidgetGrid = ({
 
   const widgets = useStore(WidgetStore, (state) => state.map(({ id, type }) => ({ id, type })).toArray());
 
-  const positions = useMemo(() => generatePositions(widgets, propsPositions), [widgets, propsPositions]);
+  const positions = useWidgetPositions();
 
   const _onPositionsChange = useCallback((newPosition: BackendWidgetPosition) => {
     const newPositions = Object.keys(positions).map((id) => {

--- a/graylog2-web-interface/src/views/components/WidgetGrid.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetGrid.tsx
@@ -33,7 +33,7 @@ import { WidgetStore } from 'views/stores/WidgetStore';
 import { CurrentViewStateStore } from 'views/stores/CurrentViewStateStore';
 
 import WidgetContainer from './WidgetContainer';
-import { PositionsMap, WidgetDataMap, WidgetErrorsMap } from './widgets/WidgetPropTypes';
+import { WidgetDataMap, WidgetErrorsMap } from './widgets/WidgetPropTypes';
 import WidgetComponent from './WidgetComponent';
 
 const COLUMNS = {
@@ -78,7 +78,6 @@ type SharedProps = {
   data: { [id: string]: any },
   errors: { [id: string]: undefined | SearchError[] },
   fields: FieldTypeMappingsList,
-  positions: WidgetPositions,
 };
 
 type Props = SharedProps & {
@@ -93,6 +92,7 @@ type WidgetsProps = SharedProps & {
   widgetDimensions: { [widgetId: string]: WidgetDimensions },
   focusedWidget: FocusContextState | undefined,
   onPositionsChange: (position: BackendWidgetPosition) => void,
+  positions: WidgetPositions,
 };
 
 const WidgetGridItem = ({
@@ -217,14 +217,12 @@ WidgetGrid.propTypes = {
   fields: CustomPropTypes.FieldListType.isRequired,
   locked: PropTypes.bool,
   onPositionsChange: PropTypes.func.isRequired,
-  positions: PositionsMap,
   staticWidgets: PropTypes.arrayOf(PropTypes.node),
 };
 
 WidgetGrid.defaultProps = {
   locked: true,
   staticWidgets: [],
-  positions: {},
 };
 
 const MemoizedWidgetGrid = React.memo(WidgetGrid);

--- a/graylog2-web-interface/src/views/components/WidgetGrid.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetGrid.tsx
@@ -125,7 +125,7 @@ const useWidgetPositions = () => {
 type GridProps = {
   children: React.ReactNode,
   locked: boolean,
-  onPositionsChange: (newPosition: BackendWidgetPosition) => void,
+  onPositionsChange: (newPositions: Array<BackendWidgetPosition>) => void,
 };
 
 const Grid = ({ children, locked, onPositionsChange }: GridProps) => {
@@ -162,10 +162,17 @@ const useQueryFieldTypes = () => {
 
 const MAXIMUM_GRID_SIZE = 12;
 
-const onPositionsChange = (newPosition: BackendWidgetPosition) => {
-  const { col, row, height, width, id } = newPosition;
-  const widgetPosition = new WidgetPosition(col, row, height, width >= MAXIMUM_GRID_SIZE ? Infinity : width);
+const convertPosition = ({ col, row, height, width }: BackendWidgetPosition) => new WidgetPosition(col, row, height, width >= MAXIMUM_GRID_SIZE ? Infinity : width);
+
+const onPositionChange = (newPosition: BackendWidgetPosition) => {
+  const { id } = newPosition;
+  const widgetPosition = convertPosition(newPosition);
   CurrentViewStateActions.updateWidgetPosition(id, widgetPosition);
+};
+
+const onPositionsChange = (newPositions: Array<BackendWidgetPosition>) => {
+  const widgetPositions = Object.fromEntries(newPositions.map((newPosition) => [newPosition.id, convertPosition(newPosition)]));
+  CurrentViewStateActions.widgetPositions(widgetPositions);
 };
 
 const WidgetGrid = ({ locked }: Props) => {
@@ -192,7 +199,7 @@ const WidgetGrid = ({ locked }: Props) => {
                             setWidgetDimensions={setWidgetDimensions}
                             widgetDimensions={widgetDimensions}
                             focusedWidget={focusedWidget}
-                            onPositionsChange={onPositionsChange} />
+                            onPositionsChange={onPositionChange} />
           </WidgetContainer>
         ))}
       </Grid>

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/AggregationBuilder.test.jsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/AggregationBuilder.test.jsx
@@ -24,6 +24,7 @@ import AggregationBuilder from './AggregationBuilder';
 import EmptyAggregationContent from './EmptyAggregationContent';
 
 import EmptyResultWidget from '../widgets/EmptyResultWidget';
+import OnVisualizationConfigChangeContext from '../aggregationwizard/OnVisualizationConfigChangeContext';
 
 const mockDummyVisualization = () => 'dummy-visualization';
 
@@ -68,10 +69,13 @@ describe('AggregationBuilder', () => {
 
   it('passes through onVisualizationConfigChange to visualization', () => {
     const onVisualizationConfigChange = jest.fn();
-    const wrapper = mount(<AggregationBuilder config={AggregationWidgetConfig.builder().rowPivots([rowPivot]).visualization('dummy').build()}
-                                              fields={{}}
-                                              onVisualizationConfigChange={onVisualizationConfigChange}
-                                              data={{ total: 42, rows: [{ value: 3.1415926 }] }} />);
+    const wrapper = mount((
+      <OnVisualizationConfigChangeContext.Provider value={onVisualizationConfigChange}>
+        <AggregationBuilder config={AggregationWidgetConfig.builder().rowPivots([rowPivot]).visualization('dummy').build()}
+                            fields={{}}
+                            data={{ total: 42, rows: [{ value: 3.1415926 }] }} />
+      </OnVisualizationConfigChangeContext.Provider>
+    ));
 
     expect(wrapper.find(EmptyAggregationContent)).toHaveLength(0);
 

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/AggregationBuilder.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/AggregationBuilder.tsx
@@ -17,13 +17,14 @@
 import * as React from 'react';
 import { PluginStore } from 'graylog-web-plugin/plugin';
 import { WidgetComponentProps } from 'views/types';
+import { useContext } from 'react';
 
 import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
 import type { FieldTypeMappingsList } from 'views/stores/FieldTypesStore';
 import type { Rows } from 'views/logic/searchtypes/pivot/PivotHandler';
 import type { Events } from 'views/logic/searchtypes/events/EventHandler';
 import type { AbsoluteTimeRange } from 'views/logic/queries/Query';
-import type { VisualizationConfigFormValues } from 'views/components/aggregationwizard';
+import OnVisualizationConfigChangeContext, { OnVisualizationConfigChange } from 'views/components/aggregationwizard/OnVisualizationConfigChangeContext';
 
 import EmptyAggregationContent from './EmptyAggregationContent';
 import FullSizeContainer from './FullSizeContainer';
@@ -90,13 +91,9 @@ const getResult = (value: RowResult | EventResult): Rows | Events => {
   return value.rows;
 };
 
-type OnVisualizationConfigChange = (newConfig: VisualizationConfigFormValues) => void;
+const AggregationBuilder = ({ config, data, editing = false, fields, toggleEdit }: WidgetComponentProps<AggregationWidgetConfig>) => {
+  const onVisualizationConfigChange = useContext(OnVisualizationConfigChangeContext);
 
-type AggregationBuilderProps = WidgetComponentProps<AggregationWidgetConfig> & {
-  onVisualizationConfigChange: OnVisualizationConfigChange,
-};
-
-const AggregationBuilder = ({ config, data, editing = false, fields, onVisualizationConfigChange = () => {}, toggleEdit }: AggregationBuilderProps) => {
   if (!config || config.isEmpty) {
     return <EmptyAggregationContent toggleEdit={toggleEdit} editing={editing} />;
   }

--- a/graylog2-web-interface/src/views/components/aggregationwizard/OnVisualizationConfigChangeContext.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/OnVisualizationConfigChangeContext.tsx
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 import * as React from 'react';
 
 import { VisualizationConfigFormValues } from 'views/components/aggregationwizard/WidgetConfigForm';

--- a/graylog2-web-interface/src/views/components/aggregationwizard/OnVisualizationConfigChangeContext.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/OnVisualizationConfigChangeContext.tsx
@@ -1,0 +1,9 @@
+import * as React from 'react';
+
+import { VisualizationConfigFormValues } from 'views/components/aggregationwizard/WidgetConfigForm';
+
+export type OnVisualizationConfigChange = (newConfig: VisualizationConfigFormValues) => void;
+
+const OnVisualizationConfigChangeContext = React.createContext<OnVisualizationConfigChange>(() => {});
+
+export default OnVisualizationConfigChangeContext;

--- a/graylog2-web-interface/src/views/components/aggregationwizard/VisualizationContainer.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/VisualizationContainer.tsx
@@ -15,9 +15,11 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { useMemo, useCallback } from 'react';
+import { useCallback } from 'react';
 import styled from 'styled-components';
 import { useFormikContext } from 'formik';
+
+import OnVisualizationConfigChangeContext from 'views/components/aggregationwizard/OnVisualizationConfigChangeContext';
 
 import type { WidgetConfigFormValues } from './WidgetConfigForm';
 
@@ -37,13 +39,11 @@ const VisualizationContainer = ({ children }: Props) => {
     setFieldValue('visualization', { ...values.visualization, config: { ...values.visualization.config, ...newVisualizationConfig } });
   }, [values.visualization, setFieldValue]);
 
-  const childrenWithCallback = useMemo(() => React.Children.map(children, (child) => React.cloneElement(child, {
-    onVisualizationConfigChange: onVisualizationConfigChange,
-  })), [children, onVisualizationConfigChange]);
-
   return (
     <Container>
-      {childrenWithCallback}
+      <OnVisualizationConfigChangeContext.Provider value={onVisualizationConfigChange}>
+        {children}
+      </OnVisualizationConfigChangeContext.Provider>
     </Container>
   );
 };

--- a/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.visualization.test.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.visualization.test.tsx
@@ -15,6 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
+import { useContext } from 'react';
 import { fireEvent, render, screen, waitFor } from 'wrappedTestingLibrary';
 import * as Immutable from 'immutable';
 import { PluginRegistration, PluginStore } from 'graylog-web-plugin/plugin';
@@ -25,6 +26,7 @@ import AggregationWizard from 'views/components/aggregationwizard/AggregationWiz
 import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
 import { makeVisualization } from 'views/components/aggregationbuilder/AggregationBuilder';
 import VisualizationConfig from 'views/logic/aggregationbuilder/visualizations/VisualizationConfig';
+import OnVisualizationConfigChangeContext from 'views/components/aggregationwizard/OnVisualizationConfigChangeContext';
 
 const widgetConfig = AggregationWidgetConfig
   .builder()
@@ -186,16 +188,23 @@ describe('AggregationWizard/Visualizations', () => {
     const worldMapConfig = widgetConfig.toBuilder().visualization('map').build();
     const onChange = jest.fn();
 
-    const WorldMap = ({ onVisualizationConfigChange }: { onVisualizationConfigChange?: (newViewport: { zoom: number, centerX: number, centerY: number }) => void }) => (
-      <button type="button" onClick={() => onVisualizationConfigChange({ zoom: 2, centerX: 40, centerY: 50 })}>Change Viewport</button>
-    );
+    const WorldMap = () => {
+      const onVisualizationConfigChange = useContext(OnVisualizationConfigChangeContext);
+
+      return (
+        <button type="button" onClick={() => onVisualizationConfigChange({ zoom: 2, centerX: 40, centerY: 50 })}>Change
+          Viewport
+        </button>
+      );
+    };
+
     WorldMap.defaultProps = { onVisualizationConfigChange: undefined };
 
-    render(
+    render((
       <SimpleAggregationWizard onChange={onChange} config={worldMapConfig}>
         <WorldMap />
-      </SimpleAggregationWizard>,
-    );
+      </SimpleAggregationWizard>
+    ));
 
     const updateViewportButton = await screen.findByRole('button', { name: 'Change Viewport' });
     userEvent.click(updateViewportButton);

--- a/graylog2-web-interface/src/views/components/aggregationwizard/grouping/configuration/Time.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/grouping/configuration/Time.tsx
@@ -70,15 +70,20 @@ const IntervalCheckboxDesc = () => (
   </IntervalCheckboxDescWithHelp>
 );
 
-const Time = ({ index }: Props) => {
-  const toggleIntervalType = (name, currentType, onChange) => {
-    if (currentType === 'auto') {
-      onChange({ target: { name, value: { type: 'timeunit', value: 1, unit: 'minutes' } } });
-    } else {
-      onChange({ target: { name, value: { type: 'auto', scaling: 1.0 } } });
-    }
-  };
+const toggleIntervalType = (name, currentType, onChange) => {
+  if (currentType === 'auto') {
+    onChange({ target: { name, value: { type: 'timeunit', value: 1, unit: 'minutes' } } });
+  } else {
+    onChange({ target: { name, value: { type: 'auto', scaling: 1.0 } } });
+  }
+};
 
+const StyledFormControl = styled(FormControl)`
+  padding: 0;
+  border: 0;
+`;
+
+const Time = ({ index }: Props) => {
   return (
     <Field name={`groupBy.groupings.${index}.interval`}>
       {({ field: { name, value, onChange }, meta: { error } }) => (
@@ -98,13 +103,12 @@ const Time = ({ index }: Props) => {
             <>
               <RangeSelect>
                 <Icon name="search-minus" size="lg" style={{ paddingRight: '0.5rem' }} />
-                <FormControl type="range"
-                             style={{ padding: 0, border: 0 }}
-                             min={0.5}
-                             max={10}
-                             step={0.5}
-                             value={value.scaling ? (1 / value.scaling) : 1.0}
-                             onChange={(e) => onChange({ target: { name, value: { ...value, scaling: 1 / parseFloat(e.target.value) } } })} />
+                <StyledFormControl type="range"
+                                   min={0.5}
+                                   max={10}
+                                   step={0.5}
+                                   value={value.scaling ? (1 / value.scaling) : 1.0}
+                                   onChange={(e) => onChange({ target: { name, value: { ...value, scaling: 1 / parseFloat(e.target.value) } } })} />
                 <Icon name="search-plus" size="lg" style={{ paddingLeft: '0.5rem' }} />
                 <CurrentScale>
                   {value.scaling ? (1 / value.scaling) : 1.0}x

--- a/graylog2-web-interface/src/views/components/useWidgetResults.tsx
+++ b/graylog2-web-interface/src/views/components/useWidgetResults.tsx
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 import { useMemo } from 'react';
 import * as Immutable from 'immutable';
 

--- a/graylog2-web-interface/src/views/components/useWidgetResults.tsx
+++ b/graylog2-web-interface/src/views/components/useWidgetResults.tsx
@@ -1,0 +1,52 @@
+import { useMemo } from 'react';
+import * as Immutable from 'immutable';
+
+import { widgetDefinition } from 'views/logic/Widgets';
+import { useStore } from 'stores/connect';
+import { SearchStore } from 'views/stores/SearchStore';
+import { WidgetStore } from 'views/stores/WidgetStore';
+import Widget from 'views/logic/widgets/Widget';
+import { WidgetMapping } from 'views/logic/views/types';
+import QueryResult from 'views/logic/QueryResult';
+import { ViewStore } from 'views/stores/ViewStore';
+
+const _getDataAndErrors = (widget: Widget, widgetMapping: WidgetMapping, results: QueryResult) => {
+  const { searchTypes } = results;
+  const widgetType = widgetDefinition(widget.type);
+  const dataTransformer = widgetType.searchResultTransformer || ((x) => x);
+  const searchTypeIds = (widgetMapping.get(widget.id, Immutable.Set()));
+  const widgetData = searchTypeIds.map((searchTypeId) => searchTypes[searchTypeId]).filter((result) => result !== undefined).toArray();
+  const widgetErrors = results.errors.filter((e) => searchTypeIds.includes(e.searchTypeId));
+  let error;
+
+  const data = dataTransformer(widgetData, widget);
+
+  if (widgetErrors && widgetErrors.length > 0) {
+    error = widgetErrors;
+  }
+
+  if (!widgetData || widgetData.length === 0) {
+    const queryErrors = results.errors.filter((e) => e.type === 'query');
+
+    if (queryErrors.length > 0) {
+      error = error ? [].concat(error, queryErrors) : queryErrors;
+    }
+  }
+
+  return { widgetData: data, error };
+};
+
+const useWidgetResults = (widgetId: string) => {
+  const { widgetMapping, results } = useStore(SearchStore, ({ result: r, widgetMapping: w }) => ({ results: r, widgetMapping: w }));
+  const widgets = useStore(WidgetStore);
+  const currentQueryId = useStore(ViewStore, ({ activeQuery }) => activeQuery);
+  const currentQueryResults = useMemo(() => results?.forId(currentQueryId), [currentQueryId, results]);
+
+  const widgetResults = useMemo(() => (currentQueryResults
+    ? widgets.map((widget) => _getDataAndErrors(widget, widgetMapping, currentQueryResults)).toMap()
+    : Immutable.Map()), [currentQueryResults, widgetMapping, widgets]);
+
+  return widgetResults.get(widgetId, {});
+};
+
+export default useWidgetResults;

--- a/graylog2-web-interface/src/views/components/useWidgetResults.tsx
+++ b/graylog2-web-interface/src/views/components/useWidgetResults.tsx
@@ -60,15 +60,18 @@ type WidgetResults = {
 
 const useWidgetResults = (widgetId: string) => {
   const { widgetMapping, results } = useStore(SearchStore, ({ result: r, widgetMapping: w }) => ({ results: r, widgetMapping: w }));
-  const widgets = useStore(WidgetStore);
+  const widget = useStore(WidgetStore, (widgets) => widgets.get(widgetId));
   const currentQueryId = useStore(ViewStore, ({ activeQuery }) => activeQuery);
-  const currentQueryResults = useMemo(() => results?.forId(currentQueryId), [currentQueryId, results]);
 
-  const widgetResults = useMemo(() => (currentQueryResults
-    ? widgets.map((widget) => _getDataAndErrors(widget, widgetMapping, currentQueryResults)).toMap()
-    : Immutable.Map()), [currentQueryResults, widgetMapping, widgets]);
+  const widgetResults = useMemo(() => {
+    const currentQueryResults = results?.forId(currentQueryId);
 
-  return widgetResults.get(widgetId, { widgetData: undefined, error: [] }) as WidgetResults;
+    return (currentQueryResults
+      ? _getDataAndErrors(widget, widgetMapping, currentQueryResults)
+      : { widgetData: undefined, error: [] });
+  }, [currentQueryId, results, widget, widgetMapping]);
+
+  return widgetResults as WidgetResults;
 };
 
 export default useWidgetResults;

--- a/graylog2-web-interface/src/views/components/useWidgetResults.tsx
+++ b/graylog2-web-interface/src/views/components/useWidgetResults.tsx
@@ -9,6 +9,7 @@ import Widget from 'views/logic/widgets/Widget';
 import { WidgetMapping } from 'views/logic/views/types';
 import QueryResult from 'views/logic/QueryResult';
 import { ViewStore } from 'views/stores/ViewStore';
+import SearchError from 'views/logic/SearchError';
 
 const _getDataAndErrors = (widget: Widget, widgetMapping: WidgetMapping, results: QueryResult) => {
   const { searchTypes } = results;
@@ -36,6 +37,11 @@ const _getDataAndErrors = (widget: Widget, widgetMapping: WidgetMapping, results
   return { widgetData: data, error };
 };
 
+type WidgetResults = {
+  widgetData: unknown | undefined,
+  error: SearchError[],
+};
+
 const useWidgetResults = (widgetId: string) => {
   const { widgetMapping, results } = useStore(SearchStore, ({ result: r, widgetMapping: w }) => ({ results: r, widgetMapping: w }));
   const widgets = useStore(WidgetStore);
@@ -46,7 +52,7 @@ const useWidgetResults = (widgetId: string) => {
     ? widgets.map((widget) => _getDataAndErrors(widget, widgetMapping, currentQueryResults)).toMap()
     : Immutable.Map()), [currentQueryResults, widgetMapping, widgets]);
 
-  return widgetResults.get(widgetId, {});
+  return widgetResults.get(widgetId, { widgetData: undefined, error: [] }) as WidgetResults;
 };
 
 export default useWidgetResults;

--- a/graylog2-web-interface/src/views/components/widgets/MessageTable.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageTable.tsx
@@ -14,7 +14,8 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import React from 'react';
+import * as React from 'react';
+import { useCallback, useState } from 'react';
 import PropTypes from 'prop-types';
 import * as Immutable from 'immutable';
 import styled, { css } from 'styled-components';
@@ -96,10 +97,6 @@ const TableHead = styled.thead(({ theme }) => css`
   }
 `);
 
-type State = {
-  expandedMessages: Immutable.Set<string>,
-};
-
 type Props = {
   activeQueryId: string,
   config: MessagesWidgetConfig,
@@ -110,136 +107,110 @@ type Props = {
   setLoadingState: (loading: boolean) => void,
 };
 
-class MessageTable extends React.Component<Props, State> {
-  static propTypes = {
-    activeQueryId: PropTypes.string.isRequired,
-    config: CustomPropTypes.instanceOf(MessagesWidgetConfig).isRequired,
-    fields: CustomPropTypes.FieldListType.isRequired,
-    messages: PropTypes.arrayOf(PropTypes.object).isRequired,
-    onSortChange: PropTypes.func.isRequired,
-    selectedFields: PropTypes.object,
-    setLoadingState: PropTypes.func.isRequired,
-  };
+const _columnStyle = (fieldName: string) => (fieldName.toLowerCase() === SOURCE_FIELD
+  ? { width: 180 }
+  : {});
 
-  static defaultProps = {
-    selectedFields: Immutable.Set<string>(),
-  };
+const _fieldTypeFor = (fieldName: string, fields: Immutable.List<FieldTypeMapping>) => ((fields
+  && fields.find((f) => f.name === fieldName)) || { type: FieldType.Unknown }).type;
 
-  constructor(props: Props) {
-    super(props);
+const _getFormattedMessages = (messages): Array<Message> => messages.map((m) => ({
+  fields: m.message,
+  formatted_fields: MessageFieldsFilter.filterFields(m.message),
+  id: m.message._id,
+  index: m.index,
+  highlight_ranges: m.highlight_ranges,
+  decoration_stats: m.decoration_stats,
+}));
 
-    this.state = {
-      expandedMessages: Immutable.Set<string>(),
-    };
+const _getSelectedFields = (selectedFields, config): Immutable.OrderedSet<string> => Immutable.OrderedSet<string>(config ? config.fields : (selectedFields || Immutable.Set<string>()));
+
+const _toggleMessageDetail = (id: string, expandedMessages: Immutable.Set<string>, setExpandedMessages: (newValue: Immutable.Set<string>) => void) => {
+  let newSet;
+
+  if (expandedMessages.contains(id)) {
+    newSet = expandedMessages.delete(id);
+  } else {
+    newSet = expandedMessages.add(id);
+    RefreshActions.disable();
   }
 
-  _columnStyle = (fieldName: string) => {
-    const { fields } = this.props;
-    const selectedFields = Immutable.OrderedSet<string>(fields);
+  setExpandedMessages(newSet);
+};
 
-    if (fieldName.toLowerCase() === SOURCE_FIELD && selectedFields.size > 1) {
-      return { width: 180 };
-    }
+const MessageTable = ({ fields, activeQueryId, messages, config, onSortChange, setLoadingState, selectedFields: defaultFields }: Props) => {
+  const [expandedMessages, setExpandedMessages] = useState(Immutable.Set<string>());
+  const formattedMessages = _getFormattedMessages(messages);
+  const selectedFields = _getSelectedFields(defaultFields, config);
 
-    return {};
-  };
+  const toggleDetail = useCallback((id: string) => _toggleMessageDetail(id, expandedMessages, setExpandedMessages), [expandedMessages]);
 
-  _fieldTypeFor = (fieldName: string, fields: Immutable.List<FieldTypeMapping>) => {
-    return ((fields && fields.find((f) => f.name === fieldName)) || { type: FieldType.Unknown }).type;
-  };
+  return (
+    <TableWrapper className="table-responsive" id="sticky-augmentations-container">
+      <Table className="table table-condensed">
+        <TableHead>
+          <tr>
+            {selectedFields.toSeq().map((selectedFieldName) => {
+              return (
+                <th key={selectedFieldName}
+                    style={_columnStyle(selectedFieldName)}>
+                  <Field type={_fieldTypeFor(selectedFieldName, fields)}
+                         name={selectedFieldName}
+                         queryId={activeQueryId}>
+                    {selectedFieldName}
+                  </Field>
+                  <InteractiveContext.Consumer>
+                    {(interactive) => (interactive && (
+                      <FieldSortIcon fieldName={selectedFieldName}
+                                     onSortChange={onSortChange}
+                                     setLoadingState={setLoadingState}
+                                     config={config} />
+                    ))}
+                  </InteractiveContext.Consumer>
+                </th>
+              );
+            })}
+          </tr>
+        </TableHead>
+        {formattedMessages.map((message) => {
+          const messageKey = `${message.index}-${message.id}`;
 
-  _getFormattedMessages = (): Array<Message> => {
-    const { messages } = this.props;
+          return (
+            <AdditionalContext.Provider key={messageKey}
+                                        value={{ message }}>
+              <HighlightMessageContext.Consumer>
+                {(highlightMessageId) => (
+                  <MessageTableEntry fields={fields}
+                                     message={message}
+                                     config={config}
+                                     showMessageRow={config && config.showMessageRow}
+                                     selectedFields={selectedFields}
+                                     expanded={expandedMessages.contains(messageKey)}
+                                     toggleDetail={toggleDetail}
+                                     highlightMessage={highlightMessageId}
+                                     expandAllRenderAsync={false} />
+                )}
+              </HighlightMessageContext.Consumer>
+            </AdditionalContext.Provider>
+          );
+        })}
+      </Table>
+    </TableWrapper>
+  );
+};
 
-    return messages.map((m) => ({
-      fields: m.message,
-      formatted_fields: MessageFieldsFilter.filterFields(m.message),
-      id: m.message._id,
-      index: m.index,
-      highlight_ranges: m.highlight_ranges,
-      decoration_stats: m.decoration_stats,
-    }));
-  };
+MessageTable.propTypes = {
+  activeQueryId: PropTypes.string.isRequired,
+  config: CustomPropTypes.instanceOf(MessagesWidgetConfig).isRequired,
+  fields: CustomPropTypes.FieldListType.isRequired,
+  messages: PropTypes.arrayOf(PropTypes.object).isRequired,
+  onSortChange: PropTypes.func.isRequired,
+  selectedFields: PropTypes.object,
+  setLoadingState: PropTypes.func.isRequired,
+};
 
-  _getSelectedFields = (): Immutable.OrderedSet<string> => {
-    const { selectedFields, config } = this.props;
+MessageTable.defaultProps = {
+  selectedFields: Immutable.Set<string>(),
+};
 
-    return Immutable.OrderedSet<string>(config ? config.fields : (selectedFields || Immutable.Set<string>()));
-  };
-
-  _toggleMessageDetail = (id: string) => {
-    let newSet;
-    const { expandedMessages } = this.state;
-
-    if (expandedMessages.contains(id)) {
-      newSet = expandedMessages.delete(id);
-    } else {
-      newSet = expandedMessages.add(id);
-      RefreshActions.disable();
-    }
-
-    this.setState({ expandedMessages: newSet });
-  };
-
-  render() {
-    const { expandedMessages } = this.state;
-    const { fields, activeQueryId, config, onSortChange, setLoadingState } = this.props;
-    const formattedMessages = this._getFormattedMessages();
-    const selectedFields = this._getSelectedFields();
-
-    return (
-      <TableWrapper className="table-responsive" id="sticky-augmentations-container">
-        <Table className="table table-condensed">
-          <TableHead>
-            <tr>
-              {selectedFields.toSeq().map((selectedFieldName) => {
-                return (
-                  <th key={selectedFieldName}
-                      style={this._columnStyle(selectedFieldName)}>
-                    <Field type={this._fieldTypeFor(selectedFieldName, fields)}
-                           name={selectedFieldName}
-                           queryId={activeQueryId}>
-                      {selectedFieldName}
-                    </Field>
-                    <InteractiveContext.Consumer>
-                      {(interactive) => (interactive && (
-                        <FieldSortIcon fieldName={selectedFieldName}
-                                       onSortChange={onSortChange}
-                                       setLoadingState={setLoadingState}
-                                       config={config} />
-                      ))}
-                    </InteractiveContext.Consumer>
-                  </th>
-                );
-              })}
-            </tr>
-          </TableHead>
-          {formattedMessages.map((message) => {
-            const messageKey = `${message.index}-${message.id}`;
-
-            return (
-              <AdditionalContext.Provider key={messageKey}
-                                          value={{ message }}>
-                <HighlightMessageContext.Consumer>
-                  {(highlightMessageId) => (
-                    <MessageTableEntry fields={fields}
-                                       message={message}
-                                       config={config}
-                                       showMessageRow={config && config.showMessageRow}
-                                       selectedFields={selectedFields}
-                                       expanded={expandedMessages.contains(messageKey)}
-                                       toggleDetail={this._toggleMessageDetail}
-                                       highlightMessage={highlightMessageId}
-                                       expandAllRenderAsync={false} />
-                  )}
-                </HighlightMessageContext.Consumer>
-              </AdditionalContext.Provider>
-            );
-          })}
-        </Table>
-      </TableWrapper>
-    );
-  }
-}
-
-export default MessageTable;
+export default React.memo(MessageTable);

--- a/graylog2-web-interface/src/views/components/widgets/TimerangeInfo.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/TimerangeInfo.tsx
@@ -53,7 +53,7 @@ const TimerangeInfo = ({ className, widget, activeQuery, widgetId }: Props) => {
 
   const configuredTimerange = timerangeToString(widget.timerange || DEFAULT_TIMERANGE, localizeTime);
 
-  const searchTypeId = widgetId ? widgetMapping.get(widgetId)?.first() : undefined;
+  const searchTypeId = widgetId ? widgetMapping?.get(widgetId)?.first() : undefined;
 
   const effectiveTimerange = (activeQuery && searchTypeId) ? getEffectiveWidgetTimerange(result, activeQuery, searchTypeId) : undefined;
   const effectiveTimerangeString = effectiveTimerange ? timerangeToString(effectiveTimerange, localizeTime) : 'Effective widget time range is currently not available.';

--- a/graylog2-web-interface/src/views/components/widgets/Widget.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/Widget.test.tsx
@@ -79,13 +79,9 @@ const pluginManifest: PluginRegistration = {
 };
 
 describe('<Widget />', () => {
-  beforeAll(() => {
-    PluginStore.register(pluginManifest);
-  });
+  beforeAll(() => PluginStore.register(pluginManifest));
 
-  afterAll(() => {
-    PluginStore.unregister(pluginManifest);
-  });
+  afterAll(() => PluginStore.unregister(pluginManifest));
 
   const widget = WidgetModel.builder().newId()
     .type('dummy')
@@ -101,11 +97,6 @@ describe('<Widget />', () => {
 
   beforeEach(() => {
     ViewStore.getInitialState = jest.fn(() => viewStoreState);
-  });
-
-  afterEach(() => {
-    jest.clearAllMocks();
-    jest.resetModules();
   });
 
   type DummyWidgetProps = Partial<WidgetComponentProps> & {
@@ -139,29 +130,28 @@ describe('<Widget />', () => {
     </WidgetFocusContext.Provider>
   );
 
-  it('should render with empty props', () => {
-    render(<DummyWidget />);
-
-    expect(screen.getByTitle('Widget Title')).toBeInTheDocument();
-  });
-
-  it('should render loading widget for widget without data', () => {
+  it('should render with empty props', async () => {
     asMock(useWidgetResults).mockReturnValue({ widgetData: undefined, error: undefined });
     render(<DummyWidget />);
 
-    expect(screen.queryAllByTestId('loading-widget')).toHaveLength(1);
+    await screen.findByTitle('Widget Title');
   });
 
-  it('should render error widget for widget with one error', () => {
+  it('should render loading widget for widget without data', async () => {
+    asMock(useWidgetResults).mockReturnValue({ widgetData: undefined, error: undefined });
+    render(<DummyWidget />);
+
+    await screen.findByTestId('loading-widget');
+  });
+
+  it('should render error widget for widget with one error', async () => {
     asMock(useWidgetResults).mockReturnValue({ error: [{ description: 'The widget has failed: the dungeon collapsed, you die!' } as SearchError], widgetData: undefined });
     render(<DummyWidget />);
 
-    const errorWidgets = screen.queryAllByText('The widget has failed: the dungeon collapsed, you die!');
-
-    expect(errorWidgets).toHaveLength(1);
+    await screen.findByText('The widget has failed: the dungeon collapsed, you die!');
   });
 
-  it('should render error widget including all error messages for widget with multiple errors', () => {
+  it('should render error widget including all error messages for widget with multiple errors', async () => {
     asMock(useWidgetResults).mockReturnValue({
       error: [
         { description: 'Something is wrong' } as SearchError,
@@ -172,24 +162,21 @@ describe('<Widget />', () => {
 
     render(<DummyWidget />);
 
-    const errorWidgets1 = screen.queryAllByText('Something is wrong');
-
-    expect(errorWidgets1).toHaveLength(1);
-
-    const errorWidgets2 = screen.queryAllByText('Very wrong');
-
-    expect(errorWidgets2).toHaveLength(1);
+    await screen.findByText('Something is wrong');
+    await screen.findByText('Very wrong');
   });
 
-  it('should render correct widget visualization for widget with data', () => {
+  it('should render correct widget visualization for widget with data', async () => {
     asMock(useWidgetResults).mockReturnValue({ widgetData: {}, error: [] });
     render(<DummyWidget />);
 
+    await screen.findByTitle('Widget Title');
+
     expect(screen.queryAllByTestId('loading-widget')).toHaveLength(0);
-    expect(screen.queryAllByTitle('Widget Title')).toHaveLength(1);
   });
 
   it('renders placeholder if widget type is unknown', async () => {
+    asMock(useWidgetResults).mockReturnValue({ widgetData: {}, error: [] });
     const unknownWidget = WidgetModel.builder()
       .id('widgetId')
       .type('i-dont-know-this-widget-type')
@@ -259,20 +246,18 @@ describe('<Widget />', () => {
     await waitFor(() => expect(TitlesActions.set).toHaveBeenCalledWith(TitleTypes.Widget, 'duplicatedWidgetId', 'Dummy Widget (copy)'));
   });
 
-  it('adds cancel action to widget in edit mode', () => {
+  it('adds cancel action to widget in edit mode', async () => {
     render(<DummyWidget editing />);
-    const cancel = screen.queryAllByText('Cancel');
-
-    expect(cancel).toHaveLength(1);
+    await screen.findByText('Cancel');
   });
 
-  it('updates focus mode, on widget edit cancel', () => {
+  it('updates focus mode, on widget edit cancel', async () => {
     const mockUnsetWidgetEditing = jest.fn();
     render(<DummyWidget editing unsetWidgetEditing={mockUnsetWidgetEditing} />);
-    const cancel = screen.getByText('Cancel');
+    const cancel = await screen.findByText('Cancel');
     fireEvent.click(cancel);
 
-    expect(mockUnsetWidgetEditing).toHaveBeenCalledTimes(1);
+    await waitFor(() => { expect(mockUnsetWidgetEditing).toHaveBeenCalledTimes(1); });
   });
 
   it('updates focus mode, on widget edit save', async () => {

--- a/graylog2-web-interface/src/views/components/widgets/Widget.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/Widget.tsx
@@ -18,6 +18,7 @@ import * as React from 'react';
 import * as Immutable from 'immutable';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
+import { BackendWidgetPosition } from 'views/types';
 
 import connect from 'stores/connect';
 import { widgetDefinition } from 'views/logic/Widgets';
@@ -61,7 +62,7 @@ export type Props = {
   title: string,
   position: WidgetPosition,
   onSizeChange: () => void,
-  onPositionsChange: () => void,
+  onPositionsChange: (position: BackendWidgetPosition) => void,
 };
 
 type State = {

--- a/graylog2-web-interface/src/views/components/widgets/Widget.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/Widget.tsx
@@ -33,7 +33,6 @@ import WidgetPosition from 'views/logic/widgets/WidgetPosition';
 import type { Rows } from 'views/logic/searchtypes/pivot/PivotHandler';
 import type { AbsoluteTimeRange } from 'views/logic/queries/Query';
 import WidgetFocusContext from 'views/components/contexts/WidgetFocusContext';
-import type VisualizationConfig from 'views/logic/aggregationbuilder/visualizations/VisualizationConfig';
 import TimerangeInfo from 'views/components/widgets/TimerangeInfo';
 import IfDashboard from 'views/components/dashboard/IfDashboard';
 import WidgetConfig from 'views/logic/widgets/WidgetConfig';
@@ -54,7 +53,7 @@ import InteractiveContext from '../contexts/InteractiveContext';
 export type Props = {
   id: string,
   widget: WidgetModel,
-  editing?: boolean,
+  editing: boolean,
   fields: Immutable.List<FieldTypeMapping>,
   height?: number,
   width?: number,
@@ -69,8 +68,6 @@ export type Result = {
   rows: Rows,
   effective_timerange: AbsoluteTimeRange,
 };
-
-export type OnVisualizationConfigChange = (newConfig: VisualizationConfig) => void;
 
 const _visualizationForType = (type) => {
   return widgetDefinition(type).visualizationComponent;
@@ -211,6 +208,7 @@ const Widget = ({ id, editing, height, width, widget, fields, onSizeChange, titl
                      type={widget.type}>
           <WidgetErrorBoundary>
             <Visualization id={id}
+                           editing={editing}
                            queryId={activeQuery}
                            widget={widget}
                            fields={fields}

--- a/graylog2-web-interface/src/views/components/widgets/WidgetActionsMenu.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/WidgetActionsMenu.test.tsx
@@ -20,6 +20,7 @@ import { render, waitFor, fireEvent, screen } from 'wrappedTestingLibrary';
 import { Map } from 'immutable';
 import mockAction from 'helpers/mocking/MockAction';
 import asMock from 'helpers/mocking/AsMock';
+import { MockStore } from 'helpers/mocking';
 
 import { WidgetActions } from 'views/stores/WidgetStore';
 import { TitlesActions, TitleTypes } from 'views/stores/TitlesStore';
@@ -38,6 +39,7 @@ import MessagesWidget from 'views/logic/widgets/MessagesWidget';
 import { loadDashboard } from 'views/logic/views/Actions';
 import { TitlesMap } from 'views/stores/TitleTypes';
 import FieldTypesContext from 'views/components/contexts/FieldTypesContext';
+import { ViewStore } from 'views/stores/ViewStore';
 
 import WidgetActionsMenu from './WidgetActionsMenu';
 
@@ -53,6 +55,24 @@ jest.mock('views/stores/ChartColorRulesStore', () => ({
 }));
 
 jest.mock('views/logic/views/Actions');
+
+jest.mock('views/stores/ViewStore', () => ({
+  ViewStore: MockStore(),
+  ViewActions: {
+    create: mockAction(),
+    load: mockAction(),
+  },
+}));
+
+jest.mock('views/stores/WidgetStore', () => ({
+  WidgetActions: {},
+}));
+
+jest.mock('views/stores/CurrentQueryStore', () => ({
+  CurrentQueryStore: MockStore(),
+}));
+
+jest.mock('views/stores/CurrentViewStateStore', () => ({ CurrentViewStateStore: MockStore(['getInitialState', () => ({})]) }));
 
 describe('<Widget />', () => {
   const widget = WidgetModel.builder().newId()
@@ -77,6 +97,8 @@ describe('<Widget />', () => {
     isNew: false,
     dirty: false,
   };
+
+  asMock(ViewStore.getInitialState).mockReturnValue(viewStoreState);
 
   const searchDB1 = Search.builder().id('search-1').build();
   const dashboard1 = View.builder().type(View.Type.Dashboard).id('view-1').title('view 1')
@@ -127,7 +149,6 @@ describe('<Widget />', () => {
           <WidgetActionsMenu isFocused={false}
                              toggleEdit={() => {}}
                              title="Widget Title"
-                             view={viewStoreState}
                              position={new WidgetPosition(1, 1, 1, 1)}
                              onPositionsChange={() => {}}
                              {...props} />

--- a/graylog2-web-interface/src/views/components/widgets/WidgetActionsMenu.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/WidgetActionsMenu.tsx
@@ -17,6 +17,7 @@
 import * as React from 'react';
 import { useState, useContext, useCallback } from 'react';
 import styled from 'styled-components';
+import { BackendWidgetPosition } from 'views/types';
 
 import ExportModal from 'views/components/export/ExportModal';
 import MoveWidgetToTab from 'views/logic/views/MoveWidgetToTab';
@@ -130,7 +131,7 @@ const _onDuplicate = (widgetId, setFocusWidget, title) => {
 
 type Props = {
   isFocused: boolean,
-  onPositionsChange: () => void,
+  onPositionsChange: (position: BackendWidgetPosition) => void,
   position: WidgetPosition,
   title: string,
   toggleEdit: () => void

--- a/graylog2-web-interface/src/views/components/widgets/WidgetActionsMenu.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/WidgetActionsMenu.tsx
@@ -26,7 +26,7 @@ import { IconButton } from 'components/common';
 import { ViewManagementActions } from 'views/stores/ViewManagementStore';
 import WidgetPosition from 'views/logic/widgets/WidgetPosition';
 import { TitlesActions, TitleTypes } from 'views/stores/TitlesStore';
-import { ViewActions } from 'views/stores/ViewStore';
+import { ViewActions, ViewStore } from 'views/stores/ViewStore';
 import View from 'views/logic/views/View';
 import SearchActions from 'views/actions/SearchActions';
 import Search from 'views/logic/search/Search';
@@ -35,6 +35,7 @@ import type { ViewStoreState } from 'views/stores/ViewStore';
 import IfSearch from 'views/components/search/IfSearch';
 import { MenuItem } from 'components/graylog';
 import { WidgetActions } from 'views/stores/WidgetStore';
+import { useStore } from 'stores/connect';
 
 import ReplaySearchButton from './ReplaySearchButton';
 import ExtraWidgetActions from './ExtraWidgetActions';
@@ -135,7 +136,6 @@ type Props = {
   position: WidgetPosition,
   title: string,
   toggleEdit: () => void
-  view: ViewStoreState,
 };
 
 const WidgetActionsMenu = ({
@@ -144,9 +144,9 @@ const WidgetActionsMenu = ({
   position,
   title,
   toggleEdit,
-  view,
 }: Props) => {
   const widget = useContext(WidgetContext);
+  const view = useStore(ViewStore);
   const { setWidgetFocusing, unsetWidgetFocusing } = useContext(WidgetFocusContext);
   const [showCopyToDashboard, setShowCopyToDashboard] = useState(false);
   const [showExport, setShowExport] = useState(false);

--- a/graylog2-web-interface/src/views/components/widgets/WidgetHorizontalStretch.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/WidgetHorizontalStretch.tsx
@@ -17,11 +17,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import Spinner from 'components/common/Spinner';
 import { widgetDefinition } from 'views/logic/Widgets';
 import { IconButton } from 'components/common';
 import { Position } from 'views/components/widgets/WidgetPropTypes';
 
-type Position = {
+type PositionType = {
   col: number,
   row: number,
   height: number,
@@ -29,8 +30,8 @@ type Position = {
 };
 
 type Props = {
-  onStretch: (args: { id: string } & Position) => void,
-  position: Position,
+  onStretch: (args: { id: string } & PositionType) => void,
+  position: PositionType,
   widgetId: string,
   widgetType: string,
 }
@@ -55,6 +56,11 @@ class WidgetHorizontalStretch extends React.Component<Props> {
 
   render() {
     const { position } = this.props;
+
+    if (!position) {
+      return <Spinner />;
+    }
+
     const { width } = position;
     const stretched = width === Infinity;
     const icon = stretched ? 'compress' : 'arrows-alt-h';

--- a/graylog2-web-interface/src/views/components/widgets/WidgetHorizontalStretch.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/WidgetHorizontalStretch.tsx
@@ -14,7 +14,8 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import React from 'react';
+import * as React from 'react';
+import { useCallback } from 'react';
 import PropTypes from 'prop-types';
 
 import Spinner from 'components/common/Spinner';
@@ -36,40 +37,35 @@ type Props = {
   widgetType: string,
 }
 
-class WidgetHorizontalStretch extends React.Component<Props> {
-  static propTypes = {
-    widgetId: PropTypes.string.isRequired,
-    widgetType: PropTypes.string.isRequired,
-    position: PropTypes.shape(Position).isRequired,
-    onStretch: PropTypes.func.isRequired,
-  };
-
-  _onClick = () => {
-    const { onStretch, position, widgetId, widgetType } = this.props;
+const WidgetHorizontalStretch = ({ onStretch, position, widgetId, widgetType }: Props) => {
+  const onClick = useCallback(() => {
     const { col, row, height, width } = position;
     const { defaultWidth } = widgetDefinition(widgetType);
 
     onStretch({
-      id: widgetId, col: col, row: row, height: height, width: width === Infinity ? defaultWidth : Infinity,
+      id: widgetId, col, row, height, width: width === Infinity ? defaultWidth : Infinity,
     });
-  };
+  }, [onStretch, position, widgetId, widgetType]);
 
-  render() {
-    const { position } = this.props;
-
-    if (!position) {
-      return <Spinner />;
-    }
-
-    const { width } = position;
-    const stretched = width === Infinity;
-    const icon = stretched ? 'compress' : 'arrows-alt-h';
-    const title = stretched ? 'Compress width' : 'Stretch width';
-
-    return (
-      <IconButton onClick={this._onClick} name={icon} title={title} />
-    );
+  if (!position) {
+    return <Spinner />;
   }
-}
+
+  const { width } = position;
+  const stretched = width === Infinity;
+  const icon = stretched ? 'compress' : 'arrows-alt-h';
+  const title = stretched ? 'Compress width' : 'Stretch width';
+
+  return (
+    <IconButton onClick={onClick} name={icon} title={title} />
+  );
+};
+
+WidgetHorizontalStretch.propTypes = {
+  widgetId: PropTypes.string.isRequired,
+  widgetType: PropTypes.string.isRequired,
+  position: PropTypes.shape(Position).isRequired,
+  onStretch: PropTypes.func.isRequired,
+};
 
 export default WidgetHorizontalStretch;

--- a/graylog2-web-interface/src/views/pages/SearchPage.tsx
+++ b/graylog2-web-interface/src/views/pages/SearchPage.tsx
@@ -61,4 +61,4 @@ SearchPage.defaultProps = {
   loadView: defaultLoadView,
 };
 
-export default SearchPage;
+export default React.memo(SearchPage);

--- a/graylog2-web-interface/src/views/stores/CurrentViewStateStore.ts
+++ b/graylog2-web-interface/src/views/stores/CurrentViewStateStore.ts
@@ -35,6 +35,7 @@ type CurrentViewStateActionsType = RefluxActions<{
   fields: (fields: Immutable.Set<string>) => Promise<unknown>,
   formatting: (formatting: FormattingSettings) => Promise<unknown>,
   titles: (titles: Immutable.Map<TitleType, Immutable.Map<string, string>>) => Promise<unknown>,
+  updateWidgetPosition: (widgetId: string, newPosition: WidgetPosition) => Promise<unknown>,
   widgets: (widgets: Immutable.List<Widget>) => Promise<unknown>,
   widgetPositions: (newPositions: Record<string, WidgetPosition>) => Promise<unknown>,
 }>;
@@ -45,6 +46,7 @@ export const CurrentViewStateActions: CurrentViewStateActionsType = singletonAct
     fields: { asyncResult: true },
     formatting: { asyncResult: true },
     titles: { asyncResult: true },
+    updateWidgetPosition: { asyncResult: true },
     widgets: { asyncResult: true },
     widgetPositions: { asyncResult: true },
   }),
@@ -128,6 +130,18 @@ export const CurrentViewStateStore: CurrentViewStateStoreType = singletonStore(
       const promise = ViewStatesActions.update(this.activeQuery, newActiveState);
 
       CurrentViewStateActions.widgetPositions.promise(promise);
+    },
+
+    updateWidgetPosition(widgetId: string, newPosition) {
+      const { widgetPositions } = this._activeState();
+      const newPositions = { ...widgetPositions, [widgetId]: newPosition };
+
+      const newActiveState = this._activeState().toBuilder().widgetPositions(newPositions).build();
+      const promise = ViewStatesActions.update(this.activeQuery, newActiveState);
+
+      CurrentViewStateActions.updateWidgetPosition.promise(promise);
+
+      return promise;
     },
 
     formatting(formatting) {

--- a/graylog2-web-interface/src/views/stores/CurrentViewStateStore.ts
+++ b/graylog2-web-interface/src/views/stores/CurrentViewStateStore.ts
@@ -58,9 +58,9 @@ type CurrentViewStateStoreState = {
 };
 export type CurrentViewStateStoreType = Store<CurrentViewStateStoreState>;
 
-export const CurrentViewStateStore: CurrentViewStateStoreType = singletonStore(
+export const CurrentViewStateStore = singletonStore(
   'views.CurrentViewState',
-  () => Reflux.createStore({
+  () => Reflux.createStore<CurrentViewStateStoreState>({
     listenables: [CurrentViewStateActions],
     states: Immutable.Map(),
     activeQuery: undefined,

--- a/graylog2-web-interface/src/views/stores/SearchLoadingStateStore.ts
+++ b/graylog2-web-interface/src/views/stores/SearchLoadingStateStore.ts
@@ -16,7 +16,6 @@
  */
 import Reflux from 'reflux';
 
-import { Store } from 'stores/StoreTypes';
 import { singletonActions, singletonStore } from 'views/logic/singleton';
 
 import { SearchActions } from './SearchStore';
@@ -30,9 +29,9 @@ type SearchLoadingStateStoreState = {
   isLoading: boolean;
 };
 
-export const SearchLoadingStateStore: Store<SearchLoadingStateStoreState> = singletonStore(
+export const SearchLoadingStateStore = singletonStore(
   'views.SearchLoadingState',
-  () => Reflux.createStore({
+  () => Reflux.createStore<SearchLoadingStateStoreState>({
     listenables: [SearchLoadingStateActions],
     isLoading: false,
     init() {

--- a/graylog2-web-interface/src/views/stores/TitlesStore.ts
+++ b/graylog2-web-interface/src/views/stores/TitlesStore.ts
@@ -37,9 +37,11 @@ export const TitlesActions: TitlesActionsTypes = singletonActions(
 
 export { default as TitleTypes } from './TitleTypes';
 
+type TitlesStoreState = Immutable.Map<TitleType, Immutable.Map<string, string>>;
+
 export const TitlesStore = singletonStore(
   'views.Titles',
-  () => Reflux.createStore({
+  () => Reflux.createStore<TitlesStoreState>({
     listenables: [TitlesActions],
 
     titles: Immutable.Map<TitleType, Immutable.Map<string, string>>(),

--- a/graylog2-web-interface/src/views/stores/WidgetStore.ts
+++ b/graylog2-web-interface/src/views/stores/WidgetStore.ts
@@ -19,7 +19,7 @@ import * as Immutable from 'immutable';
 import uuid from 'uuid/v4';
 import { get, isEqual } from 'lodash';
 
-import type { RefluxActions, Store } from 'stores/StoreTypes';
+import type { RefluxActions } from 'stores/StoreTypes';
 import Widget from 'views/logic/widgets/Widget';
 import { singletonActions, singletonStore } from 'views/logic/singleton';
 import type { QueryString, TimeRange } from 'views/logic/queries/Query';
@@ -61,9 +61,9 @@ export const WidgetActions: WidgetActionsType = singletonActions(
   }),
 );
 
-export const WidgetStore: Store<WidgetStoreState> = singletonStore(
+export const WidgetStore = singletonStore(
   'views.Widget',
-  () => Reflux.createStore({
+  () => Reflux.createStore<WidgetStoreState>({
     listenables: [WidgetActions],
 
     widgets: Immutable.Map(),

--- a/graylog2-web-interface/src/views/types.d.ts
+++ b/graylog2-web-interface/src/views/types.d.ts
@@ -44,7 +44,19 @@ import View from 'views/logic/views/View';
 import User from 'logic/users/User';
 import { Message } from 'views/components/messagelist/Types';
 import { ValuePath } from 'views/logic/valueactions/ValueActionHandler';
+import WidgetPosition from 'views/logic/widgets/WidgetPosition';
+
 import MessagesWidgetConfig from 'views/logic/widgets/MessagesWidgetConfig';
+
+type BackendWidgetPosition = {
+  id: string,
+  col: number,
+  row: number,
+  height: number,
+  width: number,
+};
+
+type WidgetPositions = { [widgetId: string]: WidgetPosition };
 
 interface EditWidgetComponentProps<Config extends WidgetConfig = WidgetConfig> {
   children: React.ReactNode,

--- a/graylog2-web-interface/src/views/types.d.ts
+++ b/graylog2-web-interface/src/views/types.d.ts
@@ -45,7 +45,6 @@ import User from 'logic/users/User';
 import { Message } from 'views/components/messagelist/Types';
 import { ValuePath } from 'views/logic/valueactions/ValueActionHandler';
 import WidgetPosition from 'views/logic/widgets/WidgetPosition';
-
 import MessagesWidgetConfig from 'views/logic/widgets/MessagesWidgetConfig';
 
 type BackendWidgetPosition = {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is improving rendering performance of the widget grid on the search/dashboard pages by reducing the amount of re-renders. This is achieved by:

  - Pushing state (mostly derived from stores) down to its actual consumption whenever possible, e.g. extracting widget results closely to the visualization component
  - Making callbacks static
  - Extracting components which do not change when the search results are updated and rendering them _next_ to components which need to update

This allowed me to improve rendering times for two scenarios:

  - Updating the search
  - Toggling edit mode on a widget

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.