### PR TITLE
Simplify search requests, provide default values

### DIFF
--- a/full-backend-tests/src/test/java/org/graylog/plugins/views/SearchSyncIT.java
+++ b/full-backend-tests/src/test/java/org/graylog/plugins/views/SearchSyncIT.java
@@ -1,0 +1,46 @@
+package org.graylog.plugins.views;
+
+import io.restassured.specification.RequestSpecification;
+import org.graylog.storage.elasticsearch7.ElasticsearchInstanceES7Factory;
+import org.graylog.testing.completebackend.ApiIntegrationTest;
+import org.graylog.testing.completebackend.GraylogBackend;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.graylog.testing.completebackend.Lifecycle.CLASS;
+import static org.hamcrest.core.IsEqual.equalTo;
+
+@ApiIntegrationTest(serverLifecycle = CLASS, elasticsearchFactory = ElasticsearchInstanceES7Factory.class)
+public class SearchSyncIT {
+
+    private final GraylogBackend sut;
+    private final RequestSpecification requestSpec;
+
+    public SearchSyncIT(GraylogBackend sut, RequestSpecification requestSpec) {
+        this.sut = sut;
+        this.requestSpec = requestSpec;
+    }
+
+    @Test
+    void testEmptyBody() {
+        given()
+                .spec(requestSpec)
+                .when()
+                .post("/views/search/sync")
+                .then()
+                .statusCode(400)
+                .assertThat().body("message[0]", equalTo("Search body is mandatory"));
+    }
+
+    @Test
+    void testMinimalisticRequest() {
+        given()
+                .spec(requestSpec)
+                .when()
+                .body(getClass().getClassLoader().getResourceAsStream("org/graylog/plugins/views/minimalistic-request.json"))
+                .post("/views/search/sync")
+                .then()
+                .statusCode(200)
+                .assertThat().body("execution.completed_exceptionally", equalTo(false));
+    }
+}

--- a/full-backend-tests/src/test/java/org/graylog/plugins/views/SearchSyncIT.java
+++ b/full-backend-tests/src/test/java/org/graylog/plugins/views/SearchSyncIT.java
@@ -1,17 +1,30 @@
 package org.graylog.plugins.views;
 
+import com.jayway.jsonpath.DocumentContext;
+import com.jayway.jsonpath.JsonPath;
+import com.revinate.assertj.json.JsonPathAssert;
+import io.restassured.response.ValidatableResponse;
 import io.restassured.specification.RequestSpecification;
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.ObjectAssert;
 import org.graylog.storage.elasticsearch7.ElasticsearchInstanceES7Factory;
 import org.graylog.testing.completebackend.ApiIntegrationTest;
 import org.graylog.testing.completebackend.GraylogBackend;
+import org.graylog.testing.utils.GelfInputUtils;
+import org.graylog.testing.utils.SearchUtils;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+
 import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.graylog.testing.completebackend.Lifecycle.CLASS;
 import static org.hamcrest.core.IsEqual.equalTo;
 
-@ApiIntegrationTest(serverLifecycle = CLASS, elasticsearchFactory = ElasticsearchInstanceES7Factory.class)
+@ApiIntegrationTest(serverLifecycle = CLASS, elasticsearchFactory = ElasticsearchInstanceES7Factory.class, extraPorts = {SearchSyncIT.GELF_HTTP_PORT})
 public class SearchSyncIT {
+
+    static final int GELF_HTTP_PORT = 12201;
 
     private final GraylogBackend sut;
     private final RequestSpecification requestSpec;
@@ -34,13 +47,25 @@ public class SearchSyncIT {
 
     @Test
     void testMinimalisticRequest() {
-        given()
+        int mappedPort = sut.mappedPortFor(GELF_HTTP_PORT);
+        GelfInputUtils.createGelfHttpInput(mappedPort, GELF_HTTP_PORT, requestSpec);
+        GelfInputUtils.postMessage(mappedPort,
+                "{\"short_message\":\"Hello there\", \"host\":\"example.org\", \"facility\":\"test\"}",
+                requestSpec);
+
+        // mainly because of the waiting logic
+        final List<String> strings = SearchUtils.searchForAllMessages(requestSpec);
+        assertThat(strings.size()).isEqualTo(1);
+
+        final ValidatableResponse validatableResponse = given()
                 .spec(requestSpec)
                 .when()
                 .body(getClass().getClassLoader().getResourceAsStream("org/graylog/plugins/views/minimalistic-request.json"))
                 .post("/views/search/sync")
                 .then()
-                .statusCode(200)
-                .assertThat().body("execution.completed_exceptionally", equalTo(false));
+                .statusCode(200);
+        validatableResponse.assertThat().body("execution.completed_exceptionally", equalTo(false));
+        final String body = validatableResponse.extract().body().asString();
+        assertThat(body).contains("Hello there");
     }
 }

--- a/full-backend-tests/src/test/java/org/graylog/plugins/views/SearchSyncIT.java
+++ b/full-backend-tests/src/test/java/org/graylog/plugins/views/SearchSyncIT.java
@@ -1,12 +1,23 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog.plugins.views;
 
-import com.jayway.jsonpath.DocumentContext;
-import com.jayway.jsonpath.JsonPath;
-import com.revinate.assertj.json.JsonPathAssert;
 import io.restassured.response.ValidatableResponse;
 import io.restassured.specification.RequestSpecification;
-import org.assertj.core.api.Assertions;
-import org.assertj.core.api.ObjectAssert;
 import org.graylog.storage.elasticsearch7.ElasticsearchInstanceES7Factory;
 import org.graylog.testing.completebackend.ApiIntegrationTest;
 import org.graylog.testing.completebackend.GraylogBackend;

--- a/full-backend-tests/src/test/java/org/graylog/plugins/views/SearchSyncIT.java
+++ b/full-backend-tests/src/test/java/org/graylog/plugins/views/SearchSyncIT.java
@@ -28,8 +28,10 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 
 import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.anyOf;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.graylog.testing.completebackend.Lifecycle.CLASS;
+import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.core.IsEqual.equalTo;
 
 @ApiIntegrationTest(serverLifecycle = CLASS, elasticsearchFactory = ElasticsearchInstanceES7Factory.class, extraPorts = {SearchSyncIT.GELF_HTTP_PORT})
@@ -76,7 +78,6 @@ public class SearchSyncIT {
                 .then()
                 .statusCode(200);
         validatableResponse.assertThat().body("execution.completed_exceptionally", equalTo(false));
-        final String body = validatableResponse.extract().body().asString();
-        assertThat(body).contains("Hello there");
+        validatableResponse.assertThat().body("results*.value.search_types[0]*.value.messages.message.message[0]", hasItem("Hello there"));
     }
 }

--- a/full-backend-tests/src/test/java/org/graylog/plugins/views/SearchSyncIT.java
+++ b/full-backend-tests/src/test/java/org/graylog/plugins/views/SearchSyncIT.java
@@ -28,7 +28,6 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 
 import static io.restassured.RestAssured.given;
-import static org.assertj.core.api.Assertions.anyOf;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.graylog.testing.completebackend.Lifecycle.CLASS;
 import static org.hamcrest.CoreMatchers.hasItem;

--- a/full-backend-tests/src/test/resources/org/graylog/plugins/views/minimalistic-request.json
+++ b/full-backend-tests/src/test/resources/org/graylog/plugins/views/minimalistic-request.json
@@ -1,0 +1,19 @@
+{
+  "queries": [
+    {
+      "query": {
+        "type": "elasticsearch",
+        "query_string": ""
+      },
+      "timerange": {
+        "type": "relative",
+        "from": 300
+      },
+      "search_types": [
+        {
+          "type": "messages"
+        }
+      ]
+    }
+  ]
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/Query.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/Query.java
@@ -28,6 +28,7 @@ import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.graph.Traverser;
+import org.graylog.plugins.views.search.elasticsearch.ElasticsearchQueryString;
 import org.graylog.plugins.views.search.engine.BackendQuery;
 import org.graylog.plugins.views.search.engine.EmptyTimeRange;
 import org.graylog.plugins.views.search.filter.AndFilter;
@@ -36,6 +37,8 @@ import org.graylog2.contentpacks.ContentPackable;
 import org.graylog2.contentpacks.EntityDescriptorIds;
 import org.graylog2.contentpacks.model.ModelTypes;
 import org.graylog2.contentpacks.model.entities.QueryEntity;
+import org.graylog2.plugin.indexer.searches.timeranges.InvalidRangeParametersException;
+import org.graylog2.plugin.indexer.searches.timeranges.RelativeRange;
 import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -246,7 +249,14 @@ public abstract class Query implements ContentPackable<QueryEntity> {
 
         @JsonCreator
         static Builder createWithDefaults() {
-            return new AutoValue_Query.Builder().searchTypes(of());
+            try {
+                return new AutoValue_Query.Builder()
+                        .searchTypes(of())
+                        .query(ElasticsearchQueryString.empty())
+                        .timerange(RelativeRange.create(300));
+            } catch (InvalidRangeParametersException e) {
+                throw new RuntimeException("Unable to create relative timerange - this should not happen!");
+            }
         }
 
         public Query build() {

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/Query.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/Query.java
@@ -250,7 +250,7 @@ public abstract class Query implements ContentPackable<QueryEntity> {
         }
 
         public Query build() {
-            if(id() == null) {
+            if (id() == null) {
                 id(UUID.randomUUID().toString());
             }
             return autoBuild();

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/Query.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/Query.java
@@ -47,6 +47,7 @@ import java.util.HashSet;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
@@ -61,6 +62,7 @@ import static java.util.stream.Collectors.toSet;
 public abstract class Query implements ContentPackable<QueryEntity> {
     private static final Logger LOG = LoggerFactory.getLogger(Query.class);
 
+    @Nullable
     @JsonProperty
     public abstract String id();
 
@@ -224,6 +226,8 @@ public abstract class Query implements ContentPackable<QueryEntity> {
         @JsonProperty
         public abstract Builder id(String id);
 
+        public abstract String id();
+
         @JsonProperty
         public abstract Builder timerange(TimeRange timerange);
 
@@ -246,6 +250,9 @@ public abstract class Query implements ContentPackable<QueryEntity> {
         }
 
         public Query build() {
+            if(id() == null) {
+                id(UUID.randomUUID().toString());
+            }
             return autoBuild();
         }
     }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/Search.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/Search.java
@@ -221,7 +221,6 @@ public abstract class Search implements ContentPackable<SearchEntity> {
         }
 
         public Search build() {
-
             if (id() == null) {
                 id(org.bson.types.ObjectId.get().toString());
             }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/Search.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/Search.java
@@ -222,7 +222,7 @@ public abstract class Search implements ContentPackable<SearchEntity> {
 
         public Search build() {
 
-            if(id() == null) {
+            if (id() == null) {
                 id(org.bson.types.ObjectId.get().toString());
             }
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/Search.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/Search.java
@@ -223,7 +223,7 @@ public abstract class Search implements ContentPackable<SearchEntity> {
         public Search build() {
 
             if(id() == null) {
-                id(UUID.randomUUID().toString());
+                id(org.bson.types.ObjectId.get().toString());
             }
 
             final Search search = autoBuild();

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/Search.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/Search.java
@@ -44,6 +44,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -192,6 +193,8 @@ public abstract class Search implements ContentPackable<SearchEntity> {
         @JsonProperty
         public abstract Builder id(String id);
 
+        public abstract String id();
+
         @JsonProperty
         public abstract Builder queries(ImmutableSet<Query> queries);
 
@@ -218,6 +221,11 @@ public abstract class Search implements ContentPackable<SearchEntity> {
         }
 
         public Search build() {
+
+            if(id() == null) {
+                id(UUID.randomUUID().toString());
+            }
+
             final Search search = autoBuild();
             search.queryIndex = Maps.uniqueIndex(search.queries(), Query::id);
             search.parameterIndex = Maps.uniqueIndex(search.parameters(), Parameter::name);

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SearchResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SearchResource.java
@@ -214,7 +214,7 @@ public class SearchResource extends RestResource implements PluginRestResource {
     @ApiOperation(value = "Execute a new synchronous search", notes = "Executes a new search and waits for its result")
     @Path("sync")
     @NoAuditEvent("Creating audit event manually in method body.")
-    public Response executeSyncJob(@ApiParam Search search,
+    public Response executeSyncJob(@ApiParam @NotNull(message = "Search body is mandatory") Search search,
                                    @ApiParam(name = "timeout", defaultValue = "60000")
                                    @QueryParam("timeout") @DefaultValue("60000") long timeout) {
         final String username = username();

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/MessageList.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/MessageList.java
@@ -49,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 
 @AutoValue
 @JsonTypeName(MessageList.NAME)
@@ -132,6 +133,8 @@ public abstract class MessageList implements SearchType {
         @JsonProperty
         public abstract Builder id(@Nullable String id);
 
+        abstract String id();
+
         @JsonProperty
         public abstract Builder name(@Nullable String name);
 
@@ -173,7 +176,14 @@ public abstract class MessageList implements SearchType {
 
         public abstract Builder decorators(List<Decorator> decorators);
 
-        public abstract MessageList build();
+        abstract MessageList autoBuild();
+
+        public MessageList build() {
+            if(id() == null) {
+                id(UUID.randomUUID().toString());
+            }
+            return autoBuild();
+        }
     }
 
     @AutoValue

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/MessageList.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/MessageList.java
@@ -179,7 +179,7 @@ public abstract class MessageList implements SearchType {
         abstract MessageList autoBuild();
 
         public MessageList build() {
-            if(id() == null) {
+            if (id() == null) {
                 id(UUID.randomUUID().toString());
             }
             return autoBuild();

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/events/EventList.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/events/EventList.java
@@ -36,6 +36,7 @@ import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 
 import static org.graylog2.plugin.streams.Stream.DEFAULT_EVENTS_STREAM_ID;
 import static org.graylog2.plugin.streams.Stream.DEFAULT_SYSTEM_EVENTS_STREAM_ID;
@@ -91,6 +92,8 @@ public abstract class EventList implements SearchType {
         @JsonProperty
         public abstract Builder id(String id);
 
+        abstract String id();
+
         @JsonProperty
         public abstract Builder name(@Nullable String name);
 
@@ -106,7 +109,14 @@ public abstract class EventList implements SearchType {
         @JsonProperty
         public abstract Builder streams(Set<String> streams);
 
-        public abstract EventList build();
+        abstract EventList autoBuild();
+
+        public EventList build() {
+            if(id() == null) {
+                id(UUID.randomUUID().toString());
+            }
+            return autoBuild();
+        }
     }
 
     @AutoValue

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/Pivot.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/Pivot.java
@@ -159,7 +159,7 @@ public abstract class Pivot implements SearchType {
         abstract Pivot autoBuild();
 
         public Pivot build() {
-            if(id() == null) {
+            if (id() == null) {
                 id(UUID.randomUUID().toString());
             }
             return autoBuild();

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/Pivot.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/Pivot.java
@@ -43,6 +43,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 
 import static com.google.common.collect.ImmutableList.of;
 
@@ -113,6 +114,8 @@ public abstract class Pivot implements SearchType {
         @JsonProperty
         public abstract Builder id(@Nullable String id);
 
+        abstract String id();
+
         @JsonProperty
         public abstract Builder name(@Nullable String name);
 
@@ -153,7 +156,14 @@ public abstract class Pivot implements SearchType {
         @JsonProperty
         public abstract Builder streams(Set<String> streams);
 
-        public abstract Pivot build();
+        abstract Pivot autoBuild();
+
+        public Pivot build() {
+            if(id() == null) {
+                id(UUID.randomUUID().toString());
+            }
+            return autoBuild();
+        }
     }
 
     @Override

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/QueryTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/QueryTest.java
@@ -164,6 +164,13 @@ public class QueryTest {
         Query query = sut.applyExecutionState(objectMapper, objectMapper.convertValue(executionState, JsonNode.class));
         assertThat(query.globalOverride()).isEmpty();
     }
+
+    @Test
+    public void builderGeneratesQueryId() {
+        final Query build = Query.builder().timerange(mock(TimeRange.class)).query(new BackendQuery.Fallback()).build();
+        assertThat(build.id()).isNotNull();
+    }
+
     private RelativeRange relativeRange(int range) {
         try {
             return RelativeRange.create(range);

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/QueryTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/QueryTest.java
@@ -171,6 +171,14 @@ public class QueryTest {
         assertThat(build.id()).isNotNull();
     }
 
+    @Test
+    public void builderGeneratesDefaultQueryAndRange() {
+        final Query build = Query.builder().build();
+        final ElasticsearchQueryString query = (ElasticsearchQueryString) build.query();
+        assertThat(query.queryString()).isEqualTo("");
+        assertThat(build.timerange()).isNotNull();
+    }
+
     private RelativeRange relativeRange(int range) {
         try {
             return RelativeRange.create(range);

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/SearchResourceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/SearchResourceTest.java
@@ -141,6 +141,13 @@ public class SearchResourceTest {
     }
 
     @Test
+    public void testBuilderGeneratesSearchId() {
+        final Search search = Search.builder().build();
+        assertThat(search.id()).isNotNull();
+        assertThat(org.bson.types.ObjectId.isValid(search.id())).isTrue();
+    }
+
+    @Test
     public void getSearchLoadsSearch() {
         final Search search = mockExistingSearch();
 

--- a/graylog2-server/src/test/java/org/graylog/testing/graylognode/NodeContainerConfig.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/graylognode/NodeContainerConfig.java
@@ -26,7 +26,6 @@ public class NodeContainerConfig {
     static final int API_PORT = 9000;
     public static final int GELF_HTTP_PORT = 12201;
     static final int DEBUG_PORT = 5005;
-    public static final int GELF_HTTP_PORT = 12201;
 
     public final Network network;
     public final String mongoDbUri;

--- a/graylog2-server/src/test/java/org/graylog/testing/graylognode/NodeContainerConfig.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/graylognode/NodeContainerConfig.java
@@ -26,6 +26,7 @@ public class NodeContainerConfig {
     static final int API_PORT = 9000;
     public static final int GELF_HTTP_PORT = 12201;
     static final int DEBUG_PORT = 5005;
+    public static final int GELF_HTTP_PORT = 12201;
 
     public final Network network;
     public final String mongoDbUri;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

The goal of this PR is to simplify search API (/api/views/search/sync) request needed to obtain a basic response.  

## Description
The first obvious road block are the IDs (both MongoDB ObjectId and UUIDs) in the request structure. Currently they are autogenerated by the frontend. But for any REST/CLI usage they are not necessary and may be generated by the backend itself. They are generated only if not provided, so there is no need to adapt the current frontend logic now. 

Completely empty requests ends with no error message and NPEs in the backend, so there need to be validation adapted. 

The (empty) query and default 300s relative time range can be provided by default, the frontend does the same.

## Motivation and Context

Fixes #11234, #6663

Without these UUIDs, a simple request may now look like this:

```
{
   "queries":[
      {
         "query":{
            "type":"elasticsearch",
            "query_string":""
         },
         "timerange":{
            "type":"relative",
            "from":300
         },
         "search_types":[
            {
               "type":"messages"
            }
         ]
      }
   ]
}
```

Adapted error handling to provide an error message in case of empty request body:

![image](https://user-images.githubusercontent.com/4102775/132343679-c864bc07-d09e-45a7-b57d-6e15ec65e8b6.png)


After providing default query and timerange, this is the shortest valid request:

```
{
   "queries":[
      {     
         "search_types":[
            {
               "type":"messages"
            }
         ]
      }
   ]
}
```

## How Has This Been Tested?
Added unit tests, manually tested.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

