### PR TITLE
Improve memory profile of `useStore`.

### DIFF
--- a/graylog2-web-interface/src/components/common/EntityListItem.tsx
+++ b/graylog2-web-interface/src/components/common/EntityListItem.tsx
@@ -71,7 +71,7 @@ const EntityListItem = ({ actions, contentRow, description, title, titleSuffix }
     <StyledListItem>
       <Row className="row-sm">
         <Col md={12}>
-          <div className="pull-right hidden-xs">
+          <div className="pull-right hidden-xs" data-testid="actions-container">
             {actionsContainer}
           </div>
           <h2>{title} {wrappedTitleSuffix}</h2>

--- a/graylog2-web-interface/src/stores/__tests__/connect.test.tsx
+++ b/graylog2-web-interface/src/stores/__tests__/connect.test.tsx
@@ -146,11 +146,13 @@ describe('connect()', () => {
     expect(Component.displayName).toEqual('ConnectStoresWrapper[Unknown/Anonymous] stores=simpleStore');
   });
 
+  // eslint-disable-next-line jest/expect-expect
   it('types store props as optional', () => {
     const Component = connect(() => <span>hello!</span>, { simpleStore: SimpleStore });
     mount(<Component />);
   });
 
+  // eslint-disable-next-line jest/expect-expect
   it('types mapped props as optional', () => {
     const Component = connect(
       () => <span>hello!</span>,
@@ -160,6 +162,7 @@ describe('connect()', () => {
     mount(<Component />);
   });
 
+  // eslint-disable-next-line jest/expect-expect
   it('types props which have a default value (defaultProps) as optional', () => {
     const BaseComponent = ({ exampleProp }: { exampleProp: string }) => <span>{exampleProp}</span>;
 

--- a/graylog2-web-interface/src/views/pages/ViewManagementPage.tsx
+++ b/graylog2-web-interface/src/views/pages/ViewManagementPage.tsx
@@ -34,7 +34,7 @@ const handleViewDelete = (view) => {
     return ViewManagementActions.delete(view);
   }
 
-  return null;
+  return Promise.resolve();
 };
 
 const ViewManagementPage = () => {

--- a/graylog2-web-interface/src/views/stores/ViewManagementStore.ts
+++ b/graylog2-web-interface/src/views/stores/ViewManagementStore.ts
@@ -76,7 +76,7 @@ const viewsUrl = qualifyUrl('/views');
 const viewsIdUrl = (id) => qualifyUrl(`/views/${id}`);
 const forValueUrl = () => qualifyUrl('/views/forValue');
 
-type ViewManagementStoreState = {
+export type ViewManagementStoreState = {
   pagination: Pagination;
   list: Array<ViewJson>;
 };

--- a/graylog2-web-interface/test/helpers/mocking/MockAction.ts
+++ b/graylog2-web-interface/test/helpers/mocking/MockAction.ts
@@ -19,11 +19,11 @@ import type { ListenableAction, PromiseProvider } from 'stores/StoreTypes';
 
 const listenable = () => ({ listen: jest.fn(() => jest.fn()) });
 
-const noop: PromiseProvider = jest.fn(() => Promise.resolve());
+const noop: () => PromiseProvider = () => jest.fn(() => Promise.resolve());
 
-function mockAction(): ListenableAction<typeof noop>;
+function mockAction(): ListenableAction<ReturnType<typeof noop>>;
 function mockAction<R extends PromiseProvider>(fn: R): ListenableAction<R>;
-function mockAction(fn = noop) {
+function mockAction(fn = noop()) {
   return Object.assign(fn, listenable(), {
     completed: listenable(),
     promise: jest.fn(),


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Prior to this change, `useStore` would hold the complete state of the store it connects to in memory. This is useful, because it allows us to check if the new state of the store is equal to the previous one before.  If it is not, the update function can exit early.

The downside of this is that if a store contains a big structure and the consumer is only interested in a very small subset, we can use the props mapper to return only the relevant part of it, but `useStore` would still keep the whole structure in memory. An example for this is:

```
const foo = useStore(FooStore, (state) => state.length);
```

Assuming that the state of `FooStore` is a very large array, keeping a reference of it in `useStore`'s memory is useless, if we are interested in its size only.

This change is now improving `useStore`'s behavior in that it maintains its internal state and references related to the _mapped_ versions of them. This allows us to keep only the relevant parts of the store state.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.