### PR TITLE
Fixing positioning of loading spinner in widget header.

### DIFF
--- a/graylog2-web-interface/src/views/components/widgets/WidgetHeader.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/WidgetHeader.tsx
@@ -16,7 +16,7 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import styled, { css, DefaultTheme } from 'styled-components';
+import styled, { css } from 'styled-components';
 
 import { Spinner, Icon } from 'components/common';
 import EditableTitle from 'views/components/common/EditableTitle';
@@ -27,14 +27,19 @@ const LoadingSpinner = styled(Spinner)`
   margin-left: 10px;
 `;
 
-const Container = styled.div(({ theme, $hideDragHandle }: {theme: DefaultTheme, $hideDragHandle: boolean }) => css`
+const Container = styled.div(({ theme }) => css`
   font-size: ${theme.fonts.size.large};
   text-overflow: ellipsis;
   margin-bottom: 5px;
   display: grid;
-  grid-template-columns: ${$hideDragHandle ? 'minmax(20px, auto) max-content' : 'max-content minmax(20px, auto) max-content'};
+  grid-template-columns: minmax(35px, 1fr) max-content;
   align-items: center;
 `);
+
+const Col = styled.div`
+  display: flex;
+  align-items: center;
+`;
 
 const WidgetDragHandle = styled(Icon)`
   cursor: move;
@@ -55,10 +60,12 @@ type Props = {
 };
 
 const WidgetHeader = ({ children, onRename, hideDragHandle, title, loading }: Props) => (
-  <Container $hideDragHandle={hideDragHandle}>
-    {hideDragHandle || <WidgetDragHandle name="bars" className="widget-drag-handle" />}
-    <EditableTitle key={title} disabled={!onRename} value={title} onChange={onRename} />
-    {loading && <LoadingSpinner text="" delay={0} />}
+  <Container>
+    <Col>
+      {hideDragHandle || <WidgetDragHandle name="bars" className="widget-drag-handle" />}
+      <EditableTitle key={title} disabled={!onRename} value={title} onChange={onRename} />
+      {loading && <LoadingSpinner text="" delay={0} />}
+    </Col>
     <WidgetActionDropdown className="pull-right">
       {children}
     </WidgetActionDropdown>

--- a/graylog2-web-interface/src/views/components/widgets/WidgetHeader.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/WidgetHeader.tsx
@@ -66,7 +66,7 @@ const WidgetHeader = ({ children, onRename, hideDragHandle, title, loading }: Pr
       <EditableTitle key={title} disabled={!onRename} value={title} onChange={onRename} />
       {loading && <LoadingSpinner text="" delay={0} />}
     </Col>
-    <WidgetActionDropdown className="pull-right">
+    <WidgetActionDropdown>
       {children}
     </WidgetActionDropdown>
   </Container>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is fixing the positioning of the widget loading spinner in widget headers. We are displaying the spinner for example while loading a page in the message table widget.

Before:
![image](https://user-images.githubusercontent.com/46300478/132522479-ca52555a-42db-4b45-b632-2c30fa72a85c.png)


After:
![image](https://user-images.githubusercontent.com/46300478/132522324-d2aa076a-a750-43c1-a131-8b0aeda7a58d.png)
