### PR TITLE
Hide search action "Export to dashboard" for users who do not have the permission to create dashboards.

### DIFF
--- a/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchControls.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchControls.test.tsx
@@ -84,6 +84,7 @@ describe('SavedSearchControls', () => {
   );
 
   const findShareButton = () => screen.findByRole('button', { name: 'Share' });
+  const expectShareButton = findShareButton;
 
   SimpleSavedSearchControls.defaultProps = {
     loadNewView: () => Promise.resolve(),
@@ -166,7 +167,7 @@ describe('SavedSearchControls', () => {
       it('includes the option to share the current search', async () => {
         render(<SimpleSavedSearchControls viewStoreState={createViewStoreState(false, 'some-id')} />);
 
-        await findShareButton();
+        await expectShareButton();
       });
 
       it('which should be disabled if current user is neither owner nor permitted to edit search', async () => {

--- a/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchControls.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchControls.tsx
@@ -38,6 +38,8 @@ import * as ViewsPermissions from 'views/Permissions';
 import User from 'logic/users/User';
 import ViewPropertiesModal from 'views/components/views/ViewPropertiesModal';
 import { loadAsDashboard, loadNewSearch } from 'views/logic/views/Actions';
+import IfPermitted from 'components/common/IfPermitted';
+import Routes from 'routing/Routes';
 
 import SavedSearchForm from './SavedSearchForm';
 import SavedSearchList from './SavedSearchList';
@@ -261,11 +263,13 @@ class SavedSearchControls extends React.Component<Props, State> {
                                onClick={this.toggleShareSearch}
                                bsStyle="default"
                                disabledInfo={!view.id && 'Only saved searches can be shared.'} />
-                  <DropdownButton title={<Icon name="ellipsis-h" />} id="search-actions-dropdown" pullRight noCaret>
+                  <DropdownButton title={<Icon name="ellipsis-h" />} aria-label="Open search actions dropdown" id="search-actions-dropdown" pullRight noCaret>
                     <MenuItem onSelect={this.toggleMetadataEdit} disabled={!isAllowedToEdit}>
                       <Icon name="edit" /> Edit metadata
                     </MenuItem>
-                    <MenuItem onSelect={this._loadAsDashboard}><Icon name="tachometer-alt" /> Export to dashboard</MenuItem>
+                    <IfPermitted permissions="dashboards:create">
+                      <MenuItem onSelect={this._loadAsDashboard}><Icon name="tachometer-alt" /> Export to dashboard</MenuItem>
+                    </IfPermitted>
                     <MenuItem onSelect={this.toggleExport}><Icon name="cloud-download-alt" /> Export</MenuItem>
                     <MenuItem disabled={disableReset} onSelect={() => loadNewView()} data-testid="reset-search">
                       <Icon name="eraser" /> Reset search

--- a/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchControls.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchControls.tsx
@@ -39,7 +39,6 @@ import User from 'logic/users/User';
 import ViewPropertiesModal from 'views/components/views/ViewPropertiesModal';
 import { loadAsDashboard, loadNewSearch } from 'views/logic/views/Actions';
 import IfPermitted from 'components/common/IfPermitted';
-import Routes from 'routing/Routes';
 
 import SavedSearchForm from './SavedSearchForm';
 import SavedSearchList from './SavedSearchList';
@@ -271,7 +270,7 @@ class SavedSearchControls extends React.Component<Props, State> {
                       <MenuItem onSelect={this._loadAsDashboard}><Icon name="tachometer-alt" /> Export to dashboard</MenuItem>
                     </IfPermitted>
                     <MenuItem onSelect={this.toggleExport}><Icon name="cloud-download-alt" /> Export</MenuItem>
-                    <MenuItem disabled={disableReset} onSelect={() => loadNewView()} data-testid="reset-search">
+                    <MenuItem disabled={disableReset} onSelect={() => loadNewView()}>
                       <Icon name="eraser" /> Reset search
                     </MenuItem>
                     <MenuItem divider />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Users need the `dashboards:create` permission to be able to create dashboards. Before this change we displayed the search action "Export to dashboard" for all users. Now we are only displaying the action for users who have the required permission.

![image](https://user-images.githubusercontent.com/46300478/132650728-1a371370-ff42-40dc-a286-c8cc12316620.png)

Fixes: #9465

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

