### PR TITLE
Publish locally produced cluster event immediately on server bus.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/events/ClusterEvent.java
+++ b/graylog2-server/src/main/java/org/graylog2/events/ClusterEvent.java
@@ -28,6 +28,7 @@ import org.mongojack.ObjectId;
 
 import javax.annotation.Nullable;
 import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
 import java.util.Collections;
 import java.util.Set;
 
@@ -72,12 +73,19 @@ public abstract class ClusterEvent {
 
     public static ClusterEvent create(@NotEmpty String producer,
                                       @NotEmpty String eventClass,
+                                      @NotNull Set<String> excludedNodeIds,
                                       @NotEmpty Object payload) {
         return create(null,
                 DateTime.now(DateTimeZone.UTC).getMillis(),
                 producer,
-                Collections.<String>emptySet(),
+                excludedNodeIds,
                 eventClass,
                 payload);
+    }
+
+    public static ClusterEvent create(@NotEmpty String producer,
+                                      @NotEmpty String eventClass,
+                                      @NotEmpty Object payload) {
+        return create(producer, eventClass, Collections.emptySet(), payload);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/events/ClusterEventPeriodical.java
+++ b/graylog2-server/src/main/java/org/graylog2/events/ClusterEventPeriodical.java
@@ -180,6 +180,9 @@ public class ClusterEventPeriodical extends Periodical {
 
         try {
             final String id = dbCollection.save(clusterEvent, WriteConcern.JOURNALED).getSavedId();
+            // We are handling a locally generated event, so we can speed up processing by posting it to the local event
+            // bus immediately. Due to having added the local node id to its list of consumers, it will not be picked up
+            // by the db cursor again, avoiding double processing of the event. See #11263 for details.
             serverEventBus.post(event);
             LOG.debug("Published cluster event with ID <{}> and type <{}>", id, className);
         } catch (MongoException e) {

--- a/graylog2-server/src/main/java/org/graylog2/events/ClusterEventPeriodical.java
+++ b/graylog2-server/src/main/java/org/graylog2/events/ClusterEventPeriodical.java
@@ -43,6 +43,8 @@ import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 
+import java.util.Collections;
+
 import static com.google.common.base.Preconditions.checkNotNull;
 
 public class ClusterEventPeriodical extends Periodical {
@@ -174,10 +176,11 @@ public class ClusterEventPeriodical extends Periodical {
         }
 
         final String className = AutoValueUtils.getCanonicalName(event.getClass());
-        final ClusterEvent clusterEvent = ClusterEvent.create(nodeId.toString(), className, event);
+        final ClusterEvent clusterEvent = ClusterEvent.create(nodeId.toString(), className, Collections.singleton(nodeId.toString()), event);
 
         try {
             final String id = dbCollection.save(clusterEvent, WriteConcern.JOURNALED).getSavedId();
+            serverEventBus.post(event);
             LOG.debug("Published cluster event with ID <{}> and type <{}>", id, className);
         } catch (MongoException e) {
             LOG.error("Couldn't publish cluster event of type <" + className + ">", e);


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Prior to this change, an event that is posted to the cluster event bus was written to the unterlying collection and picked up from there in another thread which posts it to the server event bus. This could result in minor, but significant delays between production and consumption of the event.

This change is now doing two things:

  - a locally produced event is pushed to the server event bus immediately
  - the local node id is added to the set of consumers of the event, avoiding double processing of the event

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.