### PR TITLE
Simplify maven caching in GitHub action workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,16 +10,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
-          java-version: 1.8 
-      - name: Set up Maven cache
-        uses: actions/cache@v2
-        with:
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-          path: ~/.m2/repository
+          java-version: 8
+          distribution: adopt-hotspot
+          cache: maven
       - name: Set up Yarn cache
         uses: actions/cache@v2
         with:


### PR DESCRIPTION
The setup-java action now supports caching natively.
See: https://github.blog/changelog/2021-08-30-github-actions-setup-java-now-supports-dependency-caching/