### PR TITLE
Selecting dashboard page specified in URL immediately at load.

### DIFF
--- a/graylog2-web-interface/src/views/logic/views/ViewDeserializer.ts
+++ b/graylog2-web-interface/src/views/logic/views/ViewDeserializer.ts
@@ -22,11 +22,13 @@ import type { SearchJson } from 'views/logic/search/Search';
 import View from './View';
 import type { ViewJson } from './View';
 
-export default function ViewDeserializer(viewResponse: ViewJson): Promise<View> {
+type Query = { page?: string };
+
+export default function ViewDeserializer(viewResponse: ViewJson, query: Query): Promise<View> {
   const view: View = View.fromJSON(viewResponse);
 
   return SearchActions.get(viewResponse.search_id)
     .then((search: SearchJson): Search => Search.fromJSON(search))
     .then((search: Search): View => view.toBuilder().search(search).build())
-    .then((v: View): Promise<View> => ViewActions.load(v).then(() => v));
+    .then((v: View): Promise<View> => ViewActions.load(v, false, query.page).then(() => v));
 }

--- a/graylog2-web-interface/src/views/logic/views/ViewLoader.ts
+++ b/graylog2-web-interface/src/views/logic/views/ViewLoader.ts
@@ -68,7 +68,7 @@ const ViewLoader = (viewId: string,
   onSuccess: OnSuccess = () => {},
   onError: OnError = () => {}) => {
   const promise = ViewManagementActions.get(viewId)
-    .then(ViewDeserializer, (error) => {
+    .then((viewJson) => ViewDeserializer(viewJson, query), (error) => {
       if (error.status === 404) {
         ErrorsActions.report(createFromFetchError(error));
       } else {

--- a/graylog2-web-interface/src/views/pages/ShowViewPage.test.tsx
+++ b/graylog2-web-interface/src/views/pages/ShowViewPage.test.tsx
@@ -144,7 +144,7 @@ describe('ShowViewPage', () => {
 
     render(<SimpleShowViewPage />);
 
-    await waitFor(() => expect(ViewDeserializer).toHaveBeenCalledWith(viewJson));
+    await waitFor(() => expect(ViewDeserializer).toHaveBeenCalledWith(viewJson, {}));
   });
 
   it('calls ViewLoader upon mount', () => {

--- a/graylog2-web-interface/src/views/stores/ViewStore.test.ts
+++ b/graylog2-web-interface/src/views/stores/ViewStore.test.ts
@@ -44,7 +44,15 @@ describe('ViewStore', () => {
     firstQueryId: ViewState.builder().build(),
     secondQueryId: ViewState.builder().build(),
   });
-  const dummyView = View.builder().state(dummyState).build();
+  const dummySearch = Search.builder()
+    .queries([
+      Query.builder().id('firstQueryId').build(),
+      Query.builder().id('secondQueryId').build(),
+    ]).build();
+  const dummyView = View.builder()
+    .state(dummyState)
+    .search(dummySearch)
+    .build();
 
   it('.load should select first query if activeQuery is not set', () => ViewActions.load(dummyView)
     .then((state) => expect(state.activeQuery).toBe('firstQueryId')));

--- a/graylog2-web-interface/src/views/stores/ViewStore.ts
+++ b/graylog2-web-interface/src/views/stores/ViewStore.ts
@@ -69,14 +69,14 @@ export const ViewActions: ViewActionsType = singletonActions(
 
 type ViewStoreType = Store<ViewStoreState>;
 
-const _selectedQuery = (queries: Immutable.List<string>, activeQuery: string, queryId: string) => {
+const _selectedQuery = (queries: QuerySet = Immutable.Set(), activeQuery: string, queryId: string): QueryId => {
   const selectedQuery = queryId ?? activeQuery;
 
-  if (selectedQuery && queries.find((id) => (id === selectedQuery))) {
+  if (selectedQuery && queries.find(({ id }) => (id === selectedQuery))) {
     return selectedQuery;
   }
 
-  return queries.first();
+  return queries.first()?.id;
 };
 
 export const ViewStore: ViewStoreType = singletonStore(
@@ -170,9 +170,9 @@ export const ViewStore: ViewStoreType = singletonStore(
       this.view = view;
       this.dirty = false;
 
-      /* Select query id passed thorugh URL, selected query (activeQuery) or first query in view (for now).
+      /* Select query id passed through URL, selected query (activeQuery) or first query in view (for now).
          Selected query might become a property on the view later. */
-      const queries = view.state.keySeq().toList();
+      const queries = view?.search?.queries;
       const selectedQuery = _selectedQuery(queries, this.activeQuery, queryId);
 
       this.selectQuery(selectedQuery);

--- a/graylog2-web-interface/src/views/stores/ViewStore.ts
+++ b/graylog2-web-interface/src/views/stores/ViewStore.ts
@@ -44,7 +44,7 @@ export type ViewStoreState = {
 
 type ViewActionsType = RefluxActions<{
   create: (type: ViewType, streamId?: string) => Promise<ViewStoreState>,
-  load: (view: View, isNew?: boolean) => Promise<ViewStoreState>,
+  load: (view: View, isNew?: boolean, queryId?: string) => Promise<ViewStoreState>,
   properties: (properties: Properties) => Promise<void>,
   search: (search: Search) => Promise<View>,
   selectQuery: (queryId: string) => Promise<string>,
@@ -68,6 +68,16 @@ export const ViewActions: ViewActionsType = singletonActions(
 );
 
 type ViewStoreType = Store<ViewStoreState>;
+
+const _selectedQuery = (queries: Immutable.List<string>, activeQuery: string, queryId: string) => {
+  const selectedQuery = queryId ?? activeQuery;
+
+  if (selectedQuery && queries.find((id) => (id === selectedQuery))) {
+    return selectedQuery;
+  }
+
+  return queries.first();
+};
 
 export const ViewStore: ViewStoreType = singletonStore(
   'views.View',
@@ -156,15 +166,14 @@ export const ViewStore: ViewStoreType = singletonStore(
 
       return promise;
     },
-    load(view: View, isNew = false): Promise<ViewStoreState> {
+    load(view: View, isNew = false, queryId: string = undefined): Promise<ViewStoreState> {
       this.view = view;
       this.dirty = false;
 
-      /* Select selected query (activeQuery) or first query in view (for now).
+      /* Select query id passed thorugh URL, selected query (activeQuery) or first query in view (for now).
          Selected query might become a property on the view later. */
       const queries = view.state.keySeq().toList();
-      const firstQueryId = view?.search?.queries?.first()?.id ?? queries.first();
-      const selectedQuery = this.activeQuery && queries.find((id) => (id === this.activeQuery)) ? this.activeQuery : firstQueryId;
+      const selectedQuery = _selectedQuery(queries, this.activeQuery, queryId);
 
       this.selectQuery(selectedQuery);
       this.isNew = isNew;


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Prior to this change, when a `page` parameter was part of the url when
loading a dashboard, the sequence was like this:

  - loading the dashboard
  - activating the first page during load
  - parsing the URL
  - activating the page id specified in the URL (if present)

This leads to unwanted visual artifacts, the first page will be shown
shortly before switching to the selected page. To avoid this, this PR is
now passing the query part of the URL to the view loader, which will
activate a specified page id right when loading the dashboard.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.