### PR TITLE
Make all widget positions available.

### DIFF
--- a/graylog2-web-interface/src/views/components/WidgetGrid.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetGrid.tsx
@@ -27,11 +27,12 @@ import WidgetFocusContext, { FocusContextState } from 'views/components/contexts
 import { FieldTypeMappingsList } from 'views/stores/FieldTypesStore';
 import { useStore } from 'stores/connect';
 import { WidgetStore } from 'views/stores/WidgetStore';
-import { CurrentViewStateActions, CurrentViewStateStore } from 'views/stores/CurrentViewStateStore';
+import { CurrentViewStateActions } from 'views/stores/CurrentViewStateStore';
 import FieldTypesContext from 'views/components/contexts/FieldTypesContext';
 import InteractiveContext from 'views/components/contexts/InteractiveContext';
 import { ViewMetadataStore } from 'views/stores/ViewMetadataStore';
 import { StoreState } from 'stores/StoreTypes';
+import { ViewStatesStore } from 'views/stores/ViewStatesStore';
 
 import WidgetContainer from './WidgetContainer';
 import WidgetComponent from './WidgetComponent';
@@ -112,11 +113,11 @@ const generatePositions = (widgets: Array<{ id: string, type: string }>, positio
   .map<[string, WidgetPosition]>(({ id, type }) => [id, positions[id] ?? _defaultDimensions(type)])
   .reduce((prev, [id, position]) => ({ ...prev, [id]: position }), {});
 
-const mapWidgetPositions = ({ state }: StoreState<typeof CurrentViewStateStore>) => state.widgetPositions;
+const mapWidgetPositions = (states: StoreState<typeof ViewStatesStore>) => states.map((state) => state.widgetPositions).reduce((prev, cur) => ({ ...prev, ...cur }), {});
 const mapWidgets = (state: StoreState<typeof WidgetStore>) => state.map(({ id, type }) => ({ id, type })).toArray();
 
 const useWidgetPositions = () => {
-  const initialPositions = useStore(CurrentViewStateStore, mapWidgetPositions);
+  const initialPositions = useStore(ViewStatesStore, mapWidgetPositions);
   const widgets = useStore(WidgetStore, mapWidgets);
 
   return useMemo(() => generatePositions(widgets, initialPositions), [widgets, initialPositions]);

--- a/graylog2-web-interface/src/views/stores/ViewStatesStore.ts
+++ b/graylog2-web-interface/src/views/stores/ViewStatesStore.ts
@@ -18,7 +18,7 @@ import Reflux from 'reflux';
 import * as Immutable from 'immutable';
 import { get, isEqualWith } from 'lodash';
 
-import type { RefluxActions, Store } from 'stores/StoreTypes';
+import type { RefluxActions } from 'stores/StoreTypes';
 import type { QueryId } from 'views/logic/queries/Query';
 import ViewState from 'views/logic/views/ViewState';
 import { singletonActions, singletonStore } from 'views/logic/singleton';
@@ -43,11 +43,10 @@ export const ViewStatesActions: ViewStatesActionsTypes = singletonActions(
 );
 
 export type ViewStatesStoreState = Immutable.Map<string, ViewState>;
-export type ViewStatesStoreType = Store<ViewStatesStoreState>;
 
-export const ViewStatesStore: ViewStatesStoreType = singletonStore(
+export const ViewStatesStore = singletonStore(
   'views.ViewStates',
-  () => Reflux.createStore({
+  () => Reflux.createStore<ViewStatesStoreState>({
     listenables: [ViewStatesActions],
     states: Immutable.Map(),
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This change is a fix to #11244. In this PR, the timeline of widget
positions becoming available during rendering has changed slightly.
Also, widgets where no widget position is available are not rendered
yet. This leads to widget positions changing after selecting a new
dashboard tab, due to widget positions not being available yet for this
tab.

This change is now retrieving all widget positions from all tabs, so
after the initial loading positions should always be available, avoiding
misplacing widgets.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.