### PR TITLE
mvn print version on internal builds with MavenPackager

### DIFF
--- a/graylog2-server/src/test/java/org/graylog/testing/graylognode/MavenPackager.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/graylognode/MavenPackager.java
@@ -32,7 +32,7 @@ import static org.graylog.testing.graylognode.ExecutableFileUtil.makeSureExecuta
 
 public class MavenPackager {
     private static final Logger LOG = LoggerFactory.getLogger(MavenPackager.class);
-    private static final String MVN_COMMAND = "mvn package -DskipTests -Dskip.web.build -Dforbiddenapis.skip=true -Dmaven.javadoc.skip=true";
+    private static final String MVN_COMMAND = "mvn -V package -DskipTests -Dskip.web.build -Dforbiddenapis.skip=true -Dmaven.javadoc.skip=true";
 
     static void packageJarIfNecessary(Path projectDir) {
         if (isRunFromMaven()) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This adds the '-V' command line parameter to the mvn build that's run by the MavenPackager.

## Motivation and Context
 Adding '-V' makes sure that you can find JDK version mismatches more easily while testing e.g. from within IntelliJ IDEA.

## How Has This Been Tested?
Has been tested by running a test from within IDEA and checking the output in the console.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

