### PR TITLE
Always add the GELF HTTP port to the Elastic mapped ports in ITs

### DIFF
--- a/full-backend-tests/src/test/java/org/graylog/elasticsearch/e2e/ElasticsearchE2E.java
+++ b/full-backend-tests/src/test/java/org/graylog/elasticsearch/e2e/ElasticsearchE2E.java
@@ -25,10 +25,9 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.graylog.testing.graylognode.NodeContainerConfig.GELF_HTTP_PORT;
 
 abstract class ElasticsearchE2E {
-
-    static final int GELF_HTTP_PORT = 12201;
 
     private final GraylogBackend sut;
     private final RequestSpecification requestSpec;

--- a/full-backend-tests/src/test/java/org/graylog/elasticsearch/e2e/ElasticsearchE2EES6.java
+++ b/full-backend-tests/src/test/java/org/graylog/elasticsearch/e2e/ElasticsearchE2EES6.java
@@ -23,7 +23,7 @@ import org.graylog.testing.completebackend.GraylogBackend;
 
 import static org.graylog.testing.completebackend.Lifecycle.CLASS;
 
-@ApiIntegrationTest(serverLifecycle = CLASS, extraPorts = {ElasticsearchE2E.GELF_HTTP_PORT}, elasticsearchFactory = ElasticsearchInstanceES6Factory.class)
+@ApiIntegrationTest(serverLifecycle = CLASS, elasticsearchFactory = ElasticsearchInstanceES6Factory.class)
 public class ElasticsearchE2EES6 extends ElasticsearchE2E {
     public ElasticsearchE2EES6(GraylogBackend sut, RequestSpecification requestSpec) {
         super(sut, requestSpec);

--- a/full-backend-tests/src/test/java/org/graylog/elasticsearch/e2e/ElasticsearchE2EES7.java
+++ b/full-backend-tests/src/test/java/org/graylog/elasticsearch/e2e/ElasticsearchE2EES7.java
@@ -23,7 +23,7 @@ import org.graylog.testing.completebackend.GraylogBackend;
 
 import static org.graylog.testing.completebackend.Lifecycle.CLASS;
 
-@ApiIntegrationTest(serverLifecycle = CLASS, extraPorts = {ElasticsearchE2E.GELF_HTTP_PORT}, elasticsearchFactory = ElasticsearchInstanceES7Factory.class)
+@ApiIntegrationTest(serverLifecycle = CLASS, elasticsearchFactory = ElasticsearchInstanceES7Factory.class)
 public class ElasticsearchE2EES7 extends ElasticsearchE2E {
     public ElasticsearchE2EES7(GraylogBackend sut, RequestSpecification requestSpec) {
         super(sut, requestSpec);

--- a/graylog2-server/src/test/java/org/graylog/testing/graylognode/NodeContainerConfig.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/graylognode/NodeContainerConfig.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 public class NodeContainerConfig {
 
     static final int API_PORT = 9000;
+    public static final int GELF_HTTP_PORT = 12201;
     static final int DEBUG_PORT = 5005;
 
     public final Network network;
@@ -54,7 +55,8 @@ public class NodeContainerConfig {
     }
 
     public Integer[] portsToExpose() {
-        int[] allPorts = ArrayUtils.add(extraPorts, 0, API_PORT);
+        int[] allPorts = ArrayUtils.add(extraPorts, 0, GELF_HTTP_PORT);
+        allPorts = ArrayUtils.add(allPorts, 0, API_PORT);
 
         if (enableDebugging) {
             allPorts = ArrayUtils.add(allPorts, 0, DEBUG_PORT);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Always add the GELF HTTP port to the Elastic container config in Integration Tests.

## Motivation and Context
The current integration tests suffer from incorrect caching of container instances. Changing this problem is generally addressed with #11011 - but for a simple workaround right now, the GELF port is always added to the config.

## How Has This Been Tested?
Tests that failed are now green.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

