### PR TITLE
Self-managed index templates

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/IndexMappingFactory.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/IndexMappingFactory.java
@@ -42,6 +42,7 @@ public class IndexMappingFactory {
             case MESSAGES: return indexMappingFor(elasticsearchVersion);
             case EVENTS: return eventsIndexMappingFor(elasticsearchVersion);
             case GIM_V1: return gimMappingFor(elasticsearchVersion);
+            case MESSAGES_SELF_MANAGED: return NullIndexMappingTemplate.INSTANCE;
             case FAILURES: return failureIndexMappingFactory.map(f -> f.failureIndexMappingFor(elasticsearchVersion))
                     .orElseThrow(() -> new IllegalStateException("No `FailureIndexMappingFactory` implementation provided!"));
             default: throw new IllegalStateException("Invalid index template type: " + templateType);

--- a/graylog2-server/src/main/java/org/graylog2/indexer/NullIndexMappingTemplate.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/NullIndexMappingTemplate.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.indexer;
+
+import com.google.common.collect.ImmutableMap;
+import org.graylog2.indexer.indexset.IndexSetConfig;
+
+import java.util.Map;
+
+public class NullIndexMappingTemplate implements IndexMappingTemplate {
+
+    public static final IndexMappingTemplate INSTANCE = new NullIndexMappingTemplate();
+
+    @Override
+    public Map<String, Object> toTemplate(IndexSetConfig indexSetConfig, String indexPattern, int order) {
+        return ImmutableMap.of();
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/indexer/indexset/IndexSetConfig.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indexset/IndexSetConfig.java
@@ -54,7 +54,8 @@ public abstract class IndexSetConfig implements Comparable<IndexSetConfig> {
 
     private static final Duration DEFAULT_FIELD_TYPE_REFRESH_INTERVAL = Duration.standardSeconds(5L);
     public static final TemplateType DEFAULT_INDEX_TEMPLATE_TYPE = TemplateType.MESSAGES;
-    public static final ImmutableSet<TemplateType> REGULAR_INDEX_TYPES = ImmutableSet.of(TemplateType.MESSAGES);
+    public static final ImmutableSet<TemplateType> REGULAR_INDEX_TYPES = ImmutableSet.of(TemplateType.MESSAGES,
+            TemplateType.MESSAGES_SELF_MANAGED);
 
     public static boolean isRegularIndex(@Nullable TemplateType templateType, boolean isWritable) {
         TemplateType type = templateType == null ? DEFAULT_INDEX_TEMPLATE_TYPE : templateType;
@@ -75,6 +76,13 @@ public abstract class IndexSetConfig implements Comparable<IndexSetConfig> {
         GIM_V1,
         @JsonProperty("failures")
         FAILURES,
+        /**
+         * This template type was introduced to indicate
+         * regular indices whose index templates are managed outside
+         * of the index set framework
+         */
+        @JsonProperty("messages_self_managed")
+        MESSAGES_SELF_MANAGED,
     }
 
     @JsonProperty("id")
@@ -156,6 +164,14 @@ public abstract class IndexSetConfig implements Comparable<IndexSetConfig> {
 
     @JsonProperty("field_type_refresh_interval")
     public abstract Duration fieldTypeRefreshInterval();
+
+    /**
+     * Returns true if the index template is not managed
+     * by the index set framework
+     */
+    public boolean hasSelfManagedIndexTemplateType() {
+        return indexTemplateType().map(itt -> itt == TemplateType.MESSAGES_SELF_MANAGED).orElse(false);
+    }
 
     @JsonCreator
     public static IndexSetConfig create(@Id @ObjectId @JsonProperty("_id") @Nullable String id,

--- a/graylog2-server/src/test/java/org/graylog2/indexer/indexset/IndexSetConfigTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/indexset/IndexSetConfigTest.java
@@ -20,7 +20,9 @@ import org.graylog2.indexer.retention.strategies.NoopRetentionStrategy;
 import org.graylog2.indexer.retention.strategies.NoopRetentionStrategyConfig;
 import org.graylog2.indexer.rotation.strategies.MessageCountRotationStrategy;
 import org.graylog2.indexer.rotation.strategies.MessageCountRotationStrategyConfig;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
@@ -119,5 +121,58 @@ public class IndexSetConfigTest {
 
         // A template type value of "null" should result in an empty template type
         assertThat(config4.indexTemplateType()).isNotPresent();
+    }
+
+    @Test
+    public void hasSelfManagedIndexTemplateType_returnsTrue_ifIndexTemplateTypeIs_MESSAGES_SELF_MANAGED() {
+        final IndexSetConfig config = IndexSetConfig.builder()
+                .isWritable(true)
+                .title("Test 1")
+                .description("A test index-set.")
+                .indexPrefix("graylog1")
+                .indexWildcard("graylog1_*")
+                .rotationStrategy(MessageCountRotationStrategyConfig.create(Integer.MAX_VALUE))
+                .rotationStrategyClass(MessageCountRotationStrategy.class.getCanonicalName())
+                .retentionStrategy(NoopRetentionStrategyConfig.create(Integer.MAX_VALUE))
+                .retentionStrategyClass(NoopRetentionStrategy.class.getCanonicalName())
+                .shards(4)
+                .replicas(0)
+                .creationDate(ZonedDateTime.now(ZoneOffset.UTC))
+                .indexTemplateName("graylog1-template")
+                .indexTemplateType(IndexSetConfig.TemplateType.MESSAGES_SELF_MANAGED)
+                .indexAnalyzer("standard")
+                .indexOptimizationMaxNumSegments(1)
+                .indexOptimizationDisabled(false)
+                .build();
+
+        assertThat(config.hasSelfManagedIndexTemplateType()).isTrue();
+    }
+
+    @ParameterizedTest
+    @EnumSource(mode = EnumSource.Mode.EXCLUDE, names = {"MESSAGES_SELF_MANAGED"})
+    public void hasSelfManagedIndexTemplateType_returnsFalse_ifIndexTemplateTypeIsNOT_MESSAGES_SELF_MANAGED(
+            IndexSetConfig.TemplateType templateType) {
+
+        final IndexSetConfig config = IndexSetConfig.builder()
+                .isWritable(true)
+                .title("Test 1")
+                .description("A test index-set.")
+                .indexPrefix("graylog1")
+                .indexWildcard("graylog1_*")
+                .rotationStrategy(MessageCountRotationStrategyConfig.create(Integer.MAX_VALUE))
+                .rotationStrategyClass(MessageCountRotationStrategy.class.getCanonicalName())
+                .retentionStrategy(NoopRetentionStrategyConfig.create(Integer.MAX_VALUE))
+                .retentionStrategyClass(NoopRetentionStrategy.class.getCanonicalName())
+                .shards(4)
+                .replicas(0)
+                .creationDate(ZonedDateTime.now(ZoneOffset.UTC))
+                .indexTemplateName("graylog1-template")
+                .indexTemplateType(templateType)
+                .indexAnalyzer("standard")
+                .indexOptimizationMaxNumSegments(1)
+                .indexOptimizationDisabled(false)
+                .build();
+
+        assertThat(config.hasSelfManagedIndexTemplateType()).isFalse();
     }
 }


### PR DESCRIPTION
In some scenarios we would like to take over the responsibility of the 
index template lifecycle management due to specifics of particular
features. For instance, it's applicable when one wants the same
index template to be employed by multiple index sets.

This commit Introduces a new index template type to tell the index set 
framework that the index template lifecycle is manually managed 
by the calling side.
