### PR TITLE
Rerender widget when compressing or stretching widget width.

### DIFF
--- a/graylog2-web-interface/src/views/components/WidgetGrid.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetGrid.tsx
@@ -199,9 +199,10 @@ const WidgetGrid = () => {
     }
 
     const gridCoordinates = mapPosition(widgetId, position);
+    const coordinatesIdentifier = JSON.stringify(gridCoordinates);
 
     return (
-      <WidgetContainer key={widgetId} data-grid={gridCoordinates} isFocused={focusedWidget?.id === widgetId && focusedWidget?.focusing}>
+      <WidgetContainer key={`${widgetId}-${coordinatesIdentifier}`} data-grid={gridCoordinates} isFocused={focusedWidget?.id === widgetId && focusedWidget?.focusing}>
         <WidgetGridItem fields={fields}
                         positions={positions}
                         widgetId={widgetId}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

With https://github.com/Graylog2/graylog2-server/pull/11244 we changed the way we are defining the search widget grid layout. Before this change we provided a layout prop for the grid component, now we are defining the dimensions for each widget, using the `data-grid` attribute.

While this works well in general the layout is now no longer updating when we update the layout from outside by changing the `data-grid` values.

With this PR we are fixing the described problem, by including the widget dimensions in the widget `key`. This is only a temporary fix.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

