### PR TITLE
Trigger cleanup of containers and networks after all IT tests finished

### DIFF
--- a/graylog2-server/src/test/java/org/graylog/testing/completebackend/GraylogBackend.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/completebackend/GraylogBackend.java
@@ -83,8 +83,14 @@ public class GraylogBackend {
                     elasticsearchInstanceFactory.version(),
                     extraPorts,
                     pluginJars, mavenProjectDir);
+            final GraylogBackend backend = new GraylogBackend(network, esInstance, mongoDB, node);
 
-            return new GraylogBackend(network, esInstance, mongoDB, node);
+            // ensure that all containers and networks will be removed after all tests finish
+            // We can't close the resources in an afterAll callback, as the instances are cached and reused
+            // so we need a solution that will be triggered only once after all test classes
+            Runtime.getRuntime().addShutdownHook(new Thread(backend::close));
+
+            return backend;
         } catch (InterruptedException | ExecutionException e) {
             LOG.error("Container creation aborted", e);
             throw new RuntimeException(e);
@@ -134,5 +140,12 @@ public class GraylogBackend {
 
     public Network network() {
         return this.network;
+    }
+
+    public void close() {
+        node.close();
+        mongodb.close();
+        es.close();
+        network.close();
     }
 }

--- a/graylog2-server/src/test/java/org/graylog/testing/elasticsearch/ElasticsearchInstance.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/elasticsearch/ElasticsearchInstance.java
@@ -24,6 +24,7 @@ import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
 import org.testcontainers.utility.DockerImageName;
 
+import java.io.Closeable;
 import java.net.URL;
 import java.nio.file.Paths;
 import java.util.HashMap;
@@ -35,7 +36,7 @@ import static java.util.Objects.isNull;
 /**
  * This rule starts an Elasticsearch instance and provides a configured {@link Client}.
  */
-public abstract class ElasticsearchInstance extends ExternalResource {
+public abstract class ElasticsearchInstance extends ExternalResource implements Closeable {
     private static final Map<Version, ElasticsearchContainer> containersByVersion = new HashMap<>();
 
     private static final String DEFAULT_IMAGE_OSS = "docker.elastic.co/elasticsearch/elasticsearch-oss";
@@ -111,5 +112,10 @@ public abstract class ElasticsearchInstance extends ExternalResource {
 
         // Make sure the data we just imported is visible
         client().refreshNode();
+    }
+
+    @Override
+    public void close() {
+        container.stop();
     }
 }

--- a/graylog2-server/src/test/java/org/graylog/testing/graylognode/NodeInstance.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/graylognode/NodeInstance.java
@@ -22,6 +22,7 @@ import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 
+import java.io.Closeable;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Locale;
@@ -29,7 +30,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.graylog.testing.graylognode.NodeContainerConfig.API_PORT;
 
-public class NodeInstance {
+public class NodeInstance implements Closeable {
 
     private static final Logger LOG = LoggerFactory.getLogger(NodeInstance.class);
 
@@ -68,5 +69,10 @@ public class NodeInstance {
 
     public void printLog() {
         System.out.println(container.getLogs());
+    }
+
+    @Override
+    public void close() {
+        container.stop();
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This change ensures that all testcontainers and created networks get removed after all the test finish

## Description
Register a shutdown hook that closes or started resources

## Motivation and Context
Without this change, after each test-suite run there remain a docker network and an elastic container running. With repeated suite runs it consumes all RAM of the machine and crashes.

## How Has This Been Tested?
Run the integration tests several times (may be from your IDE) and observe outputs of following commands:

```
watch docker ps
watch docker network ls
```

Before the change, you should be able to see that both running containers and networks accumulate with each run and are not stopped. After the change you shouldn't see any new networks and no running elastic containers.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/4102775/133210775-7cbaf61f-8e39-4156-87a0-669a658afece.png)

This is the state after 4 successful test-suite runs, you can see 4 elastic containers running and 4 networks created and not removed.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

