### PR TITLE
Unify widget loading indicator.

### DIFF
--- a/graylog2-web-interface/src/views/components/widgets/LoadingWidget.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/LoadingWidget.tsx
@@ -15,15 +15,21 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
+import styled from 'styled-components';
 
-import { Icon } from 'components/common';
+import Spinner from 'components/common/Spinner';
 
-import styles from './MessageWidgets.css';
+const Container = styled.div`
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
 
 const LoadingWidget = () => (
-  <div className={styles.spinnerContainer}>
-    <Icon data-testid="loading-widget" name="sync" size="3x" className="spinner" />
-  </div>
+  <Container>
+    <Spinner data-testid="loading-widget" />
+  </Container>
 );
 
 LoadingWidget.propTypes = {};

--- a/graylog2-web-interface/src/views/components/widgets/MessageWidgets.css
+++ b/graylog2-web-interface/src/views/components/widgets/MessageWidgets.css
@@ -1,10 +1,3 @@
-:local(.spinnerContainer) {
-    height: 100%;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-}
-
 :local(.iconMargin) {
     margin-right: 15px;
     margin: 3px 15px 0 0;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

With https://github.com/Graylog2/graylog2-server/pull/11244 we are now rendering the search page widgets while we are executing the search for the first time after loading the page. Previously we were not rendering the widgets and just displaying one loading spinner. We are now displaying a loading indicator for each widget, while we are executing the search initially:
![image](https://user-images.githubusercontent.com/46300478/133267813-1eb47958-f9d5-43ed-aee1-3aa605cb33ca.png)

With this PR we are unifying the loading indicator:
![image](https://user-images.githubusercontent.com/46300478/133268532-a686d1d9-9c70-4dfb-8a39-1b7f7f92f452.png)

Since the previous one was not animated and differed from our default indicator, it could create the wrong impression that the search execution was not successful and it is necessary to re-execute the search.

I tired different versions for example with the text "Updating search results...", but this simple version seems to be the best one.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

