### PR TITLE
Passing positions to grid again, instead of through widgets.

### DIFF
--- a/graylog2-web-interface/src/views/components/WidgetGrid.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetGrid.tsx
@@ -116,7 +116,7 @@ const generatePositions = (widgets: Array<{ id: string, type: string }>, positio
 const mapWidgetPositions = (states: StoreState<typeof ViewStatesStore>) => states.map((state) => state.widgetPositions).reduce((prev, cur) => ({ ...prev, ...cur }), {});
 const mapWidgets = (state: StoreState<typeof WidgetStore>) => state.map(({ id, type }) => ({ id, type })).toArray();
 
-const useWidgetPositions = () => {
+const useWidgetPositions = (): WidgetPositions => {
   const initialPositions = useStore(ViewStatesStore, mapWidgetPositions);
   const widgets = useStore(WidgetStore, mapWidgets);
 
@@ -127,9 +127,10 @@ type GridProps = {
   children: React.ReactNode,
   locked: boolean,
   onPositionsChange: (newPositions: Array<BackendWidgetPosition>) => void,
+  positions: WidgetPositions,
 };
 
-const Grid = ({ children, locked, onPositionsChange }: GridProps) => {
+const Grid = ({ children, locked, onPositionsChange, positions }: GridProps) => {
   const { focusedWidget } = useContext(WidgetFocusContext);
 
   return (
@@ -139,6 +140,7 @@ const Grid = ({ children, locked, onPositionsChange }: GridProps) => {
                                   columns={COLUMNS}
                                   isResizable={!focusedWidget?.id}
                                   locked={locked}
+                                  positions={positions}
                                   measureBeforeMount
                                   onPositionsChange={onPositionsChange}
                                   width={width}
@@ -172,14 +174,6 @@ const onPositionsChange = (newPositions: Array<BackendWidgetPosition>) => {
   CurrentViewStateActions.widgetPositions(widgetPositions);
 };
 
-const mapPosition = (id, { col, row, height, width }) => ({
-  i: id,
-  x: col ? Math.max(col - 1, 0) : 0,
-  y: (row === undefined || row <= 0 ? Infinity : row - 1),
-  h: height || 1,
-  w: width || 1,
-});
-
 const WidgetGrid = () => {
   const isInteractive = useContext(InteractiveContext);
   const { focusedWidget } = useContext(WidgetFocusContext);
@@ -198,10 +192,8 @@ const WidgetGrid = () => {
       return null;
     }
 
-    const gridCoordinates = mapPosition(widgetId, position);
-
     return (
-      <WidgetContainer key={widgetId} data-grid={gridCoordinates} isFocused={focusedWidget?.id === widgetId && focusedWidget?.focusing}>
+      <WidgetContainer key={widgetId} isFocused={focusedWidget?.id === widgetId && focusedWidget?.focusing}>
         <WidgetGridItem fields={fields}
                         positions={positions}
                         widgetId={widgetId}
@@ -218,6 +210,7 @@ const WidgetGrid = () => {
   return (
     <DashboardWrap>
       <Grid locked={!isInteractive}
+            positions={positions}
             onPositionsChange={onPositionsChange}>
         {children}
       </Grid>


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This change is effectively reverting a small change performed in #11244, which changed our way of using `react-grid-layout` by passing widget coordinates through widget props instead of a global positions object.

Unfortunately, the `getDerivedStateFromProps` method in the `ReactGridLayout` component does not take the content of the `children` props into account when determining if a new layout needs to be calculated, just the children's keys. This leads to the fact that we cannot update widget positions "from the outside" when passing coordinates through children props.

Therefore, this change is using a global positions map again, making sure that it's aligned with the current state of widgets by retrieving it in one central point in the code.

<!--- Provide a general summary of your changes in the Title above -->
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.