### PR TITLE
Make calculation fields of TrafficCounterCalculator volatile

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/periodical/TrafficCounterCalculator.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/TrafficCounterCalculator.java
@@ -35,9 +35,9 @@ public class TrafficCounterCalculator extends Periodical {
     private final NodeId nodeId;
     private final TrafficCounterService trafficService;
     private final MetricRegistry metricRegistry;
-    private long previousInputBytes = 0L;
-    private long previousOutputBytes = 0L;
-    private long previousDecodedBytes = 0L;
+    private volatile long previousInputBytes = 0L;
+    private volatile long previousOutputBytes = 0L;
+    private volatile long previousDecodedBytes = 0L;
     private Counter inputCounter;
     private Counter outputCounter;
     private Counter decodedCounter;


### PR DESCRIPTION
Fixes #11248

(cherry picked from commit abda5498aef442a75b7916a10376e40796c0ba3e)