### PR TITLE
Backend validation of search query time range limit #9487

### DIFF
--- a/full-backend-tests/src/test/java/org/graylog/plugins/views/TimeLimitIT.java
+++ b/full-backend-tests/src/test/java/org/graylog/plugins/views/TimeLimitIT.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.views;
+
+import io.restassured.response.ValidatableResponse;
+import io.restassured.specification.RequestSpecification;
+import org.graylog.storage.elasticsearch7.ElasticsearchInstanceES7Factory;
+import org.graylog.testing.completebackend.ApiIntegrationTest;
+import org.graylog.testing.completebackend.GraylogBackend;
+import org.graylog.testing.utils.GelfInputUtils;
+import org.graylog.testing.utils.SearchUtils;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.graylog.testing.completebackend.Lifecycle.CLASS;
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.core.IsEqual.equalTo;
+
+@ApiIntegrationTest(serverLifecycle = CLASS, elasticsearchFactory = ElasticsearchInstanceES7Factory.class, extraPorts = {TimeLimitIT.GELF_HTTP_PORT})
+public class TimeLimitIT {
+
+    static final int GELF_HTTP_PORT = 12201;
+
+    private final GraylogBackend sut;
+    private final RequestSpecification requestSpec;
+
+    public TimeLimitIT(GraylogBackend sut, RequestSpecification requestSpec) {
+        this.sut = sut;
+        this.requestSpec = requestSpec;
+    }
+
+    @Test
+    void testQueryTimeRangeLimit() {
+        given()
+                .spec(requestSpec)
+                .when()
+                .body(getClass().getClassLoader().getResourceAsStream("org/graylog/plugins/views/cluster-search-config.json"))
+                .put("/system/cluster_config/org.graylog2.indexer.searches.SearchesClusterConfig")
+                .then()
+                .statusCode(202)
+                .body("query_time_range_limit", equalTo("PT2M"));
+
+        final String body = given()
+                .spec(requestSpec)
+                .when()
+                .body(getClass().getClassLoader().getResourceAsStream("org/graylog/plugins/views/minimalistic-request.json"))
+                .post("/views/search/sync")
+                .then()
+                .statusCode(200)
+                .assertThat().body("execution.completed_exceptionally", equalTo(true))
+                .extract()
+                .body().asString();
+        assertThat(body).contains("Search out of allowed time range limit");
+    }
+}

--- a/full-backend-tests/src/test/java/org/graylog/plugins/views/TimeLimitIT.java
+++ b/full-backend-tests/src/test/java/org/graylog/plugins/views/TimeLimitIT.java
@@ -21,16 +21,12 @@ import io.restassured.specification.RequestSpecification;
 import org.graylog.storage.elasticsearch7.ElasticsearchInstanceES7Factory;
 import org.graylog.testing.completebackend.ApiIntegrationTest;
 import org.graylog.testing.completebackend.GraylogBackend;
-import org.graylog.testing.utils.GelfInputUtils;
-import org.graylog.testing.utils.SearchUtils;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-
-import java.util.List;
 
 import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.graylog.testing.completebackend.Lifecycle.CLASS;
-import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.core.IsEqual.equalTo;
 
 @ApiIntegrationTest(serverLifecycle = CLASS, elasticsearchFactory = ElasticsearchInstanceES7Factory.class, extraPorts = {TimeLimitIT.GELF_HTTP_PORT})
@@ -44,6 +40,17 @@ public class TimeLimitIT {
     public TimeLimitIT(GraylogBackend sut, RequestSpecification requestSpec) {
         this.sut = sut;
         this.requestSpec = requestSpec;
+    }
+
+    @AfterEach
+    public void resetConfig() {
+        final ValidatableResponse response = given()
+                .spec(requestSpec)
+                .when()
+                .body(getClass().getClassLoader().getResourceAsStream("org/graylog/plugins/views/cluster-search-config-reset.json"))
+                .put("/system/cluster_config/org.graylog2.indexer.searches.SearchesClusterConfig")
+                .then()
+                .statusCode(202);
     }
 
     @Test

--- a/full-backend-tests/src/test/java/org/graylog/testing/backenddriver/SearchDriver.java
+++ b/full-backend-tests/src/test/java/org/graylog/testing/backenddriver/SearchDriver.java
@@ -17,6 +17,7 @@
 package org.graylog.testing.backenddriver;
 
 import com.google.common.collect.ImmutableSet;
+import io.restassured.path.json.JsonPath;
 import io.restassured.specification.RequestSpecification;
 import org.bson.types.ObjectId;
 import org.graylog.plugins.views.search.Query;
@@ -26,6 +27,8 @@ import org.graylog.plugins.views.search.searchtypes.MessageList;
 import org.graylog.testing.utils.JsonUtils;
 import org.graylog.testing.utils.RangeUtils;
 import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.List;
 
@@ -41,6 +44,8 @@ import static io.restassured.RestAssured.given;
  */
 public class SearchDriver {
 
+    private static final Logger LOG = LoggerFactory.getLogger(SearchDriver.class);
+
     /**
      * @param requestSpec @see io.restassured.specification.RequestSpecification
      * @return all messages' "message" field as List<String>
@@ -55,15 +60,21 @@ public class SearchDriver {
 
         String body = allMessagesJson(queryId, messageListId, timeRange);
 
-        return given()
+        final JsonPath response = given()
                 .spec(requestSpec)
                 .when()
                 .body(body)
                 .post("/views/search/sync")
                 .then()
                 .statusCode(200)
-                .extract()
-                .jsonPath().getList(allMessagesJsonPath(queryId, messageListId), String.class);
+                .extract().body().jsonPath();
+
+        if(response.get("execution.completed_exceptionally")) {
+            final Object errors = response.getString("errors");
+            LOG.warn("Failed to obtain messages: {}", errors);
+        }
+
+        return response.getList(allMessagesJsonPath(queryId, messageListId), String.class);
     }
 
     private static String allMessagesJson(String queryId, String messageListId, TimeRange timeRange) {

--- a/full-backend-tests/src/test/resources/org/graylog/plugins/views/cluster-search-config-reset.json
+++ b/full-backend-tests/src/test/resources/org/graylog/plugins/views/cluster-search-config-reset.json
@@ -1,0 +1,36 @@
+{
+  "query_time_range_limit": "PT0S",
+  "relative_timerange_options": {
+    "PT5M": "5 minutes",
+    "PT15M": "15 minutes",
+    "PT30M": "30 minutes",
+    "PT1H": "1 hour",
+    "PT2H": "2 hours",
+    "PT8H": "8 hours",
+    "P1D": "1 day",
+    "P2D": "2 days",
+    "P5D": "5 days",
+    "P7D": "7 days",
+    "P14D": "14 days",
+    "P30D": "30 days",
+    "PT0S": "all messages"
+  },
+  "surrounding_timerange_options": {
+    "PT1S": "1 second",
+    "PT5S": "5 seconds",
+    "PT10S": "10 seconds",
+    "PT30S": "30 seconds",
+    "PT1M": "1 minute",
+    "PT5M": "5 minutes"
+  },
+  "surrounding_filter_fields": [
+    "file",
+    "source",
+    "gl2_source_input",
+    "source_file"
+  ],
+  "analysis_disabled_fields": [
+    "full_message",
+    "message"
+  ]
+}

--- a/full-backend-tests/src/test/resources/org/graylog/plugins/views/cluster-search-config.json
+++ b/full-backend-tests/src/test/resources/org/graylog/plugins/views/cluster-search-config.json
@@ -1,0 +1,36 @@
+{
+  "query_time_range_limit": "PT2M",
+  "relative_timerange_options": {
+    "PT5M": "5 minutes",
+    "PT15M": "15 minutes",
+    "PT30M": "30 minutes",
+    "PT1H": "1 hour",
+    "PT2H": "2 hours",
+    "PT8H": "8 hours",
+    "P1D": "1 day",
+    "P2D": "2 days",
+    "P5D": "5 days",
+    "P7D": "7 days",
+    "P14D": "14 days",
+    "P30D": "30 days",
+    "PT0S": "all messages"
+  },
+  "surrounding_timerange_options": {
+    "PT1S": "1 second",
+    "PT5S": "5 seconds",
+    "PT10S": "10 seconds",
+    "PT30S": "30 seconds",
+    "PT1M": "1 minute",
+    "PT5M": "5 minutes"
+  },
+  "surrounding_filter_fields": [
+    "file",
+    "source",
+    "gl2_source_input",
+    "source_file"
+  ],
+  "analysis_disabled_fields": [
+    "full_message",
+    "message"
+  ]
+}

--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/views/ElasticsearchBackend.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/views/ElasticsearchBackend.java
@@ -32,6 +32,7 @@ import org.graylog.plugins.views.search.elasticsearch.ElasticsearchQueryString;
 import org.graylog.plugins.views.search.elasticsearch.IndexLookup;
 import org.graylog.plugins.views.search.elasticsearch.QueryStringDecorators;
 import org.graylog.plugins.views.search.engine.QueryBackend;
+import org.graylog.plugins.views.search.engine.SearchConfig;
 import org.graylog.plugins.views.search.errors.SearchTypeError;
 import org.graylog.plugins.views.search.errors.SearchTypeErrorParser;
 import org.graylog.plugins.views.search.filter.AndFilter;
@@ -100,10 +101,10 @@ public class ElasticsearchBackend implements QueryBackend<ESGeneratedQueryContex
     }
 
     @Override
-    public ESGeneratedQueryContext generate(SearchJob job, Query query, Set<QueryResult> results, SearchesClusterConfig searchesClusterConfig) {
+    public ESGeneratedQueryContext generate(SearchJob job, Query query, Set<QueryResult> results, SearchConfig searchConfig) {
         final ElasticsearchQueryString backendQuery = (ElasticsearchQueryString) query.query();
 
-        validateQueryTimeRange(query, searchesClusterConfig);
+        validateQueryTimeRange(query, searchConfig);
 
         final Set<SearchType> searchTypes = query.searchTypes();
 
@@ -125,7 +126,7 @@ public class ElasticsearchBackend implements QueryBackend<ESGeneratedQueryContex
         final ESGeneratedQueryContext queryContext = queryContextFactory.create(this, searchSourceBuilder, job, query, results);
         for (SearchType searchType : searchTypes) {
 
-            final Optional<SearchTypeError> searchTypeError = validateSearchType(query, searchType, searchesClusterConfig);
+            final Optional<SearchTypeError> searchTypeError = validateSearchType(query, searchType, searchConfig);
             if(searchTypeError.isPresent()) {
                 LOG.error("Invalid search type {} for elasticsearch backend, cannot generate query part. Skipping this search type.", searchType.type());
                 queryContext.addError(searchTypeError.get());

--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/views/ElasticsearchBackend.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/views/ElasticsearchBackend.java
@@ -125,10 +125,10 @@ public class ElasticsearchBackend implements QueryBackend<ESGeneratedQueryContex
         final ESGeneratedQueryContext queryContext = queryContextFactory.create(this, searchSourceBuilder, job, query, results);
         for (SearchType searchType : searchTypes) {
 
-            final SearchTypeError searchTypeError = validateSearchType(query, searchType, searchesClusterConfig);
-            if(searchTypeError != null) {
+            final Optional<SearchTypeError> searchTypeError = validateSearchType(query, searchType, searchesClusterConfig);
+            if(searchTypeError.isPresent()) {
                 LOG.error("Invalid search type {} for elasticsearch backend, cannot generate query part. Skipping this search type.", searchType.type());
-                queryContext.addError(searchTypeError);
+                queryContext.addError(searchTypeError.get());
                 continue;
             }
 

--- a/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/views/ElasticsearchBackendMultiSearchTest.java
+++ b/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/views/ElasticsearchBackendMultiSearchTest.java
@@ -22,12 +22,14 @@ import org.graylog.plugins.views.search.QueryResult;
 import org.graylog.plugins.views.search.SearchJob;
 import org.graylog.plugins.views.search.SearchType;
 import org.graylog.plugins.views.search.elasticsearch.ElasticsearchQueryString;
+import org.graylog.plugins.views.search.engine.SearchConfig;
 import org.graylog.plugins.views.search.errors.SearchTypeError;
 import org.graylog.plugins.views.search.searchtypes.pivot.Pivot;
 import org.graylog.plugins.views.search.searchtypes.pivot.PivotResult;
 import org.graylog.plugins.views.search.searchtypes.pivot.series.Average;
 import org.graylog.plugins.views.search.searchtypes.pivot.series.Max;
 import org.graylog2.indexer.searches.SearchesClusterConfig;
+import org.joda.time.Period;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -81,7 +83,7 @@ public class ElasticsearchBackendMultiSearchTest extends ElasticsearchBackendGen
 
     @Test
     public void everySearchTypeGeneratesASearchSourceBuilder() {
-        final ESGeneratedQueryContext queryContext = this.elasticsearchBackend.generate(searchJob, query, Collections.emptySet(), mock(SearchesClusterConfig.class));
+        final ESGeneratedQueryContext queryContext = this.elasticsearchBackend.generate(searchJob, query, Collections.emptySet(), new SearchConfig(Period.ZERO));
 
         assertThat(queryContext.searchTypeQueries())
                 .hasSize(2)
@@ -90,7 +92,7 @@ public class ElasticsearchBackendMultiSearchTest extends ElasticsearchBackendGen
 
     @Test
     public void everySearchTypeGeneratesOneESQuery() throws Exception {
-        final ESGeneratedQueryContext queryContext = this.elasticsearchBackend.generate(searchJob, query, Collections.emptySet(), mock(SearchesClusterConfig.class));
+        final ESGeneratedQueryContext queryContext = this.elasticsearchBackend.generate(searchJob, query, Collections.emptySet(), new SearchConfig(Period.ZERO));
         when(jestClient.execute(any(), any())).thenReturn(resultFor(resourceFile("successfulMultiSearchResponse.json")));
 
         final String generatedRequest = run(searchJob, query, queryContext, Collections.emptySet());
@@ -100,7 +102,7 @@ public class ElasticsearchBackendMultiSearchTest extends ElasticsearchBackendGen
 
     @Test
     public void multiSearchResultsAreAssignedToSearchTypes() throws Exception {
-        final ESGeneratedQueryContext queryContext = this.elasticsearchBackend.generate(searchJob, query, Collections.emptySet(), mock(SearchesClusterConfig.class));
+        final ESGeneratedQueryContext queryContext = this.elasticsearchBackend.generate(searchJob, query, Collections.emptySet(), new SearchConfig(Period.ZERO));
 
         when(jestClient.execute(any(), any())).thenReturn(resultFor(resourceFile("successfulMultiSearchResponse.json")));
 
@@ -125,7 +127,7 @@ public class ElasticsearchBackendMultiSearchTest extends ElasticsearchBackendGen
 
     @Test
     public void oneFailingSearchTypeReturnsPartialResults() throws Exception {
-        final ESGeneratedQueryContext queryContext = this.elasticsearchBackend.generate(searchJob, query, Collections.emptySet(), mock(SearchesClusterConfig.class));
+        final ESGeneratedQueryContext queryContext = this.elasticsearchBackend.generate(searchJob, query, Collections.emptySet(), new SearchConfig(Period.ZERO));
 
         when(jestClient.execute(any(), any())).thenReturn(resultFor(resourceFile("partiallySuccessfulMultiSearchResponse.json")));
 

--- a/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/views/ElasticsearchBackendMultiSearchTest.java
+++ b/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/views/ElasticsearchBackendMultiSearchTest.java
@@ -27,6 +27,7 @@ import org.graylog.plugins.views.search.searchtypes.pivot.Pivot;
 import org.graylog.plugins.views.search.searchtypes.pivot.PivotResult;
 import org.graylog.plugins.views.search.searchtypes.pivot.series.Average;
 import org.graylog.plugins.views.search.searchtypes.pivot.series.Max;
+import org.graylog2.indexer.searches.SearchesClusterConfig;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -40,6 +41,7 @@ import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class ElasticsearchBackendMultiSearchTest extends ElasticsearchBackendGeneratedRequestTestBase {
@@ -79,7 +81,7 @@ public class ElasticsearchBackendMultiSearchTest extends ElasticsearchBackendGen
 
     @Test
     public void everySearchTypeGeneratesASearchSourceBuilder() {
-        final ESGeneratedQueryContext queryContext = this.elasticsearchBackend.generate(searchJob, query, Collections.emptySet());
+        final ESGeneratedQueryContext queryContext = this.elasticsearchBackend.generate(searchJob, query, Collections.emptySet(), mock(SearchesClusterConfig.class));
 
         assertThat(queryContext.searchTypeQueries())
                 .hasSize(2)
@@ -88,7 +90,7 @@ public class ElasticsearchBackendMultiSearchTest extends ElasticsearchBackendGen
 
     @Test
     public void everySearchTypeGeneratesOneESQuery() throws Exception {
-        final ESGeneratedQueryContext queryContext = this.elasticsearchBackend.generate(searchJob, query, Collections.emptySet());
+        final ESGeneratedQueryContext queryContext = this.elasticsearchBackend.generate(searchJob, query, Collections.emptySet(), mock(SearchesClusterConfig.class));
         when(jestClient.execute(any(), any())).thenReturn(resultFor(resourceFile("successfulMultiSearchResponse.json")));
 
         final String generatedRequest = run(searchJob, query, queryContext, Collections.emptySet());
@@ -98,7 +100,7 @@ public class ElasticsearchBackendMultiSearchTest extends ElasticsearchBackendGen
 
     @Test
     public void multiSearchResultsAreAssignedToSearchTypes() throws Exception {
-        final ESGeneratedQueryContext queryContext = this.elasticsearchBackend.generate(searchJob, query, Collections.emptySet());
+        final ESGeneratedQueryContext queryContext = this.elasticsearchBackend.generate(searchJob, query, Collections.emptySet(), mock(SearchesClusterConfig.class));
 
         when(jestClient.execute(any(), any())).thenReturn(resultFor(resourceFile("successfulMultiSearchResponse.json")));
 
@@ -123,7 +125,7 @@ public class ElasticsearchBackendMultiSearchTest extends ElasticsearchBackendGen
 
     @Test
     public void oneFailingSearchTypeReturnsPartialResults() throws Exception {
-        final ESGeneratedQueryContext queryContext = this.elasticsearchBackend.generate(searchJob, query, Collections.emptySet());
+        final ESGeneratedQueryContext queryContext = this.elasticsearchBackend.generate(searchJob, query, Collections.emptySet(), mock(SearchesClusterConfig.class));
 
         when(jestClient.execute(any(), any())).thenReturn(resultFor(resourceFile("partiallySuccessfulMultiSearchResponse.json")));
 

--- a/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/views/ElasticsearchBackendQueryStringDecoratorsTest.java
+++ b/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/views/ElasticsearchBackendQueryStringDecoratorsTest.java
@@ -29,6 +29,7 @@ import org.graylog.plugins.views.search.elasticsearch.FieldTypesLookup;
 import org.graylog.plugins.views.search.elasticsearch.IndexLookup;
 import org.graylog.plugins.views.search.elasticsearch.QueryStringDecorators;
 import org.graylog.plugins.views.search.engine.QueryStringDecorator;
+import org.graylog2.indexer.searches.SearchesClusterConfig;
 import org.graylog2.plugin.indexer.searches.timeranges.InvalidRangeParametersException;
 import org.graylog2.plugin.indexer.searches.timeranges.RelativeRange;
 import org.junit.jupiter.api.BeforeEach;
@@ -74,7 +75,7 @@ class ElasticsearchBackendQueryStringDecoratorsTest {
     }
 
     private DocumentContext generateJsonRequest(Query query, SearchJob searchJob) {
-        final ESGeneratedQueryContext context = this.backend.generate(searchJob, query, Collections.emptySet());
+        final ESGeneratedQueryContext context = this.backend.generate(searchJob, query, Collections.emptySet(), mock(SearchesClusterConfig.class));
 
         final String request = context.searchTypeQueries().get("testSearchtype").toString();
         return JsonPath.parse(request);

--- a/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/views/ElasticsearchBackendQueryStringDecoratorsTest.java
+++ b/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/views/ElasticsearchBackendQueryStringDecoratorsTest.java
@@ -29,9 +29,10 @@ import org.graylog.plugins.views.search.elasticsearch.FieldTypesLookup;
 import org.graylog.plugins.views.search.elasticsearch.IndexLookup;
 import org.graylog.plugins.views.search.elasticsearch.QueryStringDecorators;
 import org.graylog.plugins.views.search.engine.QueryStringDecorator;
-import org.graylog2.indexer.searches.SearchesClusterConfig;
+import org.graylog.plugins.views.search.engine.SearchConfig;
 import org.graylog2.plugin.indexer.searches.timeranges.InvalidRangeParametersException;
 import org.graylog2.plugin.indexer.searches.timeranges.RelativeRange;
+import org.joda.time.Period;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -75,7 +76,7 @@ class ElasticsearchBackendQueryStringDecoratorsTest {
     }
 
     private DocumentContext generateJsonRequest(Query query, SearchJob searchJob) {
-        final ESGeneratedQueryContext context = this.backend.generate(searchJob, query, Collections.emptySet(), mock(SearchesClusterConfig.class));
+        final ESGeneratedQueryContext context = this.backend.generate(searchJob, query, Collections.emptySet(), new SearchConfig(Period.ZERO));
 
         final String request = context.searchTypeQueries().get("testSearchtype").toString();
         return JsonPath.parse(request);

--- a/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/views/ElasticsearchBackendSearchTypeOverridesTest.java
+++ b/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/views/ElasticsearchBackendSearchTypeOverridesTest.java
@@ -21,6 +21,7 @@ import org.graylog.plugins.views.search.Query;
 import org.graylog.plugins.views.search.SearchJob;
 import org.graylog.plugins.views.search.SearchType;
 import org.graylog.plugins.views.search.elasticsearch.ElasticsearchQueryString;
+import org.graylog.plugins.views.search.engine.SearchConfig;
 import org.graylog.plugins.views.search.filter.StreamFilter;
 import org.graylog.plugins.views.search.searchtypes.pivot.Pivot;
 import org.graylog.plugins.views.search.searchtypes.pivot.series.Average;
@@ -30,6 +31,7 @@ import org.graylog2.indexer.searches.SearchesClusterConfig;
 import org.graylog2.plugin.indexer.searches.timeranges.AbsoluteRange;
 import org.graylog2.plugin.indexer.searches.timeranges.InvalidRangeParametersException;
 import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
+import org.joda.time.Period;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -86,7 +88,7 @@ public class ElasticsearchBackendSearchTypeOverridesTest extends ElasticsearchBa
 
     @Test
     public void overridesInSearchTypeAreIncorporatedIntoGeneratedQueries() throws IOException {
-        final ESGeneratedQueryContext queryContext = this.elasticsearchBackend.generate(searchJob, query, Collections.emptySet(), mock(SearchesClusterConfig.class));
+        final ESGeneratedQueryContext queryContext = this.elasticsearchBackend.generate(searchJob, query, Collections.emptySet(), new SearchConfig(Period.ZERO));
         when(jestClient.execute(any(), any())).thenReturn(resultFor(resourceFile("successfulMultiSearchResponse.json")));
 
         final String generatedRequest = run(searchJob, query, queryContext, Collections.emptySet());
@@ -103,7 +105,7 @@ public class ElasticsearchBackendSearchTypeOverridesTest extends ElasticsearchBa
         when(indexLookup.indexNamesForStreamsInTimeRange(ImmutableSet.of("stream1"), tr))
                 .thenReturn(ImmutableSet.of("searchTypeIndex"));
 
-        final ESGeneratedQueryContext queryContext = this.elasticsearchBackend.generate(searchJob, query, Collections.emptySet(), mock(SearchesClusterConfig.class));
+        final ESGeneratedQueryContext queryContext = this.elasticsearchBackend.generate(searchJob, query, Collections.emptySet(), new SearchConfig(Period.ZERO));
         when(jestClient.execute(any(), any())).thenReturn(resultFor(resourceFile("successfulMultiSearchResponse.json")));
 
         final String generatedRequest = run(searchJob, query, queryContext, Collections.emptySet());

--- a/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/views/ElasticsearchBackendSearchTypeOverridesTest.java
+++ b/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/views/ElasticsearchBackendSearchTypeOverridesTest.java
@@ -26,6 +26,7 @@ import org.graylog.plugins.views.search.searchtypes.pivot.Pivot;
 import org.graylog.plugins.views.search.searchtypes.pivot.series.Average;
 import org.graylog.plugins.views.search.searchtypes.pivot.series.Max;
 import org.graylog.plugins.views.search.timeranges.DerivedTimeRange;
+import org.graylog2.indexer.searches.SearchesClusterConfig;
 import org.graylog2.plugin.indexer.searches.timeranges.AbsoluteRange;
 import org.graylog2.plugin.indexer.searches.timeranges.InvalidRangeParametersException;
 import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
@@ -42,6 +43,7 @@ import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class ElasticsearchBackendSearchTypeOverridesTest extends ElasticsearchBackendGeneratedRequestTestBase {
@@ -84,7 +86,7 @@ public class ElasticsearchBackendSearchTypeOverridesTest extends ElasticsearchBa
 
     @Test
     public void overridesInSearchTypeAreIncorporatedIntoGeneratedQueries() throws IOException {
-        final ESGeneratedQueryContext queryContext = this.elasticsearchBackend.generate(searchJob, query, Collections.emptySet());
+        final ESGeneratedQueryContext queryContext = this.elasticsearchBackend.generate(searchJob, query, Collections.emptySet(), mock(SearchesClusterConfig.class));
         when(jestClient.execute(any(), any())).thenReturn(resultFor(resourceFile("successfulMultiSearchResponse.json")));
 
         final String generatedRequest = run(searchJob, query, queryContext, Collections.emptySet());
@@ -101,7 +103,7 @@ public class ElasticsearchBackendSearchTypeOverridesTest extends ElasticsearchBa
         when(indexLookup.indexNamesForStreamsInTimeRange(ImmutableSet.of("stream1"), tr))
                 .thenReturn(ImmutableSet.of("searchTypeIndex"));
 
-        final ESGeneratedQueryContext queryContext = this.elasticsearchBackend.generate(searchJob, query, Collections.emptySet());
+        final ESGeneratedQueryContext queryContext = this.elasticsearchBackend.generate(searchJob, query, Collections.emptySet(), mock(SearchesClusterConfig.class));
         when(jestClient.execute(any(), any())).thenReturn(resultFor(resourceFile("successfulMultiSearchResponse.json")));
 
         final String generatedRequest = run(searchJob, query, queryContext, Collections.emptySet());

--- a/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/views/ElasticsearchBackendSearchTypesWithStreamsOverridesTest.java
+++ b/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/views/ElasticsearchBackendSearchTypesWithStreamsOverridesTest.java
@@ -22,11 +22,13 @@ import org.graylog.plugins.views.search.Query;
 import org.graylog.plugins.views.search.SearchJob;
 import org.graylog.plugins.views.search.SearchType;
 import org.graylog.plugins.views.search.elasticsearch.ElasticsearchQueryString;
+import org.graylog.plugins.views.search.engine.SearchConfig;
 import org.graylog.plugins.views.search.filter.StreamFilter;
 import org.graylog.plugins.views.search.searchtypes.pivot.Pivot;
 import org.graylog.plugins.views.search.searchtypes.pivot.series.Average;
 import org.graylog.plugins.views.search.searchtypes.pivot.series.Max;
 import org.graylog2.indexer.searches.SearchesClusterConfig;
+import org.joda.time.Period;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -126,7 +128,7 @@ public class ElasticsearchBackendSearchTypesWithStreamsOverridesTest extends Ela
 
     private MultiSearch run(Query query) throws IOException {
         final SearchJob job = searchJobForQuery(query);
-        final ESGeneratedQueryContext context = this.elasticsearchBackend.generate(job, query, Collections.emptySet(), mock(SearchesClusterConfig.class));
+        final ESGeneratedQueryContext context = this.elasticsearchBackend.generate(job, query, Collections.emptySet(), new SearchConfig(Period.ZERO));
 
         this.elasticsearchBackend.doRun(job, query, context, Collections.emptySet());
 

--- a/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/views/ElasticsearchBackendSearchTypesWithStreamsOverridesTest.java
+++ b/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/views/ElasticsearchBackendSearchTypesWithStreamsOverridesTest.java
@@ -26,6 +26,7 @@ import org.graylog.plugins.views.search.filter.StreamFilter;
 import org.graylog.plugins.views.search.searchtypes.pivot.Pivot;
 import org.graylog.plugins.views.search.searchtypes.pivot.series.Average;
 import org.graylog.plugins.views.search.searchtypes.pivot.series.Max;
+import org.graylog2.indexer.searches.SearchesClusterConfig;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -37,6 +38,7 @@ import java.util.stream.Collectors;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -124,7 +126,7 @@ public class ElasticsearchBackendSearchTypesWithStreamsOverridesTest extends Ela
 
     private MultiSearch run(Query query) throws IOException {
         final SearchJob job = searchJobForQuery(query);
-        final ESGeneratedQueryContext context = this.elasticsearchBackend.generate(job, query, Collections.emptySet());
+        final ESGeneratedQueryContext context = this.elasticsearchBackend.generate(job, query, Collections.emptySet(), mock(SearchesClusterConfig.class));
 
         this.elasticsearchBackend.doRun(job, query, context, Collections.emptySet());
 

--- a/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/views/ElasticsearchBackendTest.java
+++ b/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/views/ElasticsearchBackendTest.java
@@ -31,6 +31,7 @@ import org.graylog.plugins.views.search.elasticsearch.QueryStringParser;
 import org.graylog.plugins.views.search.searchtypes.MessageList;
 import org.graylog.storage.elasticsearch6.views.searchtypes.ESMessageList;
 import org.graylog.storage.elasticsearch6.views.searchtypes.ESSearchTypeHandler;
+import org.graylog2.indexer.searches.SearchesClusterConfig;
 import org.graylog2.plugin.indexer.searches.timeranges.RelativeRange;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -71,7 +72,7 @@ public class ElasticsearchBackendTest {
         final Search search = Search.builder().queries(ImmutableSet.of(query)).build();
         final SearchJob job = new SearchJob("deadbeef", search, "admin");
 
-        backend.generate(job, query, Collections.emptySet());
+        backend.generate(job, query, Collections.emptySet(), mock(SearchesClusterConfig.class));
     }
 
     @Test

--- a/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/views/ElasticsearchBackendTest.java
+++ b/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/views/ElasticsearchBackendTest.java
@@ -28,11 +28,13 @@ import org.graylog.plugins.views.search.elasticsearch.FieldTypesLookup;
 import org.graylog.plugins.views.search.elasticsearch.IndexLookup;
 import org.graylog.plugins.views.search.elasticsearch.QueryStringDecorators;
 import org.graylog.plugins.views.search.elasticsearch.QueryStringParser;
+import org.graylog.plugins.views.search.engine.SearchConfig;
 import org.graylog.plugins.views.search.searchtypes.MessageList;
 import org.graylog.storage.elasticsearch6.views.searchtypes.ESMessageList;
 import org.graylog.storage.elasticsearch6.views.searchtypes.ESSearchTypeHandler;
 import org.graylog2.indexer.searches.SearchesClusterConfig;
 import org.graylog2.plugin.indexer.searches.timeranges.RelativeRange;
+import org.joda.time.Period;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -72,7 +74,7 @@ public class ElasticsearchBackendTest {
         final Search search = Search.builder().queries(ImmutableSet.of(query)).build();
         final SearchJob job = new SearchJob("deadbeef", search, "admin");
 
-        backend.generate(job, query, Collections.emptySet(), mock(SearchesClusterConfig.class));
+        backend.generate(job, query, Collections.emptySet(), new SearchConfig(Period.ZERO));
     }
 
     @Test

--- a/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/views/ElasticsearchBackendUsingCorrectIndicesTest.java
+++ b/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/views/ElasticsearchBackendUsingCorrectIndicesTest.java
@@ -33,6 +33,7 @@ import org.graylog.plugins.views.search.filter.StreamFilter;
 import org.graylog.plugins.views.search.searchtypes.MessageList;
 import org.graylog.storage.elasticsearch6.views.searchtypes.ESMessageList;
 import org.graylog.storage.elasticsearch6.views.searchtypes.ESSearchTypeHandler;
+import org.graylog2.indexer.searches.SearchesClusterConfig;
 import org.graylog2.plugin.indexer.searches.timeranges.RelativeRange;
 import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
 import org.joda.time.DateTimeUtils;
@@ -115,7 +116,7 @@ public class ElasticsearchBackendUsingCorrectIndicesTest extends ElasticsearchBa
 
     @Test
     public void queryDoesNotFallBackToUsingAllIndicesWhenNoIndexRangesAreReturned() throws Exception {
-        final ESGeneratedQueryContext context = backend.generate(job, query, Collections.emptySet());
+        final ESGeneratedQueryContext context = backend.generate(job, query, Collections.emptySet(), mock(SearchesClusterConfig.class));
         backend.doRun(job, query, context, Collections.emptySet());
 
         verify(jestClient, times(1)).execute(clientRequestCaptor.capture(), any());
@@ -130,7 +131,7 @@ public class ElasticsearchBackendUsingCorrectIndicesTest extends ElasticsearchBa
         final long datetimeFixture = 1530194810;
         DateTimeUtils.setCurrentMillisFixed(datetimeFixture);
 
-        final ESGeneratedQueryContext context = backend.generate(job, query, Collections.emptySet());
+        final ESGeneratedQueryContext context = backend.generate(job, query, Collections.emptySet(), mock(SearchesClusterConfig.class));
         backend.doRun(job, query, context, Collections.emptySet());
 
         ArgumentCaptor<TimeRange> captor = ArgumentCaptor.forClass(TimeRange.class);
@@ -166,7 +167,7 @@ public class ElasticsearchBackendUsingCorrectIndicesTest extends ElasticsearchBa
                 .build();
         final Search search = dummySearch(query);
         final SearchJob job = new SearchJob("job1", search, "admin");
-        final ESGeneratedQueryContext context = backend.generate(job, query, Collections.emptySet());
+        final ESGeneratedQueryContext context = backend.generate(job, query, Collections.emptySet(), mock(SearchesClusterConfig.class));
 
         when(indexLookup.indexNamesForStreamsInTimeRange(ImmutableSet.of("streamId"), RelativeRange.create(600)))
                 .thenReturn(ImmutableSet.of("index1", "index2"));
@@ -188,7 +189,7 @@ public class ElasticsearchBackendUsingCorrectIndicesTest extends ElasticsearchBa
                 .build();
         final Search search = dummySearch(query);
         final SearchJob job = new SearchJob("job1", search, "admin");
-        final ESGeneratedQueryContext context = backend.generate(job, query, Collections.emptySet());
+        final ESGeneratedQueryContext context = backend.generate(job, query, Collections.emptySet(), mock(SearchesClusterConfig.class));
 
         when(indexLookup.indexNamesForStreamsInTimeRange(ImmutableSet.of("stream1", "stream2"), RelativeRange.create(600)))
                 .thenReturn(ImmutableSet.of("index1", "index2"));

--- a/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/views/ElasticsearchBackendUsingCorrectIndicesTest.java
+++ b/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/views/ElasticsearchBackendUsingCorrectIndicesTest.java
@@ -28,6 +28,7 @@ import org.graylog.plugins.views.search.elasticsearch.ElasticsearchQueryString;
 import org.graylog.plugins.views.search.elasticsearch.FieldTypesLookup;
 import org.graylog.plugins.views.search.elasticsearch.IndexLookup;
 import org.graylog.plugins.views.search.elasticsearch.QueryStringDecorators;
+import org.graylog.plugins.views.search.engine.SearchConfig;
 import org.graylog.plugins.views.search.filter.AndFilter;
 import org.graylog.plugins.views.search.filter.StreamFilter;
 import org.graylog.plugins.views.search.searchtypes.MessageList;
@@ -37,6 +38,7 @@ import org.graylog2.indexer.searches.SearchesClusterConfig;
 import org.graylog2.plugin.indexer.searches.timeranges.RelativeRange;
 import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
 import org.joda.time.DateTimeUtils;
+import org.joda.time.Period;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -116,7 +118,7 @@ public class ElasticsearchBackendUsingCorrectIndicesTest extends ElasticsearchBa
 
     @Test
     public void queryDoesNotFallBackToUsingAllIndicesWhenNoIndexRangesAreReturned() throws Exception {
-        final ESGeneratedQueryContext context = backend.generate(job, query, Collections.emptySet(), mock(SearchesClusterConfig.class));
+        final ESGeneratedQueryContext context = backend.generate(job, query, Collections.emptySet(), new SearchConfig(Period.ZERO));
         backend.doRun(job, query, context, Collections.emptySet());
 
         verify(jestClient, times(1)).execute(clientRequestCaptor.capture(), any());
@@ -131,7 +133,7 @@ public class ElasticsearchBackendUsingCorrectIndicesTest extends ElasticsearchBa
         final long datetimeFixture = 1530194810;
         DateTimeUtils.setCurrentMillisFixed(datetimeFixture);
 
-        final ESGeneratedQueryContext context = backend.generate(job, query, Collections.emptySet(), mock(SearchesClusterConfig.class));
+        final ESGeneratedQueryContext context = backend.generate(job, query, Collections.emptySet(), new SearchConfig(Period.ZERO));
         backend.doRun(job, query, context, Collections.emptySet());
 
         ArgumentCaptor<TimeRange> captor = ArgumentCaptor.forClass(TimeRange.class);
@@ -167,7 +169,7 @@ public class ElasticsearchBackendUsingCorrectIndicesTest extends ElasticsearchBa
                 .build();
         final Search search = dummySearch(query);
         final SearchJob job = new SearchJob("job1", search, "admin");
-        final ESGeneratedQueryContext context = backend.generate(job, query, Collections.emptySet(), mock(SearchesClusterConfig.class));
+        final ESGeneratedQueryContext context = backend.generate(job, query, Collections.emptySet(), new SearchConfig(Period.ZERO));
 
         when(indexLookup.indexNamesForStreamsInTimeRange(ImmutableSet.of("streamId"), RelativeRange.create(600)))
                 .thenReturn(ImmutableSet.of("index1", "index2"));
@@ -189,7 +191,7 @@ public class ElasticsearchBackendUsingCorrectIndicesTest extends ElasticsearchBa
                 .build();
         final Search search = dummySearch(query);
         final SearchJob job = new SearchJob("job1", search, "admin");
-        final ESGeneratedQueryContext context = backend.generate(job, query, Collections.emptySet(), mock(SearchesClusterConfig.class));
+        final ESGeneratedQueryContext context = backend.generate(job, query, Collections.emptySet(), new SearchConfig(Period.ZERO));
 
         when(indexLookup.indexNamesForStreamsInTimeRange(ImmutableSet.of("stream1", "stream2"), RelativeRange.create(600)))
                 .thenReturn(ImmutableSet.of("index1", "index2"));

--- a/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/views/QueryPlanTest.java
+++ b/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/views/QueryPlanTest.java
@@ -33,6 +33,7 @@ import org.graylog.plugins.views.search.engine.QueryPlan;
 import org.graylog.plugins.views.search.searchtypes.MessageList;
 import org.graylog.storage.elasticsearch6.views.searchtypes.ESMessageList;
 import org.graylog.storage.elasticsearch6.views.searchtypes.ESSearchTypeHandler;
+import org.graylog2.plugin.cluster.ClusterConfigService;
 import org.graylog2.plugin.indexer.searches.timeranges.InvalidRangeParametersException;
 import org.graylog2.plugin.indexer.searches.timeranges.RelativeRange;
 import org.junit.Test;
@@ -44,6 +45,7 @@ import java.util.UUID;
 
 import static com.google.common.collect.ImmutableSet.of;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 
 public class QueryPlanTest {
@@ -62,7 +64,7 @@ public class QueryPlanTest {
                 new QueryStringDecorators.Fake(),
                 (elasticsearchBackend, ssb, job, query, results) -> new ESGeneratedQueryContext(elasticsearchBackend, ssb, job, query, results, fieldTypesLookup),
                 false);
-        queryEngine = new QueryEngine(backend, Collections.emptySet(), new QueryParser(new QueryStringParser()));
+        queryEngine = new QueryEngine(backend, Collections.emptySet(), new QueryParser(new QueryStringParser()), mock(ClusterConfigService.class, RETURNS_DEEP_STUBS));
     }
 
     private static String randomUUID() {

--- a/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/views/QueryPlanTest.java
+++ b/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/views/QueryPlanTest.java
@@ -30,12 +30,14 @@ import org.graylog.plugins.views.search.elasticsearch.QueryStringParser;
 import org.graylog.plugins.views.search.engine.QueryEngine;
 import org.graylog.plugins.views.search.engine.QueryParser;
 import org.graylog.plugins.views.search.engine.QueryPlan;
+import org.graylog.plugins.views.search.engine.SearchConfig;
 import org.graylog.plugins.views.search.searchtypes.MessageList;
 import org.graylog.storage.elasticsearch6.views.searchtypes.ESMessageList;
 import org.graylog.storage.elasticsearch6.views.searchtypes.ESSearchTypeHandler;
 import org.graylog2.plugin.cluster.ClusterConfigService;
 import org.graylog2.plugin.indexer.searches.timeranges.InvalidRangeParametersException;
 import org.graylog2.plugin.indexer.searches.timeranges.RelativeRange;
+import org.joda.time.Period;
 import org.junit.Test;
 
 import javax.inject.Provider;
@@ -64,7 +66,7 @@ public class QueryPlanTest {
                 new QueryStringDecorators.Fake(),
                 (elasticsearchBackend, ssb, job, query, results) -> new ESGeneratedQueryContext(elasticsearchBackend, ssb, job, query, results, fieldTypesLookup),
                 false);
-        queryEngine = new QueryEngine(backend, Collections.emptySet(), new QueryParser(new QueryStringParser()), mock(ClusterConfigService.class, RETURNS_DEEP_STUBS));
+        queryEngine = new QueryEngine(backend, Collections.emptySet(), new QueryParser(new QueryStringParser()), () -> new SearchConfig(Period.ZERO));
     }
 
     private static String randomUUID() {

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackend.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackend.java
@@ -124,10 +124,10 @@ public class ElasticsearchBackend implements QueryBackend<ESGeneratedQueryContex
         final ESGeneratedQueryContext queryContext = queryContextFactory.create(this, searchSourceBuilder, job, query, results);
         for (SearchType searchType : searchTypes) {
 
-            final SearchTypeError searchTypeError = validateSearchType(query, searchType, searchesClusterConfig);
-            if(searchTypeError != null) {
+            final Optional<SearchTypeError> searchTypeError = validateSearchType(query, searchType, searchesClusterConfig);
+            if(searchTypeError.isPresent()) {
                 LOG.error("Invalid search type {} for elasticsearch backend, cannot generate query part. Skipping this search type.", searchType.type());
-                queryContext.addError(searchTypeError);
+                queryContext.addError(searchTypeError.get());
                 continue;
             }
 

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackend.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackend.java
@@ -103,6 +103,8 @@ public class ElasticsearchBackend implements QueryBackend<ESGeneratedQueryContex
     public ESGeneratedQueryContext generate(SearchJob job, Query query, Set<QueryResult> results, SearchesClusterConfig searchesClusterConfig) {
         final ElasticsearchQueryString backendQuery = (ElasticsearchQueryString) query.query();
 
+        validateQueryTimeRange(query, searchesClusterConfig);
+
         final Set<SearchType> searchTypes = query.searchTypes();
 
         final String queryString = this.queryStringDecorators.decorate(backendQuery.queryString(), job, query, results);

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackend.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackend.java
@@ -28,6 +28,7 @@ import org.graylog.plugins.views.search.elasticsearch.ElasticsearchQueryString;
 import org.graylog.plugins.views.search.elasticsearch.IndexLookup;
 import org.graylog.plugins.views.search.elasticsearch.QueryStringDecorators;
 import org.graylog.plugins.views.search.engine.QueryBackend;
+import org.graylog.plugins.views.search.engine.SearchConfig;
 import org.graylog.plugins.views.search.errors.SearchTypeError;
 import org.graylog.plugins.views.search.errors.SearchTypeErrorParser;
 import org.graylog.plugins.views.search.filter.AndFilter;
@@ -100,10 +101,10 @@ public class ElasticsearchBackend implements QueryBackend<ESGeneratedQueryContex
     }
 
     @Override
-    public ESGeneratedQueryContext generate(SearchJob job, Query query, Set<QueryResult> results, SearchesClusterConfig searchesClusterConfig) {
+    public ESGeneratedQueryContext generate(SearchJob job, Query query, Set<QueryResult> results, SearchConfig searchConfig) {
         final ElasticsearchQueryString backendQuery = (ElasticsearchQueryString) query.query();
 
-        validateQueryTimeRange(query, searchesClusterConfig);
+        validateQueryTimeRange(query, searchConfig);
 
         final Set<SearchType> searchTypes = query.searchTypes();
 
@@ -126,7 +127,7 @@ public class ElasticsearchBackend implements QueryBackend<ESGeneratedQueryContex
         final ESGeneratedQueryContext queryContext = queryContextFactory.create(this, searchSourceBuilder, job, query, results);
         for (SearchType searchType : searchTypes) {
 
-            final Optional<SearchTypeError> searchTypeError = validateSearchType(query, searchType, searchesClusterConfig);
+            final Optional<SearchTypeError> searchTypeError = validateSearchType(query, searchType, searchConfig);
             if(searchTypeError.isPresent()) {
                 LOG.error("Invalid search type {} for elasticsearch backend, cannot generate query part. Skipping this search type.", searchType.type());
                 queryContext.addError(searchTypeError.get());

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackend.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackend.java
@@ -48,6 +48,7 @@ import org.graylog.storage.elasticsearch7.TimeRangeQueryFactory;
 import org.graylog.storage.elasticsearch7.views.searchtypes.ESSearchTypeHandler;
 import org.graylog2.indexer.ElasticsearchException;
 import org.graylog2.indexer.FieldTypeException;
+import org.graylog2.indexer.searches.SearchesClusterConfig;
 import org.graylog2.plugin.Message;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -99,7 +100,7 @@ public class ElasticsearchBackend implements QueryBackend<ESGeneratedQueryContex
     }
 
     @Override
-    public ESGeneratedQueryContext generate(SearchJob job, Query query, Set<QueryResult> results) {
+    public ESGeneratedQueryContext generate(SearchJob job, Query query, Set<QueryResult> results, SearchesClusterConfig searchesClusterConfig) {
         final ElasticsearchQueryString backendQuery = (ElasticsearchQueryString) query.query();
 
         final Set<SearchType> searchTypes = query.searchTypes();
@@ -122,6 +123,14 @@ public class ElasticsearchBackend implements QueryBackend<ESGeneratedQueryContex
 
         final ESGeneratedQueryContext queryContext = queryContextFactory.create(this, searchSourceBuilder, job, query, results);
         for (SearchType searchType : searchTypes) {
+
+            final SearchTypeError searchTypeError = validateSearchType(query, searchType, searchesClusterConfig);
+            if(searchTypeError != null) {
+                LOG.error("Invalid search type {} for elasticsearch backend, cannot generate query part. Skipping this search type.", searchType.type());
+                queryContext.addError(searchTypeError);
+                continue;
+            }
+
             final SearchSourceBuilder searchTypeSourceBuilder = queryContext.searchSourceBuilder(searchType);
 
             final Set<String> effectiveStreamIds = searchType.effectiveStreams().isEmpty()
@@ -154,6 +163,12 @@ public class ElasticsearchBackend implements QueryBackend<ESGeneratedQueryContex
             if (searchTypeHandler == null) {
                 LOG.error("Unknown search type {} for elasticsearch backend, cannot generate query part. Skipping this search type.", type);
                 queryContext.addError(new SearchTypeError(query, searchType.id(), "Unknown search type '" + type + "' for elasticsearch backend, cannot generate query"));
+                continue;
+            }
+
+            if(isSearchTypeWithError(queryContext, searchType.id())) {
+                LOG.error("Failed search type '{}', cannot convert query result, skipping.", searchType.type());
+                // no need to add another error here, as the query generation code will have added the error about the missing handler already
                 continue;
             }
 
@@ -246,6 +261,13 @@ public class ElasticsearchBackend implements QueryBackend<ESGeneratedQueryContex
                 // no need to add another error here, as the query generation code will have added the error about the missing handler already
                 continue;
             }
+
+            if(isSearchTypeWithError(queryContext, searchTypeId)) {
+                LOG.error("Failed search type '{}', cannot convert query result, skipping.", searchType.type());
+                // no need to add another error here, as the query generation code will have added the error about the missing handler already
+                continue;
+            }
+
             // we create a new instance because some search type handlers might need to track information between generating the query and
             // processing its result, such as aggregations, which depend on the name and type
             final ESSearchTypeHandler<? extends SearchType> handler = handlerProvider.get();

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackendMultiSearchTest.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackendMultiSearchTest.java
@@ -22,6 +22,7 @@ import org.graylog.plugins.views.search.QueryResult;
 import org.graylog.plugins.views.search.SearchJob;
 import org.graylog.plugins.views.search.SearchType;
 import org.graylog.plugins.views.search.elasticsearch.ElasticsearchQueryString;
+import org.graylog.plugins.views.search.engine.SearchConfig;
 import org.graylog.plugins.views.search.errors.SearchTypeError;
 import org.graylog.plugins.views.search.searchtypes.pivot.Pivot;
 import org.graylog.plugins.views.search.searchtypes.pivot.PivotResult;
@@ -31,6 +32,7 @@ import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.search.MultiSe
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.search.SearchRequest;
 import org.graylog.storage.elasticsearch7.testing.TestMultisearchResponse;
 import org.graylog2.indexer.searches.SearchesClusterConfig;
+import org.joda.time.Period;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -87,7 +89,7 @@ public class ElasticsearchBackendMultiSearchTest extends ElasticsearchBackendGen
 
     @Test
     public void everySearchTypeGeneratesASearchSourceBuilder() {
-        final ESGeneratedQueryContext queryContext = this.elasticsearchBackend.generate(searchJob, query, Collections.emptySet(), mock(SearchesClusterConfig.class));
+        final ESGeneratedQueryContext queryContext = this.elasticsearchBackend.generate(searchJob, query, Collections.emptySet(), new SearchConfig(Period.ZERO));
 
         assertThat(queryContext.searchTypeQueries())
                 .hasSize(2)
@@ -101,7 +103,7 @@ public class ElasticsearchBackendMultiSearchTest extends ElasticsearchBackendGen
                 .collect(Collectors.toList());
         when(client.msearch(any(), any())).thenReturn(items);
 
-        final ESGeneratedQueryContext queryContext = this.elasticsearchBackend.generate(searchJob, query, Collections.emptySet(), mock(SearchesClusterConfig.class));
+        final ESGeneratedQueryContext queryContext = this.elasticsearchBackend.generate(searchJob, query, Collections.emptySet(), new SearchConfig(Period.ZERO));
         final List<SearchRequest> generatedRequest = run(searchJob, query, queryContext, Collections.emptySet());
 
         assertThat(generatedRequest).hasSize(2);
@@ -114,7 +116,7 @@ public class ElasticsearchBackendMultiSearchTest extends ElasticsearchBackendGen
                 .collect(Collectors.toList());
         when(client.msearch(any(), any())).thenReturn(items);
 
-        final ESGeneratedQueryContext queryContext = this.elasticsearchBackend.generate(searchJob, query, Collections.emptySet(), mock(SearchesClusterConfig.class));
+        final ESGeneratedQueryContext queryContext = this.elasticsearchBackend.generate(searchJob, query, Collections.emptySet(), new SearchConfig(Period.ZERO));
         final QueryResult queryResult = this.elasticsearchBackend.doRun(searchJob, query, queryContext, Collections.emptySet());
 
         assertThat(queryResult.searchTypes()).containsOnlyKeys("pivot1", "pivot2");
@@ -136,7 +138,7 @@ public class ElasticsearchBackendMultiSearchTest extends ElasticsearchBackendGen
 
     @Test
     public void oneFailingSearchTypeReturnsPartialResults() throws Exception {
-        final ESGeneratedQueryContext queryContext = this.elasticsearchBackend.generate(searchJob, query, Collections.emptySet(), mock(SearchesClusterConfig.class));
+        final ESGeneratedQueryContext queryContext = this.elasticsearchBackend.generate(searchJob, query, Collections.emptySet(), new SearchConfig(Period.ZERO));
 
         final MultiSearchResponse response = TestMultisearchResponse.fromFixture("partiallySuccessfulMultiSearchResponse.json");
         final List<MultiSearchResponse.Item> items = Arrays.stream(response.getResponses())

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackendMultiSearchTest.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackendMultiSearchTest.java
@@ -30,6 +30,7 @@ import org.graylog.plugins.views.search.searchtypes.pivot.series.Max;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.search.MultiSearchResponse;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.search.SearchRequest;
 import org.graylog.storage.elasticsearch7.testing.TestMultisearchResponse;
+import org.graylog2.indexer.searches.SearchesClusterConfig;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -46,6 +47,7 @@ import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class ElasticsearchBackendMultiSearchTest extends ElasticsearchBackendGeneratedRequestTestBase {
@@ -85,7 +87,7 @@ public class ElasticsearchBackendMultiSearchTest extends ElasticsearchBackendGen
 
     @Test
     public void everySearchTypeGeneratesASearchSourceBuilder() {
-        final ESGeneratedQueryContext queryContext = this.elasticsearchBackend.generate(searchJob, query, Collections.emptySet());
+        final ESGeneratedQueryContext queryContext = this.elasticsearchBackend.generate(searchJob, query, Collections.emptySet(), mock(SearchesClusterConfig.class));
 
         assertThat(queryContext.searchTypeQueries())
                 .hasSize(2)
@@ -99,7 +101,7 @@ public class ElasticsearchBackendMultiSearchTest extends ElasticsearchBackendGen
                 .collect(Collectors.toList());
         when(client.msearch(any(), any())).thenReturn(items);
 
-        final ESGeneratedQueryContext queryContext = this.elasticsearchBackend.generate(searchJob, query, Collections.emptySet());
+        final ESGeneratedQueryContext queryContext = this.elasticsearchBackend.generate(searchJob, query, Collections.emptySet(), mock(SearchesClusterConfig.class));
         final List<SearchRequest> generatedRequest = run(searchJob, query, queryContext, Collections.emptySet());
 
         assertThat(generatedRequest).hasSize(2);
@@ -112,7 +114,7 @@ public class ElasticsearchBackendMultiSearchTest extends ElasticsearchBackendGen
                 .collect(Collectors.toList());
         when(client.msearch(any(), any())).thenReturn(items);
 
-        final ESGeneratedQueryContext queryContext = this.elasticsearchBackend.generate(searchJob, query, Collections.emptySet());
+        final ESGeneratedQueryContext queryContext = this.elasticsearchBackend.generate(searchJob, query, Collections.emptySet(), mock(SearchesClusterConfig.class));
         final QueryResult queryResult = this.elasticsearchBackend.doRun(searchJob, query, queryContext, Collections.emptySet());
 
         assertThat(queryResult.searchTypes()).containsOnlyKeys("pivot1", "pivot2");
@@ -134,7 +136,7 @@ public class ElasticsearchBackendMultiSearchTest extends ElasticsearchBackendGen
 
     @Test
     public void oneFailingSearchTypeReturnsPartialResults() throws Exception {
-        final ESGeneratedQueryContext queryContext = this.elasticsearchBackend.generate(searchJob, query, Collections.emptySet());
+        final ESGeneratedQueryContext queryContext = this.elasticsearchBackend.generate(searchJob, query, Collections.emptySet(), mock(SearchesClusterConfig.class));
 
         final MultiSearchResponse response = TestMultisearchResponse.fromFixture("partiallySuccessfulMultiSearchResponse.json");
         final List<MultiSearchResponse.Item> items = Arrays.stream(response.getResponses())

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackendQueryStringDecoratorsTest.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackendQueryStringDecoratorsTest.java
@@ -29,6 +29,7 @@ import org.graylog.plugins.views.search.elasticsearch.IndexLookup;
 import org.graylog.plugins.views.search.elasticsearch.QueryStringDecorators;
 import org.graylog.plugins.views.search.engine.QueryStringDecorator;
 import org.graylog.storage.elasticsearch7.ElasticsearchClient;
+import org.graylog2.indexer.searches.SearchesClusterConfig;
 import org.graylog2.plugin.indexer.searches.timeranges.InvalidRangeParametersException;
 import org.graylog2.plugin.indexer.searches.timeranges.RelativeRange;
 import org.junit.jupiter.api.BeforeEach;
@@ -74,7 +75,7 @@ class ElasticsearchBackendQueryStringDecoratorsTest {
     }
 
     private DocumentContext generateJsonRequest(Query query, SearchJob searchJob) {
-        final ESGeneratedQueryContext context = this.backend.generate(searchJob, query, Collections.emptySet());
+        final ESGeneratedQueryContext context = this.backend.generate(searchJob, query, Collections.emptySet(), mock(SearchesClusterConfig.class));
 
         final String request = context.searchTypeQueries().get("testSearchtype").toString();
         return JsonPath.parse(request);

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackendQueryStringDecoratorsTest.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackendQueryStringDecoratorsTest.java
@@ -28,10 +28,12 @@ import org.graylog.plugins.views.search.elasticsearch.FieldTypesLookup;
 import org.graylog.plugins.views.search.elasticsearch.IndexLookup;
 import org.graylog.plugins.views.search.elasticsearch.QueryStringDecorators;
 import org.graylog.plugins.views.search.engine.QueryStringDecorator;
+import org.graylog.plugins.views.search.engine.SearchConfig;
 import org.graylog.storage.elasticsearch7.ElasticsearchClient;
 import org.graylog2.indexer.searches.SearchesClusterConfig;
 import org.graylog2.plugin.indexer.searches.timeranges.InvalidRangeParametersException;
 import org.graylog2.plugin.indexer.searches.timeranges.RelativeRange;
+import org.joda.time.Period;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -75,7 +77,7 @@ class ElasticsearchBackendQueryStringDecoratorsTest {
     }
 
     private DocumentContext generateJsonRequest(Query query, SearchJob searchJob) {
-        final ESGeneratedQueryContext context = this.backend.generate(searchJob, query, Collections.emptySet(), mock(SearchesClusterConfig.class));
+        final ESGeneratedQueryContext context = this.backend.generate(searchJob, query, Collections.emptySet(), new SearchConfig(Period.ZERO));
 
         final String request = context.searchTypeQueries().get("testSearchtype").toString();
         return JsonPath.parse(request);

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackendSearchTypeOverridesTest.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackendSearchTypeOverridesTest.java
@@ -26,6 +26,7 @@ import org.graylog.plugins.views.search.Query;
 import org.graylog.plugins.views.search.SearchJob;
 import org.graylog.plugins.views.search.SearchType;
 import org.graylog.plugins.views.search.elasticsearch.ElasticsearchQueryString;
+import org.graylog.plugins.views.search.engine.SearchConfig;
 import org.graylog.plugins.views.search.filter.StreamFilter;
 import org.graylog.plugins.views.search.searchtypes.pivot.Pivot;
 import org.graylog.plugins.views.search.searchtypes.pivot.series.Average;
@@ -38,6 +39,7 @@ import org.graylog2.indexer.searches.SearchesClusterConfig;
 import org.graylog2.plugin.indexer.searches.timeranges.AbsoluteRange;
 import org.graylog2.plugin.indexer.searches.timeranges.InvalidRangeParametersException;
 import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
+import org.joda.time.Period;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -98,7 +100,7 @@ public class ElasticsearchBackendSearchTypeOverridesTest extends ElasticsearchBa
 
     @Test
     public void overridesInSearchTypeAreIncorporatedIntoGeneratedQueries() throws IOException {
-        final ESGeneratedQueryContext queryContext = this.elasticsearchBackend.generate(searchJob, query, Collections.emptySet(), mock(SearchesClusterConfig.class));
+        final ESGeneratedQueryContext queryContext = this.elasticsearchBackend.generate(searchJob, query, Collections.emptySet(), new SearchConfig(Period.ZERO));
         final MultiSearchResponse response = TestMultisearchResponse.fromFixture("successfulMultiSearchResponse.json");
         final List<MultiSearchResponse.Item> items = Arrays.stream(response.getResponses())
                 .collect(Collectors.toList());
@@ -153,7 +155,7 @@ public class ElasticsearchBackendSearchTypeOverridesTest extends ElasticsearchBa
         when(indexLookup.indexNamesForStreamsInTimeRange(ImmutableSet.of("stream1"), tr))
                 .thenReturn(ImmutableSet.of("searchTypeIndex"));
 
-        final ESGeneratedQueryContext queryContext = this.elasticsearchBackend.generate(searchJob, query, Collections.emptySet(), mock(SearchesClusterConfig.class));
+        final ESGeneratedQueryContext queryContext = this.elasticsearchBackend.generate(searchJob, query, Collections.emptySet(), new SearchConfig(Period.ZERO));
         final MultiSearchResponse response = TestMultisearchResponse.fromFixture("successfulMultiSearchResponse.json");
         final List<MultiSearchResponse.Item> items = Arrays.stream(response.getResponses())
                 .collect(Collectors.toList());

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackendSearchTypeOverridesTest.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackendSearchTypeOverridesTest.java
@@ -34,6 +34,7 @@ import org.graylog.plugins.views.search.timeranges.DerivedTimeRange;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.search.MultiSearchResponse;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.search.SearchRequest;
 import org.graylog.storage.elasticsearch7.testing.TestMultisearchResponse;
+import org.graylog2.indexer.searches.SearchesClusterConfig;
 import org.graylog2.plugin.indexer.searches.timeranges.AbsoluteRange;
 import org.graylog2.plugin.indexer.searches.timeranges.InvalidRangeParametersException;
 import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
@@ -54,6 +55,7 @@ import java.util.stream.Collectors;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.graylog.storage.elasticsearch7.views.ViewsUtils.indicesOf;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class ElasticsearchBackendSearchTypeOverridesTest extends ElasticsearchBackendGeneratedRequestTestBase {
@@ -96,7 +98,7 @@ public class ElasticsearchBackendSearchTypeOverridesTest extends ElasticsearchBa
 
     @Test
     public void overridesInSearchTypeAreIncorporatedIntoGeneratedQueries() throws IOException {
-        final ESGeneratedQueryContext queryContext = this.elasticsearchBackend.generate(searchJob, query, Collections.emptySet());
+        final ESGeneratedQueryContext queryContext = this.elasticsearchBackend.generate(searchJob, query, Collections.emptySet(), mock(SearchesClusterConfig.class));
         final MultiSearchResponse response = TestMultisearchResponse.fromFixture("successfulMultiSearchResponse.json");
         final List<MultiSearchResponse.Item> items = Arrays.stream(response.getResponses())
                 .collect(Collectors.toList());
@@ -151,7 +153,7 @@ public class ElasticsearchBackendSearchTypeOverridesTest extends ElasticsearchBa
         when(indexLookup.indexNamesForStreamsInTimeRange(ImmutableSet.of("stream1"), tr))
                 .thenReturn(ImmutableSet.of("searchTypeIndex"));
 
-        final ESGeneratedQueryContext queryContext = this.elasticsearchBackend.generate(searchJob, query, Collections.emptySet());
+        final ESGeneratedQueryContext queryContext = this.elasticsearchBackend.generate(searchJob, query, Collections.emptySet(), mock(SearchesClusterConfig.class));
         final MultiSearchResponse response = TestMultisearchResponse.fromFixture("successfulMultiSearchResponse.json");
         final List<MultiSearchResponse.Item> items = Arrays.stream(response.getResponses())
                 .collect(Collectors.toList());

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackendSearchTypesWithStreamsOverridesTest.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackendSearchTypesWithStreamsOverridesTest.java
@@ -21,6 +21,7 @@ import org.graylog.plugins.views.search.Query;
 import org.graylog.plugins.views.search.SearchJob;
 import org.graylog.plugins.views.search.SearchType;
 import org.graylog.plugins.views.search.elasticsearch.ElasticsearchQueryString;
+import org.graylog.plugins.views.search.engine.SearchConfig;
 import org.graylog.plugins.views.search.filter.StreamFilter;
 import org.graylog.plugins.views.search.searchtypes.pivot.Pivot;
 import org.graylog.plugins.views.search.searchtypes.pivot.series.Average;
@@ -29,6 +30,7 @@ import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.search.MultiSe
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.search.SearchRequest;
 import org.graylog.storage.elasticsearch7.testing.TestMultisearchResponse;
 import org.graylog2.indexer.searches.SearchesClusterConfig;
+import org.joda.time.Period;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -133,7 +135,7 @@ public class ElasticsearchBackendSearchTypesWithStreamsOverridesTest extends Ela
 
     private List<SearchRequest> run(Query query) throws IOException {
         final SearchJob job = searchJobForQuery(query);
-        final ESGeneratedQueryContext context = this.elasticsearchBackend.generate(job, query, Collections.emptySet(), mock(SearchesClusterConfig.class));
+        final ESGeneratedQueryContext context = this.elasticsearchBackend.generate(job, query, Collections.emptySet(), new SearchConfig(Period.ZERO));
 
         this.elasticsearchBackend.doRun(job, query, context, Collections.emptySet());
 

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackendSearchTypesWithStreamsOverridesTest.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackendSearchTypesWithStreamsOverridesTest.java
@@ -28,6 +28,7 @@ import org.graylog.plugins.views.search.searchtypes.pivot.series.Max;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.search.MultiSearchResponse;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.search.SearchRequest;
 import org.graylog.storage.elasticsearch7.testing.TestMultisearchResponse;
+import org.graylog2.indexer.searches.SearchesClusterConfig;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -41,6 +42,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.graylog.storage.elasticsearch7.views.ViewsUtils.indicesOf;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -131,7 +133,7 @@ public class ElasticsearchBackendSearchTypesWithStreamsOverridesTest extends Ela
 
     private List<SearchRequest> run(Query query) throws IOException {
         final SearchJob job = searchJobForQuery(query);
-        final ESGeneratedQueryContext context = this.elasticsearchBackend.generate(job, query, Collections.emptySet());
+        final ESGeneratedQueryContext context = this.elasticsearchBackend.generate(job, query, Collections.emptySet(), mock(SearchesClusterConfig.class));
 
         this.elasticsearchBackend.doRun(job, query, context, Collections.emptySet());
 

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackendTest.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackendTest.java
@@ -27,11 +27,10 @@ import org.graylog.plugins.views.search.elasticsearch.ElasticsearchQueryString;
 import org.graylog.plugins.views.search.elasticsearch.FieldTypesLookup;
 import org.graylog.plugins.views.search.elasticsearch.IndexLookup;
 import org.graylog.plugins.views.search.elasticsearch.QueryStringDecorators;
-import org.graylog.plugins.views.search.elasticsearch.QueryStringParser;
-import org.graylog.plugins.views.search.engine.QueryParser;
 import org.graylog.plugins.views.search.searchtypes.MessageList;
 import org.graylog.storage.elasticsearch7.views.searchtypes.ESMessageList;
 import org.graylog.storage.elasticsearch7.views.searchtypes.ESSearchTypeHandler;
+import org.graylog2.indexer.searches.SearchesClusterConfig;
 import org.graylog2.plugin.indexer.searches.timeranges.RelativeRange;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -70,7 +69,7 @@ public class ElasticsearchBackendTest {
         final Search search = Search.builder().queries(ImmutableSet.of(query)).build();
         final SearchJob job = new SearchJob("deadbeef", search, "admin");
 
-        backend.generate(job, query, Collections.emptySet());
+        backend.generate(job, query, Collections.emptySet(), mock(SearchesClusterConfig.class));
     }
 
     @Test

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackendTest.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackendTest.java
@@ -27,11 +27,13 @@ import org.graylog.plugins.views.search.elasticsearch.ElasticsearchQueryString;
 import org.graylog.plugins.views.search.elasticsearch.FieldTypesLookup;
 import org.graylog.plugins.views.search.elasticsearch.IndexLookup;
 import org.graylog.plugins.views.search.elasticsearch.QueryStringDecorators;
+import org.graylog.plugins.views.search.engine.SearchConfig;
 import org.graylog.plugins.views.search.searchtypes.MessageList;
 import org.graylog.storage.elasticsearch7.views.searchtypes.ESMessageList;
 import org.graylog.storage.elasticsearch7.views.searchtypes.ESSearchTypeHandler;
 import org.graylog2.indexer.searches.SearchesClusterConfig;
 import org.graylog2.plugin.indexer.searches.timeranges.RelativeRange;
+import org.joda.time.Period;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -69,7 +71,7 @@ public class ElasticsearchBackendTest {
         final Search search = Search.builder().queries(ImmutableSet.of(query)).build();
         final SearchJob job = new SearchJob("deadbeef", search, "admin");
 
-        backend.generate(job, query, Collections.emptySet(), mock(SearchesClusterConfig.class));
+        backend.generate(job, query, Collections.emptySet(), new SearchConfig(Period.ZERO));
     }
 
     @Test

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackendUsingCorrectIndicesTest.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackendUsingCorrectIndicesTest.java
@@ -35,6 +35,7 @@ import org.graylog.storage.elasticsearch7.ElasticsearchClient;
 import org.graylog.storage.elasticsearch7.testing.TestMultisearchResponse;
 import org.graylog.storage.elasticsearch7.views.searchtypes.ESMessageList;
 import org.graylog.storage.elasticsearch7.views.searchtypes.ESSearchTypeHandler;
+import org.graylog2.indexer.searches.SearchesClusterConfig;
 import org.graylog2.plugin.indexer.searches.timeranges.RelativeRange;
 import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
 import org.joda.time.DateTimeUtils;
@@ -124,7 +125,7 @@ public class ElasticsearchBackendUsingCorrectIndicesTest {
 
     @Test
     public void queryDoesNotFallBackToUsingAllIndicesWhenNoIndexRangesAreReturned() throws Exception {
-        final ESGeneratedQueryContext context = backend.generate(job, query, Collections.emptySet());
+        final ESGeneratedQueryContext context = backend.generate(job, query, Collections.emptySet(), mock(SearchesClusterConfig.class));
         backend.doRun(job, query, context, Collections.emptySet());
 
         verify(client, times(1)).msearch(clientRequestCaptor.capture(), any());
@@ -139,7 +140,7 @@ public class ElasticsearchBackendUsingCorrectIndicesTest {
         final long datetimeFixture = 1530194810;
         DateTimeUtils.setCurrentMillisFixed(datetimeFixture);
 
-        final ESGeneratedQueryContext context = backend.generate(job, query, Collections.emptySet());
+        final ESGeneratedQueryContext context = backend.generate(job, query, Collections.emptySet(), mock(SearchesClusterConfig.class));
         backend.doRun(job, query, context, Collections.emptySet());
 
         ArgumentCaptor<TimeRange> captor = ArgumentCaptor.forClass(TimeRange.class);
@@ -175,7 +176,7 @@ public class ElasticsearchBackendUsingCorrectIndicesTest {
                 .build();
         final Search search = dummySearch(query);
         final SearchJob job = new SearchJob("job1", search, "admin");
-        final ESGeneratedQueryContext context = backend.generate(job, query, Collections.emptySet());
+        final ESGeneratedQueryContext context = backend.generate(job, query, Collections.emptySet(), mock(SearchesClusterConfig.class));
 
         when(indexLookup.indexNamesForStreamsInTimeRange(ImmutableSet.of("streamId"), RelativeRange.create(600)))
                 .thenReturn(ImmutableSet.of("index1", "index2"));
@@ -196,7 +197,7 @@ public class ElasticsearchBackendUsingCorrectIndicesTest {
                 .build();
         final Search search = dummySearch(query);
         final SearchJob job = new SearchJob("job1", search, "admin");
-        final ESGeneratedQueryContext context = backend.generate(job, query, Collections.emptySet());
+        final ESGeneratedQueryContext context = backend.generate(job, query, Collections.emptySet(), mock(SearchesClusterConfig.class));
 
         when(indexLookup.indexNamesForStreamsInTimeRange(ImmutableSet.of("stream1", "stream2"), RelativeRange.create(600)))
                 .thenReturn(ImmutableSet.of("index1", "index2"));

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackendUsingCorrectIndicesTest.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackendUsingCorrectIndicesTest.java
@@ -26,6 +26,7 @@ import org.graylog.plugins.views.search.elasticsearch.ElasticsearchQueryString;
 import org.graylog.plugins.views.search.elasticsearch.FieldTypesLookup;
 import org.graylog.plugins.views.search.elasticsearch.IndexLookup;
 import org.graylog.plugins.views.search.elasticsearch.QueryStringDecorators;
+import org.graylog.plugins.views.search.engine.SearchConfig;
 import org.graylog.plugins.views.search.filter.AndFilter;
 import org.graylog.plugins.views.search.filter.StreamFilter;
 import org.graylog.plugins.views.search.searchtypes.MessageList;
@@ -39,6 +40,7 @@ import org.graylog2.indexer.searches.SearchesClusterConfig;
 import org.graylog2.plugin.indexer.searches.timeranges.RelativeRange;
 import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
 import org.joda.time.DateTimeUtils;
+import org.joda.time.Period;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -125,7 +127,7 @@ public class ElasticsearchBackendUsingCorrectIndicesTest {
 
     @Test
     public void queryDoesNotFallBackToUsingAllIndicesWhenNoIndexRangesAreReturned() throws Exception {
-        final ESGeneratedQueryContext context = backend.generate(job, query, Collections.emptySet(), mock(SearchesClusterConfig.class));
+        final ESGeneratedQueryContext context = backend.generate(job, query, Collections.emptySet(), new SearchConfig(Period.ZERO));
         backend.doRun(job, query, context, Collections.emptySet());
 
         verify(client, times(1)).msearch(clientRequestCaptor.capture(), any());
@@ -140,7 +142,7 @@ public class ElasticsearchBackendUsingCorrectIndicesTest {
         final long datetimeFixture = 1530194810;
         DateTimeUtils.setCurrentMillisFixed(datetimeFixture);
 
-        final ESGeneratedQueryContext context = backend.generate(job, query, Collections.emptySet(), mock(SearchesClusterConfig.class));
+        final ESGeneratedQueryContext context = backend.generate(job, query, Collections.emptySet(), new SearchConfig(Period.ZERO));
         backend.doRun(job, query, context, Collections.emptySet());
 
         ArgumentCaptor<TimeRange> captor = ArgumentCaptor.forClass(TimeRange.class);
@@ -176,7 +178,7 @@ public class ElasticsearchBackendUsingCorrectIndicesTest {
                 .build();
         final Search search = dummySearch(query);
         final SearchJob job = new SearchJob("job1", search, "admin");
-        final ESGeneratedQueryContext context = backend.generate(job, query, Collections.emptySet(), mock(SearchesClusterConfig.class));
+        final ESGeneratedQueryContext context = backend.generate(job, query, Collections.emptySet(), new SearchConfig(Period.ZERO));
 
         when(indexLookup.indexNamesForStreamsInTimeRange(ImmutableSet.of("streamId"), RelativeRange.create(600)))
                 .thenReturn(ImmutableSet.of("index1", "index2"));
@@ -197,7 +199,7 @@ public class ElasticsearchBackendUsingCorrectIndicesTest {
                 .build();
         final Search search = dummySearch(query);
         final SearchJob job = new SearchJob("job1", search, "admin");
-        final ESGeneratedQueryContext context = backend.generate(job, query, Collections.emptySet(), mock(SearchesClusterConfig.class));
+        final ESGeneratedQueryContext context = backend.generate(job, query, Collections.emptySet(), new SearchConfig(Period.ZERO));
 
         when(indexLookup.indexNamesForStreamsInTimeRange(ImmutableSet.of("stream1", "stream2"), RelativeRange.create(600)))
                 .thenReturn(ImmutableSet.of("index1", "index2"));

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/QueryPlanTest.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/QueryPlanTest.java
@@ -30,12 +30,14 @@ import org.graylog.plugins.views.search.elasticsearch.QueryStringParser;
 import org.graylog.plugins.views.search.engine.QueryEngine;
 import org.graylog.plugins.views.search.engine.QueryParser;
 import org.graylog.plugins.views.search.engine.QueryPlan;
+import org.graylog.plugins.views.search.engine.SearchConfig;
 import org.graylog.plugins.views.search.searchtypes.MessageList;
 import org.graylog.storage.elasticsearch7.views.searchtypes.ESMessageList;
 import org.graylog.storage.elasticsearch7.views.searchtypes.ESSearchTypeHandler;
 import org.graylog2.plugin.cluster.ClusterConfigService;
 import org.graylog2.plugin.indexer.searches.timeranges.InvalidRangeParametersException;
 import org.graylog2.plugin.indexer.searches.timeranges.RelativeRange;
+import org.joda.time.Period;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -66,7 +68,7 @@ public class QueryPlanTest {
                 new QueryStringDecorators.Fake(),
                 (elasticsearchBackend, ssb, job, query, results) -> new ESGeneratedQueryContext(elasticsearchBackend, ssb, job, query, results, fieldTypesLookup),
                 false);
-        queryEngine = new QueryEngine(backend, Collections.emptySet(), new QueryParser(queryStringParser), mock(ClusterConfigService.class, RETURNS_DEEP_STUBS));
+        queryEngine = new QueryEngine(backend, Collections.emptySet(), new QueryParser(queryStringParser), () -> new SearchConfig(Period.ZERO));
     }
 
     private static String randomUUID() {

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/QueryPlanTest.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/QueryPlanTest.java
@@ -33,9 +33,11 @@ import org.graylog.plugins.views.search.engine.QueryPlan;
 import org.graylog.plugins.views.search.searchtypes.MessageList;
 import org.graylog.storage.elasticsearch7.views.searchtypes.ESMessageList;
 import org.graylog.storage.elasticsearch7.views.searchtypes.ESSearchTypeHandler;
+import org.graylog2.plugin.cluster.ClusterConfigService;
 import org.graylog2.plugin.indexer.searches.timeranges.InvalidRangeParametersException;
 import org.graylog2.plugin.indexer.searches.timeranges.RelativeRange;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import javax.inject.Provider;
 import java.util.Collections;
@@ -44,6 +46,7 @@ import java.util.UUID;
 
 import static com.google.common.collect.ImmutableSet.of;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 
 public class QueryPlanTest {
@@ -63,7 +66,7 @@ public class QueryPlanTest {
                 new QueryStringDecorators.Fake(),
                 (elasticsearchBackend, ssb, job, query, results) -> new ESGeneratedQueryContext(elasticsearchBackend, ssb, job, query, results, fieldTypesLookup),
                 false);
-        queryEngine = new QueryEngine(backend, Collections.emptySet(), new QueryParser(queryStringParser));
+        queryEngine = new QueryEngine(backend, Collections.emptySet(), new QueryParser(queryStringParser), mock(ClusterConfigService.class, RETURNS_DEEP_STUBS));
     }
 
     private static String randomUUID() {

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/ViewsBindings.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/ViewsBindings.java
@@ -59,6 +59,7 @@ import org.graylog.plugins.views.search.rest.SavedSearchesResource;
 import org.graylog.plugins.views.search.rest.SearchResource;
 import org.graylog.plugins.views.search.rest.ViewsResource;
 import org.graylog.plugins.views.search.rest.ViewsRestPermissions;
+import org.graylog.plugins.views.search.rest.exceptionmappers.IllegalTimeRangeExceptionMapper;
 import org.graylog.plugins.views.search.rest.exceptionmappers.MissingCapabilitiesExceptionMapper;
 import org.graylog.plugins.views.search.rest.exceptionmappers.PermissionExceptionMapper;
 import org.graylog.plugins.views.search.searchtypes.MessageList;
@@ -238,5 +239,6 @@ public class ViewsBindings extends ViewsModule {
     private void registerExceptionMappers() {
         addJerseyExceptionMapper(MissingCapabilitiesExceptionMapper.class);
         addJerseyExceptionMapper(PermissionExceptionMapper.class);
+        addJerseyExceptionMapper(IllegalTimeRangeExceptionMapper.class);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/ViewsBindings.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/ViewsBindings.java
@@ -38,6 +38,8 @@ import org.graylog.plugins.views.search.db.InMemorySearchJobService;
 import org.graylog.plugins.views.search.db.SearchJobService;
 import org.graylog.plugins.views.search.db.SearchesCleanUpJob;
 import org.graylog.plugins.views.search.elasticsearch.ElasticsearchQueryString;
+import org.graylog.plugins.views.search.engine.SearchConfig;
+import org.graylog.plugins.views.search.engine.SearchConfigProvider;
 import org.graylog.plugins.views.search.export.ChunkDecorator;
 import org.graylog.plugins.views.search.export.DecoratingMessagesExporter;
 import org.graylog.plugins.views.search.export.ExportBackend;
@@ -202,6 +204,8 @@ public class ViewsBindings extends ViewsModule {
 
         jerseyAdditionalComponentsBinder().addBinding().toInstance(SimpleMessageChunkCsvWriter.class);
         jerseyAdditionalComponentsBinder().addBinding().toInstance(MessageExportFormatFilter.class);
+
+        bind(SearchConfig.class).toProvider(SearchConfigProvider.class);
     }
 
     private void registerExportBackendProvider() {

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/SearchExecutionGuard.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/SearchExecutionGuard.java
@@ -17,15 +17,23 @@
 package org.graylog.plugins.views.search;
 
 import com.google.common.base.Joiner;
+import org.graylog.plugins.views.search.errors.IllegalTimeRangeException;
 import org.graylog.plugins.views.search.errors.MissingCapabilitiesException;
 import org.graylog.plugins.views.search.views.PluginMetadataSummary;
+import org.graylog2.indexer.searches.SearchesClusterConfig;
 import org.graylog2.plugin.PluginMetaData;
+import org.graylog2.plugin.cluster.ClusterConfigService;
+import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
+import org.graylog2.plugin.rest.ValidationFailureException;
 import org.graylog2.shared.rest.exceptions.MissingStreamPermissionException;
+import org.joda.time.DateTime;
+import org.joda.time.Period;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -35,16 +43,44 @@ public class SearchExecutionGuard {
     private static final Logger LOG = LoggerFactory.getLogger(SearchExecutionGuard.class);
 
     private final Map<String, PluginMetaData> providedCapabilities;
+    private final ClusterConfigService clusterConfigService;
 
     @Inject
-    public SearchExecutionGuard(Map<String, PluginMetaData> providedCapabilities) {
+    public SearchExecutionGuard(Map<String, PluginMetaData> providedCapabilities, ClusterConfigService clusterConfigService) {
         this.providedCapabilities = providedCapabilities;
+        this.clusterConfigService = clusterConfigService;
     }
 
     public void check(Search search, Predicate<String> hasReadPermissionForStream) {
         checkUserIsPermittedToSeeStreams(search.streamIdsForPermissionsCheck(), hasReadPermissionForStream);
-
         checkMissingRequirements(search);
+        checkTimeRange(search);
+    }
+
+    private void checkTimeRange(Search search) {
+        final SearchesClusterConfig config = clusterConfigService.get(SearchesClusterConfig.class);
+
+        if (config == null || Period.ZERO.equals(config.queryTimeRangeLimit())) {
+            return; // all time ranges allowed, stop checking here
+        }
+
+        final Period timeRangeLimit = config.queryTimeRangeLimit();
+        final boolean timeRangeLimitViolation = search.queries().stream()
+                .map(Query::timerange)
+                .filter(Objects::nonNull)
+                .filter(tr -> tr.getFrom() != null && tr.getTo() != null)
+                .anyMatch(tr -> isOutOfLimit(tr, timeRangeLimit));
+
+        if(timeRangeLimitViolation) {
+            throw new IllegalTimeRangeException("Search out of allowed time range limit");
+        }
+    }
+
+    private boolean isOutOfLimit(TimeRange timeRange, Period limit) {
+        final DateTime start = timeRange.getFrom();
+        final DateTime end = timeRange.getTo();
+        final DateTime allowedStart = end.minus(limit);
+        return start.isBefore(allowedStart);
     }
 
     public void checkUserIsPermittedToSeeStreams(Set<String> streamIds, Predicate<String> hasReadPermissionForStream) {

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/engine/QueryBackend.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/engine/QueryBackend.java
@@ -146,7 +146,7 @@ public interface QueryBackend<T extends GeneratedQueryContext> {
     default void validateQueryTimeRange(Query query, SearchesClusterConfig config) {
         Optional.ofNullable(config)
                 .map(SearchesClusterConfig::queryTimeRangeLimit)
-                .filter(limit -> limit != Period.ZERO)
+                .filter(limit -> !Period.ZERO.equals(limit))
                 .flatMap(timeRangeLimit -> Optional.ofNullable(query.timerange())
                         .filter(tr -> tr.getFrom() != null && tr.getTo() != null) // TODO: is this check necessary?
                         .filter(tr -> isOutOfLimit(tr, timeRangeLimit)))

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/engine/QueryEngine.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/engine/QueryEngine.java
@@ -39,6 +39,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
+import javax.inject.Provider;
 import javax.inject.Singleton;
 import java.util.Map;
 import java.util.Objects;
@@ -56,28 +57,28 @@ public class QueryEngine {
 
     private final Set<QueryMetadataDecorator> queryMetadataDecorators;
     private final QueryParser queryParser;
-    private final ClusterConfigService clusterConfigService;
 
     // TODO proper thread pool with tunable settings
     private final Executor queryPool = Executors.newFixedThreadPool(4, new ThreadFactoryBuilder().setNameFormat("query-engine-%d").build());
     private final QueryBackend<? extends GeneratedQueryContext> elasticsearchBackend;
+    private final Provider<SearchConfig> searchConfig;
 
     @Inject
     public QueryEngine(QueryBackend<? extends GeneratedQueryContext> elasticsearchBackend,
                        Set<QueryMetadataDecorator> queryMetadataDecorators,
-                       QueryParser queryParser, ClusterConfigService clusterConfigService) {
+                       QueryParser queryParser, Provider<SearchConfig> searchConfig) {
         this.elasticsearchBackend = elasticsearchBackend;
         this.queryMetadataDecorators = queryMetadataDecorators;
         this.queryParser = queryParser;
-        this.clusterConfigService = clusterConfigService;
+        this.searchConfig = searchConfig;
     }
 
     // TODO: Backwards-compatible constructor to avoid breakage. Remove at some point.
     @Deprecated
     public QueryEngine(Map<String, QueryBackend<? extends GeneratedQueryContext>> backends,
                        Set<QueryMetadataDecorator> queryMetadataDecorators,
-                       QueryParser queryParser, ClusterConfigService clusterConfigService) {
-        this(backends.get("elasticsearch"), queryMetadataDecorators, queryParser, clusterConfigService);
+                       QueryParser queryParser, Provider<SearchConfig> searchConfig) {
+        this(backends.get("elasticsearch"), queryMetadataDecorators, queryParser, searchConfig);
     }
 
     private static Set<QueryResult> allOfResults(Set<CompletableFuture<QueryResult>> futures) {
@@ -165,12 +166,10 @@ public class QueryEngine {
         LOG.debug("[{}] Preparing query execution with results of queries: ({})",
                 query.id(), StreamEx.of(results.stream()).map(QueryResult::query).map(Query::id).joining());
 
-        final SearchesClusterConfig searchesClusterConfig = clusterConfigService.get(SearchesClusterConfig.class);
-
         // with all the results done, we can execute the current query and eventually complete our own result
         // if any of this throws an exception, the handle in #execute will convert it to an error and return a "failed" result instead
         // if the backend already returns a "failed result" then nothing special happens here
-        final GeneratedQueryContext generatedQueryContext = backend.generate(searchJob, query, results, searchesClusterConfig);
+        final GeneratedQueryContext generatedQueryContext = backend.generate(searchJob, query, results,  searchConfig.get());
         LOG.trace("[{}] Generated query {}, running it on backend {}", query.id(), generatedQueryContext, backend);
         final QueryResult result = backend.run(searchJob, query, generatedQueryContext, results);
         LOG.debug("[{}] Query returned {}", query.id(), result);

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/engine/SearchConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/engine/SearchConfig.java
@@ -34,7 +34,7 @@ public class SearchConfig {
      */
     public Optional<Period> getQueryTimeRangeLimit() {
         return Optional.of(queryTimeRangeLimit)
-                .filter(timeLimit -> Period.ZERO != timeLimit);
+                .filter(timeLimit -> !Period.ZERO.equals(timeLimit));
 
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/engine/SearchConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/engine/SearchConfig.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.views.search.engine;
+
+import org.joda.time.Period;
+
+import javax.validation.constraints.NotNull;
+import java.util.Optional;
+
+public class SearchConfig {
+
+    private final Period queryTimeRangeLimit;
+
+    public SearchConfig(@NotNull Period queryTimeRangeLimit) {
+        this.queryTimeRangeLimit = queryTimeRangeLimit;
+    }
+
+    /**
+     * @return configured time limit IF this is not {@code Period.ZERO}
+     */
+    public Optional<Period> getQueryTimeRangeLimit() {
+        return Optional.of(queryTimeRangeLimit)
+                .filter(timeLimit -> Period.ZERO != timeLimit);
+
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/engine/SearchConfigProvider.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/engine/SearchConfigProvider.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.views.search.engine;
+
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import org.graylog2.indexer.searches.SearchesClusterConfig;
+import org.graylog2.plugin.cluster.ClusterConfigService;
+import org.joda.time.Period;
+
+import java.util.Optional;
+
+public class SearchConfigProvider implements Provider<SearchConfig> {
+
+    private final ClusterConfigService clusterConfigService;
+
+    @Inject
+    public SearchConfigProvider(ClusterConfigService clusterConfigService) {
+        this.clusterConfigService = clusterConfigService;
+    }
+
+    @Override
+    public SearchConfig get() {
+        final SearchesClusterConfig searchesClusterConfig = clusterConfigService.get(SearchesClusterConfig.class);
+        final Period queryTimeRangeLimit = Optional.ofNullable(searchesClusterConfig).map(SearchesClusterConfig::queryTimeRangeLimit).orElse(Period.ZERO);
+        return new SearchConfig(queryTimeRangeLimit);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/errors/IllegalTimeRangeException.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/errors/IllegalTimeRangeException.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.views.search.errors;
+
+public class IllegalTimeRangeException extends RuntimeException {
+    public IllegalTimeRangeException(String message) {
+        super(message);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SearchResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SearchResource.java
@@ -95,6 +95,7 @@ public class SearchResource extends RestResource implements PluginRestResource {
     private final SearchDomain searchDomain;
     private final EventBus serverEventBus;
 
+
     @Inject
     public SearchResource(QueryEngine queryEngine,
                           SearchDbService searchDbService,

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/exceptionmappers/IllegalTimeRangeExceptionMapper.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/exceptionmappers/IllegalTimeRangeExceptionMapper.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.views.search.rest.exceptionmappers;
+
+import org.graylog.plugins.views.search.errors.IllegalTimeRangeException;
+import org.graylog.plugins.views.search.errors.PermissionException;
+import org.graylog2.plugin.rest.ApiError;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+public class IllegalTimeRangeExceptionMapper implements ExceptionMapper<IllegalTimeRangeException> {
+    @Override
+    public Response toResponse(IllegalTimeRangeException exception) {
+        final ApiError apiError = ApiError.create(exception.getMessage());
+        return Response.status(Response.Status.BAD_REQUEST).entity(apiError).build();
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/SearchExecutionGuardTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/SearchExecutionGuardTest.java
@@ -19,6 +19,7 @@ package org.graylog.plugins.views.search;
 import com.google.common.collect.ImmutableSet;
 import org.graylog.plugins.views.search.elasticsearch.ElasticsearchQueryString;
 import org.graylog.plugins.views.search.engine.BackendQuery;
+import org.graylog.plugins.views.search.engine.SearchConfig;
 import org.graylog.plugins.views.search.errors.IllegalTimeRangeException;
 import org.graylog.plugins.views.search.errors.MissingCapabilitiesException;
 import org.graylog.plugins.views.search.filter.OrFilter;
@@ -60,12 +61,6 @@ public class SearchExecutionGuardTest {
 
         providedCapabilities = new HashMap<>();
         providedCapabilities.put("my only capability", mock(PluginMetaData.class));
-
-        final ClusterConfigService clusterConfig = mock(ClusterConfigService.class);
-        final SearchesClusterConfig searchesConfig = mock(SearchesClusterConfig.class);
-        when(searchesConfig.queryTimeRangeLimit()).thenReturn(Period.minutes(10));
-        when(clusterConfig.get(SearchesClusterConfig.class)).thenReturn(searchesConfig);
-
         sut = new SearchExecutionGuard(providedCapabilities);
     }
 

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/SearchExecutionGuardTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/SearchExecutionGuardTest.java
@@ -65,7 +65,8 @@ public class SearchExecutionGuardTest {
         final SearchesClusterConfig searchesConfig = mock(SearchesClusterConfig.class);
         when(searchesConfig.queryTimeRangeLimit()).thenReturn(Period.minutes(10));
         when(clusterConfig.get(SearchesClusterConfig.class)).thenReturn(searchesConfig);
-        sut = new SearchExecutionGuard(providedCapabilities, clusterConfig);
+
+        sut = new SearchExecutionGuard(providedCapabilities);
     }
 
     @Test
@@ -106,14 +107,6 @@ public class SearchExecutionGuardTest {
         final Search search = searchWithCapabilityRequirements(onlyRequirement);
 
         assertSucceeds(search, id -> true);
-    }
-
-    @Test
-    public void testTimeRangeOutOfLimit() {
-        // ask for one hour search results but only have 10 minute search limit => should throw an exception
-        final Search oneHourSearch = searchWithStreamIds(createRelativeTimeRange(3600), "streamId");
-        assertThatExceptionOfType(IllegalTimeRangeException.class)
-                .isThrownBy(() -> sut.check(oneHourSearch, id -> true));
     }
 
     private void assertSucceeds(Search search, Predicate<String> isStreamIdPermitted) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This change prevents executing queries with time range out of allowed time range limit if any is configured. It adds the backend validation and complements the already existing frontend validation of the time range.

## Description
Extended SearchExecutionGuard to check time range limit configuration and validate time range of every executed query.

## Motivation and Context
Fixes #9487

/jenkins-pr-deps Graylog2/graylog-plugin-enterprise#2738

## How Has This Been Tested?
Added unit test. Manually verified on localhost:8080/search?q=&rangetype=relative&relative=2592000 with a very low time range limit configured.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/4102775/135044968-08ddc993-9b09-468d-826b-d1c6f64645b6.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

