### PR TITLE
Retry indexing if ES cluster is without coordinator.

### DIFF
--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/jest/JestUtils.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/jest/JestUtils.java
@@ -26,6 +26,7 @@ import org.graylog2.indexer.ElasticsearchException;
 import org.graylog2.indexer.FieldTypeException;
 import org.graylog2.indexer.IndexNotFoundException;
 import org.graylog2.indexer.InvalidWriteTargetException;
+import org.graylog2.indexer.MasterNotDiscoveredException;
 import org.graylog2.indexer.QueryParsingException;
 
 import java.io.IOException;
@@ -100,6 +101,12 @@ public class JestUtils {
                 continue;
             }
             switch(type.asText()) {
+                case "master_not_discovered_exception":
+                    return new MasterNotDiscoveredException();
+                case "cluster_block_exception":
+                    if (reason.asText().contains("no master")) {
+                        return new MasterNotDiscoveredException();
+                    }
                 case "query_parsing_exception":
                     return buildQueryParsingException(errorMessage, rootCause, reasons);
                 case "index_not_found_exception":

--- a/graylog2-server/src/main/java/org/graylog2/indexer/ElasticsearchException.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/ElasticsearchException.java
@@ -30,11 +30,6 @@ import java.util.List;
 public class ElasticsearchException extends RuntimeException {
     private final List<String> errorDetails;
 
-    public ElasticsearchException() {
-        super();
-        this.errorDetails = Collections.emptyList();
-    }
-
     public ElasticsearchException(String message) {
         super(message);
         this.errorDetails = Collections.emptyList();

--- a/graylog2-server/src/main/java/org/graylog2/indexer/MasterNotDiscoveredException.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/MasterNotDiscoveredException.java
@@ -1,0 +1,7 @@
+package org.graylog2.indexer;
+
+public class MasterNotDiscoveredException extends ElasticsearchException {
+    public MasterNotDiscoveredException() {
+        super("Cluster has not elected a master.");
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/indexer/MasterNotDiscoveredException.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/MasterNotDiscoveredException.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog2.indexer;
 
 public class MasterNotDiscoveredException extends ElasticsearchException {

--- a/graylog2-server/src/main/java/org/graylog2/indexer/messages/Messages.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/messages/Messages.java
@@ -30,6 +30,7 @@ import com.google.common.collect.Sets;
 import org.graylog.failure.FailureSubmissionService;
 import org.graylog2.indexer.IndexSet;
 import org.graylog2.indexer.InvalidWriteTargetException;
+import org.graylog2.indexer.MasterNotDiscoveredException;
 import org.graylog2.indexer.results.ResultMessage;
 import org.graylog2.plugin.Message;
 import org.graylog2.shared.utilities.ExceptionUtils;
@@ -75,7 +76,9 @@ public class Messages {
     @SuppressWarnings("UnstableApiUsage")
     private RetryerBuilder<List<IndexingError>> createBulkRequestRetryerBuilder() {
         return RetryerBuilder.<List<IndexingError>>newBuilder()
-                .retryIfException(t -> ExceptionUtils.hasCauseOf(t, IOException.class) || t instanceof InvalidWriteTargetException)
+                .retryIfException(t -> ExceptionUtils.hasCauseOf(t, IOException.class)
+                        || t instanceof InvalidWriteTargetException
+                        || t instanceof MasterNotDiscoveredException)
                 .withWaitStrategy(WaitStrategies.exponentialWait(MAX_WAIT_TIME.getQuantity(), MAX_WAIT_TIME.getUnit()))
                 .withRetryListener(new RetryListener() {
                     @Override


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

**Note:** _This PR contains problematic terminology (`master`) in the description as well as the code. This was a conscious decision, as this terminology is used specifically in the underlying technology (ES). Using different terminology in our product would obscur the underlying details, making it more difficult/impossible to debug this. Hopefully, this terminology will be replaced soon (see elastic/elasticsearch#67833), allowing us to replace the wording in our code as well without creating confusion._

Prior to this PR, when the connected ES cluster was without an elected "master" node, all indexing attempts would fail without being retried and messages are discarded.

This PR is now parsing the errors we are returning and creates a structured exception (`MasterNotDiscoveredException`) which can be retried.

Fixes #10440.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

For both ES6 and ES7, a cluster with three nodes was created. Only one of the nodes was declared as being master-eligibile. After starting Graylog with a functioning cluster, the single node which is master-eligible was stopped. At this point, a specific message was ingested using a GELF HTTP input.
Afterwards, the master-eligible node was started again. After indexing has caught up, the message was searched for (and found).

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.