### PR TITLE
Fixing issue in `BufferUsage` component when node metrics are missing.

### DIFF
--- a/graylog2-web-interface/src/components/nodes/BufferUsage.jsx
+++ b/graylog2-web-interface/src/components/nodes/BufferUsage.jsx
@@ -59,7 +59,8 @@ const BufferUsage = ({ nodeId, bufferType, title }) => {
 
   const { metrics } = useStore(MetricsStore);
 
-  if (!metrics) {
+  // metrics for this node could be undefined
+  if (!metrics?.[nodeId]) {
     return <Spinner />;
   }
 

--- a/graylog2-web-interface/src/components/nodes/BufferUsage.tsx
+++ b/graylog2-web-interface/src/components/nodes/BufferUsage.tsx
@@ -31,10 +31,10 @@ import { useStore } from 'stores/connect';
 const MetricsStore = StoreProvider.getStore('Metrics');
 const MetricsActions = ActionsProvider.getActions('Metrics');
 
-const NodeBufferUsage = styled.div`
-  margin-top: 10px;
-  margin-bottom: 7px;
-`;
+const NodeBufferUsage = styled.div(({ theme }) => css`
+  margin-top: ${theme.spacings.sm};
+  margin-bottom: ${theme.spacings.xs};
+`);
 
 const StyledProgressBar = styled(ProgressBar)`
   margin-bottom: 5px;

--- a/graylog2-web-interface/src/components/nodes/BufferUsage.tsx
+++ b/graylog2-web-interface/src/components/nodes/BufferUsage.tsx
@@ -36,9 +36,9 @@ const NodeBufferUsage = styled.div(({ theme }) => css`
   margin-bottom: ${theme.spacings.xs};
 `);
 
-const StyledProgressBar = styled(ProgressBar)`
-  margin-bottom: 5px;
-`;
+const StyledProgressBar = styled(ProgressBar)(({ theme }) => css`
+  margin-bottom: ${theme.spacings.xs};
+`);
 
 const _metricPrefix = (bufferType) => `org.graylog2.buffers.${bufferType}`;
 

--- a/graylog2-web-interface/src/components/nodes/BufferUsage.tsx
+++ b/graylog2-web-interface/src/components/nodes/BufferUsage.tsx
@@ -17,7 +17,7 @@
 import PropTypes from 'prop-types';
 import * as React from 'react';
 import { useEffect } from 'react';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
 import { LinkContainer } from 'components/graylog/router';
 import { Button, ProgressBar } from 'components/graylog';

--- a/graylog2-web-interface/src/components/nodes/BufferUsage.tsx
+++ b/graylog2-web-interface/src/components/nodes/BufferUsage.tsx
@@ -44,7 +44,13 @@ const _metricPrefix = (bufferType) => `org.graylog2.buffers.${bufferType}`;
 
 const _metricFilter = (bufferType) => `org\\.graylog2\\.buffers\\.${bufferType}\\.|${bufferType}buffer`;
 
-const BufferUsage = ({ nodeId, bufferType, title }) => {
+type Props = {
+  nodeId: string,
+  bufferType: string,
+  title: string,
+};
+
+const BufferUsage = ({ nodeId, bufferType, title }: Props) => {
   useEffect(() => {
     const prefix = _metricPrefix(bufferType);
     const metricNames = [


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

During work on #11317, it was discovered that node metrics might be missing, returning in an exception being thrown in the `BufferUsage` component.

In order to fix, the following steps were taken:
  - the component was converted into a functional component
    - metrics subscription was wrapped in a `useEffect`-block, returning a function that unsubscribes (previously no unsubscribing happened)
  - a guard was introduced that short-circuits to a spinner if node metrics are missing
  - the component was typed

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.