### PR TITLE
Retrieve store state 2nd time after registration to avoid race condition

### DIFF
--- a/graylog2-web-interface/src/components/permissions/EntityShareModal.test.tsx
+++ b/graylog2-web-interface/src/components/permissions/EntityShareModal.test.tsx
@@ -37,13 +37,17 @@ jest.mock('stores/permissions/EntityShareStore', () => ({
   },
   EntityShareStore: {
     listen: jest.fn(),
-    getInitialState: jest.fn(() => ({ state: mockEntityShareState })),
+    getInitialState: jest.fn(),
   },
 }));
 
 jest.setTimeout(10000);
 
 describe('EntityShareModal', () => {
+  beforeEach(() => {
+    asMock(EntityShareStore.getInitialState).mockReturnValue({ state: mockEntityShareState });
+  });
+
   beforeAll(() => {
     jest.useFakeTimers();
   });
@@ -102,7 +106,7 @@ describe('EntityShareModal', () => {
 
   describe('displays', () => {
     it('loading spinner while loading entity share state', () => {
-      asMock(EntityShareStore.getInitialState).mockReturnValueOnce(mockEmptyStore);
+      asMock(EntityShareStore.getInitialState).mockReturnValue(mockEmptyStore);
       const { getByText } = render(<SimpleEntityShareModal />);
 
       act(() => { jest.advanceTimersByTime(200); });
@@ -111,7 +115,7 @@ describe('EntityShareModal', () => {
     });
 
     it('displays an error if validation failed and disables submit', () => {
-      asMock(EntityShareStore.getInitialState).mockReturnValueOnce(mockFailedStore);
+      asMock(EntityShareStore.getInitialState).mockReturnValue(mockFailedStore);
       const { getByText } = render(<SimpleEntityShareModal />);
 
       expect(getByText('Removing the following owners will leave the entity ownerless:')).not.toBeNull();
@@ -264,7 +268,7 @@ describe('EntityShareModal', () => {
         .build();
 
       beforeEach(() => {
-        asMock(EntityShareStore.getInitialState).mockReturnValueOnce({ state: entityShareState });
+        asMock(EntityShareStore.getInitialState).mockReturnValue({ state: entityShareState });
       });
 
       const deleteGrantee = async ({ grantee }) => {

--- a/graylog2-web-interface/src/stores/connect.tsx
+++ b/graylog2-web-interface/src/stores/connect.tsx
@@ -45,12 +45,17 @@ export function useStore(store, propsMapper = id) {
 
   const mappedStoreState = useMemo(() => propsMapper(storeState), [propsMapper, storeState]);
 
-  useEffect(() => store.listen((newState) => {
-    if (!isDeepEqual(newState, storeStateRef.current)) {
-      setStoreState(newState);
-      storeStateRef.current = newState;
-    }
-  }), [store]);
+  useEffect(() => {
+    const unsub = store.listen((newState) => {
+      if (!isDeepEqual(newState, storeStateRef.current)) {
+        setStoreState(newState);
+        storeStateRef.current = newState;
+      }
+    });
+    setStoreState(store.getInitialState());
+
+    return unsub;
+  }, [store]);
 
   return mappedStoreState;
 }

--- a/graylog2-web-interface/src/views/components/widgets/TimerangeInfo.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/TimerangeInfo.test.tsx
@@ -75,6 +75,10 @@ describe('TimerangeInfo', () => {
     </TimeLocalizeContext.Provider>
   );
 
+  beforeEach(() => {
+    asMock(GlobalOverrideStore.getInitialState).mockReturnValue(GlobalOverride.empty());
+  });
+
   it('should display the effective timerange as title', () => {
     const relativeWidget = widget.toBuilder().timerange({ type: 'relative', range: 3000 }).build();
     render(<SUT widget={relativeWidget} activeQuery="active-query-id" widgetId="widget-id" />);
@@ -123,7 +127,7 @@ describe('TimerangeInfo', () => {
 
   it('should display global override', () => {
     const state: GlobalOverrideStoreState = GlobalOverride.empty().toBuilder().timerange({ type: 'relative', range: 3000 }).build();
-    asMock(GlobalOverrideStore.getInitialState).mockReturnValueOnce(state);
+    asMock(GlobalOverrideStore.getInitialState).mockReturnValue(state);
 
     const keywordWidget = widget.toBuilder()
       .timerange({ type: 'keyword', keyword: '5 minutes ago' })
@@ -137,7 +141,7 @@ describe('TimerangeInfo', () => {
   it('should not throw error when related search type is empty', () => {
     const relativeWidget = widget.toBuilder().timerange({ type: 'relative', range: 3000 }).build();
 
-    asMock(SearchStore.getInitialState).mockReturnValueOnce(mockSearchStoreState({
+    asMock(SearchStore.getInitialState).mockReturnValue(mockSearchStoreState({
       result: {
         results: {
           'active-query-id': {
@@ -153,7 +157,7 @@ describe('TimerangeInfo', () => {
   });
 
   it('should not throw error and display default time range when widget id does not exist in search widget mapping', () => {
-    asMock(SearchStore.getInitialState).mockReturnValueOnce(mockSearchStoreState({
+    asMock(SearchStore.getInitialState).mockReturnValue(mockSearchStoreState({
       widgetMapping: Immutable.Map(),
     }) as SearchStoreState);
 

--- a/graylog2-web-interface/src/views/pages/ViewManagementPage.test.tsx
+++ b/graylog2-web-interface/src/views/pages/ViewManagementPage.test.tsx
@@ -50,7 +50,7 @@ describe('ViewManagementPage', () => {
   };
 
   beforeEach(() => {
-    mockViewManagementStore.getInitialState.mockImplementationOnce(() => viewsResult);
+    mockViewManagementStore.getInitialState.mockImplementation(() => viewsResult);
   });
 
   it('passes retrieved views to list component', () => {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Prior to this PR, the `useStore` logic to connect a component with a store looked like this:

  1. retrieve current state from store and set it in state
  2. register listener on store which updates state upon store updates

This could lead to a race condition in some scenarios, where between 1.  & 2. a store update is happening, which is not processed by the `useStore` hook due to no being registered to the store at this time.

In order to prevent this, a 3rd step is added to `useStore`'s logic:

  3. retrieve current state from store again and set it in state

This helps ups keeping up with potential store updates between 1. & 2.  In addition, it does not necessarily mean that an additional rerendering of the component is triggered, if the state retrieved in 1. and 3. is shallowly equal (due to the setter function of `useState` not triggering a rerender when [both values are equal](https://reactjs.org/docs/hooks-reference.html#bailing-out-of-a-state-update)).

Fixes #11316.

/jenkins-pr-deps Graylog2/graylog-plugin-enterprise#2733

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

This PR was created mainly to fix the issue in #11316. Therefore, the `AppFacade` component was modified to render a component which is triggering a full page refresh, effectively going into an infinite loop of validating the session -> refreshing the page, until it gets stuck in the condition described in the issue.

After fixing the issue with the changes in this PR, the loop never got stuck in the condition again.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.