### PR TITLE
Fixing positioning of message augmentations.

### DIFF
--- a/graylog2-web-interface/src/components/common/ReactGridContainer.tsx
+++ b/graylog2-web-interface/src/components/common/ReactGridContainer.tsx
@@ -189,7 +189,9 @@ const ReactGridContainer = ({
                                    draggableCancel=".actions"
                                    onDragStop={onLayoutChange}
                                    onResizeStop={onLayoutChange}
-                                   useCSSTransforms
+      // While CSS transform improves the paint performance,
+      // it currently results in bug when using `react-sticky-el` inside a grid item.
+                                   useCSSTransforms={false}
                                    draggableHandle={locked ? '' : draggableHandle}>
       {children}
     </StyledWidthProvidedGridLayout>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

We recently changed the way we position widgets in the widget
grid, by using CSS transforms instead of `position: fixed;`. This
affected the sticky position of the message augmentations. 

To fix this bug we decided to disable `useCSSTransforms` for the grid  for now.


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

