### PR TITLE
Adding job to fix linter hints periodically.

### DIFF
--- a/.github/workflows/fix-linter-hints.yml
+++ b/.github/workflows/fix-linter-hints.yml
@@ -1,8 +1,8 @@
 name: Fix linter hints
 
 on: 
-schedule:
-  - cron: '0 */8 * * *'
+  schedule:
+    - cron: '0 */8 * * *'
 
 jobs:
   build:

--- a/.github/workflows/fix-linter-hints.yml
+++ b/.github/workflows/fix-linter-hints.yml
@@ -1,0 +1,33 @@
+name: Fix linter hints
+
+on: 
+schedule:
+  - cron: '0 */8 * * *'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest 
+    defaults:
+      run:
+        working-directory: graylog2-web-interface
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Yarn cache
+        uses: actions/cache@v2
+        with:
+          key: ${{ runner.os }}-yarn-${{ hashFiles('graylog2-web-interface/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+          path: ~/.cache/yarn
+      - name: Install dependencies
+        run: yarn install
+      - name: Run lint --fix
+        run: yarn lint --fix
+      - name: Create/Update Pull Request
+        uses: Graylog2/create-pull-request@7380612b49221684fefa025244f2ef4008ae50ad
+        with:
+          title: Fixing linter hints automatically
+          body: This PR was created by a job that is running periodiocally to find and fix linter hints.
+          branch: fix/linter-hints
+


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR creates a github actions job which runs periodically (starting with every 8h), running `lint --fix` to find and fix new linter hints which can be auto-fixed.

This is particularly useful as long as we do not enforce auto-fixing in PRs, as well as due to eslint rule updates introducing new, auto-fixable hints in the existing codebase.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.