### PR TITLE
Improve filtering with SelectPopover

### DIFF
--- a/graylog2-web-interface/src/components/common/SelectPopover.jsx
+++ b/graylog2-web-interface/src/components/common/SelectPopover.jsx
@@ -58,6 +58,8 @@ class SelectPopover extends React.Component {
      * and must return a React node that will be displayed on screen.
      */
     itemFormatter: PropTypes.func,
+    /** Function that returns a string representing the item when filtering the list of items. */
+    itemFilterKeyFormatter: PropTypes.func,
     /** Indicates whether the component will allow multiple selected items or not. */
     multiple: PropTypes.bool,
     /** Indicates which items are selected. This should be the same string that appears in the `items` list. */
@@ -83,6 +85,7 @@ class SelectPopover extends React.Component {
     triggerAction: 'click',
     items: [],
     itemFormatter: (item) => item,
+    itemFilterKeyFormatter: (item) => item,
     multiple: false,
     selectedItems: [],
     displayDataFilter: true,
@@ -143,7 +146,9 @@ class SelectPopover extends React.Component {
   };
 
   filterData = (filterText, items) => {
-    const newFilteredItems = items.filter((item) => item.match(new RegExp(filterText, 'i')));
+    const { itemFilterKeyFormatter } = this.props;
+    const filterRegex = new RegExp(filterText, 'i');
+    const newFilteredItems = items.filter((item) => itemFilterKeyFormatter(item).match(filterRegex));
 
     this.setState({ filterText: filterText, filteredItems: newFilteredItems });
   };

--- a/graylog2-web-interface/src/components/sidecars/administration/CollectorConfigurationSelector.jsx
+++ b/graylog2-web-interface/src/components/sidecars/administration/CollectorConfigurationSelector.jsx
@@ -87,6 +87,13 @@ class CollectorConfigurationSelector extends React.Component {
     );
   };
 
+  configurationFilterKeyFormatter = (configurationId) => {
+    const { configurations } = this.props;
+    const configuration = configurations.find((c) => c.id === configurationId);
+
+    return configuration.name;
+  };
+
   renderConfigurationSummary = (nextAssignedConfigurations, selectedSidecarCollectorPairs) => {
     const exampleSidecarCollectorPair = selectedSidecarCollectorPairs[0];
     const collectorIndicator = (
@@ -164,6 +171,7 @@ class CollectorConfigurationSelector extends React.Component {
                        triggerNode={<Button bsSize="small" bsStyle="link">Configure <span className="caret" /></Button>}
                        items={configurationIds}
                        itemFormatter={this.configurationFormatter}
+                       itemFilterKeyFormatter={this.configurationFilterKeyFormatter}
                        onItemSelect={this.handleConfigurationSelect}
                        selectedItems={assignedConfigurations.map((config) => config.id)}
                        filterPlaceholder="Filter by configuration" />

--- a/graylog2-web-interface/src/components/sidecars/administration/CollectorsAdministrationFilters.jsx
+++ b/graylog2-web-interface/src/components/sidecars/administration/CollectorsAdministrationFilters.jsx
@@ -43,40 +43,34 @@ const CollectorsAdministrationFilters = createReactClass({
 
   getCollectorsFilter() {
     const { collectors, filters } = this.props;
-    const collectorMapper = (collector) => `${collector.id};${collector.name}`;
 
-    const collectorItems = collectors
+    const collectorIds = collectors
       .sort((c1, c2) => naturalSortIgnoreCase(c1.name, c2.name))
-      // TODO: Hack to be able to filter in SelectPopover. We should change that to avoid this hack.
-      .map(collectorMapper);
+      .map((c) => c.id);
 
     const collectorFormatter = (collectorId) => {
-      const [id] = collectorId.split(';');
-      const collector = lodash.find(collectors, { id: id });
+      const collector = lodash.find(collectors, { id: collectorId });
 
       return <CollectorIndicator collector={collector.name} operatingSystem={collector.node_operating_system} />;
     };
 
-    const filter = ([collectorId], callback) => {
-      const [id] = collectorId ? collectorId.split(';') : [];
+    const collectorFilterKeyFormatter = (collectorId) => {
+      const collector = lodash.find(collectors, { id: collectorId });
 
-      this.onFilterChange('collector', id, callback);
+      return `${collector.name} on ${collector.node_operating_system}`;
     };
 
-    let collectorFilter;
+    const filter = ([collectorId], callback) => this.onFilterChange('collector', collectorId, callback);
 
-    if (filters.collector) {
-      const collector = collectors.find((c) => c.id === filters.collector);
-
-      collectorFilter = collector ? collectorMapper(collector) : undefined;
-    }
+    const collectorFilter = filters.collector ? collectors.find((c) => c.id === filters.collector) : undefined;
 
     return (
       <SelectPopover id="collector-filter"
                      title="Filter by collector"
                      triggerNode={<Button bsSize="small" bsStyle="link">Collector <span className="caret" /></Button>}
-                     items={collectorItems}
+                     items={collectorIds}
                      itemFormatter={collectorFormatter}
+                     itemFilterKeyFormatter={collectorFilterKeyFormatter}
                      onItemSelect={filter}
                      selectedItems={collectorFilter ? [collectorFilter] : []}
                      filterPlaceholder="Filter by collector" />
@@ -86,39 +80,33 @@ const CollectorsAdministrationFilters = createReactClass({
   getConfigurationFilter() {
     const { configurations, filters } = this.props;
 
-    const configurationMapper = (configuration) => `${configuration.id};${configuration.name}`;
-    const configurationItems = configurations
+    const configurationIds = configurations
       .sort((c1, c2) => naturalSortIgnoreCase(c1.name, c2.name))
-      // TODO: Hack to be able to filter in SelectPopover. We should change that to avoid this hack.
-      .map(configurationMapper);
+      .map((c) => c.id);
 
     const configurationFormatter = (configurationId) => {
-      const [id] = configurationId.split(';');
-      const configuration = lodash.find(configurations, { id: id });
+      const configuration = lodash.find(configurations, { id: configurationId });
 
       return <span><ColorLabel color={configuration.color} size="xsmall" /> {configuration.name}</span>;
     };
 
-    const filter = ([configurationId], callback) => {
-      const [id] = configurationId ? configurationId.split(';') : [];
+    const configurationFilterKeyFormatter = (configurationId) => {
+      const configuration = lodash.find(configurations, { id: configurationId });
 
-      this.onFilterChange('configuration', id, callback);
+      return configuration.name;
     };
 
-    let configurationFilter;
+    const filter = ([configurationId], callback) => this.onFilterChange('configuration', configurationId, callback);
 
-    if (filters.configuration) {
-      const configuration = configurations.find((c) => c.id === filters.configuration);
-
-      configurationFilter = configuration ? configurationMapper(configuration) : undefined;
-    }
+    const configurationFilter = filters.configuration ? configurations.find((c) => c.id === filters.configuration) : undefined;
 
     return (
       <SelectPopover id="configuration-filter"
                      title="Filter by configuration"
                      triggerNode={<Button bsSize="small" bsStyle="link">Configuration <span className="caret" /></Button>}
-                     items={configurationItems}
+                     items={configurationIds}
                      itemFormatter={configurationFormatter}
+                     itemFilterKeyFormatter={configurationFilterKeyFormatter}
                      onItemSelect={filter}
                      selectedItems={configurationFilter ? [configurationFilter] : []}
                      filterPlaceholder="Filter by configuration" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR adds `itemFilterKeyFormatter` to [`SelectPopover`](https://github.com/Graylog2/graylog2-server/blob/master/graylog2-web-interface/src/components/common/SelectPopover.jsx) and uses it in certain sidecar admin components.  `itemFilterKeyFormatter` enables passing in a function that takes an item and returns a string representation for use when filtering/searching the list of items.  For example, users could filter the Collector list (@ `/system/sidecars/administration`) using "filebeat", "Filebeat on Linux", "Windows", etc.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Filtering with certain uses of `SelectPopover` is either completely broken or requires workarounds (e.g. if not just dealing with a list of strings).  This PR is intended to make `SelectPopover` filtering a bit more intuitive.

Fixes #9133.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Aside from ensuring no errors from an editor perspective (and watching the post-PR actions) it has not.  I don't have a local testing environment set up.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

