### PR TITLE
Fix system stats with MongoDB >= 4.4

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/system/stats/mongo/DatabaseStats.java
+++ b/graylog2-server/src/main/java/org/graylog2/system/stats/mongo/DatabaseStats.java
@@ -49,7 +49,8 @@ public abstract class DatabaseStats {
     public abstract long storageSize();
 
     @JsonProperty
-    public abstract long numExtents();
+    @Nullable
+    public abstract Long numExtents();
 
     @JsonProperty
     public abstract long indexes();
@@ -79,7 +80,7 @@ public abstract class DatabaseStats {
                                        double avgObjSize,
                                        long dataSize,
                                        long storageSize,
-                                       long numExtents,
+                                       @Nullable Long numExtents,
                                        long indexes,
                                        long indexSize,
                                        @Nullable Long fileSize,

--- a/graylog2-server/src/main/java/org/graylog2/system/stats/mongo/MongoProbe.java
+++ b/graylog2-server/src/main/java/org/graylog2/system/stats/mongo/MongoProbe.java
@@ -173,7 +173,7 @@ public class MongoProbe {
                     dbStatsResult.getDouble("avgObjSize"),
                     dbStatsResult.getLong("dataSize"),
                     dbStatsResult.getLong("storageSize"),
-                    dbStatsResult.getLong("numExtents"),
+                    dbStatsResult.containsField("numExtents") ? dbStatsResult.getLong("numExtents") : null,
                     dbStatsResult.getLong("indexes"),
                     dbStatsResult.getLong("indexSize"),
                     dbStatsResult.containsField("fileSize") ? dbStatsResult.getLong("fileSize") : null,


### PR DESCRIPTION
The "numExtents" value got removed in MongoDB 4.4.

Fixes #11350

*Note:* This should be backported to 4.1.