### PR TITLE
Allow linter step to exit with non-zero return code.

### DIFF
--- a/.github/workflows/fix-linter-hints.yml
+++ b/.github/workflows/fix-linter-hints.yml
@@ -23,6 +23,7 @@ jobs:
       - name: Install dependencies
         run: yarn install
       - name: Run lint --fix
+        continue-on-error: true
         run: yarn lint --fix
       - name: Create/Update Pull Request
         uses: Graylog2/create-pull-request@7380612b49221684fefa025244f2ef4008ae50ad


### PR DESCRIPTION
Allow the linter step in the github workflow to exit with non-zero
return code.