### PR TITLE
Improve positioning of trend bar in number visualization.

### DIFF
--- a/graylog2-web-interface/src/views/components/visualizations/number/NumberVisualization.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/number/NumberVisualization.tsx
@@ -29,6 +29,7 @@ import RenderCompletionCallback from 'views/components/widgets/RenderCompletionC
 import NumberVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/NumberVisualizationConfig';
 import type { VisualizationComponentProps } from 'views/components/aggregationbuilder/AggregationBuilder';
 import { makeVisualization, retrieveChartData } from 'views/components/aggregationbuilder/AggregationBuilder';
+import { Center } from 'components/common';
 
 import Trend from './Trend';
 import AutoFontSizer from './AutoFontSizer';
@@ -38,7 +39,7 @@ import type { CurrentViewType } from '../../CustomPropTypes';
 const GridContainer = styled.div`
   display: grid;
   grid-template-columns: 1fr;
-  grid-template-rows: 4fr 1fr;
+  grid-template-rows: 4fr auto;
   grid-column-gap: 0;
   grid-row-gap: 0;
   height: 100%;

--- a/graylog2-web-interface/src/views/components/visualizations/number/NumberVisualization.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/number/NumberVisualization.tsx
@@ -29,7 +29,6 @@ import RenderCompletionCallback from 'views/components/widgets/RenderCompletionC
 import NumberVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/NumberVisualizationConfig';
 import type { VisualizationComponentProps } from 'views/components/aggregationbuilder/AggregationBuilder';
 import { makeVisualization, retrieveChartData } from 'views/components/aggregationbuilder/AggregationBuilder';
-import { Center } from 'components/common';
 
 import Trend from './Trend';
 import AutoFontSizer from './AutoFontSizer';
@@ -90,7 +89,7 @@ const _extractValueAndField = (rows: Rows) => {
 };
 
 type Props = {
-  currentView: CurrentViewType,
+  currentView: CurrentViewType;
 } & VisualizationComponentProps;
 
 const _extractFirstSeriesName = (config) => {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Prior to this PR, the trend bar of the number visualization was
positioned starting at 80% of the overall widget height. This could lead
to empty space if the trend bar was smaller than the remaining 20%.

This change is now making it stick to the bottom, leaving more space for
the number itself and looking better.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.