### PR TITLE
Adding author to lint job, deleting branch after merge.

### DIFF
--- a/.github/workflows/fix-linter-hints.yml
+++ b/.github/workflows/fix-linter-hints.yml
@@ -30,5 +30,8 @@ jobs:
         with:
           title: Fixing linter hints automatically
           body: This PR was created by a job that is running periodiocally to find and fix linter hints.
+          author: Dr. Lint-a-lot <hello@graylog.com>
           branch: fix/linter-hints
-
+          committer: Dr. Lint-a-lot <hello@graylog.com>
+          commit-message: Running lint --fix
+          delete-branch: true


### PR DESCRIPTION
This small change is adding author information, so commits do not show up as belonging to @linuspahl. It also enables that the branch is deleted after merge.