### PR TITLE
Display error page when error occures while loading a view.

### DIFF
--- a/graylog2-web-interface/src/views/logic/views/UseLoadView.tsx
+++ b/graylog2-web-interface/src/views/logic/views/UseLoadView.tsx
@@ -28,7 +28,7 @@ const LoadViewError = ({ error }: { error: Error }) => (
   <ErrorPage title="Something went wrong"
              description={<p>An unknown error has occurred. Please have a look at the following message and the graylog server log for more information.</p>}>
     <pre>
-      {JSON.stringify(error)}
+      {error?.message}
     </pre>
   </ErrorPage>
 );

--- a/graylog2-web-interface/src/views/logic/views/UseLoadView.tsx
+++ b/graylog2-web-interface/src/views/logic/views/UseLoadView.tsx
@@ -15,11 +15,23 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import { useEffect, useState } from 'react';
+import * as React from 'react';
+
+import ErrorPage from 'components/errors/ErrorPage';
 
 import type View from './View';
 import { processHooks } from './ViewLoader';
 
 import usePluginEntities from '../usePluginEntities';
+
+const LoadViewError = ({ error }: { error: Error }) => (
+  <ErrorPage title="Something went wrong"
+             description={<p>An unknown error has occurred. Please have a look at the following message and the graylog server log for more information.</p>}>
+    <pre>
+      {JSON.stringify(error)}
+    </pre>
+  </ErrorPage>
+);
 
 const useLoadView = (view: Promise<View>, query: { [key: string]: any }) => {
   const loadingViewHooks = usePluginEntities('views.hooks.loadingView');
@@ -40,7 +52,9 @@ const useLoadView = (view: Promise<View>, query: { [key: string]: any }) => {
       },
     ).catch((e) => {
       if (e instanceof Error) {
-        throw e;
+        setHookComponent(<LoadViewError error={e} />);
+
+        return;
       }
 
       setHookComponent(e);

--- a/graylog2-web-interface/src/views/pages/NewSearchPage.test.tsx
+++ b/graylog2-web-interface/src/views/pages/NewSearchPage.test.tsx
@@ -16,10 +16,11 @@
  */
 import * as React from 'react';
 import { act } from 'react-dom/test-utils';
-import { render, waitFor, fireEvent } from 'wrappedTestingLibrary';
+import { render, waitFor, fireEvent, screen } from 'wrappedTestingLibrary';
 
-import asMock from 'helpers/mocking/AsMock';
 import { MockStore } from 'helpers/mocking';
+import asMock from 'helpers/mocking/AsMock';
+import mockComponent from 'helpers/mocking/MockComponent';
 import { processHooks } from 'views/logic/views/ViewLoader';
 import { ViewActions } from 'views/stores/ViewStore';
 import NewViewLoaderContext from 'views/logic/NewViewLoaderContext';
@@ -40,7 +41,9 @@ const mockView = View.create()
 
 jest.mock('routing/withLocation', () => (x) => x);
 jest.mock('views/components/Search', () => jest.fn(() => <div>Extended search page</div>));
+jest.mock('components/common/PublicNotifications', () => mockComponent('PublicNotifications'));
 jest.mock('views/stores/SearchStore');
+jest.mock('views/logic/usePluginEntities');
 
 jest.mock('views/stores/ViewStatesStore', () => ({
   ViewStatesStore: {
@@ -122,6 +125,15 @@ describe('NewSearchPage', () => {
 
       await waitFor(() => expect(processHooksAction).toBeCalledTimes(1));
       await waitFor(() => expect(processHooksAction.mock.calls[0][3]).toStrictEqual({ q: '', rangetype: 'relative', relative: '300' }));
+    });
+
+    it('should display errors which occur when processing hooks', async () => {
+      asMock(processHooks).mockImplementation(() => Promise.reject(new Error('The Error')));
+
+      render(<SimpleNewSearchPage location={mockLocation} />);
+
+      await screen.findByText(/An unknown error has occurred./);
+      await screen.findByText(/The Error/);
     });
   });
 

--- a/graylog2-web-interface/src/views/pages/NewSearchPage.test.tsx
+++ b/graylog2-web-interface/src/views/pages/NewSearchPage.test.tsx
@@ -43,7 +43,6 @@ jest.mock('routing/withLocation', () => (x) => x);
 jest.mock('views/components/Search', () => jest.fn(() => <div>Extended search page</div>));
 jest.mock('components/common/PublicNotifications', () => mockComponent('PublicNotifications'));
 jest.mock('views/stores/SearchStore');
-jest.mock('views/logic/usePluginEntities');
 
 jest.mock('views/stores/ViewStatesStore', () => ({
   ViewStatesStore: {
@@ -128,7 +127,7 @@ describe('NewSearchPage', () => {
     });
 
     it('should display errors which occur when processing hooks', async () => {
-      asMock(processHooks).mockImplementation(() => Promise.reject(new Error('The Error')));
+      asMock(processHooks).mockImplementationOnce(() => Promise.reject(new Error('The Error')));
 
       render(<SimpleNewSearchPage location={mockLocation} />);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Before this change we were just throwing an in some cases error when loading a view, but not displaying the
error message in a way it can be read by the user.
