### PR TITLE
Avoid not needed search creation on default and stream search page

### DIFF
--- a/graylog2-web-interface/src/routing/withLocation.tsx
+++ b/graylog2-web-interface/src/routing/withLocation.tsx
@@ -21,10 +21,10 @@ import { Subtract } from 'utility-types';
 
 import useQuery from './useQuery';
 
-export type Location = {
-  query: {
-    [key: string]: unknown | null | undefined;
-  };
+export type Location<
+  Query = { [key: string]: unknown | null | undefined; }
+> = {
+  query: Query;
   pathname: string;
   search: string;
 };

--- a/graylog2-web-interface/src/views/hooks/BindSearchParamsFromQuery.ts
+++ b/graylog2-web-interface/src/views/hooks/BindSearchParamsFromQuery.ts
@@ -18,16 +18,16 @@ import isDeepEqual from 'stores/isDeepEqual';
 import { QueriesActions } from 'views/stores/QueriesStore';
 import { ViewHook } from 'views/logic/hooks/ViewHook';
 import View from 'views/logic/views/View';
-import normalizeSearchURLQueryParams, { RawQuery } from 'views/logic/NormalizeSearchURLQueryParmas';
+import normalizeSearchURLQueryParams, { RawQuery } from 'views/logic/NormalizeSearchURLQueryParams';
 
 const bindSearchParamsFromQuery: ViewHook = ({ query, view }: {query: RawQuery, view: View }) => {
   if (view.type !== View.Type.Search) {
     return Promise.resolve(true);
   }
 
-  const { queryString, timeRange, streams } = normalizeSearchURLQueryParams(query);
+  const { queryString, timeRange, streamsFilter } = normalizeSearchURLQueryParams(query);
 
-  if (!queryString && !timeRange && !streams) {
+  if (!queryString && !timeRange && !streamsFilter) {
     return Promise.resolve(true);
   }
 
@@ -48,8 +48,8 @@ const bindSearchParamsFromQuery: ViewHook = ({ query, view }: {query: RawQuery, 
     queryBuilder = queryBuilder.timerange(timeRange);
   }
 
-  if (streams) {
-    queryBuilder = queryBuilder.filter(streams);
+  if (streamsFilter) {
+    queryBuilder = queryBuilder.filter(streamsFilter);
   }
 
   const newQuery = queryBuilder.build();

--- a/graylog2-web-interface/src/views/hooks/BindSearchParamsFromQuery.ts
+++ b/graylog2-web-interface/src/views/hooks/BindSearchParamsFromQuery.ts
@@ -15,111 +15,19 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import isDeepEqual from 'stores/isDeepEqual';
-import { DEFAULT_RANGE_TYPE } from 'views/Constants';
 import { QueriesActions } from 'views/stores/QueriesStore';
 import { ViewHook } from 'views/logic/hooks/ViewHook';
 import View from 'views/logic/views/View';
-import {
-  AbsoluteTimeRange,
-  createElasticsearchQueryString,
-  filtersForQuery, KeywordTimeRange,
-} from 'views/logic/queries/Query';
+import normalizeSearchURLQueryParams, { RawQuery } from 'views/logic/NormalizeSearchURLQueryParmas';
 
-type RawRelativeRange = {
-  rangetype: 'relative';
-  relative?: string;
-};
-
-type RawAbsoluteRange = {
-  rangetype: 'absolute';
-  from?: string;
-  to?: string;
-};
-
-type RawKeywordRange = {
-  rangetype: 'keyword';
-  keyword?: string;
-  timezone?: string;
-};
-
-const _getRange = (query): RawAbsoluteRange | RawRelativeRange | RawKeywordRange => {
-  const rangetype = query.rangetype || DEFAULT_RANGE_TYPE;
-
-  return { ...query, rangetype };
-};
-
-const _getRelativeTimeRange = (range) => {
-  const parseRangeValue = (rangeValue: string) => parseInt(rangeValue, 10);
-
-  if (range.rangetype) {
-    if ('relative' in range) {
-      return { type: range.rangetype, range: parseRangeValue(range.relative) };
-    }
-
-    if ('from' in range) {
-      const result = { type: range.rangetype, from: parseRangeValue(range.from) };
-
-      if ('to' in range) {
-        return { ...result, to: parseRangeValue(range.to) };
-      }
-
-      return result;
-    }
-  }
-
-  return undefined;
-};
-
-const _getTimerange = (query = {}) => {
-  const range = _getRange(query);
-
-  switch (range.rangetype) {
-    case 'relative':
-      return _getRelativeTimeRange(range);
-    case 'absolute':
-      return (range.from || range.to)
-        ? {
-          type: range.rangetype,
-          from: range.from,
-          to: range.to,
-        } as AbsoluteTimeRange
-        : undefined;
-    case 'keyword':
-      return range.keyword ? { type: range.rangetype, keyword: range.keyword, timezone: range.timezone } as KeywordTimeRange : undefined;
-    default:
-      // @ts-ignore
-      throw new Error(`Unsupported range type ${range.rangetype}`);
-  }
-};
-
-type StreamsQuery = {
-  streams?: string;
-};
-
-const _getStreams = (query: StreamsQuery = {}): Array<string> => {
-  const rawStreams = query.streams;
-
-  if (rawStreams === undefined || rawStreams === null) {
-    return [];
-  }
-
-  return String(rawStreams).split(',')
-    .map((stream) => stream.trim())
-    .filter((stream) => stream !== '');
-};
-
-type RawQuery = (RawAbsoluteRange | RawRelativeRange | RawKeywordRange) & StreamsQuery;
-
-const bindSearchParamsFromQuery: ViewHook = ({ query, view }) => {
+const bindSearchParamsFromQuery: ViewHook = ({ query, view }: {query: RawQuery, view: View }) => {
   if (view.type !== View.Type.Search) {
     return Promise.resolve(true);
   }
 
-  const { q: queryString } = query;
-  const timerange = _getTimerange(query as RawQuery);
-  const streams = filtersForQuery(_getStreams(query));
+  const { queryString, timeRange, streams } = normalizeSearchURLQueryParams(query);
 
-  if (!queryString && !timerange && !streams) {
+  if (!queryString && !timeRange && !streams) {
     return Promise.resolve(true);
   }
 
@@ -132,12 +40,12 @@ const bindSearchParamsFromQuery: ViewHook = ({ query, view }) => {
   const firstQuery = queries.first();
   let queryBuilder = firstQuery.toBuilder();
 
-  if (queryString !== undefined) {
-    queryBuilder = queryBuilder.query(createElasticsearchQueryString(queryString));
+  if (queryString) {
+    queryBuilder = queryBuilder.query(queryString);
   }
 
-  if (timerange) {
-    queryBuilder = queryBuilder.timerange(timerange);
+  if (timeRange) {
+    queryBuilder = queryBuilder.timerange(timeRange);
   }
 
   if (streams) {

--- a/graylog2-web-interface/src/views/logic/NormalizeSearchURLQueryParams.test.ts
+++ b/graylog2-web-interface/src/views/logic/NormalizeSearchURLQueryParams.test.ts
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as Immutable from 'immutable';
+
+import normalizeSearchURLQueryParams from './NormalizeSearchURLQueryParams';
+
+describe('NormalizeSearchURLQueryParams', () => {
+  it('should normalize relative time range with only a start', async () => {
+    const result = normalizeSearchURLQueryParams({ rangetype: 'relative', relative: '600' });
+
+    expect(result).toEqual({
+      queryString: undefined,
+      streamsFilter: null,
+      timeRange: { type: 'relative', range: 600 },
+    });
+  });
+
+  it('should normalize relative time range with only a start (from)', async () => {
+    const result = normalizeSearchURLQueryParams({ rangetype: 'relative', from: '600' });
+
+    expect(result).toEqual({
+      queryString: undefined,
+      streamsFilter: null,
+      timeRange: { type: 'relative', from: 600 },
+    });
+  });
+
+  it('should normalize relative time range with start and end', async () => {
+    const result = normalizeSearchURLQueryParams({ rangetype: 'relative', from: '600', to: '300' });
+
+    expect(result).toEqual({
+      queryString: undefined,
+      streamsFilter: null,
+      timeRange: { type: 'relative', from: 600, to: 300 },
+    });
+  });
+
+  it('should normalize absolute time range', async () => {
+    const result = normalizeSearchURLQueryParams({
+      rangetype: 'absolute',
+      from: '2020-01-01T10:00:00.850Z',
+      to: '2020-01-02T10:00:00.000Z',
+    });
+
+    expect(result).toEqual({
+      queryString: undefined,
+      streamsFilter: null,
+      timeRange: { type: 'absolute', from: '2020-01-01T10:00:00.850Z', to: '2020-01-02T10:00:00.000Z' },
+    });
+  });
+
+  it('should normalize keyword time range', async () => {
+    const result = normalizeSearchURLQueryParams({ rangetype: 'keyword', keyword: 'yesterday' });
+
+    expect(result).toEqual({
+      queryString: undefined,
+      streamsFilter: null,
+      timeRange: { type: 'keyword', keyword: 'yesterday' },
+    });
+  });
+
+  it('should normalize search query', async () => {
+    const result = normalizeSearchURLQueryParams({ q: 'http_method:GET' });
+
+    expect(result).toEqual({
+      queryString: {
+        query_string: 'http_method:GET',
+        type: 'elasticsearch',
+      },
+      streamsFilter: null,
+      timeRange: undefined,
+    });
+  });
+
+  it('should normalize streams filter', async () => {
+    const result = normalizeSearchURLQueryParams({ streams: 'stream-id-1,stream-id-2' });
+
+    expect(result).toEqual({
+      queryString: undefined,
+      streamsFilter: Immutable.Map({
+        type: 'or',
+        filters: Immutable.List([
+          Immutable.Map({
+            type: 'stream',
+            id: 'stream-id-1',
+          }),
+          Immutable.Map({
+            type: 'stream',
+            id: 'stream-id-2',
+          }),
+        ]),
+      }),
+      timeRange: undefined,
+    });
+  });
+});

--- a/graylog2-web-interface/src/views/logic/NormalizeSearchURLQueryParams.ts
+++ b/graylog2-web-interface/src/views/logic/NormalizeSearchURLQueryParams.ts
@@ -58,7 +58,7 @@ type StreamsQuery = {
   streams?: string,
 };
 
-export type RawQuery = RawTimeRange & StreamsQuery & { q?: string };
+export type RawQuery = Partial<RawTimeRange> & StreamsQuery & { q?: string };
 
 const _getRange = (query): RawTimeRange => {
   const rangetype = query.rangetype || DEFAULT_RANGE_TYPE;
@@ -124,18 +124,18 @@ const normalizeStreams = (query: StreamsQuery = {}): Array<string> => {
 
 type NormalizedSearchURLQueryParams = {
   timeRange: TimeRange | undefined,
-  streams: FilterType | undefined,
+  streamsFilter: FilterType | undefined,
   queryString: ElasticsearchQueryString | undefined
 }
 
 const normalizeSearchURLQueryParams = (query: RawQuery): NormalizedSearchURLQueryParams => {
   const { q: queryString } = query ?? {};
   const timeRange = normalizeTimeRange(query);
-  const streams = filtersForQuery(normalizeStreams(query));
+  const streamsFilter = filtersForQuery(normalizeStreams(query));
 
   return {
     timeRange,
-    streams,
+    streamsFilter,
     queryString: queryString ? createElasticsearchQueryString(queryString) : undefined,
   };
 };

--- a/graylog2-web-interface/src/views/logic/NormalizeSearchURLQueryParams.ts
+++ b/graylog2-web-interface/src/views/logic/NormalizeSearchURLQueryParams.ts
@@ -105,8 +105,8 @@ const normalizeTimeRange = (query: Partial<RawTimeRange> = {}) => {
         timezone: range.timezone,
       } as KeywordTimeRange : undefined;
     default:
-      // @ts-ignore
-      throw new Error(`Unsupported range type ${range.rangetype}`);
+      // @ts-expect-error
+      throw new Error(`Unsupported range type ${range.rangetype} in range: ${JSON.stringify(range)}`);
   }
 };
 

--- a/graylog2-web-interface/src/views/logic/NormalizeSearchURLQueryParmas.ts
+++ b/graylog2-web-interface/src/views/logic/NormalizeSearchURLQueryParmas.ts
@@ -1,0 +1,143 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+
+import { DEFAULT_RANGE_TYPE } from 'views/Constants';
+import {
+  AbsoluteTimeRange,
+  KeywordTimeRange,
+  filtersForQuery,
+  RelativeTimeRange,
+  TimeRange,
+  FilterType,
+  ElasticsearchQueryString,
+  createElasticsearchQueryString,
+} from 'views/logic/queries/Query';
+
+type RawRelativeRangeStartOnly = {
+  rangetype: 'relative',
+  relative?: string,
+};
+
+type RawRelativeRangeWithEnd = {
+  rangetype: 'relative',
+  from: string,
+  to?: string,
+};
+
+type RawRelativeRange = RawRelativeRangeStartOnly | RawRelativeRangeWithEnd
+
+type RawAbsoluteRange = {
+  rangetype: 'absolute',
+  from?: string,
+  to?: string,
+};
+
+type RawKeywordRange = {
+  rangetype: 'keyword',
+  keyword?: string,
+  timezone?: string,
+};
+
+type RawTimeRange = RawAbsoluteRange | RawRelativeRange | RawKeywordRange;
+
+type StreamsQuery = {
+  streams?: string,
+};
+
+export type RawQuery = RawTimeRange & StreamsQuery & { q?: string };
+
+const _getRange = (query): RawTimeRange => {
+  const rangetype = query.rangetype || DEFAULT_RANGE_TYPE;
+
+  return { ...query, rangetype };
+};
+
+const normalizeRawRelativeTimeRange = (range: RawRelativeRange): RelativeTimeRange | undefined => {
+  const parseRangeValue = (rangeValue: string) => parseInt(rangeValue, 10);
+
+  if ('relative' in range) {
+    return { type: 'relative', range: parseRangeValue(range.relative) };
+  }
+
+  if ('from' in range) {
+    const result = { type: 'relative' as const, from: parseRangeValue(range.from) };
+
+    if ('to' in range) {
+      return { ...result, to: parseRangeValue(range.to) };
+    }
+
+    return result;
+  }
+
+  return undefined;
+};
+
+const normalizeTimeRange = (query: Partial<RawTimeRange> = {}) => {
+  const range = _getRange(query);
+
+  switch (range.rangetype) {
+    case 'relative':
+      return normalizeRawRelativeTimeRange(range);
+    case 'absolute':
+      return (range.from || range.to) ? {
+        type: range.rangetype,
+        from: range.from,
+        to: range.to,
+      } as AbsoluteTimeRange : undefined;
+    case 'keyword':
+      return range.keyword ? {
+        type: range.rangetype,
+        keyword: range.keyword,
+        timezone: range.timezone,
+      } as KeywordTimeRange : undefined;
+    default:
+      // @ts-ignore
+      throw new Error(`Unsupported range type ${range.rangetype}`);
+  }
+};
+
+const normalizeStreams = (query: StreamsQuery = {}): Array<string> => {
+  const rawStreams = query.streams;
+
+  if (rawStreams === undefined || rawStreams === null) {
+    return [];
+  }
+
+  return String(rawStreams).split(',')
+    .map((stream) => stream.trim())
+    .filter((stream) => stream !== '');
+};
+
+type NormalizedSearchURLQueryParams = {
+  timeRange: TimeRange | undefined,
+  streams: FilterType | undefined,
+  queryString: ElasticsearchQueryString | undefined
+}
+
+const normalizeSearchURLQueryParams = (query: RawQuery): NormalizedSearchURLQueryParams => {
+  const { q: queryString } = query ?? {};
+  const timeRange = normalizeTimeRange(query);
+  const streams = filtersForQuery(normalizeStreams(query));
+
+  return {
+    timeRange,
+    streams,
+    queryString: queryString ? createElasticsearchQueryString(queryString) : undefined,
+  };
+};
+
+export default normalizeSearchURLQueryParams;

--- a/graylog2-web-interface/src/views/logic/queries/QueryGenerator.ts
+++ b/graylog2-web-interface/src/views/logic/queries/QueryGenerator.ts
@@ -17,17 +17,22 @@
 import uuid from 'uuid/v4';
 
 import { DEFAULT_TIMERANGE } from 'views/Constants';
+import Query, { TimeRange, ElasticsearchQueryString, createElasticsearchQueryString, filtersForQuery } from 'views/logic/queries/Query';
 
-import Query, { createElasticsearchQueryString, filtersForQuery } from './Query';
 import type { QueryId } from './Query';
 
-export default (streamId?: string, id: QueryId = uuid()): Query => {
+export default (
+  streamId?: string,
+  id: QueryId | undefined = uuid(),
+  timeRange?: TimeRange,
+  queryString?: ElasticsearchQueryString,
+): Query => {
   const streamIds = streamId ? [streamId] : null;
   const streamFilter = filtersForQuery(streamIds);
   const builder = Query.builder()
     .id(id)
-    .query(createElasticsearchQueryString())
-    .timerange(DEFAULT_TIMERANGE);
+    .query(queryString ?? createElasticsearchQueryString())
+    .timerange(timeRange ?? DEFAULT_TIMERANGE);
 
   return streamFilter ? builder.filter(streamFilter).build() : builder.build();
 };

--- a/graylog2-web-interface/src/views/logic/views/UseCreateSavedSearch.ts
+++ b/graylog2-web-interface/src/views/logic/views/UseCreateSavedSearch.ts
@@ -18,8 +18,18 @@ import { useMemo } from 'react';
 
 import { ViewActions } from 'views/stores/ViewStore';
 import View from 'views/logic/views/View';
+import type { ElasticsearchQueryString, TimeRange } from 'views/logic/queries/Query';
 
-const useCreateSavedSearch = (streamId?: string) => useMemo(() => ViewActions.create(View.Type.Search, streamId)
-  .then(({ view: v }) => v), [streamId]);
+const useCreateSavedSearch = (
+  streamId?: string,
+  timeRange?: TimeRange,
+  queryString?: ElasticsearchQueryString,
+) => {
+  return useMemo(
+    () => ViewActions.create(View.Type.Search, streamId, timeRange, queryString).then(({ view: v }) => v),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [streamId],
+  );
+};
 
 export default useCreateSavedSearch;

--- a/graylog2-web-interface/src/views/logic/views/ViewGenerator.ts
+++ b/graylog2-web-interface/src/views/logic/views/ViewGenerator.ts
@@ -14,6 +14,8 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
+import { TimeRange, ElasticsearchQueryString } from 'views/logic/queries/Query';
+
 import View from './View';
 import ViewStateGenerator from './ViewStateGenerator';
 import type { ViewType } from './View';
@@ -21,8 +23,13 @@ import type { ViewType } from './View';
 import Search from '../search/Search';
 import QueryGenerator from '../queries/QueryGenerator';
 
-export default async (type: ViewType, streamId: string | undefined | null) => {
-  const query = QueryGenerator(streamId);
+export default async (
+  type: ViewType,
+  streamId: string | undefined | null,
+  timeRange?: TimeRange,
+  queryString?: ElasticsearchQueryString,
+) => {
+  const query = QueryGenerator(streamId, undefined, timeRange, queryString);
   const search = Search.create().toBuilder().queries([query]).build();
   const viewState = await ViewStateGenerator(type, streamId);
 

--- a/graylog2-web-interface/src/views/pages/NewSearchPage.test.tsx
+++ b/graylog2-web-interface/src/views/pages/NewSearchPage.test.tsx
@@ -112,7 +112,7 @@ describe('NewSearchPage', () => {
 
       await waitFor(() => expect(ViewActions.create).toBeCalledTimes(1));
 
-      expect(ViewActions.create).toHaveBeenCalledWith(View.Type.Search, undefined);
+      expect(ViewActions.create).toHaveBeenCalledWith(View.Type.Search, undefined, undefined, undefined);
     });
 
     it('should process hooks with provided location query', async () => {

--- a/graylog2-web-interface/src/views/pages/NewSearchPage.tsx
+++ b/graylog2-web-interface/src/views/pages/NewSearchPage.tsx
@@ -21,15 +21,17 @@ import type { Location } from 'routing/withLocation';
 import { Spinner } from 'components/common';
 import useLoadView from 'views/logic/views/UseLoadView';
 import useCreateSavedSearch from 'views/logic/views/UseCreateSavedSearch';
+import normalizeSearchURLQueryParams, { RawQuery } from 'views/logic/NormalizeSearchURLQueryParmas';
 
 import SearchPage from './SearchPage';
 
 type Props = {
-  location: Location,
+  location: Location<RawQuery>,
 };
 
 const NewSearchPage = ({ location: { query } }: Props) => {
-  const view = useCreateSavedSearch();
+  const { timeRange, queryString } = normalizeSearchURLQueryParams(query);
+  const view = useCreateSavedSearch(undefined, timeRange, queryString);
   const [loaded, HookComponent] = useLoadView(view, query);
 
   if (HookComponent) {

--- a/graylog2-web-interface/src/views/pages/NewSearchPage.tsx
+++ b/graylog2-web-interface/src/views/pages/NewSearchPage.tsx
@@ -21,7 +21,7 @@ import type { Location } from 'routing/withLocation';
 import { Spinner } from 'components/common';
 import useLoadView from 'views/logic/views/UseLoadView';
 import useCreateSavedSearch from 'views/logic/views/UseCreateSavedSearch';
-import normalizeSearchURLQueryParams, { RawQuery } from 'views/logic/NormalizeSearchURLQueryParmas';
+import normalizeSearchURLQueryParams, { RawQuery } from 'views/logic/NormalizeSearchURLQueryParams';
 
 import SearchPage from './SearchPage';
 

--- a/graylog2-web-interface/src/views/pages/StreamSearchPage.test.tsx
+++ b/graylog2-web-interface/src/views/pages/StreamSearchPage.test.tsx
@@ -114,17 +114,17 @@ describe('StreamSearchPage', () => {
 
   it('should create view with streamId passed from props', async () => {
     render(<SimpleStreamSearchPage />);
-    await waitFor(() => expect(ViewActions.create).toHaveBeenCalledWith(View.Type.Search, 'stream-id-1'));
+    await waitFor(() => expect(ViewActions.create).toHaveBeenCalledWith(View.Type.Search, 'stream-id-1', undefined, undefined));
   });
 
   it('should recreate view when streamId passed from props changes', async () => {
     const { rerender } = render(<SimpleStreamSearchPage />);
 
-    await waitFor(() => expect(ViewActions.create).toHaveBeenCalledWith(View.Type.Search, 'stream-id-1'));
+    await waitFor(() => expect(ViewActions.create).toHaveBeenCalledWith(View.Type.Search, 'stream-id-1', undefined, undefined));
 
     rerender(<SimpleStreamSearchPage params={{ streamId: 'stream-id-2' }} />);
 
-    await waitFor(() => expect(ViewActions.create).toHaveBeenCalledWith(View.Type.Search, 'stream-id-2'));
+    await waitFor(() => expect(ViewActions.create).toHaveBeenCalledWith(View.Type.Search, 'stream-id-2', undefined, undefined));
   });
 
   describe('loading another view', () => {

--- a/graylog2-web-interface/src/views/pages/StreamSearchPage.tsx
+++ b/graylog2-web-interface/src/views/pages/StreamSearchPage.tsx
@@ -24,7 +24,7 @@ import useCreateSavedSearch from 'views/logic/views/UseCreateSavedSearch';
 import withLocation from 'routing/withLocation';
 import type { Location } from 'routing/withLocation';
 import { loadNewViewForStream } from 'views/logic/views/Actions';
-import normalizeSearchURLQueryParams, { RawQuery } from 'views/logic/NormalizeSearchURLQueryParmas';
+import normalizeSearchURLQueryParams, { RawQuery } from 'views/logic/NormalizeSearchURLQueryParams';
 
 import SearchPage from './SearchPage';
 

--- a/graylog2-web-interface/src/views/pages/StreamSearchPage.tsx
+++ b/graylog2-web-interface/src/views/pages/StreamSearchPage.tsx
@@ -24,18 +24,20 @@ import useCreateSavedSearch from 'views/logic/views/UseCreateSavedSearch';
 import withLocation from 'routing/withLocation';
 import type { Location } from 'routing/withLocation';
 import { loadNewViewForStream } from 'views/logic/views/Actions';
+import normalizeSearchURLQueryParams, { RawQuery } from 'views/logic/NormalizeSearchURLQueryParmas';
 
 import SearchPage from './SearchPage';
 
 type Props = {
-  location: Location,
+  location: Location<RawQuery>,
   params: {
     streamId?: string,
   },
 };
 
 const StreamSearchPage = ({ params: { streamId }, location: { query } }: Props) => {
-  const newView = useCreateSavedSearch(streamId);
+  const { timeRange, queryString } = normalizeSearchURLQueryParams(query);
+  const newView = useCreateSavedSearch(streamId, timeRange, queryString);
   const [loaded, HookComponent] = useLoadView(newView, query);
 
   const _loadNewView = useCallback(() => {

--- a/graylog2-web-interface/src/views/stores/ViewStore.ts
+++ b/graylog2-web-interface/src/views/stores/ViewStore.ts
@@ -27,7 +27,7 @@ import View from 'views/logic/views/View';
 import type { QuerySet } from 'views/logic/search/Search';
 import Search from 'views/logic/search/Search';
 import ViewState from 'views/logic/views/ViewState';
-import Query from 'views/logic/queries/Query';
+import Query, { TimeRange, ElasticsearchQueryString } from 'views/logic/queries/Query';
 import SearchActions from 'views/actions/SearchActions';
 import { singletonActions, singletonStore } from 'logic/singleton';
 import type { QueryId } from 'views/logic/queries/Query';
@@ -43,7 +43,12 @@ export type ViewStoreState = {
 };
 
 type ViewActionsType = RefluxActions<{
-  create: (type: ViewType, streamId?: string) => Promise<ViewStoreState>,
+  create: (
+    type: ViewType,
+    streamId?: string,
+    timeRange?: TimeRange,
+    queryString?: ElasticsearchQueryString,
+  ) => Promise<ViewStoreState>,
   load: (view: View, isNew?: boolean, queryId?: string) => Promise<ViewStoreState>,
   properties: (properties: Properties) => Promise<void>,
   search: (search: Search) => Promise<View>,
@@ -101,8 +106,13 @@ export const ViewStore: ViewStoreType = singletonStore(
       return this._state();
     },
 
-    create(type: ViewType, streamId: string = null) {
-      return ViewGenerator(type, streamId)
+    create(
+      type: ViewType,
+      streamId: string = null,
+      timeRange?: TimeRange,
+      queryString?: ElasticsearchQueryString,
+    ) {
+      return ViewGenerator(type, streamId, timeRange, queryString)
         .then((newView) => {
           const [view] = this._updateSearch(newView);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Before this change we we created two searches, when opening the default or stream search page via a URL with search query params like: `?q=http_method:GET&rangetype=relative&relative=300`. This was not the case when opening a saved search. This problem occurred because we were creating a search with the default search query first and another one with the search settings provided by the URL query params.

Please note, this bug still exists when the URL query params contain a stream filter. Fixing this bug will require more complex changes, which we should implement in a follow-up PR.