### PR TITLE
Handle empty responses on plaintext requests

### DIFF
--- a/graylog2-web-interface/src/logic/rest/FetchProvider.ts
+++ b/graylog2-web-interface/src/logic/rest/FetchProvider.ts
@@ -183,15 +183,7 @@ export class Builder {
     this.body = { body, mimeType: 'text/plain' };
     this.accept = 'application/json';
 
-    this.responseHandler = (resp) => {
-      if (resp.ok) {
-        reportServerSuccess();
-
-        return resp.json();
-      }
-
-      throw resp;
-    };
+    this.responseHandler = defaultResponseHandler;
 
     this.errorHandler = (error) => onServerError(error, onUnauthorized);
 


### PR DESCRIPTION
Graylog server API returns JSON responses also when doing a plaintext
request. Sometimes though, it is possible that we get an empty response
from the server, which will throw an error when trying to parse the JSON
response using the JS `fetch` API.

Since the default response can read a JSON response from the server and
already handles the situation described above, this commit replaces the
custom response handler for plaintext responses with the default one.

Fixes #11343
