### PR TITLE
Fix keyword time range validation and time range preview.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/tools/NaturalDateTesterResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/tools/NaturalDateTesterResource.java
@@ -17,6 +17,8 @@
 package org.graylog2.rest.resources.tools;
 
 import com.codahale.metrics.annotation.Timed;
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.google.auto.value.AutoValue;
 import org.apache.shiro.authz.annotation.RequiresAuthentication;
 import org.graylog2.plugin.utilities.date.NaturalDateParser;
@@ -40,6 +42,7 @@ public class NaturalDateTesterResource extends RestResource {
     private static final Logger LOG = LoggerFactory.getLogger(RegexTesterResource.class);
 
     @AutoValue
+    @JsonAutoDetect
     public abstract static class NaturalDateResponse {
         public abstract DateTime from();
         public abstract DateTime to();

--- a/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TabKeywordTimeRange.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TabKeywordTimeRange.tsx
@@ -76,7 +76,7 @@ const TabKeywordTimeRange = ({ defaultValue, disabled, setValidatingKeyword }: P
     return 'Unable to parse keyword.';
   }, [setKeywordPreview]);
 
-  const _validateKeyword = (keyword: string): Promise<string | void> | undefined | null => {
+  const _validateKeyword = useCallback((keyword: string) => {
     if (keyword === undefined) {
       return undefined;
     }
@@ -90,7 +90,7 @@ const TabKeywordTimeRange = ({ defaultValue, disabled, setValidatingKeyword }: P
           if (mounted.current) _setSuccessfullPreview(response);
         })
         .catch(_setFailedPreview);
-  };
+  }, [_setFailedPreview, _setSuccessfullPreview, setValidatingKeyword]);
 
   useEffect(() => {
     return () => {
@@ -124,7 +124,7 @@ const TabKeywordTimeRange = ({ defaultValue, disabled, setValidatingKeyword }: P
   return (
     <Row className="no-bm">
       <Col sm={5}>
-        <Field name="nextTimeRange.keyword" validate={_validateKeyword}>
+        <Field name="nextTimeRange.keyword">
           {({ field: { name, value, onChange }, meta: { error } }) => (
             <FormGroup controlId="form-inline-keyword"
                        style={{ marginRight: 5, width: '100%', marginBottom: 0 }}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

**Note:** This PR needs a backport to `4.2`.

Prior to this change, a refactoring introduced in #11194 lead to the
server not being able to generate a preview for a keyword time range,
because the response class was not serializable due to a missing
`@JsonAutoDetect` annotation. It was added in this PR.

Additionally, the keyword preview was constantly updating due to the
component rerendering and field-level validation being triggered,
resulting in an infinite loop. The reason why this did not happen before
are unclear. Field-level validation (which was not necessary before, due
to triggering validation explicitly through a `useEffect` hook) was
removed and the validation function stabilized through `useCallback`.

Fixes #11385.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.