### PR TITLE
Fixing mail address and typo in PR body.

### DIFF
--- a/.github/workflows/fix-linter-hints.yml
+++ b/.github/workflows/fix-linter-hints.yml
@@ -29,9 +29,9 @@ jobs:
         uses: Graylog2/create-pull-request@7380612b49221684fefa025244f2ef4008ae50ad
         with:
           title: Fixing linter hints automatically
-          body: This PR was created by a job that is running periodiocally to find and fix linter hints.
+          body: This PR was created by a job that is running periodically to find and fix linter hints.
           author: Dr. Lint-a-lot <hello@graylog.com>
           branch: fix/linter-hints
-          committer: Dr. Lint-a-lot <hello@graylog.com>
+          committer: Dr. Lint-a-lot <garybot2@graylog.com>
           commit-message: Running lint --fix
           delete-branch: true


### PR DESCRIPTION
This PR is doing simple changes to the linter workflow, in order to fix
the author's mail address and a typo in the description.