### PR TITLE
Allow displaying help text for `ActionMenuItem`s.

### DIFF
--- a/graylog2-web-interface/src/components/common/HoverForHelp.tsx
+++ b/graylog2-web-interface/src/components/common/HoverForHelp.tsx
@@ -46,16 +46,18 @@ type Props = {
   placement?: 'top' | 'right' | 'bottom' | 'left',
   pullRight?: boolean,
   title: string,
+  testId?: string,
 };
 
-const HoverForHelp = ({ children, className, title, id, pullRight, placement }: Props) => (
+const HoverForHelp = ({ children, className, title, id, pullRight, placement, testId }: Props) => (
   <OverlayTrigger trigger={['hover', 'focus']}
                   placement={placement}
                   overlay={(
                     <StyledPopover title={title} id={id}>
                       {children}
                     </StyledPopover>
-                  )}>
+                  )}
+                  testId={testId}>
     <Icon className={`${className} ${pullRight ? 'pull-right' : ''}`} name="question-circle" />
   </OverlayTrigger>
 );
@@ -67,6 +69,7 @@ HoverForHelp.propTypes = {
   placement: PropTypes.oneOf(['top', 'right', 'bottom', 'left']),
   pullRight: PropTypes.bool,
   title: PropTypes.string.isRequired,
+  testId: PropTypes.string,
 };
 
 HoverForHelp.defaultProps = {
@@ -74,6 +77,7 @@ HoverForHelp.defaultProps = {
   className: '',
   pullRight: true,
   placement: 'bottom',
+  testId: undefined,
 };
 
 export default HoverForHelp;

--- a/graylog2-web-interface/src/components/common/HoverForHelp.tsx
+++ b/graylog2-web-interface/src/components/common/HoverForHelp.tsx
@@ -41,10 +41,10 @@ const StyledPopover = styled(Popover)(({ theme }) => `
 
 type Props = {
   children: React.ReactNode,
-  className: string,
+  className?: string,
   id?: string,
-  placement: 'top' | 'right' | 'bottom' | 'left',
-  pullRight: boolean,
+  placement?: 'top' | 'right' | 'bottom' | 'left',
+  pullRight?: boolean,
   title: string,
 };
 

--- a/graylog2-web-interface/src/components/graylog/OverlayTrigger.tsx
+++ b/graylog2-web-interface/src/components/graylog/OverlayTrigger.tsx
@@ -22,6 +22,7 @@ import styled from 'styled-components';
 type Triggers = 'click' | 'focus' | 'hover';
 
 type Props = {
+  testId?: string,
   children: React.ReactElement,
   overlay: React.ReactElement,
   placement: 'top' | 'right' | 'bottom' | 'left',
@@ -51,6 +52,7 @@ class OverlayTrigger extends React.Component<Props, State> {
     trigger: 'click',
     rootClose: false,
     container: null,
+    testId: undefined,
   }
 
   constructor(props) {
@@ -67,7 +69,7 @@ class OverlayTrigger extends React.Component<Props, State> {
 
   render() {
     let triggerables;
-    const { children, container, placement, overlay, rootClose, trigger, ...overlayProps } = this.props;
+    const { children, container, placement, overlay, rootClose, trigger, testId, ...overlayProps } = this.props;
     const { show } = this.state;
 
     const setShow = (isShown: boolean) => this.setState({ show: isShown });
@@ -98,7 +100,7 @@ class OverlayTrigger extends React.Component<Props, State> {
     }
 
     return (
-      <Container ref={() => this.containerRef}>
+      <Container ref={() => this.containerRef} data-testid={testId}>
         <TriggerWrap ref={this.targetRef} className={children.props.className} role="button">
           {React.cloneElement(children, { ...triggerables, className: '' })}
         </TriggerWrap>

--- a/graylog2-web-interface/src/views/components/actions/ActionHandler.tsx
+++ b/graylog2-web-interface/src/views/components/actions/ActionHandler.tsx
@@ -52,10 +52,11 @@ export type ActionConditions<Contexts> = {
   isHidden?: ActionHandlerCondition<Contexts>,
 };
 
-type ActionDefinitionBase = {
+type ActionDefinitionBase<Contexts> = {
   type: string,
   title: string,
   resetFocus: boolean,
+  help?: (args: ActionHandlerArguments<Contexts>) => { title: string, description: React.ReactNode } | undefined,
 };
 
 type FunctionHandlerAction<Contexts> = {
@@ -65,11 +66,11 @@ type ComponentsHandlerAction = {
   component: ActionComponentType,
 };
 
-export type HandlerAction<Contexts> = (FunctionHandlerAction<Contexts> | ComponentsHandlerAction) & ActionDefinitionBase;
+export type HandlerAction<Contexts> = (FunctionHandlerAction<Contexts> | ComponentsHandlerAction) & ActionDefinitionBase<Contexts>;
 
 export type ExternalLinkAction<Contexts> = {
   linkTarget: (args: ActionHandlerArguments<Contexts>) => string,
-} & ActionDefinitionBase;
+} & ActionDefinitionBase<Contexts>;
 
 export type ActionDefinition<Contexts = ActionContexts> = (HandlerAction<Contexts> | ExternalLinkAction<Contexts>) & ActionConditions<Contexts>;
 
@@ -77,7 +78,7 @@ export function isExternalLinkAction<T>(action: ActionDefinition<T>): action is 
   return 'linkTarget' in action;
 }
 
-export function createHandlerFor<T>(action: ActionDefinitionBase & HandlerAction<T>, setActionComponents: SetActionComponents): ActionHandler<T> {
+export function createHandlerFor<T>(action: ActionDefinitionBase<T> & HandlerAction<T>, setActionComponents: SetActionComponents): ActionHandler<T> {
   if ('handler' in action) {
     return action.handler;
   }

--- a/graylog2-web-interface/src/views/components/actions/ActionMenuItem.test.tsx
+++ b/graylog2-web-interface/src/views/components/actions/ActionMenuItem.test.tsx
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import { render, screen } from 'wrappedTestingLibrary';
+import { alice } from 'fixtures/users';
+
+import FieldType from 'views/logic/fieldtypes/FieldType';
+import View from 'views/logic/views/View';
+import Widget from 'views/logic/widgets/Widget';
+
+import ActionMenuItem from './ActionMenuItem';
+
+describe('ActionMenuItem', () => {
+  const baseAction = {
+    isEnabled: () => true,
+    isHidden: () => false,
+    resetFocus: false,
+    title: 'The action title',
+    type: 'hashWatchlist',
+  };
+
+  const handlerArgs = {
+    queryId: 'query-id',
+    field: 'field-name',
+    value: 'field-value',
+    type: new FieldType('string', [], []),
+    contexts: {
+      view: View.create(),
+      analysisDisabledFields: [],
+      currentUser: alice,
+      widget: Widget.empty(),
+      message: {
+        id: 'message-id',
+        index: 'index',
+        fields: [],
+      },
+      valuePath: [],
+    },
+  };
+
+  it('should display help text for actions with handler', () => {
+    const action = {
+      ...baseAction,
+      handler: () => Promise.resolve(),
+      help: () => ({ title: 'The help title', description: 'The help description' }),
+    };
+
+    render(<ActionMenuItem action={action}
+                           handlerArgs={handlerArgs}
+                           onMenuToggle={() => {}}
+                           overflowingComponents={<></>}
+                           setOverflowingComponents={() => {}}
+                           type="value" />);
+
+    expect(screen.getByTestId('menu-item-help')).toBeInTheDocument();
+  });
+
+  it('should display help text for external links', () => {
+    const action = {
+      ...baseAction,
+      linkTarget: () => '/the-link',
+      help: () => ({ title: 'The help title', description: 'The help description' }),
+    };
+
+    render(<ActionMenuItem action={action}
+                           handlerArgs={handlerArgs}
+                           onMenuToggle={() => {}}
+                           overflowingComponents={<></>}
+                           setOverflowingComponents={() => {}}
+                           type="value" />);
+
+    expect(screen.getByTestId('menu-item-help')).toBeInTheDocument();
+  });
+});

--- a/graylog2-web-interface/src/views/components/actions/ActionMenuItem.tsx
+++ b/graylog2-web-interface/src/views/components/actions/ActionMenuItem.tsx
@@ -67,7 +67,7 @@ const ActionTitle = ({ action, handlerArgs }: { action: ActionDefinition, handle
       return (
         <>
           {action.title}
-          <StyledHoverForHelp title={title}>
+          <StyledHoverForHelp title={title} testId="menu-item-help">
             {description}
           </StyledHoverForHelp>
         </>

--- a/graylog2-web-interface/src/views/components/actions/ActionMenuItem.tsx
+++ b/graylog2-web-interface/src/views/components/actions/ActionMenuItem.tsx
@@ -30,6 +30,7 @@ import {
   ExternalLinkAction,
   HandlerAction,
 } from 'views/components/actions/ActionHandler';
+import HoverForHelp from 'components/common/HoverForHelp';
 
 const StyledMenuItem = styled(MenuItem)`
   && > a {
@@ -51,6 +52,31 @@ type Props = {
   setOverflowingComponents: (components: React.ReactNode) => void,
   type: 'field' | 'value',
 }
+
+const StyledHoverForHelp = styled(HoverForHelp)`
+  margin-left: 5px;
+`;
+
+const ActionTitle = ({ action, handlerArgs }: { action: ActionDefinition, handlerArgs: ActionHandlerArguments }) => {
+  if (action.help) {
+    const help = action.help(handlerArgs);
+
+    if (help) {
+      const { title, description } = help;
+
+      return (
+        <>
+          {action.title}
+          <StyledHoverForHelp title={title}>
+            {description}
+          </StyledHoverForHelp>
+        </>
+      );
+    }
+  }
+
+  return <>{action.title}</>;
+};
 
 type ExternalLinkItemProps = Pick<Props, 'handlerArgs' | 'onMenuToggle' | 'type'> & {
   action: ExternalLinkAction<ActionContexts>,
@@ -82,7 +108,7 @@ const ExternalLinkItem = ({ action, disabled, field, handlerArgs, onMenuToggle, 
                     eventKey={{ action: type, field }}
                     onSelect={onSelect}
                     {...linkProps}>
-      {action.title}
+      <ActionTitle action={action} handlerArgs={handlerArgs} />
       <ExternalLinkIcon name="external-link" />
     </StyledMenuItem>
   );
@@ -121,7 +147,7 @@ const ActionHandlerItem = ({ disabled, action, handlerArgs, setOverflowingCompon
     <StyledMenuItem disabled={disabled}
                     eventKey={{ action: type, field }}
                     onSelect={onSelect}>
-      {action.title}
+      <ActionTitle action={action} handlerArgs={handlerArgs} />
     </StyledMenuItem>
   );
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

With this PR it is now possible to display a help for action menu items. This can be useful to describe why an item is disabled.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

