### PR TITLE
Fix keyword time range validation and time range preview. (backport of #11386 for 4.2)

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/tools/NaturalDateTesterResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/tools/NaturalDateTesterResource.java
@@ -17,6 +17,8 @@
 package org.graylog2.rest.resources.tools;
 
 import com.codahale.metrics.annotation.Timed;
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.google.auto.value.AutoValue;
 import org.apache.shiro.authz.annotation.RequiresAuthentication;
 import org.graylog2.plugin.utilities.date.NaturalDateParser;
@@ -40,6 +42,7 @@ public class NaturalDateTesterResource extends RestResource {
     private static final Logger LOG = LoggerFactory.getLogger(RegexTesterResource.class);
 
     @AutoValue
+    @JsonAutoDetect
     public abstract static class NaturalDateResponse {
         public abstract DateTime from();
         public abstract DateTime to();

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/tools/NaturalDateTesterResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/tools/NaturalDateTesterResource.java
@@ -19,6 +19,7 @@ package org.graylog2.rest.resources.tools;
 import com.codahale.metrics.annotation.Timed;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 import org.apache.shiro.authz.annotation.RequiresAuthentication;
 import org.graylog2.plugin.utilities.date.NaturalDateParser;
@@ -42,10 +43,12 @@ public class NaturalDateTesterResource extends RestResource {
     private static final Logger LOG = LoggerFactory.getLogger(RegexTesterResource.class);
 
     @AutoValue
-    @JsonAutoDetect
     public abstract static class NaturalDateResponse {
+        @JsonProperty
         public abstract DateTime from();
+        @JsonProperty
         public abstract DateTime to();
+        @JsonProperty
         public abstract String timezone();
 
         static NaturalDateResponse create(NaturalDateParser.Result result) {

--- a/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TabKeywordTimeRange.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TabKeywordTimeRange.tsx
@@ -76,7 +76,7 @@ const TabKeywordTimeRange = ({ defaultValue, disabled, setValidatingKeyword }: P
     return 'Unable to parse keyword.';
   }, [setKeywordPreview]);
 
-  const _validateKeyword = (keyword: string): Promise<string | void> | undefined | null => {
+  const _validateKeyword = useCallback((keyword: string) => {
     if (keyword === undefined) {
       return undefined;
     }
@@ -90,7 +90,7 @@ const TabKeywordTimeRange = ({ defaultValue, disabled, setValidatingKeyword }: P
           if (mounted.current) _setSuccessfullPreview(response);
         })
         .catch(_setFailedPreview);
-  };
+  }, [_setFailedPreview, _setSuccessfullPreview, setValidatingKeyword]);
 
   useEffect(() => {
     return () => {
@@ -124,7 +124,7 @@ const TabKeywordTimeRange = ({ defaultValue, disabled, setValidatingKeyword }: P
   return (
     <Row className="no-bm">
       <Col sm={5}>
-        <Field name="nextTimeRange.keyword" validate={_validateKeyword}>
+        <Field name="nextTimeRange.keyword">
           {({ field: { name, value, onChange }, meta: { error } }) => (
             <FormGroup controlId="form-inline-keyword"
                        style={{ marginRight: 5, width: '100%', marginBottom: 0 }}

--- a/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TabKeywordTimeRange.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TabKeywordTimeRange.tsx
@@ -60,7 +60,7 @@ type Props = {
 const TabKeywordTimeRange = ({ defaultValue, disabled, setValidatingKeyword }: Props) => {
   const [nextRangeProps, , nextRangeHelpers] = useField('nextTimeRange');
   const mounted = useRef(true);
-  const keywordRef = useRef();
+  const keywordRef = useRef<string>();
   const [keywordPreview, setKeywordPreview] = useState({ from: '', to: '', timezone: '' });
 
   const _setSuccessfullPreview = useCallback((response: { from: string, to: string, timezone: string }) => {
@@ -81,15 +81,21 @@ const TabKeywordTimeRange = ({ defaultValue, disabled, setValidatingKeyword }: P
       return undefined;
     }
 
-    setValidatingKeyword(true);
+    if (keywordRef.current !== keyword) {
+      keywordRef.current = keyword;
 
-    return trim(keyword) === ''
-      ? Promise.resolve('Keyword must not be empty!')
-      : ToolsStore.testNaturalDate(keyword)
-        .then((response) => {
-          if (mounted.current) _setSuccessfullPreview(response);
-        })
-        .catch(_setFailedPreview);
+      setValidatingKeyword(true);
+
+      return trim(keyword) === ''
+        ? Promise.resolve('Keyword must not be empty!')
+        : ToolsStore.testNaturalDate(keyword)
+          .then((response) => {
+            if (mounted.current) _setSuccessfullPreview(response);
+          })
+          .catch(_setFailedPreview);
+    }
+
+    return undefined;
   }, [_setFailedPreview, _setSuccessfullPreview, setValidatingKeyword]);
 
   useEffect(() => {
@@ -99,12 +105,8 @@ const TabKeywordTimeRange = ({ defaultValue, disabled, setValidatingKeyword }: P
   }, []);
 
   useEffect(() => {
-    if (keywordRef.current !== nextRangeProps?.value?.keyword) {
-      keywordRef.current = nextRangeProps.value.keyword;
-
-      _validateKeyword(keywordRef.current);
-    }
-  });
+    _validateKeyword(keywordRef.current);
+  }, [_validateKeyword]);
 
   useEffect(() => {
     if (nextRangeProps?.value) {
@@ -124,7 +126,7 @@ const TabKeywordTimeRange = ({ defaultValue, disabled, setValidatingKeyword }: P
   return (
     <Row className="no-bm">
       <Col sm={5}>
-        <Field name="nextTimeRange.keyword">
+        <Field name="nextTimeRange.keyword" validate={_validateKeyword}>
           {({ field: { name, value, onChange }, meta: { error } }) => (
             <FormGroup controlId="form-inline-keyword"
                        style={{ marginRight: 5, width: '100%', marginBottom: 0 }}


### PR DESCRIPTION
**This is a backport of #11386 for 4.2**

## Description
<!--- Describe your changes in detail -->
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Prior to this change, a refactoring introduced in #11194 lead to the server not being able to generate a preview for a keyword time range, because the response class was not serializable due to missing `@JsonProperty` annotations, which were added in this PR.

Additionally, the keyword preview was constantly updating due to the component rerendering and field-level validation being triggered, resulting in an infinite loop. The reason why this did not happen before are unclear. To address this, validation was changed to happen only if the keyword has changed, plus an initial validation being forced.

Fixes #11385.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.