### PR TITLE
Fix index count on IndexSetPage

### DIFF
--- a/graylog2-web-interface/src/pages/IndexSetPage.tsx
+++ b/graylog2-web-interface/src/pages/IndexSetPage.tsx
@@ -107,7 +107,7 @@ class IndexSetPage extends React.Component<Props, State> {
   }
 
   _totalIndexCount = () => {
-    const { indexerOverview: {indices} } = this.props;
+    const { indexerOverview: { indices } } = this.props;
 
     return indices ? Object.keys(indices).length : null;
   };

--- a/graylog2-web-interface/src/pages/IndexSetPage.tsx
+++ b/graylog2-web-interface/src/pages/IndexSetPage.tsx
@@ -107,7 +107,7 @@ class IndexSetPage extends React.Component<Props, State> {
   }
 
   _totalIndexCount = () => {
-    const { indexerOverview: indices } = this.props;
+    const { indexerOverview: {indices} } = this.props;
 
     return indices ? Object.keys(indices).length : null;
   };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes the index count on `IndexSetPage`.

## Description
<!--- Describe your changes in detail -->
Previously, `_totalIndexCount` was counting the keys of the `indexerOverview` response (introduced w/ #10401; [specifically this](https://github.com/Graylog2/graylog2-server/pull/10401/files#diff-e80e8ae830a0552545b2659d7a199aa7274ac4ffa50f68a7f0d2c822a99133d2R110-R114)), rather than the response's `indices` key.  This PR updates that function so it counts the right thing.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #11375.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
It hasn't been tested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

