### PR TITLE
Use query fields instead of all fields for aggregation wizard's field select

### DIFF
--- a/graylog2-web-interface/src/views/components/aggregationwizard/FieldSelect.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/FieldSelect.tsx
@@ -15,12 +15,15 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { useContext } from 'react';
+import { useContext, useMemo } from 'react';
+import * as Immutable from 'immutable';
 
 import { defaultCompare } from 'views/logic/DefaultCompare';
 import FieldTypesContext from 'views/components/contexts/FieldTypesContext';
 import { Input } from 'components/bootstrap';
 import Select from 'components/common/Select';
+import { useStore } from 'stores/connect';
+import { ViewMetadataStore } from 'views/stores/ViewMetadataStore';
 
 type Props = {
   ariaLabel?: string,
@@ -36,8 +39,14 @@ type Props = {
 const sortByLabel = ({ label: label1 }: { label: string }, { label: label2 }: { label: string }) => defaultCompare(label1, label2);
 
 const FieldSelect = ({ name, id, error, clearable, value, onChange, label, ariaLabel }: Props) => {
+  const { activeQuery } = useStore(ViewMetadataStore);
   const fieldTypes = useContext(FieldTypesContext);
-  const fieldTypeOptions = fieldTypes.all.map((fieldType) => ({ label: fieldType.name, value: fieldType.name })).toArray().sort(sortByLabel);
+  const fieldTypeOptions = useMemo(() => fieldTypes.queryFields
+    .get(activeQuery, Immutable.List())
+    .map((fieldType) => ({ label: fieldType.name, value: fieldType.name }))
+    .toArray()
+    .sort(sortByLabel),
+  [activeQuery, fieldTypes.queryFields]);
 
   return (
     <Input id={id}

--- a/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.groupBy.test.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.groupBy.test.tsx
@@ -21,6 +21,7 @@ import selectEvent from 'react-select-event';
 import userEvent from '@testing-library/user-event';
 import { PluginRegistration, PluginStore } from 'graylog-web-plugin/plugin';
 import { applyTimeoutMultiplier } from 'jest-preset-graylog/lib/timeouts';
+import { MockStore } from 'helpers/mocking';
 
 import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
 import DataTable from 'views/components/datatable/DataTable';
@@ -33,6 +34,10 @@ import dataTable from 'views/components/datatable/bindings';
 import AggregationWizard from '../AggregationWizard';
 
 const extendedTimeout = applyTimeoutMultiplier(15000);
+
+jest.mock('views/stores/ViewMetadataStore', () => ({
+  ViewMetadataStore: MockStore(['getInitialState', () => ({ activeQuery: 'queryId' })]),
+}));
 
 const widgetConfig = AggregationWidgetConfig
   .builder()
@@ -93,7 +98,7 @@ describe('AggregationWizard', () => {
 
     await addElement('Grouping');
 
-    await waitFor(() => expect(screen.getByText('Field is required.')).toBeInTheDocument());
+    await screen.findByText('Field is required.');
   });
 
   it('should change the config when applied', async () => {

--- a/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.metric.test.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.metric.test.tsx
@@ -20,6 +20,7 @@ import { act, fireEvent, render, screen, waitFor } from 'wrappedTestingLibrary';
 import selectEvent from 'react-select-event';
 import userEvent from '@testing-library/user-event';
 import { PluginRegistration, PluginStore } from 'graylog-web-plugin/plugin';
+import { MockStore } from 'helpers/mocking';
 
 import FieldTypeMapping from 'views/logic/fieldtypes/FieldTypeMapping';
 import SeriesConfig from 'views/logic/aggregationbuilder/SeriesConfig';
@@ -51,6 +52,10 @@ jest.mock('views/stores/AggregationFunctionsStore', () => ({
     percentile: { type: 'percentile', description: 'Percentile' },
   })),
   listen: jest.fn(),
+}));
+
+jest.mock('views/stores/ViewMetadataStore', () => ({
+  ViewMetadataStore: MockStore(['getInitialState', () => ({ activeQuery: 'queryId' })]),
 }));
 
 const selectEventConfig = { container: document.body };
@@ -103,7 +108,7 @@ describe('AggregationWizard', () => {
 
     await addElement('Metric');
 
-    await waitFor(() => expect(screen.getByText('Function is required.')).toBeInTheDocument());
+    await screen.findByText('Function is required.');
   });
 
   it('should require metric field when metric function is not count', async () => {
@@ -115,7 +120,7 @@ describe('AggregationWizard', () => {
     await selectEvent.openMenu(functionSelect);
     await selectEvent.select(functionSelect, 'Minimum', selectEventConfig);
 
-    await waitFor(() => expect(screen.getByText('Field is required for function min.')).toBeInTheDocument());
+    await screen.findByText('Field is required for function min.');
   });
 
   it('should not require metric field when metric function count', async () => {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

**Note:** This PR requires a backport to `4.2`.

Prior to this change, the options list used for the field select of the aggregation wizard was based on the "all" field types list. That one includes field types for all streams a user has access to.  Unfortunately, this list of streams is lacking e.g. the indexing failure stream. This can lead to problems like the one described in #11404.

This change is now generating the field options list from the field types of the currently selected query.

Fixes #11404.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.