### PR TITLE
Fixed Race Condition with CP Installation and Caches/LUTs

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/lookup/LookupTableService.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/LookupTableService.java
@@ -251,12 +251,10 @@ public class LookupTableService extends AbstractIdleService {
     @Subscribe
     public void handleAdapterUpdate(DataAdaptersUpdated updated) {
         scheduler.schedule(() -> {
-            // when a data adapter is updated, the lookup tables that use it need to be updated as well
             // first we create the new adapter instance and start it
             // then we retrieve the old one so we can safely stop it later
             // then we build a new lookup table instance with the new adapter instance
             // last we can remove the old lookup table instance and stop the original adapter
-            final Collection<LookupTableDto> tablesToUpdate = configService.findTablesForDataAdapterIds(updated.ids());
 
             // collect old adapter instances
             final ImmutableSet.Builder<LookupDataAdapter> existingAdapters = ImmutableSet.builder();
@@ -273,6 +271,8 @@ public class LookupTableService extends AbstractIdleService {
             // wait until everything is either running or failed before starting the
             awaitUninterruptibly(runningLatch);
 
+            // when a data adapter is updated, the lookup tables that use it need to be updated as well
+            final Collection<LookupTableDto> tablesToUpdate = configService.findTablesForDataAdapterIds(updated.ids());
             tablesToUpdate.forEach(this::createLookupTable);
 
             // stop old adapters
@@ -295,12 +295,10 @@ public class LookupTableService extends AbstractIdleService {
     @Subscribe
     public void handleCacheUpdate(CachesUpdated updated) {
         scheduler.schedule(() -> {
-            // when a cache is updated, the lookup tables that use it need to be updated as well
             // first we create the new cache instance and start it
             // then we retrieve the old one so we can safely stop it later
             // then we build a new lookup table instance with the new cache instance
             // last we can remove the old lookup table instance and stop the original cache
-            final Collection<LookupTableDto> tablesToUpdate = configService.findTablesForCacheIds(updated.ids());
 
             // collect old cache instances
             final ImmutableSet.Builder<LookupCache> existingCaches = ImmutableSet.builder();
@@ -316,6 +314,8 @@ public class LookupTableService extends AbstractIdleService {
             // wait until everything is either running or failed before starting the
             awaitUninterruptibly(runningLatch);
 
+            // when a cache is updated, the lookup tables that use it need to be updated as well
+            final Collection<LookupTableDto> tablesToUpdate = configService.findTablesForCacheIds(updated.ids());
             tablesToUpdate.forEach(this::createLookupTable);
 
             // stop old caches


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
**Note:** This PR needs a backport to `4.2`.

## Description
The call that loads all tables linked to a cache has been placed near the actual recreation of these tables to make sure that the contents of that variable are current.

## Motivation and Context
For the Watchlist functionality, a migration script had been created that imports and installs a ContentPack. After installation, 3 keys are to be created in a lookup table. This fails sometimes due to a possible race condition that occurs that saving the cache and the lookup table during import fires an update event on the EventBus but due to the ordering of the code and the runtime during the cache recreation, the lookup table never gets started properly.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

