### PR TITLE
Always display selected value in `Select`, even when no related option exists.

### DIFF
--- a/graylog2-web-interface/src/components/common/Select.tsx
+++ b/graylog2-web-interface/src/components/common/Select.tsx
@@ -445,7 +445,7 @@ class Select<OptionValue> extends React.Component<Props<OptionValue>, State> {
   _formatInputValue = (value: OptionValue): Array<Option> => {
     const { options, displayKey, valueKey, delimiter, allowCreate } = this.props;
 
-    if (value === undefined || value === null) {
+    if (value === undefined || value === null || (typeof value === 'string' && value === '')) {
       return undefined;
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
_This PR should be backported to 4.1_

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


Before this change it was possible, that the `Select` component looked empty, even when component has a value.
This could happen when no option for the defined value has been found in the provided options list.

Currently there is just one case were this could happen. When building an aggregation we display the available fields, depending on the configured streams filter. When a user selects a stream specific field and changes the streams filter, the selected field is no longer being provided as an option for the `Select`.

Since the stream specific field is still part of the aggregation, we decided to display the value for the `Select`, even when no related option exists.

I tried to add a test, but there is currently no elegant way, to check if the name of the current value of the `Select` component is correct.

Fixes: https://github.com/Graylog2/graylog2-server/issues/11433