### PR TITLE
Add and configure maven enforcer plugin

### DIFF
--- a/graylog-project-parent/pom.xml
+++ b/graylog-project-parent/pom.xml
@@ -879,33 +879,6 @@
             </build>
         </profile>
         <profile>
-            <id>dependency-check</id>
-
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-enforcer-plugin</artifactId>
-                        <version>3.0.0-M3</version>
-                        <executions>
-                            <execution>
-                                <id>check-dependencies</id>
-                                <goals>
-                                    <goal>enforce</goal>
-                                </goals>
-                                <configuration>
-                                    <rules>
-                                        <banDuplicatePomDependencyVersions/>
-                                        <dependencyConvergence/>
-                                    </rules>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
             <id>travis</id>
             <activation>
                 <property>

--- a/graylog-project-parent/pom.xml
+++ b/graylog-project-parent/pom.xml
@@ -396,6 +396,12 @@
                 <groupId>commons-validator</groupId>
                 <artifactId>commons-validator</artifactId>
                 <version>${commons-validator.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>commons-logging</groupId>
+                        <artifactId>commons-logging</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>
@@ -530,6 +536,12 @@
                 <groupId>com.maxmind.geoip2</groupId>
                 <artifactId>geoip2</artifactId>
                 <version>${geoip2.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>commons-logging</groupId>
+                        <artifactId>commons-logging</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.graylog.cef</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -396,7 +396,7 @@
                                         <!-- This dependency also pulls in log4j 1.x -->
                                         <exclude>org.apache.log4j.wso2:log4j</exclude>
                                         <!-- We use jcl-over-slf4j, so we need to make sure we don't pull in
-                                             the actual commons-logging dependency to avoid conflicts. http://www.slf4j.org/legacy.html#log4j-over-slf4j -->
+                                             the actual commons-logging dependency to avoid conflicts. http://www.slf4j.org/legacy.html#jclOverSLF4J -->
                                         <exclude>commons-logging:commons-logging</exclude>
                                         <!-- Make sure we don't pull in vulnerable log4j2 versions (CVE-2021-45046, CVE-2021-44228) -->
                                         <exclude>org.apache.logging.log4j:*:(,2.16)</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -405,7 +405,7 @@
                                 <banDuplicatePomDependencyVersions/>
                                 -->
                                 <requireMavenVersion>
-                                    <version>3.6.3</version>
+                                    <version>[3.6.0,)</version>
                                 </requireMavenVersion>
                                 <requireJavaVersion>
                                     <version>1.8</version>

--- a/pom.xml
+++ b/pom.xml
@@ -391,19 +391,20 @@
                                     <searchTransitive>true</searchTransitive>
                                     <excludes>
                                         <!-- We use log4j-over-slf4j, so we need to make sure we don't pull in
-                                             the actual log4j 1.x dependency to avoid conflicts. -->
+                                             the actual log4j 1.x dependency to avoid conflicts. http://www.slf4j.org/legacy.html#log4j-over-slf4j -->
                                         <exclude>log4j:log4j</exclude>
                                         <!-- This dependency also pulls in log4j 1.x -->
                                         <exclude>org.apache.log4j.wso2:log4j</exclude>
+                                        <!-- We use jcl-over-slf4j, so we need to make sure we don't pull in
+                                             the actual commons-logging dependency to avoid conflicts. http://www.slf4j.org/legacy.html#log4j-over-slf4j -->
+                                        <exclude>commons-logging:commons-logging</exclude>
                                         <!-- Make sure we don't pull in vulnerable log4j2 versions (CVE-2021-45046, CVE-2021-44228) -->
                                         <exclude>org.apache.logging.log4j:*:(,2.16)</exclude>
                                         <!-- Pulling in slf4j-simple creates warnings about multiple SLF4J bindings on server startup -->
                                         <exclude>org.slf4j:slf4j-simple</exclude>
                                     </excludes>
                                 </bannedDependencies>
-                                <!-- TODO: Enable once all duplicate dependency declarations have been fixed
                                 <banDuplicatePomDependencyVersions/>
-                                -->
                                 <requireMavenVersion>
                                     <version>[3.6.0,)</version>
                                 </requireMavenVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -364,10 +364,58 @@
                     <artifactId>license-maven-plugin</artifactId>
                     <version>${license-maven.version}</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-enforcer-plugin</artifactId>
+                    <version>3.0.0</version>
+                </plugin>
             </plugins>
         </pluginManagement>
 
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>enforce-versions</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <fail>true</fail>
+                            <failFast>false</failFast>
+                            <rules>
+                                <bannedDependencies>
+                                    <searchTransitive>true</searchTransitive>
+                                    <excludes>
+                                        <!-- We use log4j-over-slf4j, so we need to make sure we don't pull in
+                                             the actual log4j 1.x dependency to avoid conflicts. -->
+                                        <exclude>log4j:log4j</exclude>
+                                        <!-- This dependency also pulls in log4j 1.x -->
+                                        <exclude>org.apache.log4j.wso2:log4j</exclude>
+                                        <!-- Make sure we don't pull in vulnerable log4j2 versions (CVE-2021-45046, CVE-2021-44228) -->
+                                        <exclude>org.apache.logging.log4j:*:(,2.16)</exclude>
+                                    </excludes>
+                                </bannedDependencies>
+                                <!-- TODO: Enable once all duplicate dependency declarations have been fixed
+                                <banDuplicatePomDependencyVersions/>
+                                -->
+                                <requireMavenVersion>
+                                    <version>3.6.3</version>
+                                </requireMavenVersion>
+                                <requireJavaVersion>
+                                    <version>1.8</version>
+                                </requireJavaVersion>
+                                <requireOS>
+                                    <family>unix</family>
+                                </requireOS>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -397,6 +397,8 @@
                                         <exclude>org.apache.log4j.wso2:log4j</exclude>
                                         <!-- Make sure we don't pull in vulnerable log4j2 versions (CVE-2021-45046, CVE-2021-44228) -->
                                         <exclude>org.apache.logging.log4j:*:(,2.16)</exclude>
+                                        <!-- Pulling in slf4j-simple creates warnings about multiple SLF4J bindings on server startup -->
+                                        <exclude>org.slf4j:slf4j-simple</exclude>
                                     </excludes>
                                 </bannedDependencies>
                                 <!-- TODO: Enable once all duplicate dependency declarations have been fixed


### PR DESCRIPTION
The following rules are active:

- Require maven version >= 3.6.0
- Require a unix platform (this includes macOS and Linux)
- Require Java version 1.8
- Add banned dependencies

/jenkins-pr-deps Graylog2/graylog-plugin-threatintel#210,Graylog2/graylog-plugin-enterprise-integrations#698