### PR TITLE
Redirect to rules list pages when getting a rule return 404

### DIFF
--- a/graylog2-web-interface/src/pages/RuleDetailsPage.jsx
+++ b/graylog2-web-interface/src/pages/RuleDetailsPage.jsx
@@ -20,10 +20,12 @@ import PropTypes from 'prop-types';
 import connect from 'stores/connect';
 import { DocumentTitle, Spinner } from 'components/common';
 import Rule from 'components/rules/Rule';
+import Routes from 'routing/Routes';
 import { PipelineRulesProvider } from 'components/rules/RuleContext';
 import withParams from 'routing/withParams';
 import { PipelinesStore, PipelinesActions } from 'stores/pipelines/PipelinesStore';
 import { RulesActions, RulesStore } from 'stores/rules/RulesStore';
+import history from 'util/History';
 
 function filterRules(rule, ruleId) {
   return rule?.rules?.filter((r) => r.id === ruleId)[0];
@@ -54,10 +56,16 @@ const RuleDetailsPage = ({ params, rule, pipelines }) => {
       setIsLoading(false);
     } else {
       PipelinesActions.list();
-      RulesActions.get(params.ruleId);
+
+      RulesActions.get(params.ruleId).then(() => {}, (error) => {
+        if (error.status === 404) {
+          history.push(Routes.SYSTEM.PIPELINES.RULES);
+        }
+      });
+
       setIsLoading(!(filteredRule && pipelines));
     }
-  }, [filteredRule]);
+  }, [filteredRule, isNewRule, params.ruleId, pipelines]);
 
   if (isLoading) {
     return <Spinner text="Loading Rule Details..." />;

--- a/graylog2-web-interface/src/stores/rules/RulesStore.ts
+++ b/graylog2-web-interface/src/stores/rules/RulesStore.ts
@@ -121,6 +121,7 @@ export const RulesStore = singletonStore(
       const promise = fetch('GET', url);
 
       promise.then(this._updateRulesState, failCallback);
+      RulesActions.get.promise(promise);
 
       return promise;
     },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
These changes redirect to Rules list page when `404` is returned while when opening rule detail page. A toast telling that there was an error finding the rule with ID is still shown. 

Fix #11044 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

