### PR TITLE
Fix type name of ElasticsearchQueryString when serializing to json

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/elasticsearch/ElasticsearchQueryString.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/elasticsearch/ElasticsearchQueryString.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.auto.value.AutoValue;
 import com.google.common.base.Strings;
 import org.graylog.plugins.views.search.engine.BackendQuery;
@@ -28,6 +29,7 @@ import javax.annotation.Nullable;
 
 @AutoValue
 @JsonAutoDetect
+@JsonTypeName(ElasticsearchQueryString.NAME)
 public abstract class ElasticsearchQueryString implements BackendQuery {
 
     public static final String NAME = "elasticsearch";

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/QueryTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/QueryTest.java
@@ -17,6 +17,7 @@
 package org.graylog.plugins.views.search;
 
 import com.codahale.metrics.json.MetricsModule;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -209,5 +210,11 @@ public class QueryTest {
         final Query query = objectMapper.readValue(getClass().getResourceAsStream("/org/graylog/plugins/views/search/query/simple-query.json"), Query.class);
         final ElasticsearchQueryString queryString = (ElasticsearchQueryString) query.query();
         assertThat(queryString.queryString()).isEqualTo("some-simple-query");
+    }
+
+    @Test
+    public void testSerializeQuery() throws JsonProcessingException {
+        final String value = objectMapper.writeValueAsString(ElasticsearchQueryString.of("foo:bar"));
+        assertThat(value).isEqualTo("{\"type\":\"elasticsearch\",\"query_string\":\"foo:bar\"}");
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Serialization of the `ElasticsearchQueryString` class used wrong `type` value, providing the `AutoValue_` prefixed class name instead of plain `elasticsearch` type.  

## Description
Added `@JsonTypeName` to serialize with correct type value.


## How Has This Been Tested?
Added unit test for serialization 

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/4102775/136939443-6a01eebd-d7de-4208-afd6-1beecef24949.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

