### PR TITLE
#11467 Using TCK Tested JDK builds of OpenJDK

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,14 +8,14 @@ jobs:
     runs-on: ubuntu-latest 
     strategy:
       matrix:
-        java-version: [ 8.0.192, 8 ]
+        java-version: [ 8 ]
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK ${{ matrix.java-version }}
         uses: actions/setup-java@v2
         with:
           java-version: ${{ matrix.java-version }}
-          distribution: zulu
+          distribution: temurin
           cache: maven
       - name: Set up Yarn cache
         uses: actions/cache@v2


### PR DESCRIPTION
Issue: #11467

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

The AdoptOpenJDK has been discontinued since July 2021 (https://adoptopenjdk.net). Switching the distribution to Azul Zulu. When using Zulu you get all the latest updated (TCK Tested) builds for all versions of OpenJDK. 

Also added is a fixed (major) release version(s) such as `JDK 8.0.192`. This is often a good practice whenever a build/test triggers (push/pull events) to help determine if the latest (`JDK 8`) had failed the from the **latest build** vs something in **your code** caused (or introduced). 

**For example**, when building with `JDK 8.0.192` (fixed version) the build/tests passes (Green) and JDK 8 fails (Red) will mean that the latest `JDK 8` was the cause and not your code. 

**Note:** Other distributions such as Temurin do not support archived fixed releases prior to Sept. 2021 and many non LTS (long term support) releases if you plan to try out newer features in the language.

## Expected Behavior
<!--- If you're describing a bug, tell us what should happen -->
<!--- If you're suggesting a change/improvement, tell us how it should work -->
When building and testing the project you are expected to get the latest JDK (security patches, bug fixes, etc.). Or a major fixed version from an archived release. This is good practice if there are major vendors and customers who are still using older versions of the JDK.

## Current Behavior
<!--- If describing a bug, tell us what happens instead of the expected behavior -->
<!--- If suggesting a change/improvement, explain the difference from current behavior -->

- Not getting the latest JDK release
- Not building and testing on TCK tested JDK
- Only testing and building on the latest JDK

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Full disclosure, I work for Azul and I would like to help repos/projects avoid test/build interuptions because of `OpenJDK` distribution build versions provided from GH `setup-java@v2` are not consistent (except `zulu`). Originally GH action `setup-java@v1` was using `zulu` and the newer version (GHAction) allows you to choose `adopt`, `zulu`, and `temurin`. Because adopt has been discontinued (AdoptOpenJDK binaries) you only have two choices currently. 


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Push events are disabled on forks, so the workflow will run when on a pull_request.
## Screenshots (if appropriate):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

