### PR TITLE
Make logged in indicator consistent with elements on User Details page

### DIFF
--- a/graylog2-web-interface/src/components/users/UserDetails/ProfileSection.tsx
+++ b/graylog2-web-interface/src/components/users/UserDetails/ProfileSection.tsx
@@ -20,8 +20,6 @@ import { ReadOnlyFormGroup } from 'components/common';
 import User from 'logic/users/User';
 import SectionComponent from 'components/common/Section/SectionComponent';
 
-import LoggedInIcon from '../LoggedInIcon';
-
 type Props = {
   user: User,
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Before this change [`LoggedInIcon`](https://github.com/Graylog2/graylog2-server/blob/159525fb10b7a15670c6b8ae1d0c3cb57437ad16/graylog2-web-interface/src/components/users/LoggedInIcon.tsx) was inconsistent with other visually-similar rows (e.g. `Enabled`) on the User Details page, lacking the "yes"/"no" suffix.  The cause of this difference is that [`ReadOnlyFormGroup`](https://github.com/Graylog2/graylog2-server/blob/159525fb10b7a15670c6b8ae1d0c3cb57437ad16/graylog2-web-interface/src/components/common/ReadOnlyFormGroup.tsx) gets passed a boolean value for certain things (e.g. `Enabled`), leading to the "yes"/"no" suffix being added, but a `LoggedInIcon` component gets passed for `Logged In` (resulting in the value being used as-is).

This PR adds an optional `showReadableSuffix` property to `LoggedInIcon`, which if enabled appends "yes" or "no" (depending upon `active`), and uses that new property on the User Details page to make the `Logged In` row consistent with surrounding content.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Enables consistency with surrounding content when needed.

Fixes #9499.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Verified the User Details page's `LoggedInIcon` has the "yes"/"no" suffix, and that the Users Overview page's `LoggedInIcon` do not.

## Screenshots (if appropriate):
**Before:**

<img src="https://user-images.githubusercontent.com/288958/137630888-85f20b81-97b5-49ec-8d19-cb8a4e5d1191.png" width="40%">

**After:**

<img src="https://user-images.githubusercontent.com/288958/137630853-852546d7-b65f-4083-8108-b97031e0ee42.png" width="40%">

I noticed `LoggedInIcon` uses `theme.colors.variant.default` for the inactive/"no" state, whereas `ReadOnlyFormGroup` uses `theme.colors.variant.danger`.  I'm not sure if it'd be worth changing either, but wanted to point it out.

<img src="https://user-images.githubusercontent.com/288958/137631812-be205db4-bf57-4621-91fc-20019419aaca.png" width="40%">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.