### PR TITLE
Bump gRPC version to 1.41.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
         <gelfclient.version>1.5.0</gelfclient.version>
         <geoip2.version>2.12.0</geoip2.version>
         <grok.version>0.1.9-graylog-2</grok.version>
-        <grpc.version>1.29.0</grpc.version>
+        <grpc.version>1.41.0</grpc.version>
         <guava-retrying.version>2.0.0</guava-retrying.version>
         <guava.version>28.2-jre</guava.version>
         <guice.version>5.0.1</guice.version>


### PR DESCRIPTION
Updates our global gRPC version to `1.41.0`
