### PR TITLE
Remove injection/builtins.js from styleguide.config.js

### DIFF
--- a/graylog2-web-interface/styleguide.config.js
+++ b/graylog2-web-interface/styleguide.config.js
@@ -33,7 +33,6 @@ module.exports = {
     'bootstrap/less/bootstrap.less',
     'toastr/toastr.less',
     'stylesheets/typeahead.less',
-    'injection/builtins.js',
   ],
   sections: [
     {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
`injection/builtins.js` does not exist but keeps showing up


