### PR TITLE
Configuration options for rotation strategies

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/commands/Server.java
+++ b/graylog2-server/src/main/java/org/graylog2/commands/Server.java
@@ -153,7 +153,7 @@ public class Server extends ServerBootstrap {
                 new InitializerBindings(),
                 new MessageInputBindings(),
                 new MessageOutputBindings(configuration, chainingClassLoader),
-                new RotationStrategyBindings(),
+                new RotationStrategyBindings(elasticsearchConfiguration),
                 new RetentionStrategyBindings(),
                 new PeriodicalBindings(),
                 new ObjectMapperModule(chainingClassLoader),

--- a/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchConfiguration.java
@@ -17,14 +17,21 @@
 package org.graylog2.configuration;
 
 import com.github.joschi.jadconfig.Parameter;
+import com.github.joschi.jadconfig.converters.StringSetConverter;
 import com.github.joschi.jadconfig.util.Duration;
 import com.github.joschi.jadconfig.validators.PositiveDurationValidator;
 import com.github.joschi.jadconfig.validators.PositiveIntegerValidator;
 import com.github.joschi.jadconfig.validators.PositiveLongValidator;
 import com.github.joschi.jadconfig.validators.StringNotBlankValidator;
+import com.google.common.collect.Sets;
+import org.graylog2.configuration.validators.RotationStrategyValidator;
+import org.graylog2.indexer.rotation.strategies.MessageCountRotationStrategy;
+import org.graylog2.indexer.rotation.strategies.SizeBasedRotationStrategy;
+import org.graylog2.indexer.rotation.strategies.TimeBasedRotationStrategy;
 import org.joda.time.Period;
 
 import java.util.Locale;
+import java.util.Set;
 
 public class ElasticsearchConfiguration {
     public static final String DEFAULT_EVENTS_INDEX_PREFIX = "default_events_index_prefix";
@@ -53,6 +60,9 @@ public class ElasticsearchConfiguration {
     @Parameter(value = "elasticsearch_max_time_per_index", required = true)
     private Period maxTimePerIndex = Period.days(1);
 
+    @Parameter(value = "elasticsearch_max_write_index_age")
+    private Period maxWriteIndexAge = null;
+
     @Deprecated // Should be removed in Graylog 3.0
     @Parameter(value = "elasticsearch_shards", validator = PositiveIntegerValidator.class, required = true)
     private int shards = 4;
@@ -75,6 +85,10 @@ public class ElasticsearchConfiguration {
     @Deprecated // Should be removed in Graylog 3.0
     @Parameter(value = "retention_strategy", required = true)
     private String retentionStrategy = "delete";
+
+    @Parameter(value = "valid_rotation_strategies", converter = StringSetConverter.class, validators = RotationStrategyValidator.class)
+    private Set<String> validRotationStrategies = Sets.newHashSet(
+            MessageCountRotationStrategy.strategyName, SizeBasedRotationStrategy.strategyName, TimeBasedRotationStrategy.strategyName);
 
     @Deprecated // Should be removed in Graylog 3.0
     @Parameter(value = "rotation_strategy")
@@ -132,6 +146,10 @@ public class ElasticsearchConfiguration {
         return maxTimePerIndex;
     }
 
+    public Period getMaxWriteIndexAge() {
+        return maxWriteIndexAge;
+    }
+
     @Deprecated // Should be removed in Graylog 3.0
     public int getShards() {
         return shards;
@@ -150,6 +168,10 @@ public class ElasticsearchConfiguration {
     @Deprecated // Should be removed in Graylog 3.0
     public String getTemplateName() {
         return templateName;
+    }
+
+    public Set<String> getValidRotationStrategies() {
+        return validRotationStrategies;
     }
 
     @Deprecated // Should be removed in Graylog 3.0

--- a/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchConfiguration.java
@@ -86,13 +86,13 @@ public class ElasticsearchConfiguration {
     @Parameter(value = "retention_strategy", required = true)
     private String retentionStrategy = "delete";
 
-    @Parameter(value = "valid_rotation_strategies", converter = StringSetConverter.class, validators = RotationStrategyValidator.class)
-    private Set<String> validRotationStrategies = Sets.newHashSet(
-            MessageCountRotationStrategy.strategyName, SizeBasedRotationStrategy.strategyName, TimeBasedRotationStrategy.strategyName);
+    @Parameter(value = "enabled_index_rotation_strategies", converter = StringSetConverter.class, validators = RotationStrategyValidator.class)
+    private Set<String> enabledRotationStrategies = Sets.newHashSet(
+            MessageCountRotationStrategy.NAME, SizeBasedRotationStrategy.NAME, TimeBasedRotationStrategy.NAME);
 
     @Deprecated // Should be removed in Graylog 3.0
     @Parameter(value = "rotation_strategy")
-    private String rotationStrategy = MessageCountRotationStrategy.strategyName;
+    private String rotationStrategy = MessageCountRotationStrategy.NAME;
 
     @Deprecated // Should be removed in Graylog 3.0
     @Parameter(value = "disable_index_optimization")
@@ -170,8 +170,8 @@ public class ElasticsearchConfiguration {
         return templateName;
     }
 
-    public Set<String> getValidRotationStrategies() {
-        return validRotationStrategies;
+    public Set<String> getEnabledRotationStrategies() {
+        return enabledRotationStrategies;
     }
 
     @Deprecated // Should be removed in Graylog 3.0

--- a/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchConfiguration.java
@@ -92,7 +92,7 @@ public class ElasticsearchConfiguration {
 
     @Deprecated // Should be removed in Graylog 3.0
     @Parameter(value = "rotation_strategy")
-    private String rotationStrategy = "count";
+    private String rotationStrategy = MessageCountRotationStrategy.strategyName;
 
     @Deprecated // Should be removed in Graylog 3.0
     @Parameter(value = "disable_index_optimization")

--- a/graylog2-server/src/main/java/org/graylog2/configuration/validators/RotationStrategyValidator.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/validators/RotationStrategyValidator.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog2.configuration.validators;
 
 import com.github.joschi.jadconfig.ValidationException;
@@ -12,7 +28,7 @@ import java.util.stream.Collectors;
 
 public class RotationStrategyValidator implements Validator<Set<String>> {
     Set<String> VALID_STRATEGIES = Sets.newHashSet(
-            MessageCountRotationStrategy.strategyName, SizeBasedRotationStrategy.strategyName, TimeBasedRotationStrategy.strategyName);
+            MessageCountRotationStrategy.NAME, SizeBasedRotationStrategy.NAME, TimeBasedRotationStrategy.NAME);
 
     @Override
     // The set of valid rotation strategies must

--- a/graylog2-server/src/main/java/org/graylog2/configuration/validators/RotationStrategyValidator.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/validators/RotationStrategyValidator.java
@@ -1,0 +1,29 @@
+package org.graylog2.configuration.validators;
+
+import com.github.joschi.jadconfig.ValidationException;
+import com.github.joschi.jadconfig.Validator;
+import com.google.common.collect.Sets;
+import org.graylog2.indexer.rotation.strategies.MessageCountRotationStrategy;
+import org.graylog2.indexer.rotation.strategies.SizeBasedRotationStrategy;
+import org.graylog2.indexer.rotation.strategies.TimeBasedRotationStrategy;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class RotationStrategyValidator implements Validator<Set<String>> {
+    Set<String> VALID_STRATEGIES = Sets.newHashSet(
+            MessageCountRotationStrategy.strategyName, SizeBasedRotationStrategy.strategyName, TimeBasedRotationStrategy.strategyName);
+
+    @Override
+    public void validate(String parameter, Set<String> value) throws ValidationException {
+        if (value == null || value.isEmpty()) {
+            throw new ValidationException("Parameter " + parameter + " should be non-empty list");
+        }
+
+        if (!value.stream()
+                .filter(s -> !VALID_STRATEGIES.contains(s))
+                .collect(Collectors.toSet()).isEmpty()) {
+            throw new ValidationException("Parameter " + parameter + " contains invalid values: " + value);
+        }
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/configuration/validators/RotationStrategyValidator.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/validators/RotationStrategyValidator.java
@@ -15,6 +15,9 @@ public class RotationStrategyValidator implements Validator<Set<String>> {
             MessageCountRotationStrategy.strategyName, SizeBasedRotationStrategy.strategyName, TimeBasedRotationStrategy.strategyName);
 
     @Override
+    // The set of valid rotation strategies must
+    // - contain only names of supported strategies
+    // - not be empty
     public void validate(String parameter, Set<String> value) throws ValidationException {
         if (value == null || value.isEmpty()) {
             throw new ValidationException("Parameter " + parameter + " should be non-empty list");

--- a/graylog2-server/src/main/java/org/graylog2/indexer/rotation/RotationStrategyBindings.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/rotation/RotationStrategyBindings.java
@@ -16,17 +16,34 @@
  */
 package org.graylog2.indexer.rotation;
 
+import org.graylog2.configuration.ElasticsearchConfiguration;
 import org.graylog2.indexer.rotation.strategies.MessageCountRotationStrategy;
 import org.graylog2.indexer.rotation.strategies.SizeBasedRotationStrategy;
 import org.graylog2.indexer.rotation.strategies.TimeBasedRotationStrategy;
 import org.graylog2.plugin.PluginModule;
 
 public class RotationStrategyBindings extends PluginModule {
+    private final ElasticsearchConfiguration elasticsearchConfiguration;
+
+    public RotationStrategyBindings(ElasticsearchConfiguration elasticsearchConfiguration) {
+        this.elasticsearchConfiguration = elasticsearchConfiguration;
+    }
+
     @Override
     protected void configure() {
-        addRotationStrategy(MessageCountRotationStrategy.class);
-        addRotationStrategy(SizeBasedRotationStrategy.class);
-        addRotationStrategy(TimeBasedRotationStrategy.class);
+        for (String strategy : elasticsearchConfiguration.getValidRotationStrategies()) {
+            switch (strategy) {
+                case MessageCountRotationStrategy.strategyName:
+                    addRotationStrategy(MessageCountRotationStrategy.class);
+                    break;
+                case SizeBasedRotationStrategy.strategyName:
+                    addRotationStrategy(SizeBasedRotationStrategy.class);
+                    break;
+                case TimeBasedRotationStrategy.strategyName:
+                    addRotationStrategy(TimeBasedRotationStrategy.class);
+                    break;
+            }
+        }
     }
 
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/rotation/RotationStrategyBindings.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/rotation/RotationStrategyBindings.java
@@ -31,15 +31,15 @@ public class RotationStrategyBindings extends PluginModule {
 
     @Override
     protected void configure() {
-        for (String strategy : elasticsearchConfiguration.getValidRotationStrategies()) {
+        for (String strategy : elasticsearchConfiguration.getEnabledRotationStrategies()) {
             switch (strategy) {
-                case MessageCountRotationStrategy.strategyName:
+                case MessageCountRotationStrategy.NAME:
                     addRotationStrategy(MessageCountRotationStrategy.class);
                     break;
-                case SizeBasedRotationStrategy.strategyName:
+                case SizeBasedRotationStrategy.NAME:
                     addRotationStrategy(SizeBasedRotationStrategy.class);
                     break;
-                case TimeBasedRotationStrategy.strategyName:
+                case TimeBasedRotationStrategy.NAME:
                     addRotationStrategy(TimeBasedRotationStrategy.class);
                     break;
             }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/AbstractRotationStrategy.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/AbstractRotationStrategy.java
@@ -19,6 +19,7 @@ package org.graylog2.indexer.rotation.strategies;
 import com.google.common.collect.ImmutableMap;
 import org.graylog2.audit.AuditActor;
 import org.graylog2.audit.AuditEventSender;
+import org.graylog2.configuration.ElasticsearchConfiguration;
 import org.graylog2.indexer.IndexSet;
 import org.graylog2.indexer.NoTargetIndexException;
 import org.graylog2.plugin.indexer.rotation.RotationStrategy;
@@ -36,15 +37,19 @@ public abstract class AbstractRotationStrategy implements RotationStrategy {
 
     public interface Result {
         String getDescription();
+
         boolean shouldRotate();
     }
 
     private final AuditEventSender auditEventSender;
     private final NodeId nodeId;
+    protected final ElasticsearchConfiguration elasticsearchConfiguration;
 
-    public AbstractRotationStrategy(AuditEventSender auditEventSender, NodeId nodeId) {
+    public AbstractRotationStrategy(
+            AuditEventSender auditEventSender, NodeId nodeId, ElasticsearchConfiguration elasticsearchConfiguration) {
         this.auditEventSender = requireNonNull(auditEventSender);
         this.nodeId = nodeId;
+        this.elasticsearchConfiguration = elasticsearchConfiguration;
     }
 
     @Nullable

--- a/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/MessageCountRotationStrategy.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/MessageCountRotationStrategy.java
@@ -32,6 +32,7 @@ import java.util.Locale;
 
 public class MessageCountRotationStrategy extends AbstractRotationStrategy {
     private static final Logger log = LoggerFactory.getLogger(MessageCountRotationStrategy.class);
+    public static final String strategyName = "count";
 
     private final Indices indices;
 

--- a/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/MessageCountRotationStrategy.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/MessageCountRotationStrategy.java
@@ -33,7 +33,7 @@ import java.util.Locale;
 
 public class MessageCountRotationStrategy extends AbstractRotationStrategy {
     private static final Logger log = LoggerFactory.getLogger(MessageCountRotationStrategy.class);
-    public static final String strategyName = "count";
+    public static final String NAME = "count";
 
     private final Indices indices;
 
@@ -110,6 +110,6 @@ public class MessageCountRotationStrategy extends AbstractRotationStrategy {
 
     @Override
     public String getStrategyName() {
-        return strategyName;
+        return NAME;
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/MessageCountRotationStrategy.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/MessageCountRotationStrategy.java
@@ -17,6 +17,7 @@
 package org.graylog2.indexer.rotation.strategies;
 
 import org.graylog2.audit.AuditEventSender;
+import org.graylog2.configuration.ElasticsearchConfiguration;
 import org.graylog2.indexer.IndexNotFoundException;
 import org.graylog2.indexer.IndexSet;
 import org.graylog2.indexer.indices.Indices;
@@ -38,8 +39,9 @@ public class MessageCountRotationStrategy extends AbstractRotationStrategy {
 
     @Inject
     public MessageCountRotationStrategy(Indices indices, NodeId nodeId,
-                                        AuditEventSender auditEventSender) {
-        super(auditEventSender, nodeId);
+                                        AuditEventSender auditEventSender,
+                                        ElasticsearchConfiguration elasticsearchConfiguration) {
+        super(auditEventSender, nodeId, elasticsearchConfiguration);
         this.indices = indices;
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/MessageCountRotationStrategy.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/MessageCountRotationStrategy.java
@@ -67,9 +67,9 @@ public class MessageCountRotationStrategy extends AbstractRotationStrategy {
         try {
             final long numberOfMessages = indices.numberOfMessages(index);
             return new Result(index,
-                              numberOfMessages,
-                              config.maxDocsPerIndex(),
-                              numberOfMessages > config.maxDocsPerIndex());
+                    numberOfMessages,
+                    config.maxDocsPerIndex(),
+                    numberOfMessages > config.maxDocsPerIndex());
         } catch (IndexNotFoundException e) {
             log.error("Unknown index, cannot perform rotation", e);
             return null;
@@ -106,5 +106,10 @@ public class MessageCountRotationStrategy extends AbstractRotationStrategy {
         public boolean shouldRotate() {
             return shouldRotate;
         }
+    }
+
+    @Override
+    public String getStrategyName() {
+        return strategyName;
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/SizeBasedRotationStrategy.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/SizeBasedRotationStrategy.java
@@ -90,4 +90,9 @@ public class SizeBasedRotationStrategy extends AbstractRotationStrategy {
             }
         };
     }
+
+    @Override
+    public String getStrategyName() {
+        return strategyName;
+    }
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/SizeBasedRotationStrategy.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/SizeBasedRotationStrategy.java
@@ -29,6 +29,8 @@ import java.util.Locale;
 import java.util.Optional;
 
 public class SizeBasedRotationStrategy extends AbstractRotationStrategy {
+    public static final String strategyName = "size";
+
     private final Indices indices;
 
     @Inject

--- a/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/SizeBasedRotationStrategy.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/SizeBasedRotationStrategy.java
@@ -17,6 +17,7 @@
 package org.graylog2.indexer.rotation.strategies;
 
 import org.graylog2.audit.AuditEventSender;
+import org.graylog2.configuration.ElasticsearchConfiguration;
 import org.graylog2.indexer.IndexSet;
 import org.graylog2.indexer.indices.Indices;
 import org.graylog2.plugin.indexer.rotation.RotationStrategyConfig;
@@ -36,8 +37,9 @@ public class SizeBasedRotationStrategy extends AbstractRotationStrategy {
     @Inject
     public SizeBasedRotationStrategy(Indices indices,
                                      NodeId nodeId,
-                                     AuditEventSender auditEventSender) {
-        super(auditEventSender, nodeId);
+                                     AuditEventSender auditEventSender,
+                                     ElasticsearchConfiguration elasticsearchConfiguration) {
+        super(auditEventSender, nodeId, elasticsearchConfiguration);
         this.indices = indices;
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/SizeBasedRotationStrategy.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/SizeBasedRotationStrategy.java
@@ -30,7 +30,7 @@ import java.util.Locale;
 import java.util.Optional;
 
 public class SizeBasedRotationStrategy extends AbstractRotationStrategy {
-    public static final String strategyName = "size";
+    public static final String NAME = "size";
 
     private final Indices indices;
 
@@ -93,6 +93,6 @@ public class SizeBasedRotationStrategy extends AbstractRotationStrategy {
 
     @Override
     public String getStrategyName() {
-        return strategyName;
+        return NAME;
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/TimeBasedRotationStrategy.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/TimeBasedRotationStrategy.java
@@ -54,6 +54,7 @@ import static org.joda.time.DateTimeFieldType.year;
 @Singleton
 public class TimeBasedRotationStrategy extends AbstractRotationStrategy {
     private static final Logger log = LoggerFactory.getLogger(TimeBasedRotationStrategy.class);
+    public static final String strategyName = "time";
 
     private final Indices indices;
     private Map<String, DateTime> lastRotation;
@@ -108,13 +109,27 @@ public class TimeBasedRotationStrategy extends AbstractRotationStrategy {
 
         // find the largest non-zero stride in the period. that's our anchor type. statement order matters here!
         DateTimeFieldType largestStrideType = null;
-        if (seconds > 0) largestStrideType = secondOfMinute();
-        if (minutes > 0) largestStrideType = minuteOfHour();
-        if (hours > 0) largestStrideType = hourOfDay();
-        if (days > 0) largestStrideType = dayOfMonth();
-        if (weeks > 0) largestStrideType = weekOfWeekyear();
-        if (months > 0) largestStrideType = monthOfYear();
-        if (years > 0) largestStrideType = year();
+        if (seconds > 0) {
+            largestStrideType = secondOfMinute();
+        }
+        if (minutes > 0) {
+            largestStrideType = minuteOfHour();
+        }
+        if (hours > 0) {
+            largestStrideType = hourOfDay();
+        }
+        if (days > 0) {
+            largestStrideType = dayOfMonth();
+        }
+        if (weeks > 0) {
+            largestStrideType = weekOfWeekyear();
+        }
+        if (months > 0) {
+            largestStrideType = monthOfYear();
+        }
+        if (years > 0) {
+            largestStrideType = year();
+        }
         if (largestStrideType == null) {
             throw new IllegalArgumentException("Could not determine rotation stride length.");
         }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/TimeBasedRotationStrategy.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/TimeBasedRotationStrategy.java
@@ -57,7 +57,7 @@ import static org.joda.time.DateTimeFieldType.year;
 @Singleton
 public class TimeBasedRotationStrategy extends AbstractRotationStrategy {
     private static final Logger log = LoggerFactory.getLogger(TimeBasedRotationStrategy.class);
-    public static final String strategyName = "time";
+    public static final String NAME = "time";
 
     private final Indices indices;
     private Map<String, DateTime> lastRotation;
@@ -253,6 +253,6 @@ public class TimeBasedRotationStrategy extends AbstractRotationStrategy {
 
     @Override
     public String getStrategyName() {
-        return strategyName;
+        return NAME;
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/TimeBasedRotationStrategy.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/TimeBasedRotationStrategy.java
@@ -18,6 +18,7 @@ package org.graylog2.indexer.rotation.strategies;
 
 import com.google.common.base.MoreObjects;
 import org.graylog2.audit.AuditEventSender;
+import org.graylog2.configuration.ElasticsearchConfiguration;
 import org.graylog2.indexer.IndexSet;
 import org.graylog2.indexer.indexset.IndexSetConfig;
 import org.graylog2.indexer.indices.Indices;
@@ -28,6 +29,8 @@ import org.joda.time.DateTime;
 import org.joda.time.DateTimeField;
 import org.joda.time.DateTimeFieldType;
 import org.joda.time.DateTimeZone;
+import org.joda.time.Duration;
+import org.joda.time.Instant;
 import org.joda.time.Period;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -62,8 +65,9 @@ public class TimeBasedRotationStrategy extends AbstractRotationStrategy {
 
     @Inject
     public TimeBasedRotationStrategy(Indices indices, NodeId nodeId,
-                                     AuditEventSender auditEventSender) {
-        super(auditEventSender, nodeId);
+                                     AuditEventSender auditEventSender,
+                                     ElasticsearchConfiguration elasticsearchConfiguration) {
+        super(auditEventSender, nodeId, elasticsearchConfiguration);
         this.anchor = new ConcurrentHashMap<>();
         this.lastRotation = new ConcurrentHashMap<>();
         this.indices = requireNonNull(indices, "indices must not be null");
@@ -159,6 +163,13 @@ public class TimeBasedRotationStrategy extends AbstractRotationStrategy {
         return MoreObjects.firstNonNull(lastAnchor, Tools.nowUTC());
     }
 
+    private static boolean isLonger(Period p1, Period p2) {
+        Instant now = Instant.now();
+        Duration d1 = p1.toDurationTo(now);
+        Duration d2 = p2.toDurationTo(now);
+        return d1.isLongerThan(d2);
+    }
+
     @Nullable
     @Override
     protected Result shouldRotate(String index, IndexSet indexSet) {
@@ -167,15 +178,24 @@ public class TimeBasedRotationStrategy extends AbstractRotationStrategy {
         checkState(!isNullOrEmpty(index), "Index name must not be null or empty");
         checkState(!isNullOrEmpty(indexSetId), "Index set ID must not be null or empty");
         checkState(indexSetConfig.rotationStrategy() instanceof TimeBasedRotationStrategyConfig,
-                "Invalid rotation strategy config <" + indexSetConfig.rotationStrategy().getClass().getCanonicalName() + "> for index set <" + indexSetId + ">");
+                "Invalid rotation strategy config <"
+                        + indexSetConfig.rotationStrategy().getClass().getCanonicalName()
+                        + "> for index set <" + indexSetId + ">");
 
         final TimeBasedRotationStrategyConfig config = (TimeBasedRotationStrategyConfig) indexSetConfig.rotationStrategy();
-        final Period rotationPeriod = config.rotationPeriod().normalizedStandard();
-        final DateTime now = Tools.nowUTC();
+
+        Period rotationPeriod = config.rotationPeriod();
+        Period maxPeriod = elasticsearchConfiguration.getMaxWriteIndexAge();
+        if (maxPeriod != null && isLonger(rotationPeriod, maxPeriod)) {
+            log.warn("Max rotation limit {} overrides configured period {}", maxPeriod, rotationPeriod);
+            rotationPeriod = maxPeriod;
+        }
+        final Period normalizedPeriod = rotationPeriod.normalizedStandard();
+
         // when first started, we might not know the last rotation time, look up the creation time of the index instead.
         if (!lastRotation.containsKey(indexSetId)) {
             indices.indexCreationDate(index).ifPresent(creationDate -> {
-                final DateTime currentAnchor = determineRotationPeriodAnchor(creationDate, rotationPeriod);
+                final DateTime currentAnchor = determineRotationPeriodAnchor(creationDate, normalizedPeriod);
                 anchor.put(indexSetId, currentAnchor);
                 lastRotation.put(indexSetId, creationDate);
             });
@@ -186,8 +206,9 @@ public class TimeBasedRotationStrategy extends AbstractRotationStrategy {
             }
         }
 
+        final DateTime now = Tools.nowUTC();
         final DateTime currentAnchor = anchor.get(indexSetId);
-        final DateTime nextRotation = currentAnchor.plus(rotationPeriod);
+        final DateTime nextRotation = currentAnchor.plus(normalizedPeriod);
         if (nextRotation.isAfter(now)) {
             final String message = new MessageFormat("Next rotation at {0}", Locale.ENGLISH)
                     .format(new Object[]{nextRotation});
@@ -198,10 +219,10 @@ public class TimeBasedRotationStrategy extends AbstractRotationStrategy {
         DateTime tmpAnchor;
         int multiplicator = 0;
         do {
-            tmpAnchor = currentAnchor.withPeriodAdded(rotationPeriod, ++multiplicator);
+            tmpAnchor = currentAnchor.withPeriodAdded(normalizedPeriod, ++multiplicator);
         } while (tmpAnchor.isBefore(now));
 
-        final DateTime nextAnchor = currentAnchor.withPeriodAdded(rotationPeriod, multiplicator - 1);
+        final DateTime nextAnchor = currentAnchor.withPeriodAdded(normalizedPeriod, multiplicator - 1);
         anchor.put(indexSetId, nextAnchor);
         lastRotation.put(indexSetId, now);
         final String message = new MessageFormat("Rotation period {0} elapsed, next rotation at {1}", Locale.ENGLISH)

--- a/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/TimeBasedRotationStrategy.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/TimeBasedRotationStrategy.java
@@ -80,7 +80,7 @@ public class TimeBasedRotationStrategy extends AbstractRotationStrategy {
 
     @Override
     public RotationStrategyConfig defaultConfiguration() {
-        return TimeBasedRotationStrategyConfig.createDefault();
+        return TimeBasedRotationStrategyConfig.createDefault(elasticsearchConfiguration.getMaxWriteIndexAge());
     }
 
     /**
@@ -249,5 +249,10 @@ public class TimeBasedRotationStrategy extends AbstractRotationStrategy {
         public boolean shouldRotate() {
             return rotate;
         }
+    }
+
+    @Override
+    public String getStrategyName() {
+        return strategyName;
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/TimeBasedRotationStrategyConfig.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/TimeBasedRotationStrategyConfig.java
@@ -24,6 +24,7 @@ import org.graylog.autovalue.WithBeanGetter;
 import org.graylog2.plugin.indexer.rotation.RotationStrategyConfig;
 import org.joda.time.Period;
 
+import javax.annotation.Nullable;
 import javax.validation.constraints.NotNull;
 
 @JsonAutoDetect
@@ -35,18 +36,24 @@ public abstract class TimeBasedRotationStrategyConfig implements RotationStrateg
     @JsonProperty("rotation_period")
     public abstract Period rotationPeriod();
 
+    @JsonProperty("elasticsearch_max_write_index_age")
+    @Nullable
+    public abstract Period maxWriteIndexAge();
+
     @JsonCreator
     public static TimeBasedRotationStrategyConfig create(@JsonProperty(TYPE_FIELD) String type,
-                                                         @JsonProperty("rotation_period") @NotNull Period maxTimePerIndex) {
-        return new AutoValue_TimeBasedRotationStrategyConfig(type, maxTimePerIndex);
+                                                         @JsonProperty("rotation_period") @NotNull Period maxTimePerIndex,
+                                                         @JsonProperty("elasticsearch_max_write_index_age") Period maxWriteIndexAge) {
+        return new AutoValue_TimeBasedRotationStrategyConfig(type, maxTimePerIndex, maxWriteIndexAge);
     }
 
     @JsonCreator
-    public static TimeBasedRotationStrategyConfig create(@JsonProperty("rotation_period") @NotNull Period maxTimePerIndex) {
-        return create(TimeBasedRotationStrategyConfig.class.getCanonicalName(), maxTimePerIndex);
+    public static TimeBasedRotationStrategyConfig create(@JsonProperty("rotation_period") @NotNull Period maxTimePerIndex,
+                                                         @JsonProperty("elasticsearch_max_write_index_age") Period maxWriteIndexAge) {
+        return create(TimeBasedRotationStrategyConfig.class.getCanonicalName(), maxTimePerIndex, maxWriteIndexAge);
     }
 
-    public static TimeBasedRotationStrategyConfig createDefault() {
-        return create(DEFAULT_DAYS);
+    public static TimeBasedRotationStrategyConfig createDefault(Period maxWriteIndexAge) {
+        return create(DEFAULT_DAYS, maxWriteIndexAge);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/TimeBasedRotationStrategyConfig.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/TimeBasedRotationStrategyConfig.java
@@ -36,24 +36,24 @@ public abstract class TimeBasedRotationStrategyConfig implements RotationStrateg
     @JsonProperty("rotation_period")
     public abstract Period rotationPeriod();
 
-    @JsonProperty("elasticsearch_max_write_index_age")
+    @JsonProperty("max_rotation_period")
     @Nullable
-    public abstract Period maxWriteIndexAge();
+    public abstract Period maxRotationPeriod();
 
     @JsonCreator
     public static TimeBasedRotationStrategyConfig create(@JsonProperty(TYPE_FIELD) String type,
                                                          @JsonProperty("rotation_period") @NotNull Period maxTimePerIndex,
-                                                         @JsonProperty("elasticsearch_max_write_index_age") Period maxWriteIndexAge) {
-        return new AutoValue_TimeBasedRotationStrategyConfig(type, maxTimePerIndex, maxWriteIndexAge);
+                                                         @JsonProperty("max_rotation_period") Period maxRotationPeriod) {
+        return new AutoValue_TimeBasedRotationStrategyConfig(type, maxTimePerIndex, maxRotationPeriod);
     }
 
     @JsonCreator
     public static TimeBasedRotationStrategyConfig create(@JsonProperty("rotation_period") @NotNull Period maxTimePerIndex,
-                                                         @JsonProperty("elasticsearch_max_write_index_age") Period maxWriteIndexAge) {
-        return create(TimeBasedRotationStrategyConfig.class.getCanonicalName(), maxTimePerIndex, maxWriteIndexAge);
+                                                         @JsonProperty("max_rotation_period") Period maxRotationPeriod) {
+        return create(TimeBasedRotationStrategyConfig.class.getCanonicalName(), maxTimePerIndex, maxRotationPeriod);
     }
 
-    public static TimeBasedRotationStrategyConfig createDefault(Period maxWriteIndexAge) {
-        return create(DEFAULT_DAYS, maxWriteIndexAge);
+    public static TimeBasedRotationStrategyConfig createDefault(Period maxRotationPeriod) {
+        return create(DEFAULT_DAYS, maxRotationPeriod);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/migrations/V20151210140600_ElasticsearchConfigMigration.java
+++ b/graylog2-server/src/main/java/org/graylog2/migrations/V20151210140600_ElasticsearchConfigMigration.java
@@ -74,7 +74,9 @@ public class V20151210140600_ElasticsearchConfigMigration extends Migration {
             LOG.info("Migrated \"{}\" setting: {}", "elasticsearch_max_size_per_index", sizeConfig);
         }
         if (timeBasedRotationStrategyConfig == null) {
-            final TimeBasedRotationStrategyConfig timeConfig = TimeBasedRotationStrategyConfig.create(elasticsearchConfiguration.getMaxTimePerIndex());
+            final TimeBasedRotationStrategyConfig timeConfig =
+                    TimeBasedRotationStrategyConfig.create(elasticsearchConfiguration.getMaxTimePerIndex(),
+                            elasticsearchConfiguration.getMaxWriteIndexAge());
             clusterConfigService.write(timeConfig);
             LOG.info("Migrated \"{}\" setting: {}", "elasticsearch_max_time_per_index", timeConfig);
         }

--- a/graylog2-server/src/main/java/org/graylog2/migrations/V20190705071400_AddEventIndexSetsMigration.java
+++ b/graylog2-server/src/main/java/org/graylog2/migrations/V20190705071400_AddEventIndexSetsMigration.java
@@ -156,7 +156,7 @@ public class V20190705071400_AddEventIndexSetsMigration extends Migration {
                 .shards(elasticsearchConfiguration.getShards())
                 .replicas(elasticsearchConfiguration.getReplicas())
                 .rotationStrategyClass(TimeBasedRotationStrategy.class.getCanonicalName())
-                .rotationStrategy(TimeBasedRotationStrategyConfig.create(Period.months(1)))
+                .rotationStrategy(TimeBasedRotationStrategyConfig.create(Period.months(1), null))
                 .retentionStrategyClass(DeletionRetentionStrategy.class.getCanonicalName())
                 .retentionStrategy(DeletionRetentionStrategyConfig.create(12))
                 .creationDate(ZonedDateTime.now(ZoneOffset.UTC))

--- a/graylog2-server/src/main/java/org/graylog2/plugin/indexer/rotation/RotationStrategy.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/indexer/rotation/RotationStrategy.java
@@ -24,4 +24,6 @@ public interface RotationStrategy {
     Class<? extends RotationStrategyConfig> configurationClass();
 
     RotationStrategyConfig defaultConfiguration();
+
+    String getStrategyName();
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indices/RotationStrategyResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indices/RotationStrategyResource.java
@@ -77,7 +77,7 @@ public class RotationStrategyResource extends RestResource {
     public RotationStrategies list() {
         final Set<RotationStrategyDescription> strategies = rotationStrategies.keySet()
                 .stream()
-                .filter(this::isValidRotationStrategy)
+                .filter(this::isEnabledRotationStrategy)
                 .map(this::getRotationStrategyDescription)
                 .collect(Collectors.toSet());
 
@@ -94,14 +94,14 @@ public class RotationStrategyResource extends RestResource {
         return getRotationStrategyDescription(strategyName);
     }
 
-    // Limit available rotation strategies to those specified by configuration parameter valid_rotation_strategies
-    private boolean isValidRotationStrategy(String strategyName) {
+    // Limit available rotation strategies to those specified by configuration parameter enabled_index_rotation_strategies
+    private boolean isEnabledRotationStrategy(String strategyName) {
         final Provider<RotationStrategy> provider = rotationStrategies.get(strategyName);
         if (provider == null) {
             throw new NotFoundException("Couldn't find rotation strategy for given type " + strategyName);
         }
         final RotationStrategy rotationStrategy = provider.get();
-        return elasticsearchConfiguration.getValidRotationStrategies().contains(rotationStrategy.getStrategyName());
+        return elasticsearchConfiguration.getEnabledRotationStrategies().contains(rotationStrategy.getStrategyName());
     }
 
     private RotationStrategyDescription getRotationStrategyDescription(String strategyName) {

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indices/RotationStrategyResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indices/RotationStrategyResource.java
@@ -24,6 +24,7 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import org.apache.shiro.authz.annotation.RequiresAuthentication;
+import org.graylog2.configuration.ElasticsearchConfiguration;
 import org.graylog2.plugin.cluster.ClusterConfigService;
 import org.graylog2.plugin.indexer.rotation.RotationStrategy;
 import org.graylog2.plugin.indexer.rotation.RotationStrategyConfig;
@@ -55,24 +56,28 @@ public class RotationStrategyResource extends RestResource {
     private final Map<String, Provider<RotationStrategy>> rotationStrategies;
     private final ObjectMapper objectMapper;
     private final ClusterConfigService clusterConfigService;
+    private final ElasticsearchConfiguration elasticsearchConfiguration;
 
     @Inject
     public RotationStrategyResource(Map<String, Provider<RotationStrategy>> rotationStrategies,
                                     ObjectMapper objectMapper,
-                                    ClusterConfigService clusterConfigService) {
+                                    ClusterConfigService clusterConfigService,
+                                    ElasticsearchConfiguration elasticsearchConfiguration) {
         this.rotationStrategies = requireNonNull(rotationStrategies);
         this.objectMapper = objectMapper;
         this.clusterConfigService = requireNonNull(clusterConfigService);
+        this.elasticsearchConfiguration = elasticsearchConfiguration;
     }
 
     @GET
     @Path("strategies")
     @Timed
     @ApiOperation(value = "List available rotation strategies",
-            notes = "This resource returns a list of all available rotation strategies on this Graylog node.")
+                  notes = "This resource returns a list of all available rotation strategies on this Graylog node.")
     public RotationStrategies list() {
         final Set<RotationStrategyDescription> strategies = rotationStrategies.keySet()
                 .stream()
+                .filter(this::isValidRotationStrategy)
                 .map(this::getRotationStrategyDescription)
                 .collect(Collectors.toSet());
 
@@ -83,10 +88,19 @@ public class RotationStrategyResource extends RestResource {
     @Path("strategies/{strategy}")
     @Timed
     @ApiOperation(value = "Show JSON schema for configuration of given rotation strategies",
-            notes = "This resource returns a JSON schema for the configuration of the given rotation strategy.")
+                  notes = "This resource returns a JSON schema for the configuration of the given rotation strategy.")
     public RotationStrategyDescription configSchema(@ApiParam(name = "strategy", value = "The name of the rotation strategy", required = true)
-                                   @PathParam("strategy") @NotEmpty String strategyName) {
+                                                    @PathParam("strategy") @NotEmpty String strategyName) {
         return getRotationStrategyDescription(strategyName);
+    }
+
+    private boolean isValidRotationStrategy(String strategyName) {
+        final Provider<RotationStrategy> provider = rotationStrategies.get(strategyName);
+        if (provider == null) {
+            throw new NotFoundException("Couldn't find rotation strategy for given type " + strategyName);
+        }
+        final RotationStrategy rotationStrategy = provider.get();
+        return elasticsearchConfiguration.getValidRotationStrategies().contains(rotationStrategy.getStrategyName());
     }
 
     private RotationStrategyDescription getRotationStrategyDescription(String strategyName) {

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indices/RotationStrategyResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indices/RotationStrategyResource.java
@@ -94,6 +94,7 @@ public class RotationStrategyResource extends RestResource {
         return getRotationStrategyDescription(strategyName);
     }
 
+    // Limit available rotation strategies to those specified by configuration parameter valid_rotation_strategies
     private boolean isValidRotationStrategy(String strategyName) {
         final Provider<RotationStrategy> provider = rotationStrategies.get(strategyName);
         if (provider == null) {

--- a/graylog2-server/src/test/java/org/graylog2/indexer/rotation/strategies/MessageCountRotationStrategyTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/rotation/strategies/MessageCountRotationStrategyTest.java
@@ -17,6 +17,7 @@
 package org.graylog2.indexer.rotation.strategies;
 
 import org.graylog2.audit.AuditEventSender;
+import org.graylog2.configuration.ElasticsearchConfiguration;
 import org.graylog2.indexer.IndexNotFoundException;
 import org.graylog2.indexer.IndexSet;
 import org.graylog2.indexer.indexset.IndexSetConfig;
@@ -54,6 +55,8 @@ public class MessageCountRotationStrategyTest {
     @Mock
     private AuditEventSender auditEventSender;
 
+    private ElasticsearchConfiguration configuration = new ElasticsearchConfiguration();
+
     @Test
     public void testRotate() throws Exception {
         when(indices.numberOfMessages("name")).thenReturn(10L);
@@ -61,7 +64,7 @@ public class MessageCountRotationStrategyTest {
         when(indexSet.getConfig()).thenReturn(indexSetConfig);
         when(indexSetConfig.rotationStrategy()).thenReturn(MessageCountRotationStrategyConfig.create(5));
 
-        final MessageCountRotationStrategy strategy = new MessageCountRotationStrategy(indices, nodeId, auditEventSender);
+        final MessageCountRotationStrategy strategy = new MessageCountRotationStrategy(indices, nodeId, auditEventSender, configuration);
 
         strategy.rotate(indexSet);
         verify(indexSet, times(1)).cycle();
@@ -75,7 +78,7 @@ public class MessageCountRotationStrategyTest {
         when(indexSet.getConfig()).thenReturn(indexSetConfig);
         when(indexSetConfig.rotationStrategy()).thenReturn(MessageCountRotationStrategyConfig.create(5));
 
-        final MessageCountRotationStrategy strategy = new MessageCountRotationStrategy(indices, nodeId, auditEventSender);
+        final MessageCountRotationStrategy strategy = new MessageCountRotationStrategy(indices, nodeId, auditEventSender, configuration);
 
         strategy.rotate(indexSet);
         verify(indexSet, never()).cycle();
@@ -90,7 +93,7 @@ public class MessageCountRotationStrategyTest {
         when(indexSet.getConfig()).thenReturn(indexSetConfig);
         when(indexSetConfig.rotationStrategy()).thenReturn(MessageCountRotationStrategyConfig.create(5));
 
-        final MessageCountRotationStrategy strategy = new MessageCountRotationStrategy(indices, nodeId, auditEventSender);
+        final MessageCountRotationStrategy strategy = new MessageCountRotationStrategy(indices, nodeId, auditEventSender, configuration);
 
         strategy.rotate(indexSet);
         verify(indexSet, never()).cycle();

--- a/graylog2-server/src/test/java/org/graylog2/indexer/rotation/strategies/RotationStrategyValidatorTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/rotation/strategies/RotationStrategyValidatorTest.java
@@ -1,0 +1,52 @@
+package org.graylog2.indexer.rotation.strategies;
+
+import com.github.joschi.jadconfig.ValidationException;
+import org.graylog2.configuration.validators.RotationStrategyValidator;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.HashSet;
+
+public class RotationStrategyValidatorTest {
+    private final RotationStrategyValidator validator = new RotationStrategyValidator();
+    private final String PARAM = "parameter-name";
+
+    @Test
+    void nullSet() {
+        Assertions.assertThrows(ValidationException.class, () -> {
+            validator.validate(PARAM, null);
+        });
+    }
+
+    @Test
+    void emptySet() {
+        Assertions.assertThrows(ValidationException.class, () -> {
+            validator.validate(PARAM, new HashSet<>());
+        });
+    }
+
+    @Test
+    void invalidStrategy() {
+        Assertions.assertThrows(ValidationException.class, () -> {
+            validator.validate(PARAM, new HashSet<>(Arrays.asList("invalid-strategy")));
+        });
+        Assertions.assertThrows(ValidationException.class, () -> {
+            validator.validate(PARAM, new HashSet<>(Arrays.asList(
+                    TimeBasedRotationStrategy.strategyName,
+                    "invalid-strategy")));
+        });
+    }
+
+    @Test
+    void validStrategy() throws ValidationException {
+        validator.validate(PARAM, new HashSet<>(Arrays.asList(
+                TimeBasedRotationStrategy.strategyName
+        )));
+        validator.validate(PARAM, new HashSet<>(Arrays.asList(
+                TimeBasedRotationStrategy.strategyName,
+                SizeBasedRotationStrategy.strategyName,
+                MessageCountRotationStrategy.strategyName
+        )));
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/indexer/rotation/strategies/RotationStrategyValidatorTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/rotation/strategies/RotationStrategyValidatorTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog2.indexer.rotation.strategies;
 
 import com.github.joschi.jadconfig.ValidationException;
@@ -33,7 +49,7 @@ public class RotationStrategyValidatorTest {
         });
         Assertions.assertThrows(ValidationException.class, () -> {
             validator.validate(PARAM, new HashSet<>(Arrays.asList(
-                    TimeBasedRotationStrategy.strategyName,
+                    TimeBasedRotationStrategy.NAME,
                     "invalid-strategy")));
         });
     }
@@ -41,12 +57,12 @@ public class RotationStrategyValidatorTest {
     @Test
     void validStrategy() throws ValidationException {
         validator.validate(PARAM, new HashSet<>(Arrays.asList(
-                TimeBasedRotationStrategy.strategyName
+                TimeBasedRotationStrategy.NAME
         )));
         validator.validate(PARAM, new HashSet<>(Arrays.asList(
-                TimeBasedRotationStrategy.strategyName,
-                SizeBasedRotationStrategy.strategyName,
-                MessageCountRotationStrategy.strategyName
+                TimeBasedRotationStrategy.NAME,
+                SizeBasedRotationStrategy.NAME,
+                MessageCountRotationStrategy.NAME
         )));
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/indexer/rotation/strategies/SizeBasedRotationStrategyTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/rotation/strategies/SizeBasedRotationStrategyTest.java
@@ -17,6 +17,7 @@
 package org.graylog2.indexer.rotation.strategies;
 
 import org.graylog2.audit.AuditEventSender;
+import org.graylog2.configuration.ElasticsearchConfiguration;
 import org.graylog2.indexer.IndexSet;
 import org.graylog2.indexer.indexset.IndexSetConfig;
 import org.graylog2.indexer.indices.Indices;
@@ -54,6 +55,8 @@ public class SizeBasedRotationStrategyTest {
     @Mock
     private AuditEventSender auditEventSender;
 
+    private ElasticsearchConfiguration configuration = new ElasticsearchConfiguration();
+
     @Test
     public void testRotate() throws Exception {
         when(indices.getStoreSizeInBytes("name")).thenReturn(Optional.of(1000L));
@@ -61,7 +64,7 @@ public class SizeBasedRotationStrategyTest {
         when(indexSet.getConfig()).thenReturn(indexSetConfig);
         when(indexSetConfig.rotationStrategy()).thenReturn(SizeBasedRotationStrategyConfig.create(100L));
 
-        final SizeBasedRotationStrategy strategy = new SizeBasedRotationStrategy(indices, nodeId, auditEventSender);
+        final SizeBasedRotationStrategy strategy = new SizeBasedRotationStrategy(indices, nodeId, auditEventSender, configuration);
 
         strategy.rotate(indexSet);
         verify(indexSet, times(1)).cycle();
@@ -76,7 +79,7 @@ public class SizeBasedRotationStrategyTest {
         when(indexSet.getConfig()).thenReturn(indexSetConfig);
         when(indexSetConfig.rotationStrategy()).thenReturn(SizeBasedRotationStrategyConfig.create(100000L));
 
-        final SizeBasedRotationStrategy strategy = new SizeBasedRotationStrategy(indices, nodeId, auditEventSender);
+        final SizeBasedRotationStrategy strategy = new SizeBasedRotationStrategy(indices, nodeId, auditEventSender, configuration);
 
         strategy.rotate(indexSet);
         verify(indexSet, never()).cycle();
@@ -91,7 +94,7 @@ public class SizeBasedRotationStrategyTest {
         when(indexSet.getConfig()).thenReturn(indexSetConfig);
         when(indexSetConfig.rotationStrategy()).thenReturn(SizeBasedRotationStrategyConfig.create(100L));
 
-        final SizeBasedRotationStrategy strategy = new SizeBasedRotationStrategy(indices, nodeId, auditEventSender);
+        final SizeBasedRotationStrategy strategy = new SizeBasedRotationStrategy(indices, nodeId, auditEventSender, configuration);
 
         strategy.rotate(indexSet);
         verify(indexSet, never()).cycle();

--- a/graylog2-server/src/test/java/org/graylog2/indexer/rotation/strategies/TimeBasedRotationStrategyConfigTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/rotation/strategies/TimeBasedRotationStrategyConfigTest.java
@@ -28,32 +28,51 @@ import org.junit.Test;
 import java.io.IOException;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertNull;
 
 public class TimeBasedRotationStrategyConfigTest {
     @Test
     public void testCreate() throws Exception {
         final TimeBasedRotationStrategyConfig config = TimeBasedRotationStrategyConfig.create(Period.days(1), null);
         assertThat(config.rotationPeriod()).isEqualTo(Period.days(1));
+        assertNull(config.maxWriteIndexAge());
+
+        final TimeBasedRotationStrategyConfig configWithMaxAge = TimeBasedRotationStrategyConfig.create(Period.days(1), Period.days(99));
+        assertThat(configWithMaxAge.rotationPeriod()).isEqualTo(Period.days(1));
+        assertThat(configWithMaxAge.maxWriteIndexAge()).isEqualTo(Period.days(99));
     }
 
     @Test
     public void testSerialization() throws JsonProcessingException {
-        final RotationStrategyConfig config = TimeBasedRotationStrategyConfig.create(Period.days(1), null);
+        final RotationStrategyConfig config = TimeBasedRotationStrategyConfig.create(Period.days(1), Period.days(99));
         final ObjectMapper objectMapper = new ObjectMapperProvider().get();
         final String json = objectMapper.writeValueAsString(config);
 
         final Object document = Configuration.defaultConfiguration().jsonProvider().parse(json);
         assertThat((String) JsonPath.read(document, "$.type")).isEqualTo("org.graylog2.indexer.rotation.strategies.TimeBasedRotationStrategyConfig");
         assertThat((String) JsonPath.read(document, "$.rotation_period")).isEqualTo("P1D");
+        assertThat((String) JsonPath.read(document, "$.elasticsearch_max_write_index_age")).isEqualTo("P99D");
     }
 
     @Test
     public void testDeserialization() throws IOException {
         final ObjectMapper objectMapper = new ObjectMapperProvider().get();
-        final String json = "{ \"type\": \"org.graylog2.indexer.rotation.strategies.TimeBasedRotationStrategyConfig\", \"rotation_period\": \"P1D\" }";
+        final String json = "{ \"type\": \"org.graylog2.indexer.rotation.strategies.TimeBasedRotationStrategyConfig\", \"rotation_period\": \"P1D\", \"elasticsearch_max_write_index_age\": \"P99D\" }";
         final RotationStrategyConfig config = objectMapper.readValue(json, RotationStrategyConfig.class);
 
         assertThat(config).isInstanceOf(TimeBasedRotationStrategyConfig.class);
         assertThat(((TimeBasedRotationStrategyConfig) config).rotationPeriod()).isEqualTo(Period.days(1));
+        assertThat(((TimeBasedRotationStrategyConfig) config).maxWriteIndexAge()).isEqualTo(Period.days(99));
+    }
+
+    @Test
+    public void testDeserializationWithMissingProperty() throws IOException {
+        final ObjectMapper objectMapper = new ObjectMapperProvider().get();
+        final String json = "{ \"type\": \"org.graylog2.indexer.rotation.strategies.TimeBasedRotationStrategyConfig\", \"rotation_period\": \"P1D\"}";
+        final RotationStrategyConfig config = objectMapper.readValue(json, RotationStrategyConfig.class);
+
+        assertThat(config).isInstanceOf(TimeBasedRotationStrategyConfig.class);
+        assertThat(((TimeBasedRotationStrategyConfig) config).rotationPeriod()).isEqualTo(Period.days(1));
+        assertNull(((TimeBasedRotationStrategyConfig) config).maxWriteIndexAge());
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/indexer/rotation/strategies/TimeBasedRotationStrategyConfigTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/rotation/strategies/TimeBasedRotationStrategyConfigTest.java
@@ -35,11 +35,11 @@ public class TimeBasedRotationStrategyConfigTest {
     public void testCreate() throws Exception {
         final TimeBasedRotationStrategyConfig config = TimeBasedRotationStrategyConfig.create(Period.days(1), null);
         assertThat(config.rotationPeriod()).isEqualTo(Period.days(1));
-        assertNull(config.maxWriteIndexAge());
+        assertNull(config.maxRotationPeriod());
 
         final TimeBasedRotationStrategyConfig configWithMaxAge = TimeBasedRotationStrategyConfig.create(Period.days(1), Period.days(99));
         assertThat(configWithMaxAge.rotationPeriod()).isEqualTo(Period.days(1));
-        assertThat(configWithMaxAge.maxWriteIndexAge()).isEqualTo(Period.days(99));
+        assertThat(configWithMaxAge.maxRotationPeriod()).isEqualTo(Period.days(99));
     }
 
     @Test
@@ -51,18 +51,18 @@ public class TimeBasedRotationStrategyConfigTest {
         final Object document = Configuration.defaultConfiguration().jsonProvider().parse(json);
         assertThat((String) JsonPath.read(document, "$.type")).isEqualTo("org.graylog2.indexer.rotation.strategies.TimeBasedRotationStrategyConfig");
         assertThat((String) JsonPath.read(document, "$.rotation_period")).isEqualTo("P1D");
-        assertThat((String) JsonPath.read(document, "$.elasticsearch_max_write_index_age")).isEqualTo("P99D");
+        assertThat((String) JsonPath.read(document, "$.max_rotation_period")).isEqualTo("P99D");
     }
 
     @Test
     public void testDeserialization() throws IOException {
         final ObjectMapper objectMapper = new ObjectMapperProvider().get();
-        final String json = "{ \"type\": \"org.graylog2.indexer.rotation.strategies.TimeBasedRotationStrategyConfig\", \"rotation_period\": \"P1D\", \"elasticsearch_max_write_index_age\": \"P99D\" }";
+        final String json = "{ \"type\": \"org.graylog2.indexer.rotation.strategies.TimeBasedRotationStrategyConfig\", \"rotation_period\": \"P1D\", \"max_rotation_period\": \"P99D\" }";
         final RotationStrategyConfig config = objectMapper.readValue(json, RotationStrategyConfig.class);
 
         assertThat(config).isInstanceOf(TimeBasedRotationStrategyConfig.class);
         assertThat(((TimeBasedRotationStrategyConfig) config).rotationPeriod()).isEqualTo(Period.days(1));
-        assertThat(((TimeBasedRotationStrategyConfig) config).maxWriteIndexAge()).isEqualTo(Period.days(99));
+        assertThat(((TimeBasedRotationStrategyConfig) config).maxRotationPeriod()).isEqualTo(Period.days(99));
     }
 
     @Test
@@ -73,6 +73,6 @@ public class TimeBasedRotationStrategyConfigTest {
 
         assertThat(config).isInstanceOf(TimeBasedRotationStrategyConfig.class);
         assertThat(((TimeBasedRotationStrategyConfig) config).rotationPeriod()).isEqualTo(Period.days(1));
-        assertNull(((TimeBasedRotationStrategyConfig) config).maxWriteIndexAge());
+        assertNull(((TimeBasedRotationStrategyConfig) config).maxRotationPeriod());
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/indexer/rotation/strategies/TimeBasedRotationStrategyConfigTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/rotation/strategies/TimeBasedRotationStrategyConfigTest.java
@@ -32,13 +32,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class TimeBasedRotationStrategyConfigTest {
     @Test
     public void testCreate() throws Exception {
-        final TimeBasedRotationStrategyConfig config = TimeBasedRotationStrategyConfig.create(Period.days(1));
+        final TimeBasedRotationStrategyConfig config = TimeBasedRotationStrategyConfig.create(Period.days(1), null);
         assertThat(config.rotationPeriod()).isEqualTo(Period.days(1));
     }
 
     @Test
     public void testSerialization() throws JsonProcessingException {
-        final RotationStrategyConfig config = TimeBasedRotationStrategyConfig.create(Period.days(1));
+        final RotationStrategyConfig config = TimeBasedRotationStrategyConfig.create(Period.days(1), null);
         final ObjectMapper objectMapper = new ObjectMapperProvider().get();
         final String json = objectMapper.writeValueAsString(config);
 

--- a/graylog2-server/src/test/java/org/graylog2/indexer/rotation/strategies/TimeBasedRotationStrategyTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/rotation/strategies/TimeBasedRotationStrategyTest.java
@@ -17,6 +17,7 @@
 package org.graylog2.indexer.rotation.strategies;
 
 import org.graylog2.audit.AuditEventSender;
+import org.graylog2.configuration.ElasticsearchConfiguration;
 import org.graylog2.indexer.IndexSet;
 import org.graylog2.indexer.indexset.IndexSetConfig;
 import org.graylog2.indexer.indices.Indices;
@@ -71,13 +72,14 @@ public class TimeBasedRotationStrategyTest {
     @Mock
     private AuditEventSender auditEventSender;
 
+    private ElasticsearchConfiguration configuration = new ElasticsearchConfiguration();
     private TimeBasedRotationStrategy rotationStrategy;
 
     @Before
     public void setUp() {
         when(indexSetConfig.id()).thenReturn("index-set-id");
         when(indexSetConfig.title()).thenReturn("index-set-title");
-        rotationStrategy = new TimeBasedRotationStrategy(indices, nodeId, auditEventSender);
+        rotationStrategy = new TimeBasedRotationStrategy(indices, nodeId, auditEventSender, configuration);
     }
 
     @After

--- a/graylog2-server/src/test/java/org/graylog2/indexer/rotation/strategies/TimeBasedRotationStrategyTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/rotation/strategies/TimeBasedRotationStrategyTest.java
@@ -161,7 +161,7 @@ public class TimeBasedRotationStrategyTest {
         DateTimeUtils.setCurrentMillisProvider(clock);
 
         when(indexSet.getConfig()).thenReturn(indexSetConfig);
-        when(indexSetConfig.rotationStrategy()).thenReturn(TimeBasedRotationStrategyConfig.create(period));
+        when(indexSetConfig.rotationStrategy()).thenReturn(TimeBasedRotationStrategyConfig.create(period, null));
         when(indices.indexCreationDate(anyString())).thenReturn(Optional.of(initialTime.minus(minutes(5))));
 
         // Should not rotate the first index.
@@ -175,7 +175,7 @@ public class TimeBasedRotationStrategyTest {
         // Crossed rotation period.
         when(indexSet.getNewestIndex()).thenReturn("ignored");
         when(indexSet.getConfig()).thenReturn(indexSetConfig);
-        when(indexSetConfig.rotationStrategy()).thenReturn(TimeBasedRotationStrategyConfig.create(period));
+        when(indexSetConfig.rotationStrategy()).thenReturn(TimeBasedRotationStrategyConfig.create(period, null));
         rotationStrategy.rotate(indexSet);
         verify(indexSet, times(1)).cycle();
         reset(indexSet);
@@ -185,7 +185,7 @@ public class TimeBasedRotationStrategyTest {
         // Did not cross rotation period.
         when(indexSet.getNewestIndex()).thenReturn("ignored");
         when(indexSet.getConfig()).thenReturn(indexSetConfig);
-        when(indexSetConfig.rotationStrategy()).thenReturn(TimeBasedRotationStrategyConfig.create(period));
+        when(indexSetConfig.rotationStrategy()).thenReturn(TimeBasedRotationStrategyConfig.create(period, null));
         rotationStrategy.rotate(indexSet);
         verify(indexSet, never()).cycle();
         reset(indexSet);
@@ -200,14 +200,14 @@ public class TimeBasedRotationStrategyTest {
         final InstantMillisProvider clock = new InstantMillisProvider(initialTime);
         DateTimeUtils.setCurrentMillisProvider(clock);
         when(indexSet.getConfig()).thenReturn(indexSetConfig);
-        when(indexSetConfig.rotationStrategy()).thenReturn(TimeBasedRotationStrategyConfig.create(period));
+        when(indexSetConfig.rotationStrategy()).thenReturn(TimeBasedRotationStrategyConfig.create(period, null));
         when(indices.indexCreationDate(anyString())).thenReturn(Optional.of(initialTime.minus(minutes(11))));
 
         // Should rotate the first index.
         // time is 01:55:00, index was created at 01:44:00, so we missed one period, and should rotate
         when(indexSet.getNewestIndex()).thenReturn("ignored");
         when(indexSet.getConfig()).thenReturn(indexSetConfig);
-        when(indexSetConfig.rotationStrategy()).thenReturn(TimeBasedRotationStrategyConfig.create(period));
+        when(indexSetConfig.rotationStrategy()).thenReturn(TimeBasedRotationStrategyConfig.create(period, null));
         rotationStrategy.rotate(indexSet);
         verify(indexSet, times(1)).cycle();
         reset(indexSet);
@@ -218,7 +218,7 @@ public class TimeBasedRotationStrategyTest {
         // Did not cross rotation period.
         when(indexSet.getNewestIndex()).thenReturn("ignored");
         when(indexSet.getConfig()).thenReturn(indexSetConfig);
-        when(indexSetConfig.rotationStrategy()).thenReturn(TimeBasedRotationStrategyConfig.create(period));
+        when(indexSetConfig.rotationStrategy()).thenReturn(TimeBasedRotationStrategyConfig.create(period, null));
         rotationStrategy.rotate(indexSet);
         verify(indexSet, never()).cycle();
         reset(indexSet);
@@ -229,7 +229,7 @@ public class TimeBasedRotationStrategyTest {
         // Crossed rotation period.
         when(indexSet.getNewestIndex()).thenReturn("ignored");
         when(indexSet.getConfig()).thenReturn(indexSetConfig);
-        when(indexSetConfig.rotationStrategy()).thenReturn(TimeBasedRotationStrategyConfig.create(period));
+        when(indexSetConfig.rotationStrategy()).thenReturn(TimeBasedRotationStrategyConfig.create(period, null));
         rotationStrategy.rotate(indexSet);
         verify(indexSet, times(1)).cycle();
         reset(indexSet);
@@ -241,7 +241,7 @@ public class TimeBasedRotationStrategyTest {
         // Crossed multiple rotation periods.
         when(indexSet.getNewestIndex()).thenReturn("ignored");
         when(indexSet.getConfig()).thenReturn(indexSetConfig);
-        when(indexSetConfig.rotationStrategy()).thenReturn(TimeBasedRotationStrategyConfig.create(period));
+        when(indexSetConfig.rotationStrategy()).thenReturn(TimeBasedRotationStrategyConfig.create(period, null));
         rotationStrategy.rotate(indexSet);
         verify(indexSet, times(1)).cycle();
         reset(indexSet);
@@ -251,7 +251,7 @@ public class TimeBasedRotationStrategyTest {
         clock.tick(minutes(1));
         when(indexSet.getNewestIndex()).thenReturn("ignored");
         when(indexSet.getConfig()).thenReturn(indexSetConfig);
-        when(indexSetConfig.rotationStrategy()).thenReturn(TimeBasedRotationStrategyConfig.create(period));
+        when(indexSetConfig.rotationStrategy()).thenReturn(TimeBasedRotationStrategyConfig.create(period, null));
         rotationStrategy.rotate(indexSet);
         verify(indexSet, never()).cycle();
         reset(indexSet);
@@ -345,8 +345,8 @@ public class TimeBasedRotationStrategyTest {
         when(indexSet1.getConfig()).thenReturn(indexSetConfig1);
         when(indexSet2.getConfig()).thenReturn(indexSetConfig2);
 
-        when(indexSetConfig1.rotationStrategy()).thenReturn(TimeBasedRotationStrategyConfig.create(period));
-        when(indexSetConfig2.rotationStrategy()).thenReturn(TimeBasedRotationStrategyConfig.create(period));
+        when(indexSetConfig1.rotationStrategy()).thenReturn(TimeBasedRotationStrategyConfig.create(period, null));
+        when(indexSetConfig2.rotationStrategy()).thenReturn(TimeBasedRotationStrategyConfig.create(period, null));
 
         when(indices.indexCreationDate(anyString())).thenReturn(Optional.of(initialTime.minus(minutes(5))));
 
@@ -366,14 +366,14 @@ public class TimeBasedRotationStrategyTest {
         // Crossed rotation period.
         when(indexSet1.getNewestIndex()).thenReturn("index1");
         when(indexSet1.getConfig()).thenReturn(indexSetConfig1);
-        when(indexSetConfig1.rotationStrategy()).thenReturn(TimeBasedRotationStrategyConfig.create(period));
+        when(indexSetConfig1.rotationStrategy()).thenReturn(TimeBasedRotationStrategyConfig.create(period, null));
         rotationStrategy.rotate(indexSet1);
         verify(indexSet1, times(1)).cycle();
         reset(indexSet1);
 
         when(indexSet2.getNewestIndex()).thenReturn("index2");
         when(indexSet2.getConfig()).thenReturn(indexSetConfig2);
-        when(indexSetConfig2.rotationStrategy()).thenReturn(TimeBasedRotationStrategyConfig.create(period));
+        when(indexSetConfig2.rotationStrategy()).thenReturn(TimeBasedRotationStrategyConfig.create(period, null));
         rotationStrategy.rotate(indexSet2);
         verify(indexSet2, times(1)).cycle();
         reset(indexSet2);
@@ -383,14 +383,14 @@ public class TimeBasedRotationStrategyTest {
         // Did not cross rotation period.
         when(indexSet1.getNewestIndex()).thenReturn("index1");
         when(indexSet1.getConfig()).thenReturn(indexSetConfig1);
-        when(indexSetConfig1.rotationStrategy()).thenReturn(TimeBasedRotationStrategyConfig.create(period));
+        when(indexSetConfig1.rotationStrategy()).thenReturn(TimeBasedRotationStrategyConfig.create(period, null));
         rotationStrategy.rotate(indexSet1);
         verify(indexSet1, never()).cycle();
         reset(indexSet1);
 
         when(indexSet2.getNewestIndex()).thenReturn("index2");
         when(indexSet2.getConfig()).thenReturn(indexSetConfig2);
-        when(indexSetConfig2.rotationStrategy()).thenReturn(TimeBasedRotationStrategyConfig.create(period));
+        when(indexSetConfig2.rotationStrategy()).thenReturn(TimeBasedRotationStrategyConfig.create(period, null));
         rotationStrategy.rotate(indexSet2);
         verify(indexSet2, never()).cycle();
         reset(indexSet2);

--- a/graylog2-server/src/test/java/org/graylog2/migrations/V20161116172100_DefaultIndexSetMigrationTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/migrations/V20161116172100_DefaultIndexSetMigrationTest.java
@@ -177,6 +177,11 @@ public class V20161116172100_DefaultIndexSetMigrationTest {
         public RotationStrategyConfig defaultConfiguration() {
             return new StubRotationStrategyConfig();
         }
+
+        @Override
+        public String getStrategyName() {
+            return "StubRotationStrategy";
+        }
     }
 
     private static class StubRotationStrategyConfig implements RotationStrategyConfig {

--- a/graylog2-server/src/test/java/org/graylog2/periodical/IndexRotationThreadTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/periodical/IndexRotationThreadTest.java
@@ -150,6 +150,11 @@ public class IndexRotationThreadTest {
                 public Class<? extends RotationStrategyConfig> configurationClass() {
                     return null;
                 }
+
+                @Override
+                public String getStrategyName() {
+                    return null;
+                }
             };
         }
 

--- a/graylog2-web-interface/src/components/indices/IndexMaintenanceStrategiesConfiguration.jsx
+++ b/graylog2-web-interface/src/components/indices/IndexMaintenanceStrategiesConfiguration.jsx
@@ -62,7 +62,7 @@ class IndexMaintenanceStrategiesConfiguration extends React.Component {
     const { activeConfig } = this.state;
     const timeBasedStrategy = this._getDefaultStrategyConfig(TIME_BASED_ROTATION_STRATEGY);
 
-    return { ...activeConfig, elasticsearch_max_write_index_age: timeBasedStrategy?.elasticsearch_max_write_index_age };
+    return { ...activeConfig, max_rotation_period: timeBasedStrategy?.max_rotation_period };
   }
 
   _getStrategyConfig = (selectedStrategy) => {

--- a/graylog2-web-interface/src/components/indices/IndexMaintenanceStrategiesConfiguration.jsx
+++ b/graylog2-web-interface/src/components/indices/IndexMaintenanceStrategiesConfiguration.jsx
@@ -39,7 +39,6 @@ class IndexMaintenanceStrategiesConfiguration extends React.Component {
       activeStrategy: strategy,
       activeConfig: config,
       newStrategy: strategy,
-      newConfig: config,
     };
   }
 
@@ -80,7 +79,7 @@ class IndexMaintenanceStrategiesConfiguration extends React.Component {
 
     const newConfig = this._getStrategyConfig(newStrategy);
 
-    this.setState({ newStrategy: newStrategy, newConfig: newConfig });
+    this.setState({ newStrategy: newStrategy });
     updateState(newStrategy, newConfig);
   };
 
@@ -102,7 +101,6 @@ class IndexMaintenanceStrategiesConfiguration extends React.Component {
     const { updateState } = this.props;
     const config = this._addConfigType(newStrategy, newConfig);
 
-    this.setState({ newConfig: config });
     updateState(newStrategy, config);
   };
 

--- a/graylog2-web-interface/src/components/indices/IndexMaintenanceStrategiesConfiguration.jsx
+++ b/graylog2-web-interface/src/components/indices/IndexMaintenanceStrategiesConfiguration.jsx
@@ -20,6 +20,8 @@ import React from 'react';
 import { Input } from 'components/bootstrap';
 import { Select } from 'components/common';
 
+const TIME_BASED_ROTATION_STRATEGY = 'org.graylog2.indexer.rotation.strategies.TimeBasedRotationStrategy';
+
 class IndexMaintenanceStrategiesConfiguration extends React.Component {
   static propTypes = {
     title: PropTypes.string.isRequired,
@@ -56,12 +58,19 @@ class IndexMaintenanceStrategiesConfiguration extends React.Component {
     return result ? result.json_schema : undefined;
   };
 
+  _getTimeBaseStrategyWithElasticLimit = () => {
+    const { activeConfig } = this.state;
+    const timeBasedStrategy = this._getDefaultStrategyConfig(TIME_BASED_ROTATION_STRATEGY);
+
+    return { ...activeConfig, elasticsearch_max_write_index_age: timeBasedStrategy?.elasticsearch_max_write_index_age };
+  }
+
   _getStrategyConfig = (selectedStrategy) => {
     const { activeStrategy, activeConfig } = this.state;
 
     if (activeStrategy === selectedStrategy) {
       // If the newly selected strategy is the current active strategy, we use the active configuration.
-      return activeConfig;
+      return activeStrategy === TIME_BASED_ROTATION_STRATEGY ? this._getTimeBaseStrategyWithElasticLimit() : activeConfig;
     }
 
     // If the newly selected strategy is not the current active strategy, we use the selected strategy's default config.

--- a/graylog2-web-interface/src/components/indices/Types.ts
+++ b/graylog2-web-interface/src/components/indices/Types.ts
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 import PropTypes from 'prop-types';
 
 export type IndicesConfigurationActionsType = {

--- a/graylog2-web-interface/src/components/indices/Types.ts
+++ b/graylog2-web-interface/src/components/indices/Types.ts
@@ -1,0 +1,143 @@
+import PropTypes from 'prop-types';
+
+export type IndicesConfigurationActionsType = {
+  loadRotationStrategies: () => Promise<unknown>,
+  loadRetentionStrategies: () => Promise<unknown>,
+};
+export type IndicesConfigurationStoreState = {
+  activeRotationConfig: any,
+  rotationStrategies: any,
+  activeRetentionConfig: any,
+  retentionStrategies: any,
+}
+export type SizeBasedRotationStrategyConfig = {
+  type: string,
+  max_size: number,
+}
+export type MessageCountRotationStrategyConfig = {
+  type: string,
+  max_docs_per_index: number,
+}
+export type TimeBasedRotationStrategyConfig = {
+  type: string,
+  rotation_period: string,
+  elasticsearch_max_write_index_age: string,
+}
+export type RotationStrategyConfig = SizeBasedRotationStrategyConfig | MessageCountRotationStrategyConfig| TimeBasedRotationStrategyConfig;
+export type RetentionStrategyConfig = {
+  type: string,
+  max_number_of_indices?: number,
+  index_action?: string,
+}
+export interface JsonSchemaStringPropertyType {
+  type: string,
+}
+export interface JsonSchemaIndexActionPropertyType {
+  type: string,
+  enum: Array<string>,
+}
+export interface RotationProperties {
+  rotation_period?: JsonSchemaStringPropertyType,
+  elasticsearch_max_write_index_age?: JsonSchemaStringPropertyType,
+  type: JsonSchemaStringPropertyType,
+  max_size?: JsonSchemaStringPropertyType,
+}
+export interface RotationJsonSchema {
+  type: string,
+  id: string,
+  properties: RotationProperties,
+}
+export interface RetentionProperties {
+  max_number_of_indices: JsonSchemaStringPropertyType,
+  type: JsonSchemaStringPropertyType,
+  index_action?: JsonSchemaIndexActionPropertyType,
+}
+export interface RetentionJsonSchema {
+  type: string,
+  id: string,
+  properties: RetentionProperties,
+}
+export interface RotationStrategy {
+  type: string,
+  default_config: RotationStrategyConfig,
+  json_schema: RotationJsonSchema,
+}
+export interface RetentionStrategy {
+  type: string,
+  default_config: RetentionStrategyConfig,
+  json_schema: RetentionJsonSchema,
+}
+export interface RotationStrategyResponse {
+  total: number,
+  strategies: Array<RotationStrategy>,
+}
+export interface RetentionStrategyResponse {
+  total: number,
+  strategies: Array<RetentionStrategy>,
+}
+
+export const SizeBasedRotationStrategyConfigPropType = PropTypes.exact({
+  type: PropTypes.string.isRequired,
+  max_size: PropTypes.number.isRequired,
+});
+export const MessageCountRotationStrategyConfigPropType = PropTypes.exact({
+  type: PropTypes.string.isRequired,
+  max_docs_per_index: PropTypes.number.isRequired,
+});
+export const TimeBasedRotationStrategyConfigPropType = PropTypes.exact({
+  type: PropTypes.string.isRequired,
+  rotation_period: PropTypes.string.isRequired,
+  elasticsearch_max_write_index_age: PropTypes.string,
+});
+
+export const RotationStrategyConfigPropType = PropTypes.oneOfType([
+  SizeBasedRotationStrategyConfigPropType,
+  MessageCountRotationStrategyConfigPropType,
+  TimeBasedRotationStrategyConfigPropType,
+]);
+
+export const IndexActionPropType = PropTypes.string;
+export const RetentionStrategyConfigPropType = PropTypes.exact({
+  type: PropTypes.string.isRequired,
+  max_number_of_indices: PropTypes.number,
+  index_action: PropTypes.string,
+});
+
+export const JsonSchemaStringPropertyTypePropType = PropTypes.exact({
+  type: PropTypes.string.isRequired,
+});
+export const JsonSchemaIndexActionPropertyTypePropType = PropTypes.exact({
+  type: PropTypes.string.isRequired,
+  enum: PropTypes.arrayOf(PropTypes.string).isRequired,
+});
+export const RotationPropertiesPropType = PropTypes.exact({
+  rotation_period: JsonSchemaStringPropertyTypePropType,
+  elasticsearch_max_write_index_age: JsonSchemaStringPropertyTypePropType,
+  type: JsonSchemaStringPropertyTypePropType.isRequired,
+  max_size: JsonSchemaStringPropertyTypePropType,
+});
+export const RotationJsonSchemaPropType = PropTypes.exact({
+  type: PropTypes.string,
+  id: PropTypes.string,
+  properties: RotationPropertiesPropType.isRequired,
+});
+export const RetentionPropertiesPropType = PropTypes.exact({
+  max_number_of_indices: JsonSchemaStringPropertyTypePropType.isRequired,
+  type: JsonSchemaStringPropertyTypePropType.isRequired,
+  index_action: JsonSchemaIndexActionPropertyTypePropType,
+});
+export const RetentionJsonSchemaPropType = PropTypes.exact({
+  type: PropTypes.string,
+  id: PropTypes.string,
+  properties: RetentionPropertiesPropType,
+});
+export const RotationStrategyPropType = PropTypes.exact({
+  type: PropTypes.string.isRequired,
+  default_config: RotationStrategyConfigPropType.isRequired,
+  json_schema: RotationJsonSchemaPropType.isRequired,
+});
+export const RetentionStrategyPropType = PropTypes.exact({
+  type: PropTypes.string.isRequired,
+  default_config: RetentionStrategyConfigPropType.isRequired,
+  json_schema: RetentionJsonSchemaPropType.isRequired,
+});

--- a/graylog2-web-interface/src/components/indices/Types.ts
+++ b/graylog2-web-interface/src/components/indices/Types.ts
@@ -37,7 +37,7 @@ export type MessageCountRotationStrategyConfig = {
 export type TimeBasedRotationStrategyConfig = {
   type: string,
   rotation_period: string,
-  elasticsearch_max_write_index_age: string,
+  max_rotation_period: string,
 }
 export type RotationStrategyConfig = SizeBasedRotationStrategyConfig | MessageCountRotationStrategyConfig| TimeBasedRotationStrategyConfig;
 export type RetentionStrategyConfig = {
@@ -54,7 +54,7 @@ export interface JsonSchemaIndexActionPropertyType {
 }
 export interface RotationProperties {
   rotation_period?: JsonSchemaStringPropertyType,
-  elasticsearch_max_write_index_age?: JsonSchemaStringPropertyType,
+  max_rotation_period?: JsonSchemaStringPropertyType,
   type: JsonSchemaStringPropertyType,
   max_size?: JsonSchemaStringPropertyType,
 }
@@ -103,7 +103,7 @@ export const MessageCountRotationStrategyConfigPropType = PropTypes.exact({
 export const TimeBasedRotationStrategyConfigPropType = PropTypes.exact({
   type: PropTypes.string.isRequired,
   rotation_period: PropTypes.string.isRequired,
-  elasticsearch_max_write_index_age: PropTypes.string,
+  max_rotation_period: PropTypes.string,
 });
 
 export const RotationStrategyConfigPropType = PropTypes.oneOfType([
@@ -128,7 +128,7 @@ export const JsonSchemaIndexActionPropertyTypePropType = PropTypes.exact({
 });
 export const RotationPropertiesPropType = PropTypes.exact({
   rotation_period: JsonSchemaStringPropertyTypePropType,
-  elasticsearch_max_write_index_age: JsonSchemaStringPropertyTypePropType,
+  max_rotation_period: JsonSchemaStringPropertyTypePropType,
   type: JsonSchemaStringPropertyTypePropType.isRequired,
   max_size: JsonSchemaStringPropertyTypePropType,
 });

--- a/graylog2-web-interface/src/components/indices/rotation/TimeBasedRotationStrategyConfiguration.jsx
+++ b/graylog2-web-interface/src/components/indices/rotation/TimeBasedRotationStrategyConfiguration.jsx
@@ -32,7 +32,7 @@ class TimeBasedRotationStrategyConfiguration extends React.Component {
     super(props);
     const { config: { rotation_period: rotationPeriod } } = this.props;
 
-    const { config: { elasticsearch_max_write_index_age: rotationLimit } } = this.props;
+    const { config: { max_rotation_period: rotationLimit } } = this.props;
 
     this.state = {
       rotation_period: rotationPeriod,
@@ -86,13 +86,14 @@ class TimeBasedRotationStrategyConfiguration extends React.Component {
 
   _formatDuration = () => {
     const { rotation_period: rotationPeriod, rotationLimit } = this.state;
-    const maxErrorMessage = rotationLimit && ` and max ${moment.duration(rotationLimit).humanize()}`;
+    const maxRotationPeriodErrorMessage = rotationLimit ? ` and max ${moment.duration(rotationLimit).humanize()}` : '';
 
-    return this._isValidPeriod() ? moment.duration(rotationPeriod).humanize() : `invalid (min 1 hour${maxErrorMessage})`;
+    return this._isValidPeriod() ? moment.duration(rotationPeriod).humanize() : `invalid (min 1 hour${maxRotationPeriodErrorMessage})`;
   };
 
   render() {
-    const { rotation_period: rotationPeriod } = this.state;
+    const { rotation_period: rotationPeriod, rotationLimit } = this.state;
+    const maxRotationPeriodHelpText = rotationLimit ? ` The max rotation period is set to ${moment.duration(rotationLimit).humanize()} by Administrator.` : '';
 
     return (
       <div>
@@ -102,7 +103,7 @@ class TimeBasedRotationStrategyConfiguration extends React.Component {
                label="Rotation period (ISO8601 Duration)"
                onChange={this._onPeriodUpdate('rotation_period')}
                value={rotationPeriod}
-               help={'How long an index gets written to before it is rotated. (i.e. "P1D" for 1 day, "PT6H" for 6 hours)'}
+               help={`How long an index gets written to before it is rotated. (i.e. "P1D" for 1 day, "PT6H" for 6 hours).${maxRotationPeriodHelpText}`}
                addonAfter={this._formatDuration()}
                bsStyle={this._validationState()}
                required />

--- a/graylog2-web-interface/src/components/indices/rotation/TimeBasedRotationStrategyConfiguration.jsx
+++ b/graylog2-web-interface/src/components/indices/rotation/TimeBasedRotationStrategyConfiguration.jsx
@@ -23,7 +23,6 @@ import { Input } from 'components/bootstrap';
 class TimeBasedRotationStrategyConfiguration extends React.Component {
   static propTypes = {
     config: PropTypes.object.isRequired,
-    jsonSchema: PropTypes.object.isRequired,
     updateConfig: PropTypes.func.isRequired,
   };
 
@@ -93,14 +92,16 @@ class TimeBasedRotationStrategyConfiguration extends React.Component {
   };
 
   render() {
+    const { rotation_period: rotationPeriod } = this.state;
+
     return (
       <div>
         <Input id="rotation-period"
                type="text"
-               ref={(rotationPeriod) => { this.inputs.rotation_period = rotationPeriod; }}
+               ref={(rotationPeriodRef) => { this.inputs.rotation_period = rotationPeriodRef; }}
                label="Rotation period (ISO8601 Duration)"
                onChange={this._onPeriodUpdate('rotation_period')}
-               value={this.state.rotation_period}
+               value={rotationPeriod}
                help={'How long an index gets written to before it is rotated. (i.e. "P1D" for 1 day, "PT6H" for 6 hours)'}
                addonAfter={this._formatDuration()}
                bsStyle={this._validationState()}

--- a/graylog2-web-interface/src/pages/IndexSetConfigurationPage.jsx
+++ b/graylog2-web-interface/src/pages/IndexSetConfigurationPage.jsx
@@ -78,7 +78,7 @@ const IndexSetConfigurationPage = createReactClass({
     }
 
     const { indexSet } = this.state;
-    
+
     return (
       <DocumentTitle title="Configure Index Set">
         <div>

--- a/graylog2-web-interface/src/pages/IndexSetConfigurationPage.jsx
+++ b/graylog2-web-interface/src/pages/IndexSetConfigurationPage.jsx
@@ -78,7 +78,7 @@ const IndexSetConfigurationPage = createReactClass({
     }
 
     const { indexSet } = this.state;
-
+    
     return (
       <DocumentTitle title="Configure Index Set">
         <div>

--- a/graylog2-web-interface/src/pages/IndexSetCreationPage.tsx
+++ b/graylog2-web-interface/src/pages/IndexSetCreationPage.tsx
@@ -27,16 +27,25 @@ import history from 'util/History';
 import DocsHelper from 'util/DocsHelper';
 import Routes from 'routing/Routes';
 import connect from 'stores/connect';
-import { IndexSetsActions, IndexSetsStore } from 'stores/indices/IndexSetsStore';
+import { IndexSetPropType, IndexSetsActions, IndexSetsStore } from 'stores/indices/IndexSetsStore';
+import type { IndexSet } from 'stores/indices/IndexSetsStore';
 import { IndicesConfigurationActions, IndicesConfigurationStore } from 'stores/indices/IndicesConfigurationStore';
+import {  RetentionStrategyPropType, RotationStrategyPropType } from 'components/indices/Types';
+import type { RetentionStrategy, RotationStrategy } from 'components/indices/Types';
 
-const IndexSetCreationPage = ({ retentionStrategies, rotationStrategies, indexSet }) => {
+type Props = {
+  indexSet: Partial<IndexSet> | null | undefined,
+  retentionStrategies?: Array<RetentionStrategy>  | null | undefined,
+  rotationStrategies?: Array<RotationStrategy> | null | undefined,
+}
+
+const IndexSetCreationPage = ({ retentionStrategies, rotationStrategies, indexSet }: Props) => {
   useEffect(() => {
     IndicesConfigurationActions.loadRotationStrategies();
     IndicesConfigurationActions.loadRetentionStrategies();
   }, []);
 
-  const _saveConfiguration = (indexSetItem) => {
+  const _saveConfiguration = (indexSetItem: IndexSet) => {
     const copy = indexSetItem;
 
     copy.creation_date = DateTime.now().toISOString();
@@ -89,19 +98,20 @@ const IndexSetCreationPage = ({ retentionStrategies, rotationStrategies, indexSe
 };
 
 IndexSetCreationPage.propTypes = {
-  retentionStrategies: PropTypes.object,
-  rotationStrategies: PropTypes.object,
-  indexSet: PropTypes.object,
+  retentionStrategies: PropTypes.arrayOf(RetentionStrategyPropType),
+  rotationStrategies: PropTypes.arrayOf(RotationStrategyPropType),
+  indexSet: IndexSetPropType,
 };
 
 IndexSetCreationPage.defaultProps = {
   retentionStrategies: undefined,
   rotationStrategies: undefined,
   indexSet: {
-    title: '',
+    title: 'test',
     description: '',
     index_prefix: '',
     writable: true,
+    can_be_default: true,
     shards: 4,
     replicas: 0,
     retention_strategy_class: 'org.graylog2.indexer.retention.strategies.DeletionRetentionStrategy',

--- a/graylog2-web-interface/src/pages/IndexSetCreationPage.tsx
+++ b/graylog2-web-interface/src/pages/IndexSetCreationPage.tsx
@@ -63,6 +63,12 @@ const IndexSetCreationPage = ({ retentionStrategies, rotationStrategies, indexSe
     return <Spinner />;
   }
 
+  const defaultIndexSet = {
+    ...indexSet,
+    rotation_strategy_class: rotationStrategies[0].type,
+    rotation_strategy: rotationStrategies[0].default_config,
+  };
+
   return (
     <DocumentTitle title="Create Index Set">
       <div>
@@ -84,7 +90,7 @@ const IndexSetCreationPage = ({ retentionStrategies, rotationStrategies, indexSe
 
         <Row className="content">
           <Col md={12}>
-            <IndexSetConfigurationForm indexSet={indexSet}
+            <IndexSetConfigurationForm indexSet={defaultIndexSet}
                                        rotationStrategies={rotationStrategies}
                                        retentionStrategies={retentionStrategies}
                                        create
@@ -118,11 +124,6 @@ IndexSetCreationPage.defaultProps = {
     retention_strategy: {
       max_number_of_indices: 20,
       type: 'org.graylog2.indexer.retention.strategies.DeletionRetentionStrategyConfig',
-    },
-    rotation_strategy_class: 'org.graylog2.indexer.rotation.strategies.MessageCountRotationStrategy',
-    rotation_strategy: {
-      max_docs_per_index: 20000000,
-      type: 'org.graylog2.indexer.rotation.strategies.MessageCountRotationStrategyConfig',
     },
     index_analyzer: 'standard',
     index_optimization_max_num_segments: 1,

--- a/graylog2-web-interface/src/pages/IndexSetCreationPage.tsx
+++ b/graylog2-web-interface/src/pages/IndexSetCreationPage.tsx
@@ -30,12 +30,12 @@ import connect from 'stores/connect';
 import { IndexSetPropType, IndexSetsActions, IndexSetsStore } from 'stores/indices/IndexSetsStore';
 import type { IndexSet } from 'stores/indices/IndexSetsStore';
 import { IndicesConfigurationActions, IndicesConfigurationStore } from 'stores/indices/IndicesConfigurationStore';
-import {  RetentionStrategyPropType, RotationStrategyPropType } from 'components/indices/Types';
+import { RetentionStrategyPropType, RotationStrategyPropType } from 'components/indices/Types';
 import type { RetentionStrategy, RotationStrategy } from 'components/indices/Types';
 
 type Props = {
   indexSet: Partial<IndexSet> | null | undefined,
-  retentionStrategies?: Array<RetentionStrategy>  | null | undefined,
+  retentionStrategies?: Array<RetentionStrategy> | null | undefined,
   rotationStrategies?: Array<RotationStrategy> | null | undefined,
 }
 

--- a/graylog2-web-interface/src/pages/IndexSetCreationPage.tsx
+++ b/graylog2-web-interface/src/pages/IndexSetCreationPage.tsx
@@ -113,7 +113,7 @@ IndexSetCreationPage.defaultProps = {
   retentionStrategies: undefined,
   rotationStrategies: undefined,
   indexSet: {
-    title: 'test',
+    title: '',
     description: '',
     index_prefix: '',
     writable: true,

--- a/graylog2-web-interface/src/stores/indices/IndexSetsStore.ts
+++ b/graylog2-web-interface/src/stores/indices/IndexSetsStore.ts
@@ -15,60 +15,82 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import Reflux from 'reflux';
+import PropTypes from 'prop-types';
 
 import ApiRoutes from 'routing/ApiRoutes';
 import fetch from 'logic/rest/FetchProvider';
 import { qualifyUrl } from 'util/URLUtils';
 import UserNotification from 'util/UserNotification';
 import { singletonStore, singletonActions } from 'logic/singleton';
+import { RetentionStrategyConfig, RetentionStrategyConfigPropType, RotationStrategyConfig, RotationStrategyConfigPropType } from 'components/indices/Types';
 
+export const IndexSetPropType = PropTypes.shape({
+  can_be_default: PropTypes.bool,
+  id: PropTypes.string,
+  title: PropTypes.string,
+  description: PropTypes.string.isRequired,
+  index_prefix: PropTypes.string.isRequired,
+  shards: PropTypes.number.isRequired,
+  replicas: PropTypes.number.isRequired,
+  rotation_strategy_class: PropTypes.string.isRequired,
+  rotation_strategy: RotationStrategyConfigPropType.isRequired,
+  retention_strategy_class: PropTypes.string.isRequired,
+  retention_strategy: RetentionStrategyConfigPropType.isRequired,
+  creation_date: PropTypes.string,
+  index_analyzer: PropTypes.string.isRequired,
+  index_optimization_max_num_segments: PropTypes.number.isRequired,
+  index_optimization_disabled: PropTypes.bool.isRequired,
+  field_type_refresh_interval: PropTypes.number.isRequired,
+  index_template_type: PropTypes.string,
+  writable: PropTypes.bool.isRequired,
+  default: PropTypes.bool.isRequired,
+});
 export type IndexSet = {
-  can_be_default: boolean,
-  id: string,
+  can_be_default?: boolean,
+  id?: string,
   title: string,
   description: string,
   index_prefix: string,
   shards: number,
   replicas: number,
   rotation_strategy_class: string,
-  rotation_strategy: {
-    type: string,
-    max_docs_per_index: number,
-  },
+  rotation_strategy: RotationStrategyConfig,
   retention_strategy_class: string,
-  retention_strategy: {
-    type: string,
-    max_docs_per_index: number,
-    index_action: string,
-  },
-  creation_date: string,
+  retention_strategy: RetentionStrategyConfig
+  creation_date?: string,
   index_analyzer: string,
   index_optimization_max_num_segments: number,
   index_optimization_disabled: boolean,
   field_type_refresh_interval: number,
-  index_template_type: string,
+  index_template_type?: string,
   writable: boolean,
-  default: boolean,
+  default?: boolean,
 };
 
+type IndexSetStats = {
+  [key: string]: {
+    documents: number,
+    indices: number,
+    size: number,
+  },
+}
 type IndexSetsResponseType = {
   total: number,
   index_sets: Array<IndexSet>,
-  stats: {
-    [key: string]: {
-      documents: number,
-      indices: number,
-      size: number,
-    },
-  },
+  stats: IndexSetStats,
 };
-
+type IndexSetsStoreState = {
+  indexSetsCount: number,
+  indexSets: Array<IndexSet>,
+  indexSetStats: IndexSetStats,
+  indexSet: IndexSet,
+}
 type IndexSetsActionsType = {
   list: () => Promise<unknown>,
   listPaginated: () => Promise<unknown>,
   get: (indexSetId: string) => Promise<unknown>,
-  update: () => Promise<unknown>,
-  create: () => Promise<unknown>,
+  update: (indexSet: IndexSet) => Promise<unknown>,
+  create: (indexSet: IndexSet) => Promise<unknown>,
   delete: () => Promise<unknown>,
   setDefault: () => Promise<unknown>,
   stats: () => Promise<unknown>,
@@ -89,11 +111,12 @@ export const IndexSetsActions = singletonActions(
 
 export const IndexSetsStore = singletonStore(
   'core.IndexSets',
-  () => Reflux.createStore({
+  () => Reflux.createStore<IndexSetsStoreState>({
     listenables: [IndexSetsActions],
     indexSetsCount: undefined,
     indexSets: undefined,
     indexSetStats: undefined,
+    indexSet: undefined,
 
     getInitialState() {
       return {

--- a/graylog2-web-interface/src/stores/indices/IndicesConfigurationStore.js
+++ b/graylog2-web-interface/src/stores/indices/IndicesConfigurationStore.js
@@ -47,7 +47,14 @@ export const IndicesConfigurationStore = singletonStore(
         retentionStrategies: undefined,
       };
     },
-
+    getState() {
+      return {
+        activeRotationConfig: this.activeRotationConfig,
+        rotationStrategies: this.rotationStrategies,
+        activeRetentionConfig: this.activeRetentionConfig,
+        retentionStrategies: this.retentionStrategies,
+      };
+    },
     _url(path) {
       return URLUtils.qualifyUrl(urlPrefix + path);
     },
@@ -58,7 +65,7 @@ export const IndicesConfigurationStore = singletonStore(
       promise.then(
         (response) => {
           this.rotationStrategies = response.strategies;
-          this.trigger({ rotationStrategies: response.strategies });
+          this.trigger(this.getState());
         },
         (error) => {
           UserNotification.error(`Fetching rotation strategies failed: ${error}`, 'Could not retrieve rotation strategies');
@@ -74,7 +81,7 @@ export const IndicesConfigurationStore = singletonStore(
       promise.then(
         (response) => {
           this.retentionStrategies = response.strategies;
-          this.trigger({ retentionStrategies: response.strategies });
+          this.trigger(this.getState());
         },
         (error) => {
           UserNotification.error(`Fetching retention strategies failed: ${error}`, 'Could not retrieve retention strategies');

--- a/graylog2-web-interface/src/stores/indices/IndicesConfigurationStore.ts
+++ b/graylog2-web-interface/src/stores/indices/IndicesConfigurationStore.ts
@@ -16,6 +16,12 @@
  */
 import Reflux from 'reflux';
 
+import {
+  IndicesConfigurationActionsType,
+  IndicesConfigurationStoreState,
+  RetentionStrategyResponse,
+  RotationStrategyResponse,
+} from 'components/indices/Types';
 import UserNotification from 'util/UserNotification';
 import * as URLUtils from 'util/URLUtils';
 import fetch from 'logic/rest/FetchProvider';
@@ -23,7 +29,7 @@ import { singletonStore, singletonActions } from 'logic/singleton';
 
 export const IndicesConfigurationActions = singletonActions(
   'core.IndicesConfiguration',
-  () => Reflux.createActions({
+  () => Reflux.createActions<IndicesConfigurationActionsType>({
     loadRotationStrategies: { asyncResult: true },
     loadRetentionStrategies: { asyncResult: true },
   }),
@@ -33,7 +39,7 @@ const urlPrefix = '/system/indices';
 
 export const IndicesConfigurationStore = singletonStore(
   'core.IndicesConfiguration',
-  () => Reflux.createStore({
+  () => Reflux.createStore<IndicesConfigurationStoreState>({
     listenables: [IndicesConfigurationActions],
 
     rotationStrategies: undefined,
@@ -63,7 +69,7 @@ export const IndicesConfigurationStore = singletonStore(
       const promise = fetch('GET', this._url('/rotation/strategies'));
 
       promise.then(
-        (response) => {
+        (response: RotationStrategyResponse) => {
           this.rotationStrategies = response.strategies;
           this.trigger(this.getState());
         },
@@ -79,7 +85,7 @@ export const IndicesConfigurationStore = singletonStore(
       const promise = fetch('GET', this._url('/retention/strategies'));
 
       promise.then(
-        (response) => {
+        (response: RetentionStrategyResponse) => {
           this.retentionStrategies = response.strategies;
           this.trigger(this.getState());
         },

--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -274,8 +274,7 @@ plugin_dir = plugin
 #   - "size" per index, use elasticsearch_max_size_per_index below to configure
 #   - "time" interval between index rotations, use elasticsearch_max_time_per_index to configure
 # A strategy may be disabled by specifying the optional valid_rotation_strategies list and excluding that strategy.
-#valid_rotation_strategies = count,size,time
-valid_rotation_strategies = count,time
+valid_rotation_strategies = count,size,time
 
 #
 # ATTENTION: These settings have been moved to the database in 2.0. When you upgrade, make sure to set these
@@ -326,7 +325,7 @@ elasticsearch_max_docs_per_index = 20000000
 #elasticsearch_max_time_per_index = 1d
 
 # Optional upper bound on elasticsearch_max_time_per_index
-elasticsearch_max_write_index_age = 1d
+# elasticsearch_max_write_index_age = 1d
 
 # Disable checking the version of Elasticsearch for being compatible with this Graylog release.
 # WARNING: Using Graylog with unsupported and untested versions of Elasticsearch may lead to data loss!

--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -273,8 +273,8 @@ plugin_dir = plugin
 #   - "count" of messages per index, use elasticsearch_max_docs_per_index below to configure
 #   - "size" per index, use elasticsearch_max_size_per_index below to configure
 #   - "time" interval between index rotations, use elasticsearch_max_time_per_index to configure
-# A strategy may be disabled by specifying the optional valid_rotation_strategies list and excluding that strategy.
-valid_rotation_strategies = count,size,time
+# A strategy may be disabled by specifying the optional enabled_index_rotation_strategies list and excluding that strategy.
+#enabled_index_rotation_strategies = count,size,time
 
 #
 # ATTENTION: These settings have been moved to the database in 2.0. When you upgrade, make sure to set these

--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -267,14 +267,15 @@ plugin_dir = plugin
 # Default: true
 #elasticsearch_use_expect_continue = true
 
-# Graylog will use multiple indices to store documents in. You can configured the strategy it uses to determine
+# Graylog will use multiple indices to store documents in. You can configure the strategy it uses to determine
 # when to rotate the currently active write index.
-# It supports multiple rotation strategies:
+# It supports multiple rotation strategies, the default being "count":
 #   - "count" of messages per index, use elasticsearch_max_docs_per_index below to configure
 #   - "size" per index, use elasticsearch_max_size_per_index below to configure
-# valid values are "count", "size" and "time", default is "count". A strategy may be disabled
-# by removing it from the valid_rotation_strategies list.
-valid_rotation_strategies = count,size,time
+#   - "time" interval between index rotations, use elasticsearch_max_time_per_index to configure
+# A strategy may be disabled by specifying the optional valid_rotation_strategies list and excluding that strategy.
+#valid_rotation_strategies = count,size,time
+valid_rotation_strategies = count,time
 
 #
 # ATTENTION: These settings have been moved to the database in 2.0. When you upgrade, make sure to set these
@@ -325,7 +326,7 @@ elasticsearch_max_docs_per_index = 20000000
 #elasticsearch_max_time_per_index = 1d
 
 # Optional upper bound on elasticsearch_max_time_per_index
-#elasticsearch_max_write_index_age = 1d
+elasticsearch_max_write_index_age = 1d
 
 # Disable checking the version of Elasticsearch for being compatible with this Graylog release.
 # WARNING: Using Graylog with unsupported and untested versions of Elasticsearch may lead to data loss!

--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -272,7 +272,10 @@ plugin_dir = plugin
 # It supports multiple rotation strategies:
 #   - "count" of messages per index, use elasticsearch_max_docs_per_index below to configure
 #   - "size" per index, use elasticsearch_max_size_per_index below to configure
-# valid values are "count", "size" and "time", default is "count"
+# valid values are "count", "size" and "time", default is "count". A strategy may be disabled
+# by removing it from the valid_rotation_strategies list.
+valid_rotation_strategies = count,size,time
+
 #
 # ATTENTION: These settings have been moved to the database in 2.0. When you upgrade, make sure to set these
 #            to your previous 1.x settings so they will be migrated to the database!
@@ -320,6 +323,9 @@ elasticsearch_max_docs_per_index = 20000000
 #            index related settings can be changed in the Graylog web interface on the 'System / Indices' page.
 #            Also see https://docs.graylog.org/docs/index-model#index-set-configuration
 #elasticsearch_max_time_per_index = 1d
+
+# Optional upper bound on elasticsearch_max_time_per_index
+#elasticsearch_max_write_index_age = 1d
 
 # Disable checking the version of Elasticsearch for being compatible with this Graylog release.
 # WARNING: Using Graylog with unsupported and untested versions of Elasticsearch may lead to data loss!


### PR DESCRIPTION
Provides the ability to 
- optionally configure a global time limit for time-based index rotation
- optionally limit the available set of rotation strategies

See linked issue for details.

resolves Graylog2/graylog-plugin-cloud#972

/jenkins-pr-deps Graylog2/graylog-plugin-enterprise#2887