### PR TITLE
Fix swagger api annotation for Field Types

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/FieldTypesResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/FieldTypesResource.java
@@ -38,7 +38,7 @@ import javax.ws.rs.core.MediaType;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-@Api(value = "Field Types")
+@Api(value = "FieldTypes")
 @Path("/views/fields")
 @Produces(MediaType.APPLICATION_JSON)
 @RequiresAuthentication


### PR DESCRIPTION
The name of the resource (`@Api(value = "Field Types")`) may not contain whitespace, otherwise the swagger api browser fails:

![image](https://user-images.githubusercontent.com/4102775/138266380-e8c3f3aa-4e31-45c9-be77-848c1825b294.png)


## Description
Removed the space, changing the resource name from `Field Types` to `FieldTypes`

## How Has This Been Tested?
Manually verified in the swagger api browser

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/4102775/138266569-5c3b67f5-04d7-49e9-97dc-4298e3b7156b.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

