### PR TITLE
Disable 2 key combinations in QueryInput

### DIFF
--- a/graylog2-web-interface/src/views/components/searchbar/QueryInput.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/QueryInput.tsx
@@ -72,7 +72,7 @@ const QueryInput = ({
     if (editor) {
       editor.commands.addCommands([{
         name: 'Execute',
-        bindKey: { win: 'Enter', mac: 'Enter' },
+        bindKey: 'Enter',
         exec: _onExecute,
       },
       {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This PR disables 2 key combinations that can cause unexpected behavior with [`QueryInput`](https://github.com/Graylog2/graylog2-server/blob/a6968ad92689815fa3a61af25d9d0d22df43178a/graylog2-web-interface/src/views/components/searchbar/QueryInput.tsx):
1. `Ctrl+f` / `Command+f`:  Currently shows the Ace editor's Find dialog.  With this PR the browser's Find functionality is used.  Fixes #7884.
2. `Shift+Enter`:  Although not an Ace "command", this key combo currently results in a new line being inserted, and from a Graylog user's perspective their search querying disappearing (using the up arrow or backspace makes the first line visible again).  With this PR `Shift+Enter` is captured and has no impact.  Fixes #8348, related to #6530.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This PR prevents unexpected behavior as users enter queries and interact with the search page.

There are certainly other unnecessary key bindings (see [Ace default commands](https://github.com/ajaxorg/ace/blob/master/lib/ace/commands/default_commands.js)), but these are 2 my organization has ran into somewhat regularly.  Perhaps for `QueryInput` it'd make sense to remove all built-in commands.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Verified `Ctrl+f` falls back to the browser's Find functionality, and that `Shift+Enter` does not result in a new line in `QueryInput`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.