### PR TITLE
Limit height of event definition filter preview

### DIFF
--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterPreview.css
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterPreview.css
@@ -1,4 +1,6 @@
 :local(.filterPreview) .panel-body {
+    max-height: 400px;
+    overflow-y: auto;
     padding: 20px 10px;
 }
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This PR sets a maximum height for the body of the [event definition `FilterPreview`](https://github.com/Graylog2/graylog2-server/blob/a6968ad92689815fa3a61af25d9d0d22df43178a/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterPreview.jsx#L104)'s panel (i.e. the list of matching messages).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When an event definition's filter matches messages with large `message` content everything below the Filter section gets pushed down, requiring scrolling or jumping down.

Fixes #7886.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Verified the filter preview's panel body (containing the message list) went up to the max height, with scrolling when it was exceeded.

## Screenshots (if appropriate):
**Before:**
<img src="https://user-images.githubusercontent.com/288958/138576884-fb1fa9dc-9431-4282-93d4-e3e89c167b47.png" height="33%">

**After:**
<img src="https://user-images.githubusercontent.com/288958/138576887-6c672a8a-0bde-4dc9-80b4-d90203b25032.png" height="33%">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

