### PR TITLE
cluster id and license parameter (#11434 4.2 backport)

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/bindings/ServerBindings.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/ServerBindings.java
@@ -20,6 +20,7 @@ import com.floreysoft.jmte.Engine;
 import com.google.inject.Scopes;
 import com.google.inject.assistedinject.FactoryModuleBuilder;
 import com.google.inject.multibindings.Multibinder;
+import com.google.inject.multibindings.OptionalBinder;
 import org.apache.shiro.mgt.DefaultSecurityManager;
 import org.glassfish.grizzly.http.server.ErrorPageGenerator;
 import org.graylog2.Configuration;
@@ -51,6 +52,8 @@ import org.graylog2.inputs.InputStateListener;
 import org.graylog2.inputs.PersistedInputsImpl;
 import org.graylog2.lookup.LookupModule;
 import org.graylog2.plugin.cluster.ClusterConfigService;
+import org.graylog2.plugin.cluster.ClusterIdFactory;
+import org.graylog2.plugin.cluster.RandomUUIDClusterIdFactory;
 import org.graylog2.plugin.inject.Graylog2Module;
 import org.graylog2.plugin.rest.ValidationFailureExceptionMapper;
 import org.graylog2.plugin.streams.DefaultStream;
@@ -166,6 +169,7 @@ public class ServerBindings extends Graylog2Module {
         bind(PersistedInputs.class).to(PersistedInputsImpl.class);
 
         bind(RoleService.class).to(RoleServiceImpl.class).in(Scopes.SINGLETON);
+        OptionalBinder.newOptionalBinder(binder(), ClusterIdFactory.class).setDefault().to(RandomUUIDClusterIdFactory.class);
     }
 
     private void bindDynamicFeatures() {

--- a/graylog2-server/src/main/java/org/graylog2/periodical/ClusterIdGeneratorPeriodical.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/ClusterIdGeneratorPeriodical.java
@@ -18,21 +18,23 @@ package org.graylog2.periodical;
 
 import org.graylog2.plugin.cluster.ClusterConfigService;
 import org.graylog2.plugin.cluster.ClusterId;
+import org.graylog2.plugin.cluster.ClusterIdFactory;
 import org.graylog2.plugin.periodical.Periodical;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
-import java.util.UUID;
 
 public class ClusterIdGeneratorPeriodical extends Periodical {
     private static final Logger LOG = LoggerFactory.getLogger(ClusterIdGeneratorPeriodical.class);
 
     private final ClusterConfigService clusterConfigService;
+    private final ClusterIdFactory clusterIdFactory;
 
     @Inject
-    public ClusterIdGeneratorPeriodical(ClusterConfigService clusterConfigService) {
+    public ClusterIdGeneratorPeriodical(ClusterConfigService clusterConfigService, ClusterIdFactory clusterIdFactory) {
         this.clusterConfigService = clusterConfigService;
+        this.clusterIdFactory = clusterIdFactory;
     }
 
     @Override
@@ -78,7 +80,7 @@ public class ClusterIdGeneratorPeriodical extends Periodical {
     @Override
     public void doRun() {
         if(clusterConfigService.get(ClusterId.class) == null) {
-            ClusterId clusterId = ClusterId.create(UUID.randomUUID().toString());
+            ClusterId clusterId = clusterIdFactory.create();
             clusterConfigService.write(clusterId);
 
             LOG.debug("Generated cluster ID {}", clusterId.clusterId());

--- a/graylog2-server/src/main/java/org/graylog2/plugin/cluster/ClusterIdFactory.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/cluster/ClusterIdFactory.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.plugin.cluster;
+
+public interface ClusterIdFactory {
+    ClusterId create();
+}

--- a/graylog2-server/src/main/java/org/graylog2/plugin/cluster/RandomUUIDClusterIdFactory.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/cluster/RandomUUIDClusterIdFactory.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.plugin.cluster;
+
+import java.util.UUID;
+
+public class RandomUUIDClusterIdFactory implements ClusterIdFactory {
+    @Override
+    public ClusterId create() {
+        return ClusterId.create(UUID.randomUUID().toString());
+    }
+}


### PR DESCRIPTION
Backport for #11434.

