### PR TITLE
Fetch field types only for streams the user has access to.

### DIFF
--- a/graylog2-web-interface/src/pages/ShowMessagePage.test.tsx
+++ b/graylog2-web-interface/src/pages/ShowMessagePage.test.tsx
@@ -68,6 +68,7 @@ const SimpleShowMessagePage = ({ index, messageId }: SimpleShowMessagePageProps)
 
 describe('ShowMessagePage', () => {
   beforeEach(() => {
+    asMock(useFieldTypes).mockClear();
     asMock(useFieldTypes).mockReturnValue({ data: [] });
   });
 
@@ -91,9 +92,24 @@ describe('ShowMessagePage', () => {
     expect(container).toMatchSnapshot();
   });
 
+  it('retrieves field types only for user-accessible streams', async () => {
+    const messageWithMultipleStreams = { ...message };
+    messageWithMultipleStreams.fields.streams = ['000000000000000000000001', 'deadbeef'];
+    mockLoadMessage.mockImplementation(() => Promise.resolve(messageWithMultipleStreams));
+    mockListStreams.mockImplementation(() => Promise.resolve([{ id: 'deadbeef' }]));
+    mockGetInput.mockImplementation(() => Promise.resolve(input));
+
+    render(<SimpleShowMessagePage index="graylog_5" messageId="20f683d2-a874-11e9-8a11-0242ac130004" />);
+
+    await screen.findByText(/Deprecated field/);
+
+    expect(useFieldTypes).toHaveBeenCalledWith(['deadbeef'], { from: '2019-07-17T11:20:33.000Z', to: '2019-07-17T11:20:33.000Z', type: 'absolute' });
+  });
+
   it('renders for generic event', async () => {
     mockLoadMessage.mockImplementation(() => Promise.resolve(event));
     mockGetInput.mockImplementation(() => Promise.resolve());
+    mockListStreams.mockImplementation(() => Promise.resolve([]));
 
     const { container } = render(<SimpleShowMessagePage index="gl-events_0" messageId="01DFZQ64CMGV30NT7DW2P7HQX2" />);
 

--- a/graylog2-web-interface/src/pages/ShowMessagePage.tsx
+++ b/graylog2-web-interface/src/pages/ShowMessagePage.tsx
@@ -101,6 +101,11 @@ const FieldTypesProvider = ({ streams, timestamp, children }: FieldTypesProvider
   );
 };
 
+type MessageFields = {
+  streams: Array<string>,
+  timestamp: string,
+};
+
 const ShowMessagePage = ({ params: { index, messageId } }: Props) => {
   if (!index || !messageId) {
     throw new Error('index and messageId need to be specified!');
@@ -117,14 +122,15 @@ const ShowMessagePage = ({ params: { index, messageId } }: Props) => {
     && allStreams !== undefined), [message, streams, inputs, allStreams]);
 
   if (isLoaded) {
-    const { streams: messageStreams, timestamp } = message.fields;
+    const { streams: messageStreams, timestamp } = message.fields as MessageFields;
+    const fieldTypesStreams = messageStreams.filter((streamId) => streams.has(streamId));
 
     return (
       <DocumentTitle title={`Message ${messageId} on ${index}`}>
         <Row className="content" id="sticky-augmentations-container">
           <Col md={12}>
             <WindowDimensionsContextProvider>
-              <FieldTypesProvider streams={messageStreams as Array<string>} timestamp={timestamp as string}>
+              <FieldTypesProvider streams={fieldTypesStreams} timestamp={timestamp}>
                 <InteractiveContext.Provider value={false}>
                   <MessageDetail fields={Immutable.List()}
                                  streams={streams}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

**Note:** This needs to be backported to `4.2`.

Prior to this PR, when using a message permalink to view a single message, field types were retrieved for all streams the message belongs to, although the user potentially has access only to a subset of the streams. This can lead to the backend returning a `403` in case the user does not have access to all streams of the message. If this happens, the error page is shown instead of the single message page.

Fixes #11540.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.