### PR TITLE
Fixing ESLint import order for dependencies in plugins.

### DIFF
--- a/graylog2-web-interface/packages/eslint-config-graylog/index.js
+++ b/graylog2-web-interface/packages/eslint-config-graylog/index.js
@@ -154,7 +154,7 @@ module.exports = {
         config: './webpack.config.js',
       },
     },
-    'import/internal-regex': '^(actions|components|contexts|domainActions|helpers|hooks|logic|routing|stores|util|theme|views)',
+    'import/internal-regex': '^(actions|components|contexts|domainActions|fixtures|helpers|hooks|logic|routing|stores|util|theme|views)/',
     polyfills: [
       'fetch',
       'IntersectionObserver',

--- a/graylog2-web-interface/packages/eslint-config-graylog/index.js
+++ b/graylog2-web-interface/packages/eslint-config-graylog/index.js
@@ -154,6 +154,7 @@ module.exports = {
         config: './webpack.config.js',
       },
     },
+    'import/internal-regex': '^(actions|components|contexts|domainActions|helpers|hooks|logic|routing|stores|util|theme|views)',
     polyfills: [
       'fetch',
       'IntersectionObserver',

--- a/graylog2-web-interface/src/components/authentication/directoryServices/BackendConfigDetails/GroupSyncSection.test.tsx
+++ b/graylog2-web-interface/src/components/authentication/directoryServices/BackendConfigDetails/GroupSyncSection.test.tsx
@@ -18,9 +18,9 @@ import * as React from 'react';
 import * as Immutable from 'immutable';
 import { render, screen } from 'wrappedTestingLibrary';
 import { PluginManifest, PluginStore } from 'graylog-web-plugin/plugin';
+
 import { ldapBackend as exampleAuthBackend } from 'fixtures/authenticationBackends';
 import { DirectoryServicesGroupSync } from 'components/authentication/types';
-
 import { DirectoryServiceBackend } from 'logic/authentication/directoryServices/types';
 
 import GroupSyncSection from './GroupSyncSection';

--- a/graylog2-web-interface/src/components/common/HasOwnership.test.tsx
+++ b/graylog2-web-interface/src/components/common/HasOwnership.test.tsx
@@ -17,8 +17,8 @@
 import * as React from 'react';
 import * as Immutable from 'immutable';
 import { render } from 'wrappedTestingLibrary';
-import { alice as currentUser } from 'fixtures/users';
 
+import { alice as currentUser } from 'fixtures/users';
 import User from 'logic/users/User';
 import CurrentUserContext from 'contexts/CurrentUserContext';
 import { createGRN } from 'logic/permissions/GRN';

--- a/graylog2-web-interface/src/components/common/IfPermitted.test.tsx
+++ b/graylog2-web-interface/src/components/common/IfPermitted.test.tsx
@@ -17,8 +17,8 @@
 import * as React from 'react';
 import * as Immutable from 'immutable';
 import { render, screen } from 'wrappedTestingLibrary';
-import { alice } from 'fixtures/users';
 
+import { alice } from 'fixtures/users';
 import User from 'logic/users/User';
 import CurrentUserContext from 'contexts/CurrentUserContext';
 

--- a/graylog2-web-interface/src/components/common/PublicNotifications.test.tsx
+++ b/graylog2-web-interface/src/components/common/PublicNotifications.test.tsx
@@ -16,10 +16,10 @@
  */
 import React from 'react';
 import { fireEvent, render, screen } from 'wrappedTestingLibrary';
-import { Notifications } from 'theme/types';
-import { asMock } from 'helpers/mocking';
 import { PluginExports } from 'graylog-web-plugin/plugin';
 
+import { Notifications } from 'theme/types';
+import { asMock } from 'helpers/mocking';
 import usePluginEntities from 'views/logic/usePluginEntities';
 
 import PublicNotifications from './PublicNotifications';

--- a/graylog2-web-interface/src/components/common/PublicNotifications.tsx
+++ b/graylog2-web-interface/src/components/common/PublicNotifications.tsx
@@ -17,8 +17,8 @@
 import React, { useState } from 'react';
 import styled, { css } from 'styled-components';
 import PropTypes from 'prop-types';
-import { PublicNotificationsHooks } from 'theme/types';
 
+import { PublicNotificationsHooks } from 'theme/types';
 import usePluginEntities from 'views/logic/usePluginEntities';
 import Alert from 'components/bootstrap/Alert';
 import Button from 'components/bootstrap/Button';

--- a/graylog2-web-interface/src/components/common/ShareButton.test.tsx
+++ b/graylog2-web-interface/src/components/common/ShareButton.test.tsx
@@ -17,8 +17,8 @@
 import * as React from 'react';
 import * as Immutable from 'immutable';
 import { render, screen, fireEvent } from 'wrappedTestingLibrary';
-import { alice } from 'fixtures/users';
 
+import { alice } from 'fixtures/users';
 import { createGRN } from 'logic/permissions/GRN';
 import CurrentUserContext from 'contexts/CurrentUserContext';
 

--- a/graylog2-web-interface/src/components/configurationforms/BooleanField.test.tsx
+++ b/graylog2-web-interface/src/components/configurationforms/BooleanField.test.tsx
@@ -17,8 +17,9 @@
 
 import React from 'react';
 import { screen, render, waitFor } from 'wrappedTestingLibrary';
-import { booleanField } from 'fixtures/configurationforms';
 import userEvent from '@testing-library/user-event';
+
+import { booleanField } from 'fixtures/configurationforms';
 
 import BooleanField from './BooleanField';
 

--- a/graylog2-web-interface/src/components/configurationforms/DropdownField.test.tsx
+++ b/graylog2-web-interface/src/components/configurationforms/DropdownField.test.tsx
@@ -17,8 +17,9 @@
 
 import React from 'react';
 import { screen, render, waitFor } from 'wrappedTestingLibrary';
-import { dropdownField, requiredDropdownField } from 'fixtures/configurationforms';
 import userEvent from '@testing-library/user-event';
+
+import { dropdownField, requiredDropdownField } from 'fixtures/configurationforms';
 
 import DropdownField from './DropdownField';
 

--- a/graylog2-web-interface/src/components/configurationforms/ListField.test.tsx
+++ b/graylog2-web-interface/src/components/configurationforms/ListField.test.tsx
@@ -17,6 +17,7 @@
 import React from 'react';
 import { screen, render, waitFor } from 'wrappedTestingLibrary';
 import selectEvent from 'react-select-event';
+
 import { creatableListField, listField } from 'fixtures/configurationforms';
 
 import ListField from './ListField';

--- a/graylog2-web-interface/src/components/configurationforms/NumberField.test.tsx
+++ b/graylog2-web-interface/src/components/configurationforms/NumberField.test.tsx
@@ -16,6 +16,7 @@
  */
 import React from 'react';
 import { fireEvent, screen, render, waitFor } from 'wrappedTestingLibrary';
+
 import {
   negativeNumberField,
   numberField,

--- a/graylog2-web-interface/src/components/configurationforms/TextField.test.tsx
+++ b/graylog2-web-interface/src/components/configurationforms/TextField.test.tsx
@@ -16,6 +16,7 @@
  */
 import React from 'react';
 import { screen, render, fireEvent, waitFor } from 'wrappedTestingLibrary';
+
 import { passwordTextField, requiredTextField, textAreaField, textField } from 'fixtures/configurationforms';
 
 import TextField from './TextField';

--- a/graylog2-web-interface/src/components/errors/ReportedErrorBoundary.test.tsx
+++ b/graylog2-web-interface/src/components/errors/ReportedErrorBoundary.test.tsx
@@ -17,8 +17,8 @@
 import React from 'react';
 import { render, waitFor } from 'wrappedTestingLibrary';
 import { act } from 'react-dom/test-utils';
-import suppressConsole from 'helpers/suppressConsole';
 
+import suppressConsole from 'helpers/suppressConsole';
 import history from 'util/History';
 import ErrorsActions from 'actions/errors/ErrorsActions';
 import { createReactError, createUnauthorizedError, createNotFoundError } from 'logic/errors/ReportedErrors';

--- a/graylog2-web-interface/src/components/errors/RouterErrorBoundary.test.tsx
+++ b/graylog2-web-interface/src/components/errors/RouterErrorBoundary.test.tsx
@@ -16,6 +16,7 @@
  */
 import React from 'react';
 import { render, screen } from 'wrappedTestingLibrary';
+
 import suppressConsole from 'helpers/suppressConsole';
 import mockComponent from 'helpers/mocking/MockComponent';
 

--- a/graylog2-web-interface/src/components/errors/RuntimeErrorBoundary.test.tsx
+++ b/graylog2-web-interface/src/components/errors/RuntimeErrorBoundary.test.tsx
@@ -16,8 +16,8 @@
  */
 import React from 'react';
 import { render } from 'wrappedTestingLibrary';
-import suppressConsole from 'helpers/suppressConsole';
 
+import suppressConsole from 'helpers/suppressConsole';
 import ErrorsActions from 'actions/errors/ErrorsActions';
 import { ReactErrorType } from 'logic/errors/ReportedErrors';
 

--- a/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitionEntry.test.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitionEntry.test.tsx
@@ -17,9 +17,9 @@
 import * as React from 'react';
 import * as Immutable from 'immutable';
 import { render, screen, fireEvent } from 'wrappedTestingLibrary';
+
 import { alice } from 'fixtures/users';
 import { simpleEventDefinition } from 'fixtures/eventDefinition';
-
 import CurrentUserContext from 'contexts/CurrentUserContext';
 
 import EventDefinitionEntry from './EventDefinitionEntry';

--- a/graylog2-web-interface/src/components/layout/Footer.test.tsx
+++ b/graylog2-web-interface/src/components/layout/Footer.test.tsx
@@ -16,8 +16,9 @@
  */
 import * as React from 'react';
 import { render } from 'wrappedTestingLibrary';
-import { asMock, MockStore } from 'helpers/mocking';
 import { PluginStore } from 'graylog-web-plugin/plugin';
+
+import { asMock, MockStore } from 'helpers/mocking';
 
 import Footer from './Footer';
 

--- a/graylog2-web-interface/src/components/layout/PageContentLayout.test.tsx
+++ b/graylog2-web-interface/src/components/layout/PageContentLayout.test.tsx
@@ -17,6 +17,7 @@
 import * as React from 'react';
 import { render, screen } from 'wrappedTestingLibrary';
 import { PluginManifest, PluginStore } from 'graylog-web-plugin/plugin';
+
 import { MockStore } from 'helpers/mocking';
 
 import PageContentLayout from './PageContentLayout';

--- a/graylog2-web-interface/src/components/lookup-tables/DataAdapterCreate.test.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/DataAdapterCreate.test.jsx
@@ -16,6 +16,7 @@
  */
 import React from 'react';
 import { mount } from 'wrappedEnzyme';
+
 import mockComponent from 'helpers/mocking/MockComponent';
 
 import DataAdapterCreate from './DataAdapterCreate';

--- a/graylog2-web-interface/src/components/messageloaders/RawMessageLoader.test.tsx
+++ b/graylog2-web-interface/src/components/messageloaders/RawMessageLoader.test.tsx
@@ -17,11 +17,11 @@
 
 import React from 'react';
 import { screen, render } from 'wrappedTestingLibrary';
-import { StoreMock as MockStore } from 'helpers/mocking';
-import asMock from 'helpers/mocking/AsMock';
 import { PluginStore } from 'graylog-web-plugin/plugin';
 import userEvent from '@testing-library/user-event';
 
+import { StoreMock as MockStore } from 'helpers/mocking';
+import asMock from 'helpers/mocking/AsMock';
 import AppConfig from 'util/AppConfig';
 import { inputs } from 'components/messageloaders/MessageLoaders.fixtures';
 

--- a/graylog2-web-interface/src/components/messageloaders/RecentMessageLoader.test.tsx
+++ b/graylog2-web-interface/src/components/messageloaders/RecentMessageLoader.test.tsx
@@ -17,11 +17,11 @@
 
 import React from 'react';
 import { screen, render } from 'wrappedTestingLibrary';
-import asMock from 'helpers/mocking/AsMock';
 import { PluginStore } from 'graylog-web-plugin/plugin';
 import userEvent from '@testing-library/user-event';
-import { MockStore } from 'helpers/mocking';
 
+import asMock from 'helpers/mocking/AsMock';
+import { MockStore } from 'helpers/mocking';
 import AppConfig from 'util/AppConfig';
 import { inputs } from 'components/messageloaders/MessageLoaders.fixtures';
 

--- a/graylog2-web-interface/src/components/navigation/Navigation.test.tsx
+++ b/graylog2-web-interface/src/components/navigation/Navigation.test.tsx
@@ -18,11 +18,11 @@ import * as React from 'react';
 import * as Immutable from 'immutable';
 import { mount } from 'wrappedEnzyme';
 import { PluginStore } from 'graylog-web-plugin/plugin';
+import { Route, MemoryRouter } from 'react-router-dom';
+
 import mockComponent from 'helpers/mocking/MockComponent';
 import { alice as currentUser } from 'fixtures/users';
 import { asMock } from 'helpers/mocking';
-import { Route, MemoryRouter } from 'react-router-dom';
-
 import Routes from 'routing/Routes';
 import AppConfig from 'util/AppConfig';
 import CurrentUserContext from 'contexts/CurrentUserContext';

--- a/graylog2-web-interface/src/components/navigation/NotificationBadge.test.jsx
+++ b/graylog2-web-interface/src/components/navigation/NotificationBadge.test.jsx
@@ -16,6 +16,7 @@
  */
 import React from 'react';
 import { mount } from 'wrappedEnzyme';
+
 import { MockStore } from 'helpers/mocking';
 
 import NotificationBadge from './NotificationBadge';

--- a/graylog2-web-interface/src/components/navigation/SystemMenu.test.tsx
+++ b/graylog2-web-interface/src/components/navigation/SystemMenu.test.tsx
@@ -16,9 +16,9 @@
  */
 import * as React from 'react';
 import * as Immutable from 'immutable';
-import { alice } from 'fixtures/users';
 import { mount } from 'wrappedEnzyme';
 
+import { alice } from 'fixtures/users';
 import CurrentUserContext from 'contexts/CurrentUserContext';
 
 import AppConfig from '../../util/AppConfig';

--- a/graylog2-web-interface/src/components/permissions/EntityShareModal.test.tsx
+++ b/graylog2-web-interface/src/components/permissions/EntityShareModal.test.tsx
@@ -18,10 +18,10 @@ import * as React from 'react';
 import * as Immutable from 'immutable';
 import { render, fireEvent, waitFor } from 'wrappedTestingLibrary';
 import { act } from 'react-dom/test-utils';
-import asMock from 'helpers/mocking/AsMock';
-import mockEntityShareState, { failedEntityShareState, john, jane, everyone, security, viewer, owner, manager } from 'fixtures/entityShareState';
 import selectEvent from 'react-select-event';
 
+import asMock from 'helpers/mocking/AsMock';
+import mockEntityShareState, { failedEntityShareState, john, jane, everyone, security, viewer, owner, manager } from 'fixtures/entityShareState';
 import ActiveShare from 'logic/permissions/ActiveShare';
 import { EntityShareStore, EntityShareActions } from 'stores/permissions/EntityShareStore';
 

--- a/graylog2-web-interface/src/components/permissions/GranteesSelector.test.tsx
+++ b/graylog2-web-interface/src/components/permissions/GranteesSelector.test.tsx
@@ -16,6 +16,7 @@
  */
 import * as React from 'react';
 import { render, fireEvent } from 'wrappedTestingLibrary';
+
 import mockEntityShareState, { availableGrantees, availableCapabilities } from 'fixtures/entityShareState';
 
 import GranteesSelector from './GranteesSelector';

--- a/graylog2-web-interface/src/components/roles/RoleDetails/RoleDetails.test.tsx
+++ b/graylog2-web-interface/src/components/roles/RoleDetails/RoleDetails.test.tsx
@@ -17,6 +17,7 @@
 import * as React from 'react';
 import * as Immutable from 'immutable';
 import { render, act, screen } from 'wrappedTestingLibrary';
+
 import { alertsManager as exampleRole } from 'fixtures/roles';
 import { alice as assignedUser } from 'fixtures/userOverviews';
 

--- a/graylog2-web-interface/src/components/roles/RoleEdit/RoleEdit.test.tsx
+++ b/graylog2-web-interface/src/components/roles/RoleEdit/RoleEdit.test.tsx
@@ -16,6 +16,7 @@
  */
 import * as React from 'react';
 import { render, act, screen } from 'wrappedTestingLibrary';
+
 import { alertsManager as exampleRole } from 'fixtures/roles';
 
 import RoleEdit from './RoleEdit';

--- a/graylog2-web-interface/src/components/roles/RoleEdit/TeamsSection.test.tsx
+++ b/graylog2-web-interface/src/components/roles/RoleEdit/TeamsSection.test.tsx
@@ -16,8 +16,9 @@
  */
 import * as React from 'react';
 import { render, screen } from 'wrappedTestingLibrary';
-import { manager as exampleRole } from 'fixtures/roles';
 import { PluginManifest, PluginStore } from 'graylog-web-plugin/plugin';
+
+import { manager as exampleRole } from 'fixtures/roles';
 
 import TeamsSection from './TeamsSection';
 

--- a/graylog2-web-interface/src/components/roles/RoleEdit/UsersSection.test.tsx
+++ b/graylog2-web-interface/src/components/roles/RoleEdit/UsersSection.test.tsx
@@ -18,10 +18,10 @@ import * as React from 'react';
 import * as Immutable from 'immutable';
 import { render, fireEvent, waitFor, screen } from 'wrappedTestingLibrary';
 import selectEvent from 'react-select-event';
+
 import { alertsManager as exampleRole } from 'fixtures/roles';
 import { alice, bob, charlie } from 'fixtures/userOverviews';
 import mockAction from 'helpers/mocking/MockAction';
-
 import { AuthzRolesActions } from 'stores/roles/AuthzRolesStore';
 
 import UsersSection from './UsersSection';

--- a/graylog2-web-interface/src/components/roles/RolesOverview/ActionsCell.test.tsx
+++ b/graylog2-web-interface/src/components/roles/RolesOverview/ActionsCell.test.tsx
@@ -16,11 +16,11 @@
  */
 import * as React from 'react';
 import * as Immutable from 'immutable';
-import asMock from 'helpers/mocking/AsMock';
 import { render, waitFor, fireEvent, screen } from 'wrappedTestingLibrary';
+
+import asMock from 'helpers/mocking/AsMock';
 import { paginatedUsers } from 'fixtures/userOverviews';
 import { alice as currentUser } from 'fixtures/users';
-
 import CurrentUserContext from 'contexts/CurrentUserContext';
 import { AuthzRolesActions } from 'stores/roles/AuthzRolesStore';
 

--- a/graylog2-web-interface/src/components/roles/RolesOverview/RolesOverview.test.tsx
+++ b/graylog2-web-interface/src/components/roles/RolesOverview/RolesOverview.test.tsx
@@ -17,9 +17,9 @@
 import * as React from 'react';
 import * as Immutable from 'immutable';
 import { render, waitFor, fireEvent, screen } from 'wrappedTestingLibrary';
+
 import mockAction from 'helpers/mocking/MockAction';
 import { rolesList as mockRoles } from 'fixtures/roles';
-
 import { AuthzRolesActions } from 'stores/roles/AuthzRolesStore';
 
 import RolesOverview from './RolesOverview';

--- a/graylog2-web-interface/src/components/streamrules/StreamRuleForm.test.tsx
+++ b/graylog2-web-interface/src/components/streamrules/StreamRuleForm.test.tsx
@@ -16,6 +16,7 @@
  */
 import * as React from 'react';
 import { cleanup, render, fireEvent } from 'wrappedTestingLibrary';
+
 import { MockStore } from 'helpers/mocking';
 
 import StreamRuleForm from './StreamRuleForm';

--- a/graylog2-web-interface/src/components/users/UserCreate/UserCreate.test.tsx
+++ b/graylog2-web-interface/src/components/users/UserCreate/UserCreate.test.tsx
@@ -19,9 +19,9 @@ import * as Immutable from 'immutable';
 import { render, fireEvent, waitFor } from 'wrappedTestingLibrary';
 import selectEvent from 'react-select-event';
 import { act } from 'react-dom/test-utils';
+
 import { alice } from 'fixtures/userOverviews';
 import { rolesList } from 'fixtures/roles';
-
 import { UsersActions } from 'stores/users/UsersStore';
 
 import UserCreate from './UserCreate';

--- a/graylog2-web-interface/src/components/users/UserDetails/UserDetails.test.tsx
+++ b/graylog2-web-interface/src/components/users/UserDetails/UserDetails.test.tsx
@@ -17,10 +17,10 @@
 import * as React from 'react';
 import * as Immutable from 'immutable';
 import { render, screen, waitFor } from 'wrappedTestingLibrary';
+
 import { paginatedShares } from 'fixtures/sharedEntities';
 import { reader as assignedRole } from 'fixtures/roles';
 import { alice } from 'fixtures/users';
-
 import CurrentUserContext from 'contexts/CurrentUserContext';
 import User from 'logic/users/User';
 

--- a/graylog2-web-interface/src/components/users/UserEdit/PasswordSection.test.tsx
+++ b/graylog2-web-interface/src/components/users/UserEdit/PasswordSection.test.tsx
@@ -17,8 +17,8 @@
 import * as React from 'react';
 import * as Immutable from 'immutable';
 import { render, fireEvent, waitFor, screen } from 'wrappedTestingLibrary';
-import { alice, adminUser } from 'fixtures/users';
 
+import { alice, adminUser } from 'fixtures/users';
 import CurrentUserContext from 'contexts/CurrentUserContext';
 import { UsersActions } from 'stores/users/UsersStore';
 

--- a/graylog2-web-interface/src/components/users/UserEdit/ProfileSection.test.tsx
+++ b/graylog2-web-interface/src/components/users/UserEdit/ProfileSection.test.tsx
@@ -16,6 +16,7 @@
  */
 import * as React from 'react';
 import { render, fireEvent, waitFor, screen } from 'wrappedTestingLibrary';
+
 import { alice } from 'fixtures/users';
 
 import ProfileSection from './ProfileSection';

--- a/graylog2-web-interface/src/components/users/UserEdit/RolesSection.test.tsx
+++ b/graylog2-web-interface/src/components/users/UserEdit/RolesSection.test.tsx
@@ -18,9 +18,9 @@ import * as React from 'react';
 import * as Immutable from 'immutable';
 import selectEvent from 'react-select-event';
 import { render, fireEvent, waitFor, screen, act } from 'wrappedTestingLibrary';
+
 import { alice } from 'fixtures/users';
 import { manager as assignedRole1, reader as assignedRole2, reportCreator as notAssignedRole } from 'fixtures/roles';
-
 import { AuthzRolesActions } from 'stores/roles/AuthzRolesStore';
 
 import RolesSection from './RolesSection';

--- a/graylog2-web-interface/src/components/users/UserEdit/SettingsSection.test.tsx
+++ b/graylog2-web-interface/src/components/users/UserEdit/SettingsSection.test.tsx
@@ -16,10 +16,10 @@
  */
 import * as React from 'react';
 import { render, fireEvent, waitFor, screen, act } from 'wrappedTestingLibrary';
-import { alice, adminUser } from 'fixtures/users';
 import selectEvent from 'react-select-event';
 import { List } from 'immutable';
 
+import { alice, adminUser } from 'fixtures/users';
 import SharedEntity from 'logic/permissions/SharedEntity';
 import Grantee from 'logic/permissions/Grantee';
 import CurrentUserContext from 'contexts/CurrentUserContext';

--- a/graylog2-web-interface/src/components/users/UserEdit/TeamsSection.test.tsx
+++ b/graylog2-web-interface/src/components/users/UserEdit/TeamsSection.test.tsx
@@ -16,8 +16,9 @@
  */
 import * as React from 'react';
 import { render, screen } from 'wrappedTestingLibrary';
-import { alice as exampleUser } from 'fixtures/users';
 import { PluginManifest, PluginStore } from 'graylog-web-plugin/plugin';
+
+import { alice as exampleUser } from 'fixtures/users';
 
 import TeamsSection from './TeamsSection';
 

--- a/graylog2-web-interface/src/components/users/UserEdit/UserEdit.test.tsx
+++ b/graylog2-web-interface/src/components/users/UserEdit/UserEdit.test.tsx
@@ -16,8 +16,8 @@
  */
 import React from 'react';
 import { screen, render, act } from 'wrappedTestingLibrary';
-import { adminUser, bob } from 'fixtures/users';
 
+import { adminUser, bob } from 'fixtures/users';
 import CurrentUserContext from 'contexts/CurrentUserContext';
 
 import UserEdit from './UserEdit';

--- a/graylog2-web-interface/src/components/users/UsersOverview/UsersOverview.test.tsx
+++ b/graylog2-web-interface/src/components/users/UsersOverview/UsersOverview.test.tsx
@@ -17,11 +17,11 @@
 import * as React from 'react';
 import * as Immutable from 'immutable';
 import { render, waitFor, fireEvent, screen } from 'wrappedTestingLibrary';
+
 import { adminUser as currentUser } from 'fixtures/users';
 import { paginatedUsers, alice, bob, admin as adminOverview } from 'fixtures/userOverviews';
 import asMock from 'helpers/mocking/AsMock';
 import mockAction from 'helpers/mocking/MockAction';
-
 import CurrentUserContext from 'contexts/CurrentUserContext';
 import { UsersActions } from 'stores/users/UsersStore';
 

--- a/graylog2-web-interface/src/contexts/CurrentUserPreferencesProvider.test.tsx
+++ b/graylog2-web-interface/src/contexts/CurrentUserPreferencesProvider.test.tsx
@@ -16,9 +16,9 @@
  */
 import * as React from 'react';
 import { render } from 'wrappedTestingLibrary';
+
 import asMock from 'helpers/mocking/AsMock';
 import { MockStore } from 'helpers/mocking';
-
 import { CurrentUserStore } from 'stores/users/CurrentUserStore';
 import { UserJSON } from 'logic/users/User';
 

--- a/graylog2-web-interface/src/contexts/CurrentUserProvider.test.tsx
+++ b/graylog2-web-interface/src/contexts/CurrentUserProvider.test.tsx
@@ -16,10 +16,10 @@
  */
 import * as React from 'react';
 import { render } from 'wrappedTestingLibrary';
+
 import asMock from 'helpers/mocking/AsMock';
 import { alice } from 'fixtures/users';
 import { StoreMock as MockStore } from 'helpers/mocking';
-
 import { CurrentUserStore } from 'stores/users/CurrentUserStore';
 
 import CurrentUserContext from './CurrentUserContext';

--- a/graylog2-web-interface/src/contexts/GlobalContextProviders.test.tsx
+++ b/graylog2-web-interface/src/contexts/GlobalContextProviders.test.tsx
@@ -16,9 +16,9 @@
  */
 import * as React from 'react';
 import { render, screen } from 'wrappedTestingLibrary';
+
 import asMock from 'helpers/mocking/AsMock';
 import suppressConsole from 'helpers/suppressConsole';
-
 import GlobalContextProviders from 'contexts/GlobalContextProviders';
 import usePluginEntities from 'views/logic/usePluginEntities';
 

--- a/graylog2-web-interface/src/contexts/TimeLocalizeProvider.test.tsx
+++ b/graylog2-web-interface/src/contexts/TimeLocalizeProvider.test.tsx
@@ -18,8 +18,8 @@ import * as React from 'react';
 import { useContext } from 'react';
 import { render, screen } from 'wrappedTestingLibrary';
 import moment from 'moment-timezone';
-import { alice } from 'fixtures/users';
 
+import { alice } from 'fixtures/users';
 import TimeLocalizeProvider, { ACCEPTED_FORMATS } from 'contexts/TimeLocalizeProvider';
 import TimeLocalizeContext from 'contexts/TimeLocalizeContext';
 import CurrentUserContext from 'contexts/CurrentUserContext';

--- a/graylog2-web-interface/src/hooks/useLocationSearchPagination.test.ts
+++ b/graylog2-web-interface/src/hooks/useLocationSearchPagination.test.ts
@@ -17,8 +17,9 @@
 import { renderHook, act } from '@testing-library/react-hooks';
 import { useLocation } from 'react-router-dom';
 import { stringify } from 'qs';
-import { asMock } from 'helpers/mocking';
 import type { Location } from 'history';
+
+import { asMock } from 'helpers/mocking';
 
 import useLocationSearchPagination from './useLocationSearchPagination';
 

--- a/graylog2-web-interface/src/logic/authentication/AuthenticationBackend.ts
+++ b/graylog2-web-interface/src/logic/authentication/AuthenticationBackend.ts
@@ -16,8 +16,8 @@
  */
 import * as Immutable from 'immutable';
 import { $PropertyType } from 'utility-types';
-import { DirectoryServiceAuthenticationService } from 'components/authentication/types';
 
+import { DirectoryServiceAuthenticationService } from 'components/authentication/types';
 import { getAuthServicePlugin } from 'util/AuthenticationService';
 import { DirectoryServiceBackendConfig } from 'logic/authentication/directoryServices/types';
 import { OktaBackendConfig } from 'logic/authentication/okta/types';

--- a/graylog2-web-interface/src/logic/permissions/EntityShareState.test.tsx
+++ b/graylog2-web-interface/src/logic/permissions/EntityShareState.test.tsx
@@ -18,8 +18,8 @@ import { readFileSync } from 'fs';
 import { dirname } from 'path';
 
 import * as Immutable from 'immutable';
-import entityShareStateFixture, { alice, bob, john, jane, everyone, security, viewer, owner, manager } from 'fixtures/entityShareState';
 
+import entityShareStateFixture, { alice, bob, john, jane, everyone, security, viewer, owner, manager } from 'fixtures/entityShareState';
 import ActiveShare from 'logic/permissions/ActiveShare';
 
 import EntityShareState from './EntityShareState';

--- a/graylog2-web-interface/src/logic/permissions/SelectedGrantee.test.tsx
+++ b/graylog2-web-interface/src/logic/permissions/SelectedGrantee.test.tsx
@@ -15,8 +15,8 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as Immutable from 'immutable';
-import { alice, bob, manager, owner } from 'fixtures/entityShareState';
 
+import { alice, bob, manager, owner } from 'fixtures/entityShareState';
 import ActiveShare from 'logic/permissions/ActiveShare';
 
 import SelectedGrantee from './SelectedGrantee';

--- a/graylog2-web-interface/src/pages/ConfigurationsPage.test.tsx
+++ b/graylog2-web-interface/src/pages/ConfigurationsPage.test.tsx
@@ -16,11 +16,11 @@
  */
 import * as React from 'react';
 import { render, screen } from 'wrappedTestingLibrary';
+
 import asMock from 'helpers/mocking/AsMock';
 import suppressConsole from 'helpers/suppressConsole';
 import MockStore from 'helpers/mocking/StoreMock';
 import { configuration as mockConfiguration } from 'fixtures/configurations';
-
 import ConfigurationsPage from 'pages/ConfigurationsPage';
 import usePluginEntities from 'views/logic/usePluginEntities';
 import SidecarConfig from 'components/configurations/SidecarConfig';

--- a/graylog2-web-interface/src/pages/RuntimeErrorPage.test.tsx
+++ b/graylog2-web-interface/src/pages/RuntimeErrorPage.test.tsx
@@ -16,6 +16,7 @@
  */
 import React from 'react';
 import { render, fireEvent } from 'wrappedTestingLibrary';
+
 import mockComponent from 'helpers/mocking/MockComponent';
 
 import RuntimeErrorPage from './RuntimeErrorPage';

--- a/graylog2-web-interface/src/pages/ShowMessagePage.test.tsx
+++ b/graylog2-web-interface/src/pages/ShowMessagePage.test.tsx
@@ -16,8 +16,8 @@
  */
 import * as React from 'react';
 import { render, waitFor, screen } from 'wrappedTestingLibrary';
-import { StoreMock as MockStore, asMock } from 'helpers/mocking';
 
+import { StoreMock as MockStore, asMock } from 'helpers/mocking';
 import DefaultQueryClientProvider from 'contexts/DefaultQueryClientProvider';
 import useFieldTypes from 'views/logic/fieldtypes/useFieldTypes';
 

--- a/graylog2-web-interface/src/pages/StreamPermissionErrorPage.test.tsx
+++ b/graylog2-web-interface/src/pages/StreamPermissionErrorPage.test.tsx
@@ -16,9 +16,9 @@
  */
 import React from 'react';
 import { render, screen } from 'wrappedTestingLibrary';
+
 import suppressConsole from 'helpers/suppressConsole';
 import mockComponent from 'helpers/mocking/MockComponent';
-
 import FetchError from 'logic/errors/FetchError';
 
 import StreamPermissionErrorPage from './StreamPermissionErrorPage';

--- a/graylog2-web-interface/src/pages/UnauthorizedErrorPage.test.tsx
+++ b/graylog2-web-interface/src/pages/UnauthorizedErrorPage.test.tsx
@@ -16,9 +16,9 @@
  */
 import React from 'react';
 import { render, screen } from 'wrappedTestingLibrary';
+
 import suppressConsole from 'helpers/suppressConsole';
 import mockComponent from 'helpers/mocking/MockComponent';
-
 import FetchError from 'logic/errors/FetchError';
 
 import UnauthorizedErrorPage from './UnauthorizedErrorPage';

--- a/graylog2-web-interface/src/pages/UserHasNoStreamAccess.test.tsx
+++ b/graylog2-web-interface/src/pages/UserHasNoStreamAccess.test.tsx
@@ -16,8 +16,8 @@
  */
 import * as React from 'react';
 import { render, screen } from 'wrappedTestingLibrary';
-import mockComponent from 'helpers/mocking/MockComponent';
 
+import mockComponent from 'helpers/mocking/MockComponent';
 import UserHasNoStreamAccess from 'pages/UserHasNoStreamAccess';
 
 jest.mock('components/layout/Footer', () => mockComponent('Footer'));

--- a/graylog2-web-interface/src/pages/configurations/PluginConfigRows.tsx
+++ b/graylog2-web-interface/src/pages/configurations/PluginConfigRows.tsx
@@ -17,8 +17,8 @@
 import * as React from 'react';
 import { useMemo } from 'react';
 import { chunk } from 'lodash';
-import { SystemConfiguration } from 'views/types';
 
+import { SystemConfiguration } from 'views/types';
 import ConfigletContainer from 'pages/configurations/ConfigletContainer';
 import ConfigletRow from 'pages/configurations/ConfigletRow';
 import { ConfigurationsActions } from 'stores/configurations/ConfigurationsStore';

--- a/graylog2-web-interface/src/routing/AppRouter.test.tsx
+++ b/graylog2-web-interface/src/routing/AppRouter.test.tsx
@@ -16,11 +16,11 @@
  */
 import * as React from 'react';
 import { render } from 'wrappedTestingLibrary';
+
 import mockComponent from 'helpers/mocking/MockComponent';
 import { StoreMock as MockStore } from 'helpers/mocking';
 import asMock from 'helpers/mocking/AsMock';
 import { adminUser as currentUser } from 'fixtures/users';
-
 import CurrentUserContext from 'contexts/CurrentUserContext';
 import usePluginEntities from 'views/logic/usePluginEntities';
 import history from 'util/History';

--- a/graylog2-web-interface/src/stores/__tests__/connect.test.tsx
+++ b/graylog2-web-interface/src/stores/__tests__/connect.test.tsx
@@ -21,8 +21,8 @@ import { mount } from 'wrappedEnzyme';
 import Reflux from 'reflux';
 import PropTypes from 'prop-types';
 import { Map, List } from 'immutable';
-import { asMock } from 'helpers/mocking/index';
 
+import { asMock } from 'helpers/mocking/index';
 import type { Store } from 'stores/StoreTypes';
 
 import {

--- a/graylog2-web-interface/src/stores/users/UsersStore.test.ts
+++ b/graylog2-web-interface/src/stores/users/UsersStore.test.ts
@@ -16,7 +16,6 @@
  */
 import asMock from 'helpers/mocking/AsMock';
 import { userList as userOverviewList, admin } from 'fixtures/userOverviews';
-
 import { UsersActions } from 'stores/users/UsersStore';
 import fetch from 'logic/rest/FetchProvider';
 

--- a/graylog2-web-interface/src/util/URLUtils.test.ts
+++ b/graylog2-web-interface/src/util/URLUtils.test.ts
@@ -15,7 +15,6 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import { asMock } from 'helpers/mocking';
-
 import { qualifyUrl, qualifyUrlWithSessionCredentials } from 'util/URLUtils';
 import AppConfig from 'util/AppConfig';
 

--- a/graylog2-web-interface/src/util/conditional/HideOnCloud.test.tsx
+++ b/graylog2-web-interface/src/util/conditional/HideOnCloud.test.tsx
@@ -15,10 +15,10 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import asMock from 'helpers/mocking/AsMock';
 import { render, screen } from 'wrappedTestingLibrary';
 import userEvent from '@testing-library/user-event';
 
+import asMock from 'helpers/mocking/AsMock';
 import AppConfig from 'util/AppConfig';
 
 import HideOnCloud from './HideOnCloud';

--- a/graylog2-web-interface/src/util/conditional/filterMenuItems.test.ts
+++ b/graylog2-web-interface/src/util/conditional/filterMenuItems.test.ts
@@ -15,7 +15,6 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import asMock from 'helpers/mocking/AsMock';
-
 import AppConfig from 'util/AppConfig';
 
 import filterMenuItems, { filterCloudMenuItems } from './filterMenuItems';

--- a/graylog2-web-interface/src/util/conditional/filterValueActions.test.ts
+++ b/graylog2-web-interface/src/util/conditional/filterValueActions.test.ts
@@ -15,7 +15,6 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import asMock from 'helpers/mocking/AsMock';
-
 import { ActionDefinition } from 'views/components/actions/ActionHandler';
 import AppConfig from 'util/AppConfig';
 

--- a/graylog2-web-interface/src/views/bindings.enterpriseWidgets.test.tsx
+++ b/graylog2-web-interface/src/views/bindings.enterpriseWidgets.test.tsx
@@ -16,7 +16,6 @@
  */
 import MockStore from 'helpers/mocking/StoreMock';
 import MockAction from 'helpers/mocking/MockAction';
-
 import AggregationWidget from 'views/logic/aggregationbuilder/AggregationWidget';
 import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
 import Widget from 'views/logic/widgets/Widget';

--- a/graylog2-web-interface/src/views/bindings.fieldActions.test.tsx
+++ b/graylog2-web-interface/src/views/bindings.fieldActions.test.tsx
@@ -16,7 +16,6 @@
  */
 import MockStore from 'helpers/mocking/StoreMock';
 import MockAction from 'helpers/mocking/MockAction';
-
 import FieldType, { FieldTypes, Properties } from 'views/logic/fieldtypes/FieldType';
 import { ActionDefinition } from 'views/components/actions/ActionHandler';
 

--- a/graylog2-web-interface/src/views/bindings.routes.test.tsx
+++ b/graylog2-web-interface/src/views/bindings.routes.test.tsx
@@ -15,7 +15,6 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import MockStore from 'helpers/mocking/StoreMock';
-
 import { StreamSearchPage } from 'views/pages';
 
 import bindings from './bindings';

--- a/graylog2-web-interface/src/views/bindings.tsx
+++ b/graylog2-web-interface/src/views/bindings.tsx
@@ -17,8 +17,8 @@
 import React from 'react';
 import { get } from 'lodash';
 import { PluginExports } from 'graylog-web-plugin/plugin';
-import { WidgetComponentProps } from 'views/types';
 
+import { WidgetComponentProps } from 'views/types';
 import Routes from 'routing/Routes';
 import App from 'routing/App';
 import AppConfig from 'util/AppConfig';

--- a/graylog2-web-interface/src/views/bindings.valueActions.test.tsx
+++ b/graylog2-web-interface/src/views/bindings.valueActions.test.tsx
@@ -16,7 +16,6 @@
  */
 import MockStore from 'helpers/mocking/StoreMock';
 import MockAction from 'helpers/mocking/MockAction';
-
 import FieldType, { FieldTypes, Properties } from 'views/logic/fieldtypes/FieldType';
 import { ActionDefinition } from 'views/components/actions/ActionHandler';
 

--- a/graylog2-web-interface/src/views/components/DashboardSearchBar.test.tsx
+++ b/graylog2-web-interface/src/views/components/DashboardSearchBar.test.tsx
@@ -17,8 +17,8 @@
 import * as React from 'react';
 import { act, render, screen, waitFor } from 'wrappedTestingLibrary';
 import userEvent from '@testing-library/user-event';
-import MockStore from 'helpers/mocking/StoreMock';
 
+import MockStore from 'helpers/mocking/StoreMock';
 import { GlobalOverrideActions } from 'views/stores/GlobalOverrideStore';
 import { SearchActions } from 'views/stores/SearchStore';
 import WidgetFocusContext, {

--- a/graylog2-web-interface/src/views/components/Query.test.tsx
+++ b/graylog2-web-interface/src/views/components/Query.test.tsx
@@ -17,8 +17,8 @@
 import * as React from 'react';
 import { render, screen } from 'wrappedTestingLibrary';
 import Immutable, { Map as MockMap } from 'immutable';
-import { MockStore, asMock } from 'helpers/mocking';
 
+import { MockStore, asMock } from 'helpers/mocking';
 import ViewTypeContext from 'views/components/contexts/ViewTypeContext';
 import View, { ViewType } from 'views/logic/views/View';
 import { WidgetStore } from 'views/stores/WidgetStore';

--- a/graylog2-web-interface/src/views/components/QueryBar.test.tsx
+++ b/graylog2-web-interface/src/views/components/QueryBar.test.tsx
@@ -17,8 +17,8 @@
 import * as React from 'react';
 import * as Immutable from 'immutable';
 import { fireEvent, render, screen, waitFor, within } from 'wrappedTestingLibrary';
-import { MockStore } from 'helpers/mocking';
 
+import { MockStore } from 'helpers/mocking';
 import QueryBar from 'views/components/QueryBar';
 import { ViewActions } from 'views/stores/ViewStore';
 import DashboardPageContext from 'views/components/contexts/DashboardPageContext';

--- a/graylog2-web-interface/src/views/components/Search.dashboard.test.tsx
+++ b/graylog2-web-interface/src/views/components/Search.dashboard.test.tsx
@@ -17,11 +17,11 @@
 import * as React from 'react';
 import Immutable from 'immutable';
 import { render, screen } from 'wrappedTestingLibrary';
+
 import { StoreMock as MockStore } from 'helpers/mocking';
 import asMock from 'helpers/mocking/AsMock';
 import mockComponent from 'helpers/mocking/MockComponent';
 import mockAction from 'helpers/mocking/MockAction';
-
 import { StreamsActions } from 'views/stores/StreamsStore';
 import { WidgetStore } from 'views/stores/WidgetStore';
 import { QueryFiltersStore } from 'views/stores/QueryFiltersStore';

--- a/graylog2-web-interface/src/views/components/Search.test.tsx
+++ b/graylog2-web-interface/src/views/components/Search.test.tsx
@@ -16,11 +16,11 @@
  */
 import * as React from 'react';
 import { fireEvent, render, screen, waitFor } from 'wrappedTestingLibrary';
+
 import { StoreMock as MockStore } from 'helpers/mocking';
 import asMock from 'helpers/mocking/AsMock';
 import mockComponent from 'helpers/mocking/MockComponent';
 import mockAction from 'helpers/mocking/MockAction';
-
 import { StreamsActions } from 'views/stores/StreamsStore';
 import { WidgetStore } from 'views/stores/WidgetStore';
 import { QueryFiltersStore } from 'views/stores/QueryFiltersStore';

--- a/graylog2-web-interface/src/views/components/SearchBar.test.tsx
+++ b/graylog2-web-interface/src/views/components/SearchBar.test.tsx
@@ -16,9 +16,9 @@
  */
 import * as React from 'react';
 import { fireEvent, render, screen, waitFor } from 'wrappedTestingLibrary';
+
 import { StoreMock as MockStore } from 'helpers/mocking';
 import mockAction from 'helpers/mocking/MockAction';
-
 import { SearchActions } from 'views/stores/SearchStore';
 // eslint-disable-next-line import/no-named-default
 import { default as MockQuery } from 'views/logic/queries/Query';

--- a/graylog2-web-interface/src/views/components/SearchBarWithStatus.test.tsx
+++ b/graylog2-web-interface/src/views/components/SearchBarWithStatus.test.tsx
@@ -16,8 +16,8 @@
  */
 import React from 'react';
 import { mount } from 'wrappedEnzyme';
-import mockComponent from 'helpers/mocking/MockComponent';
 
+import mockComponent from 'helpers/mocking/MockComponent';
 import SearchMetadata from 'views/logic/search/SearchMetadata';
 import SearchExecutionState from 'views/logic/search/SearchExecutionState';
 

--- a/graylog2-web-interface/src/views/components/SearchResult.test.tsx
+++ b/graylog2-web-interface/src/views/components/SearchResult.test.tsx
@@ -17,12 +17,12 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { act } from 'react-dom/test-utils';
-import { simpleFields, simpleQueryFields } from 'fixtures/fields';
 import { render } from 'wrappedTestingLibrary';
+
+import { simpleFields, simpleQueryFields } from 'fixtures/fields';
 import asMock from 'helpers/mocking/AsMock';
 import MockStore from 'helpers/mocking/StoreMock';
 import MockAction from 'helpers/mocking/MockAction';
-
 import { SearchLoadingStateStore } from 'views/stores/SearchLoadingStateStore';
 import SearchResult from 'views/components/SearchResult';
 import FieldTypesContext from 'views/components/contexts/FieldTypesContext';

--- a/graylog2-web-interface/src/views/components/ViewActionsMenu.test.tsx
+++ b/graylog2-web-interface/src/views/components/ViewActionsMenu.test.tsx
@@ -17,8 +17,8 @@
 import React from 'react';
 import * as mockImmutable from 'immutable';
 import { render, fireEvent } from 'wrappedTestingLibrary';
-import { alice } from 'fixtures/users';
 
+import { alice } from 'fixtures/users';
 import User from 'logic/users/User';
 import Search from 'views/logic/search/Search';
 import View from 'views/logic/views/View';

--- a/graylog2-web-interface/src/views/components/WidgetComponent.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetComponent.tsx
@@ -17,8 +17,8 @@
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import * as Immutable from 'immutable';
-import { BackendWidgetPosition } from 'views/types';
 
+import { BackendWidgetPosition } from 'views/types';
 import { AdditionalContext } from 'views/logic/ActionContext';
 import WidgetContext from 'views/components/contexts/WidgetContext';
 import WidgetPosition from 'views/logic/widgets/WidgetPosition';

--- a/graylog2-web-interface/src/views/components/WidgetGrid.test.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetGrid.test.tsx
@@ -18,8 +18,8 @@ import * as React from 'react';
 import * as Immutable from 'immutable';
 import { Map as MockMap } from 'immutable';
 import { mount } from 'wrappedEnzyme';
-import { MockStore, asMock } from 'helpers/mocking';
 
+import { MockStore, asMock } from 'helpers/mocking';
 import WidgetPosition from 'views/logic/widgets/WidgetPosition';
 import Widget from 'views/components/widgets/Widget';
 import _Widget from 'views/logic/widgets/Widget';

--- a/graylog2-web-interface/src/views/components/WidgetGrid.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetGrid.tsx
@@ -18,8 +18,8 @@ import * as React from 'react';
 import { useState, useContext, useMemo } from 'react';
 import styled, { css } from 'styled-components';
 import { SizeMe } from 'react-sizeme';
-import { WidgetPositions, BackendWidgetPosition } from 'views/types';
 
+import { WidgetPositions, BackendWidgetPosition } from 'views/types';
 import ReactGridContainer from 'components/common/ReactGridContainer';
 import { widgetDefinition } from 'views/logic/Widgets';
 import WidgetPosition from 'views/logic/widgets/WidgetPosition';

--- a/graylog2-web-interface/src/views/components/WidgetOverrideElements.test.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetOverrideElements.test.tsx
@@ -16,6 +16,7 @@
  */
 import React, { useEffect } from 'react';
 import { render } from 'wrappedTestingLibrary';
+
 import suppressConsole from 'helpers/suppressConsole';
 
 import WidgetOverrideElements from './WidgetOverrideElements';

--- a/graylog2-web-interface/src/views/components/WidgetQueryControls.test.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetQueryControls.test.tsx
@@ -17,8 +17,8 @@
 import * as React from 'react';
 import { render, fireEvent, waitFor, screen } from 'wrappedTestingLibrary';
 import WrappingContainer from 'WrappingContainer';
-import MockStore from 'helpers/mocking/StoreMock';
 
+import MockStore from 'helpers/mocking/StoreMock';
 import { GlobalOverrideActions } from 'views/stores/GlobalOverrideStore';
 import SearchActions from 'views/actions/SearchActions';
 import GlobalOverride from 'views/logic/search/GlobalOverride';

--- a/graylog2-web-interface/src/views/components/__tests__/MigrateFieldCharts.test.tsx
+++ b/graylog2-web-interface/src/views/components/__tests__/MigrateFieldCharts.test.tsx
@@ -16,9 +16,9 @@
  */
 import React from 'react';
 import { render, fireEvent, waitFor } from 'wrappedTestingLibrary';
+
 import { StoreMock as MockStore } from 'helpers/mocking';
 import asMock from 'helpers/mocking/AsMock';
-
 import LineVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/LineVisualizationConfig';
 import AreaVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/AreaVisualizationConfig';
 import Series from 'views/logic/aggregationbuilder/Series';

--- a/graylog2-web-interface/src/views/components/actions/Action.test.tsx
+++ b/graylog2-web-interface/src/views/components/actions/Action.test.tsx
@@ -17,10 +17,10 @@
 import * as React from 'react';
 import { render, screen } from 'wrappedTestingLibrary';
 import userEvent from '@testing-library/user-event';
+
 import { createSimpleExternalValueAction } from 'fixtures/externalValueActions';
 import { ActionContexts } from 'views/types';
 import asMock from 'helpers/mocking/AsMock';
-
 import usePluginEntities from 'views/logic/usePluginEntities';
 import FieldType from 'views/logic/fieldtypes/FieldType';
 

--- a/graylog2-web-interface/src/views/components/actions/ActionHandler.tsx
+++ b/graylog2-web-interface/src/views/components/actions/ActionHandler.tsx
@@ -16,8 +16,8 @@
  */
 import * as React from 'react';
 import uuid from 'uuid/v4';
-import { ActionContexts } from 'views/types';
 
+import { ActionContexts } from 'views/types';
 import type { FieldName, FieldValue } from 'views/logic/fieldtypes/FieldType';
 import type { QueryId } from 'views/logic/queries/Query';
 import FieldType from 'views/logic/fieldtypes/FieldType';

--- a/graylog2-web-interface/src/views/components/actions/ActionMenuItem.test.tsx
+++ b/graylog2-web-interface/src/views/components/actions/ActionMenuItem.test.tsx
@@ -16,8 +16,8 @@
  */
 import * as React from 'react';
 import { render, screen } from 'wrappedTestingLibrary';
-import { alice } from 'fixtures/users';
 
+import { alice } from 'fixtures/users';
 import FieldType from 'views/logic/fieldtypes/FieldType';
 import View from 'views/logic/views/View';
 import Widget from 'views/logic/widgets/Widget';

--- a/graylog2-web-interface/src/views/components/actions/ActionMenuItem.tsx
+++ b/graylog2-web-interface/src/views/components/actions/ActionMenuItem.tsx
@@ -17,8 +17,8 @@
 import * as React from 'react';
 import { useContext } from 'react';
 import styled from 'styled-components';
-import { ActionContexts } from 'views/types';
 
+import { ActionContexts } from 'views/types';
 import Icon from 'components/common/Icon';
 import { MenuItem } from 'components/bootstrap';
 import WidgetFocusContext from 'views/components/contexts/WidgetFocusContext';

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/AggregationBuilder.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/AggregationBuilder.tsx
@@ -16,9 +16,9 @@
  */
 import * as React from 'react';
 import { PluginStore } from 'graylog-web-plugin/plugin';
-import { WidgetComponentProps } from 'views/types';
 import { useContext } from 'react';
 
+import { WidgetComponentProps } from 'views/types';
 import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
 import type { FieldTypeMappingsList } from 'views/stores/FieldTypesStore';
 import type { Rows } from 'views/logic/searchtypes/pivot/PivotHandler';

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/AggregationControls.test.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/AggregationControls.test.tsx
@@ -19,9 +19,9 @@ import * as Immutable from 'immutable';
 import { mount } from 'wrappedEnzyme';
 import { render, screen } from 'wrappedTestingLibrary';
 import { PluginStore } from 'graylog-web-plugin/plugin';
+
 import asMock from 'helpers/mocking/AsMock';
 import suppressConsole from 'helpers/suppressConsole';
-
 import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
 import VisualizationConfig from 'views/logic/aggregationbuilder/visualizations/VisualizationConfig';
 

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/AggregationControls.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/AggregationControls.tsx
@@ -20,8 +20,8 @@ import * as Immutable from 'immutable';
 import { PluginStore } from 'graylog-web-plugin/plugin';
 import styled from 'styled-components';
 import { $PropertyType } from 'utility-types';
-import { EditWidgetComponentProps } from 'views/types';
 
+import { EditWidgetComponentProps } from 'views/types';
 import { Col, Row } from 'components/bootstrap';
 import { defaultCompare } from 'views/logic/DefaultCompare';
 import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/PivotSelect.test.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/PivotSelect.test.tsx
@@ -17,9 +17,9 @@
 import * as React from 'react';
 import { mount } from 'wrappedEnzyme';
 import * as Immutable from 'immutable';
+
 import { simpleFields, simpleQueryFields } from 'fixtures/fields';
 import suppressConsole from 'helpers/suppressConsole';
-
 import PivotGenerator from 'views/logic/searchtypes/aggregation/PivotGenerator';
 import FieldType from 'views/logic/fieldtypes/FieldType';
 import FieldTypeMapping from 'views/logic/fieldtypes/FieldTypeMapping';

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/SeriesFunctionsSuggester.test.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/SeriesFunctionsSuggester.test.tsx
@@ -16,7 +16,6 @@
  */
 
 import { asMock } from 'helpers/mocking';
-
 import SeriesFunctionsSuggester from 'views/components/aggregationbuilder/SeriesFunctionsSuggester';
 import AggregationFunctionsStore from 'views/stores/AggregationFunctionsStore';
 

--- a/graylog2-web-interface/src/views/components/aggregationwizard/AggregationWizard.test.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/AggregationWizard.test.tsx
@@ -17,10 +17,10 @@
 import React from 'react';
 import * as Immutable from 'immutable';
 import { render, screen, waitFor, within } from 'wrappedTestingLibrary';
-import { simpleFields, simpleQueryFields } from 'fixtures/fields';
 import { PluginRegistration, PluginStore } from 'graylog-web-plugin/plugin';
 import userEvent from '@testing-library/user-event';
 
+import { simpleFields, simpleQueryFields } from 'fixtures/fields';
 import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
 import DataTable from 'views/components/datatable/DataTable';
 import FieldTypesContext from 'views/components/contexts/FieldTypesContext';

--- a/graylog2-web-interface/src/views/components/aggregationwizard/AggregationWizard.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/AggregationWizard.tsx
@@ -16,8 +16,8 @@
  */
 import * as React from 'react';
 import styled from 'styled-components';
-import { EditWidgetComponentProps } from 'views/types';
 
+import { EditWidgetComponentProps } from 'views/types';
 import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
 
 import WidgetConfigForm, { WidgetConfigFormValues } from './WidgetConfigForm';

--- a/graylog2-web-interface/src/views/components/aggregationwizard/WidgetConfigForm.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/WidgetConfigForm.tsx
@@ -17,9 +17,9 @@
 import * as React from 'react';
 import { useRef, useEffect, useContext } from 'react';
 import { Form, Formik, FormikProps } from 'formik';
-import { ConfigurationField } from 'views/types';
 import styled from 'styled-components';
 
+import { ConfigurationField } from 'views/types';
 import WidgetEditApplyAllChangesContext from 'views/components/contexts/WidgetEditApplyAllChangesContext';
 import PropagateValidationState from 'views/components/aggregationwizard/PropagateValidationState';
 import VisualizationConfig from 'views/logic/aggregationbuilder/visualizations/VisualizationConfig';

--- a/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.groupBy.test.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.groupBy.test.tsx
@@ -21,8 +21,8 @@ import selectEvent from 'react-select-event';
 import userEvent from '@testing-library/user-event';
 import { PluginRegistration, PluginStore } from 'graylog-web-plugin/plugin';
 import { applyTimeoutMultiplier } from 'jest-preset-graylog/lib/timeouts';
-import { MockStore } from 'helpers/mocking';
 
+import { MockStore } from 'helpers/mocking';
 import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
 import DataTable from 'views/components/datatable/DataTable';
 import FieldType, { FieldTypes } from 'views/logic/fieldtypes/FieldType';

--- a/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.metric.test.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.metric.test.tsx
@@ -20,8 +20,8 @@ import { act, fireEvent, render, screen, waitFor } from 'wrappedTestingLibrary';
 import selectEvent from 'react-select-event';
 import userEvent from '@testing-library/user-event';
 import { PluginRegistration, PluginStore } from 'graylog-web-plugin/plugin';
-import { MockStore } from 'helpers/mocking';
 
+import { MockStore } from 'helpers/mocking';
 import FieldTypeMapping from 'views/logic/fieldtypes/FieldTypeMapping';
 import SeriesConfig from 'views/logic/aggregationbuilder/SeriesConfig';
 import Series from 'views/logic/aggregationbuilder/Series';

--- a/graylog2-web-interface/src/views/components/aggregationwizard/visualization/VisualizationConfigurationOptions.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/visualization/VisualizationConfigurationOptions.tsx
@@ -16,9 +16,9 @@
  */
 import * as React from 'react';
 import { Field, getIn, useFormikContext } from 'formik';
-import { ConfigurationField } from 'views/types';
 import styled from 'styled-components';
 
+import { ConfigurationField } from 'views/types';
 import { VisualizationConfigFormValues } from 'views/components/aggregationwizard/WidgetConfigForm';
 import { HoverForHelp } from 'components/common';
 

--- a/graylog2-web-interface/src/views/components/aggregationwizard/visualization/VisualizationElement.ts
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/visualization/VisualizationElement.ts
@@ -16,8 +16,8 @@
  */
 import { isEmpty } from 'lodash';
 import { PluginStore } from 'graylog-web-plugin/plugin';
-import { VisualizationType } from 'views/types';
 
+import { VisualizationType } from 'views/types';
 import AggregationWidgetConfig, { AggregationWidgetConfigBuilder } from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
 import VisualizationConfig from 'views/logic/aggregationbuilder/visualizations/VisualizationConfig';
 

--- a/graylog2-web-interface/src/views/components/aggregationwizard/visualization/configurationFields/NumericField.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/visualization/configurationFields/NumericField.tsx
@@ -16,8 +16,8 @@
  */
 import * as React from 'react';
 import { useCallback } from 'react';
-import type { NumericField as NumericFieldType } from 'views/types';
 
+import type { NumericField as NumericFieldType } from 'views/types';
 import { Input } from 'components/bootstrap';
 
 import { FieldComponentProps } from '../VisualizationConfigurationOptions';

--- a/graylog2-web-interface/src/views/components/contexts/DashboardPageContextProvider.test.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/DashboardPageContextProvider.test.tsx
@@ -17,6 +17,7 @@
 import * as React from 'react';
 import { render } from 'wrappedTestingLibrary';
 import { useLocation } from 'react-router-dom';
+
 import { asMock } from 'helpers/mocking';
 
 import DashboardPageContext from './DashboardPageContext';

--- a/graylog2-web-interface/src/views/components/contexts/DefaultFieldTypesProvider.test.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/DefaultFieldTypesProvider.test.tsx
@@ -17,9 +17,9 @@
 import * as React from 'react';
 import { render } from 'wrappedTestingLibrary';
 import { Map, List } from 'immutable';
+
 import asMock from 'helpers/mocking/AsMock';
 import { simpleFields, simpleQueryFields } from 'fixtures/fields';
-
 import { FieldTypesStore } from 'views/stores/FieldTypesStore';
 
 import FieldTypesContext from './FieldTypesContext';

--- a/graylog2-web-interface/src/views/components/contexts/DrilldownContextProvider.test.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/DrilldownContextProvider.test.tsx
@@ -17,8 +17,8 @@
 import * as React from 'react';
 import { useContext } from 'react';
 import { mount } from 'wrappedEnzyme';
-import { StoreMock as mockStore, asMock } from 'helpers/mocking';
 
+import { StoreMock as mockStore, asMock } from 'helpers/mocking';
 import View from 'views/logic/views/View';
 import MessagesWidget from 'views/logic/widgets/MessagesWidget';
 import Query, { createElasticsearchQueryString, filtersForQuery } from 'views/logic/queries/Query';

--- a/graylog2-web-interface/src/views/components/contexts/HighlightingRulesProvider.test.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/HighlightingRulesProvider.test.tsx
@@ -16,8 +16,8 @@
  */
 import * as React from 'react';
 import { render } from 'wrappedTestingLibrary';
-import asMock from 'helpers/mocking/AsMock';
 
+import asMock from 'helpers/mocking/AsMock';
 import HighlightingRule from 'views/logic/views/formatting/highlighting/HighlightingRule';
 import { HighlightingRulesStore } from 'views/stores/HighlightingRulesStore';
 import { StaticColor } from 'views/logic/views/formatting/highlighting/HighlightingColor';

--- a/graylog2-web-interface/src/views/components/contexts/SearchPageLayoutProvider.test.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/SearchPageLayoutProvider.test.tsx
@@ -16,9 +16,9 @@
  */
 import * as React from 'react';
 import { render, fireEvent } from 'wrappedTestingLibrary';
+
 import asMock from 'helpers/mocking/AsMock';
 import { MockStore } from 'helpers/mocking';
-
 import CurrentUserProvider from 'contexts/CurrentUserProvider';
 import CurrentUserPreferencesProvider from 'contexts/CurrentUserPreferencesProvider';
 import Store from 'logic/local-storage/Store';

--- a/graylog2-web-interface/src/views/components/contexts/WidgetFieldTypesContextProvider.test.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/WidgetFieldTypesContextProvider.test.tsx
@@ -16,8 +16,8 @@
  */
 import * as React from 'react';
 import { render, screen } from 'wrappedTestingLibrary';
-import asMock from 'helpers/mocking/AsMock';
 
+import asMock from 'helpers/mocking/AsMock';
 import useFieldTypes from 'views/logic/fieldtypes/useFieldTypes';
 import WidgetFieldTypesContextProvider from 'views/components/contexts/WidgetFieldTypesContextProvider';
 import WidgetContext from 'views/components/contexts/WidgetContext';

--- a/graylog2-web-interface/src/views/components/contexts/WidgetFocusProvider.test.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/WidgetFocusProvider.test.tsx
@@ -18,8 +18,8 @@ import * as React from 'react';
 import { Map } from 'immutable';
 import { render } from 'wrappedTestingLibrary';
 import { useLocation } from 'react-router-dom';
-import { asMock } from 'helpers/mocking';
 
+import { asMock } from 'helpers/mocking';
 import { WidgetStore } from 'views/stores/WidgetStore';
 import WidgetFocusProvider from 'views/components/contexts/WidgetFocusProvider';
 import WidgetFocusContext from 'views/components/contexts/WidgetFocusContext';

--- a/graylog2-web-interface/src/views/components/datatable/bindings.tsx
+++ b/graylog2-web-interface/src/views/components/datatable/bindings.tsx
@@ -15,7 +15,6 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import { VisualizationType } from 'views/types';
-
 import DataTable from 'views/components/datatable/DataTable';
 
 const dataTable: VisualizationType = {

--- a/graylog2-web-interface/src/views/components/export/ExportModal.test.tsx
+++ b/graylog2-web-interface/src/views/components/export/ExportModal.test.tsx
@@ -17,11 +17,11 @@
 import * as React from 'react';
 import { render, fireEvent, waitFor } from 'wrappedTestingLibrary';
 import * as Immutable from 'immutable';
-import asMock from 'helpers/mocking/AsMock';
 import selectEvent from 'react-select-event';
 import { Optional } from 'utility-types';
 import { PluginRegistration, PluginStore } from 'graylog-web-plugin/plugin';
 
+import asMock from 'helpers/mocking/AsMock';
 import { TitleType } from 'views/stores/TitleTypes';
 import { exportSearchMessages, exportSearchTypeMessages } from 'util/MessagesExportUtils';
 import type { ViewStateMap } from 'views/logic/views/View';

--- a/graylog2-web-interface/src/views/components/messagelist/FormatReceivedBy.test.tsx
+++ b/graylog2-web-interface/src/views/components/messagelist/FormatReceivedBy.test.tsx
@@ -17,9 +17,9 @@
 import * as React from 'react';
 import { render, screen, within } from 'wrappedTestingLibrary';
 import * as Immutable from 'immutable';
-import { MockStore } from 'helpers/mocking';
 import { PluginStore } from 'graylog-web-plugin/plugin';
 
+import { MockStore } from 'helpers/mocking';
 import { Input } from 'components/messageloaders/Types';
 
 import FormatReceivedBy from './FormatReceivedBy';

--- a/graylog2-web-interface/src/views/components/messagelist/HighlightMessageInQuery.test.tsx
+++ b/graylog2-web-interface/src/views/components/messagelist/HighlightMessageInQuery.test.tsx
@@ -16,8 +16,8 @@
  */
 import * as React from 'react';
 import { render, screen } from '@testing-library/react';
-import { asMock } from 'helpers/mocking';
 
+import { asMock } from 'helpers/mocking';
 import useQuery from 'routing/useQuery';
 
 import _HighlightMessageInQuery from './HighlightMessageInQuery';

--- a/graylog2-web-interface/src/views/components/messagelist/MessageAugmentations.test.tsx
+++ b/graylog2-web-interface/src/views/components/messagelist/MessageAugmentations.test.tsx
@@ -16,9 +16,9 @@
  */
 import * as React from 'react';
 import { render, screen } from 'wrappedTestingLibrary';
+
 import asMock from 'helpers/mocking/AsMock';
 import { simpleMessage as message } from 'fixtures/messages';
-
 import usePluginEntities from 'views/logic/usePluginEntities';
 import WindowDimensionsContext from 'contexts/WindowDimensionsContext';
 

--- a/graylog2-web-interface/src/views/components/messagelist/MessageDetailProviders.test.tsx
+++ b/graylog2-web-interface/src/views/components/messagelist/MessageDetailProviders.test.tsx
@@ -16,10 +16,10 @@
  */
 import * as React from 'react';
 import { render, screen } from 'wrappedTestingLibrary';
+
 import asMock from 'helpers/mocking/AsMock';
 import suppressConsole from 'helpers/suppressConsole';
 import { simpleMessage as message } from 'fixtures/messages';
-
 import usePluginEntities from 'views/logic/usePluginEntities';
 
 import MessageDetailProviders from './MessageDetailProviders';

--- a/graylog2-web-interface/src/views/components/messagelist/MessagePreview.test.tsx
+++ b/graylog2-web-interface/src/views/components/messagelist/MessagePreview.test.tsx
@@ -16,8 +16,8 @@
  */
 import * as React from 'react';
 import { render, screen } from 'wrappedTestingLibrary';
-import { asMock } from 'helpers/mocking';
 
+import { asMock } from 'helpers/mocking';
 import usePluginEntities from 'views/logic/usePluginEntities';
 import FieldType from 'views/logic/fieldtypes/FieldType';
 import MessagesWidgetConfig from 'views/logic/widgets/MessagesWidgetConfig';

--- a/graylog2-web-interface/src/views/components/messagelist/MessageTableEntry.test.tsx
+++ b/graylog2-web-interface/src/views/components/messagelist/MessageTableEntry.test.tsx
@@ -17,9 +17,9 @@
 import * as React from 'react';
 import { render, screen } from 'wrappedTestingLibrary';
 import * as Immutable from 'immutable';
+
 import MockStore from 'helpers/mocking/StoreMock';
 import MockAction from 'helpers/mocking/MockAction';
-
 import MessagesWidgetConfig from 'views/logic/widgets/MessagesWidgetConfig';
 
 import MessageTableEntry from './MessageTableEntry';

--- a/graylog2-web-interface/src/views/components/queries/QueryTitle.test.tsx
+++ b/graylog2-web-interface/src/views/components/queries/QueryTitle.test.tsx
@@ -17,8 +17,8 @@
 import * as React from 'react';
 import * as Immutable from 'immutable';
 import { mount } from 'wrappedEnzyme';
-import mockAction from 'helpers/mocking/MockAction';
 
+import mockAction from 'helpers/mocking/MockAction';
 import { QueriesActions } from 'views/stores/QueriesStore';
 import { ViewActions } from 'views/stores/ViewStore';
 

--- a/graylog2-web-interface/src/views/components/searchbar/RangePresetDropdown.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/RangePresetDropdown.test.tsx
@@ -17,10 +17,10 @@
 import * as React from 'react';
 import * as Immutable from 'immutable';
 import { fireEvent, render, screen } from 'wrappedTestingLibrary';
+
 import MockStore from 'helpers/mocking/StoreMock';
 import { alice } from 'fixtures/users';
 import mockSearchClusterConfig from 'fixtures/searchClusterConfig';
-
 import CurrentUserContext from 'contexts/CurrentUserContext';
 
 import RangePresetDropdown from './RangePresetDropdown';

--- a/graylog2-web-interface/src/views/components/searchbar/TimeRangeDropdownButton.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/TimeRangeDropdownButton.test.tsx
@@ -17,6 +17,7 @@
 import { fireEvent, render, screen, waitFor } from 'wrappedTestingLibrary';
 import { Formik } from 'formik';
 import * as React from 'react';
+
 import MockStore from 'helpers/mocking/StoreMock';
 import mockSearchClusterConfig from 'fixtures/searchClusterConfig';
 

--- a/graylog2-web-interface/src/views/components/searchbar/TimeRangeInput.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/TimeRangeInput.test.tsx
@@ -16,10 +16,10 @@
  */
 import * as React from 'react';
 import { fireEvent, render, screen, waitFor, within } from 'wrappedTestingLibrary';
-import MockStore from 'helpers/mocking/StoreMock';
 import { Formik } from 'formik';
-import MockAction from 'helpers/mocking/MockAction';
 
+import MockStore from 'helpers/mocking/StoreMock';
+import MockAction from 'helpers/mocking/MockAction';
 import TimeRangeInput from 'views/components/searchbar/TimeRangeInput';
 
 jest.mock('stores/configurations/ConfigurationsStore', () => ({

--- a/graylog2-web-interface/src/views/components/searchbar/completions/FieldNameCompletion.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/completions/FieldNameCompletion.test.tsx
@@ -14,10 +14,10 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import { StoreMock as MockStore } from 'helpers/mocking';
-import asMock from 'helpers/mocking/AsMock';
 import * as Immutable from 'immutable';
 
+import { StoreMock as MockStore } from 'helpers/mocking';
+import asMock from 'helpers/mocking/AsMock';
 import { ViewMetaData, ViewMetadataStore } from 'views/stores/ViewMetadataStore';
 import { FieldTypeMappingsList, FieldTypesStore, FieldTypesStoreState } from 'views/stores/FieldTypesStore';
 

--- a/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TabKeywordTimeRange.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TabKeywordTimeRange.test.tsx
@@ -18,8 +18,8 @@ import React from 'react';
 import { asElement, fireEvent, render, waitFor } from 'wrappedTestingLibrary';
 import { Formik, Form } from 'formik';
 import { act } from 'react-dom/test-utils';
-import asMock from 'helpers/mocking/AsMock';
 
+import asMock from 'helpers/mocking/AsMock';
 import ToolsStore from 'stores/tools/ToolsStore';
 
 import OriginalTabKeywordTimeRange from './TabKeywordTimeRange';

--- a/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TabRelativeTimeRange.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TabRelativeTimeRange.test.tsx
@@ -17,9 +17,9 @@
 import React from 'react';
 import { fireEvent, render, screen } from 'wrappedTestingLibrary';
 import { Formik, Form } from 'formik';
+
 import MockStore from 'helpers/mocking/StoreMock';
 import MockAction from 'helpers/mocking/MockAction';
-
 import { RELATIVE_CLASSIFIED_ALL_TIME_RANGE } from 'views/components/searchbar/date-time-picker/RelativeTimeRangeClassifiedHelper';
 
 import TabRelativeTimeRange from './TabRelativeTimeRange';

--- a/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TimeRangeDropdown.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TimeRangeDropdown.test.tsx
@@ -16,9 +16,9 @@
  */
 import React from 'react';
 import { fireEvent, render, screen, waitFor } from 'wrappedTestingLibrary';
+
 import { StoreMock as MockStore, asMock } from 'helpers/mocking';
 import mockSearchClusterConfig from 'fixtures/searchClusterConfig';
-
 import ToolsStore from 'stores/tools/ToolsStore';
 
 import { DateTimeContext } from './DateTimeProvider';

--- a/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TimerangeDropdown.relativeTimeRange.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TimerangeDropdown.relativeTimeRange.test.tsx
@@ -16,8 +16,9 @@
  */
 import React from 'react';
 import { render, screen, waitFor } from 'wrappedTestingLibrary';
-import { StoreMock as MockStore } from 'helpers/mocking';
 import userEvent from '@testing-library/user-event';
+
+import { StoreMock as MockStore } from 'helpers/mocking';
 import mockSearchClusterConfig from 'fixtures/searchClusterConfig';
 
 import { DateTimeContext } from './DateTimeProvider';

--- a/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchControls.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchControls.test.tsx
@@ -17,10 +17,10 @@
 import * as React from 'react';
 import * as Immutable from 'immutable';
 import { fireEvent, render, screen, waitFor } from 'wrappedTestingLibrary';
-import { adminUser, alice as currentUser } from 'fixtures/users';
-import mockAction from 'helpers/mocking/MockAction';
 import userEvent from '@testing-library/user-event';
 
+import { adminUser, alice as currentUser } from 'fixtures/users';
+import mockAction from 'helpers/mocking/MockAction';
 import View from 'views/logic/views/View';
 import Search from 'views/logic/search/Search';
 import ViewLoaderContext, { ViewLoaderContextType } from 'views/logic/ViewLoaderContext';

--- a/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchForm.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchForm.test.tsx
@@ -16,6 +16,7 @@
  */
 import React from 'react';
 import { mount } from 'wrappedEnzyme';
+
 import mockComponent from 'helpers/mocking/MockComponent';
 
 import 'helpers/mocking/react-dom_mock';

--- a/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchList.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchList.test.tsx
@@ -16,8 +16,8 @@
  */
 import React from 'react';
 import { render, fireEvent, screen, waitFor } from 'wrappedTestingLibrary';
-import asMock from 'helpers/mocking/AsMock';
 
+import asMock from 'helpers/mocking/AsMock';
 import View from 'views/logic/views/View';
 import ViewLoaderContext from 'views/logic/ViewLoaderContext';
 import { SavedSearchesActions } from 'views/stores/SavedSearchesStore';

--- a/graylog2-web-interface/src/views/components/sidebar/Sidebar.test.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/Sidebar.test.tsx
@@ -16,8 +16,8 @@
  */
 import * as React from 'react';
 import { fireEvent, render, screen } from 'wrappedTestingLibrary';
-import { StoreMock as MockStore } from 'helpers/mocking';
 
+import { StoreMock as MockStore } from 'helpers/mocking';
 import ViewTypeContext from 'views/components/contexts/ViewTypeContext';
 import View from 'views/logic/views/View';
 import QueryResult from 'views/logic/QueryResult';

--- a/graylog2-web-interface/src/views/components/sidebar/fields/FieldsOverview.test.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/fields/FieldsOverview.test.tsx
@@ -16,8 +16,8 @@
  */
 import * as React from 'react';
 import { mount } from 'wrappedEnzyme';
-import { simpleFields, simpleQueryFields } from 'fixtures/fields';
 
+import { simpleFields, simpleQueryFields } from 'fixtures/fields';
 import FieldTypesContext from 'views/components/contexts/FieldTypesContext';
 
 import FieldsOverview from './FieldsOverview';

--- a/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightingRule.test.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightingRule.test.tsx
@@ -17,8 +17,8 @@
 import * as React from 'react';
 import type { HTMLAttributes } from 'enzyme';
 import { mount } from 'wrappedEnzyme';
-import mockAction from 'helpers/mocking/MockAction';
 
+import mockAction from 'helpers/mocking/MockAction';
 import Rule from 'views/logic/views/formatting/highlighting/HighlightingRule';
 import { HighlightingRulesActions } from 'views/stores/HighlightingRulesStore';
 import { StaticColor } from 'views/logic/views/formatting/highlighting/HighlightingColor';

--- a/graylog2-web-interface/src/views/components/visualizations/PlotLegend.test.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/PlotLegend.test.tsx
@@ -16,8 +16,8 @@
  */
 import * as React from 'react';
 import { render, screen, fireEvent, waitFor } from 'wrappedTestingLibrary';
-import { StoreMock as MockStore } from 'helpers/mocking';
 
+import { StoreMock as MockStore } from 'helpers/mocking';
 import PlotLegend from 'views/components/visualizations/PlotLegend';
 import ColorMapper from 'views/components/visualizations/ColorMapper';
 import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';

--- a/graylog2-web-interface/src/views/components/visualizations/__tests__/XYPlot.test.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/__tests__/XYPlot.test.tsx
@@ -17,12 +17,12 @@
 import * as React from 'react';
 import * as Immutable from 'immutable';
 import { mount } from 'wrappedEnzyme';
+import { $PropertyType } from 'utility-types';
+
 import mockComponent from 'helpers/mocking/MockComponent';
 import { alice as currentUser } from 'fixtures/users';
 import asMock from 'helpers/mocking/AsMock';
-import { $PropertyType } from 'utility-types';
 import { StoreMock as MockStore } from 'helpers/mocking';
-
 import User from 'logic/users/User';
 import CurrentUserContext from 'contexts/CurrentUserContext';
 import XYPlot, { Props as XYPlotProps } from 'views/components/visualizations/XYPlot';

--- a/graylog2-web-interface/src/views/components/visualizations/area/__tests__/AreaVisualization.test.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/area/__tests__/AreaVisualization.test.tsx
@@ -17,9 +17,9 @@
 import * as React from 'react';
 import { mount } from 'wrappedEnzyme';
 import * as Immutable from 'immutable';
+
 import mockComponent from 'helpers/mocking/MockComponent';
 import { StoreMock as MockStore } from 'helpers/mocking';
-
 import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
 import Pivot from 'views/logic/aggregationbuilder/Pivot';
 import Series from 'views/logic/aggregationbuilder/Series';

--- a/graylog2-web-interface/src/views/components/visualizations/area/bindings.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/area/bindings.tsx
@@ -15,7 +15,6 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import type { VisualizationType } from 'views/types';
-
 import AreaVisualization from 'views/components/visualizations/area/AreaVisualization';
 import AreaVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/AreaVisualizationConfig';
 import { hasAtLeastOneMetric } from 'views/components/visualizations/validations';

--- a/graylog2-web-interface/src/views/components/visualizations/bar/bindings.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/bar/bindings.tsx
@@ -15,8 +15,8 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import type { VisualizationType } from 'views/types';
 
+import type { VisualizationType } from 'views/types';
 import BarVisualization from 'views/components/visualizations/bar/BarVisualization';
 import BarVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/BarVisualizationConfig';
 import { hasAtLeastOneMetric } from 'views/components/visualizations/validations';

--- a/graylog2-web-interface/src/views/components/visualizations/bindings.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/bindings.tsx
@@ -15,7 +15,6 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import type { VisualizationType } from 'views/types';
-
 import dataTable from 'views/components/datatable/bindings';
 
 import areaChart from './area/bindings';

--- a/graylog2-web-interface/src/views/components/visualizations/heatmap/__tests__/HeatmapVisualization.test.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/heatmap/__tests__/HeatmapVisualization.test.tsx
@@ -17,8 +17,8 @@
 import React from 'react';
 import { mount } from 'wrappedEnzyme';
 import * as Immutable from 'immutable';
-import mockComponent from 'helpers/mocking/MockComponent';
 
+import mockComponent from 'helpers/mocking/MockComponent';
 import Pivot from 'views/logic/aggregationbuilder/Pivot';
 import Series from 'views/logic/aggregationbuilder/Series';
 import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';

--- a/graylog2-web-interface/src/views/components/visualizations/heatmap/bindings.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/heatmap/bindings.tsx
@@ -15,7 +15,6 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import type { VisualizationType } from 'views/types';
-
 import HeatmapVisualization from 'views/components/visualizations/heatmap/HeatmapVisualization';
 import HeatmapVisualizationConfig, { COLORSCALES } from 'views/logic/aggregationbuilder/visualizations/HeatmapVisualizationConfig';
 import { defaultCompare } from 'views/logic/DefaultCompare';

--- a/graylog2-web-interface/src/views/components/visualizations/line/bindings.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/line/bindings.tsx
@@ -15,7 +15,6 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import type { VisualizationType } from 'views/types';
-
 import LineVisualization from 'views/components/visualizations/line/LineVisualization';
 import LineVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/LineVisualizationConfig';
 import { hasAtLeastOneMetric } from 'views/components/visualizations/validations';

--- a/graylog2-web-interface/src/views/components/visualizations/number/bindings.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/number/bindings.tsx
@@ -15,8 +15,8 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import type { VisualizationType } from 'views/types';
 
+import type { VisualizationType } from 'views/types';
 import NumberVisualization from 'views/components/visualizations/number/NumberVisualization';
 import NumberVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/NumberVisualizationConfig';
 

--- a/graylog2-web-interface/src/views/components/visualizations/pie/bindings.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/pie/bindings.tsx
@@ -15,7 +15,6 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import type { VisualizationType } from 'views/types';
-
 import PieVisualization from 'views/components/visualizations/pie/PieVisualization';
 import { hasAtLeastOneMetric } from 'views/components/visualizations/validations';
 

--- a/graylog2-web-interface/src/views/components/visualizations/scatter/bindings.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/scatter/bindings.tsx
@@ -15,7 +15,6 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import type { VisualizationType } from 'views/types';
-
 import ScatterVisualization from 'views/components/visualizations/scatter/ScatterVisualization';
 import { hasAtLeastOneMetric } from 'views/components/visualizations/validations';
 

--- a/graylog2-web-interface/src/views/components/visualizations/worldmap/bindings.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/worldmap/bindings.tsx
@@ -15,7 +15,6 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import type { VisualizationType } from 'views/types';
-
 import Viewport from 'views/logic/aggregationbuilder/visualizations/Viewport';
 import WorldMapVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/WorldMapVisualizationConfig';
 import WorldMapVisualization from 'views/components/visualizations/worldmap/WorldMapVisualization';

--- a/graylog2-web-interface/src/views/components/widgets/CopyToDashboardForm.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/CopyToDashboardForm.test.tsx
@@ -16,8 +16,8 @@
  */
 import * as React from 'react';
 import { render, fireEvent } from 'wrappedTestingLibrary';
-import mockAction from 'helpers/mocking/MockAction';
 
+import mockAction from 'helpers/mocking/MockAction';
 import { DashboardsActions, DashboardsStoreState } from 'views/stores/DashboardsStore';
 import View from 'views/logic/views/View';
 

--- a/graylog2-web-interface/src/views/components/widgets/EditMessageList.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/EditMessageList.tsx
@@ -18,8 +18,8 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { $PropertyType } from 'utility-types';
-import { EditWidgetComponentProps } from 'views/types';
 
+import { EditWidgetComponentProps } from 'views/types';
 import usePluginEntities from 'views/logic/usePluginEntities';
 import SortConfig from 'views/logic/aggregationbuilder/SortConfig';
 import { Row, Col, Checkbox } from 'components/bootstrap';

--- a/graylog2-web-interface/src/views/components/widgets/EditWidgetFrame.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/EditWidgetFrame.test.tsx
@@ -17,8 +17,8 @@
 import * as React from 'react';
 import { render, fireEvent, waitFor, screen } from 'wrappedTestingLibrary';
 import selectEvent from 'react-select-event';
-import MockStore from 'helpers/mocking/StoreMock';
 
+import MockStore from 'helpers/mocking/StoreMock';
 import { WidgetActions } from 'views/stores/WidgetStore';
 import { SearchActions } from 'views/stores/SearchStore';
 import Widget from 'views/logic/widgets/Widget';

--- a/graylog2-web-interface/src/views/components/widgets/ExtraWidgetActions.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/ExtraWidgetActions.test.tsx
@@ -16,9 +16,9 @@
  */
 import * as React from 'react';
 import { render, screen, waitFor } from 'wrappedTestingLibrary';
-import asMock from 'helpers/mocking/AsMock';
 import userEvent from '@testing-library/user-event';
 
+import asMock from 'helpers/mocking/AsMock';
 import ExtraWidgetActions from 'views/components/widgets/ExtraWidgetActions';
 import Widget from 'views/logic/widgets/Widget';
 import usePluginEntities from 'views/logic/usePluginEntities';

--- a/graylog2-web-interface/src/views/components/widgets/MessageList.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageList.test.tsx
@@ -17,9 +17,9 @@
 import * as React from 'react';
 import { mount } from 'wrappedEnzyme';
 import * as Immutable from 'immutable';
+
 import { StoreMock as MockStore } from 'helpers/mocking';
 import asMock from 'helpers/mocking/AsMock';
-
 import { TIMESTAMP_FIELD, Messages } from 'views/Constants';
 import FieldTypeMapping from 'views/logic/fieldtypes/FieldTypeMapping';
 import FieldType from 'views/logic/fieldtypes/FieldType';

--- a/graylog2-web-interface/src/views/components/widgets/MessageList.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageList.tsx
@@ -18,8 +18,8 @@ import * as React from 'react';
 import * as Immutable from 'immutable';
 import styled from 'styled-components';
 import { isEmpty, get } from 'lodash';
-import { WidgetComponentProps } from 'views/types';
 
+import { WidgetComponentProps } from 'views/types';
 import connect from 'stores/connect';
 import { Messages } from 'views/Constants';
 import { ViewStore } from 'views/stores/ViewStore';

--- a/graylog2-web-interface/src/views/components/widgets/MessageTable.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageTable.test.tsx
@@ -17,10 +17,10 @@
 import * as React from 'react';
 import { mount } from 'wrappedEnzyme';
 import * as Immutable from 'immutable';
+
 import suppressConsole from 'helpers/suppressConsole';
 import { MockStore } from 'helpers/mocking';
 import MockAction from 'helpers/mocking/MockAction';
-
 import FieldTypeMapping from 'views/logic/fieldtypes/FieldTypeMapping';
 import FieldType from 'views/logic/fieldtypes/FieldType';
 import MessagesWidgetConfig from 'views/logic/widgets/MessagesWidgetConfig';

--- a/graylog2-web-interface/src/views/components/widgets/TimerangeInfo.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/TimerangeInfo.test.tsx
@@ -17,9 +17,9 @@
 import React from 'react';
 import Immutable from 'immutable';
 import { render, screen } from 'wrappedTestingLibrary';
+
 import { MockStore } from 'helpers/mocking';
 import asMock from 'helpers/mocking/AsMock';
-
 import Search from 'views/logic/search/Search';
 import Widget from 'views/logic/widgets/Widget';
 import TimeLocalizeContext from 'contexts/TimeLocalizeContext';

--- a/graylog2-web-interface/src/views/components/widgets/UnknownWidget.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/UnknownWidget.tsx
@@ -16,8 +16,8 @@
  */
 import * as React from 'react';
 import styled from 'styled-components';
-import { EditWidgetComponentProps, WidgetComponentProps } from 'views/types';
 
+import { EditWidgetComponentProps, WidgetComponentProps } from 'views/types';
 import { Icon } from 'components/common';
 import ClipboardButton from 'components/common/ClipboardButton';
 

--- a/graylog2-web-interface/src/views/components/widgets/Widget.aggregations.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/Widget.aggregations.test.tsx
@@ -17,14 +17,14 @@
 import React from 'react';
 import * as Immutable from 'immutable';
 import { render, waitFor, fireEvent, screen, within } from 'wrappedTestingLibrary';
-import mockAction from 'helpers/mocking/MockAction';
 import { PluginManifest, PluginStore } from 'graylog-web-plugin/plugin';
-import MockStore from 'helpers/mocking/StoreMock';
 import selectEvent from 'react-select-event';
 import userEvent from '@testing-library/user-event';
 import { applyTimeoutMultiplier } from 'jest-preset-graylog/lib/timeouts';
-import { createSearch } from 'fixtures/searches';
 
+import MockStore from 'helpers/mocking/StoreMock';
+import mockAction from 'helpers/mocking/MockAction';
+import { createSearch } from 'fixtures/searches';
 import SeriesConfig from 'views/logic/aggregationbuilder/SeriesConfig';
 import Series from 'views/logic/aggregationbuilder/Series';
 import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';

--- a/graylog2-web-interface/src/views/components/widgets/Widget.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/Widget.test.tsx
@@ -17,13 +17,13 @@
 import React from 'react';
 import * as Immutable from 'immutable';
 import { render, waitFor, fireEvent, screen } from 'wrappedTestingLibrary';
+import { PluginRegistration, PluginStore } from 'graylog-web-plugin/plugin';
+
 import mockComponent from 'helpers/mocking/MockComponent';
 import mockAction from 'helpers/mocking/MockAction';
-import { PluginRegistration, PluginStore } from 'graylog-web-plugin/plugin';
 import MockStore from 'helpers/mocking/StoreMock';
 import { createSearch } from 'fixtures/searches';
 import asMock from 'helpers/mocking/AsMock';
-
 import WidgetModel from 'views/logic/widgets/Widget';
 import { WidgetActions, Widgets } from 'views/stores/WidgetStore';
 import { TitlesActions, TitleTypes } from 'views/stores/TitlesStore';

--- a/graylog2-web-interface/src/views/components/widgets/Widget.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/Widget.tsx
@@ -19,8 +19,8 @@ import { useCallback, useContext, useMemo, useState } from 'react';
 import * as Immutable from 'immutable';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { BackendWidgetPosition, WidgetResults } from 'views/types';
 
+import { BackendWidgetPosition, WidgetResults } from 'views/types';
 import { useStore } from 'stores/connect';
 import { widgetDefinition } from 'views/logic/Widgets';
 import { WidgetActions, Widgets } from 'views/stores/WidgetStore';

--- a/graylog2-web-interface/src/views/components/widgets/WidgetActionsMenu.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/WidgetActionsMenu.test.tsx
@@ -18,10 +18,10 @@ import React from 'react';
 import * as Immutable from 'immutable';
 import { render, waitFor, fireEvent, screen } from 'wrappedTestingLibrary';
 import { Map } from 'immutable';
+
 import mockAction from 'helpers/mocking/MockAction';
 import asMock from 'helpers/mocking/AsMock';
 import { MockStore } from 'helpers/mocking';
-
 import { WidgetActions } from 'views/stores/WidgetStore';
 import { TitlesActions, TitleTypes } from 'views/stores/TitlesStore';
 import WidgetPosition from 'views/logic/widgets/WidgetPosition';

--- a/graylog2-web-interface/src/views/components/widgets/WidgetActionsMenu.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/WidgetActionsMenu.tsx
@@ -17,8 +17,8 @@
 import * as React from 'react';
 import { useState, useContext, useCallback } from 'react';
 import styled from 'styled-components';
-import { BackendWidgetPosition } from 'views/types';
 
+import { BackendWidgetPosition } from 'views/types';
 import ExportModal from 'views/components/export/ExportModal';
 import MoveWidgetToTab from 'views/logic/views/MoveWidgetToTab';
 import { loadDashboard } from 'views/logic/views/Actions';

--- a/graylog2-web-interface/src/views/components/widgets/WidgetErrorBoundary.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/WidgetErrorBoundary.test.tsx
@@ -16,6 +16,7 @@
  */
 import * as React from 'react';
 import { render } from 'wrappedTestingLibrary';
+
 import asMock from 'helpers/mocking/AsMock';
 
 import WidgetErrorBoundary from './WidgetErrorBoundary';

--- a/graylog2-web-interface/src/views/hooks/RequirementsProvided.test.tsx
+++ b/graylog2-web-interface/src/views/hooks/RequirementsProvided.test.tsx
@@ -17,8 +17,8 @@
 import * as React from 'react';
 import { mount } from 'wrappedEnzyme';
 import { PluginStore } from 'graylog-web-plugin/plugin';
-import asMock from 'helpers/mocking/AsMock';
 
+import asMock from 'helpers/mocking/AsMock';
 import type { PluginMetadata } from 'views/logic/views/View';
 import View from 'views/logic/views/View';
 

--- a/graylog2-web-interface/src/views/hooks/SyncWithQueryParameters.test.tsx
+++ b/graylog2-web-interface/src/views/hooks/SyncWithQueryParameters.test.tsx
@@ -17,9 +17,9 @@
 import * as React from 'react';
 import { render } from 'wrappedTestingLibrary';
 import * as Immutable from 'immutable';
+
 import asMock from 'helpers/mocking/AsMock';
 import mockAction from 'helpers/mocking/MockAction';
-
 import history from 'util/History';
 import { ViewStore, ViewStoreState } from 'views/stores/ViewStore';
 import View from 'views/logic/views/View';

--- a/graylog2-web-interface/src/views/logic/ActionContext.tsx
+++ b/graylog2-web-interface/src/views/logic/ActionContext.tsx
@@ -15,8 +15,8 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import type { ActionContexts } from 'views/types';
 
+import type { ActionContexts } from 'views/types';
 import { singleton } from 'logic/singleton';
 
 const ActionContext = singleton('contexts.ActionContext', () => React.createContext<ActionContexts>({} as ActionContexts));

--- a/graylog2-web-interface/src/views/logic/NewQueryActionHandler.test.ts
+++ b/graylog2-web-interface/src/views/logic/NewQueryActionHandler.test.ts
@@ -15,7 +15,6 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import asMock from 'helpers/mocking/AsMock';
-
 import { QueriesActions } from 'views/stores/QueriesStore';
 import { ViewStore, ViewStoreState } from 'views/stores/ViewStore';
 

--- a/graylog2-web-interface/src/views/logic/QueryResult.ts
+++ b/graylog2-web-interface/src/views/logic/QueryResult.ts
@@ -15,8 +15,8 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import { mapValues } from 'lodash';
-import { MessageResult, SearchTypeResults } from 'views/types';
 
+import { MessageResult, SearchTypeResults } from 'views/types';
 import searchTypeDefinition from 'views/logic/SearchType';
 import { TimeRange } from 'views/logic/queries/Query';
 

--- a/graylog2-web-interface/src/views/logic/Widgets.test.ts
+++ b/graylog2-web-interface/src/views/logic/Widgets.test.ts
@@ -15,8 +15,8 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import { PluginStore } from 'graylog-web-plugin/plugin';
-import asMock from 'helpers/mocking/AsMock';
 
+import asMock from 'helpers/mocking/AsMock';
 import { createWidget } from 'views/logic/WidgetTestHelpers';
 
 import { widgetDefinition } from './Widgets';

--- a/graylog2-web-interface/src/views/logic/fieldactions/AddToAllTablesActionHandler.test.ts
+++ b/graylog2-web-interface/src/views/logic/fieldactions/AddToAllTablesActionHandler.test.ts
@@ -15,8 +15,8 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import { Map } from 'immutable';
-import mockAction from 'helpers/mocking/MockAction';
 
+import mockAction from 'helpers/mocking/MockAction';
 import Widget from 'views/logic/widgets/Widget';
 import AddToAllTablesActionHandler from 'views/logic/fieldactions/AddToAllTablesActionHandler';
 import { FieldTypes } from 'views/logic/fieldtypes/FieldType';

--- a/graylog2-web-interface/src/views/logic/fieldactions/AggregateActionHandler.test.tsx
+++ b/graylog2-web-interface/src/views/logic/fieldactions/AggregateActionHandler.test.tsx
@@ -16,7 +16,6 @@
  */
 import asMock from 'helpers/mocking/AsMock';
 import mockAction from 'helpers/mocking/MockAction';
-
 import { WidgetActions } from 'views/stores/WidgetStore';
 
 import AggregateActionHandler from './AggregateActionHandler';

--- a/graylog2-web-interface/src/views/logic/fieldactions/ChartActionHandler.test.ts
+++ b/graylog2-web-interface/src/views/logic/fieldactions/ChartActionHandler.test.ts
@@ -15,8 +15,8 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as Immutable from 'immutable';
-import asMock from 'helpers/mocking/AsMock';
 
+import asMock from 'helpers/mocking/AsMock';
 import Widget from 'views/logic/widgets/Widget';
 import { WidgetActions } from 'views/stores/WidgetStore';
 import { FieldTypesStore } from 'views/stores/FieldTypesStore';

--- a/graylog2-web-interface/src/views/logic/fieldactions/FieldActionHandler.ts
+++ b/graylog2-web-interface/src/views/logic/fieldactions/FieldActionHandler.ts
@@ -15,7 +15,6 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import { ActionContexts } from 'views/types';
-
 import type {
   ActionHandler,
   ActionHandlerArguments,

--- a/graylog2-web-interface/src/views/logic/fieldactions/FieldStatisticsHandler.test.ts
+++ b/graylog2-web-interface/src/views/logic/fieldactions/FieldStatisticsHandler.test.ts
@@ -15,7 +15,6 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import asMock from 'helpers/mocking/AsMock';
-
 import { WidgetActions } from 'views/stores/WidgetStore';
 import Widget from 'views/logic/widgets/Widget';
 import { TitlesActions, TitleTypes } from 'views/stores/TitlesStore';

--- a/graylog2-web-interface/src/views/logic/fieldactions/RemoveFromAllTablesActionHandler.test.ts
+++ b/graylog2-web-interface/src/views/logic/fieldactions/RemoveFromAllTablesActionHandler.test.ts
@@ -15,8 +15,8 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import { Map } from 'immutable';
-import mockAction from 'helpers/mocking/MockAction';
 
+import mockAction from 'helpers/mocking/MockAction';
 import Widget from 'views/logic/widgets/Widget';
 import RemoveFromAllTablesActionHandler from 'views/logic/fieldactions/RemoveFromAllTablesActionHandler';
 import { FieldTypes } from 'views/logic/fieldtypes/FieldType';

--- a/graylog2-web-interface/src/views/logic/searchtypes/SearchTypesGenerator.test.ts
+++ b/graylog2-web-interface/src/views/logic/searchtypes/SearchTypesGenerator.test.ts
@@ -15,8 +15,8 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as Immutable from 'immutable';
-import asMock from 'helpers/mocking/AsMock';
 
+import asMock from 'helpers/mocking/AsMock';
 import { createWidget } from 'views/logic/WidgetTestHelpers';
 
 import SearchTypesGenerator from './SearchTypesGenerator';

--- a/graylog2-web-interface/src/views/logic/valueactions/AddToQueryHandler.test.ts
+++ b/graylog2-web-interface/src/views/logic/valueactions/AddToQueryHandler.test.ts
@@ -15,9 +15,9 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as Immutable from 'immutable';
+
 import mockAction from 'helpers/mocking/MockAction';
 import asMock from 'helpers/mocking/AsMock';
-
 import { QueriesActions, QueriesStore } from 'views/stores/QueriesStore';
 import { ViewStore } from 'views/stores/ViewStore';
 import FieldType from 'views/logic/fieldtypes/FieldType';

--- a/graylog2-web-interface/src/views/logic/valueactions/ExcludeFromQueryHandler.test.ts
+++ b/graylog2-web-interface/src/views/logic/valueactions/ExcludeFromQueryHandler.test.ts
@@ -15,9 +15,9 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as Immutable from 'immutable';
+
 import asMock from 'helpers/mocking/AsMock';
 import mockAction from 'helpers/mocking/MockAction';
-
 import { GlobalOverrideActions, GlobalOverrideStore, GlobalOverrideStoreState } from 'views/stores/GlobalOverrideStore';
 import { QueriesActions, QueriesStore } from 'views/stores/QueriesStore';
 import SearchActions from 'views/actions/SearchActions';

--- a/graylog2-web-interface/src/views/logic/valueactions/ShowDocumentsHandler.test.ts
+++ b/graylog2-web-interface/src/views/logic/valueactions/ShowDocumentsHandler.test.ts
@@ -15,7 +15,6 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import asMock from 'helpers/mocking/AsMock';
-
 import FieldType from 'views/logic/fieldtypes/FieldType';
 import { TitlesActions } from 'views/stores/TitlesStore';
 import TitleTypes from 'views/stores/TitleTypes';

--- a/graylog2-web-interface/src/views/logic/valueactions/ValueActionHandler.ts
+++ b/graylog2-web-interface/src/views/logic/valueactions/ValueActionHandler.ts
@@ -15,7 +15,6 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import { ActionContexts } from 'views/types';
-
 import type { ActionHandler, ActionConditions } from 'views/components/actions/ActionHandler';
 
 export type ValuePath = Array<{ [key: string]: any }>;

--- a/graylog2-web-interface/src/views/logic/views/OnSaveAsViewAction.test.ts
+++ b/graylog2-web-interface/src/views/logic/views/OnSaveAsViewAction.test.ts
@@ -15,7 +15,6 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import asMock from 'helpers/mocking/AsMock';
-
 import { ViewActions } from 'views/stores/ViewStore';
 import { ViewManagementActions } from 'views/stores/ViewManagementStore';
 import UserNotification from 'util/UserNotification';

--- a/graylog2-web-interface/src/views/logic/views/ViewLoader.test.ts
+++ b/graylog2-web-interface/src/views/logic/views/ViewLoader.test.ts
@@ -15,8 +15,8 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as Immutable from 'immutable';
-import mockAction from 'helpers/mocking/MockAction';
 
+import mockAction from 'helpers/mocking/MockAction';
 import { ViewManagementActions } from 'views/stores/ViewManagementStore';
 import { SearchActions } from 'views/stores/SearchStore';
 import { ViewActions } from 'views/stores/ViewStore';

--- a/graylog2-web-interface/src/views/pages/NewDashboardPage.test.tsx
+++ b/graylog2-web-interface/src/views/pages/NewDashboardPage.test.tsx
@@ -16,9 +16,9 @@
  */
 import * as React from 'react';
 import { render, waitFor } from 'wrappedTestingLibrary';
-import asMock from 'helpers/mocking/AsMock';
 import { act } from 'react-dom/test-utils';
 
+import asMock from 'helpers/mocking/AsMock';
 import { processHooks } from 'views/logic/views/ViewLoader';
 import { ViewActions } from 'views/stores/ViewStore';
 import Search from 'views/logic/search/Search';

--- a/graylog2-web-interface/src/views/pages/NewSearchPage.test.tsx
+++ b/graylog2-web-interface/src/views/pages/NewSearchPage.test.tsx
@@ -17,9 +17,9 @@
 import * as React from 'react';
 import { act } from 'react-dom/test-utils';
 import { render, waitFor, fireEvent } from 'wrappedTestingLibrary';
+
 import asMock from 'helpers/mocking/AsMock';
 import { MockStore } from 'helpers/mocking';
-
 import { processHooks } from 'views/logic/views/ViewLoader';
 import { ViewActions } from 'views/stores/ViewStore';
 import NewViewLoaderContext from 'views/logic/NewViewLoaderContext';

--- a/graylog2-web-interface/src/views/pages/ShowDashboardInBigDisplayMode.test.tsx
+++ b/graylog2-web-interface/src/views/pages/ShowDashboardInBigDisplayMode.test.tsx
@@ -16,8 +16,8 @@
  */
 import * as React from 'react';
 import { render, waitFor } from 'wrappedTestingLibrary';
-import { StoreMock as MockStore } from 'helpers/mocking';
 
+import { StoreMock as MockStore } from 'helpers/mocking';
 import { RefreshActions } from 'views/stores/RefreshStore';
 import View from 'views/logic/views/View';
 import _ShowDashboardInBigDisplayMode from 'views/pages/ShowDashboardInBigDisplayMode';

--- a/graylog2-web-interface/src/views/pages/ShowViewPage.test.tsx
+++ b/graylog2-web-interface/src/views/pages/ShowViewPage.test.tsx
@@ -17,9 +17,9 @@
 import * as React from 'react';
 import { List } from 'immutable';
 import { render, screen, waitFor } from 'wrappedTestingLibrary';
+
 import mockAction from 'helpers/mocking/MockAction';
 import asMock from 'helpers/mocking/AsMock';
-
 import StreamsContext from 'contexts/StreamsContext';
 import { NotFoundErrorType } from 'logic/errors/ReportedErrors';
 import { ViewManagementActions } from 'views/stores/ViewManagementStore';

--- a/graylog2-web-interface/src/views/pages/StreamSearchPage.test.tsx
+++ b/graylog2-web-interface/src/views/pages/StreamSearchPage.test.tsx
@@ -17,9 +17,9 @@
 import * as React from 'react';
 import { render, waitFor, fireEvent } from 'wrappedTestingLibrary';
 import { act } from 'react-dom/test-utils';
+
 import asMock from 'helpers/mocking/AsMock';
 import { MockStore } from 'helpers/mocking';
-
 import StreamsContext from 'contexts/StreamsContext';
 import { processHooks } from 'views/logic/views/ViewLoader';
 import { ViewActions } from 'views/stores/ViewStore';

--- a/graylog2-web-interface/src/views/pages/ViewManagementPage.test.tsx
+++ b/graylog2-web-interface/src/views/pages/ViewManagementPage.test.tsx
@@ -16,6 +16,7 @@
  */
 import React from 'react';
 import { mount, shallow } from 'wrappedEnzyme';
+
 import { StoreMock } from 'helpers/mocking';
 import mockComponent from 'helpers/mocking/MockComponent';
 

--- a/graylog2-web-interface/src/views/spec/CreateNewDashboard.it.tsx
+++ b/graylog2-web-interface/src/views/spec/CreateNewDashboard.it.tsx
@@ -17,10 +17,10 @@
 import * as React from 'react';
 import { render, fireEvent } from 'wrappedTestingLibrary';
 import { PluginManifest, PluginStore } from 'graylog-web-plugin/plugin';
-import { asMock, StoreMock as MockStore } from 'helpers/mocking';
 import { applyTimeoutMultiplier } from 'jest-preset-graylog/lib/timeouts';
-import mockAction from 'helpers/mocking/MockAction';
 
+import { asMock, StoreMock as MockStore } from 'helpers/mocking';
+import mockAction from 'helpers/mocking/MockAction';
 import history from 'util/History';
 import Routes from 'routing/Routes';
 import AppRouter from 'routing/AppRouter';

--- a/graylog2-web-interface/src/views/stores/CurrentViewStateStore.test.ts
+++ b/graylog2-web-interface/src/views/stores/CurrentViewStateStore.test.ts
@@ -16,9 +16,9 @@
  */
 import * as Immutable from 'immutable';
 import { PluginExports, PluginStore } from 'graylog-web-plugin/plugin';
+
 import mockAction from 'helpers/mocking/MockAction';
 import { WidgetExport } from 'views/types';
-
 import MessagesWidget from 'views/logic/widgets/MessagesWidget';
 import WidgetPosition from 'views/logic/widgets/WidgetPosition';
 import ViewState from 'views/logic/views/ViewState';

--- a/graylog2-web-interface/src/views/stores/QueriesStore.test.tsx
+++ b/graylog2-web-interface/src/views/stores/QueriesStore.test.tsx
@@ -16,8 +16,8 @@
  */
 import moment from 'moment';
 import * as Immutable from 'immutable';
-import asMock from 'helpers/mocking/AsMock';
 
+import asMock from 'helpers/mocking/AsMock';
 import View from 'views/logic/views/View';
 
 import { QueriesActions, QueriesStore } from './QueriesStore';

--- a/graylog2-web-interface/src/views/stores/QueryIdsStore.test.ts
+++ b/graylog2-web-interface/src/views/stores/QueryIdsStore.test.ts
@@ -15,8 +15,8 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as Immutable from 'immutable';
-import { asMock, MockStore } from 'helpers/mocking';
 
+import { asMock, MockStore } from 'helpers/mocking';
 import { ViewStore } from 'views/stores/ViewStore';
 import Query from 'views/logic/queries/Query';
 import Search from 'views/logic/search/Search';

--- a/graylog2-web-interface/src/views/stores/SearchStore.test.ts
+++ b/graylog2-web-interface/src/views/stores/SearchStore.test.ts
@@ -16,7 +16,6 @@
  */
 import asMock from 'helpers/mocking/AsMock';
 import { MockStore } from 'helpers/mocking';
-
 import fetch from 'logic/rest/FetchProvider';
 import Search from 'views/logic/search/Search';
 

--- a/graylog2-web-interface/src/views/stores/ViewManagementStore.test.ts
+++ b/graylog2-web-interface/src/views/stores/ViewManagementStore.test.ts
@@ -15,7 +15,6 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import { MockStore } from 'helpers/mocking';
-
 import View from 'views/logic/views/View';
 import Search from 'views/logic/search/Search';
 import { CurrentUserStore } from 'stores/users/CurrentUserStore';

--- a/graylog2-web-interface/src/views/stores/ViewStore.test.ts
+++ b/graylog2-web-interface/src/views/stores/ViewStore.test.ts
@@ -15,9 +15,9 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as Immutable from 'immutable';
+
 import mockAction from 'helpers/mocking/MockAction';
 import { MockStore } from 'helpers/mocking';
-
 import ViewState from 'views/logic/views/ViewState';
 import SearchActions from 'views/actions/SearchActions';
 import Search from 'views/logic/search/Search';


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Prior to this change, due to an update of `eslint-plugin-import`, import orders were determined differently in plugins. Dependencies pulled in from core were identified as external dependencies and grouped with modules like `react`.
    
This change is now adding a specifier that allows to define imports explicitly as being internal and includes all commonly imported prefixes from core.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.