### PR TITLE
Add guard checks to event bus subscriptions in index field type poller

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/IndexFieldTypePollerPeriodical.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/IndexFieldTypePollerPeriodical.java
@@ -20,6 +20,8 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
 import com.google.common.primitives.Ints;
+import org.graylog2.cluster.NodeNotFoundException;
+import org.graylog2.cluster.NodeService;
 import org.graylog2.indexer.IndexSet;
 import org.graylog2.indexer.MongoIndexSet;
 import org.graylog2.indexer.cluster.Cluster;
@@ -33,6 +35,7 @@ import org.graylog2.indexer.indices.events.IndicesDeletedEvent;
 import org.graylog2.plugin.ServerStatus;
 import org.graylog2.plugin.lifecycles.Lifecycle;
 import org.graylog2.plugin.periodical.Periodical;
+import org.graylog2.plugin.system.NodeId;
 import org.joda.time.Duration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -62,6 +65,8 @@ public class IndexFieldTypePollerPeriodical extends Periodical {
     private final MongoIndexSet.Factory mongoIndexSetFactory;
     private final Cluster cluster;
     private final ServerStatus serverStatus;
+    private final NodeService nodeService;
+    private final NodeId nodeId;
     private final com.github.joschi.jadconfig.util.Duration periodicalInterval;
     private final ScheduledExecutorService scheduler;
     private final ConcurrentMap<String, ScheduledFuture<?>> futures = new ConcurrentHashMap<>();
@@ -76,6 +81,8 @@ public class IndexFieldTypePollerPeriodical extends Periodical {
                                           final Cluster cluster,
                                           final EventBus eventBus,
                                           final ServerStatus serverStatus,
+                                          final NodeService nodeService,
+                                          final NodeId nodeId,
                                           @Named("index_field_type_periodical_interval") final com.github.joschi.jadconfig.util.Duration periodicalInterval,
                                           @Named("daemonScheduler") final ScheduledExecutorService scheduler) {
         this.poller = poller;
@@ -85,6 +92,8 @@ public class IndexFieldTypePollerPeriodical extends Periodical {
         this.mongoIndexSetFactory = mongoIndexSetFactory;
         this.cluster = cluster;
         this.serverStatus = serverStatus;
+        this.nodeService = nodeService;
+        this.nodeId = nodeId;
         this.periodicalInterval = periodicalInterval;
         this.scheduler = scheduler;
 
@@ -143,12 +152,27 @@ public class IndexFieldTypePollerPeriodical extends Periodical {
         return skippedLifecycles.contains(currentLifecycle);
     }
 
+    private boolean isNotLeader() {
+        try {
+            return !nodeService.byNodeId(nodeId).isMaster();
+        } catch (NodeNotFoundException e) {
+            LOG.warn("Couldn't find node for ID <{}>", nodeId);
+            return true;
+        }
+    }
+
     /**
      * Creates a new field type polling job for the newly created index set.
+     *
      * @param event index set creation event
      */
+    @SuppressWarnings("unused")
     @Subscribe
     public void handleIndexSetCreation(final IndexSetCreatedEvent event) {
+        if (isNotLeader()) {
+            LOG.debug("Skipping index set creation event on non-leader node. [event={}]", event);
+            return;
+        }
         final String indexSetId = event.indexSet().id();
         // We are NOT using IndexSetRegistry#get(String) here because of this: https://github.com/Graylog2/graylog2-server/issues/4625
         final Optional<IndexSetConfig> optionalIndexSet = indexSetService.get(indexSetId);
@@ -164,8 +188,13 @@ public class IndexFieldTypePollerPeriodical extends Periodical {
      * Removes the field type polling job for the now deleted index set.
      * @param event index set deletion event
      */
+    @SuppressWarnings("unused")
     @Subscribe
     public void handleIndexSetDeletion(final IndexSetDeletedEvent event) {
+        if (isNotLeader()) {
+            LOG.debug("Skipping index set deletion event on non-leader node. [event={}]", event);
+            return;
+        }
         final String indexSetId = event.id();
 
         LOG.debug("Disable field type updating for index set <{}>", indexSetId);
@@ -176,8 +205,11 @@ public class IndexFieldTypePollerPeriodical extends Periodical {
      * Removes the index field type data for the deleted index.
      * @param event index deletion event
      */
+    @SuppressWarnings("unused")
     @Subscribe
     public void handleIndexDeletion(final IndicesDeletedEvent event) {
+        // This is not a cluster event and should be allowed to be executed on non-leader nodes to ensure
+        // a timely cleanup
         event.indices().forEach(indexName -> {
             LOG.debug("Removing field type information for deleted index <{}>", indexName);
             dbService.delete(indexName);
@@ -186,6 +218,7 @@ public class IndexFieldTypePollerPeriodical extends Periodical {
 
     /**
      * Creates a new polling job for the given index set to keep the active write index information up to date.
+     *
      * @param indexSet index set
      */
     private void schedule(final IndexSet indexSet) {

--- a/graylog2-server/src/test/java/org/graylog2/indexer/fieldtypes/IndexFieldTypePollerPeriodicalTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/fieldtypes/IndexFieldTypePollerPeriodicalTest.java
@@ -19,6 +19,8 @@ package org.graylog2.indexer.fieldtypes;
 import com.github.joschi.jadconfig.util.Duration;
 import com.google.common.eventbus.EventBus;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import org.graylog2.cluster.Node;
+import org.graylog2.cluster.NodeService;
 import org.graylog2.indexer.MongoIndexSet;
 import org.graylog2.indexer.cluster.Cluster;
 import org.graylog2.indexer.indexset.IndexSetConfig;
@@ -27,6 +29,7 @@ import org.graylog2.indexer.indexset.events.IndexSetCreatedEvent;
 import org.graylog2.indexer.indices.Indices;
 import org.graylog2.plugin.ServerStatus;
 import org.graylog2.plugin.lifecycles.Lifecycle;
+import org.graylog2.plugin.system.NodeId;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -34,6 +37,7 @@ import java.util.Optional;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -49,12 +53,17 @@ class IndexFieldTypePollerPeriodicalTest {
     @SuppressWarnings("UnstableApiUsage")
     private final EventBus eventBus = mock(EventBus.class);
     private final ServerStatus serverStatus = mock(ServerStatus.class);
+    private final NodeService nodeService = mock(NodeService.class);
+    private final NodeId nodeId = mock(NodeId.class);
+    private final Node node = mock(Node.class);
     private final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor(
             new ThreadFactoryBuilder().setNameFormat("index-field-type-poller-periodical-test-%d").build()
     );
 
     @BeforeEach
-    void setUp() {
+    void setUp() throws Exception {
+        when(node.isMaster()).thenReturn(true);
+        when(nodeService.byNodeId(any(NodeId.class))).thenReturn(node);
         this.periodical = new IndexFieldTypePollerPeriodical(indexFieldTypePoller,
                 indexFieldTypesService,
                 indexSetService,
@@ -63,6 +72,8 @@ class IndexFieldTypePollerPeriodicalTest {
                 cluster,
                 eventBus,
                 serverStatus,
+                nodeService,
+                nodeId,
                 Duration.seconds(30),
                 scheduler);
     }


### PR DESCRIPTION
Without this a non-master node would start polling index field types for
newly created index sets. The periodical doesn't get started on
non-master nodes, but due to the implementation of the periodicals
system the class gets instantiated and thus subscribed to the event bus.

Fixes #11504