### PR TITLE
Refactor index field type polling

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -22,3 +22,10 @@ The following API endpoints have been removed in 4.3.
 | Endpoint                                    | Description                 |
 | ------------------------------------------- | --------------------------- |
 | `PUT /example/placeholder`                  | TODO placeholder comment    |
+
+## Configuration File Changes
+
+The following configuration option as been removed: `index_field_type_periodical_interval`.
+
+It has been replaced with a new configuration option which allows users to tweak the default full refresh interval for
+index field type information: `index_field_type_periodical_full_refresh_interval`.

--- a/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchConfiguration.java
@@ -18,6 +18,7 @@ package org.graylog2.configuration;
 
 import com.github.joschi.jadconfig.Parameter;
 import com.github.joschi.jadconfig.util.Duration;
+import com.github.joschi.jadconfig.validators.PositiveDurationValidator;
 import com.github.joschi.jadconfig.validators.PositiveIntegerValidator;
 import com.github.joschi.jadconfig.validators.PositiveLongValidator;
 import com.github.joschi.jadconfig.validators.StringNotBlankValidator;
@@ -92,6 +93,9 @@ public class ElasticsearchConfiguration {
 
     @Parameter(value = "elasticsearch_index_optimization_jobs", validator = PositiveIntegerValidator.class)
     private int indexOptimizationJobs = 20;
+
+    @Parameter(value = "index_field_type_periodical_full_refresh_interval", validators = {PositiveDurationValidator.class})
+    private Duration indexFieldTypePeriodicalFullRefreshInterval = Duration.minutes(5);
 
     @Parameter(value = DEFAULT_EVENTS_INDEX_PREFIX, validators = StringNotBlankValidator.class)
     private String defaultEventsIndexPrefix = "gl-events";

--- a/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchConfiguration.java
@@ -18,7 +18,6 @@ package org.graylog2.configuration;
 
 import com.github.joschi.jadconfig.Parameter;
 import com.github.joschi.jadconfig.util.Duration;
-import com.github.joschi.jadconfig.validators.PositiveDurationValidator;
 import com.github.joschi.jadconfig.validators.PositiveIntegerValidator;
 import com.github.joschi.jadconfig.validators.PositiveLongValidator;
 import com.github.joschi.jadconfig.validators.StringNotBlankValidator;
@@ -93,9 +92,6 @@ public class ElasticsearchConfiguration {
 
     @Parameter(value = "elasticsearch_index_optimization_jobs", validator = PositiveIntegerValidator.class)
     private int indexOptimizationJobs = 20;
-
-    @Parameter(value = "index_field_type_periodical_interval", validator = PositiveDurationValidator.class)
-    private Duration indexFieldTypePeriodicalInterval = Duration.hours(1L);
 
     @Parameter(value = DEFAULT_EVENTS_INDEX_PREFIX, validators = StringNotBlankValidator.class)
     private String defaultEventsIndexPrefix = "gl-events";
@@ -182,10 +178,6 @@ public class ElasticsearchConfiguration {
 
     public int getIndexOptimizationJobs() {
         return indexOptimizationJobs;
-    }
-
-    public Duration getIndexFieldTypePeriodicalInterval() {
-        return indexFieldTypePeriodicalInterval;
     }
 
     public String getDefaultEventsIndexPrefix() {

--- a/graylog2-server/src/test/java/org/graylog2/indexer/fieldtypes/IndexFieldTypePollerPeriodicalTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/fieldtypes/IndexFieldTypePollerPeriodicalTest.java
@@ -70,13 +70,4 @@ class IndexFieldTypePollerPeriodicalTest {
 
         verifyNoInteractions(cluster);
     }
-
-    @Test
-    void initialize() {
-        when(serverStatus.getLifecycle()).thenReturn(Lifecycle.HALTING);
-
-        periodical.doRun();
-
-        verifyNoInteractions(cluster);
-    }
 }

--- a/graylog2-server/src/test/java/org/graylog2/indexer/fieldtypes/IndexFieldTypePollerPeriodicalTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/fieldtypes/IndexFieldTypePollerPeriodicalTest.java
@@ -16,6 +16,7 @@
  */
 package org.graylog2.indexer.fieldtypes;
 
+import com.github.joschi.jadconfig.util.Duration;
 import com.google.common.eventbus.EventBus;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.graylog2.indexer.MongoIndexSet;
@@ -59,6 +60,7 @@ class IndexFieldTypePollerPeriodicalTest {
                 cluster,
                 eventBus,
                 serverStatus,
+                Duration.minutes(5),
                 scheduler);
     }
 

--- a/graylog2-server/src/test/java/org/graylog2/indexer/fieldtypes/IndexFieldTypePollerPeriodicalTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/fieldtypes/IndexFieldTypePollerPeriodicalTest.java
@@ -18,22 +18,18 @@ package org.graylog2.indexer.fieldtypes;
 
 import com.google.common.eventbus.EventBus;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
-import org.graylog2.cluster.Node;
-import org.graylog2.cluster.NodeService;
 import org.graylog2.indexer.MongoIndexSet;
 import org.graylog2.indexer.cluster.Cluster;
 import org.graylog2.indexer.indexset.IndexSetService;
 import org.graylog2.indexer.indices.Indices;
 import org.graylog2.plugin.ServerStatus;
 import org.graylog2.plugin.lifecycles.Lifecycle;
-import org.graylog2.plugin.system.NodeId;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -49,17 +45,12 @@ class IndexFieldTypePollerPeriodicalTest {
     @SuppressWarnings("UnstableApiUsage")
     private final EventBus eventBus = mock(EventBus.class);
     private final ServerStatus serverStatus = mock(ServerStatus.class);
-    private final NodeService nodeService = mock(NodeService.class);
-    private final NodeId nodeId = mock(NodeId.class);
-    private final Node node = mock(Node.class);
     private final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor(
             new ThreadFactoryBuilder().setNameFormat("index-field-type-poller-periodical-test-%d").build()
     );
 
     @BeforeEach
     void setUp() throws Exception {
-        when(node.isMaster()).thenReturn(true);
-        when(nodeService.byNodeId(any(NodeId.class))).thenReturn(node);
         this.periodical = new IndexFieldTypePollerPeriodical(indexFieldTypePoller,
                 indexFieldTypesService,
                 indexSetService,
@@ -68,8 +59,6 @@ class IndexFieldTypePollerPeriodicalTest {
                 cluster,
                 eventBus,
                 serverStatus,
-                nodeService,
-                nodeId,
                 scheduler);
     }
 

--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -414,10 +414,10 @@ elasticsearch_analyzer = standard
 # Default: 1h
 #index_ranges_cleanup_interval = 1h
 
-# Time interval for the job that runs index field type maintenance tasks like cleaning up stale entries. This doesn't
-# need to run very often.
-# Default: 1h
-#index_field_type_periodical_interval = 1h
+# Time interval to trigger a full refresh of the index field types for all indexes. This will query ES for all indexes
+# and populate any missing field type information to the database.
+# Default: 5m
+#index_field_type_periodical_full_refresh_interval = 5m
 
 # Batch size for the Elasticsearch output. This is the maximum (!) number of messages the Elasticsearch output
 # module will get at once and write to Elasticsearch in a batch call. If the configured batch size has not been


### PR DESCRIPTION
Refactoring of the index field type poller periodical.

The goal is that we can stop running the periodical on one node and start it on another node. In the previous version, the periodical was starting and maintaining separate scheduled threads, which would keep running, even if we would stop executing the periodical.

After the refactoring, the periodical only maintains the previous execution of each individual poll to determine if an index set needs polling at any given time. If we stop running the periodical, no polling will happen until we start running it again.

As suggested by @bernd 

