### PR TITLE
Avoid creating compound type for identical physical types but diff. properties (backport to 4.1)

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/MappedFieldTypesService.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/MappedFieldTypesService.java
@@ -86,7 +86,7 @@ public class MappedFieldTypesService {
                             .map(mappedFieldTypeDTO -> mappedFieldTypeDTO.type().type())
                             .sorted()
                             .collect(Collectors.toCollection(LinkedHashSet::new));
-                    final String compoundFieldType = distinctTypes.size() > 1
+                    final String resultingFieldType = distinctTypes.size() > 1
                             ? distinctTypes.stream().collect(Collectors.joining(",", "compound(", ")"))
                             : distinctTypes.stream().findFirst().orElse("unknown");
                     final Set<String> commonProperties = fieldTypes.stream()
@@ -97,7 +97,7 @@ public class MappedFieldTypesService {
                     final Set<String> properties = distinctTypes.size() > 1
                             ? Sets.union(commonProperties, Collections.singleton(PROP_COMPOUND_TYPE))
                             : commonProperties;
-                    return MappedFieldTypeDTO.create(fieldName, createType(compoundFieldType, properties));
+                    return MappedFieldTypeDTO.create(fieldName, createType(resultingFieldType, properties));
 
                 })
                 .collect(Collectors.toSet());

--- a/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/MappedFieldTypesService.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/MappedFieldTypesService.java
@@ -25,6 +25,7 @@ import org.graylog2.streams.StreamService;
 
 import javax.inject.Inject;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -88,12 +89,14 @@ public class MappedFieldTypesService {
                     final String compoundFieldType = distinctTypes.size() > 1
                             ? distinctTypes.stream().collect(Collectors.joining(",", "compound(", ")"))
                             : distinctTypes.stream().findFirst().orElse("unknown");
-                    final ImmutableSet<String> commonProperties = fieldTypes.stream()
+                    final Set<String> commonProperties = fieldTypes.stream()
                             .map(mappedFieldTypeDTO -> mappedFieldTypeDTO.type().properties())
                             .reduce((s1, s2) -> Sets.intersection(s1, s2).immutableCopy())
                             .orElse(ImmutableSet.of());
 
-                    final ImmutableSet<String> properties = ImmutableSet.<String>builder().addAll(commonProperties).add(PROP_COMPOUND_TYPE).build();
+                    final Set<String> properties = distinctTypes.size() > 1
+                            ? Sets.union(commonProperties, Collections.singleton(PROP_COMPOUND_TYPE))
+                            : commonProperties;
                     return MappedFieldTypeDTO.create(fieldName, createType(compoundFieldType, properties));
 
                 })

--- a/graylog2-server/src/test/java/org/graylog2/indexer/fieldtypes/MappedFieldTypesServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/fieldtypes/MappedFieldTypesServiceTest.java
@@ -76,14 +76,12 @@ public class MappedFieldTypesServiceTest {
                 createIndexTypes(
                         "deadbeef",
                         "testIndex",
-                        FieldTypeDTO.create("field1", "keyword"),
-                        FieldTypeDTO.create("field2", "long")
+                        FieldTypeDTO.create("field1", "keyword")
                 ),
                 createIndexTypes(
                         "affeaffe",
                         "testIndex2",
-                        FieldTypeDTO.create("field1", "text"),
-                        FieldTypeDTO.create("field2", "long")
+                        FieldTypeDTO.create("field1", "text")
                 )
         );
         when(indexFieldTypesService.findForIndexSets(Collections.singleton("indexSetId"))).thenReturn(fieldTypes);
@@ -91,8 +89,7 @@ public class MappedFieldTypesServiceTest {
 
         final Set<MappedFieldTypeDTO> result = this.mappedFieldTypesService.fieldTypesByStreamIds(Collections.singleton("stream1"), RelativeRange.allTime());
         assertThat(result).containsExactlyInAnyOrder(
-                MappedFieldTypeDTO.create("field2", FieldTypes.Type.createType("long", ImmutableSet.of("numeric", "enumerable"))),
-                MappedFieldTypeDTO.create("field1", FieldTypes.Type.createType("string", ImmutableSet.of("compound")))
+                MappedFieldTypeDTO.create("field1", FieldTypes.Type.createType("string", ImmutableSet.of()))
         );
     }
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

**Note:** backport of #11535 

Prior to this change, a physical field type of `keyword` and a physical type of `text` were being merged into a logical field type of `string` with a `compound` property. This is not correct, as it is not really a compound type. All we need to do in this case is create the set of shared properties for identical logical types.

This is fixing an issue where a user cannot aggregate on a field which is a `keyword` in one index and a `text` field in another.


<!--- Provide a general summary of your changes in the Title above -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.