### PR TITLE
Adhere to data_dir setting for netty libnative

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/bootstrap/CmdLineTool.java
+++ b/graylog2-server/src/main/java/org/graylog2/bootstrap/CmdLineTool.java
@@ -54,6 +54,7 @@ import org.apache.logging.log4j.core.LoggerContext;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.graylog2.Configuration;
 import org.graylog2.bootstrap.commands.MigrateCmd;
+import org.graylog2.configuration.PathConfiguration;
 import org.graylog2.configuration.TLSProtocolsConfiguration;
 import org.graylog2.featureflag.FeatureFlags;
 import org.graylog2.featureflag.FeatureFlagsFactory;
@@ -188,11 +189,16 @@ public abstract class CmdLineTool implements CliCommand {
 
     /**
      * Things that have to run before the {@link #startCommand()} method is being called.
+     * Please note that this happens *before* the configuration file has been parsed.
      */
     protected void beforeStart() {
     }
 
-    protected void beforeStart(TLSProtocolsConfiguration configuration) {
+    /**
+     * Things that have to run before the {@link #startCommand()} method is being called.
+     * Please note that this happens *before* the configuration file has been parsed.
+     */
+    protected void beforeStart(TLSProtocolsConfiguration configuration, PathConfiguration pathConfiguration) {
     }
 
     protected static void applySecuritySettings(TLSProtocolsConfiguration configuration) {
@@ -250,7 +256,7 @@ public abstract class CmdLineTool implements CliCommand {
         installCommandConfig();
 
         beforeStart();
-        beforeStart(parseAndGetTLSConfiguration());
+        beforeStart(parseAndGetTLSConfiguration(), parseAndGetPathConfiguration(configFile));
 
         processConfiguration(jadConfig);
 
@@ -304,6 +310,12 @@ public abstract class CmdLineTool implements CliCommand {
         processConfiguration(jadConfig);
 
         return tlsConfiguration;
+    }
+
+    private PathConfiguration parseAndGetPathConfiguration(String configFile) {
+        final PathConfiguration pathConfiguration = new PathConfiguration();
+        processConfiguration(new JadConfig(getConfigRepositories(configFile), pathConfiguration));
+        return pathConfiguration;
     }
 
     private void installCommandConfig() {

--- a/graylog2-server/src/main/java/org/graylog2/bootstrap/ServerBootstrap.java
+++ b/graylog2-server/src/main/java/org/graylog2/bootstrap/ServerBootstrap.java
@@ -29,6 +29,7 @@ import com.google.inject.util.Types;
 import org.graylog2.Configuration;
 import org.graylog2.audit.AuditActor;
 import org.graylog2.audit.AuditEventSender;
+import org.graylog2.configuration.PathConfiguration;
 import org.graylog2.configuration.TLSProtocolsConfiguration;
 import org.graylog2.migrations.Migration;
 import org.graylog2.plugin.ServerStatus;
@@ -91,8 +92,8 @@ public abstract class ServerBootstrap extends CmdLineTool {
     }
 
     @Override
-    protected void beforeStart(TLSProtocolsConfiguration configuration) {
-        super.beforeStart(configuration);
+    protected void beforeStart(TLSProtocolsConfiguration tlsProtocolsConfiguration, PathConfiguration pathConfiguration) {
+        super.beforeStart(tlsProtocolsConfiguration, pathConfiguration);
 
         // Do not use a PID file if the user requested not to
         if (!isNoPidFile()) {
@@ -100,16 +101,16 @@ public abstract class ServerBootstrap extends CmdLineTool {
         }
         // This needs to run before the first SSLContext is instantiated,
         // because it sets up the default SSLAlgorithmConstraints
-        applySecuritySettings(configuration);
+        applySecuritySettings(tlsProtocolsConfiguration);
 
         // Set these early in the startup because netty's NativeLibraryUtil uses a static initializer
-        setNettyNativeDefaults();
+        setNettyNativeDefaults(pathConfiguration);
     }
 
-    private void setNettyNativeDefaults() {
+    private void setNettyNativeDefaults(PathConfiguration pathConfiguration) {
         // Give netty a better spot than /tmp to unpack its tcnative libraries
         if (System.getProperty("io.netty.native.workdir") == null) {
-            System.setProperty("io.netty.native.workdir", configuration.getNativeLibDir().toAbsolutePath().toString());
+            System.setProperty("io.netty.native.workdir", pathConfiguration.getNativeLibDir().toAbsolutePath().toString());
         }
         // Don't delete the native lib after unpacking, as this confuses needrestart(1) on some distributions
         if (System.getProperty("io.netty.native.deleteLibAfterLoading") == null) {

--- a/graylog2-server/src/main/java/org/graylog2/bootstrap/commands/MigrateCmd.java
+++ b/graylog2-server/src/main/java/org/graylog2/bootstrap/commands/MigrateCmd.java
@@ -19,7 +19,6 @@ package org.graylog2.bootstrap.commands;
 import com.github.rvesse.airline.annotations.Command;
 import org.graylog2.Configuration;
 import org.graylog2.commands.Server;
-import org.graylog2.configuration.TLSProtocolsConfiguration;
 import org.graylog2.plugin.Tools;
 import org.graylog2.plugin.Version;
 import org.jsoftbiz.utils.OS;
@@ -37,10 +36,6 @@ public class MigrateCmd extends Server {
 
     public MigrateCmd() {
         super(MIGRATION_COMMAND);
-    }
-
-    @Override
-    protected void beforeStart(TLSProtocolsConfiguration configuration) {
     }
 
     @Override


### PR DESCRIPTION
The `io.netty.native.workdir` property always points to `data/libnative`
because the configuration hasn't been parsed at that stage.

Explicitly parse a PathConfiguration bean and pass it into the
beforeStart() method.

Fixes #11543

