### PR TITLE
Add "this {year | month | week}" to NaturalDateParser to align year/month/week correctly

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/plugin/utilities/date/NaturalDateParser.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/utilities/date/NaturalDateParser.java
@@ -67,11 +67,11 @@ public class NaturalDateParser {
     }
 
     Date alignToStartOf(final Date dateToConvert, final String string) {
-        if ("last year" .equals(string.trim())) {
+        if ("last year".equals(string.trim()) || "this year".equals(string.trim())) {
             return alignToStartOfYear(dateToConvert);
-        } else if ("last month" .equals(string.trim())) {
+        } else if ("last month".equals(string.trim()) || "this month".equals(string.trim())) {
             return alignToStartOfMonth(dateToConvert);
-        } else if ("last week" .equals(string.trim())) {
+        } else if ("last week".equals(string.trim()) || "this week".equals(string.trim())) {
             return alignToStartOfWeek(dateToConvert);
         } else {
             return alignToStartOfDay(dateToConvert);
@@ -79,11 +79,11 @@ public class NaturalDateParser {
     }
 
     Date alignToEndOf(final Date dateToConvert, final String string) {
-        if ("last year" .equals(string.trim())) {
+        if ("last year".equals(string.trim()) || "this year".equals(string.trim())) {
             return alignToEndOfYear(dateToConvert);
-        } else if ("last month" .equals(string.trim())) {
+        } else if ("last month".equals(string.trim()) || "this month".equals(string.trim())) {
             return alignToEndOfMonth(dateToConvert);
-        } else if ("last week" .equals(string.trim())) {
+        } else if ("last week".equals(string.trim()) || "this week".equals(string.trim())) {
             return alignToEndOfWeek(dateToConvert);
         } else {
             return alignToEndOfDay(dateToConvert);

--- a/graylog2-server/src/main/java/org/graylog2/plugin/utilities/date/NaturalDateParser.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/utilities/date/NaturalDateParser.java
@@ -66,12 +66,16 @@ public class NaturalDateParser {
         return Arrays.stream(TimeZone.getAvailableIDs()).anyMatch(id -> id.equals(timeZone));
     }
 
+    boolean matches(String string, String other) {
+        return string.equalsIgnoreCase(other.replaceAll("\\s", ""));
+    }
+
     Date alignToStartOf(final Date dateToConvert, final String string) {
-        if ("last year".equals(string.trim()) || "this year".equals(string.trim())) {
+        if (matches("lastyear", string) || matches("thisyear", string)) {
             return alignToStartOfYear(dateToConvert);
-        } else if ("last month".equals(string.trim()) || "this month".equals(string.trim())) {
+        } else if (matches("lastmonth", string) || matches("thismonth", string)) {
             return alignToStartOfMonth(dateToConvert);
-        } else if ("last week".equals(string.trim()) || "this week".equals(string.trim())) {
+        } else if (matches("lastweek", string) || matches("thisweek", string)) {
             return alignToStartOfWeek(dateToConvert);
         } else {
             return alignToStartOfDay(dateToConvert);
@@ -79,11 +83,11 @@ public class NaturalDateParser {
     }
 
     Date alignToEndOf(final Date dateToConvert, final String string) {
-        if ("last year".equals(string.trim()) || "this year".equals(string.trim())) {
+        if (matches("lastyear", string) || matches("thisyear", string)) {
             return alignToEndOfYear(dateToConvert);
-        } else if ("last month".equals(string.trim()) || "this month".equals(string.trim())) {
+        } else if (matches("lastmonth", string) || matches("thismonth", string)) {
             return alignToEndOfMonth(dateToConvert);
-        } else if ("last week".equals(string.trim()) || "this week".equals(string.trim())) {
+        } else if (matches("lastweek", string) || matches("thisweek", string)) {
             return alignToEndOfWeek(dateToConvert);
         } else {
             return alignToEndOfDay(dateToConvert);

--- a/graylog2-server/src/test/java/org/graylog2/plugin/utilities/date/NaturalDateParserTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/plugin/utilities/date/NaturalDateParserTest.java
@@ -49,8 +49,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  * https://www.timeanddate.com/calendar/days/#:~:text=According%20to%20international%20standard%20ISO,last%20day%20of%20the%20week.
  * - should we be able to set this to sun/mon depending on the tz/country?
  *
- *
- * TODO: when we align to day start/end in the future, all timestamps have to be updated
  */
 public class NaturalDateParserTest {
     private NaturalDateParser naturalDateParser;
@@ -162,14 +160,12 @@ public class NaturalDateParserTest {
     @Test
     public void testThisMonth() throws Exception {
         DateTime reference = DateTimeFormat.forPattern("dd.MM.yyyy HH:mm:ss").withZoneUTC().parseDateTime("12.06.2021 09:45:23");
-        DateTime startOfDay = DateTimeFormat.forPattern("dd.MM.yyyy HH:mm:ss").withZoneUTC().parseDateTime("12.06.2021 00:00:00");
         NaturalDateParser.Result result = naturalDateParser.parse("this month", reference.toDate());
-        assertThat(result.getFrom()).as("is the same as the start of the day of the reference date").isEqualTo(startOfDay);
 
-//        DateTime first = DateTimeFormat.forPattern("dd.MM.yyyy HH:mm:ss").withZoneUTC().parseDateTime("01.06.2021 09:45:23");
-//        DateTime firstNextMonth = DateTimeFormat.forPattern("dd.MM.yyyy HH:mm:ss").withZoneUTC().parseDateTime("01.07.2021 09:45:23");
-//        assertThat(result.getFrom()).as("should start at the beginning of the month").isEqualTo(first);
-//        assertThat(result.getTo()).as("should be the 1st day of the following month").isEqualTo(firstNextMonth);
+        DateTime first = DateTimeFormat.forPattern("dd.MM.yyyy HH:mm:ss").withZoneUTC().parseDateTime("01.06.2021 00:00:00");
+        DateTime firstNextMonth = DateTimeFormat.forPattern("dd.MM.yyyy HH:mm:ss").withZoneUTC().parseDateTime("01.07.2021 00:00:00");
+        assertThat(result.getFrom()).as("should start at the beginning of the month").isEqualTo(first);
+        assertThat(result.getTo()).as("should be the 1st day of the following month").isEqualTo(firstNextMonth);
     }
 
     @Test
@@ -200,7 +196,7 @@ public class NaturalDateParserTest {
         assertThat(result.getFrom()).as("should be Monday, 14.").isEqualTo(startOfMonday);
         assertThat(result.getTo()).as("should be Friday, 18.").isEqualTo(endOfFriday);
 
-        /* fails with current Natty implementaiton
+        /* fails with current Natty implementation
         reference = DateTimeFormat.forPattern("dd.MM.yyyy HH:mm:ss").withZoneUTC().parseDateTime("14.06.2021 09:45:23");
         result = naturalDateParser.parse("monday to friday", reference.toDate());
         assertThat(result.getFrom()).as("should be Monday, 14.").isEqualTo(startOfMonday);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
We already included the parsing of "last {year | month | week}" as a special case in the NaturalDateParser due to Natty being incompatible for cases like these. Now we also include "this {year | month | week}".

## How Has This Been Tested?
Has been tested manually. As it is using the same underlying code, I hope this is sufficient.
  
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

