### PR TITLE
Use english locale explicitly when finding widget subclass.

### DIFF
--- a/graylog2-web-interface/src/views/logic/widgets/Widget.ts
+++ b/graylog2-web-interface/src/views/logic/widgets/Widget.ts
@@ -108,7 +108,7 @@ class Widget {
       streams,
     } = this._value;
 
-    return { id, type: type.toLocaleLowerCase('en'), config, filter, timerange, query, streams };
+    return { id, type: type.toLowerCase(), config, filter, timerange, query, streams };
   }
 
   static fromJSON(value: WidgetState): Widget {
@@ -121,7 +121,7 @@ class Widget {
       query,
       streams,
     } = value;
-    const implementingClass = Widget.__registrations[type.toLocaleLowerCase('en')];
+    const implementingClass = Widget.__registrations[type.toLowerCase()];
 
     if (implementingClass) {
       return implementingClass.fromJSON(value);
@@ -144,7 +144,7 @@ class Widget {
   } = {};
 
   static registerSubtype(type: string, implementingClass: DeserializesWidgets) {
-    this.__registrations[type.toLocaleLowerCase('en')] = implementingClass;
+    this.__registrations[type.toLowerCase()] = implementingClass;
   }
 }
 

--- a/graylog2-web-interface/src/views/logic/widgets/Widget.ts
+++ b/graylog2-web-interface/src/views/logic/widgets/Widget.ts
@@ -108,7 +108,7 @@ class Widget {
       streams,
     } = this._value;
 
-    return { id, type: type.toLocaleLowerCase(), config, filter, timerange, query, streams };
+    return { id, type: type.toLocaleLowerCase('en'), config, filter, timerange, query, streams };
   }
 
   static fromJSON(value: WidgetState): Widget {
@@ -121,7 +121,7 @@ class Widget {
       query,
       streams,
     } = value;
-    const implementingClass = Widget.__registrations[type.toLocaleLowerCase()];
+    const implementingClass = Widget.__registrations[type.toLocaleLowerCase('en')];
 
     if (implementingClass) {
       return implementingClass.fromJSON(value);
@@ -144,7 +144,7 @@ class Widget {
   } = {};
 
   static registerSubtype(type: string, implementingClass: DeserializesWidgets) {
-    this.__registrations[type.toLocaleLowerCase()] = implementingClass;
+    this.__registrations[type.toLocaleLowerCase('en')] = implementingClass;
   }
 }
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

**Note:** This requires a backport to `4.2`.

Prior to this PR we were using the default locales when converting widget types to lower case. For the turkish language, this can lead to certain characters being changed in an unexpected way.

This PR is now using the `en` locale explicitly when lowercasing the widget type.

Thanks to @supahgreg for his work in #11601.

Fixes #11596.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.