### PR TITLE
JSON parsing: add shallow parsing up to a certain path depth

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/json/JsonParse.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/json/JsonParse.java
@@ -28,7 +28,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
-
 import java.io.IOException;
 
 import static com.google.common.collect.ImmutableList.of;
@@ -39,18 +38,24 @@ public class JsonParse extends AbstractFunction<JsonNode> {
 
     private final ObjectMapper objectMapper;
     private final ParameterDescriptor<String, String> valueParam;
+    private final ParameterDescriptor<Long, Long> depthParam;
 
     @Inject
     public JsonParse(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
         valueParam = ParameterDescriptor.string("value").description("The string to parse as a JSON tree").build();
+        depthParam = ParameterDescriptor.integer("depth").optional().description("Number of levels to parse. Default: no limit").build();
     }
 
     @Override
     public JsonNode evaluate(FunctionArgs args, EvaluationContext context) {
         final String value = valueParam.required(args, context);
+        final Long depth = depthParam.optional(args, context).orElse(Long.valueOf(0));
         try {
             final JsonNode node = objectMapper.readTree(value);
+            if (depth > 0) {
+                JsonUtils.deleteBelow(node, depth);
+            }
             if (node == null) {
                 throw new IOException("null result");
             }
@@ -66,9 +71,7 @@ public class JsonParse extends AbstractFunction<JsonNode> {
         return FunctionDescriptor.<JsonNode>builder()
                 .name(NAME)
                 .returnType(JsonNode.class)
-                .params(of(
-                        valueParam
-                ))
+                .params(of(valueParam, depthParam))
                 .description("Parses a string as a JSON tree")
                 .build();
     }

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/json/JsonParse.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/json/JsonParse.java
@@ -50,7 +50,7 @@ public class JsonParse extends AbstractFunction<JsonNode> {
     @Override
     public JsonNode evaluate(FunctionArgs args, EvaluationContext context) {
         final String value = valueParam.required(args, context);
-        final Long depth = depthParam.optional(args, context).orElse(Long.valueOf(0));
+        final long depth = depthParam.optional(args, context).orElse(0L);
         try {
             final JsonNode node = objectMapper.readTree(value);
             if (depth > 0) {

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/json/JsonUtils.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/json/JsonUtils.java
@@ -17,19 +17,10 @@
 package org.graylog.plugins.pipelineprocessor.functions.json;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-
-import static com.google.common.collect.Lists.newArrayList;
 
 public class JsonUtils {
-    private static final Logger log = LoggerFactory.getLogger(JsonUtils.class);
 
     public static JsonNode deleteBelow(JsonNode root, long maxDepth) {
         if (maxDepth > 0) {
@@ -39,39 +30,16 @@ public class JsonUtils {
     }
 
     private static void deleteBelow(JsonNode root, long maxDepth, long depth) {
-        if (root.isObject()) {
-            final Iterator<Map.Entry<String, JsonNode>> fields = root.fields();
-            while (fields.hasNext()) {
-                Map.Entry<String, JsonNode> field = fields.next();
-                if (field.getValue().isContainerNode()) {
-                    if (depth >= maxDepth) {
-                        ((ObjectNode) root).remove(field.getKey());
-                    } else {
-                        deleteBelow(field.getValue(), maxDepth, depth + 1);
-                    }
+        final Iterator<JsonNode> elements = root.elements();
+        while (elements.hasNext()) {
+            final JsonNode node = elements.next();
+            if (node.isContainerNode()) {
+                if (depth >= maxDepth) {
+                    elements.remove();
+                } else {
+                    deleteBelow(node, maxDepth, depth + 1);
                 }
-            }
-        } else if (root.isArray()) {
-            final Iterator<JsonNode> elements = root.elements();
-            List<Integer> toRemove = newArrayList();
-            int index = 0;
-            while (elements.hasNext()) {
-                JsonNode node = elements.next();
-                if (node.isContainerNode()) {
-                    if (depth >= maxDepth) {
-                        toRemove.add(index);
-                    } else {
-                        deleteBelow(node, maxDepth, depth + 1);
-                    }
-                }
-                index++;
-            }
-            // avoid ConcurrentModificationException by delaying removal
-            int offset = 0;
-            for (int i : toRemove) {
-                ((ArrayNode) root).remove(i - offset++);
             }
         }
     }
-
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/json/JsonUtils.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/json/JsonUtils.java
@@ -1,0 +1,61 @@
+package org.graylog.plugins.pipelineprocessor.functions.json;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import static com.google.common.collect.Lists.newArrayList;
+
+public class JsonUtils {
+    private static final Logger log = LoggerFactory.getLogger(JsonUtils.class);
+
+    public static JsonNode deleteBelow(JsonNode root, long maxDepth) {
+        if (maxDepth > 0) {
+            deleteBelow(root, maxDepth, 1);
+        }
+        return root;
+    }
+
+    private static void deleteBelow(JsonNode root, long maxDepth, long depth) {
+        if (root.isObject()) {
+            final Iterator<Map.Entry<String, JsonNode>> fields = root.fields();
+            while (fields.hasNext()) {
+                Map.Entry<String, JsonNode> field = fields.next();
+                if (field.getValue().isContainerNode()) {
+                    if (depth >= maxDepth) {
+                        ((ObjectNode) root).remove(field.getKey());
+                    } else {
+                        deleteBelow(field.getValue(), maxDepth, depth + 1);
+                    }
+                }
+            }
+        } else if (root.isArray()) {
+            final Iterator<JsonNode> elements = root.elements();
+            List<Integer> toRemove = newArrayList();
+            int index = 0;
+            while (elements.hasNext()) {
+                JsonNode node = elements.next();
+                if (node.isContainerNode()) {
+                    if (depth >= maxDepth) {
+                        toRemove.add(index);
+                    } else {
+                        deleteBelow(node, maxDepth, depth + 1);
+                    }
+                }
+                index++;
+            }
+            // avoid ConcurrentModificationException by delaying removal
+            int offset = 0;
+            for (int i : toRemove) {
+                ((ArrayNode) root).remove(i - offset++);
+            }
+        }
+    }
+
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/json/JsonUtils.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/json/JsonUtils.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog.plugins.pipelineprocessor.functions.json;
 
 import com.fasterxml.jackson.databind.JsonNode;

--- a/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/functions/JsonUtilsTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/functions/JsonUtilsTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog.plugins.pipelineprocessor.functions;
 
 import com.fasterxml.jackson.databind.JsonNode;

--- a/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/functions/JsonUtilsTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/functions/JsonUtilsTest.java
@@ -1,0 +1,118 @@
+package org.graylog.plugins.pipelineprocessor.functions;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.graylog.plugins.pipelineprocessor.functions.json.JsonUtils;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+public class JsonUtilsTest {
+    @Test
+    public void deleteLevel1Object() throws IOException {
+        String jsonString = "{\"k0\":\"v0\",\"obj1\":{\"k1\":\"v1\"}}";
+        ObjectMapper mapper = new ObjectMapper();
+
+        // NOOP if maxdepth == 0
+        JsonNode node = mapper.readTree(jsonString);
+        JsonUtils.deleteBelow(node, 0);
+        assertThat(mapper.writeValueAsString(node)).isEqualTo(jsonString);
+
+        // NOOP if maxdepth >= actual maximum depth
+        node = mapper.readTree(jsonString);
+        JsonUtils.deleteBelow(node, 2);
+        assertThat(mapper.writeValueAsString(node)).isEqualTo(jsonString);
+
+        // Remove all container nodes from top level
+        String expected = "{\"k0\":\"v0\"}";
+        node = mapper.readTree(jsonString);
+        JsonUtils.deleteBelow(node, 1);
+        assertThat(mapper.writeValueAsString(node)).isEqualTo(expected);
+    }
+
+    @Test
+    public void deleteLevel1Array() throws IOException {
+        String jsonString = "{\"k0\":\"v0\",\"arr1\":[\"a1\",\"a2\"]}";
+        ObjectMapper mapper = new ObjectMapper();
+
+        // NOOP if maxdepth == 0
+        JsonNode node = mapper.readTree(jsonString);
+        JsonUtils.deleteBelow(node, 0);
+        assertThat(mapper.writeValueAsString(node)).isEqualTo(jsonString);
+
+        // NOOP if maxdepth >= actual maximum depth
+        node = mapper.readTree(jsonString);
+        JsonUtils.deleteBelow(node, 2);
+        assertThat(mapper.writeValueAsString(node)).isEqualTo(jsonString);
+
+        // Remove all container nodes from top level
+        String expected = "{\"k0\":\"v0\"}";
+        node = mapper.readTree(jsonString);
+        JsonUtils.deleteBelow(node, 1);
+        assertThat(mapper.writeValueAsString(node)).isEqualTo(expected);
+    }
+
+    @Test
+    public void deleteNestedArray() throws IOException {
+        String jsonString = "{\"k0\":\"v0\",\"arr1\":[[],\"a1\",[\"a21\",\"a22\"],[],\"a2\",[]]}";
+        ObjectMapper mapper = new ObjectMapper();
+
+        // NOOP if maxdepth == 0
+        JsonNode node = mapper.readTree(jsonString);
+        JsonUtils.deleteBelow(node, 0);
+        assertThat(mapper.writeValueAsString(node)).isEqualTo(jsonString);
+
+        // NOOP if maxdepth >= actual maximum depth
+        node = mapper.readTree(jsonString);
+        JsonUtils.deleteBelow(node, 3);
+        assertThat(mapper.writeValueAsString(node)).isEqualTo(jsonString);
+
+        // Remove all container nodes from top level
+        String expected = "{\"k0\":\"v0\"}";
+        node = mapper.readTree(jsonString);
+        JsonUtils.deleteBelow(node, 1);
+        assertThat(mapper.writeValueAsString(node)).isEqualTo(expected);
+
+        // Remove singly nested container nodes
+        expected = "{\"k0\":\"v0\",\"arr1\":[\"a1\",\"a2\"]}";
+        node = mapper.readTree(jsonString);
+        JsonUtils.deleteBelow(node, 2);
+        assertThat(mapper.writeValueAsString(node)).isEqualTo(expected);
+    }
+
+    @Test
+    public void deleteNestedObject() throws IOException {
+        String jsonString = "{\"k0\":\"v0\",\"obj1\":{\"k1\":\"v1\",\"obj11\":{\"k11\":\"v11\",\"obj111\":{\"k111\":\"v111\"}}}}";
+        ObjectMapper mapper = new ObjectMapper();
+
+        // NOOP if maxdepth == 0
+        JsonNode node = mapper.readTree(jsonString);
+        JsonUtils.deleteBelow(node, 0);
+        assertThat(mapper.writeValueAsString(node)).isEqualTo(jsonString);
+
+        // NOOP if maxdepth >= actual maximum depth
+        node = mapper.readTree(jsonString);
+        JsonUtils.deleteBelow(node, 4);
+        assertThat(mapper.writeValueAsString(node)).isEqualTo(jsonString);
+
+        // Remove all container nodes from top level
+        String expected = "{\"k0\":\"v0\"}";
+        node = mapper.readTree(jsonString);
+        JsonUtils.deleteBelow(node, 1);
+        assertThat(mapper.writeValueAsString(node)).isEqualTo(expected);
+
+        // Remove singly nested container nodes
+        expected = "{\"k0\":\"v0\",\"obj1\":{\"k1\":\"v1\"}}";
+        node = mapper.readTree(jsonString);
+        JsonUtils.deleteBelow(node, 2);
+        assertThat(mapper.writeValueAsString(node)).isEqualTo(expected);
+
+        // Remove doubly nested container nodes
+        expected = "{\"k0\":\"v0\",\"obj1\":{\"k1\":\"v1\",\"obj11\":{\"k11\":\"v11\"}}}";
+        node = mapper.readTree(jsonString);
+        JsonUtils.deleteBelow(node, 3);
+        assertThat(mapper.writeValueAsString(node)).isEqualTo(expected);
+    }
+}


### PR DESCRIPTION
Adds a new optional parameter to the `parse_json` pipeline function. The parameter specifies the maximum parse depth - we ignore any nodes that are more deeply nested.

See related issues for details and use case.

Resolves Graylog2/graylog2-server#9021