### PR TITLE
Decoupling search execution from REST resources.

### DIFF
--- a/full-backend-tests/src/test/java/org/graylog/plugins/views/SearchMetadataIT.java
+++ b/full-backend-tests/src/test/java/org/graylog/plugins/views/SearchMetadataIT.java
@@ -1,0 +1,52 @@
+package org.graylog.plugins.views;
+
+import io.restassured.response.ValidatableResponse;
+import io.restassured.specification.RequestSpecification;
+import org.graylog.testing.containermatrix.annotations.ContainerMatrixTest;
+import org.graylog.testing.containermatrix.annotations.ContainerMatrixTestsConfiguration;
+
+import java.io.InputStream;
+
+import static io.restassured.RestAssured.given;
+import static org.graylog.testing.completebackend.Lifecycle.CLASS;
+import static org.hamcrest.Matchers.anEmptyMap;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.core.IsEqual.equalTo;
+
+@ContainerMatrixTestsConfiguration(serverLifecycle = CLASS)
+public class SearchMetadataIT {
+    private final RequestSpecification requestSpec;
+
+    public SearchMetadataIT(RequestSpecification requestSpec) {
+        this.requestSpec = requestSpec;
+    }
+
+    @ContainerMatrixTest
+    void testEmptyRequest() {
+        given()
+                .spec(requestSpec)
+                .when()
+                .post("/views/search/metadata")
+                .then()
+                .statusCode(400)
+                .assertThat().body("message[0]", equalTo("Search body is mandatory"));
+    }
+
+    @ContainerMatrixTest
+    void testMinimalRequestWithUndeclaredParameter() {
+        final ValidatableResponse response = given()
+                .spec(requestSpec)
+                .when()
+                .body(fixture("org/graylog/plugins/views/minimalistic-request-with-undeclared-parameter.json"))
+                .post("/views/search/metadata")
+                .then()
+                .statusCode(200);
+
+        response.assertThat().body("query_metadata.f1446410-a082-4871-b3bf-d69aa42d0c96.used_parameters_names", contains("action"));
+        response.assertThat().body("declared_parameters", anEmptyMap());
+    }
+
+    private InputStream fixture(String filename) {
+        return getClass().getClassLoader().getResourceAsStream(filename);
+    }
+}

--- a/full-backend-tests/src/test/java/org/graylog/plugins/views/SearchMetadataIT.java
+++ b/full-backend-tests/src/test/java/org/graylog/plugins/views/SearchMetadataIT.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog.plugins.views;
 
 import io.restassured.response.ValidatableResponse;

--- a/full-backend-tests/src/test/resources/org/graylog/plugins/views/minimalistic-request-with-undeclared-parameter.json
+++ b/full-backend-tests/src/test/resources/org/graylog/plugins/views/minimalistic-request-with-undeclared-parameter.json
@@ -1,0 +1,20 @@
+{
+  "queries": [
+    {
+      "id": "f1446410-a082-4871-b3bf-d69aa42d0c96",
+      "query": {
+        "type": "elasticsearch",
+        "query_string": "action:$action$"
+      },
+      "timerange": {
+        "type": "relative",
+        "from": 300
+      },
+      "search_types": [
+        {
+          "type": "messages"
+        }
+      ]
+    }
+  ]
+}

--- a/full-backend-tests/src/test/resources/org/graylog/plugins/views/mongodb-stored-searches-for-metadata-endpoint.json
+++ b/full-backend-tests/src/test/resources/org/graylog/plugins/views/mongodb-stored-searches-for-metadata-endpoint.json
@@ -1,0 +1,50 @@
+{
+  "searches": [
+    {
+      "_id": {
+        "$oid": "61977043c1f17d26b45c8a0a"
+      },
+      "queries": [
+        {
+          "id": "f1446410-a082-4871-b3bf-d69aa42d0c96",
+          "query": {
+            "type": "elasticsearch",
+            "query_string": "action:$action$"
+          },
+          "timerange": {
+            "type": "relative",
+            "from": 300
+          },
+          "search_types": [
+            {
+              "type": "messages"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "_id": {
+        "$oid": "61977428c1f17d26b45c8a0b"
+      },
+      "queries": [
+        {
+          "id": "f1446410-a082-4871-b3bf-d69aa42d0c96",
+          "query": {
+            "type": "elasticsearch",
+            "query_string": ""
+          },
+          "timerange": {
+            "type": "relative",
+            "from": 300
+          },
+          "search_types": [
+            {
+              "type": "messages"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/ViewsBindings.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/ViewsBindings.java
@@ -58,6 +58,7 @@ import org.graylog.plugins.views.search.rest.MessagesResource;
 import org.graylog.plugins.views.search.rest.PivotSeriesFunctionsResource;
 import org.graylog.plugins.views.search.rest.QualifyingViewsResource;
 import org.graylog.plugins.views.search.rest.SavedSearchesResource;
+import org.graylog.plugins.views.search.rest.SearchMetadataResource;
 import org.graylog.plugins.views.search.rest.SearchResource;
 import org.graylog.plugins.views.search.rest.ViewsResource;
 import org.graylog.plugins.views.search.rest.ViewsRestPermissions;
@@ -124,6 +125,7 @@ public class ViewsBindings extends ViewsModule {
         addSystemRestResource(QualifyingViewsResource.class);
         addSystemRestResource(SavedSearchesResource.class);
         addSystemRestResource(SearchResource.class);
+        addSystemRestResource(SearchMetadataResource.class);
         addSystemRestResource(ViewsResource.class);
 
         addPermissions(ViewsRestPermissions.class);

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/Query.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/Query.java
@@ -204,7 +204,7 @@ public abstract class Query implements ContentPackable<QueryEntity> {
         return !usedStreamIds().isEmpty();
     }
 
-    Query addStreamsToFilter(ImmutableSet<String> streamIds) {
+    Query addStreamsToFilter(Set<String> streamIds) {
         final Filter newFilter = addStreamsTo(filter(), streamIds);
         return toBuilder().filter(newFilter).build();
     }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/Search.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/Search.java
@@ -126,14 +126,14 @@ public abstract class Search implements ContentPackable<SearchEntity> {
         return builder.build();
     }
 
-    public Search addStreamsToQueriesWithoutStreams(Supplier<ImmutableSet<String>> defaultStreamsSupplier) {
+    public Search addStreamsToQueriesWithoutStreams(Supplier<Set<String>> defaultStreamsSupplier) {
         if (!hasQueriesWithoutStreams()) {
             return this;
         }
         final Set<Query> withStreams = queries().stream().filter(Query::hasStreams).collect(toSet());
         final Set<Query> withoutStreams = Sets.difference(queries(), withStreams);
 
-        final ImmutableSet<String> defaultStreams = defaultStreamsSupplier.get();
+        final Set<String> defaultStreams = defaultStreamsSupplier.get();
 
         if (defaultStreams.isEmpty()) {
             throw new MissingStreamPermissionException("User doesn't have access to any streams",

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/Search.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/Search.java
@@ -40,6 +40,7 @@ import org.joda.time.DateTimeZone;
 import org.mongojack.Id;
 import org.mongojack.ObjectId;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.Map;
@@ -84,6 +85,10 @@ public abstract class Search implements ContentPackable<SearchEntity> {
 
     @JsonProperty(FIELD_OWNER)
     public abstract Optional<String> owner();
+
+    public Search withOwner(@Nonnull String owner) {
+        return toBuilder().owner(owner).build();
+    }
 
     @JsonProperty(FIELD_CREATED_AT)
     public abstract DateTime createdAt();

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/SearchDomain.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/SearchDomain.java
@@ -59,6 +59,15 @@ public class SearchDomain {
                 .collect(Collectors.toList());
     }
 
+    public Search saveForUser(Search search, SearchUser searchUser) {
+        final Optional<Search> previous = Optional.ofNullable(search.id()).flatMap(dbService::get);
+        if (!searchUser.isAdmin() && !previous.map(searchUser::owns).orElse(true)) {
+            throw new PermissionException("Unable to update search with id <" + search.id() + ">, already exists and user is not permitted to overwrite it.");
+        }
+
+        return dbService.save(search.withOwner(searchUser.username()));
+    }
+
     private boolean hasReadPermissionFor(SearchPermissions searchPermissions, Predicate<ViewDTO> viewReadPermission, Search search) {
         if (searchPermissions.owns(search)) {
             return true;

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/SearchDomain.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/SearchDomain.java
@@ -32,11 +32,15 @@ import java.util.stream.Collectors;
 
 public class SearchDomain {
     private final SearchDbService dbService;
+    private final SearchExecutionGuard executionGuard;
     private final ViewService viewService;
 
     @Inject
-    public SearchDomain(SearchDbService dbService, ViewService viewService) {
+    public SearchDomain(SearchDbService dbService,
+                        SearchExecutionGuard executionGuard,
+                        ViewService viewService) {
         this.dbService = dbService;
+        this.executionGuard = executionGuard;
         this.viewService = viewService;
     }
 
@@ -60,6 +64,8 @@ public class SearchDomain {
     }
 
     public Search saveForUser(Search search, SearchUser searchUser) {
+        this.executionGuard.check(search, searchUser::canReadStream);
+
         final Optional<Search> previous = Optional.ofNullable(search.id()).flatMap(dbService::get);
         if (!searchUser.isAdmin() && !previous.map(searchUser::owns).orElse(true)) {
             throw new PermissionException("Unable to update search with id <" + search.id() + ">, already exists and user is not permitted to overwrite it.");

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SearchExecutor.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SearchExecutor.java
@@ -1,0 +1,88 @@
+package org.graylog.plugins.views.search.rest;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.util.concurrent.Uninterruptibles;
+import org.graylog.plugins.views.search.Search;
+import org.graylog.plugins.views.search.SearchDomain;
+import org.graylog.plugins.views.search.SearchExecutionGuard;
+import org.graylog.plugins.views.search.SearchJob;
+import org.graylog.plugins.views.search.db.SearchJobService;
+import org.graylog.plugins.views.search.engine.QueryEngine;
+import org.graylog.plugins.views.search.permissions.SearchUser;
+import org.graylog.plugins.views.search.permissions.StreamPermissions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import javax.ws.rs.InternalServerErrorException;
+import javax.ws.rs.NotFoundException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+
+public class SearchExecutor {
+    private static final Logger LOG = LoggerFactory.getLogger(SearchExecutor.class);
+
+    private final SearchDomain searchDomain;
+    private final SearchJobService searchJobService;
+    private final QueryEngine queryEngine;
+    private final SearchExecutionGuard executionGuard;
+    private final PermittedStreams permittedStreams;
+    private final ObjectMapper objectMapper;
+
+    @Inject
+    public SearchExecutor(SearchDomain searchDomain,
+                          SearchJobService searchJobService,
+                          QueryEngine queryEngine,
+                          SearchExecutionGuard executionGuard,
+                          PermittedStreams permittedStreams,
+                          ObjectMapper objectMapper) {
+        this.searchDomain = searchDomain;
+        this.searchJobService = searchJobService;
+        this.queryEngine = queryEngine;
+        this.executionGuard = executionGuard;
+        this.permittedStreams = permittedStreams;
+        this.objectMapper = objectMapper;
+    }
+
+    public SearchJob execute(String searchId, SearchUser searchUser, ExecutionState executionState) {
+        return searchDomain.getForUser(searchId, searchUser)
+                .map(s -> execute(s, searchUser, executionState))
+                .orElseThrow(() -> new NotFoundException("No search found with id <" + searchId + ">."));
+    }
+
+    public SearchJob execute(Search search, SearchUser searchUser, ExecutionState executionState) {
+        final Search searchWithStreams = search.addStreamsToQueriesWithoutStreams(() -> loadAllAllowedStreamsForUser(searchUser));
+
+        final Search searchWithExecutionState = searchWithStreams.applyExecutionState(objectMapper, firstNonNull(executionState, ExecutionState.empty()));
+
+        authorize(searchWithExecutionState, searchUser);
+
+        final SearchJob searchJob = queryEngine.execute(searchJobService.create(searchWithExecutionState, searchUser.username()));
+
+        try {
+            Uninterruptibles.getUninterruptibly(searchJob.getResultFuture(), 60000, TimeUnit.MILLISECONDS);
+        } catch (ExecutionException e) {
+            LOG.error("Error executing search job <{}>", searchJob.getId(), e);
+            throw new InternalServerErrorException("Error executing search job: " + e.getMessage(), e);
+        } catch (TimeoutException e) {
+            throw new InternalServerErrorException("Timeout while executing search job");
+        } catch (Exception e) {
+            LOG.error("Other error", e);
+            throw e;
+        }
+
+        return searchJob;
+    }
+
+    private void authorize(Search search, StreamPermissions streamPermissions) {
+        this.executionGuard.check(search, streamPermissions::canReadStream);
+    }
+
+    private ImmutableSet<String> loadAllAllowedStreamsForUser(StreamPermissions streamPermissions) {
+        return permittedStreams.load(streamPermissions::canReadStream);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SearchExecutor.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SearchExecutor.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog.plugins.views.search.rest;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SearchMetadataResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SearchMetadataResource.java
@@ -1,0 +1,67 @@
+package org.graylog.plugins.views.search.rest;
+
+import com.google.common.collect.Maps;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import one.util.streamex.StreamEx;
+import org.apache.shiro.authz.annotation.RequiresAuthentication;
+import org.graylog.plugins.views.search.Parameter;
+import org.graylog.plugins.views.search.Query;
+import org.graylog.plugins.views.search.QueryMetadata;
+import org.graylog.plugins.views.search.Search;
+import org.graylog.plugins.views.search.SearchDomain;
+import org.graylog.plugins.views.search.SearchMetadata;
+import org.graylog.plugins.views.search.engine.QueryEngine;
+import org.graylog.plugins.views.search.permissions.SearchUser;
+import org.graylog2.audit.jersey.NoAuditEvent;
+import org.graylog2.plugin.rest.PluginRestResource;
+import org.graylog2.shared.rest.resources.RestResource;
+
+import javax.inject.Inject;
+import javax.validation.constraints.NotNull;
+import javax.ws.rs.GET;
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import java.util.Map;
+
+@Api(value = "Search/Metadata")
+@Path("/views/search/metadata")
+@Produces(MediaType.APPLICATION_JSON)
+@RequiresAuthentication
+public class SearchMetadataResource extends RestResource implements PluginRestResource {
+    private final QueryEngine queryEngine;
+    private final SearchDomain searchDomain;
+
+    @Inject
+    public SearchMetadataResource(QueryEngine queryEngine,
+                                  SearchDomain searchDomain) {
+        this.queryEngine = queryEngine;
+        this.searchDomain = searchDomain;
+    }
+
+    @GET
+    @ApiOperation(value = "Metadata for the given Search object", notes = "Used for already persisted search objects")
+    @Path("{searchId}")
+    public SearchMetadata metadata(@ApiParam("searchId") @PathParam("searchId") String searchId, @Context SearchUser searchUser) {
+        final Search search = searchDomain.getForUser(searchId, searchUser)
+                .orElseThrow(() -> new NotFoundException("Search with id " + searchId + " does not exist"));
+        return metadataForObject(search);
+    }
+
+    @POST
+    @ApiOperation(value = "Metadata for the posted Search object", notes = "Intended for search objects that aren't yet persisted (e.g. for validation or interactive purposes)")
+    @NoAuditEvent("Only returning metadata for given search, not changing any data")
+    public SearchMetadata metadataForObject(@ApiParam @NotNull Search search) {
+        if (search == null) {
+            throw new IllegalArgumentException("Search must not be null.");
+        }
+        final Map<String, QueryMetadata> queryMetadatas = StreamEx.of(search.queries()).toMap(Query::id, query -> queryEngine.parse(search, query));
+        return SearchMetadata.create(queryMetadatas, Maps.uniqueIndex(search.parameters(), Parameter::name));
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SearchMetadataResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SearchMetadataResource.java
@@ -73,7 +73,7 @@ public class SearchMetadataResource extends RestResource implements PluginRestRe
     @POST
     @ApiOperation(value = "Metadata for the posted Search object", notes = "Intended for search objects that aren't yet persisted (e.g. for validation or interactive purposes)")
     @NoAuditEvent("Only returning metadata for given search, not changing any data")
-    public SearchMetadata metadataForObject(@ApiParam @NotNull Search search) {
+    public SearchMetadata metadataForObject(@ApiParam @NotNull(message = "Search body is mandatory") Search search) {
         if (search == null) {
             throw new IllegalArgumentException("Search must not be null.");
         }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SearchMetadataResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SearchMetadataResource.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog.plugins.views.search.rest;
 
 import com.google.common.collect.Maps;

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SearchResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SearchResource.java
@@ -68,19 +68,16 @@ public class SearchResource extends RestResource implements PluginRestResource {
     private static final Logger LOG = LoggerFactory.getLogger(SearchResource.class);
     private static final String BASE_PATH = "views/search";
 
-    private final SearchExecutionGuard executionGuard;
     private final SearchDomain searchDomain;
     private final SearchExecutor searchExecutor;
     private final SearchJobService searchJobService;
     private final EventBus serverEventBus;
 
     @Inject
-    public SearchResource(SearchExecutionGuard executionGuard,
-                          SearchDomain searchDomain,
+    public SearchResource(SearchDomain searchDomain,
                           SearchExecutor searchExecutor,
                           SearchJobService searchJobService,
                           EventBus serverEventBus) {
-        this.executionGuard = executionGuard;
         this.searchDomain = searchDomain;
         this.searchExecutor = searchExecutor;
         this.searchJobService = searchJobService;

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SearchResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SearchResource.java
@@ -94,8 +94,6 @@ public class SearchResource extends RestResource implements PluginRestResource {
     @ApiOperation(value = "Create a search query", response = Search.class, code = 201)
     @AuditEvent(type = ViewsAuditEventTypes.SEARCH_CREATE)
     public Response createSearch(@ApiParam Search search, @Context SearchUser searchUser) {
-        guard(search, searchUser);
-
         final Search saved = searchDomain.saveForUser(search, searchUser);
         if (saved == null || saved.id() == null) {
             return Response.serverError().build();
@@ -163,10 +161,6 @@ public class SearchResource extends RestResource implements PluginRestResource {
         } catch (ExecutionException | TimeoutException ignore) {
         }
         return searchJob;
-    }
-
-    private void guard(Search search, SearchUser searchUser) {
-        this.executionGuard.check(search, searchUser::canReadStream);
     }
 
     private void postAuditEvent(SearchJob searchJob) {

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SearchResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SearchResource.java
@@ -16,8 +16,6 @@
  */
 package org.graylog.plugins.views.search.rest;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.eventbus.EventBus;
 import com.google.common.util.concurrent.Uninterruptibles;
 import io.swagger.annotations.Api;
@@ -30,7 +28,6 @@ import org.graylog.plugins.views.search.SearchDomain;
 import org.graylog.plugins.views.search.SearchExecutionGuard;
 import org.graylog.plugins.views.search.SearchJob;
 import org.graylog.plugins.views.search.db.SearchJobService;
-import org.graylog.plugins.views.search.engine.QueryEngine;
 import org.graylog.plugins.views.search.events.SearchJobExecutionEvent;
 import org.graylog.plugins.views.search.permissions.SearchUser;
 import org.graylog2.audit.jersey.AuditEvent;

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SearchResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SearchResource.java
@@ -75,7 +75,6 @@ public class SearchResource extends RestResource implements PluginRestResource {
     private final SearchDomain searchDomain;
     private final SearchExecutor searchExecutor;
     private final SearchJobService searchJobService;
-    private final PermittedStreams permittedStreams;
     private final EventBus serverEventBus;
 
     @Inject
@@ -83,13 +82,11 @@ public class SearchResource extends RestResource implements PluginRestResource {
                           SearchDomain searchDomain,
                           SearchExecutor searchExecutor,
                           SearchJobService searchJobService,
-                         PermittedStreams permittedStreams,
                           EventBus serverEventBus) {
         this.executionGuard = executionGuard;
         this.searchDomain = searchDomain;
         this.searchExecutor = searchExecutor;
         this.searchJobService = searchJobService;
-        this.permittedStreams = permittedStreams;
         this.serverEventBus = serverEventBus;
     }
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SearchResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SearchResource.java
@@ -83,7 +83,7 @@ public class SearchResource extends RestResource implements PluginRestResource {
                           SearchDomain searchDomain,
                           SearchExecutor searchExecutor,
                           SearchJobService searchJobService,
-                          PermittedStreams permittedStreams,
+                         PermittedStreams permittedStreams,
                           EventBus serverEventBus) {
         this.executionGuard = executionGuard;
         this.searchDomain = searchDomain;
@@ -175,9 +175,5 @@ public class SearchResource extends RestResource implements PluginRestResource {
     private void postAuditEvent(SearchJob searchJob) {
         final SearchJobExecutionEvent searchJobExecutionEvent = SearchJobExecutionEvent.create(getCurrentUser(), searchJob, DateTime.now(DateTimeZone.UTC));
         this.serverEventBus.post(searchJobExecutionEvent);
-    }
-
-    private ImmutableSet<String> loadAllAllowedStreamsForUser(SearchUser searchUser) {
-        return permittedStreams.load(searchUser::canReadStream);
     }
 }

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/SearchDomainTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/SearchDomainTest.java
@@ -20,7 +20,6 @@ import com.google.common.collect.ImmutableList;
 import org.graylog.plugins.views.search.db.SearchDbService;
 import org.graylog.plugins.views.search.errors.PermissionException;
 import org.graylog.plugins.views.search.permissions.SearchUser;
-import org.graylog.plugins.views.search.rest.SearchDTO;
 import org.graylog.plugins.views.search.views.ViewDTO;
 import org.graylog.plugins.views.search.views.ViewService;
 import org.junit.Before;

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/SearchExecutorTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/SearchExecutorTest.java
@@ -1,0 +1,152 @@
+package org.graylog.plugins.views.search.rest;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.graylog.plugins.views.search.Search;
+import org.graylog.plugins.views.search.SearchDomain;
+import org.graylog.plugins.views.search.SearchExecutionGuard;
+import org.graylog.plugins.views.search.SearchJob;
+import org.graylog.plugins.views.search.db.SearchJobService;
+import org.graylog.plugins.views.search.engine.QueryEngine;
+import org.graylog.plugins.views.search.permissions.SearchUser;
+import org.graylog.plugins.views.search.views.ViewDTO;
+import org.graylog2.plugin.database.users.User;
+import org.graylog2.rest.resources.RestResourceBaseTest;
+import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import javax.ws.rs.ForbiddenException;
+import javax.ws.rs.NotFoundException;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Predicate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class SearchExecutorTest extends RestResourceBaseTest {
+    @Rule
+    public final MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    @Mock
+    private SearchDomain searchDomain;
+
+    @Mock
+    private SearchJobService searchJobService;
+
+    @Mock
+    private QueryEngine queryEngine;
+
+    @Mock
+    private SearchExecutionGuard searchExecutionGuard;
+
+    @Mock
+    private PermittedStreams permittedStreams;
+
+    @Mock
+    private User currentUser;
+
+    @Captor
+    private ArgumentCaptor<ExecutionState> executionStateCaptor;
+
+    private SearchExecutor searchExecutor;
+
+    private final Predicate<ViewDTO> isAllowed = (id) -> true;
+    private final Predicate<String> isStreamAllowed = (id) -> true;
+    private final Predicate<String> isNotAllowed = (id) -> false;
+
+    @Before
+    public void setUp() throws Exception {
+        final ObjectMapper objectMapper = new ObjectMapperProvider().get();
+        this.searchExecutor = new SearchExecutor(searchDomain, searchJobService, queryEngine, searchExecutionGuard, permittedStreams, objectMapper);
+    }
+
+    @Test
+    public void throwsExceptionIfSearchIsNotFound() {
+        final SearchUser searchUser = mock(SearchUser.class);
+        when(searchUser.canReadView(any())).thenReturn(true);
+        when(searchUser.canReadStream(any())).thenReturn(true);
+
+        when(searchDomain.getForUser(eq("search1"), eq(searchUser))).thenReturn(Optional.empty());
+
+        assertThatExceptionOfType(NotFoundException.class)
+                .isThrownBy(() -> this.searchExecutor.execute("search1", searchUser, ExecutionState.empty()))
+                .withMessage("No search found with id <search1>.");
+    }
+
+    @Test
+    public void addsStreamsToSearchWithoutStreams() {
+        final Search search = mockSearch();
+        final SearchUser searchUser = mock(SearchUser.class);
+        when(searchUser.canReadView(any())).thenReturn(true);
+        when(searchUser.canReadStream(any())).thenReturn(true);
+        when(searchUser.username()).thenReturn("frank-drebin");
+
+        final SearchJob searchJob = mock(SearchJob.class);
+        when(searchJobService.create(search, "frank-drebin")).thenReturn(searchJob);
+        when(searchJob.getResultFuture()).thenReturn(CompletableFuture.completedFuture(null));
+        when(queryEngine.execute(searchJob)).thenReturn(searchJob);
+
+        when(searchDomain.getForUser(eq("search1"), eq(searchUser))).thenReturn(Optional.of(search));
+
+        this.searchExecutor.execute("search1", searchUser, ExecutionState.empty());
+
+        verify(search, times(1)).addStreamsToQueriesWithoutStreams(any());
+    }
+
+    @Test
+    public void appliesSearchExecutionState() {
+        final Search search = mockSearch();
+        final SearchUser searchUser = mock(SearchUser.class);
+        when(searchUser.canReadView(any())).thenReturn(true);
+        when(searchUser.canReadStream(any())).thenReturn(true);
+        when(searchUser.username()).thenReturn("frank-drebin");
+
+        final SearchJob searchJob = mock(SearchJob.class);
+        when(searchJobService.create(search, "frank-drebin")).thenReturn(searchJob);
+        when(searchJob.getResultFuture()).thenReturn(CompletableFuture.completedFuture(null));
+        when(queryEngine.execute(searchJob)).thenReturn(searchJob);
+        when(searchDomain.getForUser(eq("search1"), eq(searchUser))).thenReturn(Optional.of(search));
+        final ExecutionState executionState = ExecutionState.builder().addAdditionalParameter("foo", 42).build();
+
+        this.searchExecutor.execute("search1", searchUser, executionState);
+
+        verify(search, times(1)).applyExecutionState(any(), executionStateCaptor.capture());
+
+        assertThat(executionStateCaptor.getValue()).isEqualTo(executionState);
+    }
+
+    @Test
+    public void checksUserPermissionsForSearch() {
+        final Search search = mockSearch();
+        final SearchUser searchUser = mock(SearchUser.class);
+        when(searchUser.canReadView(any())).thenReturn(true);
+        when(searchUser.canReadStream(any())).thenReturn(false);
+
+        doThrow(ForbiddenException.class).when(searchExecutionGuard).check(eq(search), any());
+        when(searchDomain.getForUser(eq("search1"), eq(searchUser))).thenReturn(Optional.of(search));
+
+        assertThatExceptionOfType(ForbiddenException.class)
+                .isThrownBy(() -> this.searchExecutor.execute("search1", searchUser, ExecutionState.empty()));
+    }
+
+    private Search mockSearch() {
+        final Search search = mock(Search.class);
+        when(search.addStreamsToQueriesWithoutStreams(any())).thenReturn(search);
+        when(search.applyExecutionState(any(), any())).thenReturn(search);
+        return search;
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/SearchExecutorTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/SearchExecutorTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog.plugins.views.search.rest;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/SearchResourceExecutionTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/SearchResourceExecutionTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog.plugins.views.search.rest;
 
 import com.google.common.collect.ImmutableSet;

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/SearchResourceExecutionTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/SearchResourceExecutionTest.java
@@ -76,7 +76,17 @@ public class SearchResourceExecutionTest {
 
     class SearchTestResource extends SearchResource {
         public SearchTestResource() {
-            super(executionGuard, searchDomain, searchJobService, objectMapperProvider.get(), permittedStreams, queryEngine, eventBus);
+            super(executionGuard,
+                    searchDomain,
+                    new SearchExecutor(searchDomain,
+                            searchJobService,
+                            queryEngine,
+                            executionGuard,
+                            permittedStreams,
+                            objectMapperProvider.get()),
+                    searchJobService,
+                    permittedStreams,
+                    eventBus);
         }
 
         @Nullable

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/SearchResourceExecutionTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/SearchResourceExecutionTest.java
@@ -76,8 +76,7 @@ public class SearchResourceExecutionTest {
 
     class SearchTestResource extends SearchResource {
         public SearchTestResource() {
-            super(executionGuard,
-                    searchDomain,
+            super(searchDomain,
                     new SearchExecutor(searchDomain,
                             searchJobService,
                             queryEngine,
@@ -85,7 +84,6 @@ public class SearchResourceExecutionTest {
                             permittedStreams,
                             objectMapperProvider.get()),
                     searchJobService,
-                    permittedStreams,
                     eventBus);
         }
 

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/SearchResourceExecutionTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/SearchResourceExecutionTest.java
@@ -1,0 +1,283 @@
+package org.graylog.plugins.views.search.rest;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.eventbus.EventBus;
+import org.graylog.plugins.views.search.Query;
+import org.graylog.plugins.views.search.Search;
+import org.graylog.plugins.views.search.SearchDomain;
+import org.graylog.plugins.views.search.SearchExecutionGuard;
+import org.graylog.plugins.views.search.SearchJob;
+import org.graylog.plugins.views.search.db.SearchDbService;
+import org.graylog.plugins.views.search.db.SearchJobService;
+import org.graylog.plugins.views.search.engine.QueryEngine;
+import org.graylog.plugins.views.search.events.SearchJobExecutionEvent;
+import org.graylog.plugins.views.search.permissions.SearchUser;
+import org.graylog2.plugin.database.users.User;
+import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import javax.annotation.Nullable;
+import javax.ws.rs.ForbiddenException;
+import javax.ws.rs.core.Response;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class SearchResourceExecutionTest {
+    private static final ObjectMapperProvider objectMapperProvider = new ObjectMapperProvider();
+
+    @Rule
+    public MockitoRule rule = MockitoJUnit.rule();
+
+    @Mock
+    private PermittedStreams permittedStreams;
+
+    @Mock
+    private SearchJobService searchJobService;
+
+    @Mock
+    private EventBus eventBus;
+
+    @Mock
+    private QueryEngine queryEngine;
+
+    @Mock
+    private SearchDbService searchDbService;
+
+    @Mock
+    private SearchExecutionGuard executionGuard;
+
+    @Mock
+    private SearchDomain searchDomain;
+
+    @Mock
+    private User currentUser;
+
+    @Mock
+    private SearchUser searchUser;
+
+    private SearchResource searchResource;
+
+    class SearchTestResource extends SearchResource {
+        public SearchTestResource() {
+            super(executionGuard, searchDomain, searchJobService, objectMapperProvider.get(), permittedStreams, queryEngine, eventBus);
+        }
+
+        @Nullable
+        @Override
+        protected User getCurrentUser() {
+            return currentUser;
+        }
+    }
+
+    @Before
+    public void setUp() {
+        this.searchResource = new SearchTestResource();
+    }
+
+    @Test
+    public void executeQueryAddsCurrentUserAsOwner() {
+        mockCurrentUserName("basti");
+
+        final Search search = mockExistingSearch();
+
+        this.searchResource.executeQuery(search.id(), ExecutionState.empty(), searchUser);
+
+        final ArgumentCaptor<String> usernameCaptor = ArgumentCaptor.forClass(String.class);
+        verify(searchJobService, times(1)).create(eq(search), usernameCaptor.capture());
+
+        assertThat(usernameCaptor.getValue()).isEqualTo("basti");
+    }
+
+    @Test
+    public void executeQueryTriggersEvent() {
+        mockCurrentUserName("basti");
+
+        final Search search = mockExistingSearch();
+
+        final Response response = this.searchResource.executeQuery(search.id(), ExecutionState.empty(), searchUser);
+
+        final ArgumentCaptor<SearchJobExecutionEvent> eventCaptor = ArgumentCaptor.forClass(SearchJobExecutionEvent.class);
+        verify(this.eventBus, times(1)).post(eventCaptor.capture());
+
+        final SearchJobExecutionEvent searchJobExecutionEvent = eventCaptor.getValue();
+        assertThat(searchJobExecutionEvent.user()).isEqualTo(currentUser);
+        assertThat(searchJobExecutionEvent.searchJob()).isEqualTo(response.getEntity());
+    }
+
+    @Test
+    public void guardExceptionPreventsTriggeringEvent() {
+        mockCurrentUserName("basti");
+
+        final Search search = mockExistingSearch();
+        throwGuardExceptionFor(search);
+
+        try {
+            this.searchResource.executeQuery(search.id(), ExecutionState.empty(), searchUser);
+        } catch (ForbiddenException ignored) {}
+
+        verify(this.eventBus, never()).post(any(SearchJobExecutionEvent.class));
+    }
+
+    @Test
+    public void executeSyncJobTriggersEvent() {
+        mockCurrentUserName("peterchen");
+
+        final Search search = mockExistingSearch();
+
+        final Response response = this.searchResource.executeSyncJob(search, 100, searchUser);
+
+        final ArgumentCaptor<SearchJobExecutionEvent> eventCaptor = ArgumentCaptor.forClass(SearchJobExecutionEvent.class);
+        verify(this.eventBus, times(1)).post(eventCaptor.capture());
+
+        final SearchJobExecutionEvent searchJobExecutionEvent = eventCaptor.getValue();
+        assertThat(searchJobExecutionEvent.user()).isEqualTo(currentUser);
+        assertThat(searchJobExecutionEvent.searchJob()).isEqualTo(response.getEntity());
+    }
+
+    @Test
+    public void guardExceptionDuringSyncExecutionPreventsTriggeringEvent() {
+        mockCurrentUserName("basti");
+
+        final Search search = mockExistingSearch();
+        throwGuardExceptionFor(search);
+
+        try {
+            this.searchResource.executeSyncJob(search, 100, searchUser);
+        } catch (ForbiddenException ignored) {}
+
+        verify(this.eventBus, never()).post(any(SearchJobExecutionEvent.class));
+    }
+
+    @Test
+    public void executeSyncJobAddsCurrentUserAsOwner() {
+        mockCurrentUserName("peterchen");
+
+        final Search search = mockExistingSearch();
+
+        this.searchResource.executeSyncJob(search, 100, searchUser);
+
+        final ArgumentCaptor<String> usernameCaptor = ArgumentCaptor.forClass(String.class);
+        verify(searchJobService, times(1)).create(eq(search), usernameCaptor.capture());
+
+        assertThat(usernameCaptor.getValue()).isEqualTo("peterchen");
+    }
+
+    @Test
+    public void executeQueryAppliesExecutionState() {
+        final Search search = mockExistingSearch();
+
+        final ExecutionState.Builder builder = ExecutionState.builder();
+        builder.addAdditionalParameter("foo", 42);
+
+
+        when(searchDbService.get(search.id())).thenReturn(Optional.of(search));
+
+        final ExecutionState executionState = builder.build();
+        this.searchResource.executeQuery(search.id(), executionState, searchUser);
+
+        //noinspection unchecked
+        final ArgumentCaptor<ExecutionState> executionStateCaptor = ArgumentCaptor.forClass(ExecutionState.class);
+        verify(search, times(1)).applyExecutionState(any(), executionStateCaptor.capture());
+
+        assertThat(executionStateCaptor.getValue()).isEqualTo(executionState);
+    }
+
+    @Test
+    public void guardExceptionInAsyncExecutionLeadsTo403() {
+        final Search search = mockExistingSearch();
+
+        throwGuardExceptionFor(search);
+
+        assertThatExceptionOfType(ForbiddenException.class)
+                .isThrownBy(() -> this.searchResource.executeQuery(search.id(), null, searchUser));
+    }
+
+    @Test
+    public void guardExceptionInSynchronousExecutionLeadsTo403() {
+        final Search search = mockExistingSearch();
+
+        throwGuardExceptionFor(search);
+
+        assertThatExceptionOfType(ForbiddenException.class)
+                .isThrownBy(() -> this.searchResource.executeSyncJob(search, 0, searchUser));
+    }
+
+    @Test
+    public void failureToAddDefaultStreamsInAsyncSearchLeadsTo403() {
+        final Search search = mockExistingSearch();
+
+        doThrow(new ForbiddenException()).when(search).addStreamsToQueriesWithoutStreams(any());
+
+        assertThatExceptionOfType(ForbiddenException.class)
+                .isThrownBy(() -> this.searchResource.executeQuery(search.id(), null, searchUser));
+    }
+
+    @Test
+    public void failureToAddDefaultStreamsInSynchronousSearchLeadsTo403() {
+        final Search search = mockExistingSearch();
+
+        doThrow(new ForbiddenException()).when(search).addStreamsToQueriesWithoutStreams(any());
+
+        assertThatExceptionOfType(ForbiddenException.class)
+                .isThrownBy(() -> this.searchResource.executeSyncJob(search, 0, searchUser));
+    }
+
+    private void throwGuardExceptionFor(Search search) {
+        doThrow(new ForbiddenException()).when(executionGuard).check(eq(search), any());
+    }
+
+    private void mockCurrentUserName(String name) {
+        when(currentUser.getName()).thenReturn(name);
+        when(searchUser.username()).thenReturn(name);
+    }
+
+   private Search mockNewSearch() {
+        final Search search = mock(Search.class);
+
+        when(search.addStreamsToQueriesWithoutStreams(any())).thenReturn(search);
+
+        final String streamId = "streamId";
+
+        final Query query = mock(Query.class);
+        when(query.usedStreamIds()).thenReturn(ImmutableSet.of(streamId));
+        when(search.queries()).thenReturn(ImmutableSet.of(query));
+
+        return search;
+    }
+
+    private Search mockExistingSearch() {
+
+        final Search search = mockNewSearch();
+
+        final String searchId = "deadbeef";
+        when(search.id()).thenReturn(searchId);
+
+        when(search.applyExecutionState(any(), any())).thenReturn(search);
+        when(searchDomain.getForUser(eq(search.id()), any())).thenReturn(Optional.of(search));
+
+        final SearchJob searchJob = mock(SearchJob.class);
+        when(searchJob.getResultFuture()).thenReturn(CompletableFuture.completedFuture(null));
+        when(searchJobService.create(any(), any())).thenReturn(searchJob);
+
+        when(queryEngine.execute(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        return search;
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/SearchResourceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/SearchResourceTest.java
@@ -69,9 +69,6 @@ public class SearchResourceTest {
     private SearchUser searchUser;
 
     @Mock
-    private PermittedStreams permittedStreams;
-
-    @Mock
     private EventBus eventBus;
 
     @Mock
@@ -85,7 +82,7 @@ public class SearchResourceTest {
     @Before
     public void setUp() throws Exception {
         GuiceInjectorHolder.createInjector(Collections.emptyList());
-        this.searchResource = new SearchResource(executionGuard, searchDomain, searchExecutor, searchJobService, permittedStreams, eventBus);
+        this.searchResource = new SearchResource(searchDomain, searchExecutor, searchJobService, eventBus);
     }
 
     @Test
@@ -124,24 +121,10 @@ public class SearchResourceTest {
     }
 
     @Test
-    public void guardExceptionOnPostLeadsTo403() {
-        final Search search = mockNewSearch();
-
-        throwGuardExceptionFor(search);
-
-        assertThatExceptionOfType(ForbiddenException.class)
-                .isThrownBy(() -> searchResource.createSearch(search, searchUser));
-    }
-
-    @Test
     public void allowCreatingNewSearchWithoutId() {
         final Search search = Search.builder().id(null).build();
 
         this.searchResource.createSearch(search, searchUser);
-    }
-
-    private void throwGuardExceptionFor(Search search) {
-        doThrow(new ForbiddenException()).when(executionGuard).check(eq(search), any());
     }
 
     private Search mockNewSearch() {

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/SearchResourceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/SearchResourceTest.java
@@ -77,12 +77,15 @@ public class SearchResourceTest {
     @Mock
     private QueryEngine queryEngine;
 
+    @Mock
+    private SearchExecutor searchExecutor;
+
     private SearchResource searchResource;
 
     @Before
     public void setUp() throws Exception {
         GuiceInjectorHolder.createInjector(Collections.emptyList());
-        this.searchResource = new SearchResource(executionGuard, searchDomain, searchJobService, objectMapperProvider.get(), permittedStreams, queryEngine, eventBus);
+        this.searchResource = new SearchResource(executionGuard, searchDomain, searchExecutor, searchJobService, permittedStreams, eventBus);
     }
 
     @Test


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

In this PR, actual search execution is decoupled and encapsulated in a `SearchExecutor` class, which was previously existing as a thin abstraction in `enterprise`, which has been transferred over to core.  This allows us to centralize preparations, validations and enforcing domain constraints in a single place, as well was encouraging reuse in REST resources (and other places) which need to execute searches.

/jenkins-pr-deps Graylog2/graylog-plugin-enterprise#2950
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.