### PR TITLE
Fix migrate command for running with cloud plugin

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/bindings/ServerBindings.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/ServerBindings.java
@@ -109,12 +109,9 @@ public class ServerBindings extends Graylog2Module {
 
         if (isMigrationCommand) {
             // If we are only running migrations, disable the journal
-            final Configuration noopConfig = new Configuration();
-            noopConfig.setMessageJournalEnabled(false);
-            install(new MessageQueueModule(noopConfig));
-        } else {
-            install(new MessageQueueModule(configuration));
+            configuration.setMessageJournalEnabled(false);
         }
+        install(new MessageQueueModule(configuration));
         bindProviders();
         bindFactoryModules();
         bindDynamicFeatures();

--- a/graylog2-server/src/main/java/org/graylog2/bootstrap/commands/MigrateCmd.java
+++ b/graylog2-server/src/main/java/org/graylog2/bootstrap/commands/MigrateCmd.java
@@ -17,7 +17,6 @@
 package org.graylog2.bootstrap.commands;
 
 import com.github.rvesse.airline.annotations.Command;
-import org.graylog2.Configuration;
 import org.graylog2.commands.Server;
 import org.graylog2.plugin.Tools;
 import org.graylog2.plugin.Version;
@@ -31,7 +30,6 @@ public class MigrateCmd extends Server {
 
     private static final Logger LOG = LoggerFactory.getLogger(MigrateCmd.class);
 
-    protected static final Configuration configuration = new Configuration();
     private final Version version = Version.CURRENT_CLASSPATH;
 
     public MigrateCmd() {

--- a/graylog2-server/src/main/java/org/graylog2/commands/Server.java
+++ b/graylog2-server/src/main/java/org/graylog2/commands/Server.java
@@ -106,7 +106,7 @@ import static org.graylog2.audit.AuditEventTypes.NODE_SHUTDOWN_INITIATE;
 public class Server extends ServerBootstrap {
     private static final Logger LOG = LoggerFactory.getLogger(Server.class);
 
-    private static final Configuration configuration = new Configuration();
+    protected static final Configuration configuration = new Configuration();
     private final HttpConfiguration httpConfiguration = new HttpConfiguration();
     private final ElasticsearchConfiguration elasticsearchConfiguration = new ElasticsearchConfiguration();
     private final ElasticsearchClientConfiguration elasticsearchClientConfiguration = new ElasticsearchClientConfiguration();


### PR DESCRIPTION
The cloud plugin gets its Configuration dependency injected.
Duplicating the configuration and disabling the journal
did not affect the cloud plugin. Thus two MessageQueue implementations
were bound.

```
1) [Guice/BindingAlreadySet]: MessageQueueReader was bound multiple times.

Bound at:
1  : PluginModule.bindMessageQueueImplementation(PluginModule.java:376)
      \_ installed by: ServerBindings -> MessageQueueModule
2  : PluginModule.bindMessageQueueImplementation(PluginModule.java:376)
      \_ installed by: PluginBindings -> GraylogCloudModule

```

Simply disabling the journal on the configuration bean ensures
that both modules receive the same setting.

Also, remove uneeded configuration field from MigrateCmd.
