### PR TITLE
Provide default content for new pipeline rules

### DIFF
--- a/graylog2-web-interface/src/components/rules/RuleContext.jsx
+++ b/graylog2-web-interface/src/components/rules/RuleContext.jsx
@@ -133,10 +133,23 @@ PipelineRulesProvider.propTypes = {
   }),
 };
 
+const DEFAULT_RULE_SOURCE = `rule "New Rule"
+when
+  true // an expression that evaluates to true or false
+then
+  // Do something awesome!
+  // set_field("is_awesome", true);
+  // set_field("confirmed_awesome_timestamp", now());
+  //
+  // let x = capitalize("hello");
+  // let y = to_string(first_non_null([$message.nonexistent_field, "world"]));
+  // set_field("special_message", join(elements: [x,y], delimiter: " ") + "!");
+end`;
+
 PipelineRulesProvider.defaultProps = {
   usedInPipelines: [],
   rule: {
     description: '',
-    source: '',
+    source: DEFAULT_RULE_SOURCE,
   },
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR adds default content for new pipeline rules.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This change has two main goals:
1. Provide new users a safe introduction to what's possible
    * not actually setting/modifying fields
    * gradually progressing in complexity while not getting too in-depth
2. Save everyone some keystrokes when creating a new rule from scratch
    * just update the condition and replace the comments

Related to #11238.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Verified the default pipeline rule content shows up as expected, and that the uncommented rule body works as expected (setting fields `is_awesome`, `confirmed_awesome_timestamp`, and `special_message`).

## Screenshots (if appropriate):
<img src="https://user-images.githubusercontent.com/288958/142337036-1223ccb3-2e60-4b05-b4cd-5f34eb286329.png" height="70%" width="70%">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.