### PR TITLE
Handle missing area chart config more gracefully. (backport of #11610 for 4.2)

### DIFF
--- a/graylog2-web-interface/src/views/components/visualizations/area/bindings.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/area/bindings.tsx
@@ -34,7 +34,7 @@ const areaChart: VisualizationType<AreaVisualizationConfig, AreaVisualizationCon
   component: AreaVisualization,
   config: {
     createConfig: () => ({ interpolation: DEFAULT_INTERPOLATION }),
-    fromConfig: (config: AreaVisualizationConfig) => ({ interpolation: config.interpolation }),
+    fromConfig: (config: AreaVisualizationConfig) => ({ interpolation: config?.interpolation }),
     toConfig: (formValues: AreaVisualizationConfigFormValues) => AreaVisualizationConfig.create(formValues.interpolation),
     fields: [{
       name: 'interpolation',


### PR DESCRIPTION
_This is a backport of #11610 for `4.2`._

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Prior to this PR, when converting an area chart config to the form state of the aggregation wizard, we were expecting the config to be present.  It seems like there a circumstances where the aggregation wizard's visualization config is `null`. In these cases, editing an aggregation widget throws an exception.

This change is now handling missing visualization configs more gracefully, returning an empty setting for the interpolation of an area chart.

Fixes #11611 for `4.2`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.