### PR TITLE
Moves simulation diff logic to backend

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/models/messages/responses/ChangedField.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/messages/responses/ChangedField.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.rest.models.messages.responses;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.auto.value.AutoValue;
+
+@AutoValue
+@JsonAutoDetect
+@JsonTypeName("ChangedField")
+@JsonDeserialize(builder = AutoValue_ChangedField.Builder.class)
+public abstract class ChangedField {
+
+    public static final String FIELD_BEFORE = "before";
+    public static final String FIELD_AFTER = "after";
+
+    @JsonProperty(FIELD_BEFORE)
+    public abstract Object before();
+
+    @JsonProperty(FIELD_AFTER)
+    public abstract Object after();
+
+    public static ChangedField.Builder builder() {
+        return new AutoValue_ChangedField.Builder();
+    }
+
+    @AutoValue.Builder
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public abstract static class Builder {
+
+        @JsonProperty(FIELD_BEFORE)
+        public abstract ChangedField.Builder before(Object before);
+
+        @JsonProperty(FIELD_AFTER)
+        public abstract ChangedField.Builder after(Object before);
+
+        public abstract ChangedField build();
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/rest/models/messages/responses/DecorationStats.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/messages/responses/DecorationStats.java
@@ -55,7 +55,8 @@ public abstract class DecorationStats {
         return Sets.intersection(originalMessage().keySet(), decoratedMessage().keySet())
                 .stream()
                 .filter(key -> !originalMessage().get(key).equals(decoratedMessage().get(key)))
-                .collect(Collectors.toMap(Function.identity(), key -> decoratedMessage().get(key)));
+                .collect(Collectors.toMap(Function.identity(), key
+                        -> ChangedField.builder().before(originalMessage().get(key)).after(decoratedMessage().get(key)).build()));
     }
 
     @SuppressWarnings("unused")

--- a/graylog2-server/src/main/java/org/graylog2/rest/models/messages/responses/DecorationStats.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/messages/responses/DecorationStats.java
@@ -53,9 +53,9 @@ public abstract class DecorationStats {
     @JsonProperty(FIELD_CHANGED_FIELDS)
     public Map<String, Object> changedFields() {
         return Sets.intersection(originalMessage().keySet(), decoratedMessage().keySet())
-            .stream()
-            .filter(key -> !originalMessage().get(key).equals(decoratedMessage().get(key)))
-            .collect(Collectors.toMap(Function.identity(), key -> originalMessage().get(key)));
+                .stream()
+                .filter(key -> !originalMessage().get(key).equals(decoratedMessage().get(key)))
+                .collect(Collectors.toMap(Function.identity(), key -> decoratedMessage().get(key)));
     }
 
     @SuppressWarnings("unused")

--- a/graylog2-server/src/test/java/org/graylog2/rest/models/messages/responses/SimulationResultsTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/rest/models/messages/responses/SimulationResultsTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.rest.models.messages.responses;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SimulationResultsTest {
+
+    @Test
+    public void testDecorationStats() {
+        Map<String, Object> originalMessage = new HashMap<>();
+        originalMessage.put("field1", true);
+        originalMessage.put("field2", "value2");
+        originalMessage.put("field3", "value3");
+        originalMessage.put("field4", "value4");
+
+        Map<String, Object> processedMessage = new HashMap<>();
+        processedMessage.put("field2", "value2"); // field1 removed, field2 unchanged
+        processedMessage.put("field3", 3); // changed
+        processedMessage.put("field4", "changed"); // changed
+        processedMessage.put("field5", "value5"); // added
+
+        DecorationStats stats = DecorationStats.create(originalMessage, processedMessage);
+        Map<String, Object> addedFields = stats.addedFields();
+        Map<String, Object> removedFields = stats.removedFields();
+        Map<String, Object> changedFields = stats.changedFields();
+        assertThat(addedFields.size()).isEqualTo(1);
+        Assert.assertTrue(addedFields.containsKey("field5"));
+        assertThat(addedFields.get("field5")).isEqualTo("value5");
+        assertThat(removedFields.size()).isEqualTo(1);
+        Assert.assertTrue(removedFields.containsKey("field1"));
+        assertThat(removedFields.get("field1")).isEqualTo(true);
+        assertThat(changedFields.size()).isEqualTo(2);
+        Assert.assertTrue(changedFields.containsKey("field3"));
+        Assert.assertTrue(changedFields.containsKey("field4"));
+        ChangedField field3 = (ChangedField) changedFields.get("field3");
+        ChangedField field4 = (ChangedField) changedFields.get("field4");
+        assertThat(field3.before()).isEqualTo("value3");
+        assertThat(field3.after()).isEqualTo(3);
+        assertThat(field4.before()).isEqualTo("value4");
+        assertThat(field4.after()).isEqualTo("changed");
+    }
+
+}

--- a/graylog2-web-interface/src/components/simulator/SimulationChanges.jsx
+++ b/graylog2-web-interface/src/components/simulator/SimulationChanges.jsx
@@ -151,19 +151,19 @@ const SimulationChanges = createReactClass({
     );
   },
 
-  _formatMutatedFields(originalMessage, processedMessage) {
-    const mutatedFields = Object.keys(processedMessage.decoration_stats.changed_fields);
+  _formatMutatedFields(mutatedFields) {
+    const keys = Object.keys(mutatedFields);
 
-    if (mutatedFields.length === 0) {
+    if (keys.length === 0) {
       return null;
     }
 
     const formattedFields = [];
 
-    mutatedFields.sort().forEach((field) => {
+    keys.sort().forEach((field) => {
       formattedFields.push(this._formatFieldTitle(field));
-      formattedFields.push(this._formatFieldValue(`${field}-original`, originalMessage.fields[field], true));
-      formattedFields.push(this._formatFieldValue(field, processedMessage.fields[field]));
+      formattedFields.push(this._formatFieldValue(`${field}-original`, mutatedFields[field].before, true));
+      formattedFields.push(this._formatFieldValue(field, mutatedFields[field].after));
     });
 
     return (
@@ -188,7 +188,7 @@ const SimulationChanges = createReactClass({
 
     const formattedAddedFields = this._formatAddedFields(processedMessage.decoration_stats.added_fields);
     const formattedRemovedFields = this._formatRemovedFields(processedMessage.decoration_stats.removed_fields);
-    const formattedMutatedFields = this._formatMutatedFields(originalMessage, processedMessage);
+    const formattedMutatedFields = this._formatMutatedFields(processedMessage.decoration_stats.changed_fields);
 
     if (!formattedAddedFields && !formattedRemovedFields && !formattedMutatedFields) {
       return <p>Original message would be not be modified during processing.</p>;

--- a/graylog2-web-interface/src/components/simulator/SimulationChanges.jsx
+++ b/graylog2-web-interface/src/components/simulator/SimulationChanges.jsx
@@ -103,21 +103,18 @@ const SimulationChanges = createReactClass({
     return <FieldValue key={`${field}-value`} removed={isRemoved}>{String(value)}</FieldValue>;
   },
 
-  _formatAddedFields(originalMessage, processedMessage) {
-    const originalFields = Object.keys(originalMessage.fields);
-    const processedFields = Object.keys(processedMessage.fields);
+  _formatAddedFields(addedFields) {
+    const keys = Object.keys(addedFields);
 
-    const addedFields = processedFields.filter((field) => originalFields.indexOf(field) === -1);
-
-    if (addedFields.length === 0) {
+    if (keys.length === 0) {
       return null;
     }
 
     const formattedFields = [];
 
-    addedFields.sort().forEach((field) => {
+    keys.sort().forEach((field) => {
       formattedFields.push(this._formatFieldTitle(field));
-      formattedFields.push(this._formatFieldValue(field, processedMessage.fields[field]));
+      formattedFields.push(this._formatFieldValue(field, addedFields[field]));
     });
 
     return (
@@ -130,21 +127,18 @@ const SimulationChanges = createReactClass({
     );
   },
 
-  _formatRemovedFields(originalMessage, processedMessage) {
-    const originalFields = Object.keys(originalMessage.fields);
-    const processedFields = Object.keys(processedMessage.fields);
+  _formatRemovedFields(removedFields) {
+    const keys = Object.keys(removedFields);
 
-    const removedFields = originalFields.filter((field) => processedFields.indexOf(field) === -1);
-
-    if (removedFields.length === 0) {
+    if (keys.length === 0) {
       return null;
     }
 
     const formattedFields = [];
 
-    removedFields.sort().forEach((field) => {
+    keys.sort().forEach((field) => {
       formattedFields.push(this._formatFieldTitle(field));
-      formattedFields.push(this._formatFieldValue(field, originalMessage.fields[field]));
+      formattedFields.push(this._formatFieldValue(field, removedFields[field]));
     });
 
     return (
@@ -158,30 +152,7 @@ const SimulationChanges = createReactClass({
   },
 
   _formatMutatedFields(originalMessage, processedMessage) {
-    const originalFields = Object.keys(originalMessage.fields);
-    const processedFields = Object.keys(processedMessage.fields);
-
-    const mutatedFields = [];
-
-    originalFields.forEach((field) => {
-      if (processedFields.indexOf(field) === -1) {
-        return;
-      }
-
-      const originalValue = originalMessage.fields[field];
-      const processedValue = processedMessage.fields[field];
-
-      if (typeof originalValue !== typeof processedValue) {
-        mutatedFields.push(field);
-
-        return;
-      }
-
-      // Convert to JSON to avoid problems comparing objects or arrays. Yes, this sucks :/
-      if (JSON.stringify(originalValue) !== JSON.stringify(processedValue)) {
-        mutatedFields.push(field);
-      }
-    });
+    const mutatedFields = Object.keys(processedMessage.decoration_stats.changed_fields);
 
     if (mutatedFields.length === 0) {
       return null;
@@ -215,8 +186,8 @@ const SimulationChanges = createReactClass({
 
     const processedMessage = processedMessages.find((message) => message.id === originalMessage.id);
 
-    const formattedAddedFields = this._formatAddedFields(originalMessage, processedMessage);
-    const formattedRemovedFields = this._formatRemovedFields(originalMessage, processedMessage);
+    const formattedAddedFields = this._formatAddedFields(processedMessage.decoration_stats.added_fields);
+    const formattedRemovedFields = this._formatRemovedFields(processedMessage.decoration_stats.removed_fields);
     const formattedMutatedFields = this._formatMutatedFields(originalMessage, processedMessage);
 
     if (!formattedAddedFields && !formattedRemovedFields && !formattedMutatedFields) {


### PR DESCRIPTION
## Description
The diff of fields added, removed, and changed during pipeline simulation is now created on the back end as opposed to the front end 

## Motivation and Context
Related to Graylog2/graylog-plugin-enterprise#2880. Generating pre/post-processing diffs on the back end makes it easier to unit test. Also logically it just makes more sense to create the diff on the back end vs front end. 

## How Has This Been Tested?
Ran Graylog locally in my development environment, set up a pipeline to change, add, and remove fields from a message, and confirmed that the output on the front end is correct based on the pre/post processed message. Also tested hitting Illuminate sim from command line with help from Michael to ensure all added, removed, and changed fields return properly. 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

