### PR TITLE
Introducing DTOs for Search API, selecting version via content negotiation.

### DIFF
--- a/full-backend-tests/src/test/java/org/graylog/testing/backenddriver/SearchDriver.java
+++ b/full-backend-tests/src/test/java/org/graylog/testing/backenddriver/SearchDriver.java
@@ -20,9 +20,9 @@ import com.google.common.collect.ImmutableSet;
 import io.restassured.path.json.JsonPath;
 import io.restassured.specification.RequestSpecification;
 import org.bson.types.ObjectId;
-import org.graylog.plugins.views.search.Query;
-import org.graylog.plugins.views.search.Search;
 import org.graylog.plugins.views.search.elasticsearch.ElasticsearchQueryString;
+import org.graylog.plugins.views.search.rest.QueryDTO;
+import org.graylog.plugins.views.search.rest.SearchDTO;
 import org.graylog.plugins.views.search.searchtypes.MessageList;
 import org.graylog.testing.utils.JsonUtils;
 import org.graylog.testing.utils.RangeUtils;
@@ -33,6 +33,7 @@ import org.slf4j.LoggerFactory;
 import java.util.List;
 
 import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.notNullValue;
 
 /**
  * WIP. This class illustrates how we could reuse common functionality for integration tests.
@@ -51,7 +52,7 @@ public class SearchDriver {
      * @return all messages' "message" field as List<String>
      */
     public static List<String> searchAllMessages(RequestSpecification requestSpec) {
-      return searchAllMessagesInTimeRange(requestSpec, RangeUtils.allMessagesTimeRange());
+        return searchAllMessagesInTimeRange(requestSpec, RangeUtils.allMessagesTimeRange());
     }
 
     public static List<String> searchAllMessagesInTimeRange(RequestSpecification requestSpec, TimeRange timeRange) {
@@ -67,9 +68,10 @@ public class SearchDriver {
                 .post("/views/search/sync")
                 .then()
                 .statusCode(200)
+                .assertThat().body("execution.completed_exceptionally", notNullValue())
                 .extract().body().jsonPath();
 
-        if(response.get("execution.completed_exceptionally")) {
+        if (response.get("execution.completed_exceptionally")) {
             final Object errors = response.getString("errors");
             LOG.warn("Failed to obtain messages: {}", errors);
         }
@@ -79,13 +81,16 @@ public class SearchDriver {
 
     private static String allMessagesJson(String queryId, String messageListId, TimeRange timeRange) {
         MessageList messageList = MessageList.builder().id(messageListId).build();
-        Query q = Query.builder()
+        QueryDTO q = QueryDTO.builder()
                 .id(queryId)
                 .query(ElasticsearchQueryString.of(""))
                 .timerange(timeRange)
                 .searchTypes(ImmutableSet.of(messageList))
                 .build();
-        Search s = Search.builder().id(new ObjectId().toHexString()).queries(ImmutableSet.of(q)).build();
+        SearchDTO s = SearchDTO.builder()
+                .id(new ObjectId().toHexString())
+                .queries(ImmutableSet.of(q))
+                .build();
 
         return JsonUtils.toJsonString(s);
     }

--- a/full-backend-tests/src/test/resources/org/graylog/plugins/views/minimalistic-request-with-streams.json
+++ b/full-backend-tests/src/test/resources/org/graylog/plugins/views/minimalistic-request-with-streams.json
@@ -1,0 +1,22 @@
+{
+  "queries": [
+    {
+      "streams": [
+        "000000000000000000000001"
+      ],
+      "query": {
+        "type": "elasticsearch",
+        "query_string": ""
+      },
+      "timerange": {
+        "type": "relative",
+        "from": 300
+      },
+      "search_types": [
+        {
+          "type": "messages"
+        }
+      ]
+    }
+  ]
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/SearchJob.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/SearchJob.java
@@ -36,9 +36,6 @@ import java.util.concurrent.CompletableFuture;
 // execution must come before results, as it signals the overall "done" state
 @JsonPropertyOrder({"execution", "results"})
 public class SearchJob {
-    private static final Logger LOG = LoggerFactory.getLogger(SearchJob.class);
-    static final String FIELD_OWNER = "owner";
-
     @JsonProperty
     private final String id;
 
@@ -51,7 +48,7 @@ public class SearchJob {
     @JsonIgnore
     private CompletableFuture<Void> resultFuture;
 
-    private Map<String, CompletableFuture<QueryResult>> queryResults = Maps.newHashMap();
+    final private Map<String, CompletableFuture<QueryResult>> queryResults = Maps.newHashMap();
 
     @JsonProperty("errors")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/SearchJob.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/SearchJob.java
@@ -115,13 +115,13 @@ public class SearchJob {
         errors.add(t);
     }
 
-    private static class ExecutionInfo {
+    public static class ExecutionInfo {
         @JsonProperty("done")
-        private final boolean done;
+        public final boolean done;
         @JsonProperty("cancelled")
-        private final boolean cancelled;
+        public final boolean cancelled;
         @JsonProperty("completed_exceptionally")
-        private final boolean hasErrors;
+        public final boolean hasErrors;
 
         ExecutionInfo(boolean done, boolean cancelled, boolean hasErrors) {
             this.done = done;

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/SearchJob.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/SearchJob.java
@@ -46,7 +46,7 @@ public class SearchJob {
     @JsonIgnore
     private CompletableFuture<Void> resultFuture;
 
-    final private Map<String, CompletableFuture<QueryResult>> queryResults = Maps.newHashMap();
+    private final Map<String, CompletableFuture<QueryResult>> queryResults = Maps.newHashMap();
 
     @JsonProperty("errors")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/SearchJob.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/SearchJob.java
@@ -25,8 +25,6 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import one.util.streamex.EntryStream;
 import org.graylog.plugins.views.search.errors.SearchError;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.Map;
 import java.util.Set;
@@ -75,6 +73,10 @@ public class SearchJob {
 
     public String getOwner() {
         return owner;
+    }
+
+    public Set<SearchError> getErrors() {
+        return errors;
     }
 
     public CompletableFuture<Void> getResultFuture() {

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/QueryDTO.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/QueryDTO.java
@@ -38,7 +38,7 @@ import java.util.Set;
 @JsonAutoDetect
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonDeserialize(builder = QueryDTO.Builder.class)
-abstract class QueryDTO {
+public abstract class QueryDTO {
     @JsonProperty
     public abstract Optional<String> id();
 
@@ -65,8 +65,12 @@ abstract class QueryDTO {
                 .build();
     }
 
+    public static Builder builder() {
+        return Builder.create();
+    }
+
     @AutoValue.Builder
-    abstract static class Builder {
+    public abstract static class Builder {
         @JsonProperty
         public abstract Builder id(@Nullable String id);
 
@@ -85,7 +89,7 @@ abstract class QueryDTO {
         public abstract QueryDTO build();
 
         @JsonCreator
-        static Builder create() {
+        public static Builder create() {
             return new AutoValue_QueryDTO.Builder();
         }
     }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/QueryDTO.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/QueryDTO.java
@@ -21,7 +21,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableSet;
 import org.graylog.plugins.views.search.Filter;
@@ -59,6 +58,7 @@ abstract class QueryDTO {
     static QueryDTO fromQuery(Query query) {
         return QueryDTO.Builder.create()
                 .id(query.id())
+                .query(query.query())
                 .filter(query.filter())
                 .searchTypes(query.searchTypes())
                 .timerange(query.timerange())

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/QueryDTO.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/QueryDTO.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.views.search.rest;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableSet;
+import org.graylog.plugins.views.search.Filter;
+import org.graylog.plugins.views.search.Query;
+import org.graylog.plugins.views.search.SearchType;
+import org.graylog.plugins.views.search.elasticsearch.ElasticsearchQueryString;
+import org.graylog.plugins.views.search.engine.BackendQuery;
+import org.graylog2.plugin.indexer.searches.timeranges.InvalidRangeParametersException;
+import org.graylog2.plugin.indexer.searches.timeranges.RelativeRange;
+import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Set;
+import java.util.UUID;
+
+import static com.google.common.collect.ImmutableSortedSet.of;
+
+@AutoValue
+@JsonAutoDetect
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonDeserialize(builder = QueryDTO.Builder.class)
+public abstract class QueryDTO {
+    @Nullable
+    @JsonProperty
+    public abstract String id();
+
+    @JsonProperty
+    public abstract TimeRange timerange();
+
+    @Nullable
+    @JsonProperty
+    public abstract Filter filter();
+
+    @Nonnull
+    @JsonProperty
+    public abstract BackendQuery query();
+
+    @Nonnull
+    @JsonProperty("search_types")
+    public abstract Set<SearchType> searchTypes();
+
+    @AutoValue.Builder
+    @JsonPOJOBuilder(withPrefix = "")
+    public abstract static class Builder {
+        @JsonProperty
+        public abstract Builder id(String id);
+
+        public abstract String id();
+
+        @JsonProperty
+        public abstract Builder timerange(TimeRange timerange);
+
+        @JsonProperty
+        public abstract Builder filter(Filter filter);
+
+        @JsonProperty
+        public abstract Builder query(BackendQuery query);
+
+        @JsonProperty("search_types")
+        public abstract Builder searchTypes(@Nullable Set<SearchType> searchTypes);
+
+        abstract QueryDTO autoBuild();
+
+        @JsonCreator
+        static Builder createWithDefaults() {
+            try {
+                return new AutoValue_QueryDTO.Builder()
+                        .searchTypes(of())
+                        .query(ElasticsearchQueryString.empty())
+                        .timerange(RelativeRange.create(300));
+            } catch (InvalidRangeParametersException e) {
+                throw new RuntimeException("Unable to create relative timerange - this should not happen!");
+            }
+        }
+
+        public QueryDTO build() {
+            if (id() == null) {
+                id(UUID.randomUUID().toString());
+            }
+            return autoBuild();
+        }
+    }
+
+    public Query toQuery() {
+        return Query.builder()
+                .id(id())
+                .timerange(timerange())
+                .filter(filter())
+                .query(query())
+                .searchTypes(ImmutableSet.copyOf(searchTypes()))
+                .build();
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/QueryDTO.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/QueryDTO.java
@@ -32,6 +32,7 @@ import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.Optional;
 import java.util.Set;
 
 @AutoValue
@@ -39,28 +40,23 @@ import java.util.Set;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonDeserialize(builder = QueryDTO.Builder.class)
 public abstract class QueryDTO {
-    @Nullable
     @JsonProperty
-    public abstract String id();
+    public abstract Optional<String> id();
 
-    @Nullable
     @JsonProperty
-    public abstract TimeRange timerange();
+    public abstract Optional<TimeRange> timerange();
 
-    @Nullable
     @JsonProperty
-    public abstract Filter filter();
+    public abstract Optional<Filter> filter();
 
-    @Nullable
     @JsonProperty
-    public abstract BackendQuery query();
+    public abstract Optional<BackendQuery> query();
 
     @Nonnull
     @JsonProperty("search_types")
     public abstract Set<SearchType> searchTypes();
 
     @AutoValue.Builder
-    @JsonPOJOBuilder(withPrefix = "")
     public abstract static class Builder {
         @JsonProperty
         public abstract Builder id(String id);
@@ -86,11 +82,13 @@ public abstract class QueryDTO {
     }
 
     public Query toQuery() {
-        return Query.builder()
-                .id(id())
-                .timerange(timerange())
-                .filter(filter())
-                .query(query())
+        Query.Builder queryBuilder = Query.builder();
+        queryBuilder = id().map(queryBuilder::id).orElse(queryBuilder);
+        queryBuilder = timerange().map(queryBuilder::timerange).orElse(queryBuilder);
+        queryBuilder = filter().map(queryBuilder::filter).orElse(queryBuilder);
+        queryBuilder = query().map(queryBuilder::query).orElse(queryBuilder);
+
+        return queryBuilder
                 .searchTypes(ImmutableSet.copyOf(searchTypes()))
                 .build();
     }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/QueryDTO.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/QueryDTO.java
@@ -27,18 +27,12 @@ import com.google.common.collect.ImmutableSet;
 import org.graylog.plugins.views.search.Filter;
 import org.graylog.plugins.views.search.Query;
 import org.graylog.plugins.views.search.SearchType;
-import org.graylog.plugins.views.search.elasticsearch.ElasticsearchQueryString;
 import org.graylog.plugins.views.search.engine.BackendQuery;
-import org.graylog2.plugin.indexer.searches.timeranges.InvalidRangeParametersException;
-import org.graylog2.plugin.indexer.searches.timeranges.RelativeRange;
 import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Set;
-import java.util.UUID;
-
-import static com.google.common.collect.ImmutableSortedSet.of;
 
 @AutoValue
 @JsonAutoDetect
@@ -49,6 +43,7 @@ public abstract class QueryDTO {
     @JsonProperty
     public abstract String id();
 
+    @Nullable
     @JsonProperty
     public abstract TimeRange timerange();
 
@@ -56,7 +51,7 @@ public abstract class QueryDTO {
     @JsonProperty
     public abstract Filter filter();
 
-    @Nonnull
+    @Nullable
     @JsonProperty
     public abstract BackendQuery query();
 
@@ -70,8 +65,6 @@ public abstract class QueryDTO {
         @JsonProperty
         public abstract Builder id(String id);
 
-        public abstract String id();
-
         @JsonProperty
         public abstract Builder timerange(TimeRange timerange);
 
@@ -82,27 +75,13 @@ public abstract class QueryDTO {
         public abstract Builder query(BackendQuery query);
 
         @JsonProperty("search_types")
-        public abstract Builder searchTypes(@Nullable Set<SearchType> searchTypes);
+        public abstract Builder searchTypes(@Nonnull Set<SearchType> searchTypes);
 
-        abstract QueryDTO autoBuild();
+        public abstract QueryDTO build();
 
         @JsonCreator
-        static Builder createWithDefaults() {
-            try {
-                return new AutoValue_QueryDTO.Builder()
-                        .searchTypes(of())
-                        .query(ElasticsearchQueryString.empty())
-                        .timerange(RelativeRange.create(300));
-            } catch (InvalidRangeParametersException e) {
-                throw new RuntimeException("Unable to create relative timerange - this should not happen!");
-            }
-        }
-
-        public QueryDTO build() {
-            if (id() == null) {
-                id(UUID.randomUUID().toString());
-            }
-            return autoBuild();
+        static Builder create() {
+            return new AutoValue_QueryDTO.Builder();
         }
     }
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/QueryDTO.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/QueryDTO.java
@@ -39,7 +39,7 @@ import java.util.Set;
 @JsonAutoDetect
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonDeserialize(builder = QueryDTO.Builder.class)
-public abstract class QueryDTO {
+abstract class QueryDTO {
     @JsonProperty
     public abstract Optional<String> id();
 
@@ -56,19 +56,28 @@ public abstract class QueryDTO {
     @JsonProperty("search_types")
     public abstract Set<SearchType> searchTypes();
 
+    static QueryDTO fromQuery(Query query) {
+        return QueryDTO.Builder.create()
+                .id(query.id())
+                .filter(query.filter())
+                .searchTypes(query.searchTypes())
+                .timerange(query.timerange())
+                .build();
+    }
+
     @AutoValue.Builder
-    public abstract static class Builder {
+    abstract static class Builder {
         @JsonProperty
-        public abstract Builder id(String id);
+        public abstract Builder id(@Nullable String id);
 
         @JsonProperty
-        public abstract Builder timerange(TimeRange timerange);
+        public abstract Builder timerange(@Nullable TimeRange timerange);
 
         @JsonProperty
-        public abstract Builder filter(Filter filter);
+        public abstract Builder filter(@Nullable Filter filter);
 
         @JsonProperty
-        public abstract Builder query(BackendQuery query);
+        public abstract Builder query(@Nullable BackendQuery query);
 
         @JsonProperty("search_types")
         public abstract Builder searchTypes(@Nonnull Set<SearchType> searchTypes);
@@ -81,7 +90,7 @@ public abstract class QueryDTO {
         }
     }
 
-    public Query toQuery() {
+    Query toQuery() {
         Query.Builder queryBuilder = Query.builder();
         queryBuilder = id().map(queryBuilder::id).orElse(queryBuilder);
         queryBuilder = timerange().map(queryBuilder::timerange).orElse(queryBuilder);

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/QueryDTOv2.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/QueryDTOv2.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.views.search.rest;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import org.graylog.plugins.views.search.Query;
+import org.graylog.plugins.views.search.SearchType;
+import org.graylog.plugins.views.search.engine.BackendQuery;
+import org.graylog.plugins.views.search.filter.StreamFilter;
+import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+@AutoValue
+@JsonAutoDetect
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonDeserialize(builder = QueryDTOv2.Builder.class)
+public abstract class QueryDTOv2 {
+    @JsonProperty
+    public abstract Optional<String> id();
+
+    @JsonProperty
+    public abstract Optional<TimeRange> timerange();
+
+    @JsonProperty
+    public abstract Optional<List<String>> streams();
+
+    @JsonProperty
+    public abstract Optional<BackendQuery> query();
+
+    @Nonnull
+    @JsonProperty("search_types")
+    public abstract Set<SearchType> searchTypes();
+
+    static QueryDTOv2 fromQuery(Query query) {
+        return QueryDTOv2.Builder.create()
+                .id(query.id())
+                .query(query.query())
+                .streams(ImmutableList.copyOf(query.usedStreamIds()))
+                .searchTypes(query.searchTypes())
+                .timerange(query.timerange())
+                .build();
+    }
+
+    public static Builder builder() {
+        return Builder.create();
+    }
+
+    @AutoValue.Builder
+    public abstract static class Builder {
+        @JsonProperty
+        public abstract Builder id(@Nullable String id);
+
+        @JsonProperty
+        public abstract Builder timerange(@Nullable TimeRange timerange);
+
+        @JsonProperty
+        public abstract Builder streams(@Nullable List<String> streams);
+
+        @JsonProperty
+        public abstract Builder query(@Nullable BackendQuery query);
+
+        @JsonProperty("search_types")
+        public abstract Builder searchTypes(@Nonnull Set<SearchType> searchTypes);
+
+        public abstract QueryDTOv2 build();
+
+        @JsonCreator
+        public static Builder create() {
+            return new AutoValue_QueryDTOv2.Builder();
+        }
+    }
+
+    Query toQuery() {
+        Query.Builder queryBuilder = Query.builder();
+        queryBuilder = id().map(queryBuilder::id).orElse(queryBuilder);
+        queryBuilder = timerange().map(queryBuilder::timerange).orElse(queryBuilder);
+        final Query.Builder finalQueryBuilder = queryBuilder;
+        queryBuilder = streams().map(streams -> finalQueryBuilder.filter(StreamFilter.anyIdOf(streams.toArray(new String[0])))).orElse(queryBuilder);
+        queryBuilder = query().map(queryBuilder::query).orElse(queryBuilder);
+
+        return queryBuilder
+                .searchTypes(ImmutableSet.copyOf(searchTypes()))
+                .build();
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SearchDTO.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SearchDTO.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.views.search.rest;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableSet;
+import org.graylog.plugins.views.search.Parameter;
+import org.graylog.plugins.views.search.Query;
+import org.graylog.plugins.views.search.Search;
+import org.mongojack.Id;
+
+import javax.annotation.Nullable;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static com.google.common.collect.ImmutableSet.of;
+
+@AutoValue
+@JsonAutoDetect
+@JsonDeserialize(builder = SearchDTO.Builder.class)
+public abstract class SearchDTO {
+    public static final String FIELD_OWNER = "owner";
+
+    @Nullable
+    @JsonProperty
+    public abstract String id();
+
+    @JsonProperty
+    public abstract Set<QueryDTO> queries();
+
+    @JsonProperty
+    public abstract Set<Parameter> parameters();
+
+    @AutoValue.Builder
+    @JsonPOJOBuilder(withPrefix = "")
+    public abstract static class Builder {
+        @Id
+        @JsonProperty
+        public abstract Builder id(String id);
+
+        public abstract String id();
+
+        @JsonProperty
+        public abstract Builder queries(Set<QueryDTO> queries);
+
+        @JsonProperty
+        public abstract Builder parameters(Set<Parameter> parameters);
+
+        public abstract SearchDTO build();
+
+        @JsonCreator
+        public static Builder create() {
+            return new AutoValue_SearchDTO.Builder()
+                    .queries(ImmutableSet.of())
+                    .parameters(of());
+        }
+    }
+
+    public Search toSearch() {
+        final ImmutableSet<Query> queries = queries().stream()
+                .map(QueryDTO::toQuery)
+                .collect(ImmutableSet.toImmutableSet());
+        return Search.builder()
+                .id(id())
+                .queries(queries)
+                .parameters(ImmutableSet.copyOf(parameters()))
+                .build();
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SearchDTO.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SearchDTO.java
@@ -35,7 +35,7 @@ import static com.google.common.collect.ImmutableSet.of;
 @AutoValue
 @JsonAutoDetect
 @JsonDeserialize(builder = SearchDTO.Builder.class)
-abstract class SearchDTO {
+public abstract class SearchDTO {
     @Nullable
     @JsonProperty
     public abstract String id();
@@ -57,8 +57,12 @@ abstract class SearchDTO {
                 .build();
     }
 
+    public static Builder builder() {
+        return Builder.create();
+    }
+
     @AutoValue.Builder
-    abstract static class Builder {
+    public abstract static class Builder {
         @JsonProperty
         public abstract Builder id(String id);
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SearchDTO.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SearchDTO.java
@@ -20,17 +20,14 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableSet;
 import org.graylog.plugins.views.search.Parameter;
 import org.graylog.plugins.views.search.Query;
 import org.graylog.plugins.views.search.Search;
-import org.mongojack.Id;
 
 import javax.annotation.Nullable;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static com.google.common.collect.ImmutableSet.of;
@@ -62,7 +59,6 @@ abstract class SearchDTO {
 
     @AutoValue.Builder
     abstract static class Builder {
-        @Id
         @JsonProperty
         public abstract Builder id(String id);
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SearchDTO.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SearchDTO.java
@@ -30,6 +30,7 @@ import org.mongojack.Id;
 
 import javax.annotation.Nullable;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static com.google.common.collect.ImmutableSet.of;
@@ -37,7 +38,7 @@ import static com.google.common.collect.ImmutableSet.of;
 @AutoValue
 @JsonAutoDetect
 @JsonDeserialize(builder = SearchDTO.Builder.class)
-public abstract class SearchDTO {
+abstract class SearchDTO {
     @Nullable
     @JsonProperty
     public abstract String id();
@@ -48,8 +49,19 @@ public abstract class SearchDTO {
     @JsonProperty
     public abstract Set<Parameter> parameters();
 
+    static SearchDTO fromSearch(Search search) {
+        return SearchDTO.Builder.create()
+                .id(search.id())
+                .parameters(search.parameters())
+                .queries(search.queries()
+                        .stream()
+                        .map(QueryDTO::fromQuery)
+                        .collect(Collectors.toSet()))
+                .build();
+    }
+
     @AutoValue.Builder
-    public abstract static class Builder {
+    abstract static class Builder {
         @Id
         @JsonProperty
         public abstract Builder id(String id);
@@ -65,14 +77,14 @@ public abstract class SearchDTO {
         public abstract SearchDTO build();
 
         @JsonCreator
-        public static Builder create() {
+        static Builder create() {
             return new AutoValue_SearchDTO.Builder()
                     .queries(ImmutableSet.of())
                     .parameters(of());
         }
     }
 
-    public Search toSearch() {
+    Search toSearch() {
         final ImmutableSet<Query> queries = queries().stream()
                 .map(QueryDTO::toQuery)
                 .collect(ImmutableSet.toImmutableSet());

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SearchDTO.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SearchDTO.java
@@ -38,8 +38,6 @@ import static com.google.common.collect.ImmutableSet.of;
 @JsonAutoDetect
 @JsonDeserialize(builder = SearchDTO.Builder.class)
 public abstract class SearchDTO {
-    public static final String FIELD_OWNER = "owner";
-
     @Nullable
     @JsonProperty
     public abstract String id();
@@ -51,7 +49,6 @@ public abstract class SearchDTO {
     public abstract Set<Parameter> parameters();
 
     @AutoValue.Builder
-    @JsonPOJOBuilder(withPrefix = "")
     public abstract static class Builder {
         @Id
         @JsonProperty

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SearchDTOv2.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SearchDTOv2.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.views.search.rest;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableSet;
+import org.graylog.plugins.views.search.Parameter;
+import org.graylog.plugins.views.search.Query;
+import org.graylog.plugins.views.search.Search;
+
+import javax.annotation.Nullable;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static com.google.common.collect.ImmutableSet.of;
+
+@AutoValue
+@JsonAutoDetect
+@JsonDeserialize(builder = SearchDTOv2.Builder.class)
+public abstract class SearchDTOv2 {
+    @Nullable
+    @JsonProperty
+    public abstract String id();
+
+    @JsonProperty
+    public abstract Set<QueryDTOv2> queries();
+
+    @JsonProperty
+    public abstract Set<Parameter> parameters();
+
+    static SearchDTOv2 fromSearch(Search search) {
+        return SearchDTOv2.Builder.create()
+                .id(search.id())
+                .parameters(search.parameters())
+                .queries(search.queries()
+                        .stream()
+                        .map(QueryDTOv2::fromQuery)
+                        .collect(Collectors.toSet()))
+                .build();
+    }
+
+    public static Builder builder() {
+        return Builder.create();
+    }
+
+    @AutoValue.Builder
+    public abstract static class Builder {
+        @JsonProperty
+        public abstract Builder id(String id);
+
+        public abstract String id();
+
+        @JsonProperty
+        public abstract Builder queries(Set<QueryDTOv2> queries);
+
+        @JsonProperty
+        public abstract Builder parameters(Set<Parameter> parameters);
+
+        public abstract SearchDTOv2 build();
+
+        @JsonCreator
+        static Builder create() {
+            return new AutoValue_SearchDTOv2.Builder()
+                    .queries(ImmutableSet.of())
+                    .parameters(of());
+        }
+    }
+
+    Search toSearch() {
+        final ImmutableSet<Query> queries = queries().stream()
+                .map(QueryDTOv2::toQuery)
+                .collect(ImmutableSet.toImmutableSet());
+        return Search.builder()
+                .id(id())
+                .queries(queries)
+                .parameters(ImmutableSet.copyOf(parameters()))
+                .build();
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SearchJobDTO.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SearchJobDTO.java
@@ -32,6 +32,9 @@ abstract class SearchJobDTO {
     @JsonProperty
     abstract Map<String, QueryResult> results();
 
+    @JsonProperty
+    abstract ExecutionInfo execution();
+
     static SearchJobDTO fromSearchJob(SearchJob searchJob) {
         return Builder.create()
                 .id(searchJob.getId())
@@ -39,6 +42,7 @@ abstract class SearchJobDTO {
                 .errors(searchJob.getErrors())
                 .results(searchJob.results())
                 .searchId(searchJob.getSearchId())
+                .execution(ExecutionInfo.fromExecutionInfo(searchJob.execution()))
                 .build();
     }
 
@@ -54,10 +58,31 @@ abstract class SearchJobDTO {
 
         abstract Builder results(Map<String, QueryResult> results);
 
+        abstract Builder execution(ExecutionInfo executionInfo);
+
         abstract SearchJobDTO build();
 
         static SearchJobDTO.Builder create() {
             return new AutoValue_SearchJobDTO.Builder();
+        }
+    }
+
+    static class ExecutionInfo {
+        @JsonProperty
+        private final boolean done;
+        @JsonProperty
+        private final boolean cancelled;
+        @JsonProperty("completed_exceptionally")
+        private final boolean hasErrors;
+
+        private ExecutionInfo(boolean done, boolean cancelled, boolean hasErrors) {
+            this.done = done;
+            this.cancelled = cancelled;
+            this.hasErrors = hasErrors;
+        }
+
+        public static ExecutionInfo fromExecutionInfo(SearchJob.ExecutionInfo execution) {
+            return new ExecutionInfo(execution.done, execution.cancelled, execution.hasErrors);
         }
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SearchJobDTO.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SearchJobDTO.java
@@ -1,0 +1,63 @@
+package org.graylog.plugins.views.search.rest;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.google.auto.value.AutoValue;
+import org.graylog.plugins.views.search.QueryResult;
+import org.graylog.plugins.views.search.SearchJob;
+import org.graylog.plugins.views.search.errors.SearchError;
+
+import java.util.Map;
+import java.util.Set;
+
+@AutoValue
+@JsonAutoDetect
+@JsonPropertyOrder({"execution", "results"})
+abstract class SearchJobDTO {
+    @JsonProperty
+    abstract String id();
+
+    @JsonProperty("search_id")
+    abstract String searchId();
+
+    @JsonProperty
+    abstract String owner();
+
+    @JsonProperty("errors")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    abstract Set<SearchError> errors();
+
+    @JsonProperty
+    abstract Map<String, QueryResult> results();
+
+    static SearchJobDTO fromSearchJob(SearchJob searchJob) {
+        return Builder.create()
+                .id(searchJob.getId())
+                .owner(searchJob.getOwner())
+                .errors(searchJob.getErrors())
+                .results(searchJob.results())
+                .searchId(searchJob.getSearchId())
+                .build();
+    }
+
+    @AutoValue.Builder
+    abstract static class Builder {
+        abstract Builder id(String id);
+
+        abstract Builder searchId(String searchId);
+
+        abstract Builder owner(String owner);
+
+        abstract Builder errors(Set<SearchError> errors);
+
+        abstract Builder results(Map<String, QueryResult> results);
+
+        abstract SearchJobDTO build();
+
+        static SearchJobDTO.Builder create() {
+            return new AutoValue_SearchJobDTO.Builder();
+        }
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SearchJobDTO.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SearchJobDTO.java
@@ -67,22 +67,19 @@ abstract class SearchJobDTO {
         }
     }
 
-    static class ExecutionInfo {
+    @AutoValue
+    abstract static class ExecutionInfo {
         @JsonProperty
-        private final boolean done;
-        @JsonProperty
-        private final boolean cancelled;
-        @JsonProperty("completed_exceptionally")
-        private final boolean hasErrors;
+        abstract boolean done();
 
-        private ExecutionInfo(boolean done, boolean cancelled, boolean hasErrors) {
-            this.done = done;
-            this.cancelled = cancelled;
-            this.hasErrors = hasErrors;
-        }
+        @JsonProperty
+        abstract boolean cancelled();
+
+        @JsonProperty("completed_exceptionally")
+        abstract boolean hasErrors();
 
         public static ExecutionInfo fromExecutionInfo(SearchJob.ExecutionInfo execution) {
-            return new ExecutionInfo(execution.done, execution.cancelled, execution.hasErrors);
+            return new AutoValue_SearchJobDTO_ExecutionInfo(execution.done, execution.cancelled, execution.hasErrors);
         }
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SearchJobDTO.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SearchJobDTO.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog.plugins.views.search.rest;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SearchResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SearchResource.java
@@ -87,7 +87,9 @@ public class SearchResource extends RestResource implements PluginRestResource {
     @POST
     @ApiOperation(value = "Create a search query", response = Search.class, code = 201)
     @AuditEvent(type = ViewsAuditEventTypes.SEARCH_CREATE)
-    public Response createSearch(@ApiParam Search search, @Context SearchUser searchUser) {
+    public Response createSearch(@ApiParam SearchDTO searchRequest, @Context SearchUser searchUser) {
+        final Search search = searchRequest.toSearch();
+
         final Search saved = searchDomain.saveForUser(search, searchUser);
         if (saved == null || saved.id() == null) {
             return Response.serverError().build();
@@ -133,10 +135,11 @@ public class SearchResource extends RestResource implements PluginRestResource {
     @ApiOperation(value = "Execute a new synchronous search", notes = "Executes a new search and waits for its result", response = SearchJob.class)
     @Path("sync")
     @NoAuditEvent("Creating audit event manually in method body.")
-    public Response executeSyncJob(@ApiParam @NotNull(message = "Search body is mandatory") Search search,
+    public Response executeSyncJob(@ApiParam @NotNull(message = "Search body is mandatory") SearchDTO searchRequest,
                                    @ApiParam(name = "timeout", defaultValue = "60000")
                                    @QueryParam("timeout") @DefaultValue("60000") long timeout,
                                    @Context SearchUser searchUser) {
+        final Search search = searchRequest.toSearch();
         final SearchJob searchJob = searchExecutor.execute(search, searchUser, ExecutionState.empty());
 
         postAuditEvent(searchJob);

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SearchResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SearchResource.java
@@ -25,7 +25,6 @@ import org.apache.shiro.authz.annotation.RequiresAuthentication;
 import org.graylog.plugins.views.audit.ViewsAuditEventTypes;
 import org.graylog.plugins.views.search.Search;
 import org.graylog.plugins.views.search.SearchDomain;
-import org.graylog.plugins.views.search.SearchExecutionGuard;
 import org.graylog.plugins.views.search.SearchJob;
 import org.graylog.plugins.views.search.db.SearchJobService;
 import org.graylog.plugins.views.search.events.SearchJobExecutionEvent;

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/SearchDomainTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/SearchDomainTest.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableList;
 import org.graylog.plugins.views.search.db.SearchDbService;
 import org.graylog.plugins.views.search.errors.PermissionException;
 import org.graylog.plugins.views.search.permissions.SearchUser;
+import org.graylog.plugins.views.search.rest.SearchDTO;
 import org.graylog.plugins.views.search.views.ViewDTO;
 import org.graylog.plugins.views.search.views.ViewService;
 import org.junit.Before;

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/SearchDomainTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/SearchDomainTest.java
@@ -25,6 +25,7 @@ import org.graylog.plugins.views.search.views.ViewService;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
@@ -42,6 +43,8 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class SearchDomainTest {
@@ -165,6 +168,23 @@ public class SearchDomainTest {
 
         assertThatExceptionOfType(ForbiddenException.class)
                 .isThrownBy(() -> sut.saveForUser(search, searchUser));
+    }
+
+    @Test
+    public void saveAddsOwnerToSearch() {
+        final Search search = mockSearchWithOwner(null);
+        final SearchUser searchUser = mock(SearchUser.class);
+        when(searchUser.username()).thenReturn("eberhard");
+        when(searchUser.isAdmin()).thenReturn(true);
+
+        sut.saveForUser(search, searchUser);
+
+        final ArgumentCaptor<Search> savedCaptor = ArgumentCaptor.forClass(Search.class);
+        verify(dbService, times(1)).save(savedCaptor.capture());
+
+        final Search result = savedCaptor.getValue();
+
+        assertThat(result.owner()).contains("eberhard");
     }
 
     private void throwGuardExceptionFor(Search search) {

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/SearchDomainTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/SearchDomainTest.java
@@ -20,7 +20,6 @@ import com.google.common.collect.ImmutableList;
 import org.graylog.plugins.views.search.db.SearchDbService;
 import org.graylog.plugins.views.search.errors.PermissionException;
 import org.graylog.plugins.views.search.permissions.SearchUser;
-import org.graylog.plugins.views.search.rest.SearchDTO;
 import org.graylog.plugins.views.search.views.ViewDTO;
 import org.graylog.plugins.views.search.views.ViewService;
 import org.junit.Before;

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/SearchResourceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/SearchResourceTest.java
@@ -47,12 +47,11 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class SearchResourceTest {
-    private static final ObjectMapperProvider objectMapperProvider = new ObjectMapperProvider();
-
     @Rule
     public MockitoRule rule = MockitoJUnit.rule();
 
@@ -72,9 +71,6 @@ public class SearchResourceTest {
     private EventBus eventBus;
 
     @Mock
-    private QueryEngine queryEngine;
-
-    @Mock
     private SearchExecutor searchExecutor;
 
     private SearchResource searchResource;
@@ -88,11 +84,22 @@ public class SearchResourceTest {
     @Test
     public void saveAddsOwnerToSearch() {
         when(searchUser.username()).thenReturn("eberhard");
-        final Search search = Search.builder().build();
+        final SearchDTO search = mockSearchDTO();
 
         this.searchResource.createSearch(search, searchUser);
 
         verify(searchDomain).saveForUser(any(), eq(searchUser));
+    }
+
+    private SearchDTO mockSearchDTO() {
+        return mockSearchDTO(null);
+    }
+    private SearchDTO mockSearchDTO(Search search) {
+        final SearchDTO searchDTO = mock(SearchDTO.class);
+
+        when(searchDTO.toSearch()).thenReturn(search);
+
+        return searchDTO;
     }
 
     @Test
@@ -122,7 +129,7 @@ public class SearchResourceTest {
 
     @Test
     public void allowCreatingNewSearchWithoutId() {
-        final Search search = Search.builder().id(null).build();
+        final SearchDTO search = SearchDTO.Builder.create().id(null).build();
 
         this.searchResource.createSearch(search, searchUser);
     }

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/SearchResourceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/SearchResourceTest.java
@@ -113,9 +113,9 @@ public class SearchResourceTest {
     public void getSearchLoadsSearch() {
         final Search search = mockExistingSearch();
 
-        final Search returnedSearch = this.searchResource.getSearch(search.id(), searchUser);
+        final SearchDTO returnedSearch = this.searchResource.getSearch(search.id(), searchUser);
 
-        assertThat(returnedSearch).isEqualTo(search);
+        assertThat(returnedSearch.id()).isEqualTo(search.id());
     }
 
     @Test
@@ -142,7 +142,9 @@ public class SearchResourceTest {
         final String streamId = "streamId";
 
         final Query query = mock(Query.class);
+        when(query.id()).thenReturn("queryId");
         when(query.usedStreamIds()).thenReturn(ImmutableSet.of(streamId));
+        when(query.searchTypes()).thenReturn(ImmutableSet.of());
         when(search.queries()).thenReturn(ImmutableSet.of(query));
 
         return search;
@@ -154,6 +156,7 @@ public class SearchResourceTest {
 
         final String searchId = "deadbeef";
         when(search.id()).thenReturn(searchId);
+        when(search.parameters()).thenReturn(ImmutableSet.of());
 
         when(search.applyExecutionState(any(), any())).thenReturn(search);
         when(searchDomain.getForUser(eq(search.id()), any())).thenReturn(Optional.of(search));


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Decoupling through DTOs

The major goal of this PR is to separate the structures used to interact with the search execution API from the entities used internally. For this, the `Search` and `Query` structures are decoupled from the REST API by introducing `SearchDTO` & `QueryDTO` classes. This allows us to:

  - change the structure of the internally used entities while keeping the request format of the API stable
  - implement different versions of the API without having to change the underlying search engine used

Intentionally, not the complete class hierarchy is duplicated as DTOs.  This should be done when changes are implemented which affects structures which are deeper in the class hierarchy, but would involve a lot of unnecessary churn initially.

### API Versioning

In addition, a sample v2 of the search execution API is introduced to demonstrate the recommended way for search API versioning. 
The following aspects have been considered:

  - We need to find a sweet spot between full decoupling between endpoints/requests/responses and excessive overhead maintaining API versions
  - In most cases the API should evolve instead of being versioned:
    - Adding API endpoints should be done in a backwards-compatible manner
    - Removing API endpoints should happen when 
      - alternatives exist
      - after being deprecated for a timeframe allowing clients to migrate
      - only for releases which allow breaking changes
  - Versioning should happen when an endpoint is supposed to consume/produce multiple versions of the same data, varying in structure
  - Selecting the version should happen through content-negotiation, by specifying `Accept`/`Content-Type`-headers
    - This allows us easier iteration of independently-versioned resources
    - A single-token media-type should be used, in the following format:
      - `application/vnd.graylog.<entity>.v<version>+json`, where `<entity>` is a name for the entity/structure being consumed/produced (e.g. `search`) and `<version>` is the numeric version (e.g. `v2` or `v1.2.3`)
    - There should always be a default endpoint consuming/producing `application/json` to support legacy clients

The example v2 is introducing a breaking change in the query format, which deprecates the `filter` attribute and replaces it with a clearer, more domain-specific `streams` attribute instead.

Existing clients should not be affected. Using the v2 search api requires opt-in from the client by specifically using it for the `Accept`/`Content-Type`-headers.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.