### PR TITLE
Improve the JavaDurationConverter

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/configuration/converters/JavaDurationConverter.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/converters/JavaDurationConverter.java
@@ -17,10 +17,11 @@
 package org.graylog2.configuration.converters;
 
 import com.github.joschi.jadconfig.Converter;
-import com.github.joschi.jadconfig.jodatime.converters.DurationConverter;
 import org.joda.time.Period;
 
 import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.concurrent.TimeUnit;
 
 public class JavaDurationConverter implements Converter<Duration> {
     @Override
@@ -31,8 +32,9 @@ public class JavaDurationConverter implements Converter<Duration> {
             return Duration.parse(period.toString());
         }
         // number + unit formats
-        final org.joda.time.Duration jodaDuration = new DurationConverter().convertFrom(value);
-        return Duration.parse(jodaDuration.toString());
+        final com.github.joschi.jadconfig.util.Duration jadDuration = com.github.joschi.jadconfig.util.Duration.parse(value);
+        final ChronoUnit chronoUnit = toChronoUnit(jadDuration.getUnit());
+        return Duration.of(jadDuration.getQuantity(), chronoUnit);
     }
 
     @Override
@@ -40,5 +42,26 @@ public class JavaDurationConverter implements Converter<Duration> {
         // Durations will always be converted to ISO8601 formatted Strings
         // There is no meaningful way to convert them back to a simple jadconfig 'number+unit' format.
         return value.toString();
+    }
+
+    public static ChronoUnit toChronoUnit(TimeUnit timeUnit) {
+        switch (timeUnit) {
+            case NANOSECONDS:
+                return ChronoUnit.NANOS;
+            case MICROSECONDS:
+                return ChronoUnit.MICROS;
+            case MILLISECONDS:
+                return ChronoUnit.MILLIS;
+            case SECONDS:
+                return ChronoUnit.SECONDS;
+            case MINUTES:
+                return ChronoUnit.MINUTES;
+            case HOURS:
+                return ChronoUnit.HOURS;
+            case DAYS:
+                return ChronoUnit.DAYS;
+            default:
+                throw new AssertionError();
+        }
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/configuration/converters/JavaDurationConverter.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/converters/JavaDurationConverter.java
@@ -17,43 +17,28 @@
 package org.graylog2.configuration.converters;
 
 import com.github.joschi.jadconfig.Converter;
+import com.github.joschi.jadconfig.jodatime.converters.DurationConverter;
+import org.joda.time.Period;
 
 import java.time.Duration;
-import java.time.temporal.ChronoUnit;
-import java.util.concurrent.TimeUnit;
 
 public class JavaDurationConverter implements Converter<Duration> {
     @Override
     public Duration convertFrom(String value) {
-        final com.github.joschi.jadconfig.util.Duration jadDuration = com.github.joschi.jadconfig.util.Duration.parse(value);
-
-        final ChronoUnit chronoUnit = toChronoUnit(jadDuration.getUnit());
-        return Duration.of(jadDuration.getQuantity(), chronoUnit);
+        // ISO8601 format
+        if (value.startsWith("P")) {
+            final Period period = Period.parse(value);
+            return Duration.parse(period.toString());
+        }
+        // number + unit formats
+        final org.joda.time.Duration jodaDuration = new DurationConverter().convertFrom(value);
+        return Duration.parse(jodaDuration.toString());
     }
 
     @Override
     public String convertTo(Duration value) {
+        // Durations will always be converted to ISO8601 formatted Strings
+        // There is no meaningful way to convert them back to a simple jadconfig 'number+unit' format.
         return value.toString();
-    }
-
-    public static ChronoUnit toChronoUnit(TimeUnit timeUnit) {
-        switch (timeUnit) {
-            case NANOSECONDS:
-                return ChronoUnit.NANOS;
-            case MICROSECONDS:
-                return ChronoUnit.MICROS;
-            case MILLISECONDS:
-                return ChronoUnit.MILLIS;
-            case SECONDS:
-                return ChronoUnit.SECONDS;
-            case MINUTES:
-                return ChronoUnit.MINUTES;
-            case HOURS:
-                return ChronoUnit.HOURS;
-            case DAYS:
-                return ChronoUnit.DAYS;
-            default:
-                throw new AssertionError();
-        }
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/configuration/converters/JavaDurationConverterTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/configuration/converters/JavaDurationConverterTest.java
@@ -32,12 +32,15 @@ class JavaDurationConverterTest {
 
     @Test
     public void convertFrom() {
+        assertThat(converter.convertFrom("10ms")).isEqualTo(Duration.ofMillis(10));
         assertThat(converter.convertFrom("10s")).isEqualTo(Duration.ofSeconds(10));
+        assertThat(converter.convertFrom("PT0.01S")).isEqualTo(Duration.ofMillis(10));
         assertThat(converter.convertFrom("PT10S")).isEqualTo(Duration.ofSeconds(10));
     }
 
     @Test
     public void convertTo() {
+        assertThat(converter.convertTo(Duration.ofMillis(10))).isEqualTo("PT0.01S");
         assertThat(converter.convertTo(Duration.ofSeconds(10))).isEqualTo("PT10S");
         assertThat(converter.convertTo(Duration.ofSeconds(70))).isEqualTo("PT1M10S");
     }

--- a/graylog2-server/src/test/java/org/graylog2/configuration/converters/JavaDurationConverterTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/configuration/converters/JavaDurationConverterTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.configuration.converters;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JavaDurationConverterTest {
+
+    private final JavaDurationConverter converter;
+
+    JavaDurationConverterTest() {
+        this.converter = new JavaDurationConverter();
+    }
+
+    @Test
+    public void convertFrom() {
+        assertThat(converter.convertFrom("10s")).isEqualTo(Duration.ofSeconds(10));
+        assertThat(converter.convertFrom("PT10S")).isEqualTo(Duration.ofSeconds(10));
+    }
+
+    @Test
+    public void convertTo() {
+        assertThat(converter.convertTo(Duration.ofSeconds(10))).isEqualTo("PT10S");
+        assertThat(converter.convertTo(Duration.ofSeconds(70))).isEqualTo("PT1M10S");
+    }
+
+    @Test
+    public void convertBackAndForth() {
+        assertThat(converter.convertFrom(converter.convertTo(Duration.ofSeconds(70)))).isEqualTo(Duration.ofSeconds(70));
+        assertThat(converter.convertTo(converter.convertFrom("70s"))).isEqualTo("PT1M10S");
+    }
+
+    @Test
+    public void convertComplex() {
+        assertThat(converter.convertTo(Duration.parse("PT1h5m"))).isEqualTo("PT1H5M");
+        assertThat(converter.convertTo(Duration.parse("PT5m3s"))).isEqualTo("PT5M3S");
+        assertThat(converter.convertTo(Duration.parse("PT0M0.25S"))).isEqualTo("PT0.25S");
+
+        assertThat(converter.convertTo(Duration.parse("P1DT2S"))).isEqualTo("PT24H2S");
+    }
+
+}


### PR DESCRIPTION
The main problem with the previous implementation was, that
it would parse jadconfig type 'value+unit' fromats like `10s`

But reproduce the Duration as ISO8601 strings: `PT10S`

When dumping a graylog configuration, these values couldn't be parsed anymore.

 -> Change the converter to accept both formats which uses joda Period as conversion helper.
 -> Add unit test

/jenkins-pr-deps Graylog2/graylog-plugin-enterprise#2797