### PR TITLE
 Always wrap components in tests with `react-query`s `QueryClientProvider`.

### DIFF
--- a/graylog2-web-interface/src/pages/ShowMessagePage.test.tsx
+++ b/graylog2-web-interface/src/pages/ShowMessagePage.test.tsx
@@ -18,7 +18,6 @@ import * as React from 'react';
 import { render, waitFor, screen } from 'wrappedTestingLibrary';
 
 import { StoreMock as MockStore, asMock } from 'helpers/mocking';
-import DefaultQueryClientProvider from 'contexts/DefaultQueryClientProvider';
 import useFieldTypes from 'views/logic/fieldtypes/useFieldTypes';
 
 import ShowMessagePage from './ShowMessagePage';
@@ -60,10 +59,8 @@ type SimpleShowMessagePageProps = {
 };
 
 const SimpleShowMessagePage = ({ index, messageId }: SimpleShowMessagePageProps) => (
-  <DefaultQueryClientProvider>
-    {/* @ts-expect-error */}
-    <ShowMessagePage params={{ index, messageId }} />
-  </DefaultQueryClientProvider>
+  // @ts-expect-error
+  <ShowMessagePage params={{ index, messageId }} />
 );
 
 describe('ShowMessagePage', () => {

--- a/graylog2-web-interface/test/WrappingContainer.jsx
+++ b/graylog2-web-interface/test/WrappingContainer.jsx
@@ -24,6 +24,7 @@ import { breakpoints, colors, fonts, utils, spacings } from 'theme';
 import { THEME_MODE_LIGHT } from 'theme/constants';
 import buttonStyles from 'components/bootstrap/styles/buttonStyles';
 import aceEditorStyles from 'components/bootstrap/styles/aceEditorStyles';
+import DefaultQueryClientProvider from 'contexts/DefaultQueryClientProvider';
 
 const WrappingContainer = ({ children }) => {
   const themeColors = colors[THEME_MODE_LIGHT];
@@ -48,11 +49,13 @@ const WrappingContainer = ({ children }) => {
   };
 
   return (
-    <Router history={history}>
-      <ThemeProvider theme={theme}>
-        {children}
-      </ThemeProvider>
-    </Router>
+    <DefaultQueryClientProvider>
+      <Router history={history}>
+        <ThemeProvider theme={theme}>
+          {children}
+        </ThemeProvider>
+      </Router>
+    </DefaultQueryClientProvider>
   );
 };
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

When using `react-query` in a component, it is necessary to setup `react-query`s `QueryClientProvider` when testing the component. With this PR we are including our `DefaultQueryClientProvider` in the `WrappingContainer`. We use the `WrappingContainer` to wrap all components which are being rendered with the `render` method provided by `wrappedTestingLibrary` and the `mount` method provided by `wrappedEnzyme`.

This way we no longer have to setup the `QueryClientProvider` again in any unit test.

_Please review this PR together with the related enterprise PR._


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
