### PR TITLE
Displaying global (shared with everyone) grant on shares page properly.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/security/entities/EntityDependencyResolver.java
+++ b/graylog2-server/src/main/java/org/graylog/security/entities/EntityDependencyResolver.java
@@ -24,6 +24,7 @@ import org.graylog.grn.GRNRegistry;
 import org.graylog.grn.GRNType;
 import org.graylog.grn.GRNTypes;
 import org.graylog.security.DBGrantService;
+import org.graylog.security.shares.Grantee;
 import org.graylog2.contentpacks.ContentPackService;
 import org.graylog2.contentpacks.model.ModelId;
 import org.graylog2.contentpacks.model.ModelType;
@@ -103,10 +104,17 @@ public class EntityDependencyResolver {
                 .collect(ImmutableSet.toImmutableSet());
     }
 
-    private Set<EntityDescriptor.Owner> getOwners(@Nullable Set<GRN> owners) {
+    private Set<Grantee> getOwners(@Nullable Set<GRN> owners) {
         return firstNonNull(owners, Collections.<GRN>emptySet()).stream()
                 .map(descriptorService::getDescriptor)
-                .map(descriptor -> EntityDescriptor.Owner.create(descriptor.grn(), descriptor.title()))
+                // TODO there is a duplicate in GranteeSharesService
+                .map(descriptor -> {
+                            if (descriptor.grn().equals(GRNRegistry.GLOBAL_USER_GRN)) {
+                                return Grantee.createGlobal();
+                            }
+                            return Grantee.create(descriptor.grn(), descriptor.grn().type(), descriptor.title());
+                        }
+                )
                 .collect(Collectors.toSet());
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/security/entities/EntityDescriptor.java
+++ b/graylog2-server/src/main/java/org/graylog/security/entities/EntityDescriptor.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableSet;
 import org.graylog.grn.GRN;
+import org.graylog.security.shares.Grantee;
 
 import java.util.Collections;
 import java.util.Set;
@@ -41,9 +42,9 @@ public abstract class EntityDescriptor {
     public abstract String title();
 
     @JsonProperty("owners")
-    public abstract ImmutableSet<Owner> owners();
+    public abstract ImmutableSet<Grantee> owners();
 
-    public static EntityDescriptor create(GRN id, String title, Set<Owner> owners) {
+    public static EntityDescriptor create(GRN id, String title, Set<Grantee> owners) {
         return builder()
                 .id(id)
                 .title(title)
@@ -71,27 +72,8 @@ public abstract class EntityDescriptor {
         public abstract Builder title(String title);
 
         @JsonProperty("owners")
-        public abstract Builder owners(Set<Owner> owners);
+        public abstract Builder owners(Set<Grantee> owners);
 
         public abstract EntityDescriptor build();
-    }
-
-    @AutoValue
-    public static abstract class Owner {
-        @JsonProperty("id")
-        public abstract GRN id();
-
-        @JsonProperty("type")
-        public String type() {
-            return id().type();
-        }
-
-        @JsonProperty("title")
-        public abstract String title();
-
-        @JsonCreator
-        public static Owner create(GRN id, String title) {
-            return new AutoValue_EntityDescriptor_Owner(id, title);
-        }
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/security/shares/EntityShareResponse.java
+++ b/graylog2-server/src/main/java/org/graylog/security/shares/EntityShareResponse.java
@@ -42,7 +42,7 @@ public abstract class EntityShareResponse {
     public abstract GRN sharingUser();
 
     @JsonProperty("available_grantees")
-    public abstract ImmutableSet<AvailableGrantee> availableGrantees();
+    public abstract ImmutableSet<Grantee> availableGrantees();
 
     @JsonProperty("available_capabilities")
     public abstract ImmutableSet<AvailableCapability> availableCapabilities();
@@ -81,7 +81,7 @@ public abstract class EntityShareResponse {
         public abstract Builder sharingUser(GRN sharingUser);
 
         @JsonProperty("available_grantees")
-        public abstract Builder availableGrantees(Set<AvailableGrantee> availableGrantees);
+        public abstract Builder availableGrantees(Set<Grantee> availableGrantees);
 
         @JsonProperty("available_capabilities")
         public abstract Builder availableCapabilities(Set<AvailableCapability> availableCapabilities);
@@ -99,25 +99,6 @@ public abstract class EntityShareResponse {
         public abstract Builder validationResult(ValidationResult validationResult);
 
         public abstract EntityShareResponse build();
-    }
-
-    @AutoValue
-    public static abstract class AvailableGrantee {
-        @JsonProperty("id")
-        public abstract GRN grn();
-
-        @JsonProperty("type")
-        public abstract String type();
-
-        @JsonProperty("title")
-        public abstract String title();
-
-        @JsonCreator
-        public static AvailableGrantee create(@JsonProperty("id") GRN grn,
-                                              @JsonProperty("type") String type,
-                                              @JsonProperty("title") String title) {
-            return new AutoValue_EntityShareResponse_AvailableGrantee(grn, type, title);
-        }
     }
 
     @AutoValue

--- a/graylog2-server/src/main/java/org/graylog/security/shares/EntitySharesService.java
+++ b/graylog2-server/src/main/java/org/graylog/security/shares/EntitySharesService.java
@@ -95,8 +95,8 @@ public class EntitySharesService {
         requireNonNull(sharingSubject, "sharingSubject cannot be null");
 
         final GRN sharingUserGRN = grnRegistry.ofUser(sharingUser);
-        final Set<EntityShareResponse.AvailableGrantee> availableGrantees = granteeService.getAvailableGrantees(sharingUser);
-        final Set<GRN> availableGranteeGRNs = availableGrantees.stream().map(EntityShareResponse.AvailableGrantee::grn).collect(Collectors.toSet());
+        final Set<Grantee> availableGrantees = granteeService.getAvailableGrantees(sharingUser);
+        final Set<GRN> availableGranteeGRNs = availableGrantees.stream().map(Grantee::grn).collect(Collectors.toSet());
         final ImmutableSet<ActiveShare> activeShares = getActiveShares(ownedEntity, sharingUser, availableGranteeGRNs);
         return EntityShareResponse.builder()
                 .entity(ownedEntity.toString())
@@ -129,8 +129,8 @@ public class EntitySharesService {
         final String userName = sharingUser.getName();
         final GRN sharingUserGRN = grnRegistry.ofUser(sharingUser);
 
-        final Set<EntityShareResponse.AvailableGrantee> availableGrantees = granteeService.getAvailableGrantees(sharingUser);
-        final Set<GRN> availableGranteeGRNs = availableGrantees.stream().map(EntityShareResponse.AvailableGrantee::grn).collect(Collectors.toSet());
+        final Set<Grantee> availableGrantees = granteeService.getAvailableGrantees(sharingUser);
+        final Set<GRN> availableGranteeGRNs = availableGrantees.stream().map(Grantee::grn).collect(Collectors.toSet());
         final List<GrantDTO> existingGrants = grantService.getForTargetExcludingGrantee(ownedEntity, sharingUserGRN);
         existingGrants.removeIf(grant -> !availableGranteeGRNs.contains(grant.grantee()));
 
@@ -139,8 +139,7 @@ public class EntitySharesService {
                 .sharingUser(sharingUserGRN)
                 .availableGrantees(availableGrantees)
                 .availableCapabilities(getAvailableCapabilities())
-                .missingPermissionsOnDependencies(checkMissingPermissionsOnDependencies(ownedEntity, sharingUserGRN, ImmutableSet.of(), request))
-                ;
+                .missingPermissionsOnDependencies(checkMissingPermissionsOnDependencies(ownedEntity, sharingUserGRN, ImmutableSet.of(), request));
 
         final EntitySharesUpdateEvent.Builder updateEventBuilder = EntitySharesUpdateEvent.builder()
                 .user(sharingUser)

--- a/graylog2-server/src/main/java/org/graylog/security/shares/Grantee.java
+++ b/graylog2-server/src/main/java/org/graylog/security/shares/Grantee.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog.security.shares;
 
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/graylog2-server/src/main/java/org/graylog/security/shares/Grantee.java
+++ b/graylog2-server/src/main/java/org/graylog/security/shares/Grantee.java
@@ -1,0 +1,31 @@
+package org.graylog.security.shares;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+import org.graylog.grn.GRN;
+import org.graylog.grn.GRNRegistry;
+
+@AutoValue
+public abstract class Grantee {
+    @JsonProperty("id")
+    public abstract GRN grn();
+
+    @JsonProperty("type")
+    public abstract String type();
+
+    @JsonProperty("title")
+    public abstract String title();
+
+    public static Grantee create(GRN grn, String type, String title) {
+        return new AutoValue_Grantee(grn, type, title);
+    }
+
+    public static Grantee createGlobal() {
+        return create(GRNRegistry.GLOBAL_USER_GRN, "global", "Everyone");
+    }
+
+    public static Grantee createUser(GRN grn, String title) {
+        return create(grn, "user", title);
+    }
+
+}

--- a/graylog2-server/src/main/java/org/graylog/security/shares/GranteeService.java
+++ b/graylog2-server/src/main/java/org/graylog/security/shares/GranteeService.java
@@ -17,13 +17,12 @@
 package org.graylog.security.shares;
 
 import org.graylog.grn.GRN;
-import org.graylog.security.shares.EntityShareResponse.AvailableGrantee;
 import org.graylog2.plugin.database.users.User;
 
 import java.util.Set;
 
 public interface GranteeService {
-    Set<AvailableGrantee> getAvailableGrantees(User sharingUser);
+    Set<Grantee> getAvailableGrantees(User sharingUser);
 
     Set<User> getVisibleUsers(User requestingUser);
 

--- a/graylog2-server/src/test/java/org/graylog/security/entities/EntityDependencyResolverTest.java
+++ b/graylog2-server/src/test/java/org/graylog/security/entities/EntityDependencyResolverTest.java
@@ -96,7 +96,7 @@ class EntityDependencyResolverTest {
             assertThat(descriptor.title()).isEqualTo(TEST_TITLE);
 
             assertThat(descriptor.owners()).hasSize(1);
-            assertThat(descriptor.owners().asList().get(0).id().toString()).isEqualTo("grn::::user:jane");
+            assertThat(descriptor.owners().asList().get(0).grn().toString()).isEqualTo("grn::::user:jane");
         });
     }
 

--- a/graylog2-server/src/test/java/org/graylog/security/shares/EntitySharesServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/security/shares/EntitySharesServiceTest.java
@@ -104,7 +104,7 @@ public class EntitySharesServiceTest {
         // This test can also see the "invisible user"
         final Set<GRN> allGrantees = dbGrantService.getAll().stream().map(GrantDTO::grantee).collect(Collectors.toSet());
         lenient().when(granteeService.getAvailableGrantees(any())).thenReturn(
-                allGrantees.stream().map(g -> EntityShareResponse.AvailableGrantee.create(g, "user", g.entity())).collect(Collectors.toSet())
+                allGrantees.stream().map(g -> Grantee.createUser(g, g.entity())).collect(Collectors.toSet())
         );
 
         final User user = createMockUser("hans");
@@ -130,7 +130,7 @@ public class EntitySharesServiceTest {
         lenient().when(granteeService.getAvailableGrantees(any())).thenReturn(
                 allGrantees.stream()
                         .filter(g -> g.toString().equals("grn::::user:invisible"))
-                        .map(g -> EntityShareResponse.AvailableGrantee.create(g, "user", g.entity())).collect(Collectors.toSet())
+                        .map(g -> Grantee.createUser(g, g.entity())).collect(Collectors.toSet())
         );
 
         final User user = createMockUser("hans");
@@ -149,7 +149,7 @@ public class EntitySharesServiceTest {
         final EntityShareRequest shareRequest = EntityShareRequest.create(ImmutableMap.of(bob, Capability.VIEW));
 
         final User user = createMockUser("requestingUser");
-        when(granteeService.getAvailableGrantees(user)).thenReturn(ImmutableSet.of(EntityShareResponse.AvailableGrantee.create(bob, "user", "bob")));
+        when(granteeService.getAvailableGrantees(user)).thenReturn(ImmutableSet.of(Grantee.createUser(bob, "bob")));
         final Subject subject = mock(Subject.class);
         final EntityShareResponse entityShareResponse = entitySharesService.prepareShare(entity, shareRequest, user, subject);
         assertThat(entityShareResponse.validationResult()).satisfies(validationResult -> {
@@ -229,7 +229,7 @@ public class EntitySharesServiceTest {
 
         final User user = createMockUser("hans");
         final GRN janeGRN = grnRegistry.newGRN(GRNTypes.USER, "jane");
-        when(granteeService.getAvailableGrantees(user)).thenReturn(ImmutableSet.of(EntityShareResponse.AvailableGrantee.create(janeGRN, "user", "jane")));
+        when(granteeService.getAvailableGrantees(user)).thenReturn(ImmutableSet.of(Grantee.createUser(janeGRN, "jane")));
         final Subject subject = mock(Subject.class);
         final EntityShareResponse entityShareResponse = entitySharesService.prepareShare(entity, shareRequest, user, subject);
         assertThat(entityShareResponse.activeShares()).satisfies(activeShares -> {

--- a/graylog2-web-interface/src/components/permissions/SharedEntitiesOverview/SharedEntitiesOverviewItem/OwnersCell.test.tsx
+++ b/graylog2-web-interface/src/components/permissions/SharedEntitiesOverview/SharedEntitiesOverviewItem/OwnersCell.test.tsx
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 import * as React from 'react';
 import * as Immutable from 'immutable';
 import { render, screen } from 'wrappedTestingLibrary';

--- a/graylog2-web-interface/src/components/permissions/SharedEntitiesOverview/SharedEntitiesOverviewItem/OwnersCell.test.tsx
+++ b/graylog2-web-interface/src/components/permissions/SharedEntitiesOverview/SharedEntitiesOverviewItem/OwnersCell.test.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react';
+import * as Immutable from 'immutable';
+import { render, screen } from 'wrappedTestingLibrary';
+
+import Grantee from 'logic/permissions/Grantee';
+
+import OwnersCell from './OwnersCell';
+
+const everyone = Grantee.builder()
+  .type('global')
+  .id('grn::::global:everyone')
+  .title('grn::::global:everyone')
+  .build();
+
+const SUT = (props: React.ComponentProps<typeof OwnersCell>) => (
+  <table>
+    <tbody>
+      <tr><OwnersCell {...props} /></tr>
+    </tbody>
+  </table>
+);
+
+describe('OwnersCell', () => {
+  it('renders global share as Everyone', async () => {
+    render(<SUT owners={Immutable.List([everyone])} />);
+    await screen.findByText('Everyone');
+  });
+});

--- a/graylog2-web-interface/src/components/permissions/SharedEntitiesOverview/SharedEntitiesOverviewItem/OwnersCell.tsx
+++ b/graylog2-web-interface/src/components/permissions/SharedEntitiesOverview/SharedEntitiesOverviewItem/OwnersCell.tsx
@@ -19,7 +19,7 @@ import { isPermitted } from 'util/PermissionsMixin';
 import * as React from 'react';
 import { useContext } from 'react';
 import { List } from 'immutable';
-import Grantee from 'src/logic/permissions/Grantee';
+import Grantee from 'logic/permissions/Grantee';
 
 import { Link } from 'components/common/router';
 import { defaultCompare } from 'views/logic/DefaultCompare';

--- a/graylog2-web-interface/src/components/permissions/SharedEntitiesOverview/SharedEntitiesOverviewItem/OwnersCell.tsx
+++ b/graylog2-web-interface/src/components/permissions/SharedEntitiesOverview/SharedEntitiesOverviewItem/OwnersCell.tsx
@@ -14,13 +14,13 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import { isPermitted } from 'util/PermissionsMixin';
 
 import * as React from 'react';
 import { useContext } from 'react';
 import { List } from 'immutable';
-import Grantee from 'logic/permissions/Grantee';
 
+import { isPermitted } from 'util/PermissionsMixin';
+import Grantee from 'logic/permissions/Grantee';
 import { Link } from 'components/common/router';
 import { defaultCompare } from 'views/logic/DefaultCompare';
 import CurrentUserContext from 'contexts/CurrentUserContext';

--- a/graylog2-web-interface/src/components/permissions/SharedEntitiesOverview/SharedEntitiesOverviewItem/OwnersCell.tsx
+++ b/graylog2-web-interface/src/components/permissions/SharedEntitiesOverview/SharedEntitiesOverviewItem/OwnersCell.tsx
@@ -38,17 +38,15 @@ const assertUnreachable = (type: 'error'): never => {
 };
 
 const _getOwnerTitle = ({ type, id, title }: Grantee, userPermissions: List<string>) => {
-  const link = getShowRouteFromGRN(id);
-
   switch (type) {
     case 'user':
       if (!isPermitted(userPermissions, 'users:list')) return title;
 
-      return <TitleWithLink to={link} title={title} />;
+      return <TitleWithLink to={getShowRouteFromGRN(id)} title={title} />;
     case 'team':
       if (!isPermitted(userPermissions, 'teams:list')) return title;
 
-      return <TitleWithLink to={link} title={title} />;
+      return <TitleWithLink to={getShowRouteFromGRN(id)} title={title} />;
     case 'global':
       return 'Everyone';
     default:

--- a/graylog2-web-interface/src/components/permissions/SharedEntitiesOverview/SharedEntitiesOverviewItem/OwnersCell.tsx
+++ b/graylog2-web-interface/src/components/permissions/SharedEntitiesOverview/SharedEntitiesOverviewItem/OwnersCell.tsx
@@ -14,12 +14,15 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
+import { isPermitted } from 'util/PermissionsMixin';
+
 import * as React from 'react';
 import { useContext } from 'react';
+import { List } from 'immutable';
+import Grantee from 'src/logic/permissions/Grantee';
 
 import { Link } from 'components/common/router';
 import { defaultCompare } from 'views/logic/DefaultCompare';
-import { isPermitted } from 'util/PermissionsMixin';
 import CurrentUserContext from 'contexts/CurrentUserContext';
 import type { GranteesList } from 'logic/permissions/EntityShareState';
 import { getShowRouteFromGRN } from 'logic/permissions/GRN';
@@ -30,7 +33,11 @@ type Props = {
 
 const TitleWithLink = ({ to, title }: { to: string, title: string }) => <Link to={to}>{title}</Link>;
 
-const _getOwnerTitle = ({ type, id, title }, userPermissions) => {
+const assertUnreachable = (type: 'error'): never => {
+  throw new Error(`Owner of entity has not supported type: ${type}`);
+};
+
+const _getOwnerTitle = ({ type, id, title }: Grantee, userPermissions: List<string>) => {
   const link = getShowRouteFromGRN(id);
 
   switch (type) {
@@ -42,8 +49,10 @@ const _getOwnerTitle = ({ type, id, title }, userPermissions) => {
       if (!isPermitted(userPermissions, 'teams:list')) return title;
 
       return <TitleWithLink to={link} title={title} />;
+    case 'global':
+      return 'Everyone';
     default:
-      throw new Error(`Owner of entity has not supported type: ${type}`);
+      return assertUnreachable(type);
   }
 };
 

--- a/graylog2-web-interface/src/logic/permissions/GRN.tsx
+++ b/graylog2-web-interface/src/logic/permissions/GRN.tsx
@@ -21,11 +21,17 @@ const _convertEmptyString = (value: string) => (value === '' ? undefined : value
 
 export const createGRN = (type: string, id: string) => `grn::::${type}:${id}`;
 
+type GRNType = 'user' | 'team' | 'dashboard' | 'event_definition' | 'notification' | 'search' | 'stream';
+
 export const getValuesFromGRN = (grn: string) => {
   const grnValues = grn.split(':');
   const [resourceNameType, cluster, tenent, scope, type, id] = grnValues.map(_convertEmptyString);
 
-  return { resourceNameType, cluster, tenent, scope, type, id };
+  return { resourceNameType, cluster, tenent, scope, type: type as GRNType, id };
+};
+
+const assertUnreachable = (grn: string, type: never): never => {
+  throw new Error(`Can't find route for grn ${grn} of type: ${type ?? '(undefined)'}`);
 };
 
 export const getShowRouteFromGRN = (grn: string) => {
@@ -47,6 +53,6 @@ export const getShowRouteFromGRN = (grn: string) => {
     case 'stream':
       return Routes.stream_search(id);
     default:
-      throw new Error(`Can't find route for grn ${grn} of type: ${type ?? '(undefined)'}`);
+      assertUnreachable(grn, type);
   }
 };

--- a/graylog2-web-interface/src/logic/permissions/GRN.tsx
+++ b/graylog2-web-interface/src/logic/permissions/GRN.tsx
@@ -16,14 +16,13 @@
  */
 // eslint-disable-next-line import/prefer-default-export
 import Routes from 'routing/Routes';
+import { GRN, GRNType } from 'logic/permissions/types';
 
 const _convertEmptyString = (value: string) => (value === '' ? undefined : value);
 
 export const createGRN = (type: string, id: string) => `grn::::${type}:${id}`;
 
-type GRNType = 'user' | 'team' | 'dashboard' | 'event_definition' | 'notification' | 'search' | 'stream';
-
-export const getValuesFromGRN = (grn: string) => {
+export const getValuesFromGRN = (grn: GRN) => {
   const grnValues = grn.split(':');
   const [resourceNameType, cluster, tenent, scope, type, id] = grnValues.map(_convertEmptyString);
 

--- a/graylog2-web-interface/src/logic/permissions/GRN.tsx
+++ b/graylog2-web-interface/src/logic/permissions/GRN.tsx
@@ -29,7 +29,7 @@ export const getValuesFromGRN = (grn: GRN) => {
   return { resourceNameType, cluster, tenent, scope, type: type as GRNType, id };
 };
 
-const assertUnreachable = (grn: string, type: never): never => {
+const assertUnreachable = (grn: string, type: 'global'): never => {
   throw new Error(`Can't find route for grn ${grn} of type: ${type ?? '(undefined)'}`);
 };
 
@@ -52,6 +52,6 @@ export const getShowRouteFromGRN = (grn: string) => {
     case 'stream':
       return Routes.stream_search(id);
     default:
-      assertUnreachable(grn, type);
+      return assertUnreachable(grn, type);
   }
 };

--- a/graylog2-web-interface/src/logic/permissions/types.tsx
+++ b/graylog2-web-interface/src/logic/permissions/types.tsx
@@ -28,7 +28,7 @@ export type GRNType =
   | 'notification'
   | 'search'
   | 'stream'
-  | 'builtin-team';
+  | 'global';
 
 export type CapabilityType = {
   id: GRN,

--- a/graylog2-web-interface/src/logic/permissions/types.tsx
+++ b/graylog2-web-interface/src/logic/permissions/types.tsx
@@ -20,6 +20,16 @@ import SharedEntity from 'logic/permissions/SharedEntity';
 
 export type GRN = string;
 
+export type GRNType =
+  'user'
+  | 'team'
+  | 'dashboard'
+  | 'event_definition'
+  | 'notification'
+  | 'search'
+  | 'stream'
+  | 'builtin-team';
+
 export type CapabilityType = {
   id: GRN,
   title: 'Viewer' | 'Manager' | 'Owner',


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

**Note:** This requires a backport to `4.1` and `4.2`.

Prior to this PR, displaying a user's shares when an entity existed which is shared with `Everyone` as owner resulted in an exception being thrown, due to the frontend code not handling the grantee's type properly when rendering a summary of the owner.

This is being fixed in this PR. In addition, an inconsistent mapping of the grantee type is addressed, which resulted in `global` grantee's being returned with a type of `builtin-type` instead.

Fixes #11697.

/jenkins-pr-deps Graylog2/graylog-plugin-enterprise#2977

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.