### PR TITLE
add queryString() to BackendQuery Interface

### DIFF
--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/views/ElasticsearchBackend.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/views/ElasticsearchBackend.java
@@ -28,9 +28,9 @@ import org.graylog.plugins.views.search.Query;
 import org.graylog.plugins.views.search.QueryResult;
 import org.graylog.plugins.views.search.SearchJob;
 import org.graylog.plugins.views.search.SearchType;
-import org.graylog.plugins.views.search.elasticsearch.ElasticsearchQueryString;
 import org.graylog.plugins.views.search.elasticsearch.IndexLookup;
 import org.graylog.plugins.views.search.elasticsearch.QueryStringDecorators;
+import org.graylog.plugins.views.search.engine.BackendQuery;
 import org.graylog.plugins.views.search.engine.QueryBackend;
 import org.graylog.plugins.views.search.engine.SearchConfig;
 import org.graylog.plugins.views.search.errors.SearchTypeError;
@@ -48,7 +48,6 @@ import org.graylog.storage.elasticsearch6.jest.JestUtils;
 import org.graylog.storage.elasticsearch6.views.searchtypes.ESSearchTypeHandler;
 import org.graylog2.indexer.ElasticsearchException;
 import org.graylog2.indexer.IndexMapping;
-import org.graylog2.indexer.searches.SearchesClusterConfig;
 import org.graylog2.plugin.Message;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -102,7 +101,7 @@ public class ElasticsearchBackend implements QueryBackend<ESGeneratedQueryContex
 
     @Override
     public ESGeneratedQueryContext generate(SearchJob job, Query query, Set<QueryResult> results, SearchConfig searchConfig) {
-        final ElasticsearchQueryString backendQuery = (ElasticsearchQueryString) query.query();
+        final BackendQuery backendQuery = query.query();
 
         validateQueryTimeRange(query, searchConfig);
 
@@ -152,8 +151,7 @@ public class ElasticsearchBackend implements QueryBackend<ESGeneratedQueryContex
                     )
                     .must(QueryBuilders.termsQuery(Message.FIELD_STREAMS, effectiveStreamIds));
 
-            searchType.query().ifPresent(q -> {
-                final ElasticsearchQueryString searchTypeBackendQuery = (ElasticsearchQueryString) q;
+            searchType.query().ifPresent(searchTypeBackendQuery -> {
                 final String searchTypeQueryString = this.queryStringDecorators.decorate(searchTypeBackendQuery.queryString(), job, query, results);
                 final QueryBuilder normalizedSearchTypeQuery = normalizeQueryString(searchTypeQueryString);
                 searchTypeOverrides.must(normalizedSearchTypeQuery);

--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/views/searchtypes/ESMessageList.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/views/searchtypes/ESMessageList.java
@@ -20,6 +20,13 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.inject.name.Named;
 import io.searchbox.core.SearchResult;
 import io.searchbox.core.search.aggregation.MetricAggregation;
+import org.graylog.plugins.views.search.LegacyDecoratorProcessor;
+import org.graylog.plugins.views.search.Query;
+import org.graylog.plugins.views.search.SearchJob;
+import org.graylog.plugins.views.search.SearchType;
+import org.graylog.plugins.views.search.elasticsearch.QueryStringDecorators;
+import org.graylog.plugins.views.search.searchtypes.MessageList;
+import org.graylog.plugins.views.search.searchtypes.Sort;
 import org.graylog.shaded.elasticsearch6.org.elasticsearch.index.query.QueryBuilders;
 import org.graylog.shaded.elasticsearch6.org.elasticsearch.index.query.QueryStringQueryBuilder;
 import org.graylog.shaded.elasticsearch6.org.elasticsearch.search.builder.SearchSourceBuilder;
@@ -27,15 +34,7 @@ import org.graylog.shaded.elasticsearch6.org.elasticsearch.search.fetch.subphase
 import org.graylog.shaded.elasticsearch6.org.elasticsearch.search.sort.FieldSortBuilder;
 import org.graylog.shaded.elasticsearch6.org.elasticsearch.search.sort.SortBuilders;
 import org.graylog.shaded.elasticsearch6.org.elasticsearch.search.sort.SortOrder;
-import org.graylog.plugins.views.search.Query;
-import org.graylog.plugins.views.search.SearchJob;
-import org.graylog.plugins.views.search.SearchType;
 import org.graylog.storage.elasticsearch6.views.ESGeneratedQueryContext;
-import org.graylog.plugins.views.search.elasticsearch.QueryStringDecorators;
-import org.graylog.plugins.views.search.elasticsearch.ElasticsearchQueryString;
-import org.graylog.plugins.views.search.LegacyDecoratorProcessor;
-import org.graylog.plugins.views.search.searchtypes.MessageList;
-import org.graylog.plugins.views.search.searchtypes.Sort;
 import org.graylog2.indexer.results.ResultMessage;
 import org.graylog2.plugin.Message;
 import org.graylog2.plugin.indexer.searches.timeranges.AbsoluteRange;
@@ -102,8 +101,9 @@ public class ESMessageList implements ESSearchTypeHandler<MessageList> {
         }
     }
     private void applyHighlightingIfActivated(SearchSourceBuilder searchSourceBuilder, SearchJob job, Query query) {
-        if (!allowHighlighting)
+        if (!allowHighlighting) {
             return;
+        }
 
         final QueryStringQueryBuilder highlightQuery = decoratedHighlightQuery(job, query);
 
@@ -115,7 +115,7 @@ public class ESMessageList implements ESSearchTypeHandler<MessageList> {
     }
 
     private QueryStringQueryBuilder decoratedHighlightQuery(SearchJob job, Query query) {
-        final String raw = ((ElasticsearchQueryString) query.query()).queryString();
+        final String raw = query.query().queryString();
 
         final String decorated = this.esQueryDecorators.decorate(raw, job, query, Collections.emptySet());
 
@@ -130,7 +130,7 @@ public class ESMessageList implements ESSearchTypeHandler<MessageList> {
                 .map((resultMessage) -> ResultMessageSummary.create(resultMessage.highlightRanges, resultMessage.getMessage().getFields(), resultMessage.getIndex()))
                 .collect(Collectors.toList());
 
-        final String undecoratedQueryString = ((ElasticsearchQueryString)query.query()).queryString();
+        final String undecoratedQueryString = query.query().queryString();
         final String queryString = this.esQueryDecorators.decorate(undecoratedQueryString, job, query, Collections.emptySet());
 
         final DateTime from = query.effectiveTimeRange(searchType).getFrom();

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackend.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackend.java
@@ -24,9 +24,9 @@ import org.graylog.plugins.views.search.Query;
 import org.graylog.plugins.views.search.QueryResult;
 import org.graylog.plugins.views.search.SearchJob;
 import org.graylog.plugins.views.search.SearchType;
-import org.graylog.plugins.views.search.elasticsearch.ElasticsearchQueryString;
 import org.graylog.plugins.views.search.elasticsearch.IndexLookup;
 import org.graylog.plugins.views.search.elasticsearch.QueryStringDecorators;
+import org.graylog.plugins.views.search.engine.BackendQuery;
 import org.graylog.plugins.views.search.engine.QueryBackend;
 import org.graylog.plugins.views.search.engine.SearchConfig;
 import org.graylog.plugins.views.search.errors.SearchTypeError;
@@ -49,7 +49,6 @@ import org.graylog.storage.elasticsearch7.TimeRangeQueryFactory;
 import org.graylog.storage.elasticsearch7.views.searchtypes.ESSearchTypeHandler;
 import org.graylog2.indexer.ElasticsearchException;
 import org.graylog2.indexer.FieldTypeException;
-import org.graylog2.indexer.searches.SearchesClusterConfig;
 import org.graylog2.plugin.Message;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -102,7 +101,7 @@ public class ElasticsearchBackend implements QueryBackend<ESGeneratedQueryContex
 
     @Override
     public ESGeneratedQueryContext generate(SearchJob job, Query query, Set<QueryResult> results, SearchConfig searchConfig) {
-        final ElasticsearchQueryString backendQuery = (ElasticsearchQueryString) query.query();
+        final BackendQuery backendQuery = query.query();
 
         validateQueryTimeRange(query, searchConfig);
 
@@ -152,9 +151,8 @@ public class ElasticsearchBackend implements QueryBackend<ESGeneratedQueryContex
                     )
                     .must(QueryBuilders.termsQuery(Message.FIELD_STREAMS, effectiveStreamIds));
 
-            searchType.query().ifPresent(q -> {
-                final ElasticsearchQueryString searchTypeBackendQuery = (ElasticsearchQueryString) q;
-                final String searchTypeQueryString = this.queryStringDecorators.decorate(searchTypeBackendQuery.queryString(), job, query, results);
+            searchType.query().ifPresent(searchTypeQuery -> {
+                final String searchTypeQueryString = this.queryStringDecorators.decorate(searchTypeQuery.queryString(), job, query, results);
                 final QueryBuilder normalizedSearchTypeQuery = normalizeQueryString(searchTypeQueryString);
                 searchTypeOverrides.must(normalizedSearchTypeQuery);
             });

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/ESMessageList.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/ESMessageList.java
@@ -22,7 +22,6 @@ import org.graylog.plugins.views.search.LegacyDecoratorProcessor;
 import org.graylog.plugins.views.search.Query;
 import org.graylog.plugins.views.search.SearchJob;
 import org.graylog.plugins.views.search.SearchType;
-import org.graylog.plugins.views.search.elasticsearch.ElasticsearchQueryString;
 import org.graylog.plugins.views.search.elasticsearch.QueryStringDecorators;
 import org.graylog.plugins.views.search.searchtypes.MessageList;
 import org.graylog.plugins.views.search.searchtypes.Sort;
@@ -119,8 +118,9 @@ public class ESMessageList implements ESSearchTypeHandler<MessageList> {
         }
     }
     private void applyHighlightingIfActivated(SearchSourceBuilder searchSourceBuilder, SearchJob job, Query query) {
-        if (!allowHighlighting)
+        if (!allowHighlighting) {
             return;
+        }
 
         final QueryStringQueryBuilder highlightQuery = decoratedHighlightQuery(job, query);
 
@@ -132,7 +132,7 @@ public class ESMessageList implements ESSearchTypeHandler<MessageList> {
     }
 
     private QueryStringQueryBuilder decoratedHighlightQuery(SearchJob job, Query query) {
-        final String raw = ((ElasticsearchQueryString) query.query()).queryString();
+        final String raw = query.query().queryString();
 
         final String decorated = this.esQueryDecorators.decorate(raw, job, query, Collections.emptySet());
 
@@ -146,7 +146,7 @@ public class ESMessageList implements ESSearchTypeHandler<MessageList> {
                 .map((resultMessage) -> ResultMessageSummary.create(resultMessage.highlightRanges, resultMessage.getMessage().getFields(), resultMessage.getIndex()))
                 .collect(Collectors.toList());
 
-        final String undecoratedQueryString = ((ElasticsearchQueryString)query.query()).queryString();
+        final String undecoratedQueryString = query.query().queryString();
         final String queryString = this.esQueryDecorators.decorate(undecoratedQueryString, job, query, Collections.emptySet());
 
         final DateTime from = query.effectiveTimeRange(searchType).getFrom();

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/elasticsearch/ElasticsearchQueryString.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/elasticsearch/ElasticsearchQueryString.java
@@ -53,6 +53,7 @@ public abstract class ElasticsearchQueryString implements BackendQuery {
     public abstract String type();
 
     @JsonProperty
+    @Override
     public abstract String queryString();
 
     @JsonIgnore

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/engine/BackendQuery.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/engine/BackendQuery.java
@@ -28,4 +28,6 @@ public interface BackendQuery {
     String TYPE_FIELD = "type";
 
     String type();
+
+    String queryString();
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/engine/QueryParser.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/engine/QueryParser.java
@@ -46,7 +46,7 @@ public class QueryParser {
 
     public QueryMetadata parse(Query query) {
         checkArgument(query.query() instanceof ElasticsearchQueryString);
-        final String mainQueryString = ((ElasticsearchQueryString) query.query()).queryString();
+        final String mainQueryString = query.query().queryString();
         final java.util.stream.Stream<String> queryStringStreams = java.util.stream.Stream.concat(
                 java.util.stream.Stream.of(mainQueryString),
                 query.searchTypes().stream().flatMap(this::queryStringsFromSearchType)
@@ -63,7 +63,7 @@ public class QueryParser {
     private java.util.stream.Stream<String> queryStringsFromSearchType(SearchType searchType) {
         return java.util.stream.Stream.concat(
                 searchType.query().filter(query -> query instanceof ElasticsearchQueryString)
-                        .map(query -> ((ElasticsearchQueryString) query).queryString())
+                        .map(query -> query.queryString())
                         .map(java.util.stream.Stream::of)
                         .orElse(java.util.stream.Stream.empty()),
                 queryStringsFromFilter(searchType.filter()).stream()

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/QueryTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/QueryTest.java
@@ -176,7 +176,7 @@ public class QueryTest {
     @Test
     public void builderGeneratesDefaultQueryAndRange() {
         final Query build = Query.builder().build();
-        final ElasticsearchQueryString query = (ElasticsearchQueryString) build.query();
+        final BackendQuery query = build.query();
         assertThat(query.queryString()).isEqualTo("");
         assertThat(build.timerange()).isNotNull();
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
I moved queryString() into BackendQuery Interface.

## Motivation and Context
This change removes a lot of necessary typecasts where they seem uncomfortable. 
The reasoning is, that for the foreseeable future, we'll always have a string-based query language for the backends. If this changes, there will be a lot more and fundamental changes than the - now typecasted - occurences.

## How Has This Been Tested?
There were no tests, the compiler would have shown any mistake.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

