### PR TITLE
Fail early if mongodb is unavailable

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/bindings/MongoDBModule.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/MongoDBModule.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.bindings;
+
+import com.google.inject.AbstractModule;
+import org.graylog2.bindings.providers.MongoConnectionProvider;
+import org.graylog2.database.MongoConnection;
+
+public class MongoDBModule extends AbstractModule {
+    @Override
+    protected void configure() {
+        bind(MongoConnection.class).toProvider(MongoConnectionProvider.class);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/bindings/ServerBindings.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/ServerBindings.java
@@ -30,12 +30,10 @@ import org.graylog2.alerts.FormattedEmailAlertSender;
 import org.graylog2.bindings.providers.ClusterEventBusProvider;
 import org.graylog2.bindings.providers.DefaultSecurityManagerProvider;
 import org.graylog2.bindings.providers.DefaultStreamProvider;
-import org.graylog2.bindings.providers.MongoConnectionProvider;
 import org.graylog2.bindings.providers.SystemJobFactoryProvider;
 import org.graylog2.bindings.providers.SystemJobManagerProvider;
 import org.graylog2.cluster.ClusterConfigServiceImpl;
 import org.graylog2.cluster.leader.LeaderElectionModule;
-import org.graylog2.database.MongoConnection;
 import org.graylog2.events.ClusterEventBus;
 import org.graylog2.grok.GrokModule;
 import org.graylog2.grok.GrokPatternRegistry;
@@ -159,7 +157,6 @@ public class ServerBindings extends Graylog2Module {
     }
 
     private void bindSingletons() {
-        bind(MongoConnection.class).toProvider(MongoConnectionProvider.class);
         bind(SystemJobManager.class).toProvider(SystemJobManagerProvider.class);
         bind(DefaultSecurityManager.class).toProvider(DefaultSecurityManagerProvider.class).asEagerSingleton();
         bind(SystemJobFactory.class).toProvider(SystemJobFactoryProvider.class);

--- a/graylog2-server/src/main/java/org/graylog2/bootstrap/CmdLineTool.java
+++ b/graylog2-server/src/main/java/org/graylog2/bootstrap/CmdLineTool.java
@@ -202,6 +202,13 @@ public abstract class CmdLineTool implements CliCommand {
     protected void beforeStart(TLSProtocolsConfiguration configuration, PathConfiguration pathConfiguration) {
     }
 
+    /**
+     * Things that have to run before the guice injector is created.
+     * This call happens *after* the configuration file has been parsed.
+     */
+    protected void beforeInjectorCreation() {
+    }
+
     protected static void applySecuritySettings(TLSProtocolsConfiguration configuration) {
         // Disable insecure TLS parameters and ciphers by default.
         // Prevent attacks like LOGJAM, LUCKY13, et al.
@@ -280,6 +287,8 @@ public abstract class CmdLineTool implements CliCommand {
 
         final List<String> arguments = ManagementFactory.getRuntimeMXBean().getInputArguments();
         LOG.info("Running with JVM arguments: {}", Joiner.on(' ').join(arguments));
+
+        beforeInjectorCreation();
 
         injector = setupInjector(
                 new NamedConfigParametersModule(jadConfig.getConfigurationBeans()),

--- a/graylog2-server/src/main/java/org/graylog2/commands/Server.java
+++ b/graylog2-server/src/main/java/org/graylog2/commands/Server.java
@@ -51,6 +51,7 @@ import org.graylog2.bindings.ElasticsearchModule;
 import org.graylog2.bindings.InitializerBindings;
 import org.graylog2.bindings.MessageFilterBindings;
 import org.graylog2.bindings.MessageOutputBindings;
+import org.graylog2.bindings.MongoDBModule;
 import org.graylog2.bindings.PasswordAlgorithmBindings;
 import org.graylog2.bindings.PeriodicalBindings;
 import org.graylog2.bindings.PersistenceServicesBindings;
@@ -145,6 +146,7 @@ public class Server extends ServerBootstrap {
         modules.add(
                 new VersionAwareStorageModule(),
                 new ConfigurationModule(configuration),
+                new MongoDBModule(),
                 new ServerBindings(configuration, isMigrationCommand()),
                 new ElasticsearchModule(),
                 new PersistenceServicesBindings(),


### PR DESCRIPTION
If the MongoDB isn't reachable during server startup,
the server will hang for about 60min before exiting with an error.

This is due to the fact, that Guice will not abort instantly when it
hits an error. For each dependency that needs a mongodb connection
a new attempt is made. The default connection timeout is 30s.

A way to improve this, is to test the mongodb connection
early during startup:

 - Extract MongoDB Binding into separate MongoDBModule
 - Add another hook into the CmdLineTool run() sequence
   that is called after the configuration is parsed, but before
   the full guice injector is created.
 - Request one MongoConnection in beforeInjectorCreation() so we
   can get an early exception at startup.

/jenkins-pr-deps Graylog2/graylog-plugin-enterprise#2797