### PR TITLE
Give up leader status instantly if lock renewal fails

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/cluster/leader/AutomaticLeaderElectionService.java
+++ b/graylog2-server/src/main/java/org/graylog2/cluster/leader/AutomaticLeaderElectionService.java
@@ -43,7 +43,6 @@ public class AutomaticLeaderElectionService extends AbstractExecutionThreadServi
 
     private volatile boolean isLeader = false;
     private Thread executionThread;
-    private long lastSuccess = 0;
 
     @Inject
     public AutomaticLeaderElectionService(Configuration configuration,

--- a/graylog2-server/src/main/java/org/graylog2/cluster/leader/AutomaticLeaderElectionService.java
+++ b/graylog2-server/src/main/java/org/graylog2/cluster/leader/AutomaticLeaderElectionService.java
@@ -89,14 +89,11 @@ public class AutomaticLeaderElectionService extends AbstractExecutionThreadServi
 
         try {
             isLeader = lockService.lock(RESOURCE_NAME).isPresent();
-            lastSuccess = System.nanoTime();
         } catch (Exception e) {
             log.error("Unable to acquire/renew leader lock.", e);
 
-            final Duration timeSinceLastSuccess = Duration.ofNanos(System.nanoTime() - lastSuccess);
-            if (wasLeader && timeSinceLastSuccess.compareTo(lockTTL) >= 0) {
-                log.error("Failed for {} to renew leader lock. Forcing fallback to follower role.",
-                        timeSinceLastSuccess);
+            if (wasLeader) {
+                log.error("Failed to renew leader lock. Forcing fallback to follower role.");
                 isLeader = false;
             }
         }

--- a/graylog2-server/src/test/java/org/graylog2/cluster/leader/AutomaticLeaderElectionServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/cluster/leader/AutomaticLeaderElectionServiceTest.java
@@ -142,20 +142,6 @@ class AutomaticLeaderElectionServiceTest {
     }
 
     @Test
-    void ignoresSingleFailure() {
-        Lock lock = mock(Lock.class);
-        when(lockService.lock(any()))
-                .thenReturn(Optional.of(lock))
-                .thenThrow(new RuntimeException("ouch"))
-                .thenReturn(Optional.of(lock));
-
-        leaderElectionService.startAsync().awaitRunning();
-        verify(lockService, timeout(10_000).atLeast(3)).lock(any());
-        verify(eventBus).post(any(LeaderChangedEvent.class));
-        assertThat(leaderElectionService.isLeader()).isTrue();
-    }
-
-    @Test
     void handlesConsistentFailure() {
         Lock lock = mock(Lock.class);
         when(lockService.lock(any()))


### PR DESCRIPTION
Idea from @bernd 

/jenkins-pr-deps Graylog2/graylog-plugin-enterprise#2797