### PR TITLE
Refactor LeaderElectionService start / shutdown

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/bootstrap/ServerBootstrap.java
+++ b/graylog2-server/src/main/java/org/graylog2/bootstrap/ServerBootstrap.java
@@ -201,7 +201,7 @@ public abstract class ServerBootstrap extends CmdLineTool {
         final ServiceManagerListener serviceManagerListener = injector.getInstance(ServiceManagerListener.class);
         serviceManager.addListener(serviceManagerListener);
         try {
-            leaderElectionService.startAsync();
+            leaderElectionService.startAsync().awaitRunning();
             serviceManager.startAsync().awaitHealthy();
         } catch (Exception e) {
             try {

--- a/graylog2-server/src/main/java/org/graylog2/cluster/leader/AutomaticLeaderElectionService.java
+++ b/graylog2-server/src/main/java/org/graylog2/cluster/leader/AutomaticLeaderElectionService.java
@@ -69,6 +69,15 @@ public class AutomaticLeaderElectionService extends AbstractExecutionThreadServi
     }
 
     @Override
+    protected void shutDown() {
+        isLeader = false;
+        // Clear interrupted flag, so we can run unlock
+        //noinspection ResultOfMethodCallIgnored
+        Thread.interrupted();
+        lockService.unlock(RESOURCE_NAME).ifPresent(l -> log.info("Gave up leader lock on shutdown"));
+    }
+
+    @Override
     public boolean isLeader() {
         return isLeader;
     }
@@ -138,11 +147,5 @@ public class AutomaticLeaderElectionService extends AbstractExecutionThreadServi
             log.error("Unable to trigger update of nodes collection.");
         }
         eventBus.post(new LeaderChangedEvent());
-    }
-
-    @Override
-    public void giveUpLeader() {
-        isLeader = false;
-        lockService.unlock(RESOURCE_NAME).ifPresent(l -> log.info("Gave up leader lock on shutdown"));
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/cluster/leader/AutomaticLeaderElectionService.java
+++ b/graylog2-server/src/main/java/org/graylog2/cluster/leader/AutomaticLeaderElectionService.java
@@ -71,9 +71,6 @@ public class AutomaticLeaderElectionService extends AbstractExecutionThreadServi
     @Override
     protected void shutDown() {
         isLeader = false;
-        // Clear interrupted flag, so we can run unlock
-        //noinspection ResultOfMethodCallIgnored
-        Thread.interrupted();
         lockService.unlock(RESOURCE_NAME).ifPresent(l -> log.info("Gave up leader lock on shutdown"));
     }
 
@@ -127,8 +124,7 @@ public class AutomaticLeaderElectionService extends AbstractExecutionThreadServi
                 Thread.sleep(pollingInterval.toMillis());
             }
         } catch (InterruptedException e) {
-            // OK, we are shutting down.
-            Thread.currentThread().interrupt();
+            // OK, we are shutting down. Don't' restore interrupted flag, so we can release the lock in shutdown()
         }
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/cluster/leader/LeaderElectionModule.java
+++ b/graylog2-server/src/main/java/org/graylog2/cluster/leader/LeaderElectionModule.java
@@ -16,7 +16,9 @@
  */
 package org.graylog2.cluster.leader;
 
+import com.google.common.util.concurrent.Service;
 import com.google.inject.Scopes;
+import com.google.inject.name.Names;
 import org.graylog2.Configuration;
 import org.graylog2.cluster.lock.LockService;
 import org.graylog2.cluster.lock.MongoLockService;
@@ -36,10 +38,11 @@ public class LeaderElectionModule extends PluginModule {
         switch (mode) {
             case STATIC:
                 bind(LeaderElectionService.class).to(StaticLeaderElectionService.class).in(Scopes.SINGLETON);
+                bind(Service.class).annotatedWith(Names.named("LeaderElectionService")).to(StaticLeaderElectionService.class);
                 break;
             case AUTOMATIC:
                 bind(LeaderElectionService.class).to(AutomaticLeaderElectionService.class).in(Scopes.SINGLETON);
-                serviceBinder().addBinding().to(AutomaticLeaderElectionService.class).in(Scopes.SINGLETON);
+                bind(Service.class).annotatedWith(Names.named("LeaderElectionService")).to(AutomaticLeaderElectionService.class);
                 bind(LockService.class).to(MongoLockService.class).in(Scopes.SINGLETON);
                 break;
             default:

--- a/graylog2-server/src/main/java/org/graylog2/cluster/leader/LeaderElectionService.java
+++ b/graylog2-server/src/main/java/org/graylog2/cluster/leader/LeaderElectionService.java
@@ -26,9 +26,4 @@ public interface LeaderElectionService {
      * @return true if the current node is the leader, false if it is not
      */
     boolean isLeader();
-
-    /**
-     * Releases leadership claim of the current node.
-     */
-    void giveUpLeader();
 }

--- a/graylog2-server/src/main/java/org/graylog2/cluster/leader/StaticLeaderElectionService.java
+++ b/graylog2-server/src/main/java/org/graylog2/cluster/leader/StaticLeaderElectionService.java
@@ -16,6 +16,7 @@
  */
 package org.graylog2.cluster.leader;
 
+import com.google.common.util.concurrent.AbstractIdleService;
 import org.graylog2.Configuration;
 
 import javax.inject.Inject;
@@ -30,7 +31,7 @@ import javax.inject.Singleton;
  * already. In that case the value will be set to false and the node will act as a follower.
  */
 @Singleton
-public class StaticLeaderElectionService implements LeaderElectionService {
+public class StaticLeaderElectionService extends AbstractIdleService implements LeaderElectionService {
     private final Configuration configuration;
 
     @Inject
@@ -45,7 +46,11 @@ public class StaticLeaderElectionService implements LeaderElectionService {
     }
 
     @Override
-    public void giveUpLeader() {
+    protected void startUp() throws Exception {
+    }
+
+    @Override
+    protected void shutDown() throws Exception {
         // This has likely no effect in the server shutdown phase
         configuration.setIsMaster(false);
     }

--- a/graylog2-server/src/main/java/org/graylog2/commands/Server.java
+++ b/graylog2-server/src/main/java/org/graylog2/commands/Server.java
@@ -289,6 +289,7 @@ public class Server extends ServerBootstrap {
             serviceManager.stopAsync().awaitStopped();
 
             leaderElectionService.stopAsync().awaitTerminated();
+
             // Some services might continue performing processing
             // after the Journal service being down. Therefore it's
             // important to flush the most actual journal offset value

--- a/graylog2-server/src/main/java/org/graylog2/commands/Server.java
+++ b/graylog2-server/src/main/java/org/graylog2/commands/Server.java
@@ -19,6 +19,7 @@ package org.graylog2.commands;
 import com.github.rvesse.airline.annotations.Command;
 import com.github.rvesse.airline.annotations.Option;
 import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.Service;
 import com.google.common.util.concurrent.ServiceManager;
 import com.google.inject.Injector;
 import com.google.inject.Module;
@@ -95,6 +96,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.EnumSet;
@@ -256,6 +258,7 @@ public class Server extends ServerBootstrap {
         private final GracefulShutdown gracefulShutdown;
         private final AuditEventSender auditEventSender;
         private final Journal journal;
+        private Service leaderElectionService;
 
         @Inject
         public ShutdownHook(ActivityWriter activityWriter,
@@ -263,13 +266,15 @@ public class Server extends ServerBootstrap {
                             NodeId nodeId,
                             GracefulShutdown gracefulShutdown,
                             AuditEventSender auditEventSender,
-                            Journal journal) {
+                            Journal journal,
+                            @Named("LeaderElectionService") Service leaderElectionService) {
             this.activityWriter = activityWriter;
             this.serviceManager = serviceManager;
             this.nodeId = nodeId;
             this.gracefulShutdown = gracefulShutdown;
             this.auditEventSender = auditEventSender;
             this.journal = journal;
+            this.leaderElectionService = leaderElectionService;
         }
 
         @Override
@@ -283,6 +288,7 @@ public class Server extends ServerBootstrap {
             gracefulShutdown.runWithoutExit();
             serviceManager.stopAsync().awaitStopped();
 
+            leaderElectionService.stopAsync().awaitTerminated();
             // Some services might continue performing processing
             // after the Journal service being down. Therefore it's
             // important to flush the most actual journal offset value

--- a/graylog2-server/src/main/java/org/graylog2/system/shutdown/GracefulShutdown.java
+++ b/graylog2-server/src/main/java/org/graylog2/system/shutdown/GracefulShutdown.java
@@ -20,7 +20,6 @@ import com.google.common.util.concurrent.Uninterruptibles;
 import org.graylog2.Configuration;
 import org.graylog2.audit.AuditActor;
 import org.graylog2.audit.AuditEventSender;
-import org.graylog2.cluster.leader.LeaderElectionService;
 import org.graylog2.initializers.BufferSynchronizerService;
 import org.graylog2.plugin.ServerStatus;
 import org.graylog2.shared.initializers.InputSetupService;
@@ -51,7 +50,6 @@ public class GracefulShutdown implements Runnable {
     private final JerseyService jerseyService;
     private final GracefulShutdownService gracefulShutdownService;
     private final AuditEventSender auditEventSender;
-    private final LeaderElectionService leaderElectionService;
 
     @Inject
     public GracefulShutdown(ServerStatus serverStatus,
@@ -62,8 +60,7 @@ public class GracefulShutdown implements Runnable {
                             InputSetupService inputSetupService,
                             JerseyService jerseyService,
                             GracefulShutdownService gracefulShutdownService,
-                            AuditEventSender auditEventSender,
-                            LeaderElectionService leaderElectionService) {
+                            AuditEventSender auditEventSender) {
         this.serverStatus = serverStatus;
         this.activityWriter = activityWriter;
         this.configuration = configuration;
@@ -73,7 +70,6 @@ public class GracefulShutdown implements Runnable {
         this.jerseyService = jerseyService;
         this.gracefulShutdownService = gracefulShutdownService;
         this.auditEventSender = auditEventSender;
-        this.leaderElectionService = leaderElectionService;
     }
 
     @Override
@@ -126,8 +122,6 @@ public class GracefulShutdown implements Runnable {
 
         // Wait until the shutdown service is done
         gracefulShutdownService.awaitTerminated();
-
-        leaderElectionService.giveUpLeader();
 
         auditEventSender.success(AuditActor.system(serverStatus.getNodeId()), NODE_SHUTDOWN_COMPLETE);
 


### PR DESCRIPTION
     - Convert all LeaderElectionService into a true guava Service.
    
     - Remove the LeaderElectionService from the ServiceManager
       so we can shutdown it independently and thus very late
       in the shutdown sequence.

     - Move unlock handling into Service#shutdown() hook.
       This is simpler than to have a separate and confusing
       giveUpLeader() method.


/jenkins-pr-deps Graylog2/graylog-plugin-enterprise#2797