### PR TITLE
Adds optional override path to CSVFileDataAdapter

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/lookup/adapters/CSVFileDataAdapter.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/adapters/CSVFileDataAdapter.java
@@ -65,7 +65,7 @@ public class CSVFileDataAdapter extends LookupDataAdapter {
 
     public static final String NAME = "csvfile";
     public static final String PATH_FIELD = "path";
-    public static final String PATH_OVERRIDE_FIELD = "override_path";
+    public static final String OVERRIDE_PATH_FIELD = "override_path";
 
     /**
      * If the AllowedAuxiliaryPathChecker is enabled (one or more paths provided to the allowed_auxiliary_paths server
@@ -319,7 +319,7 @@ public class CSVFileDataAdapter extends LookupDataAdapter {
         public abstract String path();
 
         // user-provided override to Illuminate CSVFileDataAdapters
-        @JsonProperty(PATH_OVERRIDE_FIELD)
+        @JsonProperty(OVERRIDE_PATH_FIELD)
         @Nullable
         public abstract String overridePath();
 
@@ -391,13 +391,13 @@ public class CSVFileDataAdapter extends LookupDataAdapter {
             if (canBeOverridden()) {
                 final Path overridePath = Paths.get(Objects.requireNonNull(overridePath()));
                 if (!context.getPathChecker().fileIsInAllowedPath(overridePath)) {
-                    errors.put(PATH_OVERRIDE_FIELD, ALLOWED_PATH_ERROR);
+                    errors.put(OVERRIDE_PATH_FIELD, ALLOWED_PATH_ERROR);
                 }
 
                 if (!Files.exists(overridePath)) {
-                    errors.put(PATH_OVERRIDE_FIELD, "The file does not exist.");
+                    errors.put(OVERRIDE_PATH_FIELD, "The file does not exist.");
                 } else if (!Files.isReadable(overridePath)) {
-                    errors.put(PATH_OVERRIDE_FIELD, "The file cannot be read.");
+                    errors.put(OVERRIDE_PATH_FIELD, "The file cannot be read.");
                 }
             }
 
@@ -417,7 +417,7 @@ public class CSVFileDataAdapter extends LookupDataAdapter {
             @JsonProperty(PATH_FIELD)
             public abstract Builder path(String path);
 
-            @JsonProperty(PATH_OVERRIDE_FIELD)
+            @JsonProperty(OVERRIDE_PATH_FIELD)
             public abstract Builder overridePath(String overridePath);
 
             @JsonProperty("separator")


### PR DESCRIPTION
## Description
Adds an optional overridePath field to CSVFileDataAdapter.Config

## Motivation and Context
To support Graylog2/graylog-plugin-enterprise#2878 there needs to be an option for an override path in CSVFileDataAdapters. 


## How Has This Been Tested?
This is just an addition of a field in the CSVFileDataAdapter.Config class. Since it is nullable it should not affect any existing Data Adapters and I tested that it does not affect any newly created ones.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

