### PR TITLE
Retrieve dependencies for factory in `provide` instead of construction.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/contexts/SearchUserFactory.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/contexts/SearchUserFactory.java
@@ -18,32 +18,35 @@ package org.graylog.plugins.views.search.rest.contexts;
 
 import org.apache.shiro.subject.Subject;
 import org.glassfish.hk2.api.Factory;
+import org.glassfish.hk2.api.ServiceLocator;
 import org.graylog.plugins.views.search.permissions.SearchUser;
 import org.graylog.security.UserContext;
-import org.graylog2.shared.rest.resources.RestResource;
 import org.graylog2.shared.security.ShiroPrincipal;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.ws.rs.core.Context;
+import javax.inject.Inject;
 import javax.ws.rs.core.SecurityContext;
 import java.security.Principal;
 
 public class SearchUserFactory implements Factory<SearchUser> {
     private static final Logger LOG = LoggerFactory.getLogger(SearchUserFactory.class);
 
-    @Context
-    private UserContext userContext;
+    private final ServiceLocator serviceLocator;
 
-    @Context
-    private SecurityContext securityContext;
+    @Inject
+    public SearchUserFactory(ServiceLocator serviceLocator) {
+        this.serviceLocator = serviceLocator;
+    }
 
     @Override
     public SearchUser provide() {
-        return new SearchUser(userContext.getUser(), this::isPermitted, this::isPermitted);
+        final UserContext userContext = serviceLocator.getService(UserContext.class);
+        final SecurityContext securityContext = serviceLocator.getService(SecurityContext.class);
+        return new SearchUser(userContext.getUser(), (permission) -> this.isPermitted(securityContext, permission), (permission, instanceId) -> this.isPermitted(securityContext, permission, instanceId));
     }
 
-    protected Subject getSubject() {
+    protected Subject getSubject(SecurityContext securityContext) {
         if (securityContext == null) {
             LOG.error("Cannot retrieve current subject, SecurityContext isn't set.");
             return null;
@@ -60,16 +63,15 @@ public class SearchUserFactory implements Factory<SearchUser> {
         return principal.getSubject();
     }
 
-    protected boolean isPermitted(String permission, String instanceId) {
-        return getSubject().isPermitted(permission + ":" + instanceId);
+    protected boolean isPermitted(SecurityContext securityContext, String permission, String instanceId) {
+        return getSubject(securityContext).isPermitted(permission + ":" + instanceId);
     }
 
-    protected boolean isPermitted(String permission) {
-        return getSubject().isPermitted(permission);
+    protected boolean isPermitted(SecurityContext securityContext, String permission) {
+        return getSubject(securityContext).isPermitted(permission);
     }
 
     @Override
     public void dispose(SearchUser searchUser) {
-
     }
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Prior to this PR, after introducing the `SearchUserFactory`, retrieving messages using the export endpoint resulted in an exception being thrown after the request was closed:

```
java.lang.IllegalStateException: Unable to perform operation: resolve on org.graylog.plugins.views.search.rest.contexts.SearchUserFactory
	at org.jvnet.hk2.internal.ClazzCreator.create(ClazzCreator.java:363)
	at org.jvnet.hk2.internal.SystemDescriptor.create(SystemDescriptor.java:463)
	at org.jvnet.hk2.internal.PerLookupContext.findOrCreate(PerLookupContext.java:46)
	at org.jvnet.hk2.internal.Utilities.createService(Utilities.java:2102)
	at org.jvnet.hk2.internal.ServiceHandleImpl.getService(ServiceHandleImpl.java:93)
	at org.jvnet.hk2.internal.ServiceHandleImpl.getService(ServiceHandleImpl.java:67)
	at org.jvnet.hk2.internal.FactoryCreator.dispose(FactoryCreator.java:151)
	at org.jvnet.hk2.internal.SystemDescriptor.dispose(SystemDescriptor.java:518)
	at org.glassfish.jersey.inject.hk2.RequestContext.lambda$findOrCreate$0(RequestContext.java:60)
	at org.glassfish.jersey.internal.inject.ForeignDescriptorImpl.dispose(ForeignDescriptorImpl.java:63)
	at org.glassfish.jersey.inject.hk2.Hk2RequestScope$Instance.remove(Hk2RequestScope.java:126)
	at java.lang.Iterable.forEach(Iterable.java:75)
	at org.glassfish.jersey.inject.hk2.Hk2RequestScope$Instance.release(Hk2RequestScope.java:143)
	at org.glassfish.jersey.server.ChunkedOutput.flushQueue(ChunkedOutput.java:317)
	at org.glassfish.jersey.server.ChunkedOutput.close(ChunkedOutput.java:338)
	at org.graylog.plugins.views.search.export.ChunkedRunner.close(ChunkedRunner.java:60)
	at org.graylog.plugins.views.search.export.ChunkedRunner.lambda$run$0(ChunkedRunner.java:53)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run$$$capture(FutureTask.java:266)
	at java.util.concurrent.FutureTask.run(FutureTask.java)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```

The reason for this was that HK2 is trying to dispose the `SearchUser` instance using its factory (`SearchUserFactory`) when the `ChunkedOutput` is closed. For this, it needs to instantiate the `SearchUserFactory` in order to call its `dispose` method (currently a no-op). When it is instantiated, its dependencies are also resolved, which are not available outside of a request.

In order to fix this, retrieval of dependencies (request-specific contexts) is performed through HK2's `ServiceLocator` in the `provide` method of the `SearchUserFactory` class, so the class can be instantiated without dependencies in order to call `dispose`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.