### PR TITLE
Use `CancellablePromise` type instead of `Promise` to type result of `SearchActions.reexecuteSearchTypes`.

### DIFF
--- a/graylog2-web-interface/src/views/actions/SearchActions.ts
+++ b/graylog2-web-interface/src/views/actions/SearchActions.ts
@@ -28,6 +28,7 @@ import type { RefluxActions } from 'stores/StoreTypes';
 import type { TimeRange } from 'views/logic/queries/Query';
 import type { WidgetMapping } from 'views/logic/views/types';
 import type { SearchTypeOptions } from 'views/logic/search/GlobalOverride';
+import type CancellablePromise from 'logic/rest/CancellablePromise';
 
 export type CreateSearchResponse = {
   search: Search,
@@ -48,7 +49,7 @@ type SearchActionsType = RefluxActions<{
   reexecuteSearchTypes: (
     searchTypes: SearchTypeOptions,
     effectiveTimeRange?: TimeRange,
-  ) => Promise<SearchExecutionResult>,
+  ) => CancellablePromise<SearchExecutionResult>,
   executeWithCurrentState: () => Promise<SearchExecutionResult>,
   refresh: () => Promise<void>,
   get: (searchId: SearchId) => Promise<SearchJson>,

--- a/graylog2-web-interface/src/views/components/widgets/MessageList.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageList.test.tsx
@@ -31,6 +31,7 @@ import * as messageList from 'views/components/messagelist';
 import { InputsActions, InputsStore } from 'stores/inputs/InputsStore';
 import { SearchExecutionResult } from 'views/actions/SearchActions';
 import { FieldTypeMappingsList } from 'views/stores/FieldTypesStore';
+import CancellablePromise from 'logic/rest/CancellablePromise';
 
 import MessageList, { MessageListResult } from './MessageList';
 import RenderCompletionCallback, { TRenderCompletionCallback } from './RenderCompletionCallback';
@@ -69,6 +70,8 @@ jest.mock('views/stores/SearchConfigStore', () => ({
   SearchConfigStore: MockStore('listSearchesClusterConfig', 'configurations', 'listen'),
 }));
 
+const mockReexecuteResult = CancellablePromise.of(Promise.resolve({ result: { errors: [] } }));
+
 jest.mock('views/stores/SearchStore', () => ({
   SearchStore: MockStore(
     'listen',
@@ -87,7 +90,7 @@ jest.mock('views/stores/SearchStore', () => ({
     })],
   ),
   SearchActions: {
-    reexecuteSearchTypes: jest.fn().mockReturnValue(Promise.resolve({ result: { errors: [] } })),
+    reexecuteSearchTypes: jest.fn(() => mockReexecuteResult),
     execute: { completed: { listen: jest.fn() } },
   },
 }));
@@ -239,9 +242,9 @@ describe('MessageList', () => {
   });
 
   it('displays error description, when using pagination throws an error', async () => {
-    asMock(SearchActions.reexecuteSearchTypes).mockReturnValue(Promise.resolve({
+    asMock(SearchActions.reexecuteSearchTypes).mockReturnValue(CancellablePromise.of(Promise.resolve({
       result: { errors: [{ description: 'Error description' }] },
-    } as SearchExecutionResult));
+    } as SearchExecutionResult)));
 
     const config = MessagesWidgetConfig.builder().fields([]).build();
     const secondPageSize = 10;

--- a/graylog2-web-interface/src/views/stores/SearchStore.ts
+++ b/graylog2-web-interface/src/views/stores/SearchStore.ts
@@ -38,6 +38,7 @@ import type { WidgetMapping } from 'views/logic/views/types';
 import type { TimeRange } from 'views/logic/queries/Query';
 import { singletonStore } from 'logic/singleton';
 import { SearchErrorResponse } from 'views/logic/SearchError';
+import type CancellablePromise from 'logic/rest/CancellablePromise';
 
 const createSearchUrl = qualifyUrl('/views/search');
 
@@ -161,7 +162,7 @@ export const SearchStore: Store<SearchStoreState> = singletonStore(
       return this._executePromise(executionState, startActionPromise, handleSearchResult);
     },
 
-    reexecuteSearchTypes(searchTypes: SearchTypeOptions, effectiveTimerange?: TimeRange): Promise<SearchExecutionResult> {
+    reexecuteSearchTypes(searchTypes: SearchTypeOptions, effectiveTimerange?: TimeRange): CancellablePromise<SearchExecutionResult> {
       const { parameterBindings, globalOverride } = this.executionState;
       const searchTypeIds = Object.keys(searchTypes);
       const globalQuery = globalOverride && globalOverride.query ? globalOverride.query : undefined;


### PR DESCRIPTION
## Description
## Motivation and Context

In a plugin we need to cancel the promise. the cancel method is only
available for the `CancellablePromise`. A `CancellablePromise` is being
used when working with the `FetchProvider`.

/jenkins-pr-deps https://github.com/Graylog2/graylog-plugin-enterprise/pull/2976