### PR TITLE
Add backend support for user-defined TZ in exports

### DIFF
--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/views/export/ElasticsearchExportBackend.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/views/export/ElasticsearchExportBackend.java
@@ -32,6 +32,8 @@ import org.graylog.shaded.elasticsearch6.org.elasticsearch.search.builder.Search
 import org.graylog.storage.elasticsearch6.TimeRangeQueryFactory;
 import org.graylog2.indexer.IndexMapping;
 import org.graylog2.plugin.Message;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -77,11 +79,11 @@ public class ElasticsearchExportBackend implements ExportBackend {
             List<SearchResult.Hit<Map, Void>> hits = search(command);
 
             if (hits.isEmpty()) {
-                publishChunk(chunkCollector, hits, command.fieldsInOrder(), SimpleMessageChunk.ChunkOrder.LAST);
+                publishChunk(chunkCollector, hits, command.fieldsInOrder(), command.timeZone(), SimpleMessageChunk.ChunkOrder.LAST);
                 return;
             }
 
-            boolean success = publishChunk(chunkCollector, hits, command.fieldsInOrder(), isFirstChunk ? SimpleMessageChunk.ChunkOrder.FIRST : SimpleMessageChunk.ChunkOrder.INTERMEDIATE);
+            boolean success = publishChunk(chunkCollector, hits, command.fieldsInOrder(), command.timeZone(), isFirstChunk ? SimpleMessageChunk.ChunkOrder.FIRST : SimpleMessageChunk.ChunkOrder.INTERMEDIATE);
             if (!success) {
                 return;
             }
@@ -89,7 +91,7 @@ public class ElasticsearchExportBackend implements ExportBackend {
             totalCount += hits.size();
             if (command.limit().isPresent() && totalCount >= command.limit().getAsInt()) {
                 LOG.info("Limit of {} reached. Stopping message retrieval.", command.limit().getAsInt());
-                publishChunk(chunkCollector, Collections.emptyList(), command.fieldsInOrder(), SimpleMessageChunk.ChunkOrder.LAST);
+                publishChunk(chunkCollector, Collections.emptyList(), command.fieldsInOrder(), command.timeZone(), SimpleMessageChunk.ChunkOrder.LAST);
                 return;
             }
 
@@ -152,8 +154,8 @@ public class ElasticsearchExportBackend implements ExportBackend {
         return indexLookup.indexNamesForStreamsInTimeRange(command.streams(), command.timeRange());
     }
 
-    private boolean publishChunk(Consumer<SimpleMessageChunk> chunkCollector, List<SearchResult.Hit<Map, Void>> hits, LinkedHashSet<String> desiredFieldsInOrder, SimpleMessageChunk.ChunkOrder chunkOrder) {
-        SimpleMessageChunk chunk = chunkFrom(hits, desiredFieldsInOrder, chunkOrder);
+    private boolean publishChunk(Consumer<SimpleMessageChunk> chunkCollector, List<SearchResult.Hit<Map, Void>> hits, LinkedHashSet<String> desiredFieldsInOrder, DateTimeZone timeZone, SimpleMessageChunk.ChunkOrder chunkOrder) {
+        SimpleMessageChunk chunk = chunkFrom(hits, desiredFieldsInOrder, timeZone, chunkOrder);
 
         try {
             chunkCollector.accept(chunk);
@@ -164,8 +166,8 @@ public class ElasticsearchExportBackend implements ExportBackend {
         }
     }
 
-    private SimpleMessageChunk chunkFrom(List<SearchResult.Hit<Map, Void>> hits, LinkedHashSet<String> desiredFieldsInOrder, SimpleMessageChunk.ChunkOrder chunkOrder) {
-        LinkedHashSet<SimpleMessage> messages = messagesFrom(hits);
+    private SimpleMessageChunk chunkFrom(List<SearchResult.Hit<Map, Void>> hits, LinkedHashSet<String> desiredFieldsInOrder, DateTimeZone timeZone, SimpleMessageChunk.ChunkOrder chunkOrder) {
+        LinkedHashSet<SimpleMessage> messages = messagesFrom(hits, timeZone);
 
         return SimpleMessageChunk.builder()
                 .fieldsInOrder(desiredFieldsInOrder)
@@ -174,18 +176,18 @@ public class ElasticsearchExportBackend implements ExportBackend {
                 .build();
     }
 
-    private LinkedHashSet<SimpleMessage> messagesFrom(List<SearchResult.Hit<Map, Void>> hits) {
+    private LinkedHashSet<SimpleMessage> messagesFrom(List<SearchResult.Hit<Map, Void>> hits, DateTimeZone timeZone) {
         return hits.stream()
-                .map(h -> buildHitWithAllFields(h.source, h.index))
+                .map(h -> buildHitWithAllFields(h.source, h.index, timeZone))
                 .collect(toCollection(LinkedHashSet::new));
     }
 
-    private SimpleMessage buildHitWithAllFields(Map source, String index) {
+    private SimpleMessage buildHitWithAllFields(Map source, String index, DateTimeZone timeZone) {
         LinkedHashMap<String, Object> fields = new LinkedHashMap<>();
 
         for (Object key : source.keySet()) {
             String name = (String) key;
-            Object value = valueFrom(source, name);
+            Object value = valueFrom(source, name, timeZone);
             fields.put(name, value);
         }
 
@@ -195,16 +197,17 @@ public class ElasticsearchExportBackend implements ExportBackend {
         return SimpleMessage.from(index, fields);
     }
 
-    private Object valueFrom(Map source, String name) {
+    private Object valueFrom(Map source, String name, DateTimeZone timeZone) {
         if (name.equals(Message.FIELD_TIMESTAMP)) {
-            return fixTimestampFormat(source.get(Message.FIELD_TIMESTAMP));
+            return fixTimestampFormat(source.get(Message.FIELD_TIMESTAMP), timeZone);
         }
         return source.get(name);
     }
 
-    private Object fixTimestampFormat(Object rawTimestamp) {
+    private Object fixTimestampFormat(Object rawTimestamp, DateTimeZone timeZone) {
         try {
-            return ES_DATE_FORMAT_FORMATTER.parseDateTime(String.valueOf(rawTimestamp)).toString();
+           final DateTime parsed = ES_DATE_FORMAT_FORMATTER.parseDateTime(String.valueOf(rawTimestamp));
+           return parsed.withZone(timeZone).toString();
         } catch (IllegalArgumentException e) {
             LOG.warn("Could not parse timestamp {}", rawTimestamp, e);
             return rawTimestamp;

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/export/ElasticsearchExportBackendIT.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/export/ElasticsearchExportBackendIT.java
@@ -31,6 +31,7 @@ import org.graylog.testing.elasticsearch.SearchServerInstance;
 import org.graylog2.indexer.ElasticsearchException;
 import org.graylog2.plugin.indexer.searches.timeranges.AbsoluteRange;
 import org.graylog2.plugin.indexer.searches.timeranges.InvalidRangeParametersException;
+import org.joda.time.DateTimeZone;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -211,6 +212,21 @@ public class ElasticsearchExportBackendIT extends ElasticsearchBaseTest {
                 "graylog_1, 2015-01-01T01:59:59.999Z, source-2, He",
                 "graylog_0, 2015-01-01T03:00:00.000Z, source-1, Hi",
                 "graylog_0, 2015-01-01T04:00:00.000Z, source-2, Ho");
+    }
+
+    @Test
+    public void usesProvidedTimeZone() {
+        importFixture("messages.json");
+
+        ExportMessagesCommand command = commandBuilderWithAllStreams()
+                .timeZone(DateTimeZone.forID("Europe/Vienna"))
+                .build();
+
+        runWithExpectedResult(command, "timestamp,source,message",
+                "graylog_0, 2015-01-01T02:00:00.000+01:00, source-1, Ha",
+                "graylog_1, 2015-01-01T02:59:59.999+01:00, source-2, He",
+                "graylog_0, 2015-01-01T04:00:00.000+01:00, source-1, Hi",
+                "graylog_0, 2015-01-01T05:00:00.000+01:00, source-2, Ho");
     }
 
     private Set<String> actualFieldNamesFrom(SimpleMessageChunk chunk) {

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/export/ElasticsearchExportBackendIT.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/export/ElasticsearchExportBackendIT.java
@@ -219,14 +219,14 @@ public class ElasticsearchExportBackendIT extends ElasticsearchBaseTest {
         importFixture("messages.json");
 
         ExportMessagesCommand command = commandBuilderWithAllStreams()
-                .timeZone(DateTimeZone.forID("Europe/Vienna"))
+                .timeZone(DateTimeZone.forID("Australia/Adelaide")) // UTC+9:30
                 .build();
 
         runWithExpectedResult(command, "timestamp,source,message",
-                "graylog_0, 2015-01-01T02:00:00.000+01:00, source-1, Ha",
-                "graylog_1, 2015-01-01T02:59:59.999+01:00, source-2, He",
-                "graylog_0, 2015-01-01T04:00:00.000+01:00, source-1, Hi",
-                "graylog_0, 2015-01-01T05:00:00.000+01:00, source-2, Ho");
+                "graylog_0, 2015-01-01T11:30:00.000+10:30, source-1, Ha",
+                "graylog_1, 2015-01-01T12:29:59.999+10:30, source-2, He",
+                "graylog_0, 2015-01-01T13:30:00.000+10:30, source-1, Hi",
+                "graylog_0, 2015-01-01T14:30:00.000+10:30, source-2, Ho");
     }
 
     private Set<String> actualFieldNamesFrom(SimpleMessageChunk chunk) {

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/export/CommandFactory.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/export/CommandFactory.java
@@ -44,8 +44,7 @@ public class CommandFactory {
                 .queryString(request.queryString())
                 .streams(request.streams())
                 .fieldsInOrder(request.fieldsInOrder())
-                .chunkSize(request.chunkSize())
-                .timeZone(request.timeZone());
+                .chunkSize(request.chunkSize());
 
         if (request.limit().isPresent()) {
             builder.limit(request.limit().getAsInt());
@@ -104,12 +103,15 @@ public class CommandFactory {
     }
 
     private ExportMessagesCommand.Builder builderFrom(ResultFormat resultFormat) {
-        ExportMessagesCommand.Builder requestBuilder = ExportMessagesCommand.builder();
-
-        requestBuilder.fieldsInOrder(resultFormat.fieldsInOrder());
+        ExportMessagesCommand.Builder requestBuilder = ExportMessagesCommand.builder()
+                .fieldsInOrder(resultFormat.fieldsInOrder());
 
         if (resultFormat.limit().isPresent()) {
-            requestBuilder.limit(resultFormat.limit().orElseThrow(() -> new IllegalStateException("No value present!")));
+            requestBuilder = requestBuilder.limit(resultFormat.limit().orElseThrow(() -> new IllegalStateException("No value present!")));
+        }
+
+        if (resultFormat.timeZone().isPresent()) {
+            requestBuilder = requestBuilder.timeZone(resultFormat.timeZone().orElseThrow(() -> new IllegalStateException("No time zone present!")));
         }
 
         return requestBuilder;

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/export/CommandFactory.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/export/CommandFactory.java
@@ -44,7 +44,8 @@ public class CommandFactory {
                 .queryString(request.queryString())
                 .streams(request.streams())
                 .fieldsInOrder(request.fieldsInOrder())
-                .chunkSize(request.chunkSize());
+                .chunkSize(request.chunkSize())
+                .timeZone(request.timeZone());
 
         if (request.limit().isPresent()) {
             builder.limit(request.limit().getAsInt());

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/export/CommandFactory.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/export/CommandFactory.java
@@ -106,13 +106,8 @@ public class CommandFactory {
         ExportMessagesCommand.Builder requestBuilder = ExportMessagesCommand.builder()
                 .fieldsInOrder(resultFormat.fieldsInOrder());
 
-        if (resultFormat.limit().isPresent()) {
-            requestBuilder = requestBuilder.limit(resultFormat.limit().orElseThrow(() -> new IllegalStateException("No value present!")));
-        }
-
-        if (resultFormat.timeZone().isPresent()) {
-            requestBuilder = requestBuilder.timeZone(resultFormat.timeZone().orElseThrow(() -> new IllegalStateException("No time zone present!")));
-        }
+        resultFormat.limit().ifPresent(requestBuilder::limit);
+        resultFormat.timeZone().ifPresent(requestBuilder::timeZone);
 
         return requestBuilder;
     }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/export/ExportMessagesCommand.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/export/ExportMessagesCommand.java
@@ -39,6 +39,7 @@ public abstract class ExportMessagesCommand {
     public static final Set<String> DEFAULT_STREAMS = ImmutableSet.of();
     public static final LinkedHashSet<String> DEFAULT_FIELDS = linkedHashSetOf("timestamp", "source", "message");
     public static final int DEFAULT_CHUNK_SIZE = 1000;
+    public static final DateTimeZone DEFAULT_TIME_ZONE = DateTimeZone.UTC;
 
     public static AbsoluteRange defaultTimeRange() {
         try {
@@ -114,7 +115,8 @@ public abstract class ExportMessagesCommand {
                     .queryString(DEFAULT_QUERY)
                     .fieldsInOrder(DEFAULT_FIELDS)
                     .decorators(Collections.emptyList())
-                    .chunkSize(DEFAULT_CHUNK_SIZE);
+                    .chunkSize(DEFAULT_CHUNK_SIZE)
+                    .timeZone(DEFAULT_TIME_ZONE);
         }
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/export/ExportMessagesCommand.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/export/ExportMessagesCommand.java
@@ -25,11 +25,9 @@ import org.graylog2.plugin.indexer.searches.timeranges.InvalidRangeParametersExc
 import org.graylog2.plugin.indexer.searches.timeranges.RelativeRange;
 import org.joda.time.DateTimeZone;
 
-import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Set;
 
@@ -41,7 +39,6 @@ public abstract class ExportMessagesCommand {
     public static final Set<String> DEFAULT_STREAMS = ImmutableSet.of();
     public static final LinkedHashSet<String> DEFAULT_FIELDS = linkedHashSetOf("timestamp", "source", "message");
     public static final int DEFAULT_CHUNK_SIZE = 1000;
-    public static final DateTimeZone DEFAULT_TIME_ZONE = DateTimeZone.UTC;
 
     public static AbsoluteRange defaultTimeRange() {
         try {
@@ -117,8 +114,7 @@ public abstract class ExportMessagesCommand {
                     .queryString(DEFAULT_QUERY)
                     .fieldsInOrder(DEFAULT_FIELDS)
                     .decorators(Collections.emptyList())
-                    .chunkSize(DEFAULT_CHUNK_SIZE)
-                    .timeZone(DEFAULT_TIME_ZONE);
+                    .chunkSize(DEFAULT_CHUNK_SIZE);
         }
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/export/ExportMessagesCommand.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/export/ExportMessagesCommand.java
@@ -23,10 +23,13 @@ import org.graylog2.decorators.Decorator;
 import org.graylog2.plugin.indexer.searches.timeranges.AbsoluteRange;
 import org.graylog2.plugin.indexer.searches.timeranges.InvalidRangeParametersException;
 import org.graylog2.plugin.indexer.searches.timeranges.RelativeRange;
+import org.joda.time.DateTimeZone;
 
+import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Set;
 
@@ -38,6 +41,7 @@ public abstract class ExportMessagesCommand {
     public static final Set<String> DEFAULT_STREAMS = ImmutableSet.of();
     public static final LinkedHashSet<String> DEFAULT_FIELDS = linkedHashSetOf("timestamp", "source", "message");
     public static final int DEFAULT_CHUNK_SIZE = 1000;
+    public static final DateTimeZone DEFAULT_TIME_ZONE = DateTimeZone.UTC;
 
     public static AbsoluteRange defaultTimeRange() {
         try {
@@ -61,6 +65,8 @@ public abstract class ExportMessagesCommand {
     public abstract int chunkSize();
 
     public abstract OptionalInt limit();
+
+    public abstract DateTimeZone timeZone();
 
     public static ExportMessagesCommand withDefaults() {
         return builder().build();
@@ -96,6 +102,8 @@ public abstract class ExportMessagesCommand {
 
         public abstract Builder limit(Integer limit);
 
+        public abstract Builder timeZone(DateTimeZone timeZone);
+
         abstract ExportMessagesCommand autoBuild();
 
         public ExportMessagesCommand build() {
@@ -109,7 +117,8 @@ public abstract class ExportMessagesCommand {
                     .queryString(DEFAULT_QUERY)
                     .fieldsInOrder(DEFAULT_FIELDS)
                     .decorators(Collections.emptyList())
-                    .chunkSize(DEFAULT_CHUNK_SIZE);
+                    .chunkSize(DEFAULT_CHUNK_SIZE)
+                    .timeZone(DEFAULT_TIME_ZONE);
         }
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/export/MessagesRequest.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/export/MessagesRequest.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
 import org.graylog.plugins.views.search.elasticsearch.ElasticsearchQueryString;
 import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
+import org.joda.time.DateTimeZone;
 
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.Positive;
@@ -34,6 +35,7 @@ import static org.graylog.plugins.views.search.export.ExportMessagesCommand.DEFA
 import static org.graylog.plugins.views.search.export.ExportMessagesCommand.DEFAULT_FIELDS;
 import static org.graylog.plugins.views.search.export.ExportMessagesCommand.DEFAULT_QUERY;
 import static org.graylog.plugins.views.search.export.ExportMessagesCommand.DEFAULT_STREAMS;
+import static org.graylog.plugins.views.search.export.ExportMessagesCommand.DEFAULT_TIME_ZONE;
 import static org.graylog.plugins.views.search.export.ExportMessagesCommand.defaultTimeRange;
 import static org.graylog.plugins.views.search.export.LinkedHashSetUtil.linkedHashSetOf;
 
@@ -45,6 +47,7 @@ public abstract class MessagesRequest {
     private static final String FIELD_QUERY_STRING = "query_string";
     private static final String FIELD_FIELDS = "fields_in_order";
     private static final String FIELD_CHUNK_SIZE = "chunk_size";
+    private static final String FIELD_TIME_ZONE = "time_zone";
 
     @JsonProperty(FIELD_TIMERANGE)
     public abstract TimeRange timeRange();
@@ -61,6 +64,9 @@ public abstract class MessagesRequest {
 
     @JsonProperty(FIELD_CHUNK_SIZE)
     public abstract int chunkSize();
+
+    @JsonProperty(FIELD_TIME_ZONE)
+    public abstract DateTimeZone timeZone();
 
     @JsonProperty
     @Positive
@@ -97,6 +103,9 @@ public abstract class MessagesRequest {
         @JsonProperty(FIELD_CHUNK_SIZE)
         public abstract Builder chunkSize(int chunkSize);
 
+        @JsonProperty(FIELD_TIME_ZONE)
+        public abstract Builder timeZone(DateTimeZone timeZone);
+
         @JsonProperty
         public abstract Builder limit(Integer limit);
 
@@ -109,7 +118,8 @@ public abstract class MessagesRequest {
                     .streams(DEFAULT_STREAMS)
                     .queryString(DEFAULT_QUERY)
                     .fieldsInOrder(DEFAULT_FIELDS)
-                    .chunkSize(DEFAULT_CHUNK_SIZE);
+                    .chunkSize(DEFAULT_CHUNK_SIZE)
+                    .timeZone(DEFAULT_TIME_ZONE);
         }
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/export/MessagesRequest.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/export/MessagesRequest.java
@@ -25,9 +25,11 @@ import org.graylog.plugins.views.search.elasticsearch.ElasticsearchQueryString;
 import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
 import org.joda.time.DateTimeZone;
 
+import javax.annotation.Nonnull;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.Positive;
 import java.util.LinkedHashSet;
+import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Set;
 
@@ -35,7 +37,6 @@ import static org.graylog.plugins.views.search.export.ExportMessagesCommand.DEFA
 import static org.graylog.plugins.views.search.export.ExportMessagesCommand.DEFAULT_FIELDS;
 import static org.graylog.plugins.views.search.export.ExportMessagesCommand.DEFAULT_QUERY;
 import static org.graylog.plugins.views.search.export.ExportMessagesCommand.DEFAULT_STREAMS;
-import static org.graylog.plugins.views.search.export.ExportMessagesCommand.DEFAULT_TIME_ZONE;
 import static org.graylog.plugins.views.search.export.ExportMessagesCommand.defaultTimeRange;
 import static org.graylog.plugins.views.search.export.LinkedHashSetUtil.linkedHashSetOf;
 
@@ -66,7 +67,7 @@ public abstract class MessagesRequest {
     public abstract int chunkSize();
 
     @JsonProperty(FIELD_TIME_ZONE)
-    public abstract DateTimeZone timeZone();
+    public abstract Optional<DateTimeZone> timeZone();
 
     @JsonProperty
     @Positive
@@ -78,6 +79,14 @@ public abstract class MessagesRequest {
 
     public static Builder builder() {
         return Builder.create();
+    }
+
+    public MessagesRequest withTimeZone(@Nonnull DateTimeZone timeZone) {
+        return toBuilder().timeZone(timeZone).build();
+    }
+
+    public MessagesRequest withStreams(@Nonnull Set<String> streams) {
+        return toBuilder().streams(streams).build();
     }
 
     public abstract Builder toBuilder();
@@ -118,8 +127,7 @@ public abstract class MessagesRequest {
                     .streams(DEFAULT_STREAMS)
                     .queryString(DEFAULT_QUERY)
                     .fieldsInOrder(DEFAULT_FIELDS)
-                    .chunkSize(DEFAULT_CHUNK_SIZE)
-                    .timeZone(DEFAULT_TIME_ZONE);
+                    .chunkSize(DEFAULT_CHUNK_SIZE);
         }
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/export/ResultFormat.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/export/ResultFormat.java
@@ -32,7 +32,6 @@ import java.util.LinkedHashSet;
 import java.util.Optional;
 
 import static org.graylog.plugins.views.search.export.ExportMessagesCommand.DEFAULT_FIELDS;
-import static org.graylog.plugins.views.search.export.ExportMessagesCommand.DEFAULT_TIME_ZONE;
 import static org.graylog.plugins.views.search.export.LinkedHashSetUtil.linkedHashSetOf;
 
 @JsonAutoDetect
@@ -68,6 +67,12 @@ public abstract class ResultFormat {
         return ResultFormat.builder().build();
     }
 
+    public ResultFormat withTimeZone(DateTimeZone timeZone) {
+        return toBuilder().timeZone(timeZone).build();
+    }
+
+    abstract ResultFormat.Builder toBuilder();
+
     @AutoValue.Builder
     public abstract static class Builder {
         @JsonProperty(FIELD_FIELDS)
@@ -98,8 +103,7 @@ public abstract class ResultFormat {
         public static ResultFormat.Builder create() {
             return new AutoValue_ResultFormat.Builder()
                     .fieldsInOrder(DEFAULT_FIELDS)
-                    .executionState(ExecutionState.empty())
-                    .timeZone(DEFAULT_TIME_ZONE);
+                    .executionState(ExecutionState.empty());
         }
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/export/ResultFormat.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/export/ResultFormat.java
@@ -23,16 +23,16 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
 import org.graylog.plugins.views.search.rest.ExecutionState;
 import org.graylog2.plugin.indexer.searches.timeranges.AbsoluteRange;
+import org.joda.time.DateTimeZone;
 
 import javax.annotation.Nullable;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.Positive;
-import java.util.Collections;
 import java.util.LinkedHashSet;
-import java.util.Map;
 import java.util.Optional;
 
 import static org.graylog.plugins.views.search.export.ExportMessagesCommand.DEFAULT_FIELDS;
+import static org.graylog.plugins.views.search.export.ExportMessagesCommand.DEFAULT_TIME_ZONE;
 import static org.graylog.plugins.views.search.export.LinkedHashSetUtil.linkedHashSetOf;
 
 @JsonAutoDetect
@@ -56,6 +56,9 @@ public abstract class ResultFormat {
 
     @JsonProperty
     public abstract Optional<String> filename();
+
+    @JsonProperty
+    public abstract Optional<DateTimeZone> timeZone();
 
     public static ResultFormat.Builder builder() {
         return ResultFormat.Builder.create();
@@ -86,13 +89,17 @@ public abstract class ResultFormat {
         @JsonProperty
         public abstract Builder filename(@Nullable String filename);
 
+        @JsonProperty
+        public abstract Builder timeZone(@Nullable DateTimeZone timeZone);
+
         public abstract ResultFormat build();
 
         @JsonCreator
         public static ResultFormat.Builder create() {
             return new AutoValue_ResultFormat.Builder()
                     .fieldsInOrder(DEFAULT_FIELDS)
-                    .executionState(ExecutionState.empty());
+                    .executionState(ExecutionState.empty())
+                    .timeZone(DEFAULT_TIME_ZONE);
         }
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/permissions/SearchUser.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/permissions/SearchUser.java
@@ -25,6 +25,7 @@ import org.graylog2.plugin.database.users.User;
 import org.graylog2.shared.security.RestPermissions;
 import org.joda.time.DateTimeZone;
 
+import java.util.Optional;
 import java.util.function.BiPredicate;
 import java.util.function.Predicate;
 
@@ -39,8 +40,8 @@ public class SearchUser implements SearchPermissions, StreamPermissions, ViewPer
         this.isPermittedEntity = isPermittedEntity;
     }
 
-    public DateTimeZone timeZone() {
-        return this.currentUser.getTimeZone();
+    public Optional<DateTimeZone> timeZone() {
+        return Optional.ofNullable(this.currentUser.getTimeZone());
     }
 
     public String username() {

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/permissions/SearchUser.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/permissions/SearchUser.java
@@ -23,6 +23,7 @@ import org.graylog.plugins.views.search.views.ViewDTO;
 import org.graylog.plugins.views.search.views.ViewLike;
 import org.graylog2.plugin.database.users.User;
 import org.graylog2.shared.security.RestPermissions;
+import org.joda.time.DateTimeZone;
 
 import java.util.function.BiPredicate;
 import java.util.function.Predicate;
@@ -36,6 +37,10 @@ public class SearchUser implements SearchPermissions, StreamPermissions, ViewPer
         this.currentUser = currentUser;
         this.isPermitted = isPermitted;
         this.isPermittedEntity = isPermittedEntity;
+    }
+
+    public DateTimeZone timeZone() {
+        return this.currentUser.getTimeZone();
     }
 
     public String username() {

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/MessagesResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/MessagesResource.java
@@ -46,6 +46,7 @@ import org.graylog2.audit.jersey.NoAuditEvent;
 import org.graylog2.plugin.rest.PluginRestResource;
 import org.graylog2.rest.MoreMediaTypes;
 import org.graylog2.shared.rest.resources.RestResource;
+import org.joda.time.DateTimeZone;
 
 import javax.inject.Inject;
 import javax.validation.Valid;
@@ -65,7 +66,7 @@ import java.util.function.Function;
 @Path("/views/search/messages")
 @RequiresAuthentication
 public class MessagesResource extends RestResource implements PluginRestResource {
-
+    private static final DateTimeZone FALLBACK_TIME_ZONE = DateTimeZone.UTC;
     private final CommandFactory commandFactory;
     private final SearchDomain searchDomain;
     private final SearchExecutionGuard executionGuard;
@@ -122,7 +123,7 @@ public class MessagesResource extends RestResource implements PluginRestResource
         }
 
         if (!request.timeZone().isPresent()) {
-            request = request.withTimeZone(searchUser.timeZone());
+            request = request.withTimeZone(searchUser.timeZone().orElse(FALLBACK_TIME_ZONE));
         }
 
         return request;
@@ -131,7 +132,7 @@ public class MessagesResource extends RestResource implements PluginRestResource
     private ResultFormat fillInIfNecessary(ResultFormat resultFormat, SearchUser searchUser) {
         return resultFormat.timeZone().isPresent()
                 ? resultFormat
-                : resultFormat.withTimeZone(searchUser.timeZone());
+                : resultFormat.withTimeZone(searchUser.timeZone().orElse(FALLBACK_TIME_ZONE));
     }
 
     @ApiOperation(value = "Export a search result as CSV")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR adds support for user-defined TimeZone in exports. This allows the api request to contain an optional `time_zone` field which is then used to format timestamps. If none is specified, the time zone of the user is used.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
Fixes #9546 

## How Has This Been Tested?
Added integration test, additionally manually verified via API calls (see screenshot bellow)

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/4102775/144593563-586436d2-18c6-48bf-bc60-74bbf01acc4e.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

