### PR TITLE
Prevent infinite recursion when serializing `IpAddress`.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ips/IpAddress.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ips/IpAddress.java
@@ -16,6 +16,8 @@
  */
 package org.graylog.plugins.pipelineprocessor.functions.ips;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonValue;
 import com.google.common.net.InetAddresses;
 
 import java.net.InetAddress;
@@ -43,14 +45,16 @@ public class IpAddress {
     }
 
     @Override
+    @JsonValue
     public String toString() {
         return InetAddresses.toAddrString(address);
     }
 
     @SuppressWarnings("unused")
+    @JsonIgnore
     public IpAddress getAnonymized() {
         final byte[] address = this.address.getAddress();
-        address[address.length-1] = 0x00;
+        address[address.length - 1] = 0x00;
         try {
             return new IpAddress(InetAddress.getByAddress(address));
         } catch (UnknownHostException e) {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

**Note:** Due to the simplicity of this fix, we should consider backporting it to `4.1` and `4.2`.

Prior to this PR, when a message had an instance of an `IpAddress` (added through a pipeline rule) in one of its fields, indexing that message results in an infinite recursion due to trying to serialize `IpAddress#getAnonymized` (which returns a new, "anonymized" instance of itself and another attempt to serialize that one is started). What is even worse, there is no way to recover from this than deleting the complete journal. All further message indexing will stall until this is resolved.

An example rule to trigger this could look like this:
```
rule "Adding IP field"
when
  true
then
  set_field("client_ip", to_ip("192.168.1.42"));
end
```

This PR is now marking `IpAddress#getAnonymized` to be ignored for JSON serialization and uses `IpAddress#toString` instead to retrieve the JSON value of this class.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.