### PR TITLE
Migrate legacy search API to use current search engine.

### DIFF
--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/views/searchtypes/ESMessageList.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/views/searchtypes/ESMessageList.java
@@ -84,6 +84,10 @@ public class ESMessageList implements ESSearchTypeHandler<MessageList> {
                 ? query.usedStreamIds()
                 : messageList.effectiveStreams();
 
+        if (!messageList.fields().isEmpty()) {
+            searchSourceBuilder.fetchSource(messageList.fields().toArray(new String[0]), new String[0]);
+        }
+
         final List<Sort> sorts = firstNonNull(messageList.sort(), Collections.singletonList(Sort.create(Message.FIELD_TIMESTAMP, Sort.Order.DESC)));
         sorts.forEach(sort -> {
             final FieldSortBuilder fieldSort = SortBuilders.fieldSort(sort.field())

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/ESMessageList.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/ESMessageList.java
@@ -101,6 +101,10 @@ public class ESMessageList implements ESSearchTypeHandler<MessageList> {
                 ? query.usedStreamIds()
                 : messageList.effectiveStreams();
 
+        if (!messageList.fields().isEmpty()) {
+            searchSourceBuilder.fetchSource(messageList.fields().toArray(new String[0]), new String[0]);
+        }
+
         final List<Sort> sorts = firstNonNull(messageList.sort(), Collections.singletonList(Sort.create(Message.FIELD_TIMESTAMP, Sort.Order.DESC)));
         sorts.forEach(sort -> {
             final FieldSortBuilder fieldSort = SortBuilders.fieldSort(sort.field())

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/MessageList.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/MessageList.java
@@ -83,6 +83,9 @@ public abstract class MessageList implements SearchType {
     public abstract List<Sort> sort();
 
     @JsonProperty
+    public abstract List<String> fields();
+
+    @JsonProperty
     public abstract List<Decorator> decorators();
 
     @Override
@@ -97,7 +100,8 @@ public abstract class MessageList implements SearchType {
                 .limit(150)
                 .offset(0)
                 .streams(Collections.emptySet())
-                .decorators(Collections.emptyList());
+                .decorators(Collections.emptyList())
+                .fields(Collections.emptyList());
     }
 
     public abstract Builder toBuilder();
@@ -140,6 +144,9 @@ public abstract class MessageList implements SearchType {
 
         @JsonProperty
         public abstract Builder filter(@Nullable Filter filter);
+
+        @JsonProperty
+        public abstract Builder fields(List<String> fields);
 
         @JsonProperty
         @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "type", visible = true)

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/search/AbsoluteSearchResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/search/AbsoluteSearchResource.java
@@ -69,7 +69,7 @@ public class AbsoluteSearchResource extends SearchResource {
                                   SearchExecutor searchExecutor,
                                   ClusterConfigService clusterConfigService,
                                   DecoratorProcessor decoratorProcessor) {
-        super(searches, clusterConfigService, decoratorProcessor);
+        super(searches, clusterConfigService, decoratorProcessor, searchExecutor);
         this.searchExecutor = searchExecutor;
     }
 
@@ -103,13 +103,7 @@ public class AbsoluteSearchResource extends SearchResource {
 
         final TimeRange timeRange = buildAbsoluteTimeRange(from, to);
 
-        final Search search = createSearch(query, limit, filter, fieldList, sorting, timeRange);
-
-        final Optional<String> streamId = Searches.extractStreamId(filter);
-
-        final SearchJob searchJob = searchExecutor.execute(search, searchUser, ExecutionState.empty());
-
-        return extractSearchResponse(searchJob, query, decorate, fieldList, timeRange, streamId);
+        return search(query, limit, filter, decorate, searchUser, fieldList, sorting, timeRange);
     }
 
     @GET

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/search/AbsoluteSearchResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/search/AbsoluteSearchResource.java
@@ -24,11 +24,15 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import org.apache.shiro.authz.annotation.RequiresAuthentication;
 import org.glassfish.jersey.server.ChunkedOutput;
+import org.graylog.plugins.views.search.Search;
+import org.graylog.plugins.views.search.SearchJob;
+import org.graylog.plugins.views.search.permissions.SearchUser;
+import org.graylog.plugins.views.search.rest.ExecutionState;
+import org.graylog.plugins.views.search.rest.SearchExecutor;
+import org.graylog.plugins.views.search.searchtypes.Sort;
 import org.graylog2.decorators.DecoratorProcessor;
 import org.graylog2.indexer.results.ScrollResult;
 import org.graylog2.indexer.searches.Searches;
-import org.graylog2.indexer.searches.SearchesConfig;
-import org.graylog2.indexer.searches.Sorting;
 import org.graylog2.plugin.cluster.ClusterConfigService;
 import org.graylog2.plugin.indexer.searches.timeranges.AbsoluteRange;
 import org.graylog2.plugin.indexer.searches.timeranges.InvalidRangeParametersException;
@@ -47,6 +51,7 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.util.List;
@@ -57,12 +62,15 @@ import java.util.Optional;
 @Path("/search/universal/absolute")
 public class AbsoluteSearchResource extends SearchResource {
     private static final Logger LOG = LoggerFactory.getLogger(AbsoluteSearchResource.class);
+    private final SearchExecutor searchExecutor;
 
     @Inject
     public AbsoluteSearchResource(Searches searches,
+                                  SearchExecutor searchExecutor,
                                   ClusterConfigService clusterConfigService,
                                   DecoratorProcessor decoratorProcessor) {
         super(searches, clusterConfigService, decoratorProcessor);
+        this.searchExecutor = searchExecutor;
     }
 
     @GET
@@ -81,31 +89,27 @@ public class AbsoluteSearchResource extends SearchResource {
             @QueryParam("from") @NotEmpty String from,
             @ApiParam(name = "to", value = "Timerange end. See description for date format", required = true)
             @QueryParam("to") @NotEmpty String to,
-            @ApiParam(name = "limit", value = "Maximum number of messages to return.", required = false) @QueryParam("limit") int limit,
-            @ApiParam(name = "offset", value = "Offset", required = false) @QueryParam("offset") int offset,
-            @ApiParam(name = "filter", value = "Filter", required = false) @QueryParam("filter") String filter,
-            @ApiParam(name = "fields", value = "Comma separated list of fields to return", required = false) @QueryParam("fields") String fields,
-            @ApiParam(name = "sort", value = "Sorting (field:asc / field:desc)", required = false) @QueryParam("sort") String sort,
-            @ApiParam(name = "decorate", value = "Run decorators on search result", required = false) @QueryParam("decorate") @DefaultValue("true") boolean decorate) {
+            @ApiParam(name = "limit", value = "Maximum number of messages to return.") @QueryParam("limit") int limit,
+            @ApiParam(name = "offset", value = "Offset") @QueryParam("offset") int offset,
+            @ApiParam(name = "filter", value = "Filter") @QueryParam("filter") String filter,
+            @ApiParam(name = "fields", value = "Comma separated list of fields to return") @QueryParam("fields") String fields,
+            @ApiParam(name = "sort", value = "Sorting (field:asc / field:desc)") @QueryParam("sort") String sort,
+            @ApiParam(name = "decorate", value = "Run decorators on search result") @QueryParam("decorate") @DefaultValue("true") boolean decorate,
+            @Context SearchUser searchUser) {
         checkSearchPermission(filter, RestPermissions.SEARCHES_ABSOLUTE);
 
-        final Sorting sorting = buildSorting(sort);
+        final Sort sorting = buildSortOrder(sort);
         final List<String> fieldList = parseOptionalFields(fields);
 
-        TimeRange timeRange = buildAbsoluteTimeRange(from, to);
-        final SearchesConfig searchesConfig = SearchesConfig.builder()
-                .query(query)
-                .filter(filter)
-                .fields(fieldList)
-                .range(timeRange)
-                .limit(limit)
-                .offset(offset)
-                .sorting(sorting)
-                .build();
+        final TimeRange timeRange = buildAbsoluteTimeRange(from, to);
+
+        final Search search = createSearch(query, limit, filter, fieldList, sorting, timeRange);
 
         final Optional<String> streamId = Searches.extractStreamId(filter);
 
-        return buildSearchResponse(searches.search(searchesConfig), timeRange, decorate, streamId);
+        final SearchJob searchJob = searchExecutor.execute(search, searchUser, ExecutionState.empty());
+
+        return extractSearchResponse(searchJob, query, decorate, fieldList, timeRange, streamId);
     }
 
     @GET

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/search/KeywordSearchResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/search/KeywordSearchResource.java
@@ -72,7 +72,7 @@ public class KeywordSearchResource extends SearchResource {
                                  SearchExecutor searchExecutor,
                                  ClusterConfigService clusterConfigService,
                                  DecoratorProcessor decoratorProcessor) {
-        super(searches, clusterConfigService, decoratorProcessor);
+        super(searches, clusterConfigService, decoratorProcessor, searchExecutor);
         this.searchExecutor = searchExecutor;
     }
 
@@ -104,13 +104,7 @@ public class KeywordSearchResource extends SearchResource {
 
         final TimeRange timeRange = buildKeywordTimeRange(keyword, timezone);
 
-        final Search search = createSearch(query, limit, filter, fieldList, sorting, timeRange);
-
-        final Optional<String> streamId = Searches.extractStreamId(filter);
-
-        final SearchJob searchJob = searchExecutor.execute(search, searchUser, ExecutionState.empty());
-
-        return extractSearchResponse(searchJob, query, decorate, fieldList, timeRange, streamId);
+        return search(query, limit, filter, decorate, searchUser, fieldList, sorting, timeRange);
     }
 
     @GET

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/search/RelativeSearchResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/search/RelativeSearchResource.java
@@ -24,13 +24,11 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import org.apache.shiro.authz.annotation.RequiresAuthentication;
 import org.glassfish.jersey.server.ChunkedOutput;
-import org.graylog.plugins.views.search.QueryResult;
 import org.graylog.plugins.views.search.Search;
 import org.graylog.plugins.views.search.SearchJob;
 import org.graylog.plugins.views.search.permissions.SearchUser;
 import org.graylog.plugins.views.search.rest.ExecutionState;
 import org.graylog.plugins.views.search.rest.SearchExecutor;
-import org.graylog.plugins.views.search.searchtypes.MessageList;
 import org.graylog.plugins.views.search.searchtypes.Sort;
 import org.graylog2.decorators.DecoratorProcessor;
 import org.graylog2.indexer.results.ScrollResult;
@@ -66,15 +64,13 @@ import java.util.Optional;
 public class RelativeSearchResource extends SearchResource {
 
     private static final Logger LOG = LoggerFactory.getLogger(RelativeSearchResource.class);
-    private final SearchExecutor searchExecutor;
 
     @Inject
     public RelativeSearchResource(Searches searches,
                                   ClusterConfigService clusterConfigService,
                                   DecoratorProcessor decoratorProcessor,
                                   SearchExecutor searchExecutor) {
-        super(searches, clusterConfigService, decoratorProcessor);
-        this.searchExecutor = searchExecutor;
+        super(searches, clusterConfigService, decoratorProcessor, searchExecutor);
     }
 
     @GET
@@ -105,13 +101,7 @@ public class RelativeSearchResource extends SearchResource {
 
         final TimeRange timeRange = buildRelativeTimeRange(range);
 
-        final Search search = createSearch(query, limit, filter, fieldList, sorting, timeRange);
-
-        final Optional<String> streamId = Searches.extractStreamId(filter);
-
-        final SearchJob searchJob = searchExecutor.execute(search, searchUser, ExecutionState.empty());
-
-        return extractSearchResponse(searchJob, query, decorate, fieldList, timeRange, streamId);
+        return search(query, limit, filter, decorate, searchUser, fieldList, sorting, timeRange);
     }
 
     @GET

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/search/SearchResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/search/SearchResource.java
@@ -17,9 +17,20 @@
 package org.graylog2.rest.resources.search;
 
 import com.google.common.base.Splitter;
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import org.glassfish.jersey.server.ChunkedOutput;
+import org.graylog.plugins.views.search.Query;
+import org.graylog.plugins.views.search.QueryResult;
+import org.graylog.plugins.views.search.Search;
+import org.graylog.plugins.views.search.SearchJob;
+import org.graylog.plugins.views.search.SearchType;
+import org.graylog.plugins.views.search.elasticsearch.ElasticsearchQueryString;
+import org.graylog.plugins.views.search.filter.QueryStringFilter;
+import org.graylog.plugins.views.search.searchtypes.MessageList;
+import org.graylog.plugins.views.search.searchtypes.Sort;
 import org.graylog2.decorators.DecoratorProcessor;
 import org.graylog2.indexer.ranges.IndexRange;
 import org.graylog2.indexer.results.ResultMessage;
@@ -31,6 +42,7 @@ import org.graylog2.indexer.searches.Sorting;
 import org.graylog2.plugin.Message;
 import org.graylog2.plugin.cluster.ClusterConfigService;
 import org.graylog2.plugin.indexer.searches.timeranges.AbsoluteRange;
+import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
 import org.graylog2.rest.models.messages.responses.ResultMessageSummary;
 import org.graylog2.rest.models.system.indexer.responses.IndexRangeSummary;
 import org.graylog2.rest.resources.search.responses.SearchResponse;
@@ -41,11 +53,14 @@ import org.joda.time.Period;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.validation.constraints.NotEmpty;
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.ForbiddenException;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -113,6 +128,20 @@ public abstract class SearchResource extends RestResource {
         return decorate ? decoratorProcessor.decorate(result, streamId) : result;
     }
 
+    protected SearchResponse buildSearchResponse(String query, MessageList.Result results, List<String> fieldList, long tookMs, TimeRange timeRange, boolean decorate, Optional<String> streamId) {
+        final SearchResponse result = SearchResponse.create(query,
+                query,
+                Collections.emptySet(),
+                results.messages(),
+                fieldList == null ? Collections.emptySet() : ImmutableSet.copyOf(fieldList),
+                tookMs,
+                results.totalResults(),
+                timeRange.getFrom(),
+                timeRange.getTo());
+
+        return decorate ? decoratorProcessor.decorate(result, streamId) : result;
+    }
+
     protected Set<IndexRangeSummary> indexRangeListToValueList(Set<IndexRange> indexRanges) {
         final Set<IndexRangeSummary> result = Sets.newHashSetWithExpectedSize(indexRanges.size());
 
@@ -146,6 +175,62 @@ public abstract class SearchResource extends RestResource {
             LOG.error("Falling back to default sorting.", e);
             return Sorting.DEFAULT;
         }
+    }
+
+    protected Sort buildSortOrder(String sort) {
+        if (isNullOrEmpty(sort)) {
+            return Sort.create("timestamp", Sort.Order.DESC);
+        }
+
+        if (!sort.contains(":")) {
+            throw new IllegalArgumentException("Invalid sorting parameter: " + sort);
+        }
+
+        String[] parts = sort.split(":");
+
+        return Sort.create(parts[0], Sort.Order.valueOf(parts[1].toUpperCase(Locale.ENGLISH)));
+    }
+
+    protected Search createSearch(String queryString, int limit, String filter, List<String> fieldList, Sort sorting, TimeRange timeRange) {
+        final SearchType searchType = createMessageList(sorting, limit, fieldList);
+
+        final Query query = Query.builder()
+                .query(ElasticsearchQueryString.of(queryString))
+                .filter(QueryStringFilter.builder()
+                        .query(Strings.isNullOrEmpty(filter) ? "*" : filter)
+                        .build())
+                .timerange(timeRange)
+                .searchTypes(Collections.singleton(searchType))
+                .build();
+        return Search.Builder.create()
+                .queries(ImmutableSet.of(query))
+                .build();
+    }
+
+    private SearchType createMessageList(Sort sorting, int limit, List<String> fieldList) {
+        MessageList.Builder messageListBuilder = MessageList.builder()
+                .sort(Collections.singletonList(sorting));
+        messageListBuilder = limit > 0 ? messageListBuilder.limit(limit) : messageListBuilder;
+        messageListBuilder = fieldList != null && !fieldList.isEmpty() ? messageListBuilder.fields(fieldList) : messageListBuilder;
+        return messageListBuilder.build();
+    }
+
+    protected SearchResponse extractSearchResponse(SearchJob searchJob, String query, boolean decorate, List<String> fieldList, TimeRange timeRange, Optional<String> streamId) {
+        final QueryResult queryResult = searchJob.results()
+                .values()
+                .stream()
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException("Missing query result"));
+        final MessageList.Result result = queryResult.searchTypes()
+                .values()
+                .stream()
+                .findFirst()
+                .map(searchTypeResult -> (MessageList.Result)searchTypeResult)
+                .orElseThrow(() -> new IllegalStateException("Missing search type result!"));
+
+        final long tookMs = queryResult.executionStats().duration();
+
+        return buildSearchResponse(query, result, fieldList, tookMs, timeRange, decorate, streamId);
     }
 
     protected ChunkedOutput<ScrollResult.ScrollChunk> buildChunkedOutput(final ScrollResult scroll) {

--- a/graylog2-server/src/test/java/org/graylog2/rest/resources/search/SearchResourceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/rest/resources/search/SearchResourceTest.java
@@ -16,6 +16,7 @@
  */
 package org.graylog2.rest.resources.search;
 
+import org.graylog.plugins.views.search.rest.SearchExecutor;
 import org.graylog2.decorators.DecoratorProcessor;
 import org.graylog2.indexer.searches.Searches;
 import org.graylog2.indexer.searches.SearchesClusterConfig;
@@ -48,13 +49,16 @@ public class SearchResourceTest {
     @Mock
     private DecoratorProcessor decoratorProcessor;
 
+    @Mock
+    private SearchExecutor searchExecutor;
+
     private SearchResource searchResource;
     private Period queryLimitPeriod;
 
     @Before
     public void setUp() {
         queryLimitPeriod = Period.parse("P1D");
-        searchResource = new SearchResource(searches, clusterConfigService, decoratorProcessor) {
+        searchResource = new SearchResource(searches, clusterConfigService, decoratorProcessor, searchExecutor) {
         };
 
         when(clusterConfigService.get(SearchesClusterConfig.class)).thenReturn(SearchesClusterConfig.createDefault()
@@ -87,7 +91,7 @@ public class SearchResourceTest {
                 .queryTimeRangeLimit(Period.ZERO)
                 .build());
 
-        final SearchResource resource = new SearchResource(searches, clusterConfigService, decoratorProcessor) {
+        final SearchResource resource = new SearchResource(searches, clusterConfigService, decoratorProcessor, searchExecutor) {
         };
 
         final DateTime from = new DateTime(2015, 1, 15, 12, 0, DateTimeZone.UTC);


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Prior to this PR, the legacy search API was using a separate code path to retrieve search results from ES. In order to benefit from further development, it should use our current search engine.

This PR is using the refactorings performed in #11594 & #11646 to reuse the `SearchExecutor` in the legacy search API. This is performed for the REST methods returning plain results (without scrolling). 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.