### PR TITLE
Stop processing further stages after drop_message

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -31,7 +31,14 @@ pre 2.2 Graylog installations.
 
 ## Configuration File Changes
 
-The following configuration option as been removed: `index_field_type_periodical_interval`.
+The following configuration option has been removed: `index_field_type_periodical_interval`.
 
 It has been replaced with a new configuration option which allows users to tweak the default full refresh interval for
 index field type information: `index_field_type_periodical_full_refresh_interval`.
+
+## Behaviour Changes
+
+- Pipeline function `drop_message` was modified to provide more performant and 
+predictable results: When `drop_message` is called in a rule, we complete processing of
+the current stage; following stages are skipped. Other pipelines operating on the same message will
+complete stage numbers less than or equal to the aborting stage; higher numbered stages are skipped.  

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/messages/DropMessage.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/messages/DropMessage.java
@@ -52,7 +52,7 @@ public class DropMessage extends AbstractFunction<Void> {
                 .params(ImmutableList.of(
                         messageParam
                 ))
-                .description("Discards a message from further processing")
+                .description("Discards a message from further processing, after completing the current stage")
                 .build();
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/processors/PipelineInterpreter.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/processors/PipelineInterpreter.java
@@ -266,6 +266,12 @@ public class PipelineInterpreter implements MessageProcessor {
         // iterate through all stages for all matching pipelines, per "stage slice" instead of per pipeline.
         // pipeline execution ordering is not guaranteed
         while (stages.hasNext()) {
+            // Don't execute the "stage slice" if the message has been dropped. Break out of the loop to skip all
+            // remaining stages.
+            if (message.getFilterOut()) {
+                break;
+            }
+
             final List<Stage> stageSet = stages.next();
             for (final Stage stage : stageSet) {
                 evaluateStage(stage, message, msgId, result, pipelinesToSkip, interpreterListener);

--- a/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/processors/PipelineInterpreterTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/processors/PipelineInterpreterTest.java
@@ -42,6 +42,7 @@ import org.graylog.plugins.pipelineprocessor.db.mongodb.MongoDbRuleService;
 import org.graylog.plugins.pipelineprocessor.functions.conversion.DoubleConversion;
 import org.graylog.plugins.pipelineprocessor.functions.conversion.StringConversion;
 import org.graylog.plugins.pipelineprocessor.functions.messages.CreateMessage;
+import org.graylog.plugins.pipelineprocessor.functions.messages.DropMessage;
 import org.graylog.plugins.pipelineprocessor.functions.messages.HasField;
 import org.graylog.plugins.pipelineprocessor.functions.messages.SetField;
 import org.graylog.plugins.pipelineprocessor.parser.FunctionRegistry;
@@ -61,8 +62,10 @@ import org.mockito.Mockito;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.SortedMap;
 import java.util.concurrent.Executors;
+import java.util.stream.Collectors;
 
 import static com.codahale.metrics.MetricRegistry.name;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -88,7 +91,18 @@ public class PipelineInterpreterTest {
                     "then\n" +
                     "  set_field(\"foobar\", \"covfefe\");\n" +
                     "end", null, null);
-
+    private static final java.util.function.Function<String, RuleDao> RULE_SET_FIELD = (name) -> RuleDao.create("false", "false", "false",
+            "rule \"" + name + "\"\n" +
+                    "when true\n" +
+                    "then\n" +
+                    "  set_field(\"" + name + "\", \"value\");" +
+                    "end", null, null);
+    private static final RuleDao RULE_DROP_MESSAGE = RuleDao.create("false", "false", "false",
+            "rule \"drop_message\"\n" +
+                    "when true\n" +
+                    "then\n" +
+                    "  drop_message();" +
+                    "end", null, null);
     private final MessageQueueAcknowledger messageQueueAcknowledger = mock(MessageQueueAcknowledger.class);
 
     private final RuleService ruleService = Mockito.mock(RuleService.class);
@@ -317,12 +331,75 @@ public class PipelineInterpreterTest {
         assertThat(actualMessage.getFieldAs(String.class, "foobar")).isEqualTo("covfefe");
     }
 
+    @Test
+    public void testDroppedMessageWillHaltProcessingAfterCurrentStage() {
+        final RuleService ruleService = mock(MongoDbRuleService.class);
+        when(ruleService.loadAll()).thenReturn(ImmutableList.of(
+                RULE_SET_FIELD.apply("1-a"),
+                RULE_SET_FIELD.apply("1-b"),
+                RULE_SET_FIELD.apply("2-a"),
+                RULE_SET_FIELD.apply("2-b"),
+                RULE_DROP_MESSAGE
+        ));
+
+        final PipelineService pipelineService = mock(MongoDbPipelineService.class);
+        when(pipelineService.loadAll()).thenReturn(ImmutableList.of(
+                PipelineDao.create("p1", "title1", "description",
+                        "pipeline \"pipeline1\"\n" +
+                                "stage 0 match pass\n" +
+                                "    rule \"1-a\";\n" +
+                                "    rule \"drop_message\";\n" +
+                                "stage 1 match pass\n" +
+                                "    rule \"1-b\";\n" +
+                                "end\n",
+                        Tools.nowUTC(),
+                        null),
+                PipelineDao.create("p2", "title2", "description",
+                        "pipeline \"pipeline2\"\n" +
+                                "stage 0 match pass\n" +
+                                "    rule \"2-a\";\n" +
+                                "stage 1 match pass\n" +
+                                "    rule \"2-b\";\n" +
+                                "end\n",
+                        Tools.nowUTC(),
+                        null)
+        ));
+
+        final Map<String, Function<?>> functions = ImmutableMap.of(
+                SetField.NAME, new SetField(),
+                DropMessage.NAME, new DropMessage()
+        );
+        final PipelineInterpreter interpreter = createPipelineInterpreter(ruleService, pipelineService, functions);
+
+        final Messages processed = interpreter.process(messageInDefaultStream("message", "test"));
+
+        assertThat(processed).isInstanceOf(MessageCollection.class);
+
+        // Use MessageCollection#source here to get access to the unfiltered messages
+        final List<Message> messages = ImmutableList.copyOf(((MessageCollection) processed).source());
+        assertThat(messages).hasSize(1);
+
+        final Message actualMessage = messages.get(0);
+
+        assertThat(actualMessage.getFilterOut()).isTrue();
+
+        // Even though "drop_message" has been called in one of the stages, all stages of the same number should
+        // have been executed
+        assertThat(actualMessage.getFieldAs(String.class, "1-a")).isEqualTo("value");
+        assertThat(actualMessage.getFieldAs(String.class, "2-a")).isEqualTo("value");
+
+        // The second stage in both pipelines should not have been executed due to the "drop_message" call
+        assertThat(actualMessage.getField("1-b")).isNull();
+        assertThat(actualMessage.getField("2-b")).isNull();
+    }
+
     @SuppressForbidden("Allow using default thread factory")
     private PipelineInterpreter createPipelineInterpreter(RuleService ruleService, PipelineService pipelineService, Map<String, Function<?>> functions) {
         final RuleMetricsConfigService ruleMetricsConfigService = mock(RuleMetricsConfigService.class);
         when(ruleMetricsConfigService.get()).thenReturn(RuleMetricsConfigDto.createDefault());
         final PipelineStreamConnectionsService pipelineStreamConnectionsService = mock(MongoDbPipelineStreamConnectionsService.class);
-        final PipelineConnections pipelineConnections = PipelineConnections.create("p1", DEFAULT_STREAM_ID, Collections.singleton("p1"));
+        final Set<String> pipelineIds = pipelineService.loadAll().stream().map(PipelineDao::id).collect(Collectors.toSet());
+        final PipelineConnections pipelineConnections = PipelineConnections.create("p1", DEFAULT_STREAM_ID, pipelineIds);
         when(pipelineStreamConnectionsService.loadAll()).thenReturn(Collections.singleton(pipelineConnections));
 
         final FunctionRegistry functionRegistry = new FunctionRegistry(functions);


### PR DESCRIPTION
`drop_message` has 2 purposes:
- prevent the message from being stored in ES
- improve performance by short-circuiting pipeline processing 

The current implementation does not do a good job on the latter. We are excessively conservative about avoiding unexpected side-effects between pipelines that process the same message. As a result, `drop_message` rarely achieves significant performance gains; and resulting metrics are often confusing to users.

We define the behavior more strictly now - which should also be more intuitive to users:
When `drop_message` is called, we complete processing of that stage; as well as all stages up to that stage number in other pipelines (for that message). Any subsequent stages are skipped, across all pipelines.

Resolves #4855 