### PR TITLE
Update PropTypes of ConfirmDialog for btnConfirmText and btnConfirmCancelText

### DIFF
--- a/graylog2-web-interface/src/components/common/ConfirmDialog.tsx
+++ b/graylog2-web-interface/src/components/common/ConfirmDialog.tsx
@@ -61,9 +61,15 @@ ConfirmDialog.propTypes = {
     PropTypes.element,
   ]).isRequired,
   /** Text to use in the cancel button. */
-  btnCancelText: PropTypes.string,
-  /** Text to use in the confirmation button. */
-  btnConfirmText: PropTypes.string,
+  btnCancelText: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.element,
+  ]),
+  /** Text or element to use in the confirmation button. */
+  btnConfirmText: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.element,
+  ]),
   /** Indicates whether the cancel button should be disabled or not. */
   btnCancelDisabled: PropTypes.bool,
   /** Indicates whether the confirm button should be disabled or not. */


### PR DESCRIPTION
## Description
This PR updates the propTypes of the ConfirmDialog component to allow for a string or React element as the child of the confirmation button and cancel button.

## Motivation and Context
This change is needed for https://github.com/Graylog2/graylog-plugin-enterprise/pull/3005

