### PR TITLE
Deprecate usage of the term "master"

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/events/periodicals/EventNotificationStatusCleanUp.java
+++ b/graylog2-server/src/main/java/org/graylog/events/periodicals/EventNotificationStatusCleanUp.java
@@ -54,7 +54,7 @@ public class EventNotificationStatusCleanUp extends Periodical {
     }
 
     @Override
-    public boolean masterOnly() {
+    public boolean leaderOnly() {
         return true;
     }
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/periodical/LegacyDefaultStreamMigration.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/periodical/LegacyDefaultStreamMigration.java
@@ -52,7 +52,7 @@ public class LegacyDefaultStreamMigration extends Periodical {
     }
 
     @Override
-    public boolean masterOnly() {
+    public boolean leaderOnly() {
         return true;
     }
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/periodical/PurgeExpiredConfigurationUploads.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/periodical/PurgeExpiredConfigurationUploads.java
@@ -45,7 +45,7 @@ public class PurgeExpiredConfigurationUploads extends Periodical {
     }
 
     @Override
-    public boolean masterOnly() {
+    public boolean leaderOnly() {
         return true;
     }
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/periodical/PurgeExpiredSidecarsThread.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/periodical/PurgeExpiredSidecarsThread.java
@@ -50,7 +50,7 @@ public class PurgeExpiredSidecarsThread extends Periodical {
     }
 
     @Override
-    public boolean masterOnly() {
+    public boolean leaderOnly() {
         return true;
     }
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/db/SearchesCleanUpJob.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/db/SearchesCleanUpJob.java
@@ -56,7 +56,7 @@ public class SearchesCleanUpJob extends Periodical {
     }
 
     @Override
-    public boolean masterOnly() {
+    public boolean leaderOnly() {
         return true;
     }
 

--- a/graylog2-server/src/main/java/org/graylog/scheduler/periodicals/ScheduleTriggerCleanUp.java
+++ b/graylog2-server/src/main/java/org/graylog/scheduler/periodicals/ScheduleTriggerCleanUp.java
@@ -48,7 +48,7 @@ public class ScheduleTriggerCleanUp extends Periodical {
     }
 
     @Override
-    public boolean masterOnly() {
+    public boolean leaderOnly() {
         return true;
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/events/ClusterEventCleanupPeriodical.java
+++ b/graylog2-server/src/main/java/org/graylog2/events/ClusterEventCleanupPeriodical.java
@@ -68,7 +68,7 @@ public class ClusterEventCleanupPeriodical extends Periodical {
     }
 
     @Override
-    public boolean masterOnly() {
+    public boolean leaderOnly() {
         return true;
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/events/ClusterEventPeriodical.java
+++ b/graylog2-server/src/main/java/org/graylog2/events/ClusterEventPeriodical.java
@@ -112,7 +112,7 @@ public class ClusterEventPeriodical extends Periodical {
     }
 
     @Override
-    public boolean masterOnly() {
+    public boolean leaderOnly() {
         return false;
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/IndexFieldTypePollerPeriodical.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/IndexFieldTypePollerPeriodical.java
@@ -263,7 +263,7 @@ public class IndexFieldTypePollerPeriodical extends Periodical {
     }
 
     @Override
-    public boolean masterOnly() {
+    public boolean leaderOnly() {
         // Only needs to run on the master node because results are stored in the database
         return true;
     }

--- a/graylog2-server/src/main/java/org/graylog2/periodical/AlertScannerThread.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/AlertScannerThread.java
@@ -85,7 +85,7 @@ public class AlertScannerThread extends Periodical {
     }
 
     @Override
-    public boolean masterOnly() {
+    public boolean leaderOnly() {
         return true;
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/periodical/BatchedElasticSearchOutputFlushThread.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/BatchedElasticSearchOutputFlushThread.java
@@ -48,7 +48,7 @@ public class BatchedElasticSearchOutputFlushThread extends Periodical {
     }
 
     @Override
-    public boolean masterOnly() {
+    public boolean leaderOnly() {
         return false;
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/periodical/ClusterHealthCheckThread.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/ClusterHealthCheckThread.java
@@ -98,7 +98,7 @@ public class ClusterHealthCheckThread extends Periodical {
     }
 
     @Override
-    public boolean masterOnly() {
+    public boolean leaderOnly() {
         return true;
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/periodical/ClusterIdGeneratorPeriodical.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/ClusterIdGeneratorPeriodical.java
@@ -48,7 +48,7 @@ public class ClusterIdGeneratorPeriodical extends Periodical {
     }
 
     @Override
-    public boolean masterOnly() {
+    public boolean leaderOnly() {
         return true;
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/periodical/ContentPackLoaderPeriodical.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/ContentPackLoaderPeriodical.java
@@ -85,7 +85,7 @@ public class ContentPackLoaderPeriodical extends Periodical {
     }
 
     @Override
-    public boolean masterOnly() {
+    public boolean leaderOnly() {
         return true;
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/periodical/ESVersionCheckPeriodical.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/ESVersionCheckPeriodical.java
@@ -64,7 +64,7 @@ public class ESVersionCheckPeriodical extends Periodical {
     }
 
     @Override
-    public boolean masterOnly() {
+    public boolean leaderOnly() {
         return true;
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/periodical/GarbageCollectionWarningThread.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/GarbageCollectionWarningThread.java
@@ -78,7 +78,7 @@ public class GarbageCollectionWarningThread extends Periodical {
     }
 
     @Override
-    public boolean masterOnly() {
+    public boolean leaderOnly() {
         return false;
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/periodical/IndexRangesCleanupPeriodical.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/IndexRangesCleanupPeriodical.java
@@ -99,7 +99,7 @@ public class IndexRangesCleanupPeriodical extends Periodical {
     }
 
     @Override
-    public boolean masterOnly() {
+    public boolean leaderOnly() {
         return true;
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/periodical/IndexRetentionThread.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/IndexRetentionThread.java
@@ -112,7 +112,7 @@ public class IndexRetentionThread extends Periodical {
     }
 
     @Override
-    public boolean masterOnly() {
+    public boolean leaderOnly() {
         return true;
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/periodical/IndexRotationThread.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/IndexRotationThread.java
@@ -184,7 +184,7 @@ public class IndexRotationThread extends Periodical {
     }
 
     @Override
-    public boolean masterOnly() {
+    public boolean leaderOnly() {
         return true;
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/periodical/IndexerClusterCheckerThread.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/IndexerClusterCheckerThread.java
@@ -215,7 +215,7 @@ public class IndexerClusterCheckerThread extends Periodical {
     }
 
     @Override
-    public boolean masterOnly() {
+    public boolean leaderOnly() {
         return true;
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/periodical/NodePingThread.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/NodePingThread.java
@@ -117,7 +117,7 @@ public class NodePingThread extends Periodical {
     }
 
     @Override
-    public boolean masterOnly() {
+    public boolean leaderOnly() {
         return false;
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/periodical/ThrottleStateUpdaterThread.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/ThrottleStateUpdaterThread.java
@@ -160,7 +160,7 @@ public class ThrottleStateUpdaterThread extends Periodical {
     }
 
     @Override
-    public boolean masterOnly() {
+    public boolean leaderOnly() {
         return false;
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/periodical/ThroughputCalculator.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/ThroughputCalculator.java
@@ -70,7 +70,7 @@ public class ThroughputCalculator extends Periodical {
     }
 
     @Override
-    public boolean masterOnly() {
+    public boolean leaderOnly() {
         return false;
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/periodical/TrafficCounterCalculator.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/TrafficCounterCalculator.java
@@ -99,7 +99,7 @@ public class TrafficCounterCalculator extends Periodical {
     }
 
     @Override
-    public boolean masterOnly() {
+    public boolean leaderOnly() {
         return false;
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/periodical/UserSessionTerminationPeriodical.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/UserSessionTerminationPeriodical.java
@@ -54,7 +54,7 @@ public class UserSessionTerminationPeriodical extends Periodical {
     }
 
     @Override
-    public boolean masterOnly() {
+    public boolean leaderOnly() {
         return true;
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/periodical/VersionCheckThread.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/VersionCheckThread.java
@@ -152,7 +152,7 @@ public class VersionCheckThread extends Periodical {
     }
 
     @Override
-    public boolean masterOnly() {
+    public boolean leaderOnly() {
         return true;
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/plugin/ServerStatus.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/ServerStatus.java
@@ -22,6 +22,7 @@ import com.google.common.util.concurrent.Uninterruptibles;
 import com.google.inject.Provider;
 import org.graylog2.audit.AuditActor;
 import org.graylog2.audit.AuditEventSender;
+import org.graylog2.cluster.leader.LeaderElectionService;
 import org.graylog2.plugin.lifecycles.Lifecycle;
 import org.graylog2.plugin.system.NodeId;
 import org.graylog2.shared.SuppressForbidden;
@@ -49,6 +50,11 @@ public class ServerStatus {
 
     public enum Capability {
         SERVER,
+        /**
+         * @deprecated Use {@link LeaderElectionService#isLeader()} to determine if the node currently acts as a leader,
+         * if you absolutely must.
+         */
+        @Deprecated
         MASTER,
         LOCALMODE
     }

--- a/graylog2-server/src/main/java/org/graylog2/plugin/periodical/Periodical.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/periodical/Periodical.java
@@ -39,12 +39,27 @@ public abstract class Periodical implements Runnable {
     /**
      * Only start this thread on master nodes?
      *
-     * @return
+     * @deprecated Use {@link #leaderOnly()} instead.
      */
-    public abstract boolean masterOnly();
+    @Deprecated
+    public boolean masterOnly() {
+        return false;
+    }
+
+    /**
+     * Determines if this periodical should run only on the leader node.
+     *
+     * @return {@code false} (default) if this periodical may run on every node. {@code true} if it may run only on the
+     * leader node
+     */
+    public boolean leaderOnly() {
+        // Defaulting to the now deprecated original method to not break existing implementations.
+        return masterOnly();
+    }
 
     /**
      * Start on this node? Useful to decide if to start the periodical based on local configuration.
+     *
      * @return
      */
     public abstract boolean startOnThisNode();

--- a/graylog2-server/src/main/java/org/graylog2/shared/initializers/PeriodicalsService.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/initializers/PeriodicalsService.java
@@ -55,7 +55,7 @@ public class PeriodicalsService extends AbstractIdleService {
         this.leaderElectionService = leaderElectionService;
 
         allPeriodicals.forEach(p -> {
-            if (p.masterOnly()) {
+            if (p.leaderOnly()) {
                 leaderNodePeriodicals.add(p);
             } else {
                 anyNodePeriodicals.add(p);

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/constraints/PluginVersionConstraintCheckerTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/constraints/PluginVersionConstraintCheckerTest.java
@@ -102,7 +102,7 @@ public class PluginVersionConstraintCheckerTest {
 
         @Override
         public Set<ServerStatus.Capability> getRequiredCapabilities() {
-            return Collections.singleton(ServerStatus.Capability.MASTER);
+            return Collections.singleton(ServerStatus.Capability.SERVER);
         }
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/periodical/PeriodicalsTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/periodical/PeriodicalsTest.java
@@ -206,7 +206,7 @@ public class PeriodicalsTest {
             }
 
             @Override
-            public boolean masterOnly() {
+            public boolean leaderOnly() {
                 return false;
             }
 

--- a/graylog2-server/src/test/java/org/graylog2/plugin/ServerStatusTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/plugin/ServerStatusTest.java
@@ -64,7 +64,7 @@ public class ServerStatusTest {
 
         when(config.getNodeIdFile()).thenReturn(tempFile.getPath());
 
-        status = new ServerStatus(config, Collections.singleton(ServerStatus.Capability.MASTER), eventBus, NullAuditEventSender::new);
+        status = new ServerStatus(config, Collections.singleton(ServerStatus.Capability.SERVER), eventBus, NullAuditEventSender::new);
     }
 
     @Test
@@ -171,14 +171,8 @@ public class ServerStatusTest {
 
     @Test
     public void testAddCapability() throws Exception {
-        assertEquals(status, status.addCapability(ServerStatus.Capability.SERVER));
-        assertTrue(status.hasCapabilities(ServerStatus.Capability.MASTER, ServerStatus.Capability.SERVER));
-    }
-
-    @Test
-    public void testAddCapabilities() throws Exception {
-        assertEquals(status, status.addCapabilities(ServerStatus.Capability.LOCALMODE));
-        assertTrue(status.hasCapabilities(ServerStatus.Capability.MASTER, ServerStatus.Capability.LOCALMODE));
+        assertEquals(status, status.addCapability(ServerStatus.Capability.LOCALMODE));
+        assertTrue(status.hasCapabilities(ServerStatus.Capability.SERVER, ServerStatus.Capability.LOCALMODE));
     }
 
     @Test

--- a/graylog2-server/src/test/java/org/graylog2/shared/journal/LocalKafkaJournalTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/shared/journal/LocalKafkaJournalTest.java
@@ -100,7 +100,7 @@ public class LocalKafkaJournalTest {
                 return nodeId.getAbsolutePath();
             }
         };
-        serverStatus = new ServerStatus(configuration, EnumSet.of(ServerStatus.Capability.MASTER), new EventBus("KafkaJournalTest"), NullAuditEventSender::new);
+        serverStatus = new ServerStatus(configuration, EnumSet.of(ServerStatus.Capability.SERVER), new EventBus("KafkaJournalTest"), NullAuditEventSender::new);
     }
 
     @After


### PR DESCRIPTION
TODO:
- [ ] `org.graylog2.cluster.leader.StaticLeaderElectionService` and `org.graylog2.commands.Server` are using the `isMaster` to demote a server from leader to follower in case there is a second leader in the cluster on startup. Consider refactoring this by moving the duplicate leader detection logic into the static leader election service itself.
- [ ] Consider refactoring/removing everything related to `org.graylog2.plugin.ServerStatus.Capability`.