### PR TITLE
Consider fielddata for field types, making them enumerable if enabled.

### DIFF
--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/IndexFieldTypePollerAdapterES6.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/IndexFieldTypePollerAdapterES6.java
@@ -86,7 +86,7 @@ public class IndexFieldTypePollerAdapterES6 implements IndexFieldTypePollerAdapt
                         .filter(field -> !field.getValue().path("type").asText().isEmpty())
                         .map(field -> {
                             final boolean fielddata = field.getValue().path("fielddata").asBoolean(false);
-                            final Set<FieldTypeDTO.Properties> fieldProperties = fielddata ? Collections.singleton(FieldTypeDTO.Properties.FIELDATA) : Collections.emptySet();
+                            final Set<FieldTypeDTO.Properties> fieldProperties = fielddata ? Collections.singleton(FieldTypeDTO.Properties.FIELDDATA) : Collections.emptySet();
                             return FieldTypeDTO.create(field.getKey(), field.getValue().path("type").asText(), fieldProperties);
                         })
                         .collect(Collectors.toSet())

--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/IndexFieldTypePollerAdapterES6.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/IndexFieldTypePollerAdapterES6.java
@@ -30,6 +30,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -78,15 +79,16 @@ public class IndexFieldTypePollerAdapterES6 implements IndexFieldTypePollerAdapt
 
         final Spliterator<Map.Entry<String, JsonNode>> fieldSpliterator = Spliterators.spliteratorUnknownSize(properties.fields(), Spliterator.IMMUTABLE);
 
-        final Map<String, String> fieldTypes = StreamSupport.stream(fieldSpliterator, false)
-                .collect(Collectors.toMap(Map.Entry::getKey, field -> field.getValue().path("type").asText()));
         return Optional.of(
-                fieldTypes.entrySet()
-                        .stream()
+                StreamSupport.stream(fieldSpliterator, false)
                         // The "type" value is empty if we deal with a nested data type
                         // TODO: Figure out how to handle nested fields, for now we only support the top-level fields
-                        .filter(field -> !field.getValue().isEmpty())
-                        .map(field -> FieldTypeDTO.create(field.getKey(), field.getValue()))
+                        .filter(field -> !field.getValue().path("type").asText().isEmpty())
+                        .map(field -> {
+                            final boolean fielddata = field.getValue().path("fielddata").asBoolean(false);
+                            final Set<FieldTypeDTO.Properties> fieldProperties = fielddata ? Collections.singleton(FieldTypeDTO.Properties.FIELDATA) : Collections.emptySet();
+                            return FieldTypeDTO.create(field.getKey(), field.getValue().path("type").asText(), fieldProperties);
+                        })
                         .collect(Collectors.toSet())
         );
     }

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/IndexFieldTypePollerAdapterES7.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/IndexFieldTypePollerAdapterES7.java
@@ -64,7 +64,7 @@ public class IndexFieldTypePollerAdapterES7 implements IndexFieldTypePollerAdapt
                     final FieldMappingApi.FieldMapping mapping = field.getValue();
                     final Boolean fielddata = mapping.fielddata().orElse(false);
                     return FieldTypeDTO.create(field.getKey(), mapping.type(), fielddata
-                            ? Collections.singleton(FieldTypeDTO.Properties.FIELDATA)
+                            ? Collections.singleton(FieldTypeDTO.Properties.FIELDDATA)
                             : Collections.emptySet());
                 })
                 .collect(Collectors.toSet())

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/IndexFieldTypePollerAdapterES7.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/IndexFieldTypePollerAdapterES7.java
@@ -26,6 +26,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -33,19 +34,16 @@ import java.util.stream.Collectors;
 
 public class IndexFieldTypePollerAdapterES7 implements IndexFieldTypePollerAdapter {
     private static final Logger LOG = LoggerFactory.getLogger(IndexFieldTypePollerAdapterES7.class);
-    private final ElasticsearchClient client;
     private final FieldMappingApi fieldMappingApi;
 
     @Inject
-    public IndexFieldTypePollerAdapterES7(ElasticsearchClient client,
-                                          FieldMappingApi fieldMappingApi) {
-        this.client = client;
+    public IndexFieldTypePollerAdapterES7(FieldMappingApi fieldMappingApi) {
         this.fieldMappingApi = fieldMappingApi;
     }
 
     @Override
     public Optional<Set<FieldTypeDTO>> pollIndex(String indexName, Timer pollTimer) {
-        final Map<String, String> fieldTypes;
+        final Map<String, FieldMappingApi.FieldMapping> fieldTypes;
         try (final Timer.Context ignored = pollTimer.time()) {
             fieldTypes = fieldMappingApi.fieldTypes(indexName);
         } catch (IndexNotFoundException e) {
@@ -58,12 +56,18 @@ public class IndexFieldTypePollerAdapterES7 implements IndexFieldTypePollerAdapt
         }
 
         return Optional.of(fieldTypes.entrySet()
-                        .stream()
-                        // The "type" value is empty if we deal with a nested data type
-                        // TODO: Figure out how to handle nested fields, for now we only support the top-level fields
-                        .filter(field -> !field.getValue().isEmpty())
-                        .map(field -> FieldTypeDTO.create(field.getKey(), field.getValue()))
-                        .collect(Collectors.toSet())
+                .stream()
+                // The "type" value is empty if we deal with a nested data type
+                // TODO: Figure out how to handle nested fields, for now we only support the top-level fields
+                .filter(field -> !field.getValue().type().isEmpty())
+                .map(field -> {
+                    final FieldMappingApi.FieldMapping mapping = field.getValue();
+                    final Boolean fielddata = mapping.fielddata().orElse(false);
+                    return FieldTypeDTO.create(field.getKey(), mapping.type(), fielddata
+                            ? Collections.singleton(FieldTypeDTO.Properties.FIELDATA)
+                            : Collections.emptySet());
+                })
+                .collect(Collectors.toSet())
         );
     }
 }

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/IndexFieldTypePollerES7IT.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/IndexFieldTypePollerES7IT.java
@@ -49,7 +49,7 @@ public class IndexFieldTypePollerES7IT extends IndexFieldTypePollerIT {
     @Override
     protected IndexFieldTypePollerAdapter createIndexFieldTypePollerAdapter() {
         final ElasticsearchClient client = elasticsearch.elasticsearchClient();
-        return new IndexFieldTypePollerAdapterES7(client, new FieldMappingApi(objectMapper, client));
+        return new IndexFieldTypePollerAdapterES7(new FieldMappingApi(objectMapper, client));
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/FieldTypeDTO.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/FieldTypeDTO.java
@@ -32,7 +32,7 @@ public abstract class FieldTypeDTO {
     static final String FIELD_PROPERTIES = "properties";
 
     public enum Properties {
-        FIELDATA
+        FIELDDATA
     }
 
     @JsonProperty(FIELD_NAME)

--- a/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/FieldTypeDTO.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/FieldTypeDTO.java
@@ -21,11 +21,19 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
 
+import java.util.Collections;
+import java.util.Set;
+
 @AutoValue
 @JsonDeserialize(builder = FieldTypeDTO.Builder.class)
 public abstract class FieldTypeDTO {
     static final String FIELD_NAME = "field_name";
     static final String FIELD_PHYSICAL_TYPE = "physical_type";
+    static final String FIELD_PROPERTIES = "properties";
+
+    public enum Properties {
+        FIELDATA
+    }
 
     @JsonProperty(FIELD_NAME)
     public abstract String fieldName();
@@ -33,8 +41,19 @@ public abstract class FieldTypeDTO {
     @JsonProperty(FIELD_PHYSICAL_TYPE)
     public abstract String physicalType();
 
+    @JsonProperty(FIELD_PROPERTIES)
+    public abstract Set<Properties> properties();
+
     public static FieldTypeDTO create(String fieldName, String physicalType) {
         return builder().fieldName(fieldName).physicalType(physicalType).build();
+    }
+
+    public static FieldTypeDTO create(String fieldName, String physicalType, Set<Properties> properties) {
+        return builder()
+                .fieldName(fieldName)
+                .physicalType(physicalType)
+                .properties(properties)
+                .build();
     }
 
     public static Builder builder() {
@@ -47,7 +66,8 @@ public abstract class FieldTypeDTO {
     public static abstract class Builder {
         @JsonCreator
         public static Builder create() {
-            return new AutoValue_FieldTypeDTO.Builder();
+            return new AutoValue_FieldTypeDTO.Builder()
+                    .properties(Collections.emptySet());
         }
 
         @JsonProperty(FIELD_NAME)
@@ -55,6 +75,9 @@ public abstract class FieldTypeDTO {
 
         @JsonProperty(FIELD_PHYSICAL_TYPE)
         public abstract Builder physicalType(String physicalType);
+
+        @JsonProperty(FIELD_PROPERTIES)
+        public abstract Builder properties(Set<Properties> properties);
 
         public abstract FieldTypeDTO build();
     }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/FieldTypeMapper.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/FieldTypeMapper.java
@@ -17,6 +17,7 @@
 package org.graylog2.indexer.fieldtypes;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 
 import javax.inject.Singleton;
 import java.util.Optional;
@@ -27,6 +28,7 @@ import static org.graylog2.indexer.fieldtypes.FieldTypes.Type.createType;
 /**
  * Maps Elasticsearch field types to Graylog types.
  * <p>
+ *
  * @see <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-types.html">Elasticsearch mapping types</a>
  */
 @Singleton
@@ -72,10 +74,14 @@ public class FieldTypeMapper {
 
     /**
      * Map the given Elasticsearch field type to a Graylog type.
-     * @param typeName Elasticsearch type name
+     *
+     * @param type Elasticsearch type name
      * @return the Graylog type object
      */
-    public Optional<FieldTypes.Type> mapType(String typeName) {
-        return Optional.ofNullable(TYPE_MAP.get(typeName));
+    public Optional<FieldTypes.Type> mapType(FieldTypeDTO type) {
+        return Optional.ofNullable(TYPE_MAP.get(type.physicalType()))
+                .map(mappedType -> type.properties().contains(FieldTypeDTO.Properties.FIELDATA)
+                        ? mappedType.toBuilder().properties(new ImmutableSet.Builder<String>().addAll(mappedType.properties()).add(PROP_ENUMERABLE).build()).build()
+                        : mappedType);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/FieldTypeMapper.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/FieldTypeMapper.java
@@ -80,7 +80,7 @@ public class FieldTypeMapper {
      */
     public Optional<FieldTypes.Type> mapType(FieldTypeDTO type) {
         return Optional.ofNullable(TYPE_MAP.get(type.physicalType()))
-                .map(mappedType -> type.properties().contains(FieldTypeDTO.Properties.FIELDATA)
+                .map(mappedType -> type.properties().contains(FieldTypeDTO.Properties.FIELDDATA)
                         ? mappedType.toBuilder().properties(new ImmutableSet.Builder<String>().addAll(mappedType.properties()).add(PROP_ENUMERABLE).build()).build()
                         : mappedType);
     }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/MappedFieldTypesService.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/MappedFieldTypesService.java
@@ -67,7 +67,7 @@ public class MappedFieldTypesService {
     }
 
     private MappedFieldTypeDTO mapPhysicalFieldType(FieldTypeDTO fieldType) {
-        final FieldTypes.Type mappedFieldType = fieldTypeMapper.mapType(fieldType.physicalType()).orElse(UNKNOWN_TYPE);
+        final FieldTypes.Type mappedFieldType = fieldTypeMapper.mapType(fieldType).orElse(UNKNOWN_TYPE);
         return MappedFieldTypeDTO.create(fieldType.fieldName(), mappedFieldType);
     }
 

--- a/graylog2-server/src/test/java/org/graylog2/indexer/fieldtypes/FieldTypeMapperTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/fieldtypes/FieldTypeMapperTest.java
@@ -30,7 +30,7 @@ public class FieldTypeMapperTest {
     private static final FieldTypeDTO textWithFielddata = FieldTypeDTO.builder()
             .physicalType("text")
             .fieldName("test")
-            .properties(Collections.singleton(FieldTypeDTO.Properties.FIELDATA))
+            .properties(Collections.singleton(FieldTypeDTO.Properties.FIELDDATA))
             .build();
 
     @Before

--- a/graylog2-server/src/test/java/org/graylog2/indexer/fieldtypes/FieldTypeMapperTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/fieldtypes/FieldTypeMapperTest.java
@@ -19,12 +19,19 @@ package org.graylog2.indexer.fieldtypes;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Collections;
+
 import static com.google.common.collect.ImmutableSet.copyOf;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.graylog2.indexer.fieldtypes.FieldTypes.Type.createType;
 
 public class FieldTypeMapperTest {
     private FieldTypeMapper mapper;
+    private static final FieldTypeDTO textWithFielddata = FieldTypeDTO.builder()
+            .physicalType("text")
+            .fieldName("test")
+            .properties(Collections.singleton(FieldTypeDTO.Properties.FIELDATA))
+            .build();
 
     @Before
     public void setUp() throws Exception {
@@ -32,6 +39,15 @@ public class FieldTypeMapperTest {
     }
 
     private void assertMapping(String esType, String glType, String... properties) {
+        assertMapping(FieldTypeDTO.builder()
+                        .fieldName("test")
+                        .physicalType(esType)
+                        .build(),
+                glType,
+                properties);
+    }
+
+    private void assertMapping(FieldTypeDTO esType, String glType, String... properties) {
         assertThat(mapper.mapType(esType))
                 .isPresent().get()
                 .isEqualTo(createType(glType, copyOf(properties)));
@@ -40,6 +56,7 @@ public class FieldTypeMapperTest {
     @Test
     public void mappings() {
         assertMapping("text", "string", "full-text-search");
+        assertMapping(textWithFielddata, "string", "full-text-search", "enumerable");
         assertMapping("keyword", "string", "enumerable");
 
         assertMapping("long", "long", "numeric", "enumerable");

--- a/graylog2-server/src/test/java/org/graylog2/indexer/fieldtypes/IndexFieldTypePollerIT.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/fieldtypes/IndexFieldTypePollerIT.java
@@ -117,7 +117,7 @@ public abstract class IndexFieldTypePollerIT extends ElasticsearchBaseTest {
         assertThat(dto.fields()).containsOnly(
                 FieldTypeDTO.create("message", "text"),
                 FieldTypeDTO.create("full_message", "text"),
-                FieldTypeDTO.create("source", "text", Collections.singleton(FieldTypeDTO.Properties.FIELDATA)),
+                FieldTypeDTO.create("source", "text", Collections.singleton(FieldTypeDTO.Properties.FIELDDATA)),
                 FieldTypeDTO.create("http_status", "keyword"),
                 FieldTypeDTO.create("http_response_time", "long"),
                 FieldTypeDTO.create("timestamp", "date"),
@@ -141,7 +141,7 @@ public abstract class IndexFieldTypePollerIT extends ElasticsearchBaseTest {
         assertThat(dto.fields()).containsOnly(
                 FieldTypeDTO.create("message", "text"),
                 FieldTypeDTO.create("full_message", "text"),
-                FieldTypeDTO.create("source", "text", Collections.singleton(FieldTypeDTO.Properties.FIELDATA)),
+                FieldTypeDTO.create("source", "text", Collections.singleton(FieldTypeDTO.Properties.FIELDDATA)),
                 FieldTypeDTO.create("http_status", "keyword"),
                 FieldTypeDTO.create("http_response_time", "long"),
                 FieldTypeDTO.create("timestamp", "date"),

--- a/graylog2-server/src/test/java/org/graylog2/indexer/fieldtypes/IndexFieldTypePollerIT.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/fieldtypes/IndexFieldTypePollerIT.java
@@ -71,12 +71,14 @@ public abstract class IndexFieldTypePollerIT extends ElasticsearchBaseTest {
     private TestIndexSet indexSet;
 
     protected abstract IndicesAdapter createIndicesAdapter();
+
     protected abstract IndexFieldTypePollerAdapter createIndexFieldTypePollerAdapter();
 
     @Before
     public void setUp() throws Exception {
         final Node node = mock(Node.class);
-        @SuppressWarnings("UnstableApiUsage") final Indices indices = new Indices(
+        @SuppressWarnings("UnstableApiUsage")
+        final Indices indices = new Indices(
                 new IndexMappingFactory(node, ImmutableMap.of(
                         MESSAGE_TEMPLATE_TYPE, new MessageIndexTemplateProvider()
                 )),
@@ -115,7 +117,7 @@ public abstract class IndexFieldTypePollerIT extends ElasticsearchBaseTest {
         assertThat(dto.fields()).containsOnly(
                 FieldTypeDTO.create("message", "text"),
                 FieldTypeDTO.create("full_message", "text"),
-                FieldTypeDTO.create("source", "text"),
+                FieldTypeDTO.create("source", "text", Collections.singleton(FieldTypeDTO.Properties.FIELDATA)),
                 FieldTypeDTO.create("http_status", "keyword"),
                 FieldTypeDTO.create("http_response_time", "long"),
                 FieldTypeDTO.create("timestamp", "date"),
@@ -139,7 +141,7 @@ public abstract class IndexFieldTypePollerIT extends ElasticsearchBaseTest {
         assertThat(dto.fields()).containsOnly(
                 FieldTypeDTO.create("message", "text"),
                 FieldTypeDTO.create("full_message", "text"),
-                FieldTypeDTO.create("source", "text"),
+                FieldTypeDTO.create("source", "text", Collections.singleton(FieldTypeDTO.Properties.FIELDATA)),
                 FieldTypeDTO.create("http_status", "keyword"),
                 FieldTypeDTO.create("http_response_time", "long"),
                 FieldTypeDTO.create("timestamp", "date"),


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Prior to this PR, generating field types relied solely on the type literal returned by the indexer and other properties of the index mapping were not considered. This could lead to e.g. the `source` field, which is mapped as a `text` field, but with `fielddata` enabled, to be mapped as a `string` field which is not `enumerable`.

This change is now taking the `fielddata` property into account. If it is present (therefore explicitly requested), the resulting type will be `enumerable`. If it is not present, it is up to the mapped type if it is `enumerable` or not (e.g. for `keyword` being `enumerable` anyway).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

We are relying more and more on field types and their properties to decide if certain functionalities in the frontend (enabling aggregations, providing suggestions etc.) are active or not. These field types must be accurate and reflect the capabilities present on the field as good as possible.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.