### PR TITLE
Fixes for log4j CVE-2021-44228 (#11786)

### DIFF
--- a/bin/graylogctl
+++ b/bin/graylogctl
@@ -51,7 +51,7 @@ GRAYLOG_CONF=${GRAYLOG_CONF:=/etc/graylog/server/server.conf}
 GRAYLOG_PID=${GRAYLOG_PID:=/tmp/graylog.pid}
 LOG_FILE=${LOG_FILE:=log/graylog-server.log}
 LOG4J=${LOG4J:=}
-DEFAULT_JAVA_OPTS="-Djava.library.path=${GRAYLOGCTL_DIR}/../lib/sigar -Xms1g -Xmx1g -XX:NewRatio=1 -server -XX:+ResizeTLAB -XX:+UseConcMarkSweepGC -XX:+CMSConcurrentMTEnabled -XX:+CMSClassUnloadingEnabled -XX:-OmitStackTraceInFastThrow"
+DEFAULT_JAVA_OPTS="-Djava.library.path=${GRAYLOGCTL_DIR}/../lib/sigar -Dlog4j2.formatMsgNoLookups=true -Xms1g -Xmx1g -XX:NewRatio=1 -server -XX:+ResizeTLAB -XX:+UseConcMarkSweepGC -XX:+CMSConcurrentMTEnabled -XX:+CMSClassUnloadingEnabled -XX:-OmitStackTraceInFastThrow"
 if $JAVA_CMD -XX:+PrintFlagsFinal 2>&1 |grep -q UseParNewGC; then
 	DEFAULT_JAVA_OPTS="${DEFAULT_JAVA_OPTS} -XX:+UseParNewGC"
 fi

--- a/graylog2-server/src/test/java/org/graylog/testing/elasticsearch/ElasticsearchInstance.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/elasticsearch/ElasticsearchInstance.java
@@ -33,6 +33,7 @@ import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
+import org.testcontainers.utility.DockerImageName;
 
 import java.net.URI;
 import java.net.URL;
@@ -116,7 +117,7 @@ public class ElasticsearchInstance extends ExternalResource {
     }
 
     private ElasticsearchContainer buildContainer(String image, Network network) {
-        return new ElasticsearchContainer(image)
+        return new ElasticsearchContainer(DockerImageName.parse(image).asCompatibleSubstituteFor("docker.elastic.co/elasticsearch/elasticsearch"))
                 .withReuse(true)
                 .withEnv("ES_JAVA_OPTS", "-Xms512m -Xmx512m")
                 .withEnv("discovery.type", "single-node")

--- a/graylog2-server/src/test/java/org/graylog2/security/ldap/LdapConnectorSSLTLSIT.java
+++ b/graylog2-server/src/test/java/org/graylog2/security/ldap/LdapConnectorSSLTLSIT.java
@@ -22,7 +22,6 @@ import org.apache.directory.ldap.client.api.LdapNetworkConnection;
 import org.assertj.core.api.Assertions;
 import org.graylog2.rest.models.system.ldap.requests.LdapTestConfigRequest;
 import org.graylog2.security.DefaultX509TrustManager;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -31,6 +30,7 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
+import javax.annotation.Nonnull;
 import javax.net.ssl.TrustManager;
 import java.io.File;
 import java.io.IOException;
@@ -159,12 +159,12 @@ public class LdapConnectorSSLTLSIT {
         assertConnectionSuccess(request);
     }
 
-    @NotNull
+    @Nonnull
     private LdapTestConfigRequest createTLSTestRequest(boolean trustAllCertificates) {
         return createRequest(internalSSLUri(), true, trustAllCertificates);
     }
 
-    @NotNull
+    @Nonnull
     private LdapTestConfigRequest createSSLTestRequest(boolean trustAllCertificates) {
         return createRequest(internalSSLUri(), false, trustAllCertificates);
     }

--- a/graylog2-server/src/test/resources/org/graylog/testing/graylognode/Dockerfile
+++ b/graylog2-server/src/test/resources/org/graylog/testing/graylognode/Dockerfile
@@ -16,7 +16,7 @@ RUN \
   echo "export JAVA_HOME=/usr/local/openjdk-8"     > /etc/profile.d/graylog.sh && \
   echo "export BUILD_DATE=${BUILD_DATE}"           >> /etc/profile.d/graylog.sh && \
   echo "export GRAYLOG_VERSION=${GRAYLOG_VERSION}" >> /etc/profile.d/graylog.sh && \
-  echo "export GRAYLOG_SERVER_JAVA_OPTS='-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -XX:NewRatio=1 -XX:MaxMetaspaceSize=256m -server -XX:+ResizeTLAB -XX:+UseConcMarkSweepGC -XX:+CMSConcurrentMTEnabled -XX:+CMSClassUnloadingEnabled -XX:+UseParNewGC -XX:-OmitStackTraceInFastThrow " ${DEBUG_OPTS} "'" >> /etc/profile.d/graylog.sh && \
+  echo "export GRAYLOG_SERVER_JAVA_OPTS='-Dlog4j2.formatMsgNoLookups=true -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -XX:NewRatio=1 -XX:MaxMetaspaceSize=256m -server -XX:+ResizeTLAB -XX:+UseConcMarkSweepGC -XX:+CMSConcurrentMTEnabled -XX:+CMSClassUnloadingEnabled -XX:+UseParNewGC -XX:-OmitStackTraceInFastThrow " ${DEBUG_OPTS} "'" >> /etc/profile.d/graylog.sh && \
   echo "export GRAYLOG_HOME=${GRAYLOG_HOME}"       >> /etc/profile.d/graylog.sh && \
   echo "export GRAYLOG_USER=${GRAYLOG_USER}"       >> /etc/profile.d/graylog.sh && \
   echo "export GRAYLOG_GROUP=${GRAYLOG_GROUP}"     >> /etc/profile.d/graylog.sh && \

--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@
         <jool.version>0.9.14</jool.version>
         <json-path.version>2.4.0</json-path.version>
         <kafka.version>0.9.0.1</kafka.version>
-        <log4j.version>2.13.0</log4j.version>
+        <log4j.version>2.15.0</log4j.version>
         <metrics.version>4.0.3</metrics.version>
         <mongodb-driver.version>3.12.1</mongodb-driver.version>
         <mongojack.version>2.10.1</mongojack.version>

--- a/pom.xml
+++ b/pom.xml
@@ -171,7 +171,7 @@
         <nosqlunit.version>1.0.0-rc.5</nosqlunit.version>
         <restassured.version>4.2.0</restassured.version>
         <system-rules.version>1.19.0</system-rules.version>
-        <testcontainers.version>1.14.3</testcontainers.version>
+        <testcontainers.version>1.15.2</testcontainers.version>
 
         <!-- Nodejs dependencies -->
         <nodejs.version>v12.13.1</nodejs.version>


### PR DESCRIPTION
Apache Log4j2 JNDI features do not protect against attacker controlled
LDAP and other JNDI related endpoints.

- Configure log4j2.formatMsgNoLookups=true by default
- Update log4j to 2.15.0

Details: https://logging.apache.org/log4j/2.x/security.html
(cherry picked from commit eb0296dff8537f0f188e8c31c82454a963e9e30c)
