### PR TITLE
Normalize time range when validating search query.

### DIFF
--- a/graylog2-web-interface/src/views/components/searchbar/queryvalidation/validateQuery.test.ts
+++ b/graylog2-web-interface/src/views/components/searchbar/queryvalidation/validateQuery.test.ts
@@ -18,30 +18,50 @@ import * as Immutable from 'immutable';
 import { waitFor } from 'wrappedTestingLibrary';
 
 import fetch from 'logic/rest/FetchProvider';
+import { StoreMock as MockStore } from 'helpers/mocking';
 
-import validateQuery from './validateQuery';
+import validateQuery, { ValidationQuery } from './validateQuery';
 
 jest.mock('logic/rest/FetchProvider', () => jest.fn(() => Promise.resolve()));
+jest.mock('stores/users/CurrentUserStore', () => ({ CurrentUserStore: MockStore('get') }));
 
 describe('validateQuery', () => {
+  const validationInput: ValidationQuery = {
+    queryString: 'source:',
+    timeRange: { type: 'relative', from: 300 } as const,
+    streams: ['stream-id'],
+    parameters: Immutable.Set(),
+    parameterBindings: Immutable.Map(),
+  };
+
+  const requestPayload = {
+    query: 'source:',
+    filter: undefined,
+    timerange: { type: 'relative', from: 300 },
+    streams: ['stream-id'],
+    parameters: Immutable.Set(),
+    parameter_bindings: Immutable.Map(),
+  };
+
   it('calls validate API', async () => {
+    await validateQuery(validationInput);
+
+    await waitFor(() => expect(fetch).toHaveBeenCalledTimes(1));
+
+    expect(fetch).toHaveBeenCalledWith('POST', expect.any(String), requestPayload);
+  });
+
+  it('normalizes absolute time ranges', async () => {
     await validateQuery({
-      queryString: 'source:',
-      timeRange: { type: 'relative', from: 300 },
-      streams: ['stream-id'],
-      parameters: Immutable.Set(),
-      parameterBindings: Immutable.Map(),
+      ...validationInput,
+      timeRange: { type: 'absolute', from: '2021-01-01 16:00:00.000', to: '2021-01-01 17:00:00.000' },
     });
 
     await waitFor(() => expect(fetch).toHaveBeenCalledTimes(1));
 
     const expectedPayload = {
-      query: 'source:',
-      filter: undefined,
-      timerange: { type: 'relative', from: 300 },
-      streams: ['stream-id'],
-      parameters: Immutable.Set(),
-      parameter_bindings: Immutable.Map(),
+      ...requestPayload,
+      timerange: { type: 'absolute', from: '2021-01-01T22:00:00.000Z', to: '2021-01-01T23:00:00.000Z' },
     };
 
     expect(fetch).toHaveBeenCalledWith('POST', expect.any(String), expectedPayload);

--- a/graylog2-web-interface/src/views/components/searchbar/queryvalidation/validateQuery.test.ts
+++ b/graylog2-web-interface/src/views/components/searchbar/queryvalidation/validateQuery.test.ts
@@ -26,6 +26,10 @@ jest.mock('logic/rest/FetchProvider', () => jest.fn(() => Promise.resolve()));
 jest.mock('stores/users/CurrentUserStore', () => ({ CurrentUserStore: MockStore('get') }));
 
 describe('validateQuery', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   const validationInput: ValidationQuery = {
     queryString: 'source:',
     timeRange: { type: 'relative', from: 300 } as const,

--- a/graylog2-web-interface/src/views/components/searchbar/queryvalidation/validateQuery.ts
+++ b/graylog2-web-interface/src/views/components/searchbar/queryvalidation/validateQuery.ts
@@ -18,14 +18,15 @@ import * as Immutable from 'immutable';
 
 import fetch from 'logic/rest/FetchProvider';
 import { qualifyUrl } from 'util/URLUtils';
-import { ElasticsearchQueryString, TimeRange, NoTimeRangeOverride } from 'views/logic/queries/Query';
+import { ElasticsearchQueryString, TimeRange } from 'views/logic/queries/Query';
 import Parameter from 'views/logic/parameters/Parameter';
 import { ParameterBindings } from 'views/logic/search/SearchExecutionState';
 import type { QueryValidationState } from 'views/components/searchbar/queryvalidation/types';
+import { onSubmittingTimerange } from 'views/components/TimerangeForForm';
 
-type ValidationQuery = {
+export type ValidationQuery = {
   queryString: ElasticsearchQueryString | string,
-  timeRange: TimeRange | NoTimeRangeOverride,
+  timeRange: TimeRange | undefined,
   streams?: Array<string>,
   parameters: Immutable.Set<Parameter>,
   parameterBindings: ParameterBindings,
@@ -50,7 +51,7 @@ export const validateQuery = ({
 
   const payload = {
     query: queryString,
-    timerange: timeRange,
+    timerange: timeRange ? onSubmittingTimerange(timeRange) : undefined,
     streams,
     filter,
     parameters,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

With this change we are using ISO 8601 for times in an absolute
time range. The API expects this format and will throw an
error when using a different format.


