### PR TITLE
Opens up LookupTableService for extension

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/lookup/LookupTableService.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/LookupTableService.java
@@ -108,6 +108,26 @@ public class LookupTableService extends AbstractIdleService {
         this.adapterRefreshService = new LookupDataAdapterRefreshService(scheduler, liveTables);
     }
 
+    public LookupTableConfigService getConfigService() {
+        return configService;
+    }
+
+    public LookupDataAdapterRefreshService getAdapterRefreshService() {
+        return adapterRefreshService;
+    }
+
+    public ScheduledExecutorService getScheduler() {
+        return scheduler;
+    }
+
+    public Map<String, LookupDataAdapter.Factory> getAdapterFactories() {
+        return adapterFactories;
+    }
+
+    public Map<String, LookupDataAdapter.Factory2> getAdapterFactories2() {
+        return adapterFactories2;
+    }
+
     @Override
     protected void startUp() throws Exception {
         // Start refresh service and wait until it's running so the adapters can register themselves
@@ -160,7 +180,7 @@ public class LookupTableService extends AbstractIdleService {
         adapterRefreshService.stopAsync();
     }
 
-    private class DataAdapterListener extends Service.Listener {
+    protected class DataAdapterListener extends Service.Listener {
         private final DataAdapterDto dto;
         private final LookupDataAdapter adapter;
         private final CountDownLatch latch;
@@ -361,7 +381,7 @@ public class LookupTableService extends AbstractIdleService {
         scheduler.schedule(() -> deleted.lookupTableNames().forEach(liveTables::remove), 0, TimeUnit.SECONDS);
     }
 
-    private CountDownLatch createAndStartAdapters() {
+    protected CountDownLatch createAndStartAdapters() {
         final Map<DataAdapterDto, LookupDataAdapter> adapters = createAdapters(configService.loadAllDataAdapters());
         final CountDownLatch latch = new CountDownLatch(toIntExact(adapters.size()));
 

--- a/graylog2-server/src/main/java/org/graylog2/lookup/LookupTableService.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/LookupTableService.java
@@ -112,10 +112,6 @@ public class LookupTableService extends AbstractIdleService {
         return configService;
     }
 
-    public LookupDataAdapterRefreshService getAdapterRefreshService() {
-        return adapterRefreshService;
-    }
-
     public ScheduledExecutorService getScheduler() {
         return scheduler;
     }
@@ -406,18 +402,23 @@ public class LookupTableService extends AbstractIdleService {
                 // TODO system notification
                 return null;
             }
-            adapter.addListener(new LoggingServiceListener(
-                            "Data Adapter",
-                            String.format(Locale.ENGLISH, "%s/%s [@%s]", dto.name(), dto.id(), objectId(adapter)),
-                            LOG),
-                    scheduler);
-            // Each adapter needs to be added to the refresh scheduler
-            adapter.addListener(adapterRefreshService.newServiceListener(adapter), scheduler);
+            addListeners(adapter, dto);
             return adapter;
         } catch (Exception e) {
             LOG.error("Couldn't create adapter <{}/{}>", dto.name(), dto.id(), e);
             return null;
         }
+    }
+
+    protected void addListeners(LookupDataAdapter adapter, DataAdapterDto dto) {
+
+        adapter.addListener(new LoggingServiceListener(
+                        "Data Adapter",
+                        String.format(Locale.ENGLISH, "%s/%s [@%s]", dto.name(), dto.id(), objectId(adapter)),
+                        LOG),
+                scheduler);
+        // Each adapter needs to be added to the refresh scheduler
+        adapter.addListener(adapterRefreshService.newServiceListener(adapter), scheduler);
     }
 
     private CountDownLatch createAndStartCaches() {

--- a/graylog2-server/src/main/java/org/graylog2/lookup/LookupTableService.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/LookupTableService.java
@@ -120,14 +120,6 @@ public class LookupTableService extends AbstractIdleService {
         return scheduler;
     }
 
-    public Map<String, LookupDataAdapter.Factory> getAdapterFactories() {
-        return adapterFactories;
-    }
-
-    public Map<String, LookupDataAdapter.Factory2> getAdapterFactories2() {
-        return adapterFactories2;
-    }
-
     @Override
     protected void startUp() throws Exception {
         // Start refresh service and wait until it's running so the adapters can register themselves
@@ -399,7 +391,7 @@ public class LookupTableService extends AbstractIdleService {
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 
-    private LookupDataAdapter createAdapter(DataAdapterDto dto) {
+    protected LookupDataAdapter createAdapter(DataAdapterDto dto) {
         try {
             final LookupDataAdapter.Factory2 factory2 = adapterFactories2.get(dto.config().type());
             final LookupDataAdapter.Factory factory = adapterFactories.get(dto.config().type());

--- a/graylog2-server/src/main/java/org/graylog2/lookup/LookupTableService.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/LookupTableService.java
@@ -108,11 +108,11 @@ public class LookupTableService extends AbstractIdleService {
         this.adapterRefreshService = new LookupDataAdapterRefreshService(scheduler, liveTables);
     }
 
-    public LookupTableConfigService getConfigService() {
+    protected LookupTableConfigService getConfigService() {
         return configService;
     }
 
-    public ScheduledExecutorService getScheduler() {
+    protected ScheduledExecutorService getScheduler() {
         return scheduler;
     }
 


### PR DESCRIPTION
## Description
Opens up LookupTableService a bit to allow for easier extending. Just adds a handful of getter methods and changes a couple private modifiers to protected to allow for subclass visibility.

## Motivation and Context
Allows for an IlluminateLookupTableService to extend the existing service, take advantage of existing code, and apply Illuminate-specific logic on top

## How Has This Been Tested?
locally in a development environment 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

