### PR TITLE
Fix typo in deprecation warnings filter

### DIFF
--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/ElasticsearchFilterDeprecationWarningsInterceptor.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/ElasticsearchFilterDeprecationWarningsInterceptor.java
@@ -30,7 +30,7 @@ import java.util.stream.Collectors;
 public class ElasticsearchFilterDeprecationWarningsInterceptor implements HttpResponseInterceptor {
     private String[] messagesToFilter = {
             "setting was deprecated in Elasticsearch",
-            "but in a future major version, directaccess to system indices and their aliases will not be allowed",
+            "but in a future major version, direct access to system indices and their aliases will not be allowed",
             "in epoch time formats is deprecated and will not be supported in the next major version of Elasticsearch",
             org.graylog.shaded.elasticsearch7.org.elasticsearch.common.joda.JodaDeprecationPatterns.USE_NEW_FORMAT_SPECIFIERS
     };

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/ElasticsearchFilterDeprecationWarningsInterceptorTest.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/ElasticsearchFilterDeprecationWarningsInterceptorTest.java
@@ -98,7 +98,7 @@ public class ElasticsearchFilterDeprecationWarningsInterceptorTest {
         HttpResponse response = new BasicHttpResponse(new BasicStatusLine(new ProtocolVersion("HTTP", 0, 0), 0, null));
         response.addHeader("Test", "This header should not trigger the interceptor.");
         response.addHeader("Warning", "This warning should not trigger the interceptor.");
-        response.addHeader("Warning", "This text contains the trigger: but in a future major version, directaccess to system indices and their aliases will not be allowed - and should be filtered out");
+        response.addHeader("Warning", "This text contains the trigger: but in a future major version, direct access to system indices and their aliases will not be allowed - and should be filtered out");
 
         assertThat(response.getAllHeaders())
                 .as("Number of Headers should be 3 before start.")
@@ -118,7 +118,7 @@ public class ElasticsearchFilterDeprecationWarningsInterceptorTest {
         HttpResponse response = new BasicHttpResponse(new BasicStatusLine(new ProtocolVersion("HTTP", 0, 0), 0, null));
         response.addHeader("Test", "This header should not trigger the interceptor.");
         response.addHeader("Warning", "This warning should not trigger the interceptor.");
-        response.addHeader("Warning", "This text contains the trigger: but in a future major version, directaccess to system indices and their aliases will not be allowed - and should be filtered out");
+        response.addHeader("Warning", "This text contains the trigger: but in a future major version, direct access to system indices and their aliases will not be allowed - and should be filtered out");
         response.addHeader("Warning", "This text contains the trigger: setting was deprecated in Elasticsearch - and should be filtered out");
 
         assertThat(response.getAllHeaders())


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
`elasticsearch_mute_deprecation_warnings = true` doesn't work for the warning about "system indices" because of a typo that omits a space between "direct" and "access". The warning in question, in full, reads: `299 Elasticsearch-7.15.2-93d5a7f6192e8a1a12e154a2b81bf6fa7309da0c "this request accesses aliases with names reserved for system indices: [.security], but in a future major version, direct access to system indices and their aliases will not be allowed`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes issue #9822.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Not tested, but confirmed that the Elasticsearch error message has *always had a space in it*, by reviewing the `git blame` from the [deprecation commit](https://github.com/elastic/elasticsearch/commit/91f4b58bf71249cf81562bd6069c64aafa46591b) to HEAD in the elasticsearch repository: https://github.com/elastic/elasticsearch/blame/4e09186b3d3a20e97e44713d4200b22bc3cec332/server/src/main/java/org/elasticsearch/action/admin/indices/alias/get/TransportGetAliasesAction.java#L151-L153

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.