### PR TITLE
Update Log4J to 2.16.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
         <json-path.version>2.4.0</json-path.version>
         <kafka.version>2.7.0</kafka.version>
         <kafka09.version>0.9.0.1-6</kafka09.version>
-        <log4j.version>2.15.0</log4j.version>
+        <log4j.version>2.16.0</log4j.version>
         <lucene.version>8.10.1</lucene.version>
         <metrics.version>4.1.9</metrics.version>
         <mongodb-driver.version>3.12.1</mongodb-driver.version>


### PR DESCRIPTION
From Log4j 2.16.0, support for lookups in log messages has been removed for security reasons.

CVE-2021-44228 has shown the JNDI has significant security issues.
2.16.0 disables JNDI by default.

https://logging.apache.org/log4j/2.x/changes-report.html#a2.16.0

