### PR TITLE
Fixing issue when auto-fixing deflector alias with multiple targets (backport to 4.1)

### DIFF
--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/IndicesAdapterES7.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/IndicesAdapterES7.java
@@ -381,9 +381,9 @@ public class IndicesAdapterES7 implements IndicesAdapter {
     @Override
     public void removeAliases(Set<String> indices, String alias) {
         final IndicesAliasesRequest indicesAliasesRequest = new IndicesAliasesRequest();
-        final IndicesAliasesRequest.AliasActions aliasAction = new IndicesAliasesRequest.AliasActions(IndicesAliasesRequest.AliasActions.Type.REMOVE_INDEX)
-                .indices(indices.toArray(new String[0]))
-                .alias(alias);
+        final IndicesAliasesRequest.AliasActions aliasAction = IndicesAliasesRequest.AliasActions.remove()
+                .alias(alias)
+                .indices(indices.toArray(new String[0]));
         indicesAliasesRequest.addAliasAction(aliasAction);
 
         client.execute((c, requestOptions) -> c.indices().updateAliases(indicesAliasesRequest, requestOptions),
@@ -488,8 +488,10 @@ public class IndicesAdapterES7 implements IndicesAdapter {
 
         static State parse(String state) {
             switch (state.toLowerCase(Locale.ENGLISH)) {
-                case "open": return Open;
-                case "close": return Closed;
+                case "open":
+                    return Open;
+                case "close":
+                    return Closed;
             }
 
             throw new IllegalStateException("Unable to parse invalid index state: " + state);

--- a/graylog2-server/src/test/java/org/graylog2/indexer/indices/IndicesIT.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/indices/IndicesIT.java
@@ -60,6 +60,7 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -478,5 +479,24 @@ public abstract class IndicesIT extends ElasticsearchBaseTest {
         client().addAliasMapping(index, alias);
 
         assertThat(indices.aliasTarget(prefixWithPlus + "*")).contains(index);
+    }
+
+    @Test
+    public void removeAliasesRemovesSecondTarget() {
+        final String randomIndices = "random_";
+        final String index = client().createRandomIndex(randomIndices);
+        final String index2 = client().createRandomIndex(randomIndices);
+        final String alias = randomIndices + "deflector";
+        assertThat(indices.aliasTarget(alias)).isEmpty();
+
+        client().addAliasMapping(index, alias);
+        client().addAliasMapping(index2, alias);
+
+        assertThatThrownBy(() -> indices.aliasTarget(alias))
+                .isInstanceOf(TooManyAliasesException.class);
+
+        indices.removeAliases(alias, Collections.singleton(index));
+
+        assertThat(indices.aliasTarget(alias)).contains(index2);
     }
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

**Note:** backport from #11781

During index rotation checks, we are also checking if the current deflector alias points to more than one index. If that is the case (for whatever reason), we are trying to repair it by removing the older target. For ES6 this was working before, for ES7 we are using the wrong alias command in the request.

This PR is now fixing the command used and adds an integration test to verify that it is working as expected.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.