### PR TITLE
Replace `react-portal` with native react portals.

### DIFF
--- a/graylog2-web-interface/package.json
+++ b/graylog2-web-interface/package.json
@@ -93,7 +93,6 @@
     "react-mops": "v2.0.0-beta.0",
     "react-overlays": "^0.7.0",
     "react-plotly.js": "2.5.1",
-    "react-portal": "^4.2.0",
     "react-resizable": "^1.8.0",
     "react-rnd": "^10.1.1",
     "react-select": "4.3.0",

--- a/graylog2-web-interface/src/components/common/Portal.test.tsx
+++ b/graylog2-web-interface/src/components/common/Portal.test.tsx
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import { render, screen } from 'wrappedTestingLibrary';
+import { useRef } from 'react';
+
+import Portal from './Portal';
+
+describe('Portal', () => {
+  it('should render children', async () => {
+    render(<Portal>The portal children</Portal>);
+
+    await screen.findByText('The portal children');
+  });
+
+  it('should render children when a container is specified', async () => {
+    const ExampleComponent = () => {
+      const container = useRef<HTMLDivElement>();
+
+      return (
+        <>
+          <div ref={container}>
+            Current container children
+          </div>
+          <Portal container={container.current}>
+            The portal children
+          </Portal>
+        </>
+      );
+    };
+
+    render(<ExampleComponent />);
+
+    await screen.findByText('The portal children');
+    await screen.findByText('Current container children');
+  });
+});

--- a/graylog2-web-interface/src/components/common/Portal.tsx
+++ b/graylog2-web-interface/src/components/common/Portal.tsx
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import type * as React from 'react';
+import { createPortal } from 'react-dom';
+
+type Props = {
+  children: React.ReactNode
+  container?: Element,
+};
+
+/**
+ * Simple wrapper component for ReactDOMs native portal functionality.
+ */
+const Portal = ({ children, container }: Props) => createPortal(children, container);
+
+Portal.defaultProps = {
+  container: document.body,
+};
+
+export default Portal;

--- a/graylog2-web-interface/src/components/common/SortableList/SortableListItem.tsx
+++ b/graylog2-web-interface/src/components/common/SortableList/SortableListItem.tsx
@@ -15,9 +15,10 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { createPortal } from 'react-dom';
 import { Draggable } from 'react-beautiful-dnd';
 import styled from 'styled-components';
+
+import { Portal } from 'components/common';
 
 import ListItem from './ListItem';
 import type { ListItemType, CustomContentRender, CustomListItemRender } from './ListItem';
@@ -62,7 +63,7 @@ const SortableListItem = <ItemType extends ListItemType>({
       );
 
       return (displayOverlayInPortal && isDragging)
-        ? createPortal(listItem, document.body)
+        ? <Portal>{listItem}</Portal>
         : listItem;
     }}
   </Draggable>

--- a/graylog2-web-interface/src/components/common/index.tsx
+++ b/graylog2-web-interface/src/components/common/index.tsx
@@ -77,6 +77,7 @@ export { default as PaginatedList } from './PaginatedList';
 export { default as Pagination } from './Pagination';
 export { default as Pluralize } from './Pluralize';
 export { default as ProgressBar } from './ProgressBar';
+export { default as Portal } from './Portal';
 export { default as QueryHelper } from './QueryHelper';
 export { default as ReactGridContainer } from './ReactGridContainer';
 export { default as ReadOnlyFormGroup } from './ReadOnlyFormGroup';

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/ConfigurableElement.jsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/ConfigurableElement.jsx
@@ -16,9 +16,9 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Portal } from 'react-portal';
 import { Position } from 'react-overlays';
 
+import { Portal } from 'components/common';
 import { Popover } from 'components/bootstrap';
 
 import styles from './ConfigurableElement.css';
@@ -59,8 +59,7 @@ export default class ConfigurableElement extends React.Component {
     const { title } = this.props;
     const popover = this.state.isOpen && (
       <Portal>
-        <Position container={document.body}
-                  placement="bottom"
+        <Position placement="bottom"
                   target={this.target}>
           <Popover title={title} id="configuration-popover">
             <ConfigurationElement onClose={this._onClose} />

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/DescriptionBox.jsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/DescriptionBox.jsx
@@ -16,12 +16,11 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Portal } from 'react-portal';
 import { Position } from 'react-overlays';
 import styled, { css } from 'styled-components';
 
 import { Popover } from 'components/bootstrap';
-import { Icon, HoverForHelp } from 'components/common';
+import { Icon, HoverForHelp, Portal } from 'components/common';
 
 const StyledDescriptionBox = styled.div(({ theme }) => css`
   background-color: ${theme.colors.variant.lightest.default};
@@ -71,8 +70,7 @@ class DescriptionBox extends React.Component {
 
     return (
       <Portal>
-        <Position container={document.body}
-                  placement="bottom"
+        <Position placement="bottom"
                   target={this.target}>
           <Popover title="Config options" id="config-popover">
             {configurableElement}

--- a/graylog2-web-interface/src/views/components/common/PortaledPopover.tsx
+++ b/graylog2-web-interface/src/views/components/common/PortaledPopover.tsx
@@ -16,9 +16,9 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Portal } from 'react-portal';
 import { Position } from 'react-overlays';
 
+import { Portal } from 'components/common';
 import { Popover } from 'components/bootstrap';
 
 import CustomPropTypes from '../CustomPropTypes';
@@ -62,7 +62,7 @@ export default class PortaledPopover extends React.Component<Props, State> {
     const { children, container, popover, title, ...rest } = this.props;
     const { isOpen } = this.state;
     const popoverElem = isOpen && (
-      <Portal node={container}>
+      <Portal container={container}>
         <Position container={container}
                   placement="bottom"
                   target={this.target}>

--- a/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchForm.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchForm.test.tsx
@@ -23,7 +23,7 @@ import 'helpers/mocking/react-dom_mock';
 import SavedSearchForm from './SavedSearchForm';
 
 jest.mock('react-overlays', () => ({ Position: mockComponent('MockPosition') }));
-jest.mock('react-portal', () => ({ Portal: mockComponent('MockPortal') }));
+jest.mock('components/common/Portal', () => ({ children }) => (children));
 
 describe('SavedSearchForm', () => {
   describe('render the SavedSearchForm', () => {

--- a/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchForm.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchForm.tsx
@@ -15,10 +15,10 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import React from 'react';
-import { Portal } from 'react-portal';
 import { Position } from 'react-overlays';
 import styled from 'styled-components';
 
+import { Portal } from 'components/common';
 import { Button, ControlLabel, FormControl, FormGroup, Popover } from 'components/bootstrap';
 
 import styles from './SavedSearchForm.css';
@@ -59,8 +59,7 @@ const SavedSearchForm = (props: Props) => {
 
   return (
     <Portal>
-      <Position container={document.body}
-                placement="left"
+      <Position placement="left"
                 target={target}>
         <Popover title="Name of search" id="saved-search-popover">
           <StyledForm onSubmit={stopEvent}>

--- a/graylog2-web-interface/yarn.lock
+++ b/graylog2-web-interface/yarn.lock
@@ -7825,11 +7825,11 @@ graceful-fs@^4.2.4:
     "@babel/preset-env" "7.13.10"
     "@babel/preset-typescript" "7.13.0"
     create-react-class "15.7.0"
-    eslint-config-graylog "file:../../../../.cache/yarn/v6/npm-graylog-web-plugin-4.3.0-SNAPSHOT-f40940c5-39d3-4337-92ea-2310756ad7d6-1639487444591/node_modules/eslint-config-graylog"
+    eslint-config-graylog "file:packages/eslint-config-graylog"
     formik "2.2.9"
     html-webpack-plugin "^5.5.0"
     javascript-natural-sort "0.7.1"
-    jest-preset-graylog "file:../../../../.cache/yarn/v6/npm-graylog-web-plugin-4.3.0-SNAPSHOT-f40940c5-39d3-4337-92ea-2310756ad7d6-1639487444591/node_modules/jest-preset-graylog"
+    jest-preset-graylog "file:packages/jest-preset-graylog"
     jquery "3.5.1"
     moment "2.29.1"
     moment-timezone "0.5.31"
@@ -7843,7 +7843,7 @@ graceful-fs@^4.2.4:
     react-router-dom "5.3.0"
     reflux "0.2.13"
     styled-components "5.3.3"
-    stylelint-config-graylog "file:../../../../.cache/yarn/v6/npm-graylog-web-plugin-4.3.0-SNAPSHOT-f40940c5-39d3-4337-92ea-2310756ad7d6-1639487444591/node_modules/stylelint-config-graylog"
+    stylelint-config-graylog "file:packages/stylelint-config-graylog"
     typescript "4.5.4"
     webpack "5.65.0"
     webpack-cleanup-plugin "0.5.1"
@@ -12507,13 +12507,6 @@ react-plotly.js@2.5.1:
   integrity sha512-Oya14whSHvPsYXdI0nHOGs1pZhMzV2edV7HAW1xFHD58Y73m/LbG2Encvyz1tztL0vfjph0JNhiwO8cGBJnlhg==
   dependencies:
     prop-types "^15.7.2"
-
-react-portal@^4.2.0:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/react-portal/-/react-portal-4.2.1.tgz#12c1599238c06fb08a9800f3070bea2a3f78b1a6"
-  integrity sha512-fE9kOBagwmTXZ3YGRYb4gcMy+kSA+yLO0xnPankjRlfBv4uCpFXqKPfkpsGQQR15wkZ9EssnvTOl1yMzbkxhPQ==
-  dependencies:
-    prop-types "^15.5.8"
 
 react-prop-types@^0.4.0:
   version "0.4.0"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

With this PR we are replacing the library `react-portal`, since it is no longer being maintained.
This will make it easier to upgrade to react v17.

Instead of the `Portal` component provided by `react-portal` we are now using our own `Portal` component, which is just a wrapper for `react-dom`s `createPortal`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

