### PR TITLE
Update Log4J to 2.16.0 (#11814)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@
         <jool.version>0.9.14</jool.version>
         <json-path.version>2.4.0</json-path.version>
         <kafka.version>0.9.0.1</kafka.version>
-        <log4j.version>2.15.0</log4j.version>
+        <log4j.version>2.16.0</log4j.version>
         <metrics.version>4.0.3</metrics.version>
         <mongodb-driver.version>3.12.1</mongodb-driver.version>
         <mongojack.version>2.10.1</mongojack.version>


### PR DESCRIPTION
From Log4j 2.16.0, support for lookups in log messages has been removed for security reasons.

CVE-2021-44228 has shown the JNDI has significant security issues.
2.16.0 disables JNDI by default.

https://logging.apache.org/log4j/2.x/changes-report.html#a2.16.0
(cherry picked from commit dd24b85cd1bbe1d8504d4670f6b0c394b41cc2d9)

