### PR TITLE
Cleaning up usage of test helper function `MockAction`.

### DIFF
--- a/graylog2-web-interface/src/components/roles/RoleEdit/UsersSection.test.tsx
+++ b/graylog2-web-interface/src/components/roles/RoleEdit/UsersSection.test.tsx
@@ -38,8 +38,8 @@ const mockLoadUsersForRolePromise = Promise.resolve({
 jest.mock('stores/roles/AuthzRolesStore', () => ({
   AuthzRolesStore: {},
   AuthzRolesActions: {
-    removeMember: mockAction(jest.fn(() => Promise.resolve())),
-    addMembers: mockAction(jest.fn(() => Promise.resolve())),
+    removeMember: mockAction(),
+    addMembers: mockAction(),
     loadUsersForRole: jest.fn(() => mockLoadUsersForRolePromise),
   },
 }));

--- a/graylog2-web-interface/src/components/roles/RolesOverview/RolesOverview.test.tsx
+++ b/graylog2-web-interface/src/components/roles/RolesOverview/RolesOverview.test.tsx
@@ -48,7 +48,7 @@ jest.mock('stores/roles/AuthzRolesStore', () => ({
     listen: jest.fn(),
   },
   AuthzRolesActions: {
-    delete: mockAction(jest.fn(() => Promise.resolve())),
+    delete: mockAction(),
     loadRolesPaginated: jest.fn(() => mockLoadRolesPaginatedPromise),
   },
 }));

--- a/graylog2-web-interface/src/components/users/UsersOverview/UsersOverview.test.tsx
+++ b/graylog2-web-interface/src/components/users/UsersOverview/UsersOverview.test.tsx
@@ -37,8 +37,8 @@ const mockLoadUsersPaginatedPromise = Promise.resolve(paginatedUsers);
 jest.mock('stores/users/UsersStore', () => ({
   UsersActions: {
     loadUsersPaginated: jest.fn(() => mockLoadUsersPaginatedPromise),
-    delete: mockAction(jest.fn(() => Promise.resolve())),
-    setStatus: mockAction(jest.fn(() => Promise.resolve())),
+    delete: mockAction(),
+    setStatus: mockAction(),
   },
 }));
 

--- a/graylog2-web-interface/src/views/components/Search.dashboard.test.tsx
+++ b/graylog2-web-interface/src/views/components/Search.dashboard.test.tsx
@@ -108,8 +108,8 @@ describe('Dashboard Search', () => {
     WidgetStore.listen = jest.fn(() => jest.fn());
     QueryFiltersStore.listen = jest.fn(() => jest.fn());
     SearchActions.execute = mockAction(jest.fn(() => Promise.resolve({} as SearchExecutionResult)));
-    StreamsActions.refresh = mockAction(jest.fn());
-    SearchConfigActions.refresh = mockAction(jest.fn());
+    StreamsActions.refresh = mockAction();
+    SearchConfigActions.refresh = mockAction();
 
     ViewStore.getInitialState = jest.fn(() => ({
       view: View.create().toBuilder().type(View.Type.Dashboard).build(),
@@ -120,7 +120,7 @@ describe('Dashboard Search', () => {
 
     FieldTypesActions.all = mockAction(jest.fn(async () => {}));
     SearchMetadataStore.listen = jest.fn(() => jest.fn());
-    SearchActions.refresh = mockAction(jest.fn(() => Promise.resolve()));
+    SearchActions.refresh = mockAction();
 
     asMock(WidgetFocusProvider as React.FunctionComponent).mockImplementation(({ children }) => (
       <WidgetFocusContext.Provider value={{

--- a/graylog2-web-interface/src/views/components/Search.test.tsx
+++ b/graylog2-web-interface/src/views/components/Search.test.tsx
@@ -135,8 +135,8 @@ describe('Search', () => {
     WidgetStore.listen = jest.fn(() => jest.fn());
     QueryFiltersStore.listen = jest.fn(() => jest.fn());
     SearchActions.execute = mockAction(jest.fn(async () => ({} as SearchExecutionResult)));
-    StreamsActions.refresh = mockAction(jest.fn());
-    SearchConfigActions.refresh = mockAction(jest.fn());
+    StreamsActions.refresh = mockAction();
+    SearchConfigActions.refresh = mockAction();
     SearchExecutionStateStore.listen = jest.fn(() => jest.fn());
     ViewActions.search.completed.listen = jest.fn(() => jest.fn());
 
@@ -151,7 +151,7 @@ describe('Search', () => {
     FieldTypesActions.refresh = mockAction(jest.fn(async () => {}));
     SearchMetadataActions.parseSearch = mockAction(jest.fn(() => mockPromise(SearchMetadata.empty())));
     SearchMetadataStore.listen = jest.fn(() => jest.fn());
-    SearchActions.refresh = mockAction(jest.fn(() => Promise.resolve()));
+    SearchActions.refresh = mockAction();
     asMock(CurrentViewTypeProvider as React.FunctionComponent).mockImplementation(({ children }) => <ViewTypeContext.Provider value={View.Type.Dashboard}>{children}</ViewTypeContext.Provider>);
   });
 

--- a/graylog2-web-interface/src/views/components/SearchBar.test.tsx
+++ b/graylog2-web-interface/src/views/components/SearchBar.test.tsx
@@ -84,7 +84,7 @@ describe('SearchBar', () => {
   };
 
   beforeEach(() => {
-    SearchActions.refresh = mockAction(jest.fn());
+    SearchActions.refresh = mockAction();
   });
 
   it('should render the SearchBar', async () => {

--- a/graylog2-web-interface/src/views/logic/valueactions/AddToQueryHandler.test.ts
+++ b/graylog2-web-interface/src/views/logic/valueactions/AddToQueryHandler.test.ts
@@ -121,7 +121,7 @@ describe('AddToQueryHandler', () => {
         .build());
 
       GlobalOverrideActions.query = mockAction(jest.fn(() => Promise.resolve(undefined as GlobalOverrideStoreState)));
-      SearchActions.refresh = mockAction(jest.fn(() => Promise.resolve()));
+      SearchActions.refresh = mockAction();
     });
 
     it('retrieves query string from global override', () => {

--- a/graylog2-web-interface/src/views/logic/valueactions/ExcludeFromQueryHandler.test.ts
+++ b/graylog2-web-interface/src/views/logic/valueactions/ExcludeFromQueryHandler.test.ts
@@ -125,7 +125,7 @@ describe('ExcludeFromQueryHandler', () => {
         .build());
 
       GlobalOverrideActions.query = mockAction(jest.fn(() => Promise.resolve(undefined as GlobalOverrideStoreState)));
-      SearchActions.refresh = mockAction(jest.fn(() => Promise.resolve()));
+      SearchActions.refresh = mockAction();
     });
 
     it('retrieves query string from global override', () => {

--- a/graylog2-web-interface/src/views/pages/ShowViewPage.test.tsx
+++ b/graylog2-web-interface/src/views/pages/ShowViewPage.test.tsx
@@ -48,7 +48,7 @@ jest.mock('views/stores/ViewManagementStore', () => ({
 
 jest.mock('views/stores/SearchStore', () => ({
   SearchActions: {
-    execute: mockAction(jest.fn()),
+    execute: mockAction(),
   },
 }));
 
@@ -133,7 +133,7 @@ describe('ShowViewPage', () => {
 
   it('passes loaded view to ViewDeserializer', async () => {
     asMock(ViewManagementActions.get).mockImplementation(mockAction(jest.fn(() => Promise.resolve(viewJson))));
-    SearchExecutionStateActions.setParameterValues = mockAction(jest.fn());
+    SearchExecutionStateActions.setParameterValues = mockAction();
     const search = Search.create().toBuilder().parameters([]).build();
 
     asMock(ViewDeserializer).mockImplementation((response: ViewJson) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

`MockAction` is using `jest.fn(() => Promise.resolve())` per default to
mock an action. With this change we are cleaning up the cases where we
provided a payload for `MockAction` unnecessarily.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)