### PR TITLE
Prevent infinite recursion when serializing `IpAddress`. (#11736)

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ips/IpAddress.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ips/IpAddress.java
@@ -16,6 +16,8 @@
  */
 package org.graylog.plugins.pipelineprocessor.functions.ips;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonValue;
 import com.google.common.net.InetAddresses;
 
 import java.net.InetAddress;
@@ -43,14 +45,16 @@ public class IpAddress {
     }
 
     @Override
+    @JsonValue
     public String toString() {
         return InetAddresses.toAddrString(address);
     }
 
     @SuppressWarnings("unused")
+    @JsonIgnore
     public IpAddress getAnonymized() {
         final byte[] address = this.address.getAddress();
-        address[address.length-1] = 0x00;
+        address[address.length - 1] = 0x00;
         try {
             return new IpAddress(InetAddress.getByAddress(address));
         } catch (UnknownHostException e) {


### PR DESCRIPTION
(cherry picked from commit a306d4b79255ef7e4e9b635148dea724ee84a850)
