### PR TITLE
update log4j from 2.16.0 to 2.17.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
         <json-path.version>2.4.0</json-path.version>
         <kafka.version>2.7.0</kafka.version>
         <kafka09.version>0.9.0.1-6</kafka09.version>
-        <log4j.version>2.16.0</log4j.version>
+        <log4j.version>2.17.0</log4j.version>
         <lucene.version>8.10.1</lucene.version>
         <metrics.version>4.1.9</metrics.version>
         <mongodb-driver.version>3.12.1</mongodb-driver.version>


### PR DESCRIPTION
From Log4j 2.17.0, fix string substitution recursion and limit JNDI to the java protocol only

CVE-2021-45105  - https://logging.apache.org/log4j/2.x/security.html

https://logging.apache.org/log4j/2.x/changes-report.html#a2.17.0