### PR TITLE
Preserve build metadata in graylog version

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/plugin/Version.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/Version.java
@@ -236,6 +236,13 @@ public class Version implements Comparable<Version> {
             final int minor = version.getMinorVersion();
             final int patch = version.getPatchVersion();
             final String qualifier = version.getPreReleaseVersion();
+            final String buildMetadata = version.getBuildMetadata();
+
+            // If the version property already contains build metadata we want to use that instead of replacing it
+            // with the Git commit ID
+            if (!isNullOrEmpty(buildMetadata)) {
+                return from(major, minor, patch, qualifier, buildMetadata);
+            }
 
             String commitSha = null;
             try {


### PR DESCRIPTION
This updates our Version class to keep any existing build metadata
instead of overwriting it with the Git revision.

**Note:** This PR must be backported to the 4.2 branch.