### PR TITLE
Replace removed `internalRuntimeForbidden` for forbiddenapis

### DIFF
--- a/graylog-project-parent/pom.xml
+++ b/graylog-project-parent/pom.xml
@@ -776,8 +776,6 @@
                     <suppressAnnotations>
                         <suppressAnnotation>org.graylog2.shared.SuppressForbidden</suppressAnnotation>
                     </suppressAnnotations>
-                    <!-- disallow undocumented classes like sun.misc.Unsafe: -->
-                    <internalRuntimeForbidden>false</internalRuntimeForbidden>
                     <!-- if the used Java version is too new, don't fail, just do nothing: -->
                     <failOnUnsupportedJava>false</failOnUnsupportedJava>
                     <failOnViolation>true</failOnViolation>
@@ -786,9 +784,9 @@
                         <bundledSignature>jdk-unsafe</bundledSignature>
                         <bundledSignature>jdk-deprecated</bundledSignature>
                         <bundledSignature>jdk-reflection</bundledSignature>
-                        <!-- Required until https://github.com/policeman-tools/forbidden-apis/pull/133 has been merged -->
-                        <bundledSignature>commons-io-unsafe-2.5</bundledSignature>
-                        <!--bundledSignature>commons-io-unsafe-${commons-io.version}</bundledSignature-->
+                        <!-- disallow undocumented classes like sun.misc.Unsafe: -->
+                        <bundledSignature>jdk-non-portable</bundledSignature>
+                        <bundledSignature>commons-io-unsafe-${commons-io.version}</bundledSignature>
                     </bundledSignatures>
                     <signaturesFiles>
                         <signaturesFile>${project.basedir}/../config/forbidden-apis/netty3.txt</signaturesFile>

--- a/graylog2-server/src/main/java/org/graylog/metrics/prometheus/PrometheusExporterHTTPServer.java
+++ b/graylog2-server/src/main/java/org/graylog/metrics/prometheus/PrometheusExporterHTTPServer.java
@@ -23,6 +23,7 @@ import com.sun.net.httpserver.HttpServer;
 import io.prometheus.client.Collector;
 import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.exporter.HTTPServer;
+import org.graylog2.shared.SuppressForbidden;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -64,6 +65,7 @@ public class PrometheusExporterHTTPServer {
         registryRef.set(newRegistry);
     }
 
+    @SuppressForbidden("Deliberate usage of HttpServer")
     public void start() {
         try {
             final InetSocketAddress addr = new InetSocketAddress(bindAddress.getHost(), bindAddress.getPort());

--- a/graylog2-server/src/main/java/org/graylog2/periodical/GarbageCollectionWarningThread.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/GarbageCollectionWarningThread.java
@@ -25,6 +25,7 @@ import org.graylog2.notifications.NotificationService;
 import org.graylog2.plugin.Tools;
 import org.graylog2.plugin.periodical.Periodical;
 import org.graylog2.plugin.system.NodeId;
+import org.graylog2.shared.SuppressForbidden;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -120,6 +121,7 @@ public class GarbageCollectionWarningThread extends Periodical {
 
             final NotificationEmitter emitter = (NotificationEmitter) gc;
             final NotificationListener listener = new NotificationListener() {
+                @SuppressForbidden("Deliberate usage of GcInfo and GarbageCollectionNotificationInfo")
                 @Override
                 public void handleNotification(javax.management.Notification notification, Object handback) {
                     if (GarbageCollectionNotificationInfo.GARBAGE_COLLECTION_NOTIFICATION.equals(notification.getType())) {


### PR DESCRIPTION
The `internalRuntimeForbidden` option got removed in forbiddenapis
version 3.0. It got replaced with the `jdk-non-portable` bundled
signature.

Also use the `commons-io.version` property to select the correct
`commons-io-unsafe` bundled signature.