### PR TITLE
Perform message timestamp conversion after processing

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/shared/buffers/processors/ProcessBufferProcessor.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/buffers/processors/ProcessBufferProcessor.java
@@ -157,7 +157,10 @@ public class ProcessBufferProcessor implements WorkHandler<MessageEvent> {
         for (MessageProcessor messageProcessor : orderedMessageProcessors) {
             messages = messageProcessor.process(messages);
         }
+
         for (Message message : messages) {
+            message.ensureValidTimestamp();
+
             if (!message.hasField(Message.FIELD_GL2_MESSAGE_ID) || isNullOrEmpty(message.getFieldAs(String.class, Message.FIELD_GL2_MESSAGE_ID))) {
                 // Set the message ID once all message processors have finished
                 // See documentation of Message.FIELD_GL2_MESSAGE_ID for details

--- a/graylog2-server/src/test/java/org/graylog2/plugin/MessageTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/plugin/MessageTest.java
@@ -762,7 +762,7 @@ public class MessageTest {
         final Message message = new Message("message", "source", Tools.nowUTC().minusMinutes(2));
         final DateTime previousTimestamp = message.getTimestamp();
 
-        message.addField(Message.FIELD_TIMESTAMP, 1234);
+        message.addField(Message.FIELD_TIMESTAMP, "1234");
 
         assertThat(message.getTimestamp()).isInstanceOf(DateTime.class);
         // got replaced by a current timestamp
@@ -772,12 +772,12 @@ public class MessageTest {
             assertThat(e).hasSize(1);
             assertThat(e.get(0).getCause()).isEqualTo(ProcessingFailureCause.InvalidTimestampException);
             assertThat(e.get(0).getMessage()).startsWith("Replaced invalid timestamp value in message <");
-            assertThat(e.get(0).getDetails()).startsWith("Value <1234> caused exception: Value of invalid type <Integer> provided");
+            assertThat(e.get(0).getDetails()).startsWith("Value <1234> caused exception: Invalid format: \"1234\" is too short");
         });
     }
 
     @Test
-    public void testTimestampConversionWithNullDate() {
+    public void testTimestampNoConversionWithNullDate() {
         // Do not use fixed time from setUp() in this test
         DateTimeUtils.setCurrentMillisSystem();
 
@@ -786,9 +786,16 @@ public class MessageTest {
 
         message.addField(Message.FIELD_TIMESTAMP, null);
 
+        // null does not replace existing timestamp
         assertThat(message.getTimestamp()).isInstanceOf(DateTime.class);
-        // got replaced by a current timestamp
-        assertThat(message.getTimestamp()).isNotEqualTo(previousTimestamp);
+        assertThat(message.getTimestamp()).isEqualTo(previousTimestamp);
+    }
+
+    @Test
+    public void testNullDateGetsReplacesWithCurrentDate() {
+        final Message message = new Message("message", "source", null);
+
+        assertThat(message.getTimestamp()).isInstanceOf(DateTime.class);
 
         assertThat(message.processingErrors()).satisfies(e -> {
             assertThat(e).hasSize(1);

--- a/graylog2-server/src/test/java/org/graylog2/plugin/inputs/ExtractorTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/plugin/inputs/ExtractorTest.java
@@ -981,32 +981,6 @@ public class ExtractorTest {
         assertThat(msg.getTimestamp()).isEqualTo(new DateTime(2021, 10, 20, 9, 5, 39, 892, UTC));
     }
 
-    @Test
-    public void testTimestampIsFixedWhenConverterHasFailed() throws Exception {
-        final Converter converter = new TestConverter.Builder()
-                .multiple(true)
-                .callback(new Function<Object, Object>() {
-                    @Nullable
-                    @Override
-                    public Object apply(Object input) {
-                        throw new IllegalArgumentException("Invalid format: FOO");
-                    }
-                })
-                .build();
-
-        final TestExtractor extractor = new TestExtractor.Builder()
-                .targetField("timestamp")
-                .converters(Collections.singletonList(converter))
-                .callback(() -> new Result[]{new Result("FOO", -1, -1)})
-                .build();
-
-        final Message msg = createMessage("the message");
-
-        extractor.runExtractor(msg);
-
-        assertThat(msg.getTimestamp()).isInstanceOf(DateTime.class);
-    }
-
     private Message createMessage(String message) {
         return new Message(message, "localhost", DateTime.now(UTC));
     }


### PR DESCRIPTION
With #11149 we introduced a change that ensured that a message will
have a valid DateTime as the timestamp field.
The conversion or fallback (plus recording errors) was performed when
setting the `timestamp` field.

This caused problems (#11495) with date converters on extractors.
They work by first assiging the non-converted timestamp string to the
message, and then use this string in the date converter.
A fix for this was done in #11750

However, looking at another user's issue with a json extractor
(https://github.com/Graylog2/graylog2-server/issues/11495#issuecomment-996536075)
made me rethink the previous approach.

Our processing works by mutating a Message object and thus passing field
values from one processing step to another.
Enforcing a DateTime object on the timestamp field in the middle of the
processing has the potential to break configurations where multiple
steps are taken to convert a field.
E.g. the json extractor will just assign a tempoarary timestamp string,
which will later be converted using a pipeline rule.

Therefore, we only perform timestamp conversion/fallback under two
circumstances:

 - The processing is completed
 - An explicit call to Message.getTimestamp() is made
