### PR TITLE
Update log4j from 2.17.0 to 2.17.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
         <json-path.version>2.4.0</json-path.version>
         <kafka.version>2.7.0</kafka.version>
         <kafka09.version>0.9.0.1-6</kafka09.version>
-        <log4j.version>2.17.0</log4j.version>
+        <log4j.version>2.17.1</log4j.version>
         <lucene.version>8.10.1</lucene.version>
         <metrics.version>4.1.9</metrics.version>
         <mongodb-driver.version>3.12.1</mongodb-driver.version>


### PR DESCRIPTION
Log4j 2.17.1 fixes a new vulnerability, [found by Yaniv Nizry](https://twitter.com/YNizry/status/1475916671953117184). Apache [announced](https://logging.apache.org/log4j/2.x/security.html#CVE-2021-44832) 2.17.1 yesterday. Sources:

- https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44832
- https://checkmarx.com/blog/cve-2021-44832-apache-log4j-2-17-0-arbitrary-code-execution-via-jdbcappender-datasource-element/