### PR TITLE
Update Log4J to 2.17.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
         <json-path.version>2.4.0</json-path.version>
         <kafka.version>2.7.0</kafka.version>
         <kafka09.version>0.9.0.1-6</kafka09.version>
-        <log4j.version>2.17.0</log4j.version>
+        <log4j.version>2.17.1</log4j.version>
         <lucene.version>8.10.1</lucene.version>
         <metrics.version>4.1.9</metrics.version>
         <mongodb-driver.version>3.12.1</mongodb-driver.version>


### PR DESCRIPTION
Fixes CVE-2021-44832  (https://logging.apache.org/log4j/2.x/security.html#CVE-2021-44832)
which is not critical, because it requires an attacker that can modify your local
log4j logging configuration.
