### PR TITLE
Improve "key_value" pipeline function to handle quoted values

### DIFF
--- a/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
@@ -943,6 +943,33 @@ public class FunctionsSnippetsTest extends BaseParserTest {
 
         assertThat(message.getField("dup_first")).isEqualTo("1");
         assertThat(message.getField("dup_last")).isEqualTo("2");
+
+        assertThat(message.getField("spacequote1")).isEqualTo("\"a space quote\"");
+        assertThat(message.getField("spacequote2")).isEqualTo("a space quote");
+        assertThat(message.getField("spacequote3")).isEqualTo("'a space quote'");
+        assertThat(message.getField("spacequote4")).isEqualTo("a space quote");
+        assertThat(message.getField("spacequote5")).isEqualTo("a space 'quote'");
+        assertThat(message.getField("spacequote6")).isEqualTo("a space \"quote\"");
+        assertThat(message.getField("spacequote7")).isEqualTo("it's a space 'quote'");
+
+        assertThat(message.getField("sq1")).isEqualTo("a");
+        assertThat(message.getField("sq2")).isEqualTo("b");
+        assertThat(message.getField("sq3")).isEqualTo("c");
+        assertThat(message.getField("sq4")).isEqualTo("' d '");
+        assertThat(message.getField("sq5")).isEqualTo("\" e\"");
+        assertThat(message.getField("sq6")).isEqualTo("it\"s a space");
+
+        assertThat(message.getField("sq7")).isEqualTo("a, b");
+        assertThat(message.getField("sq8")).isEqualTo("c|d");
+        assertThat(message.getField("sq9")).isEqualTo("e| \"f, g\" | h");
+        assertThat(message.getField("sq10")).isEqualTo("' i,j '");
+        assertThat(message.getField("sq11")).isEqualTo("\" k|\"");
+        assertThat(message.getField("sq12")).isEqualTo("l\"m n, o");
+
+        assertThat(message.getField("dup-spacequote")).isEqualTo("it's a space 'quote'|another");
+
+        assertThat(message.getField("sq@1")).isEqualTo("space quote");
+        assertThat(message.getField("sq@2")).isEqualTo("hello");
     }
 
     @Test

--- a/graylog2-server/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/keyValue.txt
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/keyValue.txt
@@ -20,4 +20,53 @@ then
         value: "dup_last=1 dup_last=2",
         handle_dup_keys: "take_last"
     ));
+
+    set_fields(key_value(
+        value: "spacequote1=\"a space quote\""
+    ));
+    set_fields(key_value(
+        value: "spacequote2=\"a space quote\"",
+        trim_value_chars: "\""
+    ));
+    set_fields(key_value(
+        value: "spacequote3='a space quote'"
+    ));
+    set_fields(key_value(
+        value: "spacequote4='a space quote'",
+        trim_value_chars: "'"
+    ));
+    set_fields(key_value(
+        value: "spacequote5=\"a space 'quote'\"",
+        trim_value_chars: "\""
+    ));
+    set_fields(key_value(
+        value: "spacequote6='a space \"quote\"'",
+        trim_value_chars: "'"
+    ));
+    set_fields(key_value(
+        value: "spacequote7=\"it's a space 'quote'\"",
+        trim_value_chars: "\""
+    ));
+    set_fields(key_value(
+        value: "sq1=\" a \" sq2=\" b\" sq3=' c  ' sq4=\" ' d ' \" sq5=' \" e\" ' sq6='it\"s a space'",
+        trim_value_chars: "\"'"
+    ));
+    set_fields(key_value(
+        value: "dup-spacequote=\"it's a space 'quote'\" dup-spacequote=another",
+        trim_value_chars: "\"",
+        handle_dup_keys: "|"
+    ));
+
+    set_fields(key_value(
+        value: "sq7=\"a, b\"|sq8=\"c|d\"|sq9='e| \"f, g\" | h'|sq10=\" ' i,j ' \",sq11=' \" k|\" ',sq12='l\"m n, o'",
+        delimiters: ",|",
+        trim_value_chars: "\"'"
+    ));
+
+    set_fields(key_value(
+        value: "\"sq@1\"='space quote'@\"sq@2\"=hello",
+        delimiters: "@",
+        trim_key_chars: "\"",
+        trim_value_chars: "'"
+    ));
 end


### PR DESCRIPTION
The "key_value" pipeline function can now handle quoted values that
contain the configured "delimiter". (by default whitespace)

Example:
The value extracted from "key='a value'" will now be "a value" instead
of "a".

Fixes #11731
Fixes #4751

(cherry picked from commit 701903a9f3e3cc81281a31cbc3fea539c0ce304e)