### PR TITLE
ContainerMatrixTests running against existing Instances

### DIFF
--- a/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/ClusterES6IT.java
+++ b/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/ClusterES6IT.java
@@ -23,6 +23,7 @@ import io.searchbox.core.CatResult;
 import org.graylog.storage.elasticsearch6.jest.JestUtils;
 import org.graylog.storage.elasticsearch6.testing.ElasticsearchInstanceES6;
 import org.graylog.testing.elasticsearch.SearchServerInstance;
+import org.graylog.testing.elasticsearch.TestableSearchServerInstance;
 import org.graylog2.indexer.cluster.ClusterAdapter;
 import org.graylog2.indexer.cluster.ClusterIT;
 import org.junit.Rule;
@@ -32,7 +33,7 @@ import static org.graylog.storage.elasticsearch6.testing.TestUtils.jestClient;
 
 public class ClusterES6IT extends ClusterIT {
     @Rule
-    public final SearchServerInstance elasticsearch = ElasticsearchInstanceES6.create();
+    public final TestableSearchServerInstance elasticsearch = ElasticsearchInstanceES6.create();
 
     @Override
     protected ClusterAdapter clusterAdapter(Duration timeout) {

--- a/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/IndexFieldTypePollerES6IT.java
+++ b/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/IndexFieldTypePollerES6IT.java
@@ -19,6 +19,7 @@ package org.graylog.storage.elasticsearch6;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.graylog.storage.elasticsearch6.testing.ElasticsearchInstanceES6;
 import org.graylog.testing.elasticsearch.SearchServerInstance;
+import org.graylog.testing.elasticsearch.TestableSearchServerInstance;
 import org.graylog2.indexer.fieldtypes.IndexFieldTypePollerAdapter;
 import org.graylog2.indexer.fieldtypes.IndexFieldTypePollerIT;
 import org.graylog2.indexer.indices.IndicesAdapter;
@@ -29,7 +30,7 @@ import static org.graylog.storage.elasticsearch6.testing.TestUtils.jestClient;
 
 public class IndexFieldTypePollerES6IT extends IndexFieldTypePollerIT {
     @Rule
-    public final SearchServerInstance elasticsearch = ElasticsearchInstanceES6.create();
+    public final TestableSearchServerInstance elasticsearch = ElasticsearchInstanceES6.create();
 
     @Override
     protected SearchServerInstance elasticsearch() {

--- a/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/IndicesGetAllMessageFieldsES6IT.java
+++ b/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/IndicesGetAllMessageFieldsES6IT.java
@@ -18,6 +18,7 @@ package org.graylog.storage.elasticsearch6;
 
 import org.graylog.storage.elasticsearch6.testing.ElasticsearchInstanceES6;
 import org.graylog.testing.elasticsearch.SearchServerInstance;
+import org.graylog.testing.elasticsearch.TestableSearchServerInstance;
 import org.graylog2.indexer.indices.IndicesAdapter;
 import org.graylog2.indexer.indices.IndicesGetAllMessageFieldsIT;
 import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
@@ -27,7 +28,7 @@ import static org.graylog.storage.elasticsearch6.testing.TestUtils.jestClient;
 
 public class IndicesGetAllMessageFieldsES6IT extends IndicesGetAllMessageFieldsIT {
     @Rule
-    public final SearchServerInstance elasticsearch = ElasticsearchInstanceES6.create();
+    public final TestableSearchServerInstance elasticsearch = ElasticsearchInstanceES6.create();
 
     @Override
     protected SearchServerInstance elasticsearch() {

--- a/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/MessagesES6IT.java
+++ b/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/MessagesES6IT.java
@@ -26,6 +26,7 @@ import io.searchbox.core.Index;
 import org.graylog.storage.elasticsearch6.jest.JestUtils;
 import org.graylog.storage.elasticsearch6.testing.ElasticsearchInstanceES6;
 import org.graylog.testing.elasticsearch.SearchServerInstance;
+import org.graylog.testing.elasticsearch.TestableSearchServerInstance;
 import org.graylog2.indexer.messages.ChunkedBulkIndexer;
 import org.graylog2.indexer.messages.MessagesAdapter;
 import org.graylog2.indexer.messages.MessagesIT;
@@ -43,7 +44,7 @@ import static org.graylog.storage.elasticsearch6.testing.TestUtils.jestClient;
 
 public class MessagesES6IT extends MessagesIT {
     @Rule
-    public final SearchServerInstance elasticsearch = ElasticsearchInstanceES6.create();
+    public final TestableSearchServerInstance elasticsearch = ElasticsearchInstanceES6.create();
 
     private final ObjectMapper objectMapper = new ObjectMapperProvider().get();
 

--- a/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/NodeES6IT.java
+++ b/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/NodeES6IT.java
@@ -18,6 +18,7 @@ package org.graylog.storage.elasticsearch6;
 
 import org.graylog.storage.elasticsearch6.testing.ElasticsearchInstanceES6;
 import org.graylog.testing.elasticsearch.SearchServerInstance;
+import org.graylog.testing.elasticsearch.TestableSearchServerInstance;
 import org.graylog2.indexer.cluster.NodeAdapter;
 import org.graylog2.indexer.cluster.NodeIT;
 import org.junit.Rule;
@@ -26,7 +27,7 @@ import static org.graylog.storage.elasticsearch6.testing.TestUtils.jestClient;
 
 public class NodeES6IT extends NodeIT {
     @Rule
-    public final SearchServerInstance elasticsearch = ElasticsearchInstanceES6.create();
+    public final TestableSearchServerInstance elasticsearch = ElasticsearchInstanceES6.create();
 
     @Override
     protected SearchServerInstance elasticsearch() {

--- a/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/ScrollResultES6IT.java
+++ b/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/ScrollResultES6IT.java
@@ -25,6 +25,7 @@ import org.graylog.storage.elasticsearch6.jest.JestUtils;
 import org.graylog.storage.elasticsearch6.testing.ElasticsearchInstanceES6;
 import org.graylog.testing.elasticsearch.ElasticsearchBaseTest;
 import org.graylog.testing.elasticsearch.SearchServerInstance;
+import org.graylog.testing.elasticsearch.TestableSearchServerInstance;
 import org.graylog2.indexer.IndexMapping;
 import org.graylog2.indexer.results.ScrollResult;
 import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
@@ -42,7 +43,7 @@ import static org.graylog.storage.elasticsearch6.testing.TestUtils.jestClient;
 
 public class ScrollResultES6IT extends ElasticsearchBaseTest {
     @Rule
-    public final SearchServerInstance elasticsearch = ElasticsearchInstanceES6.create();
+    public final TestableSearchServerInstance elasticsearch = ElasticsearchInstanceES6.create();
 
     @Override
     protected SearchServerInstance elasticsearch() {

--- a/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/SearchesES6IT.java
+++ b/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/SearchesES6IT.java
@@ -19,6 +19,7 @@ package org.graylog.storage.elasticsearch6;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.graylog.storage.elasticsearch6.testing.ElasticsearchInstanceES6;
 import org.graylog.testing.elasticsearch.SearchServerInstance;
+import org.graylog.testing.elasticsearch.TestableSearchServerInstance;
 import org.graylog2.Configuration;
 import org.graylog2.indexer.searches.Searches;
 import org.graylog2.indexer.searches.SearchesAdapter;
@@ -29,7 +30,7 @@ import static org.graylog.storage.elasticsearch6.testing.TestUtils.jestClient;
 
 public class SearchesES6IT extends SearchesIT {
     @Rule
-    public final SearchServerInstance elasticsearch = ElasticsearchInstanceES6.create();
+    public final TestableSearchServerInstance elasticsearch = ElasticsearchInstanceES6.create();
 
     @Override
     protected SearchServerInstance elasticsearch() {

--- a/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/testing/ElasticsearchBaseTestIT.java
+++ b/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/testing/ElasticsearchBaseTestIT.java
@@ -18,6 +18,7 @@ package org.graylog.storage.elasticsearch6.testing;
 
 import org.graylog.testing.elasticsearch.ElasticsearchBaseTest;
 import org.graylog.testing.elasticsearch.SearchServerInstance;
+import org.graylog.testing.elasticsearch.TestableSearchServerInstance;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -25,7 +26,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class ElasticsearchBaseTestIT extends ElasticsearchBaseTest {
     @Rule
-    public final SearchServerInstance elasticsearch = ElasticsearchInstanceES6.create();
+    public final TestableSearchServerInstance elasticsearch = ElasticsearchInstanceES6.create();
 
     @Override
     protected SearchServerInstance elasticsearch() {

--- a/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/testing/ElasticsearchInstanceES6.java
+++ b/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/testing/ElasticsearchInstanceES6.java
@@ -67,15 +67,15 @@ public class ElasticsearchInstanceES6 extends TestableSearchServerInstance {
         return this.jestClient;
     }
 
-    public static SearchServerInstance create() {
+    public static TestableSearchServerInstance create() {
         return create(Network.newNetwork());
     }
 
-    public static SearchServerInstance create(Network network) {
+    public static TestableSearchServerInstance create(Network network) {
         return create(SearchServer.ES6.getSearchVersion(), network);
     }
 
-    public static SearchServerInstance create(SearchVersion version, Network network) {
+    public static TestableSearchServerInstance create(SearchVersion version, Network network) {
         final String image = imageNameFrom(version);
 
         LOG.debug("Creating instance {}", image);

--- a/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/testing/ElasticsearchInstanceES6.java
+++ b/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/testing/ElasticsearchInstanceES6.java
@@ -24,6 +24,7 @@ import org.graylog.testing.containermatrix.SearchServer;
 import org.graylog.testing.elasticsearch.Client;
 import org.graylog.testing.elasticsearch.FixtureImporter;
 import org.graylog.testing.elasticsearch.SearchServerInstance;
+import org.graylog.testing.elasticsearch.TestableSearchServerInstance;
 import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
 import org.graylog2.storage.SearchVersion;
 import org.slf4j.Logger;
@@ -32,7 +33,7 @@ import org.testcontainers.containers.Network;
 
 import java.net.URI;
 
-public class ElasticsearchInstanceES6 extends SearchServerInstance {
+public class ElasticsearchInstanceES6 extends TestableSearchServerInstance {
     private static final Logger LOG = LoggerFactory.getLogger(SearchServerInstance.class);
     private static final String DEFAULT_IMAGE_OSS = "docker.elastic.co/elasticsearch/elasticsearch-oss";
 
@@ -53,12 +54,12 @@ public class ElasticsearchInstanceES6 extends SearchServerInstance {
     }
 
     @Override
-    protected Client client() {
+    public Client client() {
         return this.client;
     }
 
     @Override
-    protected FixtureImporter fixtureImporter() {
+    public FixtureImporter fixtureImporter() {
         return this.fixtureImporter;
     }
 

--- a/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/views/export/ElasticsearchExportBackendScrollingIT.java
+++ b/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/views/export/ElasticsearchExportBackendScrollingIT.java
@@ -19,6 +19,7 @@ package org.graylog.storage.elasticsearch6.views.export;
 import org.graylog.plugins.views.search.export.ExportMessagesCommand;
 import org.graylog.storage.elasticsearch6.testing.ElasticsearchInstanceES6;
 import org.graylog.testing.elasticsearch.SearchServerInstance;
+import org.graylog.testing.elasticsearch.TestableSearchServerInstance;
 import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
 import org.junit.Rule;
 import org.junit.Test;
@@ -27,7 +28,7 @@ import static org.graylog.storage.elasticsearch6.testing.TestUtils.jestClient;
 
 public class ElasticsearchExportBackendScrollingIT extends ElasticsearchExportBackendITBase {
     @Rule
-    public final SearchServerInstance elasticsearch = ElasticsearchInstanceES6.create();
+    public final TestableSearchServerInstance elasticsearch = ElasticsearchInstanceES6.create();
 
     @Override
     protected SearchServerInstance elasticsearch() {

--- a/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/views/export/ElasticsearchExportBackendSearchAfterIT.java
+++ b/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/views/export/ElasticsearchExportBackendSearchAfterIT.java
@@ -19,6 +19,7 @@ package org.graylog.storage.elasticsearch6.views.export;
 import org.graylog.plugins.views.search.export.ExportMessagesCommand;
 import org.graylog.storage.elasticsearch6.testing.ElasticsearchInstanceES6;
 import org.graylog.testing.elasticsearch.SearchServerInstance;
+import org.graylog.testing.elasticsearch.TestableSearchServerInstance;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -26,7 +27,7 @@ import static org.graylog.storage.elasticsearch6.testing.TestUtils.jestClient;
 
 public class ElasticsearchExportBackendSearchAfterIT extends ElasticsearchExportBackendITBase {
     @Rule
-    public final SearchServerInstance elasticsearch = ElasticsearchInstanceES6.create();
+    public final TestableSearchServerInstance elasticsearch = ElasticsearchInstanceES6.create();
 
     @Override
     protected SearchServerInstance elasticsearch() {

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/testing/OpensearchInstance.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/testing/OpensearchInstance.java
@@ -25,7 +25,7 @@ import org.graylog.storage.elasticsearch7.RestHighLevelClientProvider;
 import org.graylog.testing.containermatrix.SearchServer;
 import org.graylog.testing.elasticsearch.Client;
 import org.graylog.testing.elasticsearch.FixtureImporter;
-import org.graylog.testing.elasticsearch.SearchServerInstance;
+import org.graylog.testing.elasticsearch.TestableSearchServerInstance;
 import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
 import org.graylog2.storage.SearchVersion;
 import org.graylog2.system.shutdown.GracefulShutdownService;
@@ -41,7 +41,7 @@ import java.util.Locale;
 
 import static java.util.Objects.isNull;
 
-public class OpensearchInstance extends SearchServerInstance {
+public class OpensearchInstance extends TestableSearchServerInstance {
     private static final Logger LOG = LoggerFactory.getLogger(OpensearchInstance.class);
 
     private static final int ES_PORT = 9200;
@@ -98,12 +98,12 @@ public class OpensearchInstance extends SearchServerInstance {
     }
 
     @Override
-    protected Client client() {
+    public Client client() {
         return this.client;
     }
 
     @Override
-    protected FixtureImporter fixtureImporter() {
+    public FixtureImporter fixtureImporter() {
         return this.fixtureImporter;
     }
 
@@ -116,7 +116,7 @@ public class OpensearchInstance extends SearchServerInstance {
     }
 
     @Override
-    protected GenericContainer<?> buildContainer(String image, Network network) {
+    public GenericContainer<?> buildContainer(String image, Network network) {
         return new OpensearchContainer(DockerImageName.parse(image))
                 // Avoids reuse warning on Jenkins (we don't want reuse in our CI environment)
                 .withReuse(isNull(System.getenv("BUILD_ID")))

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/testing/RunningElasticsearchInstanceES7.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/testing/RunningElasticsearchInstanceES7.java
@@ -23,6 +23,7 @@ import org.graylog.shaded.elasticsearch7.org.apache.http.impl.client.BasicCreden
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.client.RestHighLevelClient;
 import org.graylog.storage.elasticsearch7.ElasticsearchClient;
 import org.graylog.storage.elasticsearch7.RestHighLevelClientProvider;
+import org.graylog.testing.containermatrix.SearchServer;
 import org.graylog.testing.elasticsearch.Client;
 import org.graylog.testing.elasticsearch.FixtureImporter;
 import org.graylog.testing.elasticsearch.SearchServerInstance;
@@ -72,6 +73,11 @@ public class RunningElasticsearchInstanceES7 implements SearchServerInstance {
                 false,
                 new BasicCredentialsProvider())
                 .get();
+    }
+
+    @Override
+    public SearchServer searchServer() {
+        return SearchServer.ES7;
     }
 
     @Override

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/testing/RunningElasticsearchInstanceES7.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/testing/RunningElasticsearchInstanceES7.java
@@ -17,53 +17,47 @@
 package org.graylog.storage.elasticsearch7.testing;
 
 import com.github.joschi.jadconfig.util.Duration;
-import com.github.zafarkhaja.semver.Version;
 import com.google.common.collect.ImmutableList;
+import com.google.common.io.Resources;
 import org.graylog.shaded.elasticsearch7.org.apache.http.impl.client.BasicCredentialsProvider;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.client.RestHighLevelClient;
 import org.graylog.storage.elasticsearch7.ElasticsearchClient;
 import org.graylog.storage.elasticsearch7.RestHighLevelClientProvider;
-import org.graylog.testing.containermatrix.SearchServer;
 import org.graylog.testing.elasticsearch.Client;
 import org.graylog.testing.elasticsearch.FixtureImporter;
-import org.graylog.testing.elasticsearch.TestableSearchServerInstance;
-import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
 import org.graylog.testing.elasticsearch.SearchServerInstance;
+import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
 import org.graylog2.storage.SearchVersion;
 import org.graylog2.system.shutdown.GracefulShutdownService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 
 import java.net.URI;
+import java.net.URL;
+import java.nio.file.Paths;
 
-public class ElasticsearchInstanceES7 extends TestableSearchServerInstance {
-    private static final Logger LOG = LoggerFactory.getLogger(ElasticsearchInstanceES7.class);
+public class RunningElasticsearchInstanceES7 implements SearchServerInstance {
+    private static final Logger LOG = LoggerFactory.getLogger(RunningElasticsearchInstanceES7.class);
     private static final String ES_VERSION = "7.10.2";
-    private static final String DEFAULT_IMAGE_OSS = "docker.elastic.co/elasticsearch/elasticsearch-oss";
 
     private final RestHighLevelClient restHighLevelClient;
     private final ElasticsearchClient elasticsearchClient;
     private final Client client;
     private final FixtureImporter fixtureImporter;
 
-    protected ElasticsearchInstanceES7(String image, SearchVersion version, Network network) {
-        super(image, version, network);
+    public RunningElasticsearchInstanceES7() {
         this.restHighLevelClient = buildRestClient();
         this.elasticsearchClient = new ElasticsearchClient(this.restHighLevelClient, false, new ObjectMapperProvider().get());
         this.client = new ClientES7(this.elasticsearchClient);
         this.fixtureImporter = new FixtureImporterES7(this.elasticsearchClient);
     }
 
-    @Override
-    public SearchServer searchServer() {
-        return SearchServer.ES7;
-    }
-
     private RestHighLevelClient buildRestClient() {
         return new RestHighLevelClientProvider(
                 new GracefulShutdownService(),
-                ImmutableList.of(URI.create("http://" + this.getHttpHostAddress())),
+                ImmutableList.of(URI.create("http://localhost:9200")),
                 Duration.seconds(60),
                 Duration.seconds(60),
                 Duration.seconds(60),
@@ -80,27 +74,6 @@ public class ElasticsearchInstanceES7 extends TestableSearchServerInstance {
                 .get();
     }
 
-    public static ElasticsearchInstanceES7 create() {
-        return create(Network.newNetwork());
-    }
-
-    public static ElasticsearchInstanceES7 create(Network network) {
-        return create(SearchVersion.elasticsearch(ES_VERSION), network);
-    }
-
-    public static ElasticsearchInstanceES7 create(SearchVersion searchVersion, Network network) {
-        final String image = imageNameFrom(searchVersion.version());
-
-        LOG.debug("Creating instance {}", image);
-
-        return new ElasticsearchInstanceES7(image, searchVersion, network);
-    }
-
-
-    protected static String imageNameFrom(Version version) {
-        return DEFAULT_IMAGE_OSS + ":" + version.toString();
-    }
-
     @Override
     public Client client() {
         return this.client;
@@ -109,6 +82,56 @@ public class ElasticsearchInstanceES7 extends TestableSearchServerInstance {
     @Override
     public FixtureImporter fixtureImporter() {
         return this.fixtureImporter;
+    }
+
+    @Override
+    public GenericContainer<?> createContainer(String image, SearchVersion version, Network network) {
+        return null;
+    }
+
+    @Override
+    public GenericContainer<?> buildContainer(String image, Network network) {
+        return null;
+    }
+
+    @Override
+    public String internalUri() {
+        return null;
+    }
+
+    @Override
+    public SearchVersion version() {
+        return null;
+    }
+
+    @Override
+    public void importFixtureResource(String resourcePath, Class<?> testClass) {
+        boolean isFullResourcePath = Paths.get(resourcePath).getNameCount() > 1;
+
+        @SuppressWarnings("UnstableApiUsage")
+        final URL fixtureResource = isFullResourcePath
+                ? Resources.getResource(resourcePath)
+                : Resources.getResource(testClass, resourcePath);
+
+        fixtureImporter().importResource(fixtureResource);
+
+        // Make sure the data we just imported is visible
+        client().refreshNode();
+    }
+
+    @Override
+    public String getHttpHostAddress() {
+        return null;
+    }
+
+    @Override
+    public void cleanUp() {
+
+    }
+
+    @Override
+    public void close() {
+
     }
 
     public ElasticsearchClient elasticsearchClient() {

--- a/graylog2-server/src/test/java/org/graylog/testing/completebackend/ContainerizedGraylogBackend.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/completebackend/ContainerizedGraylogBackend.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.testing.completebackend;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import org.graylog.testing.containermatrix.MongodbServer;
+import org.graylog.testing.elasticsearch.SearchServerInstance;
+import org.graylog.testing.graylognode.NodeInstance;
+import org.graylog.testing.mongodb.MongoDBInstance;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.Network;
+
+import java.net.URL;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+public class ContainerizedGraylogBackend implements GraylogBackend, AutoCloseable {
+    private static final Logger LOG = LoggerFactory.getLogger(GraylogBackend.class);
+    private final Network network;
+    private final SearchServerInstance searchServer;
+    private final MongoDBInstance mongodb;
+    private final NodeInstance node;
+
+    // Starting ES instance in parallel thread to save time.
+    // MongoDB and the node have to be started in sequence however, because the node might crash,
+    // if a MongoDb instance isn't already present while it's starting up.
+    public static ContainerizedGraylogBackend createStarted(int[] extraPorts, MongodbServer mongoVersion,
+                                                            SearchServerInstanceFactory searchServerInstanceFactory, List<Path> pluginJars, Path mavenProjectDir,
+                                                            List<URL> mongoDBFixtures) {
+        Network network = Network.newNetwork();
+        ExecutorService executor = Executors.newSingleThreadExecutor(new ThreadFactoryBuilder().setNameFormat("build-es-container-for-api-it").build());
+        Future<SearchServerInstance> esFuture = executor.submit(() -> searchServerInstanceFactory.create(network));
+        MongoDBInstance mongoDB = MongoDBInstance.createStartedWithUniqueName(network, Lifecycle.CLASS, mongoVersion);
+        mongoDB.dropDatabase();
+        mongoDB.importFixtures(mongoDBFixtures);
+
+        try {
+            // Wait for ES before starting the Graylog node to avoid any race conditions
+            SearchServerInstance esInstance = esFuture.get();
+            NodeInstance node = NodeInstance.createStarted(
+                    network,
+                    MongoDBInstance.internalUri(),
+                    esInstance.internalUri(),
+                    searchServerInstanceFactory.getVersion(),
+                    extraPorts,
+                    pluginJars, mavenProjectDir);
+            final ContainerizedGraylogBackend backend = new ContainerizedGraylogBackend(network, esInstance, mongoDB, node);
+
+            // ensure that all containers and networks will be removed after all tests finish
+            // We can't close the resources in an afterAll callback, as the instances are cached and reused
+            // so we need a solution that will be triggered only once after all test classes
+            Runtime.getRuntime().addShutdownHook(new Thread(backend::close));
+
+            return backend;
+        } catch (InterruptedException | ExecutionException e) {
+            LOG.error("Container creation aborted", e);
+            throw new RuntimeException(e);
+        } finally {
+            executor.shutdown();
+        }
+    }
+
+    private ContainerizedGraylogBackend(Network network, SearchServerInstance searchServer, MongoDBInstance mongodb, NodeInstance node) {
+        this.network = network;
+        this.searchServer = searchServer;
+        this.mongodb = mongodb;
+        this.node = node;
+    }
+
+    public void purgeData() {
+        mongodb.dropDatabase();
+        searchServer.cleanUp();
+    }
+
+    public void fullReset(List<URL> mongoDBFixtures) {
+        LOG.debug("Resetting backend.");
+        purgeData();
+        mongodb.importFixtures(mongoDBFixtures);
+        node.restart();
+    }
+
+    @Override
+    public void importElasticsearchFixture(String resourcePath, Class<?> testClass) {
+        searchServer.importFixtureResource(resourcePath, testClass);
+    }
+
+    @Override
+    public void importMongoDBFixture(String resourcePath, Class<?> testClass) {
+        mongodb.importFixture(resourcePath, testClass);
+    }
+
+    @Override
+    public String uri() {
+        return node.uri();
+    }
+
+    @Override
+    public int apiPort() {
+        return node.apiPort();
+    }
+
+    @Override
+    public int mappedPortFor(int originalPort) {
+        return node.mappedPortFor(originalPort);
+    }
+
+    @Override
+    public Network network() {
+        return this.network;
+    }
+
+    public MongoDBInstance mongoDB() {
+        return mongodb;
+    }
+
+    @Override
+    public void close() {
+        node.close();
+        mongodb.close();
+        searchServer.close();
+        network.close();
+    }
+
+    @Override
+    public SearchServerInstance searchServerInstance() {
+        return searchServer;
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog/testing/completebackend/GraylogBackend.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/completebackend/GraylogBackend.java
@@ -16,159 +16,21 @@
  */
 package org.graylog.testing.completebackend;
 
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
-import org.graylog.testing.containermatrix.MongodbServer;
 import org.graylog.testing.elasticsearch.SearchServerInstance;
-import org.graylog.testing.graylognode.NodeInstance;
-import org.graylog.testing.mongodb.MongoDBInstance;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.Network;
 
-import javax.annotation.Nonnull;
-import java.net.URL;
-import java.nio.file.Path;
-import java.util.List;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
+public interface GraylogBackend {
+    String uri();
 
-public class GraylogBackend implements AutoCloseable {
-    private static final Logger LOG = LoggerFactory.getLogger(GraylogBackend.class);
-    private final Network network;
-    private final SearchServerInstance searchServer;
-    private final MongoDBInstance mongodb;
-    private final NodeInstance node;
+    int apiPort();
 
-    private static GraylogBackend instance;
+    SearchServerInstance searchServerInstance();
 
-    public static GraylogBackend createStarted(int[] extraPorts, MongodbServer mongoVersion,
-                                               SearchServerInstanceFactory searchServerInstanceFactory, List<Path> pluginJars, Path mavenProjectDir,
-                                               List<URL> mongoDBFixtures) {
-        // if a cached version exists, shut it down first
-        if (instance != null) {
-            instance.close();
-        }
-        return doCreateStartedBackend(extraPorts, mongoVersion, searchServerInstanceFactory, pluginJars, mavenProjectDir,
-                mongoDBFixtures);
-    }
+    int mappedPortFor(int originalPort);
 
-    /**
-     * TODO: use or remove this method, currently is not used anywhere
-     */
-    public static GraylogBackend createStarted(int[] extraPorts,
-                                               SearchServerInstanceFactory searchServerInstanceFactory, List<Path> pluginJars, Path mavenProjectDir,
-                                               List<URL> mongoDBFixtures) {
-        if (instance == null) {
-            instance = doCreateStartedBackend(extraPorts, MongodbServer.DEFAULT_VERSION, searchServerInstanceFactory, pluginJars, mavenProjectDir,
-                    mongoDBFixtures);
-        } else {
-            instance.fullReset(mongoDBFixtures);
-            LOG.info("Reusing running backend");
-        }
-        return instance;
-    }
+    void importMongoDBFixture(String resourcePath, Class<?> testClass);
 
-    // Starting ES instance in parallel thread to save time.
-    // MongoDB and the node have to be started in sequence however, because the node might crash,
-    // if a MongoDb instance isn't already present while it's starting up.
-    private static GraylogBackend doCreateStartedBackend(int[] extraPorts, @Nonnull MongodbServer mongodbVersion,
-                                                         SearchServerInstanceFactory searchServerInstanceFactory, List<Path> pluginJars, Path mavenProjectDir,
-                                                         List<URL> mongoDBFixtures) {
-        Network network = Network.newNetwork();
-        ExecutorService executor = Executors.newSingleThreadExecutor(new ThreadFactoryBuilder().setNameFormat("build-es-container-for-api-it").build());
-        Future<SearchServerInstance> esFuture = executor.submit(() -> searchServerInstanceFactory.create(network));
-        MongoDBInstance mongoDB = MongoDBInstance.createStartedWithUniqueName(network, Lifecycle.CLASS, mongodbVersion);
-        mongoDB.dropDatabase();
-        mongoDB.importFixtures(mongoDBFixtures);
+    void importElasticsearchFixture(String resourcePath, Class<?> testClass);
 
-        try {
-            // Wait for ES before starting the Graylog node to avoid any race conditions
-            SearchServerInstance esInstance = esFuture.get();
-            NodeInstance node = NodeInstance.createStarted(
-                    network,
-                    MongoDBInstance.internalUri(),
-                    SearchServerInstance.internalUri(),
-                    searchServerInstanceFactory.getVersion(),
-                    extraPorts,
-                    pluginJars, mavenProjectDir);
-            final GraylogBackend backend = new GraylogBackend(network, esInstance, mongoDB, node);
-
-            // ensure that all containers and networks will be removed after all tests finish
-            // We can't close the resources in an afterAll callback, as the instances are cached and reused
-            // so we need a solution that will be triggered only once after all test classes
-            Runtime.getRuntime().addShutdownHook(new Thread(backend::close));
-
-            return backend;
-        } catch (InterruptedException | ExecutionException e) {
-            LOG.error("Container creation aborted", e);
-            throw new RuntimeException(e);
-        } finally {
-            executor.shutdown();
-        }
-    }
-
-    private GraylogBackend(Network network, SearchServerInstance searchServer, MongoDBInstance mongodb, NodeInstance node) {
-        this.network = network;
-        this.searchServer = searchServer;
-        this.mongodb = mongodb;
-        this.node = node;
-    }
-
-    public void purgeData() {
-        mongodb.dropDatabase();
-        searchServer.cleanUp();
-    }
-
-    public void fullReset(List<URL> mongoDBFixtures) {
-        LOG.debug("Resetting backend.");
-        purgeData();
-        mongodb.importFixtures(mongoDBFixtures);
-        node.restart();
-    }
-
-    public void importElasticsearchFixture(String resourcePath, Class<?> testClass) {
-        searchServer.importFixtureResource(resourcePath, testClass);
-    }
-
-    public void importMongoDBFixture(String resourcePath, Class<?> testClass) {
-        mongodb.importFixture(resourcePath, testClass);
-    }
-
-    public String uri() {
-        return node.uri();
-    }
-
-    public int apiPort() {
-        return node.apiPort();
-    }
-
-    public void printServerLog() {
-        node.printLog();
-    }
-
-    public int mappedPortFor(int originalPort) {
-        return node.mappedPortFor(originalPort);
-    }
-
-    public Network network() {
-        return this.network;
-    }
-
-    public MongoDBInstance mongoDB() {
-        return mongodb;
-    }
-
-    @Override
-    public void close() {
-        node.close();
-        mongodb.close();
-        searchServer.close();
-        network.close();
-    }
-
-    public SearchServerInstance searchServerInstance() {
-        return searchServer;
-    }
+    Network network();
 }

--- a/graylog2-server/src/test/java/org/graylog/testing/completebackend/RunningGraylogBackend.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/completebackend/RunningGraylogBackend.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog.testing.completebackend;
 
 import org.apache.commons.lang3.NotImplementedException;

--- a/graylog2-server/src/test/java/org/graylog/testing/completebackend/RunningGraylogBackend.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/completebackend/RunningGraylogBackend.java
@@ -1,0 +1,60 @@
+package org.graylog.testing.completebackend;
+
+import org.apache.commons.lang3.NotImplementedException;
+import org.graylog.testing.elasticsearch.SearchServerInstance;
+import org.testcontainers.containers.Network;
+
+import java.lang.reflect.Constructor;
+
+public class RunningGraylogBackend implements GraylogBackend {
+    private final SearchServerInstance searchServerInstance;
+
+    public RunningGraylogBackend() {
+        try {
+            Class<?> clazz = Class.forName("org.graylog.storage.elasticsearch7.testing.RunningElasticsearchInstanceES7");
+            Constructor constructor = clazz.getConstructor();
+            this.searchServerInstance = (SearchServerInstance) constructor.newInstance();
+        } catch (Exception ex) {
+            throw new NotImplementedException("Could not create Search instance.", ex);
+        }
+    }
+
+    public static GraylogBackend createStarted() {
+        return new RunningGraylogBackend();
+    }
+
+    @Override
+    public String uri() {
+        return "http://localhost";
+    }
+
+    @Override
+    public int apiPort() {
+        return 9000;
+    }
+
+    @Override
+    public SearchServerInstance searchServerInstance() {
+        return this.searchServerInstance;
+    }
+
+    @Override
+    public int mappedPortFor(int originalPort) {
+        return originalPort;
+    }
+
+    @Override
+    public void importMongoDBFixture(String resourcePath, Class<?> testClass) {
+        throw new NotImplementedException("Feature needs implementation...");
+    }
+
+    @Override
+    public void importElasticsearchFixture(String resourcePath, Class<?> testClass) {
+        this.searchServerInstance.importFixtureResource(resourcePath, testClass);
+    }
+
+    @Override
+    public Network network() {
+        throw new NotImplementedException("Feature not implemented on Running backends (no container)");
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog/testing/containermatrix/ContainerMatrixTestEngine.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/containermatrix/ContainerMatrixTestEngine.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.engine.config.CachingJupiterConfiguration;
 import org.junit.jupiter.engine.config.DefaultJupiterConfiguration;
 import org.junit.jupiter.engine.config.JupiterConfiguration;
 import org.junit.jupiter.engine.descriptor.ContainerMatrixEngineDescriptor;
+import org.junit.jupiter.engine.descriptor.ContainerMatrixTestWithRunningESMongoTestsDescriptor;
 import org.junit.jupiter.engine.descriptor.ContainerMatrixTestsDescriptor;
 import org.junit.jupiter.engine.discovery.ContainerMatrixTestsDiscoverySelectorResolver;
 import org.junit.jupiter.engine.execution.JupiterEngineExecutionContext;
@@ -50,6 +51,8 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
 
 public class ContainerMatrixTestEngine extends ContainerMatrixHierarchicalTestEngine<JupiterEngineExecutionContext> {
     private static final String ENGINE_ID = "graylog-container-matrix-tests";
@@ -133,6 +136,10 @@ public class ContainerMatrixTestEngine extends ContainerMatrixHierarchicalTestEn
         }
     }
 
+    protected boolean testAgainstRunningESMongoDB() {
+        return !isBlank(System.getenv("GRAYLOG_TEST_WITH_RUNNING_ES_AND_MONGODB"));
+    }
+
     @Override
     public TestDescriptor discover(EngineDiscoveryRequest discoveryRequest, UniqueId uniqueId) {
         JupiterConfiguration configuration = new CachingJupiterConfiguration(
@@ -144,53 +151,63 @@ public class ContainerMatrixTestEngine extends ContainerMatrixHierarchicalTestEn
         final Set<Integer> extraPorts = getExtraPorts(annotated);
         final List<URL> mongoDBFixtures = getMongoDBFixtures(annotated);
 
-        // create all combinations of tests, first differentiate for maven builds
-        getMavenProjectDirProvider(annotated)
-                .forEach(mavenProjectDirProvider -> getPluginJarsProvider(annotated)
-                        .forEach(pluginJarsProvider -> {
-                            MavenProjectDirProvider mpdp = instantiateFactory(mavenProjectDirProvider);
-                            PluginJarsProvider pjp = instantiateFactory(pluginJarsProvider);
-                            // now add all grouped tests for Lifecycle.VM
-                            getSearchServerVersions(annotated)
-                                    .stream().map(SearchServer::getSearchVersion)
-                                    .forEach(searchVersion -> getMongoVersions(annotated)
-                                            .forEach(mongoVersion -> {
-                                                ContainerMatrixTestsDescriptor testsDescriptor = new ContainerMatrixTestsDescriptor(engineDescriptor,
-                                                        Lifecycle.VM,
-                                                        mavenProjectDirProvider,
-                                                        mpdp.getUniqueId(),
-                                                        pluginJarsProvider,
-                                                        pjp.getUniqueId(),
-                                                        searchVersion,
-                                                        mongoVersion,
-                                                        extraPorts,
-                                                        mongoDBFixtures);
-                                                new ContainerMatrixTestsDiscoverySelectorResolver(engineDescriptor).resolveSelectors(discoveryRequest, testsDescriptor);
-                                                engineDescriptor.addChild(testsDescriptor);
-                                            })
-                                    );
-                            // add separate test classes (Lifecycle.CLASS)
-                            getSearchServerVersions(annotated)
-                                    .stream().map(SearchServer::getSearchVersion)
-                                    .forEach(esVersion -> getMongoVersions(annotated)
-                                                    .forEach(mongoVersion -> {
-                                                        ContainerMatrixTestsDescriptor testsDescriptor = new ContainerMatrixTestsDescriptor(engineDescriptor,
-                                                                Lifecycle.CLASS,
-                                                                mavenProjectDirProvider,
-                                                                mpdp.getUniqueId(),
-                                                                pluginJarsProvider,
-                                                                pjp.getUniqueId(),
-                                                                esVersion,
-                                                                mongoVersion,
-                                                                extraPorts,
-                                                                new ArrayList<>());
-                                                        new ContainerMatrixTestsDiscoverySelectorResolver(engineDescriptor).resolveSelectors(discoveryRequest, testsDescriptor);
-                                                        engineDescriptor.addChild(testsDescriptor);
-                                                    })
-                                            );
-                                }
-                        )
-                );
+        if (testAgainstRunningESMongoDB()) {
+            // if you test from inside an IDE against running containers
+            ContainerMatrixTestsDescriptor testsDescriptor = new ContainerMatrixTestWithRunningESMongoTestsDescriptor(
+                    engineDescriptor,
+                    extraPorts,
+                    mongoDBFixtures);
+            new ContainerMatrixTestsDiscoverySelectorResolver(engineDescriptor).resolveSelectors(discoveryRequest, testsDescriptor);
+            engineDescriptor.addChild(testsDescriptor);
+        } else {
+            // for full tests, create all combinations of tests. First differentiate for maven builds.
+            getMavenProjectDirProvider(annotated)
+                    .forEach(mavenProjectDirProvider -> getPluginJarsProvider(annotated)
+                            .forEach(pluginJarsProvider -> {
+                                        MavenProjectDirProvider mpdp = instantiateFactory(mavenProjectDirProvider);
+                                        PluginJarsProvider pjp = instantiateFactory(pluginJarsProvider);
+                                        // now add all grouped tests for Lifecycle.VM
+                                        getSearchServerVersions(annotated)
+                                                .stream().map(SearchServer::getSearchVersion)
+                                                .forEach(searchVersion -> getMongoVersions(annotated)
+                                                        .forEach(mongoVersion -> {
+                                                            ContainerMatrixTestsDescriptor testsDescriptor = new ContainerMatrixTestsDescriptor(engineDescriptor,
+                                                                    Lifecycle.VM,
+                                                                    mavenProjectDirProvider,
+                                                                    mpdp.getUniqueId(),
+                                                                    pluginJarsProvider,
+                                                                    pjp.getUniqueId(),
+                                                                    searchVersion,
+                                                                    mongoVersion,
+                                                                    extraPorts,
+                                                                    mongoDBFixtures);
+                                                            new ContainerMatrixTestsDiscoverySelectorResolver(engineDescriptor).resolveSelectors(discoveryRequest, testsDescriptor);
+                                                            engineDescriptor.addChild(testsDescriptor);
+                                                        })
+                                                );
+                                        // add separate test classes (Lifecycle.CLASS)
+                                        getSearchServerVersions(annotated)
+                                                .stream().map(SearchServer::getSearchVersion)
+                                                .forEach(esVersion -> getMongoVersions(annotated)
+                                                        .forEach(mongoVersion -> {
+                                                            ContainerMatrixTestsDescriptor testsDescriptor = new ContainerMatrixTestsDescriptor(engineDescriptor,
+                                                                    Lifecycle.CLASS,
+                                                                    mavenProjectDirProvider,
+                                                                    mpdp.getUniqueId(),
+                                                                    pluginJarsProvider,
+                                                                    pjp.getUniqueId(),
+                                                                    esVersion,
+                                                                    mongoVersion,
+                                                                    extraPorts,
+                                                                    new ArrayList<>());
+                                                            new ContainerMatrixTestsDiscoverySelectorResolver(engineDescriptor).resolveSelectors(discoveryRequest, testsDescriptor);
+                                                            engineDescriptor.addChild(testsDescriptor);
+                                                        })
+                                                );
+                                    }
+                            )
+                    );
+        }
 
         return engineDescriptor;
     }

--- a/graylog2-server/src/test/java/org/graylog/testing/elasticsearch/SearchServerInstance.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/elasticsearch/SearchServerInstance.java
@@ -19,73 +19,35 @@ package org.graylog.testing.elasticsearch;
 import com.google.common.io.Resources;
 import org.graylog.testing.containermatrix.SearchServer;
 import org.graylog2.storage.SearchVersion;
-import org.junit.rules.ExternalResource;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
-import org.testcontainers.containers.wait.strategy.Wait;
-import org.testcontainers.elasticsearch.ElasticsearchContainer;
-import org.testcontainers.utility.DockerImageName;
 
 import java.io.Closeable;
-import java.net.URL;
-import java.nio.file.Paths;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.stream.Collectors;
-
-import static java.util.Objects.isNull;
 
 /**
  * This rule starts an Elasticsearch instance and provides a configured {@link Client}.
  */
-public abstract class SearchServerInstance extends ExternalResource implements Closeable {
+public interface SearchServerInstance extends Closeable {
+    Client client();
 
-    private static final Logger LOG = LoggerFactory.getLogger(SearchServerInstance.class);
+    FixtureImporter fixtureImporter();
 
-    private static final Map<SearchVersion, GenericContainer<?>> containersByVersion = new HashMap<>();
+    GenericContainer<?> createContainer(String image, SearchVersion version, Network network);
 
-    private static final int ES_PORT = 9200;
-    private static final String NETWORK_ALIAS = "elasticsearch";
+    GenericContainer<?> buildContainer(String image, Network network);
 
-    private final SearchVersion version;
-    protected final GenericContainer<?> container;
+    String internalUri();
 
-    protected abstract Client client();
+    SearchVersion version();
 
-    protected abstract FixtureImporter fixtureImporter();
+    void importFixtureResource(String resourcePath, Class<?> testClass);
 
-    protected SearchServerInstance(String image, SearchVersion version, Network network) {
-        this.version = version;
-        this.container = createContainer(image, version, network);
-    }
+    String getHttpHostAddress();
 
-    private GenericContainer<?> createContainer(String image, SearchVersion version, Network network) {
-        if (!containersByVersion.containsKey(version)) {
-            GenericContainer<?> container = buildContainer(image, network);
-            container.start();
-            containersByVersion.put(version, container);
-        }
-        return containersByVersion.get(version);
-    }
-
-    protected GenericContainer<?> buildContainer(String image, Network network) {
-        return new ElasticsearchContainer(DockerImageName.parse(image).asCompatibleSubstituteFor("docker.elastic.co/elasticsearch/elasticsearch"))
-                // Avoids reuse warning on Jenkins (we don't want reuse in our CI environment)
-                .withReuse(isNull(System.getenv("BUILD_ID")))
-                .withEnv("ES_JAVA_OPTS", "-Xms2g -Xmx2g -Dlog4j2.formatMsgNoLookups=true")
-                .withEnv("discovery.type", "single-node")
-                .withEnv("action.auto_create_index", "false")
-                .withEnv("cluster.info.update.interval", "10s")
-                .withNetwork(network)
-                .withNetworkAliases(NETWORK_ALIAS)
-                .waitingFor(Wait.forHttp("/").forPort(ES_PORT));
-    }
+    void cleanUp();
 
     @Override
+    void close();
     protected void after() {
         cleanUp();
     }

--- a/graylog2-server/src/test/java/org/graylog/testing/elasticsearch/SearchServerInstance.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/elasticsearch/SearchServerInstance.java
@@ -16,7 +16,6 @@
  */
 package org.graylog.testing.elasticsearch;
 
-import com.google.common.io.Resources;
 import org.graylog.testing.containermatrix.SearchServer;
 import org.graylog2.storage.SearchVersion;
 import org.testcontainers.containers.GenericContainer;
@@ -24,11 +23,10 @@ import org.testcontainers.containers.Network;
 
 import java.io.Closeable;
 
-/**
- * This rule starts an Elasticsearch instance and provides a configured {@link Client}.
- */
 public interface SearchServerInstance extends Closeable {
     Client client();
+
+    SearchServer searchServer();
 
     FixtureImporter fixtureImporter();
 
@@ -48,48 +46,4 @@ public interface SearchServerInstance extends Closeable {
 
     @Override
     void close();
-    protected void after() {
-        cleanUp();
-    }
-
-    public void cleanUp() {
-        client().cleanUp();
-    }
-
-    @Override
-    public void close() {
-        container.close();
-        final List<SearchVersion> version = containersByVersion.keySet().stream().filter(k -> container == containersByVersion.get(k)).collect(Collectors.toList());
-        version.forEach(containersByVersion::remove);
-    }
-
-    public static String internalUri() {
-        return String.format(Locale.US, "http://%s:%d", NETWORK_ALIAS, ES_PORT);
-    }
-
-    public SearchVersion version() {
-        return version;
-    }
-
-    public abstract SearchServer searchServer();
-
-    public void importFixtureResource(String resourcePath, Class<?> testClass) {
-        boolean isFullResourcePath = Paths.get(resourcePath).getNameCount() > 1;
-
-        @SuppressWarnings("UnstableApiUsage")
-        final URL fixtureResource = isFullResourcePath
-                ? Resources.getResource(resourcePath)
-                : Resources.getResource(testClass, resourcePath);
-
-        fixtureImporter().importResource(fixtureResource);
-
-        // Make sure the data we just imported is visible
-        client().refreshNode();
-    }
-
-
-    public String getHttpHostAddress() {
-        return this.container.getHost() + ":" + this.container.getMappedPort(9200);
-    }
-
 }

--- a/graylog2-server/src/test/java/org/graylog/testing/elasticsearch/TestableSearchServerInstance.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/elasticsearch/TestableSearchServerInstance.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.testing.elasticsearch;
+
+import com.google.common.io.Resources;
+import org.graylog2.storage.SearchVersion;
+import org.junit.rules.ExternalResource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import java.net.URL;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static java.util.Objects.isNull;
+
+/**
+ * This rule starts an Elasticsearch instance and provides a configured {@link Client}.
+ */
+public abstract class TestableSearchServerInstance extends ExternalResource implements SearchServerInstance {
+    private static final Logger LOG = LoggerFactory.getLogger(TestableSearchServerInstance.class);
+
+    private static final Map<SearchVersion, GenericContainer<?>> containersByVersion = new HashMap<>();
+
+    private static final int ES_PORT = 9200;
+    private static final String NETWORK_ALIAS = "elasticsearch";
+
+    private final SearchVersion version;
+    protected final GenericContainer<?> container;
+
+    @Override
+    public abstract Client client();
+
+    @Override
+    public abstract FixtureImporter fixtureImporter();
+
+    protected TestableSearchServerInstance(String image, SearchVersion version, Network network) {
+        this.version = version;
+        this.container = createContainer(image, version, network);
+    }
+
+    @Override
+    public GenericContainer<?> createContainer(String image, SearchVersion version, Network network) {
+        if (!containersByVersion.containsKey(version)) {
+            GenericContainer<?> container = buildContainer(image, network);
+            container.start();
+            containersByVersion.put(version, container);
+        }
+        return containersByVersion.get(version);
+    }
+
+    @Override
+    public GenericContainer<?> buildContainer(String image, Network network) {
+        return new ElasticsearchContainer(DockerImageName.parse(image).asCompatibleSubstituteFor("docker.elastic.co/elasticsearch/elasticsearch"))
+                // Avoids reuse warning on Jenkins (we don't want reuse in our CI environment)
+                .withReuse(isNull(System.getenv("BUILD_ID")))
+                .withEnv("ES_JAVA_OPTS", "-Xms2g -Xmx2g -Dlog4j2.formatMsgNoLookups=true")
+                .withEnv("discovery.type", "single-node")
+                .withEnv("action.auto_create_index", "false")
+                .withEnv("cluster.info.update.interval", "10s")
+                .withNetwork(network)
+                .withNetworkAliases(NETWORK_ALIAS)
+                .waitingFor(Wait.forHttp("/").forPort(ES_PORT));
+    }
+
+    @Override
+    protected void after() {
+        cleanUp();
+    }
+
+    @Override
+    public void cleanUp() {
+        client().cleanUp();
+    }
+
+    @Override
+    public void close() {
+        container.close();
+        final List<SearchVersion> version = containersByVersion.keySet().stream().filter(k -> container == containersByVersion.get(k)).collect(Collectors.toList());
+        version.forEach(containersByVersion::remove);
+    }
+
+    @Override
+    public String internalUri() {
+        return String.format(Locale.US, "http://%s:%d", NETWORK_ALIAS, ES_PORT);
+    }
+
+    @Override
+    public SearchVersion version() {
+        return version;
+    }
+
+    @Override
+    public void importFixtureResource(String resourcePath, Class<?> testClass) {
+        boolean isFullResourcePath = Paths.get(resourcePath).getNameCount() > 1;
+
+        @SuppressWarnings("UnstableApiUsage")
+        final URL fixtureResource = isFullResourcePath
+                ? Resources.getResource(resourcePath)
+                : Resources.getResource(testClass, resourcePath);
+
+        fixtureImporter().importResource(fixtureResource);
+
+        // Make sure the data we just imported is visible
+        client().refreshNode();
+    }
+
+
+    @Override
+    public String getHttpHostAddress() {
+        return this.container.getHost() + ":" + this.container.getMappedPort(9200);
+    }
+
+}

--- a/graylog2-server/src/test/java/org/junit/jupiter/engine/descriptor/ContainerMatrixTestWithRunningESMongoTestsDescriptor.java
+++ b/graylog2-server/src/test/java/org/junit/jupiter/engine/descriptor/ContainerMatrixTestWithRunningESMongoTestsDescriptor.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.junit.jupiter.engine.descriptor;
+
+import org.junit.platform.engine.TestDescriptor;
+
+import java.net.URL;
+import java.util.List;
+import java.util.Set;
+
+public class ContainerMatrixTestWithRunningESMongoTestsDescriptor extends ContainerMatrixTestsDescriptor {
+    public ContainerMatrixTestWithRunningESMongoTestsDescriptor(TestDescriptor parent,
+                                                                Set<Integer> extraPorts,
+                                                                List<URL> mongoDBFixtures) {
+        super(parent, "Testing with running ES and MongoDB instances.", extraPorts, mongoDBFixtures);
+    }
+}
+
+

--- a/graylog2-server/src/test/java/org/junit/jupiter/engine/descriptor/ContainerMatrixTestsDescriptor.java
+++ b/graylog2-server/src/test/java/org/junit/jupiter/engine/descriptor/ContainerMatrixTestsDescriptor.java
@@ -16,10 +16,13 @@
  */
 package org.junit.jupiter.engine.descriptor;
 
+import org.graylog.testing.completebackend.DefaultMavenProjectDirProvider;
+import org.graylog.testing.completebackend.DefaultPluginJarsProvider;
 import org.graylog.testing.completebackend.Lifecycle;
 import org.graylog.testing.completebackend.MavenProjectDirProvider;
 import org.graylog.testing.completebackend.PluginJarsProvider;
 import org.graylog.testing.containermatrix.MongodbServer;
+import org.graylog.testing.containermatrix.SearchServer;
 import org.graylog2.storage.SearchVersion;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.support.descriptor.AbstractTestDescriptor;
@@ -66,7 +69,24 @@ public class ContainerMatrixTestsDescriptor extends AbstractTestDescriptor {
         this.mongoDBFixtures.addAll(mongoDBFixtures);
     }
 
-    private static String createKey(Lifecycle lifecycle, String mavenProjectDirProvider, String pluginJarsProvider, SearchVersion esVersion, MongodbServer mongoVersion) {
+    public ContainerMatrixTestsDescriptor(TestDescriptor parent,
+                                          String displayName,
+                                          Set<Integer> extraPorts,
+                                          List<URL> mongoDBFixtures) {
+        super(parent.getUniqueId().append(SEGMENT_TYPE,
+                        displayName),
+                displayName);
+        setParent(parent);
+        this.lifecycle = Lifecycle.VM;
+        this.mavenProjectDirProvider = DefaultMavenProjectDirProvider.class;
+        this.pluginJarsProvider = DefaultPluginJarsProvider.class;
+        this.esVersion = SearchServer.DEFAULT_VERSION.getSearchVersion();
+        this.mongoVersion = MongodbServer.DEFAULT_VERSION;
+        this.extraPorts.addAll(extraPorts);
+        this.mongoDBFixtures.addAll(mongoDBFixtures);
+    }
+
+    protected static String createKey(Lifecycle lifecycle, String mavenProjectDirProvider, String pluginJarsProvider, SearchVersion esVersion, MongodbServer mongoVersion) {
         return "Lifecycle: " + lifecycle.name() + ", MavenProjectDirProvider: " + mavenProjectDirProvider + ", PluginJarsProvider: " + pluginJarsProvider + ", Search: " + esVersion + ", MongoDB: " + mongoVersion.getVersion();
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
A new type of GraylogBackend has been created to support faster testing of Integration Tests during development of said tests.

`GRAYLOG_TEST_WITH_RUNNING_ES_AND_MONGODB=true`

## Motivation and Context
Motivation is, that you want to be able to test Integration Tests easily during development of said tests. The process of running the test in the IDE is time consuming because all of the packages and images are created and started. This is naturally what you want during full builds with maven or while running the CI - but not while you're creating the test in development.
You can now add an ENV-var while running the test from the IDE and test with an existing, running GL Backend and running ES and Mongo Containers.

# How does it work?

- You need a running ES7 and MongoDB on their standard ports (either locally installed or Docker containers are fine).
- You have to have your Graylog instance started also. (I have it started via "Debug" from IntelliJ)
- You can now start your integration test that has been annotated with @ContainerMatrixTest



## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

