### PR TITLE
Allow Index Set selection on stream in Cloud

### DIFF
--- a/graylog2-web-interface/src/components/streams/StreamForm.jsx
+++ b/graylog2-web-interface/src/components/streams/StreamForm.jsx
@@ -21,7 +21,6 @@ import BootstrapModalForm from 'components/bootstrap/BootstrapModalForm';
 import { Input } from 'components/bootstrap';
 import { Select, Spinner } from 'components/common';
 import * as FormsUtils from 'util/FormsUtils';
-import AppConfig from 'util/AppConfig';
 import { IndexSetsActions } from 'stores/indices/IndexSetsStore';
 
 class StreamForm extends React.Component {
@@ -117,10 +116,6 @@ class StreamForm extends React.Component {
   _indexSetSelect = () => {
     const { indexSetId } = this.state;
     const { indexSets } = this.props;
-
-    if (AppConfig.isCloud()) {
-      return null;
-    }
 
     if (indexSets) {
       return (


### PR DESCRIPTION
These changes enable selecting Index Sets when using Stream form in Cloud. 

fix https://github.com/Graylog2/graylog-plugin-cloud/issues/988

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

