### PR TITLE
Replace `react-sizeme` with own implementation which has a slightly better performance.

### DIFF
--- a/graylog2-web-interface/package.json
+++ b/graylog2-web-interface/package.json
@@ -97,7 +97,6 @@
     "react-resizable": "^1.8.0",
     "react-rnd": "^10.1.1",
     "react-select": "4.3.0",
-    "react-sizeme": "^2.6.7",
     "react-sortable-hoc": "^1.7.1",
     "react-sticky-el": "^2.0.9",
     "react-ultimate-pagination": "^1.2.0",

--- a/graylog2-web-interface/src/components/common/ElementDimensions.test.tsx
+++ b/graylog2-web-interface/src/components/common/ElementDimensions.test.tsx
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import { render } from 'wrappedTestingLibrary';
+
+import ElementDimensions from './ElementDimensions';
+
+jest.mock('hooks/useElementDimensions', () => jest.fn(() => ({ width: 1024, height: 768 })));
+
+describe('ElementDimensions', () => {
+  it('should provide width and height', () => {
+    const childrenMock = jest.fn();
+    render(<ElementDimensions>{childrenMock}</ElementDimensions>);
+
+    expect(childrenMock).toHaveBeenCalledTimes(1);
+    expect(childrenMock).toHaveBeenCalledWith({ width: 1024, height: 768 });
+  });
+});

--- a/graylog2-web-interface/src/components/common/ElementDimensions.tsx
+++ b/graylog2-web-interface/src/components/common/ElementDimensions.tsx
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import { useRef } from 'react';
+
+import useElementDimensions from 'hooks/useElementDimensions';
+
+type Props = {
+  children: (dimensions: { width: number, height: number}) => React.ReactNode
+  className?: string,
+  resizeDelay?: number,
+};
+
+/**
+ * Wrapper for the useElementDimensions hook.
+ */
+const ElementDimensions = ({ children, className, resizeDelay }: Props) => {
+  const element = useRef(null);
+  const dimensions = useElementDimensions(element, resizeDelay);
+
+  return (
+    <div ref={element} className={className}>
+      {children(dimensions)}
+    </div>
+  );
+};
+
+ElementDimensions.defaultProps = {
+  className: undefined,
+  resizeDelay: undefined,
+};
+
+export default ElementDimensions;

--- a/graylog2-web-interface/src/components/common/index.tsx
+++ b/graylog2-web-interface/src/components/common/index.tsx
@@ -35,6 +35,7 @@ export { default as DatePicker } from './DatePicker';
 export { default as DocumentTitle } from './DocumentTitle';
 export { default as DropdownMenu } from './DropdownMenu';
 export { default as DropdownSubmenu } from './DropdownSubmenu';
+export { default as ElementDimensions } from './ElementDimensions';
 export { default as EmptyEntity } from './EmptyEntity';
 export { default as EmptyResult } from './EmptyResult';
 export { default as EnterprisePluginNotFound } from './EnterprisePluginNotFound';

--- a/graylog2-web-interface/src/views/components/QueryBar.test.tsx
+++ b/graylog2-web-interface/src/views/components/QueryBar.test.tsx
@@ -23,9 +23,7 @@ import QueryBar from 'views/components/QueryBar';
 import { ViewActions } from 'views/stores/ViewStore';
 import DashboardPageContext from 'views/components/contexts/DashboardPageContext';
 
-jest.mock('react-sizeme', () => ({
-  SizeMe: ({ children: fn }) => fn({ size: { width: 1024, height: 768 } }),
-}));
+jest.mock('hooks/useElementDimensions', () => () => ({ width: 1024, height: 768 }));
 
 jest.mock('views/stores/ViewStore', () => ({
   ViewActions: {

--- a/graylog2-web-interface/src/views/components/QueryTabs.tsx
+++ b/graylog2-web-interface/src/views/components/QueryTabs.tsx
@@ -19,7 +19,6 @@ import { useRef } from 'react';
 import type * as Immutable from 'immutable';
 import PropTypes from 'prop-types';
 import ImmutablePropTypes from 'react-immutable-proptypes';
-import type { OrderedSet } from 'immutable';
 
 import { Col, Row } from 'components/bootstrap';
 import type { QueryId } from 'views/logic/queries/Query';
@@ -35,7 +34,7 @@ export interface QueryTabsProps {
   onRemove: (queryId: string) => Promise<void> | Promise<ViewState>,
   onSelect: (queryId: string) => Promise<Query> | Promise<string>,
   onTitleChange: (queryId: string, newTitle: string) => Promise<TitlesMap>,
-  queries: OrderedSet<QueryId>,
+  queries: Immutable.OrderedSet<QueryId>,
   selectedQueryId: string,
   titles: Immutable.Map<string, string>,
 }

--- a/graylog2-web-interface/src/views/components/QueryTabs.tsx
+++ b/graylog2-web-interface/src/views/components/QueryTabs.tsx
@@ -18,7 +18,6 @@ import * as React from 'react';
 import { useRef } from 'react';
 import type * as Immutable from 'immutable';
 import PropTypes from 'prop-types';
-import { SizeMe } from 'react-sizeme';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import type { OrderedSet } from 'immutable';
 
@@ -27,6 +26,7 @@ import type { QueryId } from 'views/logic/queries/Query';
 import type Query from 'views/logic/queries/Query';
 import type { TitlesMap } from 'views/stores/TitleTypes';
 import type ViewState from 'views/logic/views/ViewState';
+import ElementDimensions from 'components/common/ElementDimensions';
 
 import QueryTitleEditModal from './queries/QueryTitleEditModal';
 import AdaptableQueryTabs from './AdaptableQueryTabs';
@@ -46,9 +46,9 @@ const QueryTabs = ({ onRemove, onSelect, onTitleChange, queries, selectedQueryId
   return (
     <Row>
       <Col>
-        <SizeMe>
-          {({ size }) => (size.width ? (
-            <AdaptableQueryTabs maxWidth={size.width}
+        <ElementDimensions>
+          {({ width }) => (width ? (
+            <AdaptableQueryTabs maxWidth={width}
                                 queries={queries}
                                 titles={titles}
                                 selectedQueryId={selectedQueryId}
@@ -57,7 +57,7 @@ const QueryTabs = ({ onRemove, onSelect, onTitleChange, queries, selectedQueryId
                                 queryTitleEditModal={queryTitleEditModal}
                                 onTitleChange={onTitleChange} />
           ) : <div />)}
-        </SizeMe>
+        </ElementDimensions>
 
         {/*
           The title edit modal can't be part of the QueryTitle component,

--- a/graylog2-web-interface/src/views/components/Search.dashboard.test.tsx
+++ b/graylog2-web-interface/src/views/components/Search.dashboard.test.tsx
@@ -46,10 +46,7 @@ jest.mock('views/stores/ViewMetadataStore', () => ({
   ),
 }));
 
-jest.mock('react-sizeme', () => ({
-  // eslint-disable-next-line react/prop-types
-  SizeMe: ({ children }) => <div>{children({ size: { width: 1024 } })}</div>,
-}));
+jest.mock('hooks/useElementDimensions', () => () => ({ width: 1024, height: 768 }));
 
 const mockedQueryIds = Immutable.OrderedSet(['query-id-1', 'query-id-2']);
 

--- a/graylog2-web-interface/src/views/components/WidgetGrid.test.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetGrid.test.tsx
@@ -48,11 +48,6 @@ jest.mock('graylog-web-plugin/plugin', () => ({
   },
 }));
 
-jest.mock('react-sizeme', () => ({
-  // eslint-disable-next-line react/prop-types
-  SizeMe: ({ children }) => <div>{children({ size: { width: 200 } })}</div>,
-}));
-
 jest.mock('views/components/contexts/WidgetFieldTypesContextProvider', () => ({ children }) => children);
 
 jest.mock('views/stores/WidgetStore', () => ({

--- a/graylog2-web-interface/src/views/components/WidgetGrid.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetGrid.tsx
@@ -17,7 +17,6 @@
 import * as React from 'react';
 import { useContext, useMemo } from 'react';
 import styled, { css } from 'styled-components';
-import { SizeMe } from 'react-sizeme';
 
 import type { WidgetPositions, BackendWidgetPosition } from 'views/types';
 import ReactGridContainer from 'components/common/ReactGridContainer';
@@ -34,6 +33,7 @@ import InteractiveContext from 'views/components/contexts/InteractiveContext';
 import { ViewMetadataStore } from 'views/stores/ViewMetadataStore';
 import type { StoreState } from 'stores/StoreTypes';
 import { ViewStatesStore } from 'views/stores/ViewStatesStore';
+import ElementDimensions from 'components/common/ElementDimensions';
 
 import WidgetContainer from './WidgetContainer';
 import WidgetComponent from './WidgetComponent';
@@ -47,7 +47,7 @@ const COLUMNS = {
   xs: 12,
 };
 
-const DashboardWrap = styled.div(({ theme }) => css`
+const DashboardWrap = styled(ElementDimensions)(({ theme }) => css`
   color: ${theme.colors.global.textDefault};
   margin: 0;
   width: 100%;
@@ -113,29 +113,26 @@ type GridProps = {
   locked: boolean,
   onPositionsChange: (newPositions: Array<BackendWidgetPosition>) => void,
   positions: WidgetPositions,
+  width: number,
 };
 
-const Grid = ({ children, locked, onPositionsChange, positions }: GridProps) => {
+const Grid = ({ children, locked, onPositionsChange, positions, width }: GridProps) => {
   const { focusedWidget } = useContext(WidgetFocusContext);
 
   // The SizeMe component is required to update the widget grid
   // when its content height results in a scrollbar
   return (
-    <SizeMe monitorWidth refreshRate={100}>
-      {({ size: { width } }) => (
-        <StyledReactGridContainer $hasFocusedWidget={!!focusedWidget?.id}
-                                  columns={COLUMNS}
-                                  isResizable={!focusedWidget?.id}
-                                  locked={locked}
-                                  positions={positions}
-                                  measureBeforeMount
-                                  onPositionsChange={onPositionsChange}
-                                  width={width}
-                                  draggableHandle=".widget-drag-handle">
-          {children}
-        </StyledReactGridContainer>
-      )}
-    </SizeMe>
+    <StyledReactGridContainer $hasFocusedWidget={!!focusedWidget?.id}
+                              columns={COLUMNS}
+                              isResizable={!focusedWidget?.id}
+                              locked={locked}
+                              positions={positions}
+                              measureBeforeMount
+                              onPositionsChange={onPositionsChange}
+                              width={width}
+                              draggableHandle=".widget-drag-handle">
+      {children}
+    </StyledReactGridContainer>
   );
 };
 
@@ -191,11 +188,14 @@ const WidgetGrid = () => {
 
   return (
     <DashboardWrap>
-      <Grid locked={!isInteractive}
-            positions={positions}
-            onPositionsChange={onPositionsChange}>
-        {children}
-      </Grid>
+      {({ width }) => (
+        <Grid locked={!isInteractive}
+              positions={positions}
+              onPositionsChange={onPositionsChange}
+              width={width}>
+          {children}
+        </Grid>
+      )}
     </DashboardWrap>
   );
 };

--- a/graylog2-web-interface/src/views/components/WidgetGrid.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetGrid.tsx
@@ -119,8 +119,6 @@ type GridProps = {
 const Grid = ({ children, locked, onPositionsChange, positions, width }: GridProps) => {
   const { focusedWidget } = useContext(WidgetFocusContext);
 
-  // The SizeMe component is required to update the widget grid
-  // when its content height results in a scrollbar
   return (
     <StyledReactGridContainer $hasFocusedWidget={!!focusedWidget?.id}
                               columns={COLUMNS}
@@ -186,6 +184,8 @@ const WidgetGrid = () => {
     );
   }).filter((x) => (x !== null)), [fields, focusedWidget, positions, widgets]);
 
+  // Measuring the width is required to update the widget grid
+  // when its content height results in a scrollbar
   return (
     <DashboardWrap>
       {({ width }) => (

--- a/graylog2-web-interface/src/views/components/sidebar/fields/List.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/fields/List.tsx
@@ -15,7 +15,6 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { SizeMe } from 'react-sizeme';
 import { FixedSizeList } from 'react-window';
 import type { List as ImmutableList } from 'immutable';
 import styled from 'styled-components';
@@ -23,12 +22,13 @@ import styled from 'styled-components';
 import MessageFieldsFilter from 'logic/message/MessageFieldsFilter';
 import type { ViewMetaData as ViewMetadata } from 'views/stores/ViewMetadataStore';
 import type FieldTypeMapping from 'views/logic/fieldtypes/FieldTypeMapping';
+import ElementDimensions from 'components/common/ElementDimensions';
 
 import ListItem from './ListItem';
 
 const DEFAULT_HEIGHT_PX = 50;
 
-const DynamicHeight = styled.div`
+const DynamicHeight = styled(ElementDimensions)`
   overflow: hidden;
 `;
 
@@ -79,18 +79,16 @@ const List = ({ viewMetadata: { activeQuery }, filter, activeQueryFields, allFie
   );
 
   return (
-    <SizeMe monitorHeight refreshRate={100}>
-      {({ size: { height, width } }) => (
-        <DynamicHeight>
-          <FixedSizeList height={height || DEFAULT_HEIGHT_PX}
-                         width={width}
-                         itemCount={fieldList.size}
-                         itemSize={20}>
-            {Row}
-          </FixedSizeList>
-        </DynamicHeight>
+    <DynamicHeight>
+      {({ width, height }) => (
+        <FixedSizeList height={height || DEFAULT_HEIGHT_PX}
+                       width={width}
+                       itemCount={fieldList.size}
+                       itemSize={20}>
+          {Row}
+        </FixedSizeList>
       )}
-    </SizeMe>
+    </DynamicHeight>
   );
 };
 

--- a/graylog2-web-interface/src/views/components/sidebar/fields/List.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/fields/List.tsx
@@ -42,7 +42,7 @@ type Props = {
 
 const isReservedField = (fieldName) => MessageFieldsFilter.FILTERED_FIELDS.includes(fieldName);
 
-const _fieldsToShow = (fields, allFields, currentGroup = 'all') => {
+const _fieldsToShow = (fields, allFields, currentGroup = 'all'): ImmutableList<FieldTypeMapping> => {
   const isNotReservedField = (f) => !isReservedField(f.name);
 
   switch (currentGroup) {
@@ -71,13 +71,6 @@ const List = ({ viewMetadata: { activeQuery }, filter, activeQueryFields, allFie
     return <i>No fields to show. Try changing your filter term or select a different field set above.</i>;
   }
 
-  const Row = ({ index, style }: { index: number, style: React.CSSProperties }) => (
-    <ListItem fieldType={fieldList.get(index)}
-              selectedQuery={activeQuery}
-              activeQueryFields={activeQueryFields}
-              style={style} />
-  );
-
   return (
     <DynamicHeight>
       {({ width, height }) => (
@@ -85,7 +78,12 @@ const List = ({ viewMetadata: { activeQuery }, filter, activeQueryFields, allFie
                        width={width}
                        itemCount={fieldList.size}
                        itemSize={20}>
-          {Row}
+          {({ index, style }) => (
+            <ListItem fieldType={fieldList.get(index)}
+                      selectedQuery={activeQuery}
+                      activeQueryFields={activeQueryFields}
+                      style={style} />
+          )}
         </FixedSizeList>
       )}
     </DynamicHeight>

--- a/graylog2-web-interface/src/views/components/visualizations/number/NumberVisualization.test.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/number/NumberVisualization.test.tsx
@@ -96,14 +96,16 @@ describe('NumberVisualization', () => {
     expect(wrapper.find(NumberVisualization)).toExist();
   });
 
-  it('calls render completion callback after first render', (done) => {
-    const onRenderComplete = jest.fn(done);
+  it('calls render completion callback after first render', () => {
+    const onRenderComplete = jest.fn();
 
     mount((
       <RenderCompletionCallback.Provider value={onRenderComplete}>
         <SimplifiedNumberVisualization />
       </RenderCompletionCallback.Provider>
     ));
+
+    expect(onRenderComplete).toHaveBeenCalledTimes(1);
   });
 
   it('renders 0 if value is 0', () => {

--- a/graylog2-web-interface/src/views/components/visualizations/number/NumberVisualization.test.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/number/NumberVisualization.test.tsx
@@ -28,10 +28,6 @@ import type { CurrentViewType } from 'views/components/CustomPropTypes';
 
 import NumberVisualization from './NumberVisualization';
 
-jest.mock('react-sizeme', () => ({
-  SizeMe: ({ children: fn }) => fn({ size: { width: 320, height: 240 } }),
-}));
-
 jest.mock('./AutoFontSizer', () => ({ children }) => children);
 jest.mock('stores/connect', () => (x) => x);
 

--- a/graylog2-web-interface/src/views/components/visualizations/number/NumberVisualization.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/number/NumberVisualization.tsx
@@ -16,7 +16,6 @@
  */
 import React, { useContext, useEffect, useRef } from 'react';
 import styled from 'styled-components';
-import { SizeMe } from 'react-sizeme';
 
 import type { Rows } from 'views/logic/searchtypes/pivot/PivotHandler';
 import connect from 'stores/connect';
@@ -29,6 +28,7 @@ import RenderCompletionCallback from 'views/components/widgets/RenderCompletionC
 import NumberVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/NumberVisualizationConfig';
 import type { VisualizationComponentProps } from 'views/components/aggregationbuilder/AggregationBuilder';
 import { makeVisualization, retrieveChartData } from 'views/components/aggregationbuilder/AggregationBuilder';
+import ElementDimensions from 'components/common/ElementDimensions';
 
 import Trend from './Trend';
 import AutoFontSizer from './AutoFontSizer';
@@ -55,7 +55,7 @@ const SingleItemGrid = styled.div`
   width: 100%;
 `;
 
-const NumberBox = styled.div`
+const NumberBox = styled(ElementDimensions)`
   display: flex;
   justify-content: center;
   align-items: center;
@@ -65,7 +65,7 @@ const NumberBox = styled.div`
   padding-bottom: 10px;
 `;
 
-const TrendBox = styled.div`
+const TrendBox = styled(ElementDimensions)`
   height: 100%;
   width: 100%;
 `;
@@ -122,33 +122,29 @@ const NumberVisualization = ({ config, currentView, fields, data }: Props) => {
 
   return (
     <Container>
-      <NumberBox>
-        <SizeMe monitorHeight monitorWidth>
-          {({ size }) => (
-            <AutoFontSizer height={size.height} width={size.width}>
-              <CustomHighlighting field={field} value={value}>
-                <Value field={field}
-                       type={fieldTypeFor(field, fields)}
-                       value={value}
-                       queryId={activeQuery}
-                       render={DecoratedValue} />
-              </CustomHighlighting>
-            </AutoFontSizer>
-          )}
-        </SizeMe>
+      <NumberBox resizeDelay={20}>
+        {({ height, width }) => (
+          <AutoFontSizer height={height} width={width}>
+            <CustomHighlighting field={field} value={value}>
+              <Value field={field}
+                     type={fieldTypeFor(field, fields)}
+                     value={value}
+                     queryId={activeQuery}
+                     render={DecoratedValue} />
+            </CustomHighlighting>
+          </AutoFontSizer>
+        )}
       </NumberBox>
       {visualizationConfig.trend && (
         <TrendBox>
-          <SizeMe monitorHeight monitorWidth>
-            {({ size }) => (
-              <AutoFontSizer height={size.height} width={size.width} target={targetRef}>
-                <Trend ref={targetRef}
-                       current={value}
-                       previous={previousValue}
-                       trendPreference={visualizationConfig.trendPreference} />
-              </AutoFontSizer>
-            )}
-          </SizeMe>
+          {({ height, width }) => (
+            <AutoFontSizer height={height} width={width} target={targetRef}>
+              <Trend ref={targetRef}
+                     current={value}
+                     previous={previousValue}
+                     trendPreference={visualizationConfig.trendPreference} />
+            </AutoFontSizer>
+          )}
         </TrendBox>
       )}
     </Container>

--- a/graylog2-web-interface/test/setup-jest.js
+++ b/graylog2-web-interface/test/setup-jest.js
@@ -15,7 +15,3 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 /// <reference types="jest-enzyme" />
-
-import sizeMe from 'react-sizeme';
-
-sizeMe.noPlaceholders = true;

--- a/graylog2-web-interface/yarn.lock
+++ b/graylog2-web-interface/yarn.lock
@@ -4170,11 +4170,6 @@ base@^0.11.1:
     mixin-deep "^1.2.0"
     pascalcase "^0.1.1"
 
-batch-processor@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/batch-processor/-/batch-processor-1.0.0.tgz#75c95c32b748e0850d10c2b168f6bdbe9891ace8"
-  integrity sha1-dclcMrdI4IUNEMKxaPa9vpiRrOg=
-
 batch@0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/batch/-/batch-0.6.1.tgz#dc34314f4e679318093fc760272525f94bf25c16"
@@ -6031,13 +6026,6 @@ electron-to-chromium@^1.3.719:
   version "1.4.10"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.10.tgz#5f44ae6f6725b1949d6e8d34352f80d4c1880734"
   integrity sha512-tFgA40Iq2oy4k2PnZrLJowbgpij+lD6ZLxkw8Ht1NKTYyN8dvSvC5xlo8X0WW2jqhKSzITrbr5mpB4/AZ/8OUA==
-
-element-resize-detector@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/element-resize-detector/-/element-resize-detector-1.2.1.tgz#b0305194447a4863155e58f13323a0aef30851d1"
-  integrity sha512-BdFsPepnQr9fznNPF9nF4vQ457U/ZJXQDSNF1zBe7yaga8v9AdZf3/NElYxFdUh7SitSGt040QygiTo6dtatIw==
-  dependencies:
-    batch-processor "1.0.0"
 
 element-size@^1.1.1:
   version "1.1.1"
@@ -12704,16 +12692,6 @@ react-simple-code-editor@^0.10.0:
   resolved "https://registry.yarnpkg.com/react-simple-code-editor/-/react-simple-code-editor-0.10.0.tgz#73e7ac550a928069715482aeb33ccba36efe2373"
   integrity sha512-bL5W5mAxSW6+cLwqqVWY47Silqgy2DKDTR4hDBrLrUqC5BXc29YVx17l2IZk5v36VcDEq1Bszu2oHm1qBwKqBA==
 
-react-sizeme@^2.6.7:
-  version "2.6.12"
-  resolved "https://registry.yarnpkg.com/react-sizeme/-/react-sizeme-2.6.12.tgz#ed207be5476f4a85bf364e92042520499455453e"
-  integrity sha512-tL4sCgfmvapYRZ1FO2VmBmjPVzzqgHA7kI8lSJ6JS6L78jXFNRdOZFpXyK6P1NBZvKPPCZxReNgzZNUajAerZw==
-  dependencies:
-    element-resize-detector "^1.2.1"
-    invariant "^2.2.4"
-    shallowequal "^1.1.0"
-    throttle-debounce "^2.1.0"
-
 react-sortable-hoc@^1.7.1:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/react-sortable-hoc/-/react-sortable-hoc-1.11.0.tgz#fe4022362bbafc4b836f5104b9676608a40a278f"
@@ -14732,11 +14710,6 @@ throat@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/throat/-/throat-6.0.1.tgz#d514fedad95740c12c2d7fc70ea863eb51ade375"
   integrity sha512-8hmiGIJMDlwjg7dlJ4yKGLK8EsYqKgPWbG3b4wjJddKNwc7N7Dpn08Df4szr/sZdMVeOstrdYSsqzX6BYbcB+w==
-
-throttle-debounce@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/throttle-debounce/-/throttle-debounce-2.1.0.tgz#257e648f0a56bd9e54fe0f132c4ab8611df4e1d5"
-  integrity sha512-AOvyNahXQuU7NN+VVvOOX+uW6FPaWdAOdRP5HfwYxAfCzXTFKRMoIMk+n+po318+ktcChx+F1Dd91G3YHeMKyg==
 
 through2@^0.6.3:
   version "0.6.5"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

With https://github.com/Graylog2/graylog2-server/pull/11933 we implemented a hook to get the current dimensions of an element by using the `ResizeObserver` interface.

With this PR we are creating the common component `ElementDimensions` which implements this hook and which replaces the `SizeMe` component from `react-sizeme`.  `react-sizeme` is not using the `ResizeObserver` interface and has a slightly lower performance.

Since the `useElementDimensions` hook is working with a ref, the `ElementDimensions` component behaves slightly different than the `SizeMe` component. `ElementDimensions` is rendering a `div`, which is not the case when using the `SizeMe` component.

For our current use cases this is fine and in most cases we can just do the following: `const ParentComponent = styled(ElementDimensions)`. When we do not want to render an extra div, we can just use the `useElementDimension` hook instead.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
