### PR TITLE
Pass ChangeUserRequest to user mgmt service

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/users/UsersResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/users/UsersResource.java
@@ -417,7 +417,7 @@ public class UsersResource extends RestResource {
                 user.setSessionTimeoutMs(sessionTimeoutMs);
             }
         }
-        userManagementService.update(user);
+        userManagementService.update(user, cr);
     }
 
     @DELETE

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/users/UsersResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/users/UsersResource.java
@@ -40,7 +40,7 @@ import org.graylog2.plugin.database.ValidationException;
 import org.graylog2.plugin.database.users.User;
 import org.graylog2.rest.models.PaginatedResponse;
 import org.graylog2.rest.models.users.requests.ChangePasswordRequest;
-import org.graylog2.rest.models.users.requests.ChangeUserRequest;
+import org.graylog2.shared.users.ChangeUserRequest;
 import org.graylog2.rest.models.users.requests.CreateUserRequest;
 import org.graylog2.rest.models.users.requests.PermissionEditRequest;
 import org.graylog2.rest.models.users.requests.Startpage;

--- a/graylog2-server/src/main/java/org/graylog2/shared/users/ChangeUserRequest.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/users/ChangeUserRequest.java
@@ -14,7 +14,7 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-package org.graylog2.rest.models.users.requests;
+package org.graylog2.shared.users;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 import org.graylog.autovalue.WithBeanGetter;
+import org.graylog2.rest.models.users.requests.Startpage;
 
 import javax.annotation.Nullable;
 import javax.validation.Valid;

--- a/graylog2-server/src/main/java/org/graylog2/shared/users/UserManagementService.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/users/UserManagementService.java
@@ -18,6 +18,9 @@ package org.graylog2.shared.users;
 
 import org.graylog2.plugin.database.ValidationException;
 import org.graylog2.plugin.database.users.User;
+import org.graylog2.rest.models.users.requests.ChangeUserRequest;
+
+import javax.validation.Valid;
 
 /**
  * User management extension for the UserService. Initially intended to be used in the UserResource for user
@@ -37,7 +40,7 @@ public interface UserManagementService extends UserService {
      * Additional method allows explicit update operations to be carried out
      * (as opposed to calling .save)
      */
-    String update(User user) throws ValidationException;
+    String update(User user, ChangeUserRequest cr) throws ValidationException;
 
     void setUserStatus(User user, User.AccountStatus status) throws ValidationException;
 

--- a/graylog2-server/src/main/java/org/graylog2/shared/users/UserManagementService.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/users/UserManagementService.java
@@ -18,9 +18,6 @@ package org.graylog2.shared.users;
 
 import org.graylog2.plugin.database.ValidationException;
 import org.graylog2.plugin.database.users.User;
-import org.graylog2.rest.models.users.requests.ChangeUserRequest;
-
-import javax.validation.Valid;
 
 /**
  * User management extension for the UserService. Initially intended to be used in the UserResource for user

--- a/graylog2-server/src/main/java/org/graylog2/users/UserManagementServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/users/UserManagementServiceImpl.java
@@ -23,13 +23,12 @@ import org.graylog2.Configuration;
 import org.graylog2.database.MongoConnection;
 import org.graylog2.plugin.database.ValidationException;
 import org.graylog2.plugin.database.users.User;
-import org.graylog2.rest.models.users.requests.ChangeUserRequest;
+import org.graylog2.shared.users.ChangeUserRequest;
 import org.graylog2.security.AccessTokenService;
 import org.graylog2.security.InMemoryRolePermissionResolver;
 import org.graylog2.shared.users.UserManagementService;
 
 import javax.inject.Inject;
-import javax.validation.Valid;
 
 public class UserManagementServiceImpl extends UserServiceImpl implements UserManagementService {
 

--- a/graylog2-server/src/main/java/org/graylog2/users/UserManagementServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/users/UserManagementServiceImpl.java
@@ -23,11 +23,13 @@ import org.graylog2.Configuration;
 import org.graylog2.database.MongoConnection;
 import org.graylog2.plugin.database.ValidationException;
 import org.graylog2.plugin.database.users.User;
+import org.graylog2.rest.models.users.requests.ChangeUserRequest;
 import org.graylog2.security.AccessTokenService;
 import org.graylog2.security.InMemoryRolePermissionResolver;
 import org.graylog2.shared.users.UserManagementService;
 
 import javax.inject.Inject;
+import javax.validation.Valid;
 
 public class UserManagementServiceImpl extends UserServiceImpl implements UserManagementService {
 
@@ -51,7 +53,7 @@ public class UserManagementServiceImpl extends UserServiceImpl implements UserMa
     }
 
     @Override
-    public String update(User user) throws ValidationException {
+    public String update(User user, ChangeUserRequest cr) throws ValidationException {
         return super.save(user);
     }
 


### PR DESCRIPTION
User profile data is store in the DB. In the case of external users in the cloud we also sync changes back to the Identity Provider (i.e. Okta). However, we only want to do this when changing attributes that are actually managed by the IP.

Pass the `ChangeUserRequest` object to the `UserManagementService`, so it can determine whether a sync is needed.