### PR TITLE
Improve handling of escaped quotes in key_value pipeline function

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/strings/KeyValue.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/strings/KeyValue.java
@@ -46,6 +46,7 @@ public class KeyValue extends AbstractFunction<Map<String, String>> {
     private final ParameterDescriptor<String, String> duplicateHandlingParam;
     private final ParameterDescriptor<String, CharMatcher> trimCharactersParam;
     private final ParameterDescriptor<String, CharMatcher> trimValueCharactersParam;
+    private final ParameterDescriptor<String, CharMatcher> removeValueCharactersParam;
 
     public KeyValue() {
         valueParam = string("value").description("The string to extract key/value pairs from").build();
@@ -64,6 +65,11 @@ public class KeyValue extends AbstractFunction<Map<String, String>> {
                 .transform(CharMatcher::anyOf)
                 .optional()
                 .description("The characters to trim from values, default is not to trim")
+                .build();
+        removeValueCharactersParam = string("remove_value_chars", CharMatcher.class)
+                .transform(CharMatcher::anyOf)
+                .optional()
+                .description("The characters to remove from values, default is not to remove any")
                 .build();
     }
 
@@ -85,12 +91,13 @@ public class KeyValue extends AbstractFunction<Map<String, String>> {
                 .limit(2)
                 .trimResults();
         return new MapSplitter(outerSplitter,
-                               entrySplitter,
-                               ignoreEmptyValuesParam.optional(args, context).orElse(true),
-                               trimCharactersParam.optional(args, context).orElse(CharMatcher.none()),
-                               trimValueCharactersParam.optional(args, context).orElse(CharMatcher.none()),
-                               allowDupeKeysParam.optional(args, context).orElse(true),
-                               duplicateHandlingParam.optional(args, context).orElse("take_first"))
+                entrySplitter,
+                ignoreEmptyValuesParam.optional(args, context).orElse(true),
+                trimCharactersParam.optional(args, context).orElse(CharMatcher.none()),
+                trimValueCharactersParam.optional(args, context).orElse(CharMatcher.none()),
+                removeValueCharactersParam.optional(args, context).orElse(CharMatcher.none()),
+                allowDupeKeysParam.optional(args, context).orElse(true),
+                duplicateHandlingParam.optional(args, context).orElse("take_first"))
                 .split(value);
     }
 
@@ -107,7 +114,8 @@ public class KeyValue extends AbstractFunction<Map<String, String>> {
                         allowDupeKeysParam,
                         duplicateHandlingParam,
                         trimCharactersParam,
-                        trimValueCharactersParam
+                        trimValueCharactersParam,
+                        removeValueCharactersParam
                 )
                 .description("Extracts key/value pairs from a string")
                 .build();
@@ -117,6 +125,7 @@ public class KeyValue extends AbstractFunction<Map<String, String>> {
         private final char wrapperChar;
 
         private boolean inWrapper = false;
+        private boolean isEscaped = false;
 
         /**
          * An implementation that doesn't split when the given delimiter char matcher appears in double or single quotes.
@@ -136,9 +145,14 @@ public class KeyValue extends AbstractFunction<Map<String, String>> {
 
         @Override
         public boolean matches(char c) {
-            if (wrapperChar == c) {
+            if (c == '\\') {
+                isEscaped = true; // Remember escape status for the upcoming char
+                return true;
+            }
+            if (wrapperChar == c && !isEscaped) {
                 inWrapper = !inWrapper;
             }
+            isEscaped = false; // Clear escape status
             return !inWrapper;
         }
     }
@@ -150,6 +164,7 @@ public class KeyValue extends AbstractFunction<Map<String, String>> {
         private final boolean ignoreEmptyValues;
         private final CharMatcher keyTrimMatcher;
         private final CharMatcher valueTrimMatcher;
+        private final CharMatcher valueRemoveMatcher;
         private final Boolean allowDupeKeys;
         private final String duplicateHandling;
 
@@ -158,6 +173,7 @@ public class KeyValue extends AbstractFunction<Map<String, String>> {
                     boolean ignoreEmptyValues,
                     CharMatcher keyTrimMatcher,
                     CharMatcher valueTrimMatcher,
+                    CharMatcher valueRemoveMatcher,
                     Boolean allowDupeKeys,
                     String duplicateHandling) {
             this.outerSplitter = outerSplitter;
@@ -165,6 +181,7 @@ public class KeyValue extends AbstractFunction<Map<String, String>> {
             this.ignoreEmptyValues = ignoreEmptyValues;
             this.keyTrimMatcher = keyTrimMatcher;
             this.valueTrimMatcher = valueTrimMatcher;
+            this.valueRemoveMatcher = valueRemoveMatcher;
             this.allowDupeKeys = allowDupeKeys;
             this.duplicateHandling = duplicateHandling;
         }
@@ -200,7 +217,7 @@ public class KeyValue extends AbstractFunction<Map<String, String>> {
 
                 if (entryFields.hasNext()) {
                     String value = entryFields.next();
-                    value = valueTrimMatcher.trimFrom(value);
+                    value = valueRemoveMatcher.removeFrom(valueTrimMatcher.trimFrom(value));
                     // already have a value, concating old+delim+new
                     if (concat) {
                         value = map.get(key) + duplicateHandling + value;

--- a/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
@@ -951,6 +951,8 @@ public class FunctionsSnippetsTest extends BaseParserTest {
         assertThat(message.getField("spacequote5")).isEqualTo("a space 'quote'");
         assertThat(message.getField("spacequote6")).isEqualTo("a space \"quote\"");
         assertThat(message.getField("spacequote7")).isEqualTo("it's a space 'quote'");
+        assertThat(message.getField("spacequote8")).isEqualTo("it's a \"space quote\" with quotes");
+        assertThat(message.getField("spacequote9")).isEqualTo("it's a \\\"space quote\\\" with quotes");
 
         assertThat(message.getField("sq1")).isEqualTo("a");
         assertThat(message.getField("sq2")).isEqualTo("b");

--- a/graylog2-server/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/keyValue.txt
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/keyValue.txt
@@ -48,6 +48,15 @@ then
         trim_value_chars: "\""
     ));
     set_fields(key_value(
+        value: "spacequote8=\"it's a \\\"space quote\\\" with quotes\"",
+        trim_value_chars: "\"",
+        remove_value_chars: "\\"
+    ));
+    set_fields(key_value(
+        value: "spacequote9=\"it's a \\\"space quote\\\" with quotes\"",
+        trim_value_chars: "\""
+    ));
+    set_fields(key_value(
         value: "sq1=\" a \" sq2=\" b\" sq3=' c  ' sq4=\" ' d ' \" sq5=' \" e\" ' sq6='it\"s a space'",
         trim_value_chars: "\"'"
     ));


### PR DESCRIPTION
This PR updates the `key_value` pipeline rule function to handle escaped quotes inside quoted strings.

Example: `key="a \"quoted\" string"