### PR TITLE
Suggestions size param, other docs count

### DIFF
--- a/full-backend-tests/src/test/java/org/graylog/plugins/views/SuggestionResourceIT.java
+++ b/full-backend-tests/src/test/java/org/graylog/plugins/views/SuggestionResourceIT.java
@@ -51,9 +51,17 @@ public class SuggestionResourceIT {
         int mappedPort = sut.mappedPortFor(GELF_HTTP_PORT);
         GelfInputUtils.createGelfHttpInput(mappedPort, GELF_HTTP_PORT, requestSpec);
         GelfInputUtils.postMessage(mappedPort,
-                "{\"short_message\":\"SuggestionResourceIT\", \"host\":\"example.org\", \"facility\":\"test\"}",
+                "{\"short_message\":\"SuggestionResourceIT#1\", \"host\":\"example.org\", \"facility\":\"junit\"}",
                 requestSpec);
-         SearchUtils.waitForMessage(requestSpec, "SuggestionResourceIT");
+        GelfInputUtils.postMessage(mappedPort,
+                "{\"short_message\":\"SuggestionResourceIT#2\", \"host\":\"example.org\", \"facility\":\"test\"}",
+                requestSpec);
+        GelfInputUtils.postMessage(mappedPort,
+                "{\"short_message\":\"SuggestionResourceIT#3\", \"host\":\"example.org\", \"facility\":\"test\"}",
+                requestSpec);
+         SearchUtils.waitForMessage(requestSpec, "SuggestionResourceIT#1");
+         SearchUtils.waitForMessage(requestSpec, "SuggestionResourceIT#2");
+         SearchUtils.waitForMessage(requestSpec, "SuggestionResourceIT#3");
     }
 
     @ContainerMatrixTest
@@ -66,7 +74,7 @@ public class SuggestionResourceIT {
                 .then()
                 .statusCode(200);
         validatableResponse.assertThat().body("suggestions.value[0]", equalTo("test"));
-        validatableResponse.assertThat().body("suggestions.occurrence[0]", greaterThanOrEqualTo(1));
+        validatableResponse.assertThat().body("suggestions.occurrence[0]", greaterThanOrEqualTo(2));
     }
 
     @ContainerMatrixTest
@@ -80,7 +88,20 @@ public class SuggestionResourceIT {
                 .statusCode(200);
         // error types and messages are different for each ES version, so let's just check that there is an error in the response
         validatableResponse.assertThat().body("error", notNullValue());
+    }
 
+    @ContainerMatrixTest
+    void testSizeOtherDocsCount() {
+        final ValidatableResponse validatableResponse = given()
+                .spec(requestSpec)
+                .when()
+                .body("{\"field\":\"facility\", \"input\":\"\", \"size\":1}")
+                .post("/search/suggest")
+                .then()
+                .statusCode(200);
+        validatableResponse.assertThat().body("suggestions.value[0]", equalTo("test"));
+        validatableResponse.assertThat().body("suggestions.occurrence[0]", greaterThanOrEqualTo(2));
+        validatableResponse.assertThat().body("sum_other_docs_count", greaterThanOrEqualTo(1));
     }
 
     @ContainerMatrixTest
@@ -95,4 +116,5 @@ public class SuggestionResourceIT {
         validatableResponse.assertThat().body("suggestions.value[0]", equalTo("test"));
         validatableResponse.assertThat().body("suggestions.occurrence[0]", greaterThanOrEqualTo(1));
     }
+
 }

--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/QuerySuggestionsES6.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/QuerySuggestionsES6.java
@@ -16,7 +16,6 @@
  */
 package org.graylog.storage.elasticsearch6;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import io.searchbox.client.JestClient;
 import io.searchbox.core.Search;
 import io.searchbox.core.SearchResult;
@@ -32,14 +31,12 @@ import org.graylog.shaded.elasticsearch6.org.elasticsearch.search.aggregations.A
 import org.graylog.shaded.elasticsearch6.org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.graylog.shaded.elasticsearch6.org.elasticsearch.search.suggest.SuggestBuilder;
 import org.graylog.shaded.elasticsearch6.org.elasticsearch.search.suggest.SuggestBuilders;
-import org.graylog.shaded.elasticsearch6.org.elasticsearch.search.suggest.term.TermSuggestion;
 import org.graylog.storage.elasticsearch6.jest.JestUtils;
 import org.graylog2.indexer.IndexMapping;
 
 import javax.inject.Inject;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.Spliterator;
@@ -64,10 +61,10 @@ public class QuerySuggestionsES6 implements QuerySuggestionsService {
         final SearchSourceBuilder search = new SearchSourceBuilder()
                 .query(QueryBuilders.prefixQuery(req.field(), req.input()))
                 .size(0)
-                .aggregation(AggregationBuilders.terms("fieldvalues").field(req.field()).size(10))
+                .aggregation(AggregationBuilders.terms("fieldvalues").field(req.field()).size(req.size()))
                 .suggest(new SuggestBuilder()
                         .addSuggestion("corrections",
-                                SuggestBuilders.termSuggestion(req.field()).text(req.input()).size(10)));
+                                SuggestBuilders.termSuggestion(req.field()).text(req.input()).size(req.size())));
 
         final Search.Builder searchBuilder = new Search.Builder(search.toString())
                 .addType(IndexMapping.TYPE_MESSAGE)
@@ -81,7 +78,7 @@ public class QuerySuggestionsES6 implements QuerySuggestionsService {
             final TermsAggregation aggregation = result.getAggregations().getTermsAggregation("fieldvalues");
             final List<SuggestionEntry> entries = aggregation.getBuckets().stream().map(b -> new SuggestionEntry(b.getKeyAsString(), b.getCount())).collect(Collectors.toList());
             if(!entries.isEmpty()) {
-                return SuggestionResponse.forSuggestions(req.field(), req.input(), entries);
+                return SuggestionResponse.forSuggestions(req.field(), req.input(), entries, aggregation.getSumOtherDocCount());
             } else {
                 final List<SuggestionEntry> corrections = Optional.of(result.getJsonObject())
                         .map(o -> o.get("suggest"))
@@ -92,7 +89,7 @@ public class QuerySuggestionsES6 implements QuerySuggestionsService {
                                 .map(option -> new SuggestionEntry(option.get("text").textValue(), option.get("freq").longValue()))
                                 .collect(Collectors.toList()))
                         .orElseGet(Collections::emptyList);
-                return SuggestionResponse.forSuggestions(req.field(), req.input(), corrections);
+                return SuggestionResponse.forSuggestions(req.field(), req.input(), corrections, null);
             }
         } catch (Exception e) {
             final SuggestionError err = SuggestionError.create(e.getClass().getSimpleName(), e.getMessage());

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/engine/suggestions/SuggestionRequest.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/engine/suggestions/SuggestionRequest.java
@@ -17,6 +17,7 @@
 package org.graylog.plugins.views.search.engine.suggestions;
 
 import com.google.auto.value.AutoValue;
+import org.graylog.plugins.views.search.rest.FieldTypesForStreamsRequest;
 import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
 
 import java.util.Set;
@@ -28,6 +29,7 @@ public abstract class SuggestionRequest {
     public abstract String input();
     public abstract TimeRange timerange();
     public abstract Set<String> streams();
+    public abstract int size();
 
     public static Builder builder() {
         return new AutoValue_SuggestionRequest.Builder();
@@ -41,11 +43,14 @@ public abstract class SuggestionRequest {
         public abstract SuggestionRequest.Builder input(String input);
         public abstract SuggestionRequest.Builder streams(Set<String> streams);
         public abstract SuggestionRequest.Builder timerange(TimeRange timerange);
+        public abstract SuggestionRequest.Builder size(int size);
 
         public abstract SuggestionRequest build();
 
         public static SuggestionRequest.Builder builder() {
             return new AutoValue_SuggestionRequest.Builder();
         }
+
+
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/engine/suggestions/SuggestionResponse.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/engine/suggestions/SuggestionResponse.java
@@ -35,12 +35,15 @@ public abstract class SuggestionResponse {
 
     public abstract Optional<SuggestionError> suggestionError();
 
+    @Nullable
+    public abstract Long sumOtherDocsCount();
 
-    public static SuggestionResponse forSuggestions(final String field, final String input, final List<SuggestionEntry> suggestions) {
-        return new AutoValue_SuggestionResponse(field, input, suggestions, Optional.empty());
+
+    public static SuggestionResponse forSuggestions(final String field, final String input, final List<SuggestionEntry> suggestions, Long sumOtherDocsCount) {
+        return new AutoValue_SuggestionResponse(field, input, suggestions, Optional.empty(), sumOtherDocsCount);
     }
 
     public static SuggestionResponse forError(final String field, final String input, final SuggestionError error) {
-        return new AutoValue_SuggestionResponse(field, input, Collections.emptyList(), Optional.of(error));
+        return new AutoValue_SuggestionResponse(field, input, Collections.emptyList(), Optional.of(error), null);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/suggestions/SuggestionsDTO.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/suggestions/SuggestionsDTO.java
@@ -42,6 +42,11 @@ public abstract class SuggestionsDTO {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public abstract SuggestionsErrorDTO error();
 
+    @Nullable
+    @JsonProperty
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public abstract Long sumOtherDocsCount();
+
     public static Builder builder(final String field, final String input) {
         return new AutoValue_SuggestionsDTO.Builder().field(field).input(input).suggestions(Collections.emptyList());
     }
@@ -55,6 +60,8 @@ public abstract class SuggestionsDTO {
         public abstract Builder suggestions(final List<SuggestionEntryDTO> entries);
 
         public abstract Builder error(@Nullable final SuggestionsErrorDTO error);
+
+        public abstract Builder sumOtherDocsCount(@Nullable final Long sumOtherDocsCount);
 
         public abstract SuggestionsDTO build();
     }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/suggestions/SuggestionsRequestDTO.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/suggestions/SuggestionsRequestDTO.java
@@ -33,12 +33,16 @@ public abstract class SuggestionsRequestDTO {
 
     private static final String FIELD_STREAMS = "streams";
     private static final String FIELD_TIMERANGE = "timerange";
+    public static final int DEFAULT_SUGGESTIONS_COUNT = 10;
 
     @JsonProperty
     public abstract String field();
 
     @JsonProperty
     public abstract String input();
+
+    @JsonProperty
+    public abstract int size();
 
     @Nullable
     @JsonProperty(FIELD_TIMERANGE)
@@ -57,18 +61,21 @@ public abstract class SuggestionsRequestDTO {
         @JsonProperty
         public abstract SuggestionsRequestDTO.Builder input(String input);
 
-
         @JsonProperty(FIELD_STREAMS)
         public abstract SuggestionsRequestDTO.Builder streams(@Nullable Set<String> streams);
 
         @JsonProperty(FIELD_TIMERANGE)
         public abstract SuggestionsRequestDTO.Builder timerange(@Nullable TimeRange timerange);
 
+        @JsonProperty
+        public abstract SuggestionsRequestDTO.Builder size(int size);
+
         public abstract SuggestionsRequestDTO build();
 
         @JsonCreator
         public static SuggestionsRequestDTO.Builder builder() {
-            return new AutoValue_SuggestionsRequestDTO.Builder();
+            return new AutoValue_SuggestionsRequestDTO.Builder()
+                    .size(DEFAULT_SUGGESTIONS_COUNT);
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Allow controlling the size param, requesting a specified count of suggestions (with default 10 and max 100). Additionally, the response now contains the `sum_other_docs_count`, indicating how many documents with the requested fields exist out of the suggestion(=aggregation) scope. If the value is zero, the provided suggestions cover all possible values.


## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/4102775/149339679-bf54b4cd-174b-49ae-aa04-e7b72903ef71.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

