### PR TITLE
Display error specific documentation links for query input validation.

### DIFF
--- a/graylog2-web-interface/src/util/DocsHelper.js
+++ b/graylog2-web-interface/src/util/DocsHelper.js
@@ -44,9 +44,9 @@ class DocsHelper {
     REPORTING: 'reporting',
     ROLLING_ES_UPGRADE: 'rolling-es-upgrade',
     SEARCH_QUERY_ERRORS: {
-      UNKNOWN_FIELD: 'query-language#unkown-field',
+      UNKNOWN_FIELD: 'query-language#unknown-field',
       PARSE_EXCEPTION: 'query-language#parse-exception',
-      INVALID_OPERATOR: 'query-language#invali-operator',
+      INVALID_OPERATOR: 'query-language#invalid-operator',
     },
     SEARCH_QUERY_LANGUAGE: 'query-language',
     STREAMS: 'streams',

--- a/graylog2-web-interface/src/util/DocsHelper.js
+++ b/graylog2-web-interface/src/util/DocsHelper.js
@@ -43,6 +43,11 @@ class DocsHelper {
     PIPELINES: 'pipelines',
     REPORTING: 'reporting',
     ROLLING_ES_UPGRADE: 'rolling-es-upgrade',
+    SEARCH_QUERY_ERRORS: {
+      UNKNOWN_FIELD: 'query-language#unkown-field',
+      PARSE_EXCEPTION: 'query-language#parse-exception',
+      INVALID_OPERATOR: 'query-language#invali-operator',
+    },
     SEARCH_QUERY_LANGUAGE: 'query-language',
     STREAMS: 'streams',
     STREAM_PROCESSING_RUNTIME_LIMITS: 'streams#stream-processing-runtime-limits',

--- a/graylog2-web-interface/src/views/components/searchbar/queryvalidation/QueryValidation.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/queryvalidation/QueryValidation.test.tsx
@@ -70,6 +70,11 @@ describe('QueryValidation', () => {
 
   const validationErrorIconTitle = 'Toggle validation error explanation';
 
+  const openExplanation = async () => {
+    const validationExplanationTrigger = await screen.findByTitle(validationErrorIconTitle);
+    userEvent.click(validationExplanationTrigger);
+  };
+
   const SUT = ({ error, warning }: SUTProps) => (
     <Formik onSubmit={() => {}} initialValues={{}} initialErrors={error ? { queryString: error } : {}}>
       <Form>
@@ -99,11 +104,19 @@ describe('QueryValidation', () => {
   it('should display validation error explanation', async () => {
     render(<SUT error={errorResponse} />);
 
-    const validationExplanationTrigger = await screen.findByTitle(validationErrorIconTitle);
-    userEvent.click(validationExplanationTrigger);
+    await openExplanation();
 
     await screen.findByText('Error');
     await screen.findByText('ParseException');
     await screen.findByText(/Cannot parse 'source: '/);
+  });
+
+  it('should display validation error specific documentation links', async () => {
+    render(<SUT error={errorResponse} />);
+
+    await openExplanation();
+
+    await screen.findByText('ParseException');
+    await screen.findByTitle('ParseException documentation');
   });
 });

--- a/graylog2-web-interface/src/views/components/searchbar/queryvalidation/QueryValidation.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/queryvalidation/QueryValidation.tsx
@@ -61,6 +61,11 @@ const Title = styled.div`
   justify-content: space-between;
 `;
 
+const Explanation = styled.div`
+  display: flex;
+  justify-content: space-between;
+`;
+
 const shakeAnimation = keyframes`
   10%,
   90% {
@@ -97,9 +102,6 @@ const StyledPopover = styled(Popover)(({ $shaking }) => {
 const ExplanationTitle = ({ title }: { title: string }) => (
   <Title>
     {title}
-    <DocumentationLink page={DocsHelper.PAGES.SEARCH_QUERY_LANGUAGE}
-                       title="Search query syntax documentation"
-                       text={<DocumentationIcon name="lightbulb" />} />
   </Title>
 );
 
@@ -135,6 +137,19 @@ const useTriggerIfErrorsPersist = (trigger: () => void) => {
   }, [trigger, showExplanation, toggleShow]);
 
   return [showExplanation, toggleShow] as const;
+};
+
+const getErrorDocumentationLink = (errorType: string) => {
+  switch (errorType) {
+    case 'Unknown field':
+      return DocsHelper.PAGES.SEARCH_QUERY_ERRORS.UNKNOWN_FIELD;
+    case 'ParseException':
+      return DocsHelper.PAGES.SEARCH_QUERY_ERRORS.PARSE_EXCEPTION;
+    case 'Invalid operator':
+      return DocsHelper.PAGES.SEARCH_QUERY_ERRORS.INVALID_OPERATOR;
+    default:
+      return DocsHelper.PAGES.SEARCH_QUERY_LANGUAGE;
+  }
 };
 
 const QueryValidation = () => {
@@ -176,9 +191,12 @@ const QueryValidation = () => {
                          $shaking={shakingPopover}>
             <div role="alert">
               {explanations.map(({ errorType, errorMessage }) => (
-                <p key={errorMessage}>
-                  <b>{errorType}</b>: {errorMessage}
-                </p>
+                <Explanation key={errorMessage}>
+                  <span><b>{errorType}</b>: {errorMessage}</span>
+                  <DocumentationLink page={getErrorDocumentationLink(errorType)}
+                                     title={`${errorType} documentation`}
+                                     text={<DocumentationIcon name="lightbulb" />} />
+                </Explanation>
               ))}
             </div>
           </StyledPopover>

--- a/graylog2-web-interface/src/views/components/searchbar/queryvalidation/QueryValidation.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/queryvalidation/QueryValidation.tsx
@@ -64,6 +64,10 @@ const Title = styled.div`
 const Explanation = styled.div`
   display: flex;
   justify-content: space-between;
+
+  :not(:last-child) {
+    margin-bottom: 6px;
+  }
 `;
 
 const shakeAnimation = keyframes`


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

With https://github.com/Graylog2/graylog2-server/pull/11534 we are now validating the search query and display an explanation when there is an error.

Currently the popover for the explanations contains just a link for the search query language documentation.
With this PR we are now displaying an error specific documentation link. The supported error types are `Parse Exception`, `Invalid Operator` and `Unknown field`.

Please note, the documentation does not yet include the sections for the related explanations. But we can already merge this PR, since the error specific documentation links are still pointing to https://docs.graylog.org/docs/query-language.

Fixes: https://github.com/Graylog2/graylog2-server/issues/11849

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

