### PR TITLE
Improve handling of server errors when validating a search query.

### DIFF
--- a/graylog2-web-interface/src/views/components/searchbar/queryvalidation/validateQuery.ts
+++ b/graylog2-web-interface/src/views/components/searchbar/queryvalidation/validateQuery.ts
@@ -16,6 +16,7 @@
  */
 import type * as Immutable from 'immutable';
 
+import UserNotification from 'util/UserNotification';
 import fetch from 'logic/rest/FetchProvider';
 import { qualifyUrl } from 'util/URLUtils';
 import type { ElasticsearchQueryString, TimeRange } from 'views/logic/queries/Query';
@@ -83,6 +84,12 @@ export const validateQuery = ({
     }
 
     return undefined;
+  }).catch((error) => {
+    UserNotification.error(`Validating search query failed with status: ${error}`);
+
+    return ({
+      status: 'OK',
+    });
   });
 };
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Currently we do not catch server errors when validating a search query,
which can affect the search bar validation and lead to unexpected behaviours.

We are now displaying a user notification and returning status: 'OK' in
this case. By returning this status we can avoid unexpected behaviours.

Before this change we had a problem when using undeclared parameters in a search query, which results in a server error.
In another PR we will handle undeclared parameters differently and return common validation errors. This way we will handle "undeclared parameter" errors like other validation errors.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

