### PR TITLE
Improve fetching of field value suggestions which are being displayed for the search query input.

### DIFF
--- a/graylog2-web-interface/src/views/components/searchbar/completions/FieldValueCompletion.test.ts
+++ b/graylog2-web-interface/src/views/components/searchbar/completions/FieldValueCompletion.test.ts
@@ -60,10 +60,10 @@ describe('FieldValueCompletion', () => {
     ],
   };
   const expectedSuggestions = [
-    { name: 'GET', value: 'GET', score: 100 },
-    { name: 'DELETE', value: 'DELETE', score: 200 },
-    { name: 'POST', value: 'POST', score: 300 },
-    { name: 'PUT', value: 'PUT', score: 400 },
+    { name: 'GET', value: 'GET', score: 100, meta: '100 (occ)' },
+    { name: 'DELETE', value: 'DELETE', score: 200, meta: '200 (occ)' },
+    { name: 'POST', value: 'POST', score: 300, meta: '300 (occ)' },
+    { name: 'PUT', value: 'PUT', score: 400, meta: '400 (occ)' },
   ];
 
   const createKeywordToken = (value: string) => ({

--- a/graylog2-web-interface/src/views/components/searchbar/completions/FieldValueCompletion.ts
+++ b/graylog2-web-interface/src/views/components/searchbar/completions/FieldValueCompletion.ts
@@ -49,6 +49,14 @@ const formatValue = (value: string, type: string) => {
   return value;
 };
 
+const completionCaption = (fieldValue: string, input: string | number) => {
+  if (fieldValue.startsWith(String(input))) {
+    return fieldValue;
+  }
+
+  return `${fieldValue} ⭢ ${input}`;
+};
+
 const getFieldNameAndInput = (currentToken: Token | undefined | null, lastToken: Token | undefined | null) => {
   if (currentToken?.type === 'keyword' && currentToken?.value.endsWith(':')) {
     return {
@@ -165,7 +173,11 @@ class FieldValueCompletion implements Completer {
     }
 
     if (this.alreadyFetchedAllSuggestions(input, fieldName, streams, timeRange)) {
-      return this.filterExistingSuggestions(input);
+      const existingSuggestions = this.filterExistingSuggestions(input);
+
+      if (existingSuggestions.length) {
+        return existingSuggestions;
+      }
     }
 
     const normalizedTimeRange = (!timeRange || isNoTimeRangeOverride(timeRange)) ? undefined : onSubmittingTimerange(timeRange);
@@ -185,7 +197,8 @@ class FieldValueCompletion implements Completer {
         name: value,
         value: value,
         score: occurrence,
-        meta: `${occurrence} (occ)`,
+        caption: completionCaption(value, input),
+        meta: `${occurrence} hits`,
       }));
 
       this.previousSuggestions = {

--- a/graylog2-web-interface/src/views/components/searchbar/completions/FieldValueCompletion.ts
+++ b/graylog2-web-interface/src/views/components/searchbar/completions/FieldValueCompletion.ts
@@ -140,9 +140,10 @@ class FieldValueCompletion implements Completer {
       streams: prevStreams,
       timeRange: prevTimeRange,
       furtherSuggestionsCount,
+      input: prevInput,
     } = this.previousSuggestions;
 
-    return String(input).startsWith(String(this.previousSuggestions?.input))
+    return String(input).startsWith(String(prevInput))
       && prevFieldName === fieldName
       && isEqual(prevStreams, streams)
       && isEqual(prevTimeRange, timeRange)

--- a/graylog2-web-interface/src/views/components/searchbar/completions/FieldValueCompletion.ts
+++ b/graylog2-web-interface/src/views/components/searchbar/completions/FieldValueCompletion.ts
@@ -160,9 +160,20 @@ class FieldValueCompletion implements Completer {
   };
 
   shouldShowCompletions = (currentLine: number, lines: Array<Array<Line>>) => {
-    const currentToken = lines[currentLine - 1].find((token) => token?.start !== undefined);
+    console.log('shouldShowCompletions', currentLine, lines);
+    const currentLineTokens = lines[currentLine - 1];
+    const currentTokenIndex = currentLineTokens.findIndex((token) => token?.start !== undefined);
+    const currentToken = currentLineTokens[currentTokenIndex];
 
-    return currentToken?.type === 'keyword' && currentToken?.value.endsWith(':');
+    if (!currentToken) {
+      return false;
+    }
+
+    const previousToken = currentLineTokens[currentTokenIndex - 1];
+    const currentTokenIsFieldName = currentToken?.type === 'keyword' && currentToken?.value.endsWith(':');
+    const currentTokenIsFieldValue = currentToken?.type === 'term' && previousToken?.type === 'keyword';
+
+    return currentTokenIsFieldName || currentTokenIsFieldValue;
   }
 }
 

--- a/graylog2-web-interface/src/views/components/searchbar/completions/FieldValueCompletion.ts
+++ b/graylog2-web-interface/src/views/components/searchbar/completions/FieldValueCompletion.ts
@@ -84,7 +84,7 @@ class FieldValueCompletion implements Completer {
 
   fields: FieldTypesStoreState;
 
-  previousState: undefined | {
+  previousSuggestions: undefined | {
     furtherSuggestionsCount: number,
     completions: Array<CompletionResult>,
     fieldName: string,
@@ -123,7 +123,7 @@ class FieldValueCompletion implements Completer {
     streams: Array<string> | undefined,
     timeRange: TimeRange | NoTimeRangeOverride | undefined,
   ) {
-    if (!this.previousState) {
+    if (!this.previousSuggestions) {
       return false;
     }
 
@@ -132,9 +132,9 @@ class FieldValueCompletion implements Completer {
       streams: prevStreams,
       timeRange: prevTimeRange,
       furtherSuggestionsCount,
-    } = this.previousState;
+    } = this.previousSuggestions;
 
-    return String(input).startsWith(String(this.previousState?.input))
+    return String(input).startsWith(String(this.previousSuggestions?.input))
       && prevFieldName === fieldName
       && isEqual(prevStreams, streams)
       && isEqual(prevTimeRange, timeRange)
@@ -142,8 +142,8 @@ class FieldValueCompletion implements Completer {
   }
 
   filterExistingSuggestions(input: string | number) {
-    if (this.previousState) {
-      return this.previousState.completions.filter((completion) => completion.name.startsWith(String(input)));
+    if (this.previousSuggestions) {
+      return this.previousSuggestions.completions.filter((completion) => completion.name.startsWith(String(input)));
     }
 
     return [];
@@ -188,7 +188,7 @@ class FieldValueCompletion implements Completer {
         meta: `${occurrence} (occ)`,
       }));
 
-      this.previousState = {
+      this.previousSuggestions = {
         furtherSuggestionsCount,
         streams,
         timeRange,


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Please note, this PR needs be tested together with https://github.com/Graylog2/graylog2-server/pull/11959 or after the PR has been merged.

As described in https://github.com/Graylog2/graylog2-server/issues/11850 we are currently only fetching the 10 most important field value suggestions after writing the field name in a search query.

With this PR we are now fetching 30 suggestions and we are refetching the suggestions when the user continues typing in a more specific field value prefix. We only fetch more suggestions, when we did not fetched all suggestions with the first request.

We are also displaying spelling corrections slightly different than suggestions which are just based on the field value prefix. These corrections include the currently defined field value name in their caption. This is necessary, because otherwise they would be filtered by the ace editor.


Fixes https://github.com/Graylog2/graylog2-server/issues/11850
