### PR TITLE
Implement new components to display times relatively and based on the browser time zone.

### DIFF
--- a/graylog2-web-interface/src/components/common/BrowserTime.test.tsx
+++ b/graylog2-web-interface/src/components/common/BrowserTime.test.tsx
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import { render, screen } from 'wrappedTestingLibrary';
+
+import BrowserTime from './BrowserTime';
+
+jest.mock('util/DateTime', () => {
+  const DateTime = jest.requireActual('util/DateTime');
+  DateTime.getBrowserTimezone('America/Chicago');
+
+  return DateTime;
+});
+
+describe('BrowserTime', () => {
+  it('should display browser time', () => {
+    render(
+      <BrowserTime dateTime="2020-01-01T10:00:00.000Z" />,
+    );
+
+    expect(screen.getByText('2020-01-01 04:00:00')).toBeInTheDocument();
+  });
+
+  it('should display browser time in a specific format', () => {
+    render(
+      <BrowserTime dateTime="2020-01-01T10:00:00.000Z" format="withTz" />,
+    );
+
+    expect(screen.getByText('2020-01-01 04:00:00 -06:00')).toBeInTheDocument();
+  });
+});

--- a/graylog2-web-interface/src/components/common/BrowserTime.tsx
+++ b/graylog2-web-interface/src/components/common/BrowserTime.tsx
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import PropTypes from 'prop-types';
+import type { Moment } from 'moment';
+
+import type { DateTimeFormats } from 'util/DateTime';
+import { formatAsBrowserTime, adjustFormat } from 'util/DateTime';
+
+type Props = {
+  dateTime: string | number | Date | Moment,
+  format?: DateTimeFormats,
+};
+
+/**
+ * This component receives any date time and displays it in the browser time zone.
+ */
+const BrowserTime = ({ dateTime, format }: Props) => {
+  const dateTimeString = adjustFormat(dateTime, 'internal');
+  const timeInBrowserTimeZone = formatAsBrowserTime(dateTime, format);
+
+  return (
+    <time dateTime={dateTimeString} title={String(dateTime)}>
+      {timeInBrowserTimeZone}
+    </time>
+  );
+};
+
+BrowserTime.propTypes = {
+  /**
+   * Date time to be displayed in the component. You can provide an ISO
+   * 8601 string, a JS native `Date` object, a moment `Date` object, or
+   * a number containing seconds after UNIX epoch.
+   */
+  dateTime: PropTypes.oneOfType([PropTypes.string, PropTypes.object, PropTypes.number]).isRequired,
+  /**
+   * Format to use to represent the date time.
+   */
+  format: PropTypes.string,
+};
+
+BrowserTime.defaultProps = {
+  format: 'default',
+};
+
+export default BrowserTime;

--- a/graylog2-web-interface/src/components/common/BrowserTime.tsx
+++ b/graylog2-web-interface/src/components/common/BrowserTime.tsx
@@ -34,7 +34,7 @@ const BrowserTime = ({ dateTime, format }: Props) => {
   const timeInBrowserTimeZone = formatAsBrowserTime(dateTime, format);
 
   return (
-    <time dateTime={dateTimeString} title={String(dateTime)}>
+    <time dateTime={dateTimeString} title={dateTimeString}>
       {timeInBrowserTimeZone}
     </time>
   );

--- a/graylog2-web-interface/src/components/common/RelativeTime.test.tsx
+++ b/graylog2-web-interface/src/components/common/RelativeTime.test.tsx
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import { render, screen } from 'wrappedTestingLibrary';
+
+import RelativeTime from './RelativeTime';
+
+const mockedUnixTime = 1577836800000; // 2020-01-01 00:00:00.000
+
+jest.useFakeTimers()
+  // @ts-expect-error
+  .setSystemTime(mockedUnixTime);
+
+describe('RelativeTime', () => {
+  it('should display relative time', () => {
+    render(
+      <RelativeTime dateTime="2019-01-01 10:00:00" />,
+    );
+
+    expect(screen.getByText('a year ago')).toBeInTheDocument();
+  });
+});

--- a/graylog2-web-interface/src/components/common/RelativeTime.tsx
+++ b/graylog2-web-interface/src/components/common/RelativeTime.tsx
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import PropTypes from 'prop-types';
+import type { Moment } from 'moment';
+
+import { relativeDifference, adjustFormat } from 'util/DateTime';
+
+type Props = {
+  dateTime: string | number | Date | Moment,
+};
+
+/**
+ * This component receives any date time and displays the relative time until now in a human readable format.
+ */
+
+const RelativeTime = ({ dateTime }: Props) => {
+  const relativeTime = relativeDifference(dateTime);
+  const dateTimeString = adjustFormat(dateTime, 'internal');
+
+  return (
+    <time dateTime={dateTimeString}>{relativeTime}</time>
+  );
+};
+
+RelativeTime.propTypes = {
+  /**
+   * Date time to be displayed in the component. You can provide an ISO
+   * 8601 string, a JS native `Date` object, a moment `Date` object, or
+   * a number containing seconds after UNIX epoch.
+   */
+  dateTime: PropTypes.oneOfType([PropTypes.string, PropTypes.object, PropTypes.number]).isRequired,
+};
+
+export default RelativeTime;

--- a/graylog2-web-interface/src/components/common/RelativeTime.tsx
+++ b/graylog2-web-interface/src/components/common/RelativeTime.tsx
@@ -33,7 +33,9 @@ const RelativeTime = ({ dateTime }: Props) => {
   const dateTimeString = adjustFormat(dateTime, 'internal');
 
   return (
-    <time dateTime={dateTimeString}>{relativeTime}</time>
+    <time dateTime={dateTimeString} title={dateTimeString}>
+      {relativeTime}
+    </time>
   );
 };
 

--- a/graylog2-web-interface/src/components/common/index.tsx
+++ b/graylog2-web-interface/src/components/common/index.tsx
@@ -21,6 +21,7 @@ const SourceCodeEditor = loadAsync(() => import('./SourceCodeEditor'));
 export { SourceCodeEditor };
 export { default as Accordion } from './Accordion';
 export { default as AccordionItem } from './AccordionItem';
+export { default as BrowserTime } from './BrowserTime';
 export { default as Center } from './Center';
 export { default as ClipboardButton } from './ClipboardButton';
 export { default as ColorPicker } from './ColorPicker';

--- a/graylog2-web-interface/src/components/common/index.tsx
+++ b/graylog2-web-interface/src/components/common/index.tsx
@@ -82,6 +82,7 @@ export { default as Portal } from './Portal';
 export { default as QueryHelper } from './QueryHelper';
 export { default as ReactGridContainer } from './ReactGridContainer';
 export { default as ReadOnlyFormGroup } from './ReadOnlyFormGroup';
+export { default as RelativeTime } from './RelativeTime';
 export { default as ScrollButton } from './ScrollButton';
 export { default as SearchForm } from './SearchForm';
 export { default as Select } from './Select';

--- a/graylog2-web-interface/src/components/indexers/IndexerFailure.jsx
+++ b/graylog2-web-interface/src/components/indexers/IndexerFailure.jsx
@@ -17,7 +17,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import { Timestamp } from 'components/common';
+import RelativeTime from 'components/common/RelativeTime';
 
 class IndexerFailure extends React.Component {
   static propTypes = {
@@ -29,7 +29,9 @@ class IndexerFailure extends React.Component {
 
     return (
       <tr>
-        <td title={failure.timestamp}><Timestamp dateTime={failure.timestamp} relative /></td>
+        <td title={failure.timestamp}>
+          <RelativeTime dateTime={failure.timestamp} />
+        </td>
         <td>{failure.index}</td>
         <td>{failure.letter_id}</td>
         <td>{failure.message}</td>

--- a/graylog2-web-interface/src/components/indexers/IndexerFailure.jsx
+++ b/graylog2-web-interface/src/components/indexers/IndexerFailure.jsx
@@ -29,9 +29,7 @@ class IndexerFailure extends React.Component {
 
     return (
       <tr>
-        <td title={failure.timestamp}>
-          <RelativeTime dateTime={failure.timestamp} />
-        </td>
+        <td><RelativeTime dateTime={failure.timestamp} /></td>
         <td>{failure.index}</td>
         <td>{failure.letter_id}</td>
         <td>{failure.message}</td>

--- a/graylog2-web-interface/src/components/indices/IndexRangeSummary.jsx
+++ b/graylog2-web-interface/src/components/indices/IndexRangeSummary.jsx
@@ -17,7 +17,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import { Timestamp } from 'components/common';
+import RelativeTime from 'components/common/RelativeTime';
 
 class IndexRangeSummary extends React.Component {
   static propTypes = {
@@ -33,7 +33,9 @@ class IndexRangeSummary extends React.Component {
 
     return (
       <span>Range re-calculated{' '}
-        <span title={indexRange.calculated_at}><Timestamp dateTime={indexRange.calculated_at} relative /></span>{' '}
+        <span title={indexRange.calculated_at}>
+          <RelativeTime dateTime={indexRange.calculated_at} />
+        </span>{' '}
         in {indexRange.took_ms}ms.
       </span>
     );

--- a/graylog2-web-interface/src/components/indices/IndexRangeSummary.jsx
+++ b/graylog2-web-interface/src/components/indices/IndexRangeSummary.jsx
@@ -33,9 +33,7 @@ class IndexRangeSummary extends React.Component {
 
     return (
       <span>Range re-calculated{' '}
-        <span title={indexRange.calculated_at}>
-          <RelativeTime dateTime={indexRange.calculated_at} />
-        </span>{' '}
+        <RelativeTime dateTime={indexRange.calculated_at} />{' '}
         in {indexRange.took_ms}ms.
       </span>
     );

--- a/graylog2-web-interface/src/components/indices/IndexSummary.jsx
+++ b/graylog2-web-interface/src/components/indices/IndexSummary.jsx
@@ -18,8 +18,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import { Label } from 'components/bootstrap';
-import { Timestamp, Icon } from 'components/common';
-import DateTime from 'logic/datetimes/DateTime';
+import { RelativeTime, Icon } from 'components/common';
 import { IndexSizeSummary } from 'components/indices';
 
 class IndexSummary extends React.Component {
@@ -53,7 +52,7 @@ class IndexSummary extends React.Component {
 
   _formatIndexRange = () => {
     if (this.props.isDeflector) {
-      return <span>Contains messages up to <Timestamp dateTime={new DateTime().toISOString()} relative /></span>;
+      return <span>Contains messages up to <RelativeTime dateTime={new Date()} /></span>;
     }
 
     const sizes = this.props.index.size;
@@ -72,13 +71,13 @@ class IndexSummary extends React.Component {
     }
 
     if (this.props.indexRange.begin === 0) {
-      return <span>Contains messages up to <Timestamp dateTime={this.props.indexRange.end} relative /></span>;
+      return <span>Contains messages up to <RelativeTime dateTime={this.props.indexRange.end} /></span>;
     }
 
     return (
       <span>
-        Contains messages from <Timestamp dateTime={this.props.indexRange.begin} relative /> up to{' '}
-        <Timestamp dateTime={this.props.indexRange.end} relative />
+        Contains messages from <RelativeTime dateTime={this.props.indexRange.begin} /> up to{' '}
+        <RelativeTime dateTime={this.props.indexRange.end} />
       </span>
     );
   };

--- a/graylog2-web-interface/src/components/nodes/JournalDetails.jsx
+++ b/graylog2-web-interface/src/components/nodes/JournalDetails.jsx
@@ -26,7 +26,7 @@ import styled from 'styled-components';
 
 import { Link } from 'components/common/router';
 import { Row, Col, Alert } from 'components/bootstrap';
-import { Spinner, Timestamp, Icon } from 'components/common';
+import { Spinner, RelativeTime, Icon } from 'components/common';
 import ProgressBar, { Bar } from 'components/common/ProgressBar';
 import MetricsExtractor from 'logic/metrics/MetricsExtractor';
 import NumberUtils from 'util/NumberUtils';
@@ -147,7 +147,7 @@ const JournalDetails = createReactClass({
             <dt>Path:</dt>
             <dd>{journalInformation.journal_config.directory}</dd>
             <dt>Earliest entry:</dt>
-            <dd><Timestamp dateTime={oldestSegment} relative /></dd>
+            <dd><RelativeTime dateTime={oldestSegment} /></dd>
             <dt>Maximum size:</dt>
             <dd>{NumberUtils.formatBytes(journalInformation.journal_config.max_size)}</dd>
             <dt>Maximum age:</dt>

--- a/graylog2-web-interface/src/components/nodes/RestApiOverview.jsx
+++ b/graylog2-web-interface/src/components/nodes/RestApiOverview.jsx
@@ -18,7 +18,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'styled-components';
 
-import { Timestamp } from 'components/common';
+import RelativeTime from 'components/common/RelativeTime';
 
 const StyledDl = styled.dl`
   margin-top: 5px;
@@ -41,7 +41,7 @@ const RestApiOverview = ({ node }) => {
       <dt>Transport address:</dt>
       <dd>{transport_address}</dd>
       <dt>Last seen:</dt>
-      <dd><Timestamp dateTime={last_seen} relative /></dd>
+      <dd><RelativeTime dateTime={last_seen} /></dd>
     </StyledDl>
   );
 };

--- a/graylog2-web-interface/src/components/notifications/Notification.jsx
+++ b/graylog2-web-interface/src/components/notifications/Notification.jsx
@@ -19,7 +19,7 @@ import React from 'react';
 import styled, { css } from 'styled-components';
 
 import { Alert, Button } from 'components/bootstrap';
-import { Timestamp, Icon } from 'components/common';
+import { RelativeTime, Icon } from 'components/common';
 import NotificationsFactory from 'logic/notifications/NotificationsFactory';
 import { NotificationsActions } from 'stores/notifications/NotificationsStore';
 
@@ -77,7 +77,7 @@ class Notification extends React.Component {
           {notificationView.title}{' '}
 
           <NotificationTimestamp>
-            (triggered <Timestamp dateTime={notification.timestamp} relative />)
+            (triggered <RelativeTime dateTime={notification.timestamp} />)
           </NotificationTimestamp>
         </NotificationHead>
         <div className="notification-description">

--- a/graylog2-web-interface/src/components/pipelines/PipelineDetails.tsx
+++ b/graylog2-web-interface/src/components/pipelines/PipelineDetails.tsx
@@ -19,7 +19,7 @@ import React from 'react';
 import styled from 'styled-components';
 
 import { Row, Col } from 'components/bootstrap';
-import { Timestamp } from 'components/common';
+import { RelativeTime } from 'components/common';
 import { MetricContainer, CounterRate } from 'components/metrics';
 import type { PipelineType } from 'stores/pipelines/PipelinesStore';
 
@@ -71,9 +71,9 @@ const PipelineDetails = ({ pipeline, create, onChange, onCancel }: Props) => {
             <dt>Description</dt>
             <dd>{pipeline.description}</dd>
             <dt>Created</dt>
-            <dd><Timestamp dateTime={pipeline.created_at} relative /></dd>
+            <dd><RelativeTime dateTime={pipeline.created_at} /></dd>
             <dt>Last modified</dt>
-            <dd><Timestamp dateTime={pipeline.modified_at} relative /></dd>
+            <dd><RelativeTime dateTime={pipeline.modified_at} /></dd>
             <dt>Current throughput</dt>
             <dd>
               <MetricContainer name={`org.graylog.plugins.pipelineprocessor.ast.Pipeline.${pipeline.id}.executed`}>

--- a/graylog2-web-interface/src/components/rules/RuleListEntry.tsx
+++ b/graylog2-web-interface/src/components/rules/RuleListEntry.tsx
@@ -20,7 +20,7 @@ import styled, { css } from 'styled-components';
 
 import { LinkContainer, Link } from 'components/common/router';
 import { MetricContainer, CounterRate } from 'components/metrics';
-import { Timestamp, OverlayTrigger, CountBadge } from 'components/common';
+import { RelativeTime, OverlayTrigger, CountBadge } from 'components/common';
 import { Button, ButtonToolbar, Tooltip } from 'components/bootstrap';
 import Routes from 'routing/Routes';
 import type { RuleType, PipelineSummary } from 'stores/rules/RulesStore';
@@ -86,8 +86,8 @@ const RuleListEntry = ({ rule, onDelete, usingPipelines }: Props) => {
         </Link>
       </td>
       <td className="limited">{description}</td>
-      <td className="limited"><Timestamp dateTime={created_at} relative /></td>
-      <td className="limited"><Timestamp dateTime={modified_at} relative /></td>
+      <td className="limited"><RelativeTime dateTime={created_at} /></td>
+      <td className="limited"><RelativeTime dateTime={modified_at} /></td>
       <td>
         <MetricContainer name={`org.graylog.plugins.pipelineprocessor.ast.Rule.${id}.executed`} zeroOnMissing>
           <CounterRate suffix="msg/s" />

--- a/graylog2-web-interface/src/components/sidecars/sidecars/SidecarRow.jsx
+++ b/graylog2-web-interface/src/components/sidecars/sidecars/SidecarRow.jsx
@@ -20,7 +20,7 @@ import styled, { css } from 'styled-components';
 
 import { Link, LinkContainer } from 'components/common/router';
 import { Button, ButtonToolbar } from 'components/bootstrap';
-import { Timestamp } from 'components/common';
+import { RelativeTime, Timestamp } from 'components/common';
 import Routes from 'routing/Routes';
 import OperatingSystemIcon from 'components/sidecars/common/OperatingSystemIcon';
 import StatusIndicator from 'components/sidecars/common/StatusIndicator';
@@ -90,7 +90,9 @@ class SidecarRow extends React.Component {
           {sidecar.node_details.operating_system}
         </td>
         <td>
-          <Timestamp dateTime={sidecar.last_seen} relative={showRelativeTime} />
+          {showRelativeTime
+            ? <RelativeTime dateTime={sidecar.last_seen} />
+            : <Timestamp dateTime={sidecar.last_seen} />}
         </td>
         <td>
           {sidecar.node_id}

--- a/graylog2-web-interface/src/components/systemjobs/SystemJob.jsx
+++ b/graylog2-web-interface/src/components/systemjobs/SystemJob.jsx
@@ -18,7 +18,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
-import { ProgressBar, LinkToNode, Timestamp, Icon } from 'components/common';
+import { ProgressBar, LinkToNode, RelativeTime, Icon } from 'components/common';
 import { Button } from 'components/bootstrap';
 import { SystemJobsActions } from 'stores/systemjobs/SystemJobsStore';
 
@@ -70,7 +70,7 @@ class SystemJob extends React.Component {
           <Icon name="cog" />{' '}
           <span data-toggle="tooltip" title={job.name}>{job.info}</span>{' '}
           - Started on <LinkToNode nodeId={job.node_id} />{' '}
-          <Timestamp dateTime={job.started_at} relative />{' '}
+          <RelativeTime dateTime={job.started_at} />{' '}
           {cancel}
         </JobWrap>
 

--- a/graylog2-web-interface/src/components/times/TimesList.jsx
+++ b/graylog2-web-interface/src/components/times/TimesList.jsx
@@ -20,7 +20,7 @@ import Reflux from 'reflux';
 import moment from 'moment';
 
 import { Col, Row } from 'components/bootstrap';
-import { Spinner, Timestamp } from 'components/common';
+import { Spinner, Timestamp, BrowserTime } from 'components/common';
 import DateTime from 'logic/datetimes/DateTime';
 import { CurrentUserStore } from 'stores/users/CurrentUserStore';
 import { SystemStore } from 'stores/system/SystemStore';
@@ -65,7 +65,7 @@ const TimesList = createReactClass({
             <dt>User <em>{currentUser.username}</em>:</dt>
             <dd><Timestamp dateTime={time} format={timeFormat} /></dd>
             <dt>Your web browser:</dt>
-            <dd><Timestamp dateTime={time} format={timeFormat} tz="browser" /></dd>
+            <dd><BrowserTime dateTime={time} format={timeFormat} /></dd>
             <dt>Graylog server:</dt>
             <dd><Timestamp dateTime={time} format={timeFormat} tz={serverTimezone} /></dd>
           </dl>

--- a/graylog2-web-interface/src/components/users/TokenList.test.jsx
+++ b/graylog2-web-interface/src/components/users/TokenList.test.jsx
@@ -80,7 +80,7 @@ describe('<TokenList />', () => {
   it('show include token last access time', () => {
     const wrapper = mount(<TokenList tokens={tokens} />);
 
-    expect(wrapper.find(`time[dateTime="${tokens[0].last_access}"]`)).toHaveLength(1);
+    expect(wrapper.find('time[dateTime="2020-12-08T16:46:00.000+00:00"]')).toHaveLength(1);
     expect(wrapper.find('div[children="Never used"]')).toHaveLength(1);
 
     expect(wrapper).toExist();

--- a/graylog2-web-interface/src/components/users/TokenList.tsx
+++ b/graylog2-web-interface/src/components/users/TokenList.tsx
@@ -18,7 +18,7 @@ import PropTypes from 'prop-types';
 import React, { useMemo, useState } from 'react';
 import styled from 'styled-components';
 
-import { ClipboardButton, ControlledTableList, Icon, Timestamp, SearchForm, Spinner } from 'components/common';
+import { ClipboardButton, ControlledTableList, Icon, RelativeTime, SearchForm, Spinner } from 'components/common';
 import { Button, Col, Panel, Row } from 'components/bootstrap';
 import type { Token, TokenSummary } from 'stores/users/UsersStore';
 import { sortByDate } from 'util/SortUtils';
@@ -131,7 +131,7 @@ const TokenList = ({ creatingToken, deletingToken, onCreate, onDelete, tokens }:
                 <Col md={9}>
                   {token.name}
                   <StyledLastAccess>
-                    {tokenNeverUsed ? 'Never used' : <>Last used <Timestamp dateTime={token.last_access} relative /></>}
+                    {tokenNeverUsed ? 'Never used' : <>Last used <RelativeTime dateTime={token.last_access} /></>}
                   </StyledLastAccess>
                 </Col>
                 <Col md={3} className="text-right">

--- a/graylog2-web-interface/src/components/users/UsersOverview/UserOverviewItem/LoggedInCell.tsx
+++ b/graylog2-web-interface/src/components/users/UsersOverview/UserOverviewItem/LoggedInCell.tsx
@@ -19,7 +19,7 @@ import styled from 'styled-components';
 import type { $PropertyType } from 'utility-types';
 
 import type UserOverview from 'logic/users/UserOverview';
-import { OverlayTrigger, Timestamp } from 'components/common';
+import { OverlayTrigger, RelativeTime } from 'components/common';
 import { Popover } from 'components/bootstrap';
 
 import LoggedInIcon from '../../LoggedInIcon';
@@ -46,7 +46,7 @@ const LoggedInCell = ({ lastActivity, sessionActive, clientAddress }: Props) => 
                           {sessionActive ? (
                             <>
                               <div>Last activity: {lastActivity
-                                ? <Timestamp dateTime={lastActivity} relative /> : '-'}
+                                ? <RelativeTime dateTime={lastActivity} /> : '-'}
                               </div>
                               <div>Client address: {clientAddress ?? '-'}</div>
                             </>


### PR DESCRIPTION
Please note:
- this PR needs to be tested together with https://github.com/Graylog2/graylog-plugin-enterprise/pull/3121

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

With https://github.com/Graylog2/graylog2-server/pull/11986 we added date time utility functions. With this PR are creating the `RelativeTime` and `BrowserTime` components which are basically just wrapper for these utility functions.

Before this change the `Timestamp` component was responsible for displaying relative times and times based on the user time zone. In a follow-up PR we will refactor the `Timestamp` in a way it will only be responsible to display a time based on the user time zone. This way we can separate the concerns.
 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

