### PR TITLE
Simplify `Timestamp` component and unify format of timestamps displayed in the UI.

### DIFF
--- a/graylog2-web-interface/src/components/alarmcallbacks/AlarmCallbackHistory.jsx
+++ b/graylog2-web-interface/src/components/alarmcallbacks/AlarmCallbackHistory.jsx
@@ -44,8 +44,8 @@ class AlarmCallbackHistory extends React.Component {
       </span>
     );
     const description = (hadError
-      ? <span>Error sending notification at <Timestamp dateTime={history.created_at} format={DateTime.Formats.DATETIME} />: {history.result.error}</span>
-      : <span>Notification was sent successfully at <Timestamp dateTime={history.created_at} format={DateTime.Formats.DATETIME} />.</span>);
+      ? <span>Error sending notification at <Timestamp dateTime={history.created_at} />: {history.result.error}</span>
+      : <span>Notification was sent successfully at <Timestamp dateTime={history.created_at} />.</span>);
 
     let configurationWell;
     let configurationInfo;

--- a/graylog2-web-interface/src/components/alerts/Alert.jsx
+++ b/graylog2-web-interface/src/components/alerts/Alert.jsx
@@ -72,14 +72,14 @@ class Alert extends React.Component {
       statusBadge = <Label bsStyle="danger">Unresolved</Label>;
     }
 
-    let alertTime = <Timestamp dateTime={alert.triggered_at} format={DateTime.Formats.DATETIME} />;
+    let alertTime = <Timestamp dateTime={alert.triggered_at} />;
 
     if (alert.is_interval) {
       alertTime = (
         <span>
           Triggered at {alertTime},&nbsp;
           {alert.resolved_at
-            ? <span>resolved at <Timestamp dateTime={alert.resolved_at} format={DateTime.Formats.DATETIME} />.</span>
+            ? <span>resolved at <Timestamp dateTime={alert.resolved_at} />.</span>
             : <span><strong>still ongoing</strong>.</span>}
         </span>
       );

--- a/graylog2-web-interface/src/components/alerts/AlertMessages.jsx
+++ b/graylog2-web-interface/src/components/alerts/AlertMessages.jsx
@@ -107,8 +107,8 @@ class AlertMessages extends React.Component {
     return (
       <span>
         (
-        <Timestamp dateTime={this._getFrom()} format={DateTime.Formats.DATETIME} />&nbsp;&#8211;&nbsp;
-        <Timestamp dateTime={this._getTo()} format={DateTime.Formats.DATETIME} />
+        <Timestamp dateTime={this._getFrom()} />&nbsp;&#8211;&nbsp;
+        <Timestamp dateTime={this._getTo()} />
         )
       </span>
     );

--- a/graylog2-web-interface/src/components/common/Timestamp.test.tsx
+++ b/graylog2-web-interface/src/components/common/Timestamp.test.tsx
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import { render, screen } from 'wrappedTestingLibrary';
+
+import Timestamp from './Timestamp';
+
+jest.mock('hooks/useUserDateTime');
+
+describe('Timestamp', () => {
+  it('should render date time', () => {
+    render(<Timestamp dateTime="2020-01-01T10:00:00.000Z" />);
+
+    expect(screen.getByText('2020-01-01 10:00:00')).toBeInTheDocument();
+  });
+
+  it('should render date time based on defined time zone', () => {
+    render(<Timestamp dateTime="2020-01-01T10:00:00.000Z" tz="Europe/Moscow" />);
+
+    expect(screen.getByText('2020-01-01 13:00:00')).toBeInTheDocument();
+  });
+
+  it('should render date time in a defined format and based on defined time zone', () => {
+    render(<Timestamp dateTime="2020-01-01T10:00:00.000Z" format="internal" tz="Europe/Moscow" />);
+
+    expect(screen.getByText('2020-01-01T13:00:00.000+03:00')).toBeInTheDocument();
+  });
+});

--- a/graylog2-web-interface/src/components/common/Timestamp.tsx
+++ b/graylog2-web-interface/src/components/common/Timestamp.tsx
@@ -45,7 +45,7 @@ type Props = {
  */
 const Timestamp = ({ dateTime, field, format, render: Component, tz }: Props) => {
   const { formatTime: formatWithUserTz } = useUserDateTime();
-  const formattedDateTime = tz ? adjustFormat(dateTime, format) : formatWithUserTz(dateTime, format);
+  const formattedDateTime = tz ? adjustFormat(dateTime, format, tz) : formatWithUserTz(dateTime, format);
   const dateTimeString = adjustFormat(dateTime, 'internal');
 
   return (

--- a/graylog2-web-interface/src/components/common/Timestamp.tsx
+++ b/graylog2-web-interface/src/components/common/Timestamp.tsx
@@ -31,16 +31,13 @@ type Props = {
 }
 
 /**
- * Component that renders a `time` HTML element with a given date time. It is
- * capable of render date times in different formats, accepting ISO 8601
+ * Component that renders a given date time based on the user time zone in a `time` HTML element.
+ * It is capable of render date times in different formats, accepting ISO 8601
  * strings, JS native Date objects, and Moment.js Date objects.
  *
- * The component can display the date time in different formats, and also can
- * show the relative time from/until now.
- *
- * It is also possible to change the time zone for the given date, something
- * that helps, for instance, to display a local time from a UTC time that
- * was used in the server.
+ * While the component is using the user time zone by default, it is also possible
+ * to change the time zone for the given date, something that helps, for instance, to display a local time
+ * from a UTC time that was used in the server.
  *
  */
 const Timestamp = ({ dateTime, field, format, render: Component, tz }: Props) => {
@@ -63,13 +60,14 @@ Timestamp.propTypes = {
    */
   dateTime: PropTypes.oneOfType([PropTypes.string, PropTypes.object, PropTypes.number]).isRequired,
   /**
-   * Format to use to represent the date time.
+   * Format to represent the date time.
    */
   format: PropTypes.string,
   /** Provides field prop for the render function. */
   field: PropTypes.string,
   /**
-   * Specifies the timezone to convert `dateTime`.
+   * Specifies the time zone to convert `dateTime` to.
+   * If not defined the user zone will be used.
    */
   tz: PropTypes.string,
   /**

--- a/graylog2-web-interface/src/components/common/Timestamp.tsx
+++ b/graylog2-web-interface/src/components/common/Timestamp.tsx
@@ -16,34 +16,16 @@
  */
 import PropTypes from 'prop-types';
 import * as React from 'react';
-import { useMemo } from 'react';
 import type { Moment } from 'moment';
 
-import DateTime from 'logic/datetimes/DateTime';
-
-export const formatDateTime = (dateTime, format, tz, relative = false): string => {
-  const _dateTime = new DateTime(dateTime);
-
-  if (relative) {
-    return _dateTime.toRelativeString();
-  }
-
-  switch (tz) {
-    case null:
-    case undefined:
-      return _dateTime.toString(format);
-    case 'browser':
-      return _dateTime.toBrowserLocalTime().toString(format);
-    default:
-      return _dateTime.toTimeZone(tz).toString(format);
-  }
-};
+import type { DateTimeFormats } from 'util/DateTime';
+import useUserDateTime from 'hooks/useUserDateTime';
+import { adjustFormat } from 'util/DateTime';
 
 type Props = {
   dateTime: string | number | Date | Moment,
   field?: string,
-  format?: string,
-  relative?: boolean,
+  format?: DateTimeFormats,
   render?: React.ComponentType<{ value: string, field: string | undefined }>,
   tz?: string,
 }
@@ -61,14 +43,13 @@ type Props = {
  * was used in the server.
  *
  */
-const Timestamp = ({ dateTime, field, format, relative, render: Component, tz }: Props) => {
-  const formattedDateTime = useMemo(
-    () => formatDateTime(dateTime, format, tz, relative),
-    [dateTime, format, tz, relative],
-  );
+const Timestamp = ({ dateTime, field, format, render: Component, tz }: Props) => {
+  const { formatTime: formatWithUserTz } = useUserDateTime();
+  const formattedDateTime = tz ? adjustFormat(dateTime, format) : formatWithUserTz(dateTime, format);
+  const dateTimeString = adjustFormat(dateTime, 'internal');
 
   return (
-    <time key={`time-${dateTime}`} dateTime={String(dateTime)} title={String(dateTime)}>
+    <time dateTime={dateTimeString} title={dateTimeString}>
       <Component value={formattedDateTime} field={field} />
     </time>
   );
@@ -82,27 +63,13 @@ Timestamp.propTypes = {
    */
   dateTime: PropTypes.oneOfType([PropTypes.string, PropTypes.object, PropTypes.number]).isRequired,
   /**
-   * Format to use to represent the date time. It supports any format
-   * supported by momentjs http://momentjs.com/docs/#/displaying/format/.
-   * We also provide a list of default formats in 'logic/datetimes/DateTime':
-   *
-   *  - DATE: `YYYY-MM-DD`
-   *  - DATETIME: `YYYY-MM-DD HH:mm:ss`, local times when decimal second precision is not important
-   *  - DATETIME_TZ: `YYYY-MM-DD HH:mm:ss Z`, when decimal second precision is not important, but TZ is
-   *  - TIMESTAMP: `YYYY-MM-DD HH:mm:ss.SSS`, local times when decimal second precision is important (e.g. search results)
-   *  - TIMESTAMP_TZ: `YYYY-MM-DD HH:mm:ss.SSS Z`, when decimal second precision is important, in a different TZ
-   *  - COMPLETE: `dddd D MMMM YYYY, HH:mm ZZ`, easy to read date time
-   *  - ISO_8601: `YYYY-MM-DDTHH:mm:ss.SSSZ`
+   * Format to use to represent the date time.
    */
   format: PropTypes.string,
-  /** Provides field prop for the render function.  */
+  /** Provides field prop for the render function. */
   field: PropTypes.string,
-  /** Specifies if the component should display relative time or not. */
-  relative: PropTypes.bool,
   /**
-   * Specifies the timezone to convert `dateTime`. Use `browser` to
-   * convert the date time to the browser's local time, or one of the
-   * time zones supported by moment timezone.
+   * Specifies the timezone to convert `dateTime`.
    */
   tz: PropTypes.string,
   /**
@@ -113,8 +80,7 @@ Timestamp.propTypes = {
 
 Timestamp.defaultProps = {
   field: undefined,
-  format: DateTime.Formats.TIMESTAMP,
-  relative: false,
+  format: 'default',
   render: ({ value }) => value,
   tz: undefined,
 };

--- a/graylog2-web-interface/src/components/content-packs/ContentPackInstallView.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackInstallView.jsx
@@ -40,7 +40,7 @@ const ContentPackInstallView = (props) => {
             <dt>Installed by:</dt>
             <dd>{createdBy}&nbsp;</dd>
             <dt>Installed at:</dt>
-            <dd><Timestamp dateTime={createdAt} format={DateTime.Formats.COMPLETE} tz="browser" /></dd>
+            <dd><Timestamp dateTime={createdAt} /></dd>
           </dl>
         </Col>
       </Row>

--- a/graylog2-web-interface/src/components/events/events/Events.jsx
+++ b/graylog2-web-interface/src/components/events/events/Events.jsx
@@ -180,7 +180,7 @@ class Events extends React.Component {
           <td>
             {this.renderLinkToEventDefinition(event, eventDefinitionContext)}
           </td>
-          <td><Timestamp dateTime={event.timestamp} format={DateTime.Formats.DATETIME} /></td>
+          <td><Timestamp dateTime={event.timestamp} /></td>
         </CollapsibleTr>
         {expanded.includes(event.id) && (
           <ExpandedTR>

--- a/graylog2-web-interface/src/components/indexers/IndexerFailure.jsx
+++ b/graylog2-web-interface/src/components/indexers/IndexerFailure.jsx
@@ -17,7 +17,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import { Timestamp } from 'components/common';
+import RelativeTime from 'components/common/RelativeTime';
 
 class IndexerFailure extends React.Component {
   static propTypes = {

--- a/graylog2-web-interface/src/components/indexers/IndexerFailure.jsx
+++ b/graylog2-web-interface/src/components/indexers/IndexerFailure.jsx
@@ -17,7 +17,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import RelativeTime from 'components/common/RelativeTime';
+import { Timestamp } from 'components/common';
 
 class IndexerFailure extends React.Component {
   static propTypes = {

--- a/graylog2-web-interface/src/components/indices/IndexRangeSummary.jsx
+++ b/graylog2-web-interface/src/components/indices/IndexRangeSummary.jsx
@@ -17,7 +17,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import { Timestamp } from 'components/common';
+import RelativeTime from 'components/common/RelativeTime';
 
 class IndexRangeSummary extends React.Component {
   static propTypes = {

--- a/graylog2-web-interface/src/components/indices/IndexRangeSummary.jsx
+++ b/graylog2-web-interface/src/components/indices/IndexRangeSummary.jsx
@@ -17,7 +17,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import RelativeTime from 'components/common/RelativeTime';
+import { Timestamp } from 'components/common';
 
 class IndexRangeSummary extends React.Component {
   static propTypes = {

--- a/graylog2-web-interface/src/components/nodes/SystemInformation.jsx
+++ b/graylog2-web-interface/src/components/nodes/SystemInformation.jsx
@@ -85,7 +85,7 @@ class SystemInformation extends React.Component {
         <dt>JVM:</dt>
         <dd>{jvmInformationText}</dd>
         <dt>Time:</dt>
-        <dd><Timestamp dateTime={time} format={DateTime.Formats.DATETIME_TZ} tz={timezone} /></dd>
+        <dd><Timestamp dateTime={time} format="withTz" tz={timezone} /></dd>
       </StyledDl>
     );
   }

--- a/graylog2-web-interface/src/components/sidecars/configuration-forms/ImportsViewModal.jsx
+++ b/graylog2-web-interface/src/components/sidecars/configuration-forms/ImportsViewModal.jsx
@@ -90,7 +90,7 @@ class ImportsViewModal extends React.Component {
           </OverlayTrigger>
         </td>
         <td>{upload.collector_name}</td>
-        <td><Timestamp dateTime={upload.created} format="YYYY-MM-DD HH:mm:ss z" /></td>
+        <td><Timestamp dateTime={upload.created} /></td>
         <td>
           <Button bsStyle="info" bsSize="xsmall" onClick={() => this._onApplyButton(upload.rendered_configuration)}>
             Apply

--- a/graylog2-web-interface/src/components/sidecars/sidecars/SidecarStatusFileList.jsx
+++ b/graylog2-web-interface/src/components/sidecars/sidecars/SidecarStatusFileList.jsx
@@ -47,17 +47,13 @@ class SidecarStatusFileList extends React.Component {
     return (<span><Icon name="file" type="regular" />&nbsp;&nbsp;{file.path}</span>);
   };
 
-  _fileListFormatter = (file) => {
-    const format = 'YYYY-MM-DD HH:mm:ss';
-
-    return (
-      <tr key={file.path} className={this._activityFormatter(file.mod_time)}>
-        <td className="limited"><Timestamp dateTime={file.mod_time} format={format} /></td>
-        <td className="limited">{file.size}</td>
-        <td>{this._dirFormatter(file)}</td>
-      </tr>
-    );
-  };
+  _fileListFormatter = (file) => (
+    <tr key={file.path} className={this._activityFormatter(file.mod_time)}>
+      <td className="limited"><Timestamp dateTime={file.mod_time} /></td>
+      <td className="limited">{file.size}</td>
+      <td>{this._dirFormatter(file)}</td>
+    </tr>
+  );
 
   render() {
     const filterKeys = [];

--- a/graylog2-web-interface/src/components/times/TimesList.jsx
+++ b/graylog2-web-interface/src/components/times/TimesList.jsx
@@ -47,7 +47,7 @@ const TimesList = createReactClass({
     }
 
     const { time } = this.state;
-    const timeFormat = DateTime.Formats.DATETIME_TZ;
+    const timeFormat = 'withTz';
     const { currentUser } = this.state;
     const serverTimezone = this.state.system.timezone;
 

--- a/graylog2-web-interface/src/pages/ShowAlertPage.jsx
+++ b/graylog2-web-interface/src/pages/ShowAlertPage.jsx
@@ -103,7 +103,7 @@ const ShowAlertPage = createReactClass({
       if (resolvedAtTime) {
         resolvedState = (
           <span>
-            This alert was resolved at <Timestamp dateTime={resolvedAtTime} format={DateTime.Formats.DATETIME} />.
+            This alert was resolved at <Timestamp dateTime={resolvedAtTime} />.
           </span>
         );
       }
@@ -113,7 +113,7 @@ const ShowAlertPage = createReactClass({
       resolvedState = (
         <span>
           This alert was triggered at{' '}
-          <Timestamp dateTime={alert.triggered_at} format={DateTime.Formats.DATETIME} />{' '}
+          <Timestamp dateTime={alert.triggered_at} />{' '}
           and is still unresolved.
         </span>
       );

--- a/graylog2-web-interface/src/views/components/DashboardSearchBar.test.tsx
+++ b/graylog2-web-interface/src/views/components/DashboardSearchBar.test.tsx
@@ -31,6 +31,7 @@ import WidgetFocusContext from 'views/components/contexts/WidgetFocusContext';
 import DashboardSearchBar from './DashboardSearchBar';
 
 jest.mock('views/components/ViewActionsMenu', () => () => <span>View Actions</span>);
+jest.mock('hooks/useUserDateTime');
 
 jest.mock('views/stores/GlobalOverrideStore', () => ({
   GlobalOverrideStore: MockStore(),

--- a/graylog2-web-interface/src/views/components/Value.test.tsx
+++ b/graylog2-web-interface/src/views/components/Value.test.tsx
@@ -23,6 +23,8 @@ import FieldType from 'views/logic/fieldtypes/FieldType';
 import Value from './Value';
 import InteractiveContext from './contexts/InteractiveContext';
 
+jest.mock('hooks/useUserDateTime');
+
 describe('Value', () => {
   const openActionsMenu = (value) => {
     userEvent.click(screen.getByText(value));
@@ -46,10 +48,10 @@ describe('Value', () => {
                         render={({ value }) => `The date ${value}`}
                         type={new FieldType('date', [], [])} />);
 
-      openActionsMenu('The date 2018-10-02 09:45:40.000');
+      openActionsMenu('The date 2018-10-02 14:45:40');
       const title = await screen.findByTestId('value-actions-title');
 
-      expect(title).toHaveTextContent('foo = 2018-10-02 09:45:40.000');
+      expect(title).toHaveTextContent('foo = 2018-10-02 14:45:40');
     });
 
     it('renders numeric timestamps with a custom component', async () => {
@@ -118,12 +120,12 @@ describe('Value', () => {
   it.each`
      interactive | value                     | type                                                         | result
      ${true}     | ${42}                     | ${undefined}                                                 | ${'42'}
-     ${true}     | ${'2018-10-02T14:45:40Z'} | ${new FieldType('date', [], [])}    | ${'2018-10-02 09:45:40.000'}
+     ${true}     | ${'2018-10-02T14:45:40Z'} | ${new FieldType('date', [], [])}    | ${'2018-10-02 14:45:40'}
      ${true}     | ${false}                  | ${new FieldType('boolean', [], [])} | ${'false'}
      ${true}     | ${[23, 'foo']}            | ${FieldType.Unknown}                                         | ${'[23,"foo"]'}                
      ${true}     | ${{ foo: 23 }}            | ${FieldType.Unknown}                                         | ${'{"foo":23}'}
      ${false}    | ${42}                     | ${undefined}                                                 | ${'42'}
-     ${false}    | ${'2018-10-02T14:45:40Z'} | ${new FieldType('date', [], [])}    | ${'2018-10-02 09:45:40.000'}
+     ${false}    | ${'2018-10-02T14:45:40Z'} | ${new FieldType('date', [], [])}    | ${'2018-10-02 14:45:40'}
      ${false}    | ${false}                  | ${new FieldType('boolean', [], [])} | ${'false'}
      ${false}    | ${[23, 'foo']}            | ${FieldType.Unknown}                                         | ${'[23,"foo"]'}
      ${false}    | ${{ foo: 23 }}            | ${FieldType.Unknown}                                         | ${'{"foo":23}'}

--- a/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.metric.test.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.metric.test.tsx
@@ -59,6 +59,8 @@ jest.mock('views/stores/ViewMetadataStore', () => ({
   ViewMetadataStore: MockStore(['getInitialState', () => ({ activeQuery: 'queryId' })]),
 }));
 
+jest.mock('hooks/useUserDateTime');
+
 const selectEventConfig = { container: document.body };
 
 const plugin: PluginRegistration = { exports: { visualizationTypes: [dataTable] } };

--- a/graylog2-web-interface/src/views/components/datatable/DataTable.test.tsx
+++ b/graylog2-web-interface/src/views/components/datatable/DataTable.test.tsx
@@ -29,6 +29,8 @@ import DataTable from 'views/components/datatable/DataTable';
 
 import RenderCompletionCallback from '../widgets/RenderCompletionCallback';
 
+jest.mock('hooks/useUserDateTime');
+
 describe('DataTable', () => {
   const currentView = { activeQuery: 'deadbeef-23' };
 

--- a/graylog2-web-interface/src/views/components/datatable/DataTableEntry.test.tsx
+++ b/graylog2-web-interface/src/views/components/datatable/DataTableEntry.test.tsx
@@ -27,6 +27,8 @@ import DataTableEntry from './DataTableEntry';
 
 import EmptyValue from '../EmptyValue';
 
+jest.mock('hooks/useUserDateTime');
+
 const f = (source: string, field: string = source): { field: string, source: string } => ({ field, source });
 const createFields = (fields: Array<string>) => OrderedSet(fields.map((field) => f(field)));
 const fields = createFields(['nf_dst_address', 'count()', 'max(timestamp)', 'card(timestamp)']);

--- a/graylog2-web-interface/src/views/components/messagelist/CustomHighlighting.test.tsx
+++ b/graylog2-web-interface/src/views/components/messagelist/CustomHighlighting.test.tsx
@@ -25,6 +25,8 @@ import { StaticColor } from 'views/logic/views/formatting/highlighting/Highlight
 
 import CustomHighlighting from './CustomHighlighting';
 
+jest.mock('hooks/useUserDateTime');
+
 const renderDecorators = (decorators, field, value) => decorators.map((Decorator) => (
   <Decorator key={Decorator.name}
              type={FieldType.Unknown}

--- a/graylog2-web-interface/src/views/components/messagelist/CustomHighlighting.tsx
+++ b/graylog2-web-interface/src/views/components/messagelist/CustomHighlighting.tsx
@@ -18,14 +18,11 @@ import * as React from 'react';
 import { useContext } from 'react';
 import PropTypes from 'prop-types';
 
-import AppConfig from 'util/AppConfig';
-import DateTime from 'logic/datetimes/DateTime';
 import DecoratorContext from 'views/components/messagelist/decoration/DecoratorContext';
 import HighlightingRulesContext from 'views/components/contexts/HighlightingRulesContext';
-import CurrentUserContext from 'contexts/CurrentUserContext';
 import FieldTypesContext from 'views/components/contexts/FieldTypesContext';
-import { formatDateTime } from 'components/common/Timestamp';
 import FieldType from 'views/logic/fieldtypes/FieldType';
+import useUserDateTime from 'hooks/useUserDateTime';
 
 import PossiblyHighlight from './PossiblyHighlight';
 import Highlight from './Highlight';
@@ -37,10 +34,9 @@ type Props = {
 };
 
 const CustomHighlighting = ({ children, field: fieldName, value: fieldValue }: Props) => {
+  const { formatTime } = useUserDateTime();
   const decorators = [];
   const highlightingRules = useContext(HighlightingRulesContext) ?? [];
-  const currentUser = useContext(CurrentUserContext);
-  const timezone = currentUser?.timezone ?? AppConfig.rootTimeZone();
   const fieldTypes = useContext(FieldTypesContext);
   let type;
 
@@ -51,7 +47,7 @@ const CustomHighlighting = ({ children, field: fieldName, value: fieldValue }: P
 
   const highlightingRulesMap = highlightingRules.reduce((prev, cur) => ({ ...prev, [cur.field]: prev[cur.field] ? [...prev[cur.field], cur] : [cur] }), {});
   const rules = highlightingRulesMap[fieldName] ?? [];
-  const formattedValue = type === 'date' ? formatDateTime(fieldValue, DateTime.Formats.TIMESTAMP_TZ, timezone) : fieldValue;
+  const formattedValue = type === 'date' ? formatTime(fieldValue) : fieldValue;
 
   rules.forEach((rule) => {
     const ranges = [];

--- a/graylog2-web-interface/src/views/components/messagelist/MessagePreview.test.tsx
+++ b/graylog2-web-interface/src/views/components/messagelist/MessagePreview.test.tsx
@@ -25,6 +25,7 @@ import MessagesWidgetConfig from 'views/logic/widgets/MessagesWidgetConfig';
 import MessagePreview from './MessagePreview';
 
 jest.mock('views/logic/usePluginEntities', () => jest.fn());
+jest.mock('hooks/useUserDateTime');
 
 describe('MessagePreview', () => {
   afterEach(() => {

--- a/graylog2-web-interface/src/views/components/messagelist/MessageTableEntry.test.tsx
+++ b/graylog2-web-interface/src/views/components/messagelist/MessageTableEntry.test.tsx
@@ -31,6 +31,8 @@ jest.mock('stores/configurations/ConfigurationsStore', () => ({
   },
 }));
 
+jest.mock('hooks/useUserDateTime');
+
 describe('MessageTableEntry', () => {
   it('renders message for unknown selected fields', () => {
     const message = {

--- a/graylog2-web-interface/src/views/components/sidebar/Sidebar.test.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/Sidebar.test.tsx
@@ -39,6 +39,8 @@ jest.mock('util/AppConfig', () => ({
   gl2ServerUrl: jest.fn(() => undefined),
 }));
 
+jest.mock('hooks/useUserDateTime');
+
 describe('<Sidebar />', () => {
   const viewMetaData = {
     activeQuery: '34efae1e-e78e-48ab-ab3f-e83c8611a683',
@@ -89,7 +91,7 @@ describe('<Sidebar />', () => {
 
     fireEvent.click(await screen.findByTitle(/open sidebar/i));
 
-    await screen.findAllByText((content, node) => (node.textContent === 'Query executed in 64ms at 2018-08-28 09:39:26.'));
+    await screen.findAllByText((content, node) => (node.textContent === 'Query executed in 64ms at 2018-08-28 14:39:26.'));
   });
 
   const emptyViewMetaData = {

--- a/graylog2-web-interface/src/views/components/sidebar/description/SearchResultOverview.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/description/SearchResultOverview.tsx
@@ -14,14 +14,11 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import React, { useContext } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import numeral from 'numeral';
 
-import AppConfig from 'util/AppConfig';
 import { Timestamp } from 'components/common';
-import CurrentUserContext from 'contexts/CurrentUserContext';
-import DateTime from 'logic/datetimes/DateTime';
 
 type Props = {
   results: {
@@ -31,16 +28,13 @@ type Props = {
 };
 
 const SearchResultOverview = ({ results: { timestamp, duration } }: Props) => {
-  const currentUser = useContext(CurrentUserContext);
-  const timezone = currentUser?.timezone ?? AppConfig.rootTimeZone();
-
   if (!timestamp || !duration) {
     return <i>No query executed yet.</i>;
   }
 
   return (
     <span>
-      Query executed in {numeral(duration).format('0,0')}ms at <Timestamp dateTime={timestamp} format={DateTime.Formats.DATETIME} tz={timezone} />.
+      Query executed in {numeral(duration).format('0,0')}ms at <Timestamp dateTime={timestamp} />.
     </span>
   );
 };

--- a/graylog2-web-interface/src/views/components/widgets/MessageTable.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageTable.test.tsx
@@ -38,6 +38,8 @@ jest.mock('stores/configurations/ConfigurationsStore', () => ({
   },
 }));
 
+jest.mock('hooks/useUserDateTime');
+
 const messages = [
   {
     highlight_ranges: {},


### PR DESCRIPTION
Please note this PR needs to be tested together with https://github.com/Graylog2/graylog-plugin-enterprise/pull/3122

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

With this PR we are refactoring the `Timestamp` component. With this change we are unifying the way we display most timestamps in the UI.

Before these changes the component was also responsible for displaying a time relatively and based on the browser time zone. Now its main responsibility is displaying times based on the user time zone. It is still possible to define a custom time zone, when needed.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

/jenkins-pr-deps https://github.com/Graylog2/graylog-plugin-enterprise/pull/3122
