### PR TITLE
SearchVersion cleanup and refactoring

### DIFF
--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/Elasticsearch6Plugin.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/Elasticsearch6Plugin.java
@@ -20,13 +20,12 @@ import com.google.common.collect.ImmutableList;
 import org.graylog2.plugin.Plugin;
 import org.graylog2.plugin.PluginMetaData;
 import org.graylog2.plugin.PluginModule;
-import org.graylog2.plugin.Version;
 import org.graylog2.storage.SearchVersion;
 
 import java.util.Collection;
 
 public class Elasticsearch6Plugin implements Plugin {
-    public static final SearchVersion SUPPORTED_ES_VERSION = SearchVersion.elasticsearch(Version.from(6, 0, 0));
+    public static final SearchVersion SUPPORTED_ES_VERSION = SearchVersion.elasticsearch(6, 0, 0);
 
     @Override
     public PluginMetaData metadata() {

--- a/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/testing/ElasticsearchInstanceES6.java
+++ b/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/testing/ElasticsearchInstanceES6.java
@@ -79,7 +79,7 @@ public class ElasticsearchInstanceES6 extends SearchServerInstance {
     }
 
     protected static String imageNameFrom(SearchVersion version) {
-        return DEFAULT_IMAGE_OSS + ":" + version.version().getVersion().toString();
+        return DEFAULT_IMAGE_OSS + ":" + version.version().toString();
     }
 
     private JestClient jestClientFrom() {

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/Elasticsearch7Plugin.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/Elasticsearch7Plugin.java
@@ -26,8 +26,8 @@ import org.graylog2.storage.SearchVersion;
 import java.util.Collection;
 
 public class Elasticsearch7Plugin implements Plugin {
-    public static final SearchVersion SUPPORTED_ES_VERSION = SearchVersion.elasticsearch(Version.from(7, 0, 0));
-    public static final SearchVersion SUPPORTED_OPENSEARCH_VERSION = SearchVersion.create(SearchVersion.Distribution.OPENSEARCH, Version.from(1, 0, 0));
+    public static final SearchVersion SUPPORTED_ES_VERSION = SearchVersion.elasticsearch(7, 0, 0);
+    public static final SearchVersion SUPPORTED_OPENSEARCH_VERSION = SearchVersion.create(SearchVersion.Distribution.OPENSEARCH, com.github.zafarkhaja.semver.Version.forIntegers(1, 0, 0));
 
     @Override
     public PluginMetaData metadata() {

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/testing/ElasticsearchInstanceES7.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/testing/ElasticsearchInstanceES7.java
@@ -83,7 +83,7 @@ public class ElasticsearchInstanceES7 extends SearchServerInstance {
     }
 
     public static ElasticsearchInstanceES7 create(SearchVersion searchVersion, Network network) {
-        final String image = imageNameFrom(searchVersion.version().getVersion());
+        final String image = imageNameFrom(searchVersion.version());
 
         LOG.debug("Creating instance {}", image);
 

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/testing/OpensearchInstance.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/testing/OpensearchInstance.java
@@ -88,7 +88,7 @@ public class OpensearchInstance extends SearchServerInstance {
     }
 
     private static String imageNameFrom(SearchVersion version) {
-        return String.format(Locale.ROOT, "opensearchproject/opensearch:%s", version.version().getVersion());
+        return String.format(Locale.ROOT, "opensearchproject/opensearch:%s", version.version());
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20200730000000_AddGl2MessageIdFieldAliasForEvents.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20200730000000_AddGl2MessageIdFieldAliasForEvents.java
@@ -79,7 +79,7 @@ public class V20200730000000_AddGl2MessageIdFieldAliasForEvents extends Migratio
     }
 
     private boolean shouldSkip() {
-        if (!elasticsearchVersion.version().sameOrHigher(MINIMUM_ELASTICSEARCH_VERSION)) {
+        if (!new Version(elasticsearchVersion.version()).sameOrHigher(MINIMUM_ELASTICSEARCH_VERSION)) {
             LOG.debug("Skipping migration, because Elasticsearch major version of {} " +
                             "is lower than the required minimum version of {}.",
                     elasticsearchVersion, MINIMUM_ELASTICSEARCH_VERSION);

--- a/graylog2-server/src/main/java/org/graylog2/configuration/converters/MajorVersionConverter.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/converters/MajorVersionConverter.java
@@ -17,7 +17,6 @@
 package org.graylog2.configuration.converters;
 
 import com.github.joschi.jadconfig.Converter;
-import org.graylog2.plugin.Version;
 import org.graylog2.storage.SearchVersion;
 
 public class MajorVersionConverter implements Converter<SearchVersion> {
@@ -26,7 +25,7 @@ public class MajorVersionConverter implements Converter<SearchVersion> {
         try {
             // only major version - we know it's elasticsearch
             final int majorVersion = Integer.parseInt(value);
-            return SearchVersion.elasticsearch(Version.from(majorVersion, 0, 0));
+            return SearchVersion.elasticsearch(majorVersion, 0, 0);
         } catch (NumberFormatException nfe) {
             // It's probably a distribution:version format
             // caution, this format assumes full version X.Y.Z, not just major number

--- a/graylog2-server/src/main/java/org/graylog2/periodical/ESVersionCheckPeriodical.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/ESVersionCheckPeriodical.java
@@ -119,6 +119,6 @@ public class ESVersionCheckPeriodical extends Periodical {
     }
 
     private boolean compatible(SearchVersion initialElasticsearchMajorVersion, SearchVersion version) {
-        return initialElasticsearchMajorVersion.version().getVersion().getMajorVersion() == version.version().getVersion().getMajorVersion();
+        return initialElasticsearchMajorVersion.version().getMajorVersion() == version.version().getMajorVersion();
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/storage/SearchVersion.java
+++ b/graylog2-server/src/main/java/org/graylog2/storage/SearchVersion.java
@@ -16,11 +16,10 @@
  */
 package org.graylog2.storage;
 
+import com.github.zafarkhaja.semver.Version;
 import com.google.auto.value.AutoValue;
 import org.graylog2.configuration.validators.SearchVersionRange;
 import org.graylog2.indexer.ElasticsearchException;
-import org.graylog2.plugin.Version;
-import org.graylog2.storage.AutoValue_SearchVersion;
 
 import javax.annotation.Nullable;
 import java.util.Locale;
@@ -39,32 +38,25 @@ public abstract class SearchVersion {
             this.printName = printName;
         }
 
-
         @Override
         public String toString() {
             return this.printName;
         }
-
     }
+
+    public abstract Distribution distribution();
+    public abstract Version version();
+
     public SearchVersion major() {
-        return create(distribution(), Version.from(version().getVersion().getMajorVersion(), 0, 0));
+        return create(distribution(), Version.forIntegers(version().getMajorVersion(), 0, 0));
     }
 
     public boolean satisfies(final Distribution distribution, final String expression) {
-        return this.distribution().equals(distribution) && version().getVersion().satisfies(expression);
+        return this.distribution().equals(distribution) && version().satisfies(expression);
     }
 
     public boolean satisfies(SearchVersionRange range) {
         return satisfies(range.distribution(), range.expression());
-    }
-
-    public abstract Distribution distribution();
-
-    public abstract Version version();
-
-
-    public static SearchVersion create(Distribution distribution, com.github.zafarkhaja.semver.Version v) {
-        return create(distribution, new Version(v));
     }
 
     public static SearchVersion elasticsearch(final String version) {
@@ -75,18 +67,18 @@ public abstract class SearchVersion {
         return create(Distribution.ELASTICSEARCH, version);
     }
 
-    public static SearchVersion elasticsearch(com.github.zafarkhaja.semver.Version version) {
-        return elasticsearch(new Version(version));
+    public static SearchVersion elasticsearch(final int major, final int minor, final int patch) {
+        return create(Distribution.ELASTICSEARCH, Version.forIntegers(major, minor, patch));
     }
 
     public String encode() {
-        return String.format(Locale.ROOT, "%s:%s", this.distribution().name().toUpperCase(Locale.ROOT), this.version().getVersion());
+        return String.format(Locale.ROOT, "%s:%s", this.distribution().name().toUpperCase(Locale.ROOT), this.version());
     }
 
     public static SearchVersion decode(final String searchServerIdentifier) {
         final String[] parts = searchServerIdentifier.split(":");
-        if(parts.length == 2) {
-            return SearchVersion.create(Distribution.valueOf(parts[0].toUpperCase(Locale.ROOT)), com.github.zafarkhaja.semver.Version.valueOf((parts[1])));
+        if (parts.length == 2) {
+            return SearchVersion.create(Distribution.valueOf(parts[0].toUpperCase(Locale.ROOT)), Version.valueOf((parts[1])));
         } else {
             return SearchVersion.elasticsearch(searchServerIdentifier);
         }
@@ -110,7 +102,7 @@ public abstract class SearchVersion {
 
     protected static com.github.zafarkhaja.semver.Version parseVersion(final String version) {
         try {
-            return com.github.zafarkhaja.semver.Version.valueOf(version);
+            return Version.valueOf(version);
         } catch (Exception e) {
             throw new ElasticsearchException("Unable to parse Elasticsearch version: " + version, e);
         }

--- a/graylog2-server/src/main/java/org/graylog2/storage/versionprobe/VersionProbe.java
+++ b/graylog2-server/src/main/java/org/graylog2/storage/versionprobe/VersionProbe.java
@@ -162,7 +162,7 @@ public class VersionProbe {
     private Optional<SearchVersion> parseVersion(VersionResponse versionResponse) {
         try {
             final com.github.zafarkhaja.semver.Version version = com.github.zafarkhaja.semver.Version.valueOf(versionResponse.number());
-            return Optional.of(SearchVersion.create(versionResponse.distribution(), new Version(version)));
+            return Optional.of(SearchVersion.create(versionResponse.distribution(), version));
         } catch (Exception e) {
             LOG.error("Unable to parse version retrieved from Elasticsearch node: <{}>", versionResponse.number(), e);
             return Optional.empty();

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/migrations/V20200730000000_AddGl2MessageIdFieldAliasForEventsTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/migrations/V20200730000000_AddGl2MessageIdFieldAliasForEventsTest.java
@@ -52,7 +52,7 @@ class V20200730000000_AddGl2MessageIdFieldAliasForEventsTest {
     }
 
     private V20200730000000_AddGl2MessageIdFieldAliasForEvents buildSut(int major) {
-        return new V20200730000000_AddGl2MessageIdFieldAliasForEvents(SearchVersion.elasticsearch(Version.from(major, 0, 0)), clusterConfigService, elasticsearchAdapter, elasticsearchConfig);
+        return new V20200730000000_AddGl2MessageIdFieldAliasForEvents(SearchVersion.elasticsearch(major, 0, 0), clusterConfigService, elasticsearchAdapter, elasticsearchConfig);
     }
 
     @Test

--- a/graylog2-server/src/test/java/org/graylog2/configuration/validators/DetectedSearchVersionValidatorTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/configuration/validators/DetectedSearchVersionValidatorTest.java
@@ -33,17 +33,17 @@ class DetectedSearchVersionValidatorTest {
 
     @Test
     void validateMajorVersion() {
-        assertDoesNotThrow(() -> validator.validate("OS1", SearchVersion.create(OPENSEARCH, Version.from(1, 0, 0))));
-        assertDoesNotThrow(() -> validator.validate("ES7", SearchVersion.create(ELASTICSEARCH, Version.from(7, 0, 0))));
+        assertDoesNotThrow(() -> validator.validate("OS1", SearchVersion.create(OPENSEARCH, com.github.zafarkhaja.semver.Version.forIntegers(1, 0, 0))));
+        assertDoesNotThrow(() -> validator.validate("ES7", SearchVersion.create(ELASTICSEARCH, com.github.zafarkhaja.semver.Version.forIntegers(7, 0, 0))));
     }
 
     @Test
     void testPatchVersion() {
-        assertDoesNotThrow(() -> validator.validate("ES7", SearchVersion.create(ELASTICSEARCH, Version.from(7, 10, 2))));
+        assertDoesNotThrow(() -> validator.validate("ES7", SearchVersion.create(ELASTICSEARCH, com.github.zafarkhaja.semver.Version.forIntegers(7, 10, 2))));
     }
 
     @Test
     void testInvalidCombination() {
-        assertThrows(ValidationException.class, () -> validator.validate("ES5", SearchVersion.create(ELASTICSEARCH, Version.from(5, 0, 0))));
+        assertThrows(ValidationException.class, () -> validator.validate("ES5", SearchVersion.create(ELASTICSEARCH, com.github.zafarkhaja.semver.Version.forIntegers(5, 0, 0))));
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/indexer/EventsIndexMappingTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/EventsIndexMappingTest.java
@@ -44,7 +44,7 @@ public class EventsIndexMappingTest {
             "7.0.0"
     })
     void createsValidMappingTemplates(String versionString) throws Exception {
-        final SearchVersion version = SearchVersion.elasticsearch(Version.valueOf(versionString));
+        final SearchVersion version = SearchVersion.elasticsearch(versionString);
         final IndexMappingTemplate mapping = new EventIndexTemplateProvider().create(version, null);
 
         assertJsonPath(mapping.toTemplate(indexSetConfig, "test_*"), at -> {
@@ -104,7 +104,7 @@ public class EventsIndexMappingTest {
     }
 
     private String dateFormat(SearchVersion version) {
-        if (version.version().getVersion().greaterThanOrEqualTo(Version.valueOf("7.0.0"))) {
+        if (version.version().greaterThanOrEqualTo(Version.valueOf("7.0.0"))) {
             return "uuuu-MM-dd HH:mm:ss.SSS";
         }
 
@@ -112,7 +112,7 @@ public class EventsIndexMappingTest {
     }
 
     private String keyFor(String keySuffix, SearchVersion version) {
-        if (version.version().getVersion().greaterThanOrEqualTo(Version.valueOf("7.0.0"))) {
+        if (version.version().greaterThanOrEqualTo(Version.valueOf("7.0.0"))) {
             return "$.mappings." + keySuffix;
         }
         return "$.mappings.message." + keySuffix;

--- a/graylog2-server/src/test/java/org/graylog2/indexer/IndexMappingFactoryTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/IndexMappingFactoryTest.java
@@ -129,6 +129,6 @@ public class IndexMappingFactoryTest {
     }
 
     private void mockNodeVersion(String version) {
-        when(node.getVersion()).thenReturn(Optional.of(SearchVersion.elasticsearch(Version.valueOf(version))));
+        when(node.getVersion()).thenReturn(Optional.of(SearchVersion.elasticsearch(version)));
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/indexer/IndexMappingTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/IndexMappingTest.java
@@ -60,7 +60,7 @@ class IndexMappingTest {
             "7.0.0"
     })
     void createsValidMappingTemplates(String versionString) throws Exception {
-        final SearchVersion version = SearchVersion.elasticsearch(Version.valueOf(versionString));
+        final SearchVersion version = SearchVersion.elasticsearch(versionString);
         final IndexMappingTemplate mapping = new MessageIndexTemplateProvider().create(version, null);
 
         final Map<String, Object> template = mapping.toTemplate(indexSetConfig, "sampleIndexTemplate");
@@ -70,7 +70,7 @@ class IndexMappingTest {
     }
 
     private String fixtureFor(SearchVersion version) {
-        final String fixtureFileName = String.format(Locale.ENGLISH, "expected_template%s.json", version.version().getVersion().getMajorVersion());
+        final String fixtureFileName = String.format(Locale.ENGLISH, "expected_template%s.json", version.version().getMajorVersion());
         return resourceFile(fixtureFileName);
     }
 

--- a/graylog2-server/src/test/java/org/graylog2/indexer/cluster/NodeTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/cluster/NodeTest.java
@@ -63,7 +63,7 @@ public class NodeTest {
 
         final Optional<SearchVersion> elasticsearchVersion = node.getVersion();
 
-        assertThat(elasticsearchVersion).contains(SearchVersion.elasticsearch(Version.forIntegers(5, 4, 0)));
+        assertThat(elasticsearchVersion).contains(SearchVersion.elasticsearch(5, 4, 0));
     }
 
     @Ignore("TODO: fix this test or remove?")

--- a/graylog2-server/src/test/java/org/graylog2/periodical/ESVersionCheckPeriodicalTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/periodical/ESVersionCheckPeriodicalTest.java
@@ -53,7 +53,7 @@ class ESVersionCheckPeriodicalTest {
 
     @Test
     void doesNotRunIfVersionOverrideIsSet() {
-        createPeriodical(SearchVersion.elasticsearch(Version.from(8, 0, 0)), SearchVersion.elasticsearch(Version.from(7, 0, 0))).doRun();
+        createPeriodical(SearchVersion.elasticsearch(8, 0, 0), SearchVersion.elasticsearch(7, 0, 0)).doRun();
 
         verifyNoInteractions(notificationService);
     }
@@ -61,33 +61,33 @@ class ESVersionCheckPeriodicalTest {
     @Test
     void doesNotDoAnythingIfVersionWasNotProbed() {
         returnProbedVersion(null);
-        createPeriodical(SearchVersion.elasticsearch(Version.from(8, 0, 0))).doRun();
+        createPeriodical(SearchVersion.elasticsearch(8, 0, 0)).doRun();
         verifyNoInteractions(notificationService);
     }
 
     @Test
     void createsNotificationIfCurrentVersionIsIncompatibleWithInitialOne() {
-        returnProbedVersion(Version.from(9, 2, 3));
+        returnProbedVersion(com.github.zafarkhaja.semver.Version.forIntegers(9, 2, 3));
 
-        createPeriodical(SearchVersion.elasticsearch(Version.from(8, 1, 2))).doRun();
+        createPeriodical(SearchVersion.elasticsearch(8, 1, 2)).doRun();
 
         assertNotificationWasRaised();
     }
 
     @Test
     void createsNotificationIfCurrentVersionIncompatiblyOlderThanInitialOne() {
-        returnProbedVersion(Version.from(6, 8, 1));
+        returnProbedVersion(com.github.zafarkhaja.semver.Version.forIntegers(6, 8, 1));
 
-        createPeriodical(SearchVersion.elasticsearch(Version.from(8, 1, 2))).doRun();
+        createPeriodical(SearchVersion.elasticsearch(8, 1, 2)).doRun();
 
         assertNotificationWasRaised();
     }
 
     @Test
     void fixesNotificationIfCurrentVersionIsIncompatibleWithInitialOne() {
-        returnProbedVersion(Version.from(8, 2, 3));
+        returnProbedVersion(com.github.zafarkhaja.semver.Version.forIntegers(8, 2, 3));
 
-        createPeriodical(SearchVersion.elasticsearch(Version.from(8, 1, 2))).doRun();
+        createPeriodical(SearchVersion.elasticsearch(8, 1, 2)).doRun();
 
         assertNotificationWasFixed();
     }
@@ -106,7 +106,7 @@ class ESVersionCheckPeriodicalTest {
         assertThat(captor.getValue().getType()).isEqualTo(Notification.Type.ES_VERSION_MISMATCH);
     }
 
-    private void returnProbedVersion(@Nullable Version probedVersion) {
+    private void returnProbedVersion(@Nullable com.github.zafarkhaja.semver.Version probedVersion) {
         when(versionProbe.probe(anyCollection())).thenReturn(Optional.ofNullable(probedVersion).map(SearchVersion::elasticsearch));
     }
 

--- a/graylog2-server/src/test/java/org/graylog2/storage/SearchVersionTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/storage/SearchVersionTest.java
@@ -16,8 +16,8 @@
  */
 package org.graylog2.storage;
 
+import com.github.zafarkhaja.semver.Version;
 import org.graylog2.indexer.ElasticsearchException;
-import org.graylog2.plugin.Version;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -54,6 +54,6 @@ class SearchVersionTest {
     }
 
     private Version ver(final String version) {
-        return new Version(com.github.zafarkhaja.semver.Version.valueOf(version));
+        return com.github.zafarkhaja.semver.Version.valueOf(version);
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Removed the unnecessary org.graylog2.plugin.Version dependency (and its eager `CURRENT_CLASSPATH` init) from the SearchVersion class.

Majority of the `SearchVersion` usages accessed the underlying `com.github.zafarkhaja.semver.Version`, not the `org.graylog2.plugin.Version` and the `org.graylog2.plugin.Version` served only as a wrapper.

## Motivation and Context
/jenkins-pr-deps Graylog2/graylog-plugin-enterprise#3125

## How Has This Been Tested?
Existing test suite that covers the usage on many places.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

