### PR TITLE
Align Graylog node API Browser links with latter's base URL.

### DIFF
--- a/graylog2-web-interface/src/components/nodes/NodeMaintenanceDropdown.jsx
+++ b/graylog2-web-interface/src/components/nodes/NodeMaintenanceDropdown.jsx
@@ -30,24 +30,25 @@ class NodeMaintenanceDropdown extends React.Component {
   };
 
   render() {
-    const apiBrowserURI = new URI(`${this.props.node.transport_address}/api-browser/`).normalizePathname().toString();
+    const { node } = this.props;
+    const apiBrowserURI = new URI(`${node.transport_address}/api-browser/`).normalizePathname().toString();
 
     return (
       <ButtonGroup>
         <DropdownButton bsStyle="info" bsSize="lg" title="Actions" id="node-maintenance-actions" pullRight>
           <IfPermitted permissions="threads:dump">
-            <LinkContainer to={Routes.SYSTEM.THREADDUMP(this.props.node.node_id)}>
+            <LinkContainer to={Routes.SYSTEM.THREADDUMP(node.node_id)}>
               <MenuItem>Get thread dump</MenuItem>
             </LinkContainer>
           </IfPermitted>
 
           <IfPermitted permissions="processbuffer:dump">
-            <LinkContainer to={Routes.SYSTEM.PROCESSBUFFERDUMP(this.props.node.node_id)}>
+            <LinkContainer to={Routes.SYSTEM.PROCESSBUFFERDUMP(node.node_id)}>
               <MenuItem>Get process-buffer dump</MenuItem>
             </LinkContainer>
           </IfPermitted>
 
-          <LinkContainer to={Routes.SYSTEM.METRICS(this.props.node.node_id)}>
+          <LinkContainer to={Routes.SYSTEM.METRICS(node.node_id)}>
             <MenuItem>Metrics</MenuItem>
           </LinkContainer>
 

--- a/graylog2-web-interface/src/components/nodes/NodeMaintenanceDropdown.jsx
+++ b/graylog2-web-interface/src/components/nodes/NodeMaintenanceDropdown.jsx
@@ -30,7 +30,7 @@ class NodeMaintenanceDropdown extends React.Component {
   };
 
   render() {
-    const apiBrowserURI = new URI(`${this.props.node.transport_address}/api-browser`).normalizePathname().toString();
+    const apiBrowserURI = new URI(`${this.props.node.transport_address}/api-browser/`).normalizePathname().toString();
 
     return (
       <ButtonGroup>

--- a/graylog2-web-interface/src/components/nodes/NodesActions.jsx
+++ b/graylog2-web-interface/src/components/nodes/NodesActions.jsx
@@ -57,7 +57,7 @@ class NodesActions extends React.Component {
 
   render() {
     const { systemOverview, node } = this.props;
-    const apiBrowserURI = new URI(`${node.transport_address}/api-browser`).normalizePathname().toString();
+    const apiBrowserURI = new URI(`${node.transport_address}/api-browser/`).normalizePathname().toString();
 
     return (
       <div className="item-actions">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Currently, node-specific API Browser links don't match up with the base URL that gets set when [`graylog2-server/src/main/resources/swagger/index.html.template`](https://github.com/Graylog2/graylog2-server/blob/4dd8d8740fa387ee37b23954c6d13877d6680b79/graylog2-server/src/main/resources/swagger/index.html.template) is rendered.  This results in the API Browser appearing to reload or refresh when a user clicks a link due to the transition from `/api-browser` to `/api-browser/`.

This PR updates up the node-specific API Browser links to match that page's base URL (i.e. adds a trailing `/`), and also deals with some `react/destructuring-assignment` linter errors.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #11802.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Clicked the node-specific links to load  `/api-browser/`, and then confirmed clicking anchor links didn't result in the page appearing to reload. 
2. Verified `NodeMaintenanceDropdown` links were still valid.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.