### PR TITLE
Attempt to fix timeout issues in github builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
       - name: License check
         run: mvn -B --fail-fast license:check
       - name: Build with Maven
-        run: mvn -B --fail-fast -Pedantic -Dspotbugs.skip -Dit.es -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3 verify javadoc:javadoc
+        run: mvn -B --fail-fast -Pedantic -Dspotbugs.skip -Dit.es -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3 -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 verify javadoc:javadoc
         env:
           JAVA_OPTS: -Xmx6G
           TIMEOUT_MULTIPLIER: 2.0


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
We are still experiencing timeouts during maven builds running on github infrastructure. @dennisoelkers discovered this https://github.com/actions/virtual-environments/issues/1499#issuecomment-689467080, which should help. 

This PR adds a workaround for the connections, configuring various http options that should prevent the issue.   

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

