### PR TITLE
StringUtils toTitleCase and upgrade to TS

### DIFF
--- a/graylog2-web-interface/src/util/StringUtils.test.ts
+++ b/graylog2-web-interface/src/util/StringUtils.test.ts
@@ -1,0 +1,157 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+
+import StringUtils from 'util/StringUtils';
+
+describe('capitalizeFirstLetter', () => {
+  it('capitalizes the first letter of a string supplied', () => {
+    const testString = 'capitalizeMe';
+    const expectedOutcome = 'CapitalizeMe';
+
+    const newString = StringUtils.capitalizeFirstLetter(testString);
+
+    expect(newString).toBe(expectedOutcome);
+  });
+});
+
+describe('HTML escape unescape', () => {
+  const unescapedString = 'Hello<enter-name> & enjoy';
+  const escapedString = 'Hello&lt;enter-name&gt; &amp; enjoy';
+
+  it('escapes a string for HTML use', () => {
+    const result = StringUtils.escapeHTML(unescapedString);
+
+    expect(result).toBe(escapedString);
+  });
+
+  it('unescapes a string used in HTML', () => {
+    const result = StringUtils.unescapeHTML(escapedString);
+
+    expect(result).toBe(unescapedString);
+  });
+});
+
+describe('pluralize', () => {
+  it('pluralizes a string', () => {
+    const singular = 'racecar';
+    const plural = 'racecars';
+    const resultSingular = StringUtils.pluralize(1, singular, plural);
+
+    expect(resultSingular).toBe(singular);
+
+    const resultPlural = StringUtils.pluralize(2, singular, plural);
+
+    expect(resultPlural).toBe(plural);
+  });
+});
+
+describe('stringify', () => {
+  const testObj = {
+    fruitName: 'Apple',
+    brixRating: 7,
+    color: 'red',
+  };
+  const stringifiedObj = '{"fruitName":"Apple","brixRating":7,"color":"red"}';
+
+  it('stringifies an object', () => {
+    const result = StringUtils.stringify(testObj);
+
+    expect(result).toBe(stringifiedObj);
+  });
+
+  it('returns anything else as a string', () => {
+    const testNum = 7;
+    const testArray = [1, 2, 3];
+
+    const numResult = StringUtils.stringify(testNum);
+
+    expect(numResult).toBe('7');
+
+    const arrayResult = StringUtils.stringify(testArray);
+
+    expect(arrayResult).toBe('[1,2,3]');
+  });
+
+  it('returns an empty string if String() would return an error', () => {
+    const canNotStringMe = undefined;
+    const result = StringUtils.stringify(canNotStringMe);
+
+    expect(result).toBe('undefined');
+  });
+});
+
+describe('replaceSpaces', () => {
+  it('replaces spaces in a string with "-"', () => {
+    const makeHyphenized = 'Rubber baby bunky bumpers';
+    const hyphenized = 'Rubber-baby-bunky-bumpers';
+    const result = StringUtils.replaceSpaces(makeHyphenized);
+
+    expect(result).toBe(hyphenized);
+  });
+
+  it('replaces spaces in a string with a supplied character', () => {
+    const makePipified = 'Rubber baby bunky bumpers';
+    const pipified = 'Rubber|baby|bunky|bumpers';
+    const result = StringUtils.replaceSpaces(makePipified, '|');
+
+    expect(result).toBe(pipified);
+  });
+});
+
+describe('toTitleCase', () => {
+  it('title cases a string and defaults the split to " "', () => {
+    const makeTitleCase = 'Rubber baby bunky bumpers.';
+    const titleCased = 'Rubber Baby Bunky Bumpers.';
+    const result = StringUtils.toTitleCase(makeTitleCase);
+
+    expect(result).toBe(titleCased);
+  });
+
+  it('titles cases a string based on supplied split character', () => {
+    const makeTitleCase = 'Rubber-baby-bunky-bumpers.';
+    const titleCased = 'Rubber Baby Bunky Bumpers.';
+    const result = StringUtils.toTitleCase(makeTitleCase, '-');
+
+    expect(result).toBe(titleCased);
+  });
+});
+
+describe('truncateWithEllipses', () => {
+  it('truncates a string with a default length of 10 and ending string of "..."', () => {
+    const makeShorter = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent nec.';
+    const truncated = 'Lorem ipsu...';
+    const result = StringUtils.truncateWithEllipses(makeShorter);
+
+    expect(result).toBe(truncated);
+  });
+
+  it('truncates a string with supplied length and default ending string of "..."', () => {
+    const makeShorter = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent nec.';
+    const truncated = 'Lorem ipsum dol...';
+    const result = StringUtils.truncateWithEllipses(makeShorter, 15);
+
+    expect(result).toBe(truncated);
+  });
+
+  it('truncates a string with supplied length and supplied ending string', () => {
+    const makeShorter = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent nec.';
+    const truncated = 'Lorem ipsum dol|||';
+    const result = StringUtils.truncateWithEllipses(makeShorter, 15, '|||');
+
+    expect(result).toBe(truncated);
+  });
+});

--- a/graylog2-web-interface/src/util/StringUtils.ts
+++ b/graylog2-web-interface/src/util/StringUtils.ts
@@ -16,27 +16,32 @@
  */
 const StringUtils = {
   tempDocument: document.createElement('textarea'),
-  capitalizeFirstLetter(text) {
+  capitalizeFirstLetter(text: string) {
     return text.charAt(0).toUpperCase() + text.slice(1);
   },
-  escapeHTML(text) {
+  escapeHTML(text: string) {
     this.tempDocument.textContent = text;
 
     return this.tempDocument.innerHTML;
   },
-  unescapeHTML(text) {
+  unescapeHTML(text: string) {
     this.tempDocument.innerHTML = text;
 
     return this.tempDocument.textContent;
   },
-  pluralize(number, singular, plural) {
+  pluralize(number: string | number, singular: string, plural: string) {
     return (number === 1 || number === '1' ? singular : plural);
   },
   stringify(text) {
     return (typeof text === 'object' ? JSON.stringify(text) : String(text)) || '';
   },
-  replaceSpaces(text, newCharacter = '-') {
+  replaceSpaces(text: string, newCharacter = '-') {
     return text.replace(/\s/g, newCharacter);
+  },
+  toTitleCase(str: string, splitCharacter: string = ' ') {
+    return str.toLowerCase().split(splitCharacter).map((word) => {
+      return (`${word.charAt(0).toUpperCase()}${word.slice(1)}`);
+    }).join(' ');
   },
   truncateWithEllipses(text = '', maxLength = 10, end = '...') {
     if (text.length > maxLength) {

--- a/graylog2-web-interface/src/views/components/ViewTypeLabel.test.tsx
+++ b/graylog2-web-interface/src/views/components/ViewTypeLabel.test.tsx
@@ -23,19 +23,22 @@ import ViewTypeLabel from './ViewTypeLabel';
 
 describe('ViewTypeLabel', () => {
   it('should create correct label for view type search', () => {
-    const { getByText } = render(<ViewTypeLabel type={View.Type.Search} />);
+    const viewTypeLabel = ViewTypeLabel({ type: View.Type.Search });
+    const { getByText } = render(<div>{viewTypeLabel}</div>);
 
     expect(getByText('search')).not.toBe(null);
   });
 
   it('should create correct label for view type dasboard', () => {
-    const { getByText } = render(<ViewTypeLabel type={View.Type.Dashboard} />);
+    const viewTypeLabel = ViewTypeLabel({ type: View.Type.Dashboard });
+    const { getByText } = render(<div>{viewTypeLabel}</div>);
 
     expect(getByText('dashboard')).not.toBe(null);
   });
 
   it('should create capitalized label', () => {
-    const { getByText } = render(<ViewTypeLabel type={View.Type.Search} capitalize />);
+    const viewTypeLabel = ViewTypeLabel({ type: View.Type.Search, capitalize: true });
+    const { getByText } = render(<div>{viewTypeLabel}</div>);
 
     expect(getByText('Search')).not.toBe(null);
   });

--- a/graylog2-web-interface/src/views/components/ViewTypeLabel.ts
+++ b/graylog2-web-interface/src/views/components/ViewTypeLabel.ts
@@ -14,17 +14,16 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import PropTypes from 'prop-types';
 
 import StringUtils from 'util/StringUtils';
 import type { ViewType } from 'views/logic/views/View';
 
 type Props = {
-  type: ViewType | undefined | null,
-  capitalize?: boolean,
-};
+  type: ViewType | undefined | null;
+  capitalize?: boolean;
+}
 
-const ViewTypeLabel = ({ type, capitalize }: Props) => {
+const ViewTypeLabel = ({ type, capitalize = false }: Props) => {
   if (!type) {
     return '';
   }
@@ -32,15 +31,6 @@ const ViewTypeLabel = ({ type, capitalize }: Props) => {
   const typeLabel = type.toLowerCase();
 
   return capitalize ? StringUtils.capitalizeFirstLetter(typeLabel) : typeLabel;
-};
-
-ViewTypeLabel.propTypes = {
-  type: PropTypes.string.isRequired,
-  capitalize: PropTypes.bool,
-};
-
-ViewTypeLabel.defaultProps = {
-  capitalize: false,
 };
 
 export default ViewTypeLabel;

--- a/graylog2-web-interface/src/views/components/messagelist/PossiblyHighlight.tsx
+++ b/graylog2-web-interface/src/views/components/messagelist/PossiblyHighlight.tsx
@@ -95,7 +95,7 @@ const PossiblyHighlight = ({ color = DEFAULT_HIGHLIGHT_COLOR, field, value, high
   const highlights = ranges
     .filter(({ start }) => (start >= 0))
     .filter(({ length }) => (length >= 0))
-    .reduce<[HighlightRange[], number]>(([acc, i], cur, idx) => [
+    .reduce<[Array<HighlightRange | string | JSX.Element>, number]>(([acc, i], cur, idx) => [
       [...acc,
         subst(i, Math.max(0, cur.start - i)), // non-highlighted string before this range
         highlight(subst(Math.max(cur.start, i), Math.max(0, cur.length - Math.max(0, i - cur.start))), idx, style), // highlighted string in range
@@ -107,7 +107,7 @@ const PossiblyHighlight = ({ color = DEFAULT_HIGHLIGHT_COLOR, field, value, high
 
   highlights.push(rest(lastRange.start + lastRange.length));
 
-  return <>{highlights}</>;
+  return <div>{highlights}</div>;
 };
 
 PossiblyHighlight.propTypes = {

--- a/graylog2-web-interface/src/views/components/sidebar/description/ViewDescription.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/description/ViewDescription.tsx
@@ -37,7 +37,7 @@ type Props = {
 const ViewDescription = ({ results, viewMetadata }: Props) => {
   const isAdHocSearch = !viewMetadata.id;
   const viewType = useContext(ViewTypeContext);
-  const viewTypeLabel = viewType ? <ViewTypeLabel type={viewType} /> : '';
+  const viewTypeLabel = viewType ? ViewTypeLabel({ type: viewType }) : '';
   const resultsSection = (
     <>
       <SectionSubheadline>


### PR DESCRIPTION
# StringUtils `toTitleCase` function and update to TS

## Description
- Adds the `toTitleCase` function the StringUtils which converts a string to title case based on string separator.
- It also adds unit tests for the file that covers the new functionality and old existing functionality.
- This also contains conversion to Typescript.
This was needed functionality for a separate component in
enterprise-plugins.

## Motivation and Context
- Needed string functionality for a feature in the enterprise-plugin

## How Has This Been Tested?
- The frontend unit test suite was run

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

