### PR TITLE
StreamsContext singleton wrapper

### DIFF
--- a/graylog2-web-interface/src/contexts/StreamsContext.tsx
+++ b/graylog2-web-interface/src/contexts/StreamsContext.tsx
@@ -16,6 +16,8 @@
  */
 import * as React from 'react';
 
+import { singleton } from 'logic/singleton';
+
 const StreamsContext = React.createContext<Array<any> | undefined>(undefined);
 
-export default StreamsContext;
+export default singleton('contexts.StreamsContext', () => StreamsContext);


### PR DESCRIPTION
# StreamsContext wrapped in singleton

This is needed for the enterprise\security plugin to be able to use the
singleton StreamsContext

## Description
- StreamsContext is now wrapped in our singleton method.

## Motivation and Context
- Needed so that the enterprise plugin can consume the StreamsContext without creating a new one.

## How Has This Been Tested?
- Tested locally and unit tests ran.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

