### PR TITLE
Don't print a stacktrace for missing version files

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/plugin/Version.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/Version.java
@@ -260,7 +260,7 @@ public class Version implements Comparable<Version> {
 
             return from(major, minor, patch, qualifier, commitSha);
         } catch (Exception e) {
-            LOG.error("Unable to read " + path + ", this build has no version number.", e);
+            LOG.error("Unable to read " + path + ", this build has no version number. <{}>", e.toString());
         }
         return defaultVersion;
     }


### PR DESCRIPTION
In a cloud dev environment the version info for the cloud
is missing. This makes it hard to see other messages
in the server log.
