### PR TITLE
Allow overwriting `ExpandableList` styles.

### DIFF
--- a/graylog2-web-interface/src/components/common/ExpandableList.tsx
+++ b/graylog2-web-interface/src/components/common/ExpandableList.tsx
@@ -32,7 +32,7 @@ type Props = {
  */
 const ExpandableList = ({ children, className }: Props) => {
   return (
-    <ul className={`${style.list} ${className}`}>
+    <ul className={className ? `${style.list} ${className}` : style.list}>
       {children}
     </ul>
   );

--- a/graylog2-web-interface/src/components/common/ExpandableList.tsx
+++ b/graylog2-web-interface/src/components/common/ExpandableList.tsx
@@ -21,6 +21,7 @@ import style from './ExpandableList.css';
 
 type Props = {
   children?: React.ReactElement,
+  className?: string,
 };
 
 /**
@@ -29,9 +30,9 @@ type Props = {
  * of categories. Inside the categories the user has the possibility of doing a selection.
  * The ExpandableList can be used nested.
  */
-const ExpandableList = ({ children }: Props) => {
+const ExpandableList = ({ children, className }: Props) => {
   return (
-    <ul className={style.list}>
+    <ul className={`${style.list} ${className}`}>
       {children}
     </ul>
   );
@@ -39,6 +40,7 @@ const ExpandableList = ({ children }: Props) => {
 
 ExpandableList.defaultProps = {
   children: [],
+  className: undefined,
 };
 
 ExpandableList.propTypes = {
@@ -49,6 +51,7 @@ ExpandableList.propTypes = {
     PropTypes.element,
     PropTypes.arrayOf(PropTypes.element),
   ]),
+  className: PropTypes.string,
 };
 
 export default ExpandableList;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This change for the `ExpandableList` component is necessary to style the component with `styled-components`.
