### PR TITLE
Fixing deserialization of global override.

### DIFF
--- a/full-backend-tests/src/test/java/org/graylog/plugins/views/SearchSyncIT.java
+++ b/full-backend-tests/src/test/java/org/graylog/plugins/views/SearchSyncIT.java
@@ -16,10 +16,15 @@
  */
 package org.graylog.plugins.views;
 
+import com.github.rholder.retry.RetryException;
+import com.github.rholder.retry.Retryer;
+import com.github.rholder.retry.RetryerBuilder;
+import com.github.rholder.retry.StopStrategies;
+import com.github.rholder.retry.WaitStrategies;
+import com.google.common.collect.ImmutableMap;
+import io.restassured.response.ValidatableResponse;
 import io.restassured.specification.RequestSpecification;
 import org.graylog.testing.completebackend.GraylogBackend;
-import org.graylog.testing.containermatrix.MongodbServer;
-import org.graylog.testing.containermatrix.SearchServer;
 import org.graylog.testing.containermatrix.annotations.ContainerMatrixTest;
 import org.graylog.testing.containermatrix.annotations.ContainerMatrixTestsConfiguration;
 import org.graylog.testing.utils.GelfInputUtils;
@@ -27,15 +32,19 @@ import org.graylog.testing.utils.SearchUtils;
 import org.junit.jupiter.api.BeforeAll;
 
 import java.io.InputStream;
+import java.util.Collections;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 
 import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.core.IsEqual.equalTo;
 
 @ContainerMatrixTestsConfiguration
 public class SearchSyncIT {
-
     static final int GELF_HTTP_PORT = 12201;
 
     private final GraylogBackend sut;
@@ -48,6 +57,8 @@ public class SearchSyncIT {
 
     @BeforeAll
     public void importMongoFixtures() {
+        this.sut.importMongoDBFixture("mongodb-stored-searches-for-execution-endpoint.json", SearchSyncIT.class);
+
         int mappedPort = sut.mappedPortFor(GELF_HTTP_PORT);
         GelfInputUtils.createGelfHttpInput(mappedPort, GELF_HTTP_PORT, requestSpec);
         GelfInputUtils.postMessage(mappedPort,
@@ -114,6 +125,63 @@ public class SearchSyncIT {
                 .assertThat()
                 .body("execution.completed_exceptionally", equalTo(false))
                 .body("results*.value.search_types[0]*.value.messages.message.message[0]", hasItem("search-sync-test"));
+    }
+
+    @ContainerMatrixTest
+    void testRequestStoredSearch() throws ExecutionException, RetryException {
+        final ValidatableResponse result = given()
+                .spec(requestSpec)
+                .when()
+                .post("/views/search/61977043c1f17d26b45c8a0a/execute")
+                .then()
+                .statusCode(201);
+
+        final String jobId = result.extract().path("id").toString();
+
+        assertThat(jobId).isNotBlank();
+
+        retrieveSearchResults(jobId)
+                .body("execution.completed_exceptionally", equalTo(false))
+                .body("results.f1446410-a082-4871-b3bf-d69aa42d0c96.search_types.8306779b-933f-473f-837d-b7a7d83a9a40.name", equalTo("chart"));
+    }
+
+    @ContainerMatrixTest
+    void testRequestStoredSearchWithGlobalOverrideKeepingOnlySingleSearchType() throws ExecutionException, RetryException {
+        final ValidatableResponse result = given()
+                .spec(requestSpec)
+                .when()
+                .body(ImmutableMap.of(
+                        "global_override", ImmutableMap.of(
+                                "keep_search_types", Collections.singleton("01c76680-377b-4930-86e2-a55fdb867b58")
+                        )
+                ))
+                .post("/views/search/61977043c1f17d26b45c8a0a/execute")
+                .then()
+                .statusCode(201);
+
+        final String jobId = result.extract().path("id").toString();
+
+        assertThat(jobId).isNotBlank();
+
+        retrieveSearchResults(jobId)
+                .body("execution.completed_exceptionally", equalTo(false))
+                .body("results.f1446410-a082-4871-b3bf-d69aa42d0c96.search_types", not(hasKey("f1446410-a082-4871-b3bf-d69aa42d0c97")))
+                .body("results.f1446410-a082-4871-b3bf-d69aa42d0c97.search_types", hasKey("01c76680-377b-4930-86e2-a55fdb867b58"));
+    }
+
+    private ValidatableResponse retrieveSearchResults(String jobId) throws ExecutionException, RetryException {
+        final Retryer<ValidatableResponse> retryer = RetryerBuilder.<ValidatableResponse>newBuilder()
+                .withWaitStrategy(WaitStrategies.fixedWait(1, TimeUnit.SECONDS))
+                .withStopStrategy(StopStrategies.stopAfterAttempt(5))
+                .build();
+
+        return retryer.call(() -> given()
+                .spec(requestSpec)
+                .when()
+                .get("/views/search/status/{jobId}", jobId)
+                .then()
+                .statusCode(200)
+                .body("execution.done", equalTo(true)));
     }
 
     private InputStream fixture(String filename) {

--- a/full-backend-tests/src/test/java/org/graylog/plugins/views/SearchSyncIT.java
+++ b/full-backend-tests/src/test/java/org/graylog/plugins/views/SearchSyncIT.java
@@ -128,7 +128,7 @@ public class SearchSyncIT {
 
     @ContainerMatrixTest
     void testRequestStoredSearch() throws ExecutionException, RetryException {
-        final String jobId = executeStoredSearch("61977043c1f17d26b45c8a0a");
+        final String jobId = executeStoredSearch("61977043c1f17d26b45c8a0b");
 
         retrieveSearchResults(jobId)
                 .body("execution.completed_exceptionally", equalTo(false))
@@ -137,7 +137,7 @@ public class SearchSyncIT {
 
     @ContainerMatrixTest
     void testRequestStoredSearchWithGlobalOverrideKeepingOnlySingleSearchType() throws ExecutionException, RetryException {
-        final String jobId = executeStoredSearch("61977043c1f17d26b45c8a0a", Collections.singletonMap(
+        final String jobId = executeStoredSearch("61977043c1f17d26b45c8a0b", Collections.singletonMap(
                 "global_override", Collections.singletonMap(
                         "keep_search_types", Collections.singleton("01c76680-377b-4930-86e2-a55fdb867b58")
                 )

--- a/full-backend-tests/src/test/resources/org/graylog/plugins/views/mongodb-stored-searches-for-execution-endpoint.json
+++ b/full-backend-tests/src/test/resources/org/graylog/plugins/views/mongodb-stored-searches-for-execution-endpoint.json
@@ -2,7 +2,7 @@
   "searches": [
     {
       "_id": {
-        "$oid": "61977043c1f17d26b45c8a0a"
+        "$oid": "61977043c1f17d26b45c8a0b"
       },
       "queries": [
         {

--- a/full-backend-tests/src/test/resources/org/graylog/plugins/views/mongodb-stored-searches-for-execution-endpoint.json
+++ b/full-backend-tests/src/test/resources/org/graylog/plugins/views/mongodb-stored-searches-for-execution-endpoint.json
@@ -1,0 +1,82 @@
+{
+  "searches": [
+    {
+      "_id": {
+        "$oid": "61977043c1f17d26b45c8a0a"
+      },
+      "queries": [
+        {
+          "id": "f1446410-a082-4871-b3bf-d69aa42d0c96",
+          "query": {
+            "type": "elasticsearch",
+            "query_string": "action:$action$"
+          },
+          "timerange": {
+            "type": "relative",
+            "from": 300
+          },
+          "search_types": [
+            {
+              "timerange": null,
+              "query": null,
+              "streams": [],
+              "id": "8306779b-933f-473f-837d-b7a7d83a9a40",
+              "name": "chart",
+              "series": [
+                {
+                  "type": "count",
+                  "id": "count()"
+                }
+              ],
+              "sort": [],
+              "rollup": true,
+              "type": "pivot",
+              "row_groups": [
+                {
+                  "type": "time",
+                  "field": "timestamp",
+                  "interval": {
+                    "type": "auto",
+                    "scaling": 1.0
+                  }
+                }
+              ],
+              "column_groups": []
+            }
+          ]
+        },
+        {
+          "id": "f1446410-a082-4871-b3bf-d69aa42d0c97",
+          "query": {
+            "type": "elasticsearch",
+            "query_string": ""
+          },
+          "timerange": {
+            "type": "relative",
+            "from": 300
+          },
+          "search_types": [
+            {
+              "timerange": null,
+              "query": null,
+              "streams": [],
+              "id": "01c76680-377b-4930-86e2-a55fdb867b58",
+              "name": null,
+              "limit": 150,
+              "offset": 0,
+              "sort": [
+                {
+                  "field": "timestamp",
+                  "order": "DESC"
+                }
+              ],
+              "fields": [],
+              "decorators": [],
+              "type": "messages"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/ExecutionStateGlobalOverride.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/ExecutionStateGlobalOverride.java
@@ -32,16 +32,22 @@ import java.util.Optional;
 public abstract class ExecutionStateGlobalOverride {
     @JsonProperty
     public abstract Optional<TimeRange> timerange();
+
     @JsonProperty
     public abstract Optional<BackendQuery> query();
+
     @JsonProperty
     public abstract Optional<Integer> limit();
+
     @JsonProperty
     public abstract Optional<Integer> offset();
+
     @JsonProperty
     public abstract ImmutableMap<String, SearchTypeExecutionState> searchTypes();
+
     @JsonProperty
     public abstract ImmutableSet<String> keepSearchTypes();
+
     public abstract Builder toBuilder();
 
     public static Builder builder() {
@@ -50,11 +56,11 @@ public abstract class ExecutionStateGlobalOverride {
 
     public boolean hasValues() {
         return timerange().isPresent() ||
-       query().isPresent() ||
-       limit().isPresent() ||
-       offset().isPresent() ||
-       !searchTypes().isEmpty() ||
-       !keepSearchTypes().isEmpty();
+                query().isPresent() ||
+                limit().isPresent() ||
+                offset().isPresent() ||
+                !searchTypes().isEmpty() ||
+                !keepSearchTypes().isEmpty();
     }
 
     public static ExecutionStateGlobalOverride empty() {
@@ -65,22 +71,32 @@ public abstract class ExecutionStateGlobalOverride {
     public abstract static class Builder {
 
         @JsonCreator
-        public static ExecutionStateGlobalOverride.Builder create() {
+        public static Builder create() {
             return ExecutionStateGlobalOverride.builder();
         }
 
         @JsonProperty
         public abstract Builder timerange(TimeRange timerange);
+
         @JsonProperty
         public abstract Builder query(BackendQuery query);
+
         @JsonProperty
         public abstract Builder limit(Integer limit);
+
         @JsonProperty
         public abstract Builder offset(Integer offset);
+
         @JsonProperty
+        public abstract Builder keepSearchTypes(ImmutableSet<String> keepSearchTypes);
+
+        @JsonProperty
+        public abstract Builder searchTypes(ImmutableMap<String, SearchTypeExecutionState> searchTypes);
+
         public abstract ImmutableMap.Builder<String, SearchTypeExecutionState> searchTypesBuilder();
-        @JsonProperty
+
         public abstract ImmutableSet.Builder<String> keepSearchTypesBuilder();
+
         public abstract ExecutionStateGlobalOverride build();
     }
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Prior to this change, the `keep_search_types`/`search_types` properties were not deserialized properly, because a collection builder was used. Jackson seems to be unable to use these for properties, so additional builder methods were added for these.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.