### PR TITLE
Ensure query input editor always references the latest provided data.

### DIFF
--- a/graylog2-web-interface/src/views/components/searchbar/QueryInput.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/QueryInput.tsx
@@ -57,9 +57,7 @@ const defaultCompleterFactory = (
   completers: Array<Completer>,
   timeRange: TimeRange | NoTimeRangeOverride,
   streams: Array<string>,
-) => {
-  return new SearchBarAutoCompletions(completers, timeRange, streams);
-};
+) => new SearchBarAutoCompletions(completers, timeRange, streams);
 
 const handleExecution = (editor: Editor, onExecute: (query: string) => void, value: string, error: QueryValidationState | undefined) => {
   if (editor?.completer && editor.completer.popup) {

--- a/graylog2-web-interface/src/views/components/searchbar/queryvalidation/QueryValidation.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/queryvalidation/QueryValidation.test.tsx
@@ -22,6 +22,7 @@ import { Form, Formik } from 'formik';
 import QueryValidation from 'views/components/searchbar/queryvalidation/QueryValidation';
 import SearchExecutionState from 'views/logic/search/SearchExecutionState';
 import FormWarningsContext from 'contexts/FormWarningsContext'; import type { QueryValidationState } from 'views/components/searchbar/queryvalidation/types';
+import { validationError } from 'fixtures/queryValidationState';
 
 jest.mock('views/stores/QueriesStore', () => ({
   QueriesActions: {
@@ -56,18 +57,6 @@ type SUTProps = {
 }
 
 describe('QueryValidation', () => {
-  const errorResponse: QueryValidationState = {
-    status: 'ERROR',
-    explanations: [{
-      errorType: 'ParseException',
-      errorMessage: "Cannot parse 'source: '",
-      beginLine: 1,
-      endLine: 1,
-      beginColumn: 1,
-      endColumn: 5,
-    }],
-  };
-
   const validationErrorIconTitle = 'Toggle validation error explanation';
 
   const openExplanation = async () => {
@@ -90,7 +79,7 @@ describe('QueryValidation', () => {
   });
 
   it('should display validation error icon when there is a validation error', async () => {
-    render(<SUT error={errorResponse} />);
+    render(<SUT error={validationError} />);
 
     await screen.findByTitle(validationErrorIconTitle);
   });
@@ -102,7 +91,7 @@ describe('QueryValidation', () => {
   });
 
   it('should display validation error explanation', async () => {
-    render(<SUT error={errorResponse} />);
+    render(<SUT error={validationError} />);
 
     await openExplanation();
 
@@ -112,7 +101,7 @@ describe('QueryValidation', () => {
   });
 
   it('should display validation error specific documentation links', async () => {
-    render(<SUT error={errorResponse} />);
+    render(<SUT error={validationError} />);
 
     await openExplanation();
 

--- a/graylog2-web-interface/test/fixtures/queryValidationState.ts
+++ b/graylog2-web-interface/test/fixtures/queryValidationState.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+
+import type { QueryValidationState } from 'views/components/searchbar/queryvalidation/types';
+
+// eslint-disable-next-line import/prefer-default-export
+export const validationError: QueryValidationState = {
+  status: 'ERROR',
+  explanations: [{
+    errorType: 'ParseException',
+    errorMessage: "Cannot parse 'source: '",
+    beginLine: 1,
+    endLine: 1,
+    beginColumn: 1,
+    endColumn: 5,
+  }],
+};


### PR DESCRIPTION
## Description
This PR is fixing two bugs for the query input where an action provided for the `QueryInput` worked with outdated references:
- the `completers`, before this change they references an outdated version of the selected time range and streams.
- the `onExecute` action, before this change this function referenced an outdated an outed version of the `error` prop.

Before this change we tried to configure the editor, by using the relevant editor prop, like
- `onLoad` for the initial configuration
- `completers` for the custom completers
- `commands` for the custom commands

Unfortunately this is not an option when defining data which relies on external data, like `error`, `timeRange` and `streams`. In this case the reference for the external data is not up to date, whenever the ace editor is executing code which implements the mentioned props.

With this PR we are using the editor `ref` prop (again) to ensure we update the editor config and references to external data on every render.

I added tests for the query input and made sure we are testing the actual implementation, but I plan to add more tests in a follow-up PR, also for use cases which are not related to this bugfix.