### PR TITLE
Define more flexible widget export types.

### DIFF
--- a/graylog2-web-interface/src/views/components/defaultTitle.ts
+++ b/graylog2-web-interface/src/views/components/defaultTitle.ts
@@ -20,7 +20,7 @@ import { widgetDefinition } from 'views/logic/Widgets';
 
 const defaultTitleGenerator = (w) => `Untitled ${w.type.replace('_', ' ').split(' ').map(capitalize).join(' ')}`;
 
-const defaultTitle = (widget) => {
+const defaultTitle = (widget: { type: string }) => {
   const widgetDef = widgetDefinition(widget.type);
 
   return (widgetDef.titleGenerator || defaultTitleGenerator)(widget);

--- a/graylog2-web-interface/src/views/components/useWidgetResults.ts
+++ b/graylog2-web-interface/src/views/components/useWidgetResults.ts
@@ -36,7 +36,7 @@ const _getDataAndErrors = (widget: Widget, widgetMapping: WidgetMapping, results
   const widgetErrors = results.errors.filter((e) => searchTypeIds.includes(e.searchTypeId));
   let error;
 
-  const data = dataTransformer(widgetData, widget);
+  const data = dataTransformer(widgetData);
 
   if (widgetErrors && widgetErrors.length > 0) {
     error = widgetErrors;

--- a/graylog2-web-interface/src/views/types.ts
+++ b/graylog2-web-interface/src/views/types.ts
@@ -93,7 +93,7 @@ export interface WidgetExport {
   visualizationComponent: React.ComponentType<WidgetComponentProps>;
   editComponent: React.ComponentType<EditWidgetComponentProps>;
   needsControlledHeight: (widget: { config: Widget['config'] }) => boolean;
-  searchResultTransformer?: (data: Array<unknown>, widget?: Widget) => unknown;
+  searchResultTransformer?: (data: Array<unknown>) => unknown;
   searchTypes: (widget: Widget) => Array<any>;
   titleGenerator?: (widget: Widget) => string;
   reportStyle?: () => { width: React.CSSProperties['width'] };

--- a/graylog2-web-interface/src/views/types.ts
+++ b/graylog2-web-interface/src/views/types.ts
@@ -92,8 +92,8 @@ export interface WidgetExport {
   defaultWidth?: number;
   visualizationComponent: React.ComponentType<WidgetComponentProps>;
   editComponent: React.ComponentType<EditWidgetComponentProps>;
-  needsControlledHeight: (widget: Widget) => boolean;
-  searchResultTransformer?: (data: Array<unknown>, widget: Widget) => unknown;
+  needsControlledHeight: (widget: { config: Widget['config'] }) => boolean;
+  searchResultTransformer?: (data: Array<unknown>, widget?: Widget) => unknown;
   searchTypes: (widget: Widget) => Array<any>;
   titleGenerator?: (widget: Widget) => string;
   reportStyle?: () => { width: React.CSSProperties['width'] };


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

For some widget export helper functions we are now only typing the data we are really using.
Before this change these functions expected a complete `Widget`.
With the less complex types they are more flexible because we do not need provide a complete widget to satisfy TypeScript.

