### PR TITLE
Allow overriding user timezone in `UserDateTimeProvider`.

### DIFF
--- a/graylog2-web-interface/src/contexts/UserDateTimeProvider.test.tsx
+++ b/graylog2-web-interface/src/contexts/UserDateTimeProvider.test.tsx
@@ -41,7 +41,7 @@ describe('DateTimeProvider', () => {
 
     render(
       <CurrentUserContext.Provider value={currentUser}>
-        <UserDateTimeProvider tzOverride={tzOverride}>
+        <UserDateTimeProvider tz={tzOverride}>
           <UserDateTimeContext.Consumer>
             {(value) => {
               contextValue = value;

--- a/graylog2-web-interface/src/contexts/UserDateTimeProvider.tsx
+++ b/graylog2-web-interface/src/contexts/UserDateTimeProvider.tsx
@@ -25,7 +25,7 @@ import { DATE_TIME_FORMATS, getBrowserTimezone, toDateObject } from 'util/DateTi
 
 type Props = {
   children: React.ReactNode,
-  tzOverride?: string,
+  tz?: string,
 };
 
 const getUserTimezone = (userTimezone, tzOverride) => {
@@ -41,7 +41,7 @@ const getUserTimezone = (userTimezone, tzOverride) => {
  * Should be used when displaying times and the related components are not a suitable option.
  */
 
-const UserDateTimeProvider = ({ children, tzOverride }: Props) => {
+const UserDateTimeProvider = ({ children, tz: tzOverride }: Props) => {
   const currentUser = useContext(CurrentUserContext);
   const userTimezone = useMemo(() => getUserTimezone(currentUser?.timezone, tzOverride), [currentUser?.timezone, tzOverride]);
 
@@ -66,7 +66,7 @@ const UserDateTimeProvider = ({ children, tzOverride }: Props) => {
 };
 
 UserDateTimeProvider.defaultProps = {
-  tzOverride: undefined,
+  tz: undefined,
 };
 
 export default UserDateTimeProvider;

--- a/graylog2-web-interface/src/contexts/UserDateTimeProvider.tsx
+++ b/graylog2-web-interface/src/contexts/UserDateTimeProvider.tsx
@@ -17,7 +17,6 @@
 import * as React from 'react';
 import { useCallback, useMemo, useContext } from 'react';
 
-import type { UserDateTimeContextType } from 'contexts/UserDateTimeContext';
 import UserDateTimeContext from 'contexts/UserDateTimeContext';
 import AppConfig from 'util/AppConfig';
 import CurrentUserContext from 'contexts/CurrentUserContext';
@@ -25,10 +24,15 @@ import type { DateTime, DateTimeFormats } from 'util/DateTime';
 import { DATE_TIME_FORMATS, getBrowserTimezone, toDateObject } from 'util/DateTime';
 
 type Props = {
-  children: React.ReactChildren | React.ReactChild | ((timeLocalize: UserDateTimeContextType) => Element),
+  children: React.ReactNode,
+  tzOverride?: string,
 };
 
-const getUserTimezone = (userTimezone) => {
+const getUserTimezone = (userTimezone, tzOverride) => {
+  if (tzOverride) {
+    return tzOverride;
+  }
+
   return userTimezone ?? getBrowserTimezone() ?? AppConfig.rootTimeZone() ?? 'UTC';
 };
 
@@ -37,9 +41,9 @@ const getUserTimezone = (userTimezone) => {
  * Should be used when displaying times and the related components are not a suitable option.
  */
 
-const UserDateTimeProvider = ({ children }: Props) => {
+const UserDateTimeProvider = ({ children, tzOverride }: Props) => {
   const currentUser = useContext(CurrentUserContext);
-  const userTimezone = useMemo(() => getUserTimezone(currentUser?.timezone), [currentUser?.timezone]);
+  const userTimezone = useMemo(() => getUserTimezone(currentUser?.timezone, tzOverride), [currentUser?.timezone, tzOverride]);
 
   const toUserTimezone = useCallback((time: DateTime) => {
     return toDateObject(time, undefined, userTimezone);
@@ -59,6 +63,10 @@ const UserDateTimeProvider = ({ children }: Props) => {
       {children}
     </UserDateTimeContext.Provider>
   );
+};
+
+UserDateTimeProvider.defaultProps = {
+  tzOverride: undefined,
 };
 
 export default UserDateTimeProvider;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

We are using the `UserDateTimeContext` to display times based on the user time zone. In some cases it can be useful to be able to control this timezone. For example if you want to display all times on a page in a specific timezone.

By overriding the timezone in the `UserDateTimeProvider` we are changing the timezone for all displayed times.
