### PR TITLE
Only display margin between loading spinner icon and text when text is provided.

### DIFF
--- a/graylog2-web-interface/src/components/common/Spinner.tsx
+++ b/graylog2-web-interface/src/components/common/Spinner.tsx
@@ -38,7 +38,7 @@ type Props = {
  */
 const Spinner = ({ name, text, delay, ...rest }: Props) => (
   <Delayed delay={delay}>
-    <StyledIcon {...rest} name={name} $displayMargin={!!text} spin />{text}
+    <StyledIcon {...rest} name={name} $displayMargin={!!text?.trim()} spin />{text}
   </Delayed>
 );
 

--- a/graylog2-web-interface/src/components/common/Spinner.tsx
+++ b/graylog2-web-interface/src/components/common/Spinner.tsx
@@ -23,9 +23,9 @@ import type { IconName } from 'components/common/Icon';
 import Icon from './Icon';
 import Delayed from './Delayed';
 
-const StyledIcon = styled(Icon)`
-  margin-right: 6px;
-`;
+const StyledIcon = styled(Icon)(({ $displayMargin }: { $displayMargin: boolean }) => (
+  $displayMargin ? 'margin-right: 6px;' : ''
+));
 
 type Props = {
   delay?: number,
@@ -38,7 +38,7 @@ type Props = {
  */
 const Spinner = ({ name, text, delay, ...rest }: Props) => (
   <Delayed delay={delay}>
-    <StyledIcon {...rest} name={name} spin />{text}
+    <StyledIcon {...rest} name={name} $displayMargin={!!text} spin />{text}
   </Delayed>
 );
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The `Spinner` component has a `margin-right` for the spinner icon, which creates space between the icon and the text.
With this PR we are not setting the margin, when there is no text.
