### PR TITLE
Use current time per default for the `Timestamp`, `RelativeTime` and `BrowserTime` component when `dateTime` prop is not defined.

### DIFF
--- a/graylog2-web-interface/src/components/common/BrowserTime.test.tsx
+++ b/graylog2-web-interface/src/components/common/BrowserTime.test.tsx
@@ -19,6 +19,12 @@ import { render, screen } from 'wrappedTestingLibrary';
 
 import BrowserTime from './BrowserTime';
 
+const mockedUnixTime = 1577836800000; // 2020-01-01 00:00:00.000
+
+jest.useFakeTimers()
+  // @ts-expect-error
+  .setSystemTime(mockedUnixTime);
+
 jest.mock('util/DateTime', () => {
   const DateTime = jest.requireActual('util/DateTime');
   DateTime.getBrowserTimezone('America/Chicago');
@@ -32,7 +38,7 @@ describe('BrowserTime', () => {
       <BrowserTime dateTime="2020-01-01T10:00:00.000Z" />,
     );
 
-    expect(screen.getByText('2020-01-01 04:00:00')).toBeInTheDocument();
+    expect(screen.getByText('2019-12-31 18:00:00')).toBeInTheDocument();
   });
 
   it('should display browser time in a specific format', () => {
@@ -41,5 +47,23 @@ describe('BrowserTime', () => {
     );
 
     expect(screen.getByText('2020-01-01 04:00:00 -06:00')).toBeInTheDocument();
+  });
+
+  it('should display current browser time, when date time is not defined', () => {
+    render(<BrowserTime />);
+
+    expect(screen.getByText('2019-12-31 18:00:00')).toBeInTheDocument();
+  });
+
+  it('should display current browser time, when date time is undefined', () => {
+    render(<BrowserTime dateTime={undefined} />);
+
+    expect(screen.getByText('2019-12-31 18:00:00')).toBeInTheDocument();
+  });
+
+  it('should display current browser time, when date time is null', () => {
+    render(<BrowserTime dateTime={null} />);
+
+    expect(screen.getByText('2019-12-31 18:00:00')).toBeInTheDocument();
   });
 });

--- a/graylog2-web-interface/src/components/common/BrowserTime.test.tsx
+++ b/graylog2-web-interface/src/components/common/BrowserTime.test.tsx
@@ -38,7 +38,7 @@ describe('BrowserTime', () => {
       <BrowserTime dateTime="2020-01-01T10:00:00.000Z" />,
     );
 
-    expect(screen.getByText('2019-12-31 18:00:00')).toBeInTheDocument();
+    expect(screen.getByText('2020-01-01 04:00:00')).toBeInTheDocument();
   });
 
   it('should display browser time in a specific format', () => {

--- a/graylog2-web-interface/src/components/common/BrowserTime.tsx
+++ b/graylog2-web-interface/src/components/common/BrowserTime.tsx
@@ -22,14 +22,15 @@ import type { DateTimeFormats } from 'util/DateTime';
 import { formatAsBrowserTime, adjustFormat } from 'util/DateTime';
 
 type Props = {
-  dateTime: string | number | Date | Moment,
+  dateTime?: string | number | Date | Moment,
   format?: DateTimeFormats,
 };
 
 /**
  * This component receives any date time and displays it in the browser time zone.
  */
-const BrowserTime = ({ dateTime, format }: Props) => {
+const BrowserTime = ({ dateTime: dateTimeProp, format }: Props) => {
+  const dateTime = dateTimeProp ?? new Date();
   const dateTimeString = adjustFormat(dateTime, 'internal');
   const timeInBrowserTimeZone = formatAsBrowserTime(dateTime, format);
 
@@ -46,7 +47,7 @@ BrowserTime.propTypes = {
    * 8601 string, a JS native `Date` object, a moment `Date` object, or
    * a number containing seconds after UNIX epoch.
    */
-  dateTime: PropTypes.oneOfType([PropTypes.string, PropTypes.object, PropTypes.number]).isRequired,
+  dateTime: PropTypes.oneOfType([PropTypes.string, PropTypes.object, PropTypes.number]),
   /**
    * Format to use to represent the date time.
    */
@@ -55,6 +56,7 @@ BrowserTime.propTypes = {
 
 BrowserTime.defaultProps = {
   format: 'default',
+  dateTime: undefined,
 };
 
 export default BrowserTime;

--- a/graylog2-web-interface/src/components/common/RelativeTime.test.tsx
+++ b/graylog2-web-interface/src/components/common/RelativeTime.test.tsx
@@ -33,4 +33,22 @@ describe('RelativeTime', () => {
 
     expect(screen.getByText('a year ago')).toBeInTheDocument();
   });
+
+  it('should display time relative to current time, when date time is not defined', () => {
+    render(<RelativeTime />);
+
+    expect(screen.getByText('a few seconds ago')).toBeInTheDocument();
+  });
+
+  it('should display time relative to current time, when date time is undefined', () => {
+    render(<RelativeTime dateTime={undefined} />);
+
+    expect(screen.getByText('a few seconds ago')).toBeInTheDocument();
+  });
+
+  it('should display time relative to current time, when date time is null', () => {
+    render(<RelativeTime dateTime={null} />);
+
+    expect(screen.getByText('a few seconds ago')).toBeInTheDocument();
+  });
 });

--- a/graylog2-web-interface/src/components/common/RelativeTime.tsx
+++ b/graylog2-web-interface/src/components/common/RelativeTime.tsx
@@ -21,14 +21,15 @@ import type { Moment } from 'moment';
 import { relativeDifference, adjustFormat } from 'util/DateTime';
 
 type Props = {
-  dateTime: string | number | Date | Moment,
+  dateTime?: string | number | Date | Moment,
 };
 
 /**
  * This component receives any date time and displays the relative time until now in a human readable format.
  */
 
-const RelativeTime = ({ dateTime }: Props) => {
+const RelativeTime = ({ dateTime: dateTimeProp }: Props) => {
+  const dateTime = dateTimeProp ?? new Date();
   const relativeTime = relativeDifference(dateTime);
   const dateTimeString = adjustFormat(dateTime, 'internal');
 
@@ -45,7 +46,11 @@ RelativeTime.propTypes = {
    * 8601 string, a JS native `Date` object, a moment `Date` object, or
    * a number containing seconds after UNIX epoch.
    */
-  dateTime: PropTypes.oneOfType([PropTypes.string, PropTypes.object, PropTypes.number]).isRequired,
+  dateTime: PropTypes.oneOfType([PropTypes.string, PropTypes.object, PropTypes.number]),
+};
+
+RelativeTime.defaultProps = {
+  dateTime: undefined,
 };
 
 export default RelativeTime;

--- a/graylog2-web-interface/src/components/common/Timestamp.test.tsx
+++ b/graylog2-web-interface/src/components/common/Timestamp.test.tsx
@@ -21,6 +21,12 @@ import Timestamp from './Timestamp';
 
 jest.mock('hooks/useUserDateTime');
 
+const mockedUnixTime = 1577836800000; // 2020-01-01 00:00:00.000
+
+jest.useFakeTimers()
+  // @ts-expect-error
+  .setSystemTime(mockedUnixTime);
+
 describe('Timestamp', () => {
   it('should render date time', () => {
     render(<Timestamp dateTime="2020-01-01T10:00:00.000Z" />);
@@ -38,5 +44,23 @@ describe('Timestamp', () => {
     render(<Timestamp dateTime="2020-01-01T10:00:00.000Z" format="internal" tz="Europe/Moscow" />);
 
     expect(screen.getByText('2020-01-01T13:00:00.000+03:00')).toBeInTheDocument();
+  });
+
+  it('should display current time, when date time is not defined', () => {
+    render(<Timestamp />);
+
+    expect(screen.getByText('2020-01-01 00:00:00')).toBeInTheDocument();
+  });
+
+  it('should display current time, when date time is undefined', () => {
+    render(<Timestamp dateTime={undefined} />);
+
+    expect(screen.getByText('2020-01-01 00:00:00')).toBeInTheDocument();
+  });
+
+  it('should display current time, when date time is null', () => {
+    render(<Timestamp dateTime={null} />);
+
+    expect(screen.getByText('2020-01-01 00:00:00')).toBeInTheDocument();
   });
 });

--- a/graylog2-web-interface/src/components/common/Timestamp.tsx
+++ b/graylog2-web-interface/src/components/common/Timestamp.tsx
@@ -23,7 +23,7 @@ import useUserDateTime from 'hooks/useUserDateTime';
 import { adjustFormat } from 'util/DateTime';
 
 type Props = {
-  dateTime: string | number | Date | Moment,
+  dateTime?: string | number | Date | Moment,
   field?: string,
   format?: DateTimeFormats,
   render?: React.ComponentType<{ value: string, field: string | undefined }>,
@@ -40,8 +40,9 @@ type Props = {
  * from a UTC time that was used in the server.
  *
  */
-const Timestamp = ({ dateTime, field, format, render: Component, tz }: Props) => {
+const Timestamp = ({ dateTime: dateTimeProp, field, format, render: Component, tz }: Props) => {
   const { formatTime: formatWithUserTz } = useUserDateTime();
+  const dateTime = dateTimeProp ?? new Date();
   const formattedDateTime = tz ? adjustFormat(dateTime, format, tz) : formatWithUserTz(dateTime, format);
   const dateTimeString = adjustFormat(dateTime, 'internal');
 
@@ -58,7 +59,7 @@ Timestamp.propTypes = {
    * 8601 string, a JS native `Date` object, a moment `Date` object, or
    * a number containing seconds after UNIX epoch.
    */
-  dateTime: PropTypes.oneOfType([PropTypes.string, PropTypes.object, PropTypes.number]).isRequired,
+  dateTime: PropTypes.oneOfType([PropTypes.string, PropTypes.object, PropTypes.number]),
   /**
    * Format to represent the date time.
    */
@@ -77,6 +78,7 @@ Timestamp.propTypes = {
 };
 
 Timestamp.defaultProps = {
+  dateTime: undefined,
   field: undefined,
   format: 'default',
   render: ({ value }) => value,


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

We recently refactored the `Timestamp`, and implemented the `RelativeTime` and `BrowserTime` components to unify the way we display times in the UI.

One part of the refactoring was replacing the usage of the `logic/DateTime` class. The class constructor used the current time by default when no date time has been provided. With this PR we are now also using the current time by default for the mentioned components.

This is also fixing a bug, since the current implementation throws an error (`Date time null is not valid.`) when the date time for these components is not defined. This happened on the system overview page because the `started_at` field of system jobs can be null.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

