### PR TITLE
Do not enforce destructuring assignments in linter.

### DIFF
--- a/graylog2-web-interface/packages/eslint-config-graylog/index.js
+++ b/graylog2-web-interface/packages/eslint-config-graylog/index.js
@@ -107,6 +107,7 @@ module.exports = {
     'no-underscore-dangle': 'off',
     'object-curly-newline': ['error', { multiline: true, consistent: true }],
     'object-shorthand': ['error', 'methods'],
+    'react/destructuring-assignment': 'off',
     'react/forbid-prop-types': 'off',
     'react/function-component-definition': 'off',
     'react/jsx-closing-bracket-location': ['warn', 'after-props'],

--- a/graylog2-web-interface/src/components/common/SourceCodeEditor.jsx
+++ b/graylog2-web-interface/src/components/common/SourceCodeEditor.jsx
@@ -191,16 +191,12 @@ class SourceCodeEditor extends React.Component {
     }
   };
 
-  /* eslint-disable-next-line react/destructuring-assignment */
   isCopyDisabled = () => this.props.readOnly || this.state.selectedText === '';
 
-  /* eslint-disable-next-line react/destructuring-assignment */
   isPasteDisabled = () => this.props.readOnly;
 
-  /* eslint-disable-next-line react/destructuring-assignment */
   isRedoDisabled = () => this.props.readOnly || !this.reactAce || !this.reactAce.editor.getSession().getUndoManager().hasRedo();
 
-  /* eslint-disable-next-line react/destructuring-assignment */
   isUndoDisabled = () => this.props.readOnly || !this.reactAce || !this.reactAce.editor.getSession().getUndoManager().hasUndo();
 
   handleRedo = () => {

--- a/graylog2-web-interface/src/components/pipelines/Pipeline.tsx
+++ b/graylog2-web-interface/src/components/pipelines/Pipeline.tsx
@@ -94,7 +94,6 @@ const Pipeline = ({ pipeline, connections, streams, onConnectionsChange, onStage
   }, [pipeline, onStagesChange]);
 
   const _formatConnectedStreams = (connectedStreams: Stream[]) => {
-    // eslint-disable-next-line react/destructuring-assignment
     const formattedStreams = connectedStreams.map((s) => `"${s.title}"`);
     const streamList = formattedStreams.length > 1 ? [formattedStreams.slice(0, -1).join(', '), formattedStreams.slice(-1)].join(' and ') : formattedStreams[0];
 

--- a/graylog2-web-interface/src/components/search/MessageDetail.jsx
+++ b/graylog2-web-interface/src/components/search/MessageDetail.jsx
@@ -99,7 +99,6 @@ class MessageDetail extends React.Component {
     const { renderForDisplay, nodes, message, customFieldActions } = this.props;
     const streamIds = Immutable.Set(message.stream_ids);
     const streams = streamIds.map((id) => {
-      // eslint-disable-next-line react/destructuring-assignment
       const stream = this.props.streams.get(id);
 
       if (stream !== undefined) {

--- a/graylog2-web-interface/src/pages/ConfigurationsPage.tsx
+++ b/graylog2-web-interface/src/pages/ConfigurationsPage.tsx
@@ -46,7 +46,6 @@ const EVENTS_CONFIG = 'org.graylog.events.configuration.EventsConfiguration';
 const URL_WHITELIST_CONFIG = 'org.graylog2.system.urlwhitelist.UrlWhitelist';
 const PERMISSIONS_CONFIG = 'org.graylog2.users.UserAndTeamsConfig';
 
-// eslint-disable-next-line react/destructuring-assignment
 const _getConfig = (configType, configuration) => configuration?.[configType] ?? null;
 
 const _onUpdate = (configType: string) => {

--- a/graylog2-web-interface/src/pages/EditExtractorsPage.jsx
+++ b/graylog2-web-interface/src/pages/EditExtractorsPage.jsx
@@ -63,7 +63,6 @@ const EditExtractorsPage = createReactClass({
   },
 
   _isLoading() {
-    // eslint-disable-next-line react/destructuring-assignment
     return !(this.state.input && this.state.extractor && this.state.exampleMessage);
   },
 

--- a/graylog2-web-interface/src/pages/ExportExtractorsPage.jsx
+++ b/graylog2-web-interface/src/pages/ExportExtractorsPage.jsx
@@ -40,7 +40,6 @@ const ExportExtractorsPage = createReactClass({
   },
 
   _isLoading() {
-    // eslint-disable-next-line react/destructuring-assignment
     return !this.state.input;
   },
 

--- a/graylog2-web-interface/src/pages/ImportExtractorsPage.jsx
+++ b/graylog2-web-interface/src/pages/ImportExtractorsPage.jsx
@@ -40,7 +40,6 @@ const ImportExtractorsPage = createReactClass({
   },
 
   _isLoading() {
-    // eslint-disable-next-line react/destructuring-assignment
     return !this.state.input;
   },
 

--- a/graylog2-web-interface/src/views/components/messagelist/FormatReceivedBy.tsx
+++ b/graylog2-web-interface/src/views/components/messagelist/FormatReceivedBy.tsx
@@ -25,7 +25,6 @@ import usePluginEntities from 'views/logic/usePluginEntities';
 type Inputs = Immutable.Map<string, Input>;
 
 const _inputName = (inputs: Inputs, inputId: string) => {
-  // eslint-disable-next-line react/destructuring-assignment
   const input = inputs.get(inputId);
 
   return input ? <span style={{ wordBreak: 'break-word' }}>{input.title}</span> : 'deleted input';

--- a/graylog2-web-interface/src/views/components/messagelist/MessageActions.tsx
+++ b/graylog2-web-interface/src/views/components/messagelist/MessageActions.tsx
@@ -41,7 +41,6 @@ type Props = {
 };
 
 const _getTestAgainstStreamButton = (streams: Immutable.List<any>, index: string, id: string) => {
-  // eslint-disable-next-line react/destructuring-assignment
   const streamList = streams.map((stream) => {
     if (stream.is_default) {
       return <MenuItem key={stream.id} disabled title="Cannot test against the default stream">{stream.title}</MenuItem>;

--- a/graylog2-web-interface/src/views/components/messagelist/MessageDetail.tsx
+++ b/graylog2-web-interface/src/views/components/messagelist/MessageDetail.tsx
@@ -101,7 +101,6 @@ const MessageDetail = ({
 
   const streamIds = Immutable.Set(fields.streams as Array<string>);
   const streamsListItems = streamIds.map((streamId) => {
-    // eslint-disable-next-line react/destructuring-assignment
     const stream = streams.get(streamId);
 
     if (stream !== undefined) {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is disabling the [`react/destructuring-assignment`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/destructuring-assignment.md) rule. While destructuring props is still encouraged, it does not make sense to enforce this for legacy code which is otherwise working well. In addition, it does produce unwanted errors in some cases while providing very little benefits for most situations.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.