### PR TITLE
Add default Analyst Tools page text

### DIFF
--- a/graylog2-web-interface/src/pages/SecurityPage.tsx
+++ b/graylog2-web-interface/src/pages/SecurityPage.tsx
@@ -20,15 +20,17 @@ import styled, { css } from 'styled-components';
 
 import { DocumentTitle, IfPermitted, PageHeader } from 'components/common';
 import HideOnCloud from 'util/conditional/HideOnCloud';
-import { Col, Row } from 'components/bootstrap';
+import {Col, Row, Alert} from 'components/bootstrap';
+import {Link} from 'components/common/router';
+import Routes from 'routing/Routes';
+import AppConfig from 'util/AppConfig';
 
-const BiggerFontSize = styled.div(({ theme }) => css`
-  font-size: ${theme.fonts.size.large};
-`);
-
-const GraylogSecurityHeader = styled.h2`
-  margin-bottom: 10px;
+const StyledH4 = styled.h4`
+  font-weight: bold;
+  margin-bottom: 5px;
 `;
+
+const isCloud = AppConfig.isCloud();
 
 /*
   TODO: This is a placeholder promotional page. We are still waiting on copy from marketing
@@ -37,18 +39,29 @@ const SecurityPage = () => {
   return (
     <DocumentTitle title="Try Graylog Security">
       <div>
-        <PageHeader title="Try Graylog for Security">
-          <span>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Asperiores at autem dignissimos, doloremque eaque earum eligendi expedita minus molestias nam numquam officia optio provident quaerat qui sint sit ullam veritatis.</span>
+        <PageHeader title="Graylog for Security">
+          <span>Analyst tools that help you use Graylog for Security.</span>
         </PageHeader>
 
         <HideOnCloud>
           <IfPermitted permissions="freelicenses:create">
             <Row className="content">
               <Col md={6}>
-                <GraylogSecurityHeader>Graylog for Security</GraylogSecurityHeader>
-                <BiggerFontSize>
-                  Lorem ipsum dolor sit amet, consectetur adipisicing elit. Accusantium beatae consequatur ducimus ea eos eveniet, laboriosam molestias nisi, pariatur perferendis porro quae quas quo suscipit veritatis vitae voluptatem voluptates voluptatum!
-                </BiggerFontSize>
+                <Alert bsStyle="danger">
+                  <StyledH4>Graylog for Security is disabled</StyledH4>
+                  <p>
+                    Graylog for Security Analyst Tools are disabled because a valid Graylog for Security license was not found.
+                  </p>
+                  {isCloud
+                    ? (<>Contact your Graylog account manager.</>)
+                    : (
+                      <IfPermitted permissions="licenses:create">
+                        <p>
+                          See <Link to={Routes.pluginRoute('SYSTEM_LICENSES')}>Licenses page</Link> for details.
+                        </p>
+                      </IfPermitted>
+                    )}
+                </Alert>
               </Col>
               <Col md={6}>
                 {/* Put License Status here */}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds default text that displays in the main Analyst Tools page when a Graylog Security license is not installed. As discussed with @bud1979, the page currently displays a warning indicating that a Graylog for Security license is not installed.

Previously, the page just displayed placeholder "lorem ipsum" text.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Verify that the page displays when a Graylog Security license is not installed, and also that the normal Overview page displays when the license is installed. 

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/3423655/154147427-a415e4aa-0f46-4393-ba5a-591ec170d0f6.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

