### PR TITLE
Add props onClick, onMouseEnter, onMouseLeave, onFocus, tabIndex, title to Icon component

### DIFF
--- a/graylog2-web-interface/src/components/common/Icon.tsx
+++ b/graylog2-web-interface/src/components/common/Icon.tsx
@@ -14,11 +14,11 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
+import type { SyntheticEvent } from 'react';
 import React from 'react';
 import { find } from 'lodash';
 import type { IconName } from '@fortawesome/fontawesome-common-types';
 import type { SizeProp } from '@fortawesome/fontawesome-svg-core';
-import type { FontAwesomeIconProps } from '@fortawesome/react-fontawesome';
 
 import deprecationNotice from 'util/deprecationNotice';
 import loadAsync from 'routing/loadAsync';
@@ -64,7 +64,7 @@ const getPrefixForType = (type: IconTypes) => {
   }
 };
 
-type Props = FontAwesomeIconProps & {
+type Props = {
   className?: string,
   'data-testid'?: string,
   /** Name of Font Awesome 5 Icon without `fa-` prefix */
@@ -80,6 +80,12 @@ type Props = FontAwesomeIconProps & {
   fixedWidth?: boolean,
   inverse?: boolean,
   style?: React.CSSProperties,
+  onClick?: (event: SyntheticEvent) => void,
+  onMouseEnter?: (event: SyntheticEvent) => void,
+  onMouseLeave?: (event: SyntheticEvent) => void,
+  onFocus?: (event: SyntheticEvent) => void,
+  tabIndex?: number,
+  title?: string,
 }
 
 /**
@@ -137,6 +143,12 @@ Icon.defaultProps = {
   spin: false,
   style: undefined,
   type: 'solid',
+  onClick: undefined,
+  onMouseEnter: undefined,
+  onMouseLeave: undefined,
+  onFocus: undefined,
+  tabIndex: undefined,
+  title: undefined,
 };
 
 export type { IconName };

--- a/graylog2-web-interface/src/components/common/Icon.tsx
+++ b/graylog2-web-interface/src/components/common/Icon.tsx
@@ -14,7 +14,7 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import type { SyntheticEvent } from 'react';
+
 import React from 'react';
 import { find } from 'lodash';
 import type { IconName } from '@fortawesome/fontawesome-common-types';
@@ -80,10 +80,10 @@ type Props = {
   fixedWidth?: boolean,
   inverse?: boolean,
   style?: React.CSSProperties,
-  onClick?: (event: SyntheticEvent) => void,
-  onMouseEnter?: (event: SyntheticEvent) => void,
-  onMouseLeave?: (event: SyntheticEvent) => void,
-  onFocus?: (event: SyntheticEvent) => void,
+  onClick?: (event: React.MouseEvent<SVGSVGElement>) => void,
+  onMouseEnter?: (event: React.MouseEvent<SVGSVGElement>) => void,
+  onMouseLeave?: (event: React.MouseEvent<SVGSVGElement>) => void,
+  onFocus?: (event: React.FocusEvent<SVGSVGElement>) => void,
   tabIndex?: number,
   title?: string,
 }

--- a/graylog2-web-interface/src/components/common/Icon.tsx
+++ b/graylog2-web-interface/src/components/common/Icon.tsx
@@ -18,6 +18,7 @@ import React from 'react';
 import { find } from 'lodash';
 import type { IconName } from '@fortawesome/fontawesome-common-types';
 import type { SizeProp } from '@fortawesome/fontawesome-svg-core';
+import type { FontAwesomeIconProps } from '@fortawesome/react-fontawesome';
 
 import deprecationNotice from 'util/deprecationNotice';
 import loadAsync from 'routing/loadAsync';
@@ -63,7 +64,7 @@ const getPrefixForType = (type: IconTypes) => {
   }
 };
 
-type Props = {
+type Props = FontAwesomeIconProps & {
   className?: string,
   'data-testid'?: string,
   /** Name of Font Awesome 5 Icon without `fa-` prefix */
@@ -78,7 +79,7 @@ type Props = {
   type?: IconTypes,
   fixedWidth?: boolean,
   inverse?: boolean,
-  style?: React.CSSProperties
+  style?: React.CSSProperties,
 }
 
 /**
@@ -89,7 +90,23 @@ type Props = {
  * Visit [React FontAwesome Features](https://github.com/FortAwesome/react-fontawesome#features) for more information.
  */
 
-const Icon = ({ name, type, size, className, spin, fixedWidth, inverse, style, 'data-testid': testId }: Props) => {
+const Icon = ({
+  name,
+  type,
+  size,
+  className,
+  spin,
+  fixedWidth,
+  inverse,
+  style,
+  'data-testid': testId,
+  onClick,
+  onMouseEnter,
+  onMouseLeave,
+  onFocus,
+  tabIndex,
+  title,
+}: Props) => {
   const iconName = cleanIconName(name, type);
   const prefix = getPrefixForType(type);
 
@@ -101,7 +118,13 @@ const Icon = ({ name, type, size, className, spin, fixedWidth, inverse, style, '
                            inverse={inverse}
                            size={size}
                            spin={spin}
-                           style={style} />
+                           style={style}
+                           onClick={onClick}
+                           onMouseEnter={onMouseEnter}
+                           onMouseLeave={onMouseLeave}
+                           tabIndex={tabIndex}
+                           title={title}
+                           onFocus={onFocus} />
   );
 };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes https://github.com/Graylog2/graylog2-server/issues/12131
Fixes https://github.com/Graylog2/graylog2-server/issues/12166
During investigation I found that Icon component doesn't expect some necessary props.  
So I checked in the code which props we try to use and add them to the Icon  component

## Motivation and Context
As component doesn't expect a lot of props we are not able to handle events when we use Icon component
[<!--- If it fixes an open issue, please link to the issue here. -->](https://github.com/Graylog2/graylog2-server/issues/12131 )

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

