### PR TITLE
Lucene query parser code cleanup

### DIFF
--- a/full-backend-tests/src/test/java/org/graylog/plugins/views/QueryValidationResourceIT.java
+++ b/full-backend-tests/src/test/java/org/graylog/plugins/views/QueryValidationResourceIT.java
@@ -58,7 +58,7 @@ public class QueryValidationResourceIT {
                 .then()
                 .statusCode(200);
         validatableResponse.assertThat().body("status", equalTo("ERROR"));
-        validatableResponse.assertThat().body("explanations.error_message[0]", containsString("Cannot parse query 'foo:', cause: incomplete query, query ended unexpectedly"));
+        validatableResponse.assertThat().body("explanations.error_message[0]", containsString("Cannot parse query, cause: incomplete query, query ended unexpectedly"));
     }
 
     @ContainerMatrixTest

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/validation/ParsedTerm.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/validation/ParsedTerm.java
@@ -20,7 +20,9 @@ import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
 import org.apache.lucene.queryparser.classic.Token;
 
+import javax.annotation.Nullable;
 import javax.validation.constraints.NotNull;
+import java.util.Optional;
 
 @AutoValue
 public abstract class ParsedTerm {
@@ -32,7 +34,7 @@ public abstract class ParsedTerm {
 
     public abstract String value();
 
-    public abstract ImmutableList<ImmutableToken> tokens();
+    public abstract Optional<ImmutableToken> keyToken();
 
     public static ParsedTerm create(final String field, final String value) {
         return builder().field(field).value(value).build();
@@ -71,7 +73,7 @@ public abstract class ParsedTerm {
     public abstract static class Builder {
         public abstract Builder field(@NotNull String field);
         public abstract Builder value(@NotNull String value);
-        public abstract ImmutableList.Builder<ImmutableToken> tokensBuilder();
+        public abstract Builder keyToken(@NotNull ImmutableToken keyToken);
         public abstract ParsedTerm build();
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/validation/TermCollectingQueryVisitor.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/validation/TermCollectingQueryVisitor.java
@@ -59,7 +59,7 @@ public class TermCollectingQueryVisitor extends QueryVisitor {
                         .filter(token -> token.matches(QueryParserConstants.TERM, t.text()))
                         .findFirst()
                         .ifPresent(token -> {
-                            termBuilder.tokensBuilder().add(token);
+                            termBuilder.keyToken(token);
                             processedTokens.add(token);
                             availableTokens.remove(token);
                         });
@@ -69,7 +69,7 @@ public class TermCollectingQueryVisitor extends QueryVisitor {
                         .filter(token -> token.image().equals(t.field()))
                         .findFirst()
                         .ifPresent(token -> {
-                            termBuilder.tokensBuilder().add(token);
+                            termBuilder.keyToken(token);
                             processedTokens.add(token);
                             availableTokens.remove(token);
                         });

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/validation/ValidationMessage.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/validation/ValidationMessage.java
@@ -58,7 +58,7 @@ public abstract class ValidationMessage {
     @JsonProperty
     public abstract String errorMessage();
 
-    public static ValidationMessage fromException(final String query, final Exception exception) {
+    public static ValidationMessage fromException(final Exception exception) {
 
         final String input = exception.toString();
 
@@ -66,7 +66,7 @@ public abstract class ValidationMessage {
 
         errorBuilder.errorType("Query parsing error");
         final String rootCause = getErrorMessage(exception);
-        errorBuilder.errorMessage(String.format(Locale.ROOT, "Cannot parse query '%s', cause: %s", query, rootCause));
+        errorBuilder.errorMessage(String.format(Locale.ROOT, "Cannot parse query, cause: %s", rootCause));
 
         final Matcher positionMatcher = regexPosition.matcher(input);
         if (positionMatcher.find()) {

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/validation/ValidationMessageTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/validation/ValidationMessageTest.java
@@ -33,13 +33,13 @@ class ValidationMessageTest {
             luceneQueryParser.parse(query);
             fail("Should throw an exception!");
         } catch (ParseException e) {
-            final ValidationMessage validationMessage = ValidationMessage.fromException(query, e);
+            final ValidationMessage validationMessage = ValidationMessage.fromException( e);
             assertThat(validationMessage.beginLine()).isEqualTo(1);
             assertThat(validationMessage.endLine()).isEqualTo(1);
             assertThat(validationMessage.beginColumn()).isEqualTo(0);
             assertThat(validationMessage.endColumn()).isEqualTo(4);
             assertThat(validationMessage.errorType()).isEqualTo("Query parsing error");
-            assertThat(validationMessage.errorMessage()).startsWith("Cannot parse query 'foo:', cause: incomplete query, query ended unexpectedly");
+            assertThat(validationMessage.errorMessage()).startsWith("Cannot parse query, cause: incomplete query, query ended unexpectedly");
         }
     }
 }


### PR DESCRIPTION
Code cleanup + removed the original query from parsing exception message (see the screenshot bellow)

## Description
<!--- Describe your changes in detail -->

## Motivation and Context

- Cleaner approach to term key token (the key is always only one token, we don't need a list for that).
- The failed parsing of query triggered a huge warning message when the query was long. We don't need to repeat the whole query, as the user already sees it in the UI anyway.

## How Has This Been Tested?
Adapted unit and integration tests

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/4102775/154296400-1ce84d30-14d4-4b2d-ae96-e30b66389763.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

