### PR TITLE
Use formatter from user's date time context in charts.

### DIFF
--- a/graylog2-web-interface/src/contexts/UserDateTimeContext.ts
+++ b/graylog2-web-interface/src/contexts/UserDateTimeContext.ts
@@ -21,7 +21,7 @@ import { singleton } from 'logic/singleton';
 import type { DateTime, DateTimeFormats } from 'util/DateTime';
 
 export type UserDateTimeContextType = {
-  formatTime: (time: DateTime, format?: DateTimeFormats) => string
+  formatTime: (time: DateTime, format?: DateTimeFormats) => string,
   toUserTimezone: (time: DateTime) => Moment,
   userTimezone: string,
 };

--- a/graylog2-web-interface/src/contexts/UserDateTimeProvider.tsx
+++ b/graylog2-web-interface/src/contexts/UserDateTimeProvider.tsx
@@ -41,7 +41,7 @@ const getUserTimezone = (userTimezone: string, tzOverride?: string) => {
  * Should be used when displaying times and the related components are not a suitable option.
  */
 
-const StaticTimezoneProvider = ({ children, tz }: Props) => {
+const StaticTimezoneProvider = ({ children, tz }: Required<Props>) => {
   const toUserTimezone = useCallback((time: DateTime) => {
     return toDateObject(time, undefined, tz);
   }, [tz]);

--- a/graylog2-web-interface/src/util/DateTime.ts
+++ b/graylog2-web-interface/src/util/DateTime.ts
@@ -89,3 +89,5 @@ export const relativeDifference = (dateTime: DateTime) => {
 
   return validateDateTime(dateObject, dateTime).fromNow();
 };
+
+export const isValidDate = (dateTime: DateTime) => moment(dateTime, Object.values(DATE_TIME_FORMATS), true).isValid();

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/AggregationBuilder.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/AggregationBuilder.tsx
@@ -15,8 +15,8 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { PluginStore } from 'graylog-web-plugin/plugin';
 import { useContext } from 'react';
+import { PluginStore } from 'graylog-web-plugin/plugin';
 
 import type { WidgetComponentProps } from 'views/types';
 import type AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
@@ -65,7 +65,7 @@ export type VisualizationComponent<T extends string> =
 
 export const retrieveChartData = (data: VisualizationResult): Rows => data.chart ?? data[Object.keys(data).filter((name) => name !== 'events')[0]];
 
-export const makeVisualization = <T extends string>(component: React.ComponentType<VisualizationComponentProps>, type: T): VisualizationComponent<T> => {
+export const makeVisualization = <T extends string> (component: React.ComponentType<VisualizationComponentProps>, type: T): VisualizationComponent<T> => {
   const visualizationComponent = component as VisualizationComponent<T>;
 
   visualizationComponent.type = type;
@@ -73,7 +73,7 @@ export const makeVisualization = <T extends string>(component: React.ComponentTy
   return visualizationComponent;
 };
 
-const _visualizationForType = <T extends string>(type: T): VisualizationComponent<T> => {
+const _visualizationForType = <T extends string> (type: T): VisualizationComponent<T> => {
   const visualizationTypes = PluginStore.exports('visualizationTypes');
   const visualization = visualizationTypes.filter((viz) => viz.type === type)[0];
 
@@ -92,7 +92,13 @@ const getResult = (value: RowResult | EventResult): Rows | Events => {
   return value.rows;
 };
 
-const AggregationBuilder = ({ config, data, editing = false, fields, toggleEdit }: WidgetComponentProps<AggregationWidgetConfig>) => {
+const AggregationBuilder = ({
+  config,
+  data,
+  editing = false,
+  fields,
+  toggleEdit,
+}: WidgetComponentProps<AggregationWidgetConfig>) => {
   const onVisualizationConfigChange = useContext(OnVisualizationConfigChangeContext);
 
   if (!config || config.isEmpty) {
@@ -101,6 +107,8 @@ const AggregationBuilder = ({ config, data, editing = false, fields, toggleEdit 
 
   const VisComponent = _visualizationForType(config.visualization || defaultVisualizationType);
   const { effective_timerange: effectiveTimerange } = data.chart || Object.values(data)[0] || {};
+
+  // TODO: Use Object.fromEntries
   const rows = Object.entries(data)
     .map((tuple) => tuple as ([string, RowResult] | ['events', EventResult]))
     .map(

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/AggregationBuilder.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/AggregationBuilder.tsx
@@ -108,13 +108,13 @@ const AggregationBuilder = ({
   const VisComponent = _visualizationForType(config.visualization || defaultVisualizationType);
   const { effective_timerange: effectiveTimerange } = data.chart || Object.values(data)[0] || {};
 
-  // TODO: Use Object.fromEntries
-  const rows = Object.entries(data)
-    .map((tuple) => tuple as ([string, RowResult] | ['events', EventResult]))
-    .map(
-      ([key, value]): [string, Rows | Events] => [key, getResult(value)],
-    )
-    .reduce((prev, [key, value]) => ({ ...prev, [key]: value }), {});
+  const rows = Object.fromEntries(
+    Object.entries(data)
+      .map((tuple) => tuple as ([string, RowResult] | ['events', EventResult]))
+      .map(
+        ([key, value]): [string, Rows | Events] => [key, getResult(value)],
+      ),
+  ) as VisualizationResult;
 
   return (
     <FullSizeContainer>

--- a/graylog2-web-interface/src/views/components/defaultTitle.ts
+++ b/graylog2-web-interface/src/views/components/defaultTitle.ts
@@ -17,11 +17,14 @@
 import { capitalize } from 'lodash';
 
 import { widgetDefinition } from 'views/logic/Widgets';
-import type Widget from 'views/logic/widgets/Widget';
 
-const defaultTitleGenerator = ({ type }: Widget) => `Untitled ${type.replace('_', ' ').split(' ').map(capitalize).join(' ')}`;
+interface WidgetLike {
+  type: string;
+}
 
-const defaultTitle = (widget: Widget) => {
+const defaultTitleGenerator = ({ type }: WidgetLike) => `Untitled ${type.replace('_', ' ').split(' ').map(capitalize).join(' ')}`;
+
+const defaultTitle = (widget: WidgetLike) => {
   const widgetDef = widgetDefinition(widget.type);
 
   return (widgetDef.titleGenerator || defaultTitleGenerator)(widget);

--- a/graylog2-web-interface/src/views/components/defaultTitle.ts
+++ b/graylog2-web-interface/src/views/components/defaultTitle.ts
@@ -17,10 +17,11 @@
 import { capitalize } from 'lodash';
 
 import { widgetDefinition } from 'views/logic/Widgets';
+import type Widget from 'views/logic/widgets/Widget';
 
-const defaultTitleGenerator = (w) => `Untitled ${w.type.replace('_', ' ').split(' ').map(capitalize).join(' ')}`;
+const defaultTitleGenerator = ({ type }: Widget) => `Untitled ${type.replace('_', ' ').split(' ').map(capitalize).join(' ')}`;
 
-const defaultTitle = (widget: { type: string }) => {
+const defaultTitle = (widget: Widget) => {
   const widgetDef = widgetDefinition(widget.type);
 
   return (widgetDef.titleGenerator || defaultTitleGenerator)(widget);

--- a/graylog2-web-interface/src/views/components/visualizations/ChartData.ts
+++ b/graylog2-web-interface/src/views/components/visualizations/ChartData.ts
@@ -18,6 +18,7 @@ import { flatten, flow, isEqual, set } from 'lodash';
 
 import type { Key, Leaf, Row, Rows, Value } from 'views/logic/searchtypes/pivot/PivotHandler';
 import type AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
+import type { DateTime, DateTimeFormats } from 'util/DateTime';
 
 import transformKeys from './TransformKeys';
 
@@ -126,12 +127,13 @@ export const removeNulls = (): ((ExtractedSeries) => ExtractedSeries) => {
 
 const doNotSuffixTraceForSingleSeries = (keys) => (keys.length > 1 ? keys.slice(0, -1).join('-') : keys[0]);
 
-type ChartConfig = {
+export type ChartDataConfig = {
   widgetConfig: AggregationWidgetConfig,
   chartType: string,
   generator?: Generator,
   seriesFormatter?: (values: { valuesBySeries: ValuesBySeries, xLabels: Array<any> }) => ExtractedSeries,
   leafValueMatcher?: (value: Value) => boolean,
+  formatTime: (time: DateTime, format?: DateTimeFormats) => string,
 };
 
 export const chartData = (
@@ -142,12 +144,13 @@ export const chartData = (
     generator = _defaultChartGenerator,
     seriesFormatter: customSeriesFormatter = formatSeries,
     leafValueMatcher,
-  }: ChartConfig,
+    formatTime,
+  }: ChartDataConfig,
 ): Array<ChartDefinition> => {
   const { rowPivots, columnPivots, series } = config;
 
   return flow([
-    transformKeys(rowPivots, columnPivots),
+    transformKeys(rowPivots, columnPivots, formatTime),
     extractSeries(series.length === 1 ? doNotSuffixTraceForSingleSeries : undefined, leafValueMatcher),
     customSeriesFormatter,
     removeNulls(),

--- a/graylog2-web-interface/src/views/components/visualizations/ChartData.ts
+++ b/graylog2-web-interface/src/views/components/visualizations/ChartData.ts
@@ -46,7 +46,7 @@ export type ChartDefinition = {
 
 export type ChartData = [any, Array<Key>, Array<any>, Array<Array<any>>];
 export type ExtractedSeries = Array<ChartData>;
-export type ValuesBySeries = { [key: string]: Array<number>};
+export type ValuesBySeries = { [key: string]: Array<number> };
 
 export type KeyJoiner = (keys: Array<any>) => string;
 
@@ -60,7 +60,10 @@ export const flattenLeafs = (leafs: Array<Leaf>, matcher: (value: Value) => bool
   return flatten(leafs.map((l) => l.values.filter((value) => matcher(value)).map((v) => [l.key, v])));
 };
 
-export const formatSeries = ({ valuesBySeries = {}, xLabels = [] }: {valuesBySeries: ValuesBySeries, xLabels: Array<any>}): ExtractedSeries => {
+export const formatSeries = ({
+  valuesBySeries = {},
+  xLabels = [],
+}: { valuesBySeries: ValuesBySeries, xLabels: Array<any> }): ExtractedSeries => {
   return Object.keys(valuesBySeries).map((value) => [
     value,
     xLabels,
@@ -77,7 +80,7 @@ export const getLeafsFromRows = (rows: Rows): Array<Leaf> => {
 
 export const getXLabelsFromLeafs = (leafs: Array<Leaf>): Array<Array<Key>> => leafs.map(({ key }) => key);
 
-export const extractSeries = (keyJoiner: KeyJoiner = _defaultKeyJoiner, leafValueMatcher?: (value: Value) => boolean) => {
+export const extractSeries = (keyJoiner: KeyJoiner = _defaultKeyJoiner, leafValueMatcher: (value: Value) => boolean = undefined) => {
   return (results: Rows) => {
     const leafs = getLeafsFromRows(results);
     const xLabels = getXLabelsFromLeafs(leafs);
@@ -97,7 +100,7 @@ export const extractSeries = (keyJoiner: KeyJoiner = _defaultKeyJoiner, leafValu
   };
 };
 
-export const generateChart = (chartType: string, generator: Generator = _defaultChartGenerator, config?: AggregationWidgetConfig): ((ExtractedSeries) => Array<ChartDefinition>) => {
+export const generateChart = (chartType: string, generator: Generator = _defaultChartGenerator, config: AggregationWidgetConfig = undefined): ((ExtractedSeries) => Array<ChartDefinition>) => {
   return (results: ExtractedSeries) => {
     const allCharts: Array<[string, string, Array<string>, Array<any>, Array<Array<any>>]> = results.map(([value, x, values, z]) => [
       chartType,
@@ -123,13 +126,23 @@ export const removeNulls = (): ((ExtractedSeries) => ExtractedSeries) => {
 
 const doNotSuffixTraceForSingleSeries = (keys) => (keys.length > 1 ? keys.slice(0, -1).join('-') : keys[0]);
 
-export const chartData = (
-  config: AggregationWidgetConfig,
-  data: Rows,
+type ChartConfig = {
+  widgetConfig: AggregationWidgetConfig,
   chartType: string,
-  generator: Generator = _defaultChartGenerator,
-  customSeriesFormatter: (values: { valuesBySeries: ValuesBySeries, xLabels: Array<any> }) => ExtractedSeries = formatSeries,
+  generator?: Generator,
+  seriesFormatter?: (values: { valuesBySeries: ValuesBySeries, xLabels: Array<any> }) => ExtractedSeries,
   leafValueMatcher?: (value: Value) => boolean,
+};
+
+export const chartData = (
+  data: Rows,
+  {
+    chartType,
+    widgetConfig: config,
+    generator = _defaultChartGenerator,
+    seriesFormatter: customSeriesFormatter = formatSeries,
+    leafValueMatcher,
+  }: ChartConfig,
 ): Array<ChartDefinition> => {
   const { rowPivots, columnPivots, series } = config;
 

--- a/graylog2-web-interface/src/views/components/visualizations/TransformKeys.ts
+++ b/graylog2-web-interface/src/views/components/visualizations/TransformKeys.ts
@@ -21,7 +21,7 @@ import type Pivot from 'views/logic/aggregationbuilder/Pivot';
 import type { ColLeaf, Leaf, Key, Rows } from 'views/logic/searchtypes/pivot/PivotHandler';
 import { CurrentUserStore } from 'stores/users/CurrentUserStore';
 
-const formatTimestamp = (timestamp, tz = AppConfig.rootTimeZone()): string => {
+const formatTimestamp = (timestamp: moment.MomentInput, tz = AppConfig.rootTimeZone()): string => {
   // the `true` parameter prevents returning the iso string in UTC (http://momentjs.com/docs/#/displaying/as-iso-string/)
   return moment(timestamp).tz(tz).toISOString(true);
 };
@@ -42,12 +42,12 @@ const transformKey = (key: Key, indices: Array<number>, tz: string) => {
   return newKey;
 };
 
-const findIndices = <T>(ary: Array<T>, predicate: (T) => boolean): Array<number> => ary
+const findIndices = <T> (ary: Array<T>, predicate: (T) => boolean): Array<number> => ary
   .map((value, idx) => ({ value, idx }))
   .filter(({ value }) => predicate(value))
   .map(({ idx }) => idx);
 
-export default (rowPivots: Array<Pivot>, columnPivots: Array<Pivot>): ((Rows) => Rows) => {
+export default (rowPivots: Array<Pivot>, columnPivots: Array<Pivot>): ((rows: Rows) => Rows) => {
   return (result = []) => {
     const rowIndices = findIndices(rowPivots, (pivot) => (pivot.type === 'time'));
     const columnIndices = findIndices(columnPivots, (pivot) => (pivot.type === 'time'));

--- a/graylog2-web-interface/src/views/components/visualizations/TransformKeys.ts
+++ b/graylog2-web-interface/src/views/components/visualizations/TransformKeys.ts
@@ -17,6 +17,7 @@
 import type Pivot from 'views/logic/aggregationbuilder/Pivot';
 import type { ColLeaf, Leaf, Key, Rows } from 'views/logic/searchtypes/pivot/PivotHandler';
 import type { DateTime, DateTimeFormats } from 'util/DateTime';
+import { isValidDate } from 'util/DateTime';
 
 type TimeFormatter = (time: DateTime, format?: DateTimeFormats) => string;
 
@@ -29,14 +30,15 @@ const transformKey = (key: Key, indices: Array<number>, formatTimestamp: TimeFor
 
   indices.forEach((idx) => {
     if (newKey[idx]) {
-      newKey[idx] = formatTimestamp(newKey[idx], 'internal');
+      const value = newKey[idx];
+      newKey[idx] = isValidDate(value) ? formatTimestamp(newKey[idx], 'internal') : value;
     }
   });
 
   return newKey;
 };
 
-const findIndices = <T> (ary: Array<T>, predicate: (T) => boolean): Array<number> => ary
+const findIndices = <T> (ary: Array<T>, predicate: (value: T) => boolean): Array<number> => ary
   .map((value, idx) => ({ value, idx }))
   .filter(({ value }) => predicate(value))
   .map(({ idx }) => idx);

--- a/graylog2-web-interface/src/views/components/visualizations/TransformKeys.ts
+++ b/graylog2-web-interface/src/views/components/visualizations/TransformKeys.ts
@@ -14,19 +14,13 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import moment from 'moment-timezone';
-
-import AppConfig from 'util/AppConfig';
 import type Pivot from 'views/logic/aggregationbuilder/Pivot';
 import type { ColLeaf, Leaf, Key, Rows } from 'views/logic/searchtypes/pivot/PivotHandler';
-import { CurrentUserStore } from 'stores/users/CurrentUserStore';
+import type { DateTime, DateTimeFormats } from 'util/DateTime';
 
-const formatTimestamp = (timestamp: moment.MomentInput, tz = AppConfig.rootTimeZone()): string => {
-  // the `true` parameter prevents returning the iso string in UTC (http://momentjs.com/docs/#/displaying/as-iso-string/)
-  return moment(timestamp).tz(tz).toISOString(true);
-};
+type TimeFormatter = (time: DateTime, format?: DateTimeFormats) => string;
 
-const transformKey = (key: Key, indices: Array<number>, tz: string) => {
+const transformKey = (key: Key, indices: Array<number>, formatTimestamp: TimeFormatter) => {
   if (indices.length === 0) {
     return key;
   }
@@ -35,7 +29,7 @@ const transformKey = (key: Key, indices: Array<number>, tz: string) => {
 
   indices.forEach((idx) => {
     if (newKey[idx]) {
-      newKey[idx] = formatTimestamp(newKey[idx], tz);
+      newKey[idx] = formatTimestamp(newKey[idx], 'internal');
     }
   });
 
@@ -47,7 +41,7 @@ const findIndices = <T> (ary: Array<T>, predicate: (T) => boolean): Array<number
   .filter(({ value }) => predicate(value))
   .map(({ idx }) => idx);
 
-export default (rowPivots: Array<Pivot>, columnPivots: Array<Pivot>): ((rows: Rows) => Rows) => {
+export default (rowPivots: Array<Pivot>, columnPivots: Array<Pivot>, formatTime: TimeFormatter): (rows: Rows) => Rows => {
   return (result = []) => {
     const rowIndices = findIndices(rowPivots, (pivot) => (pivot.type === 'time'));
     const columnIndices = findIndices(columnPivots, (pivot) => (pivot.type === 'time'));
@@ -56,9 +50,6 @@ export default (rowPivots: Array<Pivot>, columnPivots: Array<Pivot>): ((rows: Ro
       return result;
     }
 
-    const currentUser = CurrentUserStore.get();
-    const timezone = currentUser?.timezone ?? AppConfig.rootTimeZone();
-
     return result.map((row) => {
       if (row.source !== 'leaf') {
         return row;
@@ -66,7 +57,7 @@ export default (rowPivots: Array<Pivot>, columnPivots: Array<Pivot>): ((rows: Ro
 
       const newRow: Leaf = { ...row };
 
-      newRow.key = transformKey(row.key, rowIndices, timezone);
+      newRow.key = transformKey(row.key, rowIndices, formatTime);
 
       if (columnIndices.length > 0) {
         newRow.values = row.values.map((values) => {
@@ -76,7 +67,7 @@ export default (rowPivots: Array<Pivot>, columnPivots: Array<Pivot>): ((rows: Ro
 
           const newValues: ColLeaf = { ...values };
 
-          newValues.key = transformKey(values.key, columnIndices, timezone);
+          newValues.key = transformKey(values.key, columnIndices, formatTime);
 
           return newValues;
         });

--- a/graylog2-web-interface/src/views/components/visualizations/XYPlot.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/XYPlot.tsx
@@ -17,22 +17,20 @@
 
 import React, { useCallback, useContext } from 'react';
 import PropTypes from 'prop-types';
-import moment from 'moment-timezone';
 import { merge } from 'lodash';
 
-import AppConfig from 'util/AppConfig';
 import connect from 'stores/connect';
 import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
 import { CurrentQueryStore } from 'views/stores/CurrentQueryStore';
 import Query from 'views/logic/queries/Query';
 import type { ViewType } from 'views/logic/views/View';
-import CurrentUserContext from 'contexts/CurrentUserContext';
 import type ColorMapper from 'views/components/visualizations/ColorMapper';
 import PlotLegend from 'views/components/visualizations/PlotLegend';
+import UserDateTimeContext from 'contexts/UserDateTimeContext';
 
 import GenericPlot from './GenericPlot';
-import OnZoom from './OnZoom';
 import type { ChartColor, ChartConfig } from './GenericPlot';
+import OnZoom from './OnZoom';
 
 import CustomPropTypes from '../CustomPropTypes';
 import ViewTypeContext from '../contexts/ViewTypeContext';
@@ -75,12 +73,11 @@ const XYPlot = ({
   plotLayout = {},
   onZoom = OnZoom,
 }: Props) => {
-  const currentUser = useContext(CurrentUserContext);
-  const timezone = currentUser?.timezone ?? AppConfig.rootTimeZone();
+  const { formatTime } = useContext(UserDateTimeContext);
   const yaxis = { fixedrange: true, rangemode: 'tozero', tickformat: ',g' };
   const defaultLayout: {
-    yaxis: { fixedrange?: boolean},
-    legend?: {y?: number},
+    yaxis: { fixedrange?: boolean },
+    legend?: { y?: number },
     showlegend: boolean,
   } = { yaxis, showlegend: false };
 
@@ -96,8 +93,8 @@ const XYPlot = ({
     : () => true, [config.isTimeline, onZoom]);
 
   if (config.isTimeline && effectiveTimerange) {
-    const normalizedFrom = moment.tz(effectiveTimerange.from, timezone).format();
-    const normalizedTo = moment.tz(effectiveTimerange.to, timezone).format();
+    const normalizedFrom = formatTime(effectiveTimerange.from, 'internal');
+    const normalizedTo = formatTime(effectiveTimerange.to, 'internal');
 
     layout.xaxis = {
       range: [normalizedFrom, normalizedTo],

--- a/graylog2-web-interface/src/views/components/visualizations/XYPlot.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/XYPlot.tsx
@@ -89,7 +89,7 @@ const XYPlot = ({
   const viewType = useContext(ViewTypeContext);
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const _onZoom = useCallback(config.isTimeline
-    ? (from, to) => onZoom(currentQuery, from, to, viewType)
+    ? (from: string, to: string) => onZoom(currentQuery, from, to, viewType)
     : () => true, [config.isTimeline, onZoom]);
 
   if (config.isTimeline && effectiveTimerange) {

--- a/graylog2-web-interface/src/views/components/visualizations/__tests__/ChartData.test.ts
+++ b/graylog2-web-interface/src/views/components/visualizations/__tests__/ChartData.test.ts
@@ -27,21 +27,22 @@ import { chartData, extractSeries, formatSeries, generateChart } from '../ChartD
 import transformKeys from '../TransformKeys';
 
 const cwd = dirname(__filename);
-const readFixture = (filename) => JSON.parse(readFileSync(`${cwd}/${filename}`, 'utf-8'));
+const readFixture = (filename: string) => JSON.parse(readFileSync(`${cwd}/${filename}`, 'utf-8'));
+const formatTime = (timestamp: string) => timestamp;
 
 describe('Chart helper functions', () => {
   const config = AggregationWidgetConfig.builder().build();
 
   describe('chartData', () => {
     it('should not fail for empty data', () => {
-      const result = chartData([], { widgetConfig: config, chartType: 'dummy' });
+      const result = chartData([], { widgetConfig: config, chartType: 'dummy', formatTime });
 
       expect(result).toHaveLength(0);
     });
 
     it('should properly extract series from simplest fixture with one series and one row pivot', () => {
       const input = readFixture('ChartData.test.simplest.json');
-      const result = chartData(input, { widgetConfig: config, chartType: 'dummy' });
+      const result = chartData(input, { widgetConfig: config, chartType: 'dummy', formatTime });
       const expectedResult = [{
         name: 'count()',
         type: 'dummy',
@@ -55,7 +56,7 @@ describe('Chart helper functions', () => {
 
     it('should properly extract series from simplest fixture and include provided chart type', () => {
       const input = readFixture('ChartData.test.simplest.json');
-      const result = chartData(input, { widgetConfig: config, chartType: 'bar' });
+      const result = chartData(input, { widgetConfig: config, chartType: 'bar', formatTime });
       const expectedResult = [{
         name: 'count()',
         type: 'bar',
@@ -69,7 +70,7 @@ describe('Chart helper functions', () => {
 
     it('should remove non-present data points and leave order of values intact', () => {
       const input = readFixture('ChartData.test.withHoles.json');
-      const result = chartData(input, { widgetConfig: config, chartType: 'bar' });
+      const result = chartData(input, { widgetConfig: config, chartType: 'bar', formatTime });
       const expectedResult = [{
         name: 'count()',
         type: 'bar',
@@ -100,7 +101,7 @@ describe('Chart helper functions', () => {
 
     it('should not remove data points with a value of zero', () => {
       const input = readFixture('ChartData.test.withZeros.json');
-      const result = chartData(input, { widgetConfig: config, chartType: 'bar' });
+      const result = chartData(input, { widgetConfig: config, chartType: 'bar', formatTime });
       const expectedResult = [{
         name: 'count()',
         type: 'bar',
@@ -120,7 +121,7 @@ describe('Chart helper functions', () => {
 
     it('should remove data points with a value of null or undefined', () => {
       const input = readFixture('ChartData.test.withNullAndUndefined.json');
-      const result = chartData(input, { widgetConfig: config, chartType: 'bar' });
+      const result = chartData(input, { widgetConfig: config, chartType: 'bar', formatTime });
       const expectedResult = [{
         name: 'count()',
         type: 'bar',
@@ -137,7 +138,7 @@ describe('Chart helper functions', () => {
 
     it('should properly extract series from fixture with two column pivots', () => {
       const input = readFixture('ChartData.test.twoColumnPivots.json');
-      const result = chartData(input, { widgetConfig: config, chartType: 'dummy' });
+      const result = chartData(input, { widgetConfig: config, chartType: 'dummy', formatTime });
       const expectedResult = readFixture('ChartData.test.twoColumnPivots.result.json');
 
       expect(result).toHaveLength(6);
@@ -146,7 +147,7 @@ describe('Chart helper functions', () => {
 
     it('should include chart type in result', () => {
       const input = readFixture('ChartData.test.simple.json');
-      const result = chartData(input, { widgetConfig: config, chartType: 'scatter' });
+      const result = chartData(input, { widgetConfig: config, chartType: 'scatter', formatTime });
       const expectedResult = readFixture('ChartData.test.simple.result.json');
 
       expect(result).toHaveLength(6);
@@ -182,6 +183,7 @@ describe('Chart helper functions', () => {
         chartType: 'heatmap',
         generator: generatorFunction,
         seriesFormatter: formatSeriesCustom,
+        formatTime,
       });
       const expectedResult = readFixture('ChartData.test.oneColumOneRowPivot.result.json');
 
@@ -196,6 +198,7 @@ describe('Chart helper functions', () => {
         widgetConfig: config,
         chartType: 'scatter',
         leafValueMatcher: leafSourceMatcher,
+        formatTime,
       });
       const expectedResult = readFixture('ChartData.test.simple.sourceMatcher.result.json');
 
@@ -212,7 +215,7 @@ describe('Chart helper functions', () => {
         name: md5(JSON.stringify({ type, name, labels, values })),
       });
       const pipeline = flow([
-        transformKeys(config.rowPivots, config.columnPivots),
+        transformKeys(config.rowPivots, config.columnPivots, formatTime),
         extractSeries(),
         formatSeries,
         generateChart('scatter', generatorFunction),

--- a/graylog2-web-interface/src/views/components/visualizations/__tests__/TransformKeys.fixtures.ts
+++ b/graylog2-web-interface/src/views/components/visualizations/__tests__/TransformKeys.fixtures.ts
@@ -14,6 +14,8 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
+import type { Rows } from 'views/logic/searchtypes/pivot/PivotHandler';
+
 export const singleRowPivot = {
   rowPivots: [{ field: 'timestamp', type: 'time', config: { interval: { type: 'auto' } } }],
   columnPivots: [],
@@ -134,7 +136,7 @@ export const singleRowPivot = {
       key: [],
       values: [{ key: ['count()'], value: 28265, rollup: true, source: 'row-inner' }],
       source: 'non-leaf',
-    }],
+    }] as Rows,
   output: [
     {
       key: ['2018-10-02T07:12:30.000-04:00'],
@@ -467,7 +469,7 @@ export const noTimePivots = {
       values: [{ key: ['count()'], value: 45662, rollup: true, source: 'row-inner' }],
       source: 'non-leaf',
     },
-  ],
+  ] as Rows,
   output: [
     {
       key: ['GET'],

--- a/graylog2-web-interface/src/views/components/visualizations/__tests__/TransformKeys.test.ts
+++ b/graylog2-web-interface/src/views/components/visualizations/__tests__/TransformKeys.test.ts
@@ -14,16 +14,17 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
+import moment from 'moment-timezone';
+
 import Pivot from 'views/logic/aggregationbuilder/Pivot';
-import { CurrentUserStore } from 'stores/users/CurrentUserStore';
 import type { Rows } from 'views/logic/searchtypes/pivot/PivotHandler';
 
 import * as fixtures from './TransformKeys.fixtures';
 
 import transformKeys from '../TransformKeys';
 
-jest.mock('stores/users/CurrentUserStore', () => ({ CurrentUserStore: { get: jest.fn() } }));
-jest.mock('util/AppConfig', () => ({ rootTimeZone: jest.fn(() => 'America/Chicago') }));
+const formatTime = (timestamp: string) => timestamp;
+const formatTimeForLocalTz = (timezone: string) => (timestamp: string) => moment.tz(timestamp, timezone).toISOString(true);
 
 // eslint-disable-next-line global-require
 describe('TransformKeys', () => {
@@ -34,7 +35,7 @@ describe('TransformKeys', () => {
       key: ['foo'],
       rollup: false,
     }];
-    const result = transformKeys([], [])(rows);
+    const result = transformKeys([], [], formatTime)(rows);
 
     expect(result).toEqual(rows);
   });
@@ -46,13 +47,12 @@ describe('TransformKeys', () => {
       key: ['foo'],
       rollup: false,
     }];
-    const result = transformKeys([Pivot.create('foo', 'value')], [Pivot.create('bar', 'value')])(rows);
+    const result = transformKeys([Pivot.create('foo', 'value')], [Pivot.create('bar', 'value')], formatTime)(rows);
 
     expect(result).toEqual(rows);
   });
 
   it('transforms row keys using current user\'s timezone', () => {
-    CurrentUserStore.get.mockReturnValue({ timezone: 'Europe/Berlin' });
     const input: Rows = [
       {
         source: 'leaf',
@@ -66,7 +66,7 @@ describe('TransformKeys', () => {
       },
     ];
 
-    const result = transformKeys([Pivot.create('timestamp', 'time')], [])(input);
+    const result = transformKeys([Pivot.create('timestamp', 'time')], [], formatTimeForLocalTz('Europe/Berlin'))(input);
 
     expect(result).toEqual([
       {
@@ -82,7 +82,6 @@ describe('TransformKeys', () => {
   });
 
   it('transforms column keys using current user\'s timezone', () => {
-    CurrentUserStore.get.mockReturnValueOnce({ timezone: 'America/Los_Angeles' });
     const input: Rows = [
       {
         source: 'leaf',
@@ -96,7 +95,7 @@ describe('TransformKeys', () => {
       },
     ];
 
-    const result = transformKeys([Pivot.create('timestamp', 'time')], [])(input);
+    const result = transformKeys([Pivot.create('timestamp', 'time')], [], formatTimeForLocalTz('America/Los_Angeles'))(input);
 
     expect(result).toEqual([
       {
@@ -111,48 +110,16 @@ describe('TransformKeys', () => {
     ]);
   });
 
-  it('transforms column keys using AppConfig rootTimeZone if user\'s timezone is null', () => {
-    CurrentUserStore.get.mockReturnValueOnce({ timezone: null });
-
-    const input: Rows = [
-      {
-        source: 'leaf',
-        key: ['2018-10-01T15:10:55.323Z'],
-        values: [],
-      },
-      {
-        source: 'leaf',
-        key: ['2017-03-12T09:32:21.283-08:00'],
-        values: [],
-      },
-    ];
-
-    const result = transformKeys([Pivot.create('timestamp', 'time')], [])(input);
-
-    expect(result).toEqual([
-      {
-        key: ['2018-10-01T10:10:55.323-05:00'],
-        source: 'leaf',
-        values: [],
-      }, {
-        key: ['2017-03-12T12:32:21.283-05:00'],
-        source: 'leaf',
-        values: [],
-      },
-    ]);
-  });
-
   it('transforms complete results using current user\'s timezone', () => {
-    CurrentUserStore.get.mockReturnValueOnce({ timezone: 'America/New_York' });
     const { rowPivots, columnPivots, input, output } = fixtures.singleRowPivot;
-    const result = transformKeys(rowPivots as Pivot[], columnPivots)(input);
+    const result = transformKeys(rowPivots as Pivot[], columnPivots, formatTimeForLocalTz('America/New_York'))(input);
 
     expect(result).toEqual(output);
   });
 
   it('does not transform complete results without time pivots', () => {
     const { rowPivots, columnPivots, input, output } = fixtures.noTimePivots;
-    const result = transformKeys(rowPivots as Pivot[], columnPivots as Pivot[])(input);
+    const result = transformKeys(rowPivots as Pivot[], columnPivots as Pivot[], formatTime)(input);
 
     expect(result).toEqual(output);
   });

--- a/graylog2-web-interface/src/views/components/visualizations/__tests__/TransformKeys.test.ts
+++ b/graylog2-web-interface/src/views/components/visualizations/__tests__/TransformKeys.test.ts
@@ -16,6 +16,7 @@
  */
 import Pivot from 'views/logic/aggregationbuilder/Pivot';
 import { CurrentUserStore } from 'stores/users/CurrentUserStore';
+import type { Rows } from 'views/logic/searchtypes/pivot/PivotHandler';
 
 import * as fixtures from './TransformKeys.fixtures';
 
@@ -27,7 +28,7 @@ jest.mock('util/AppConfig', () => ({ rootTimeZone: jest.fn(() => 'America/Chicag
 // eslint-disable-next-line global-require
 describe('TransformKeys', () => {
   it('returns original result when no aggregations are present', () => {
-    const rows = [{
+    const rows: Rows = [{
       source: 'row-leaf',
       value: 42,
       key: ['foo'],
@@ -39,7 +40,7 @@ describe('TransformKeys', () => {
   });
 
   it('returns original result when no time aggregations are present', () => {
-    const rows = [{
+    const rows: Rows = [{
       source: 'row-leaf',
       value: 42,
       key: ['foo'],
@@ -52,7 +53,7 @@ describe('TransformKeys', () => {
 
   it('transforms row keys using current user\'s timezone', () => {
     CurrentUserStore.get.mockReturnValue({ timezone: 'Europe/Berlin' });
-    const input = [
+    const input: Rows = [
       {
         source: 'leaf',
         key: ['2018-10-01T15:10:55.323Z'],
@@ -82,7 +83,7 @@ describe('TransformKeys', () => {
 
   it('transforms column keys using current user\'s timezone', () => {
     CurrentUserStore.get.mockReturnValueOnce({ timezone: 'America/Los_Angeles' });
-    const input = [
+    const input: Rows = [
       {
         source: 'leaf',
         key: ['2018-10-01T15:10:55.323Z'],
@@ -113,7 +114,7 @@ describe('TransformKeys', () => {
   it('transforms column keys using AppConfig rootTimeZone if user\'s timezone is null', () => {
     CurrentUserStore.get.mockReturnValueOnce({ timezone: null });
 
-    const input = [
+    const input: Rows = [
       {
         source: 'leaf',
         key: ['2018-10-01T15:10:55.323Z'],

--- a/graylog2-web-interface/src/views/components/visualizations/__tests__/XYPlot.test.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/__tests__/XYPlot.test.tsx
@@ -32,7 +32,9 @@ import Pivot from 'views/logic/aggregationbuilder/Pivot';
 import Query from 'views/logic/queries/Query';
 import { QueriesActions } from 'views/stores/QueriesStore';
 import { SearchActions } from 'views/stores/SearchStore';
-import { CurrentUserStore } from 'stores/users/CurrentUserStore'; import { ALL_MESSAGES_TIMERANGE } from 'views/Constants';
+import { CurrentUserStore } from 'stores/users/CurrentUserStore';
+import { ALL_MESSAGES_TIMERANGE } from 'views/Constants';
+import UserDateTimeProvider from 'contexts/UserDateTimeProvider';
 
 jest.mock('views/stores/CurrentViewStateStore', () => ({
   CurrentViewStateStore: MockStore(
@@ -82,12 +84,14 @@ describe('XYPlot', () => {
 
   const SimpleXYPlot = ({ currentUser: user, ...props }: SimpleXYPlotProps) => (
     <CurrentUserContext.Provider value={user}>
-      <XYPlot chartData={chartData}
-              config={config}
-              getChartColor={getChartColor}
-              setChartColor={setChartColor}
-              currentQuery={currentQuery}
-              {...props} />
+      <UserDateTimeProvider tz="UTC">
+        <XYPlot chartData={chartData}
+                config={config}
+                getChartColor={getChartColor}
+                setChartColor={setChartColor}
+                currentQuery={currentQuery}
+                {...props} />
+      </UserDateTimeProvider>
     </CurrentUserContext.Provider>
   );
 
@@ -135,7 +139,7 @@ describe('XYPlot', () => {
     const genericPlot = wrapper.find('GenericPlot');
 
     expect(genericPlot).toHaveProp('layout', expect.objectContaining({
-      xaxis: { range: ['2018-10-12T02:04:21Z', '2018-10-12T10:04:21Z'], type: 'date' },
+      xaxis: { range: ['2018-10-12T02:04:21.723+00:00', '2018-10-12T10:04:21.723+00:00'], type: 'date' },
     }));
 
     genericPlot.get(0).props.onZoom('2018-10-12T04:04:21.723Z', '2018-10-12T08:04:21.723Z');
@@ -153,11 +157,13 @@ describe('XYPlot', () => {
     const timerange = { from: '2018-10-12T02:04:21.723Z', to: '2018-10-12T10:04:21.723Z', type: 'absolute' };
     const currentQueryForAllMessages = currentQuery.toBuilder().timerange(ALL_MESSAGES_TIMERANGE).build();
     const user = currentUser.toBuilder().timezone('UTC').build();
-    const wrapper = mount(<SimpleXYPlot effectiveTimerange={timerange} currentQuery={currentQueryForAllMessages} currentUser={user} />);
+    const wrapper = mount(<SimpleXYPlot effectiveTimerange={timerange}
+                                        currentQuery={currentQueryForAllMessages}
+                                        currentUser={user} />);
     const genericPlot = wrapper.find('GenericPlot');
 
     expect(genericPlot).toHaveProp('layout', expect.objectContaining({
-      xaxis: { range: ['2018-10-12T02:04:21Z', '2018-10-12T10:04:21Z'], type: 'date' },
+      xaxis: { range: ['2018-10-12T02:04:21.723+00:00', '2018-10-12T10:04:21.723+00:00'], type: 'date' },
     }));
   });
 

--- a/graylog2-web-interface/src/views/components/visualizations/area/AreaVisualization.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/area/AreaVisualization.tsx
@@ -21,13 +21,13 @@ import type { Shapes } from 'views/logic/searchtypes/events/EventHandler';
 import EventHandler from 'views/logic/searchtypes/events/EventHandler';
 import toPlotly from 'views/logic/aggregationbuilder/visualizations/Interpolation';
 import type { VisualizationComponentProps } from 'views/components/aggregationbuilder/AggregationBuilder';
+import { makeVisualization, retrieveChartData } from 'views/components/aggregationbuilder/AggregationBuilder';
 import { AggregationType, AggregationResult } from 'views/components/aggregationbuilder/AggregationBuilderPropTypes';
 import AreaVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/AreaVisualizationConfig';
-import { makeVisualization, retrieveChartData } from 'views/components/aggregationbuilder/AggregationBuilder';
 
 import type { ChartDefinition } from '../ChartData';
-import XYPlot from '../XYPlot';
 import { chartData } from '../ChartData';
+import XYPlot from '../XYPlot';
 
 const getChartColor = (fullData, name) => {
   const data = fullData.find((d) => (d.name === name));
@@ -43,7 +43,12 @@ const getChartColor = (fullData, name) => {
 
 const setChartColor = (chart, colors) => ({ line: { color: colors.get(chart.name) } });
 
-const AreaVisualization = makeVisualization(({ config, data, effectiveTimerange, height }: VisualizationComponentProps) => {
+const AreaVisualization = makeVisualization(({
+  config,
+  data,
+  effectiveTimerange,
+  height,
+}: VisualizationComponentProps) => {
   const visualizationConfig = (config.visualizationConfig || AreaVisualizationConfig.empty()) as AreaVisualizationConfig;
   const { interpolation = 'linear' } = visualizationConfig;
   const chartGenerator = useCallback((type, name, labels, values): ChartDefinition => ({
@@ -57,7 +62,7 @@ const AreaVisualization = makeVisualization(({ config, data, effectiveTimerange,
 
   const rows = retrieveChartData(data);
 
-  const chartDataResult = chartData(config, rows, 'scatter', chartGenerator);
+  const chartDataResult = chartData(rows, { widgetConfig: config, chartType: 'scatter', generator: chartGenerator });
   const layout: { shapes?: Shapes } = {};
 
   if (config.eventAnnotation && data.events) {

--- a/graylog2-web-interface/src/views/components/visualizations/area/AreaVisualization.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/area/AreaVisualization.tsx
@@ -14,7 +14,7 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import React, { useCallback } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import PropTypes from 'prop-types';
 
 import type { Shapes } from 'views/logic/searchtypes/events/EventHandler';
@@ -24,9 +24,9 @@ import type { VisualizationComponentProps } from 'views/components/aggregationbu
 import { makeVisualization, retrieveChartData } from 'views/components/aggregationbuilder/AggregationBuilder';
 import { AggregationType, AggregationResult } from 'views/components/aggregationbuilder/AggregationBuilderPropTypes';
 import AreaVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/AreaVisualizationConfig';
+import useChartData from 'views/components/visualizations/useChartData';
 
 import type { ChartDefinition } from '../ChartData';
-import { chartData } from '../ChartData';
 import XYPlot from '../XYPlot';
 
 const getChartColor = (fullData, name) => {
@@ -60,9 +60,9 @@ const AreaVisualization = makeVisualization(({
     line: { shape: toPlotly(interpolation) },
   }), [interpolation]);
 
-  const rows = retrieveChartData(data);
+  const rows = useMemo(() => retrieveChartData(data), [data]);
 
-  const chartDataResult = chartData(rows, { widgetConfig: config, chartType: 'scatter', generator: chartGenerator });
+  const chartDataResult = useChartData(rows, { widgetConfig: config, chartType: 'scatter', generator: chartGenerator });
   const layout: { shapes?: Shapes } = {};
 
   if (config.eventAnnotation && data.events) {

--- a/graylog2-web-interface/src/views/components/visualizations/area/AreaVisualization.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/area/AreaVisualization.tsx
@@ -18,13 +18,13 @@ import React, { useCallback, useMemo } from 'react';
 import PropTypes from 'prop-types';
 
 import type { Shapes } from 'views/logic/searchtypes/events/EventHandler';
-import EventHandler from 'views/logic/searchtypes/events/EventHandler';
 import toPlotly from 'views/logic/aggregationbuilder/visualizations/Interpolation';
 import type { VisualizationComponentProps } from 'views/components/aggregationbuilder/AggregationBuilder';
 import { makeVisualization, retrieveChartData } from 'views/components/aggregationbuilder/AggregationBuilder';
 import { AggregationType, AggregationResult } from 'views/components/aggregationbuilder/AggregationBuilderPropTypes';
 import AreaVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/AreaVisualizationConfig';
 import useChartData from 'views/components/visualizations/useChartData';
+import useEvents from 'views/components/visualizations/useEvents';
 
 import type { ChartDefinition } from '../ChartData';
 import XYPlot from '../XYPlot';
@@ -62,15 +62,16 @@ const AreaVisualization = makeVisualization(({
 
   const rows = useMemo(() => retrieveChartData(data), [data]);
 
-  const chartDataResult = useChartData(rows, { widgetConfig: config, chartType: 'scatter', generator: chartGenerator });
-  const layout: { shapes?: Shapes } = {};
+  const _chartDataResult = useChartData(rows, {
+    widgetConfig: config,
+    chartType: 'scatter',
+    generator: chartGenerator,
+  });
 
-  if (config.eventAnnotation && data.events) {
-    const { eventChartData, shapes } = EventHandler.toVisualizationData(data.events);
+  const { eventChartData, shapes } = useEvents(config, data.events);
 
-    chartDataResult.push(eventChartData);
-    layout.shapes = shapes;
-  }
+  const chartDataResult = eventChartData ? [..._chartDataResult, eventChartData] : _chartDataResult;
+  const layout: { shapes?: Shapes } = shapes ? { shapes } : {};
 
   return (
     <XYPlot config={config}

--- a/graylog2-web-interface/src/views/components/visualizations/area/__tests__/AreaVisualization.test.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/area/__tests__/AreaVisualization.test.tsx
@@ -24,6 +24,7 @@ import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationW
 import Pivot from 'views/logic/aggregationbuilder/Pivot';
 import Series from 'views/logic/aggregationbuilder/Series';
 import MockQuery from 'views/logic/queries/Query';
+import UserDateTimeProvider from 'contexts/UserDateTimeProvider';
 
 import { effectiveTimerange, simpleChartData } from './AreaVisualization.fixtures';
 
@@ -41,6 +42,12 @@ jest.mock('util/AppConfig', () => ({
   gl2ServerUrl: jest.fn(() => undefined),
 }));
 
+const SUT = (props: React.ComponentProps<typeof AreaVisualization>) => (
+  <UserDateTimeProvider tz="Canada/Saskatchewan">
+    <AreaVisualization {...props} />
+  </UserDateTimeProvider>
+);
+
 describe('AreaVisualization', () => {
   it('generates correct props for plot component', () => {
     const config = AggregationWidgetConfig.builder()
@@ -50,19 +57,19 @@ describe('AreaVisualization', () => {
       .series([Series.forFunction('avg(nf_bytes)'), Series.forFunction('sum(nf_pkts)')])
       .build();
 
-    const wrapper = mount(<AreaVisualization config={config}
-                                             data={simpleChartData}
-                                             effectiveTimerange={effectiveTimerange}
-                                             fields={Immutable.List()}
-                                             height={1024}
-                                             onChange={() => {}}
-                                             toggleEdit={() => {}}
-                                             width={800} />);
+    const wrapper = mount(<SUT config={config}
+                               data={simpleChartData}
+                               effectiveTimerange={effectiveTimerange}
+                               fields={Immutable.List()}
+                               height={1024}
+                               onChange={() => {}}
+                               toggleEdit={() => {}}
+                               width={800} />);
 
     const genericPlot = wrapper.find('GenericPlot');
 
     expect(genericPlot).toHaveProp('layout', expect.objectContaining({
-      xaxis: { range: ['2019-11-28T09:21:00-06:00', '2019-11-28T09:25:57-06:00'], type: 'date' },
+      xaxis: { range: ['2019-11-28T09:21:00.486-06:00', '2019-11-28T09:25:57.000-06:00'], type: 'date' },
       legend: { y: -0.14 },
     }));
 

--- a/graylog2-web-interface/src/views/components/visualizations/bar/BarVisualization.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/bar/BarVisualization.tsx
@@ -19,10 +19,10 @@ import PropTypes from 'prop-types';
 
 import { AggregationType, AggregationResult } from 'views/components/aggregationbuilder/AggregationBuilderPropTypes';
 import type { VisualizationComponentProps } from 'views/components/aggregationbuilder/AggregationBuilder';
+import { makeVisualization, retrieveChartData } from 'views/components/aggregationbuilder/AggregationBuilder';
 import type { Shapes } from 'views/logic/searchtypes/events/EventHandler';
 import EventHandler from 'views/logic/searchtypes/events/EventHandler';
 import { DateType } from 'views/logic/aggregationbuilder/Pivot';
-import { makeVisualization, retrieveChartData } from 'views/components/aggregationbuilder/AggregationBuilder';
 import type BarVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/BarVisualizationConfig';
 
 import { chartData } from '../ChartData';
@@ -80,7 +80,12 @@ type Layout = {
   barmode?: string;
 };
 
-const BarVisualization = makeVisualization(({ config, data, effectiveTimerange, height }: VisualizationComponentProps) => {
+const BarVisualization = makeVisualization(({
+  config,
+  data,
+  effectiveTimerange,
+  height,
+}: VisualizationComponentProps) => {
   const visualizationConfig = config.visualizationConfig as BarVisualizationConfig;
   const layout: Layout = {};
 
@@ -90,10 +95,16 @@ const BarVisualization = makeVisualization(({ config, data, effectiveTimerange, 
 
   const opacity = visualizationConfig ? visualizationConfig.opacity : 1.0;
 
-  const _seriesGenerator = (type, name, labels, values): ChartDefinition => ({ type, name, x: labels, y: values, opacity });
+  const _seriesGenerator = (type, name, labels, values): ChartDefinition => ({
+    type,
+    name,
+    x: labels,
+    y: values,
+    opacity,
+  });
 
   const rows = retrieveChartData(data);
-  const chartDataResult = chartData(config, rows, 'bar', _seriesGenerator);
+  const chartDataResult = chartData(rows, { widgetConfig: config, chartType: 'bar', generator: _seriesGenerator });
 
   if (config.eventAnnotation && data.events) {
     const { eventChartData, shapes } = EventHandler.toVisualizationData(data.events);

--- a/graylog2-web-interface/src/views/components/visualizations/bar/BarVisualization.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/bar/BarVisualization.tsx
@@ -22,10 +22,10 @@ import { AggregationType, AggregationResult } from 'views/components/aggregation
 import type { VisualizationComponentProps } from 'views/components/aggregationbuilder/AggregationBuilder';
 import { makeVisualization, retrieveChartData } from 'views/components/aggregationbuilder/AggregationBuilder';
 import type { Shapes } from 'views/logic/searchtypes/events/EventHandler';
-import EventHandler from 'views/logic/searchtypes/events/EventHandler';
 import { DateType } from 'views/logic/aggregationbuilder/Pivot';
 import type BarVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/BarVisualizationConfig';
 import useChartData from 'views/components/visualizations/useChartData';
+import useEvents from 'views/components/visualizations/useEvents';
 
 import type { Generator } from '../ChartData';
 import XYPlot from '../XYPlot';
@@ -89,10 +89,10 @@ const BarVisualization = makeVisualization(({
   height,
 }: VisualizationComponentProps) => {
   const visualizationConfig = config.visualizationConfig as BarVisualizationConfig;
-  const layout: Layout = {};
+  const _layout: Layout = {};
 
   if (visualizationConfig && visualizationConfig.barmode) {
-    layout.barmode = visualizationConfig?.barmode;
+    _layout.barmode = visualizationConfig?.barmode;
   }
 
   const opacity = visualizationConfig?.opacity ?? 1.0;
@@ -106,14 +106,12 @@ const BarVisualization = makeVisualization(({
   }), [opacity]);
 
   const rows = useMemo(() => retrieveChartData(data), [data]);
-  const chartDataResult = useChartData(rows, { widgetConfig: config, chartType: 'bar', generator: _seriesGenerator });
+  const _chartDataResult = useChartData(rows, { widgetConfig: config, chartType: 'bar', generator: _seriesGenerator });
 
-  if (config.eventAnnotation && data.events) {
-    const { eventChartData, shapes } = EventHandler.toVisualizationData(data.events);
+  const { eventChartData, shapes } = useEvents(config, data.events);
 
-    chartDataResult.push(eventChartData);
-    layout.shapes = shapes;
-  }
+  const chartDataResult = eventChartData ? [..._chartDataResult, eventChartData] : _chartDataResult;
+  const layout = shapes ? { ..._layout, shapes } : _layout;
 
   return (
     <XYPlot config={config}

--- a/graylog2-web-interface/src/views/components/visualizations/bar/BarVisualization.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/bar/BarVisualization.tsx
@@ -15,6 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
+import { useCallback, useMemo } from 'react';
 import PropTypes from 'prop-types';
 
 import { AggregationType, AggregationResult } from 'views/components/aggregationbuilder/AggregationBuilderPropTypes';
@@ -24,8 +25,9 @@ import type { Shapes } from 'views/logic/searchtypes/events/EventHandler';
 import EventHandler from 'views/logic/searchtypes/events/EventHandler';
 import { DateType } from 'views/logic/aggregationbuilder/Pivot';
 import type BarVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/BarVisualizationConfig';
+import useChartData from 'views/components/visualizations/useChartData';
 
-import { chartData } from '../ChartData';
+import type { Generator } from '../ChartData';
 import XYPlot from '../XYPlot';
 
 type ChartDefinition = {
@@ -90,21 +92,21 @@ const BarVisualization = makeVisualization(({
   const layout: Layout = {};
 
   if (visualizationConfig && visualizationConfig.barmode) {
-    layout.barmode = visualizationConfig.barmode;
+    layout.barmode = visualizationConfig?.barmode;
   }
 
-  const opacity = visualizationConfig ? visualizationConfig.opacity : 1.0;
+  const opacity = visualizationConfig?.opacity ?? 1.0;
 
-  const _seriesGenerator = (type, name, labels, values): ChartDefinition => ({
+  const _seriesGenerator: Generator = useCallback((type, name, labels, values): ChartDefinition => ({
     type,
     name,
     x: labels,
     y: values,
     opacity,
-  });
+  }), [opacity]);
 
-  const rows = retrieveChartData(data);
-  const chartDataResult = chartData(rows, { widgetConfig: config, chartType: 'bar', generator: _seriesGenerator });
+  const rows = useMemo(() => retrieveChartData(data), [data]);
+  const chartDataResult = useChartData(rows, { widgetConfig: config, chartType: 'bar', generator: _seriesGenerator });
 
   if (config.eventAnnotation && data.events) {
     const { eventChartData, shapes } = EventHandler.toVisualizationData(data.events);

--- a/graylog2-web-interface/src/views/components/visualizations/heatmap/HeatmapVisualization.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/heatmap/HeatmapVisualization.tsx
@@ -21,9 +21,9 @@ import { AggregationType, AggregationResult } from 'views/components/aggregation
 import type { VisualizationComponentProps } from 'views/components/aggregationbuilder/AggregationBuilder';
 import { makeVisualization, retrieveChartData } from 'views/components/aggregationbuilder/AggregationBuilder';
 import HeatmapVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/HeatmapVisualizationConfig';
+import useChartData from 'views/components/visualizations/useChartData';
 
 import type { ChartDefinition, ExtractedSeries, ValuesBySeries } from '../ChartData';
-import { chartData } from '../ChartData';
 import GenericPlot from '../GenericPlot';
 
 const _generateSeriesTitles = (config, x, y) => {
@@ -140,7 +140,7 @@ const _leafSourceMatcher = ({ source }) => source.endsWith('leaf') && source !==
 const HeatmapVisualization = makeVisualization(({ config, data }: VisualizationComponentProps) => {
   const visualizationConfig = (config.visualizationConfig || HeatmapVisualizationConfig.empty()) as HeatmapVisualizationConfig;
   const rows = retrieveChartData(data);
-  const heatmapData = chartData(rows, {
+  const heatmapData = useChartData(rows, {
     widgetConfig: config,
     chartType: 'heatmap',
     generator: _generateSeries(visualizationConfig),

--- a/graylog2-web-interface/src/views/components/visualizations/heatmap/HeatmapVisualization.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/heatmap/HeatmapVisualization.tsx
@@ -23,8 +23,8 @@ import { makeVisualization, retrieveChartData } from 'views/components/aggregati
 import HeatmapVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/HeatmapVisualizationConfig';
 
 import type { ChartDefinition, ExtractedSeries, ValuesBySeries } from '../ChartData';
-import GenericPlot from '../GenericPlot';
 import { chartData } from '../ChartData';
+import GenericPlot from '../GenericPlot';
 
 const _generateSeriesTitles = (config, x, y) => {
   const seriesTitles = config.series.map((s) => s.function);
@@ -73,14 +73,23 @@ const _fillUpMatrix = (z: Array<Array<any>>, xLabels: Array<any>, defaultValue =
 };
 
 const _transposeMatrix = (z: Array<Array<any>> = []) => {
-  if (!z[0]) { return z; }
+  if (!z[0]) {
+    return z;
+  }
 
-  return z[0].map((_, c) => { return z.map((r) => { return r[c]; }); });
+  return z[0].map((_, c) => {
+    return z.map((r) => {
+      return r[c];
+    });
+  });
 };
 
 const _findSmallestValue = (valuesFound: Array<Array<number>>) => valuesFound.reduce((result, valueArray) => valueArray.reduce((acc, value) => (acc > value ? value : acc), result), (valuesFound[0] || [])[0]);
 
-const _formatSeries = (visualizationConfig) => ({ valuesBySeries, xLabels }: {valuesBySeries: ValuesBySeries, xLabels: Array<any>}): ExtractedSeries => {
+const _formatSeries = (visualizationConfig) => ({
+  valuesBySeries,
+  xLabels,
+}: { valuesBySeries: ValuesBySeries, xLabels: Array<any> }): ExtractedSeries => {
   const valuesFoundBySeries = values(valuesBySeries);
   // When using the hovertemplate, we need to provie a value for empty z values.
   // Otherwise plotly would throw errors when hovering over a field.
@@ -131,7 +140,13 @@ const _leafSourceMatcher = ({ source }) => source.endsWith('leaf') && source !==
 const HeatmapVisualization = makeVisualization(({ config, data }: VisualizationComponentProps) => {
   const visualizationConfig = (config.visualizationConfig || HeatmapVisualizationConfig.empty()) as HeatmapVisualizationConfig;
   const rows = retrieveChartData(data);
-  const heatmapData = chartData(config, rows, 'heatmap', _generateSeries(visualizationConfig), _formatSeries(visualizationConfig), _leafSourceMatcher);
+  const heatmapData = chartData(rows, {
+    widgetConfig: config,
+    chartType: 'heatmap',
+    generator: _generateSeries(visualizationConfig),
+    seriesFormatter: _formatSeries(visualizationConfig),
+    leafValueMatcher: _leafSourceMatcher,
+  });
   const layout = _chartLayout(heatmapData);
 
   return (

--- a/graylog2-web-interface/src/views/components/visualizations/heatmap/__tests__/HeatmapVisualization.test.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/heatmap/__tests__/HeatmapVisualization.test.tsx
@@ -24,12 +24,19 @@ import Series from 'views/logic/aggregationbuilder/Series';
 import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
 import type { AbsoluteTimeRange } from 'views/logic/queries/Query';
 import HeatmapVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/HeatmapVisualizationConfig';
+import UserDateTimeProvider from 'contexts/UserDateTimeProvider';
 
 import * as fixtures from './HeatmapVisualization.fixtures';
 
 import HeatmapVisualization from '../HeatmapVisualization';
 
 jest.mock('../../GenericPlot', () => mockComponent('GenericPlot'));
+
+const SUT = (props: React.ComponentProps<typeof HeatmapVisualization>) => (
+  <UserDateTimeProvider tz="Europe/Berlin">
+    <HeatmapVisualization {...props} />
+  </UserDateTimeProvider>
+);
 
 describe('HeatmapVisualization', () => {
   it('generates correct props for plot component', () => {
@@ -58,14 +65,14 @@ describe('HeatmapVisualization', () => {
       },
     ];
 
-    const wrapper = mount(<HeatmapVisualization data={fixtures.validData}
-                                                config={config}
-                                                effectiveTimerange={effectiveTimerange}
-                                                fields={Immutable.List()}
-                                                height={1024}
-                                                onChange={() => {}}
-                                                toggleEdit={() => {}}
-                                                width={800} />);
+    const wrapper = mount(<SUT data={fixtures.validData}
+                               config={config}
+                               effectiveTimerange={effectiveTimerange}
+                               fields={Immutable.List()}
+                               height={1024}
+                               onChange={() => {}}
+                               toggleEdit={() => {}}
+                               width={800} />);
     const genericPlot = wrapper.find('GenericPlot');
 
     expect(genericPlot).toHaveProp('layout', plotLayout);
@@ -103,16 +110,14 @@ describe('HeatmapVisualization', () => {
       },
     ];
 
-    const wrapper = mount(<HeatmapVisualization data={{ chart: [] }}
-                                                config={config}
-                                                effectiveTimerange={effectiveTimerange}
-                                                fields={Immutable.List()}
-                                                height={1024}
-                                                onChange={() => {
-                                                }}
-                                                toggleEdit={() => {
-                                                }}
-                                                width={800} />);
+    const wrapper = mount(<SUT data={{ chart: [] }}
+                               config={config}
+                               effectiveTimerange={effectiveTimerange}
+                               fields={Immutable.List()}
+                               height={1024}
+                               onChange={() => {}}
+                               toggleEdit={() => {}}
+                               width={800} />);
     const genericPlot = wrapper.find('GenericPlot');
 
     expect(genericPlot).toHaveProp('layout', plotLayout);

--- a/graylog2-web-interface/src/views/components/visualizations/line/LineVisualization.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/line/LineVisualization.tsx
@@ -23,8 +23,8 @@ import { makeVisualization, retrieveChartData } from 'views/components/aggregati
 import LineVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/LineVisualizationConfig';
 import toPlotly from 'views/logic/aggregationbuilder/visualizations/Interpolation';
 import type { Shapes } from 'views/logic/searchtypes/events/EventHandler';
-import EventHandler from 'views/logic/searchtypes/events/EventHandler';
 import useChartData from 'views/components/visualizations/useChartData';
+import useEvents from 'views/components/visualizations/useEvents';
 
 import type { ChartDefinition } from '../ChartData';
 import XYPlot from '../XYPlot';
@@ -60,15 +60,16 @@ const LineVisualization = makeVisualization(({
   }), [interpolation]);
 
   const rows = useMemo(() => retrieveChartData(data), [data]);
-  const chartDataResult = useChartData(rows, { widgetConfig: config, chartType: 'scatter', generator: chartGenerator });
-  const layout: { shapes?: Shapes } = {};
+  const _chartDataResult = useChartData(rows, {
+    widgetConfig: config,
+    chartType: 'scatter',
+    generator: chartGenerator,
+  });
 
-  if (config.eventAnnotation && data.events) {
-    const { eventChartData, shapes } = EventHandler.toVisualizationData(data.events);
+  const { eventChartData, shapes } = useEvents(config, data.events);
 
-    chartDataResult.push(eventChartData);
-    layout.shapes = shapes;
-  }
+  const chartDataResult = eventChartData ? [..._chartDataResult, eventChartData] : _chartDataResult;
+  const layout: { shapes?: Shapes } = shapes ? { shapes } : {};
 
   return (
     <XYPlot config={config}

--- a/graylog2-web-interface/src/views/components/visualizations/line/LineVisualization.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/line/LineVisualization.tsx
@@ -19,11 +19,11 @@ import PropTypes from 'prop-types';
 
 import { AggregationType, AggregationResult } from 'views/components/aggregationbuilder/AggregationBuilderPropTypes';
 import type { VisualizationComponentProps } from 'views/components/aggregationbuilder/AggregationBuilder';
+import { makeVisualization, retrieveChartData } from 'views/components/aggregationbuilder/AggregationBuilder';
 import LineVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/LineVisualizationConfig';
 import toPlotly from 'views/logic/aggregationbuilder/visualizations/Interpolation';
 import type { Shapes } from 'views/logic/searchtypes/events/EventHandler';
 import EventHandler from 'views/logic/searchtypes/events/EventHandler';
-import { makeVisualization, retrieveChartData } from 'views/components/aggregationbuilder/AggregationBuilder';
 
 import type { ChartDefinition } from '../ChartData';
 import { chartData } from '../ChartData';
@@ -43,7 +43,12 @@ const getChartColor = (fullData, name) => {
 
 const setChartColor = (chart, colors) => ({ line: { color: colors.get(chart.name) } });
 
-const LineVisualization = makeVisualization(({ config, data, effectiveTimerange, height }: VisualizationComponentProps) => {
+const LineVisualization = makeVisualization(({
+  config,
+  data,
+  effectiveTimerange,
+  height,
+}: VisualizationComponentProps) => {
   const visualizationConfig = (config.visualizationConfig || LineVisualizationConfig.empty()) as LineVisualizationConfig;
   const { interpolation = 'linear' } = visualizationConfig;
   const chartGenerator = useCallback((type, name, labels, values): ChartDefinition => ({
@@ -55,7 +60,7 @@ const LineVisualization = makeVisualization(({ config, data, effectiveTimerange,
   }), [interpolation]);
 
   const rows = retrieveChartData(data);
-  const chartDataResult = chartData(config, rows, 'scatter', chartGenerator);
+  const chartDataResult = chartData(rows, { widgetConfig: config, chartType: 'scatter', generator: chartGenerator });
   const layout: { shapes?: Shapes } = {};
 
   if (config.eventAnnotation && data.events) {

--- a/graylog2-web-interface/src/views/components/visualizations/line/LineVisualization.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/line/LineVisualization.tsx
@@ -14,7 +14,7 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import React, { useCallback } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import PropTypes from 'prop-types';
 
 import { AggregationType, AggregationResult } from 'views/components/aggregationbuilder/AggregationBuilderPropTypes';
@@ -24,9 +24,9 @@ import LineVisualizationConfig from 'views/logic/aggregationbuilder/visualizatio
 import toPlotly from 'views/logic/aggregationbuilder/visualizations/Interpolation';
 import type { Shapes } from 'views/logic/searchtypes/events/EventHandler';
 import EventHandler from 'views/logic/searchtypes/events/EventHandler';
+import useChartData from 'views/components/visualizations/useChartData';
 
 import type { ChartDefinition } from '../ChartData';
-import { chartData } from '../ChartData';
 import XYPlot from '../XYPlot';
 
 const getChartColor = (fullData, name) => {
@@ -59,8 +59,8 @@ const LineVisualization = makeVisualization(({
     line: { shape: toPlotly(interpolation) },
   }), [interpolation]);
 
-  const rows = retrieveChartData(data);
-  const chartDataResult = chartData(rows, { widgetConfig: config, chartType: 'scatter', generator: chartGenerator });
+  const rows = useMemo(() => retrieveChartData(data), [data]);
+  const chartDataResult = useChartData(rows, { widgetConfig: config, chartType: 'scatter', generator: chartGenerator });
   const layout: { shapes?: Shapes } = {};
 
   if (config.eventAnnotation && data.events) {

--- a/graylog2-web-interface/src/views/components/visualizations/line/LineVisualization.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/line/LineVisualization.tsx
@@ -49,7 +49,7 @@ const LineVisualization = makeVisualization(({
   effectiveTimerange,
   height,
 }: VisualizationComponentProps) => {
-  const visualizationConfig = (config.visualizationConfig || LineVisualizationConfig.empty()) as LineVisualizationConfig;
+  const visualizationConfig = (config.visualizationConfig ?? LineVisualizationConfig.empty()) as LineVisualizationConfig;
   const { interpolation = 'linear' } = visualizationConfig;
   const chartGenerator = useCallback((type, name, labels, values): ChartDefinition => ({
     type,

--- a/graylog2-web-interface/src/views/components/visualizations/pie/PieVisualization.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/pie/PieVisualization.tsx
@@ -77,13 +77,13 @@ const setChartColor = (chart, colorMap) => {
   return { marker: { colors } };
 };
 
-const labelMapper = (data: Array<{ labels: Array<string>}>) => data.reduce((acc, { labels }) => {
+const labelMapper = (data: Array<{ labels: Array<string> }>) => data.reduce((acc, { labels }) => {
   return union(acc, labels);
 }, []);
 
 const PieVisualization = makeVisualization(({ config, data }: VisualizationComponentProps) => {
   const rows = retrieveChartData(data);
-  const transformedData = chartData(config, rows, 'pie', _generateSeries);
+  const transformedData = chartData(rows, { widgetConfig: config, chartType: 'pie', generator: _generateSeries });
 
   return (
     <PlotLegend config={config} chartData={transformedData} labelMapper={labelMapper} neverHide>

--- a/graylog2-web-interface/src/views/components/visualizations/pie/PieVisualization.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/pie/PieVisualization.tsx
@@ -15,15 +15,19 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
+import { useMemo } from 'react';
 import { union } from 'lodash';
 
 import { AggregationType, AggregationResult } from 'views/components/aggregationbuilder/AggregationBuilderPropTypes';
 import type { VisualizationComponentProps } from 'views/components/aggregationbuilder/AggregationBuilder';
 import { makeVisualization, retrieveChartData } from 'views/components/aggregationbuilder/AggregationBuilder';
 import PlotLegend from 'views/components/visualizations/PlotLegend';
+import useChartData from 'views/components/visualizations/useChartData';
+import type { Generator } from 'views/components/visualizations/ChartData';
+import type ColorMapper from 'views/components/visualizations/ColorMapper';
 
+import type { ChartConfig } from '../GenericPlot';
 import GenericPlot from '../GenericPlot';
-import { chartData } from '../ChartData';
 
 const maxItemsPerRow = 4;
 
@@ -37,7 +41,7 @@ const _verticalDimensions = (idx, total) => {
   return [(sliceSize * position) + spacer, (sliceSize * (position + 1)) - spacer];
 };
 
-const _horizontalDimensions = (idx, total) => {
+const _horizontalDimensions = (idx: number, total: number) => {
   const position = idx % maxItemsPerRow;
 
   const sliceSize = 1 / Math.min(total, maxItemsPerRow);
@@ -46,7 +50,7 @@ const _horizontalDimensions = (idx, total) => {
   return [(sliceSize * position) + spacer, (sliceSize * (position + 1)) - spacer];
 };
 
-const _generateSeries = (type, name, x, y, z, idx, total) => ({
+const _generateSeries: Generator = (type, name, x, y, z, idx, total) => ({
   type,
   name,
   hole: 0.4,
@@ -58,7 +62,7 @@ const _generateSeries = (type, name, x, y, z, idx, total) => ({
   },
 });
 
-const getChartColor = (fullDataArray, name) => {
+const getChartColor = (fullDataArray: ChartConfig[], name: string) => {
   const fullData = fullDataArray.find((d) => d.labels.indexOf(name) >= 0);
 
   if (fullData && fullData.labels && fullData.marker && fullData.marker.colors) {
@@ -71,7 +75,7 @@ const getChartColor = (fullDataArray, name) => {
   return undefined;
 };
 
-const setChartColor = (chart, colorMap) => {
+const setChartColor = (chart: ChartConfig, colorMap: ColorMapper) => {
   const colors = chart.labels.map((label) => colorMap.get(label));
 
   return { marker: { colors } };
@@ -82,8 +86,8 @@ const labelMapper = (data: Array<{ labels: Array<string> }>) => data.reduce((acc
 }, []);
 
 const PieVisualization = makeVisualization(({ config, data }: VisualizationComponentProps) => {
-  const rows = retrieveChartData(data);
-  const transformedData = chartData(rows, { widgetConfig: config, chartType: 'pie', generator: _generateSeries });
+  const rows = useMemo(() => retrieveChartData(data), [data]);
+  const transformedData = useChartData(rows, { widgetConfig: config, chartType: 'pie', generator: _generateSeries });
 
   return (
     <PlotLegend config={config} chartData={transformedData} labelMapper={labelMapper} neverHide>

--- a/graylog2-web-interface/src/views/components/visualizations/scatter/ScatterVisualization.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/scatter/ScatterVisualization.tsx
@@ -19,11 +19,11 @@ import { useMemo } from 'react';
 import PropTypes from 'prop-types';
 
 import type { Shapes } from 'views/logic/searchtypes/events/EventHandler';
-import EventHandler from 'views/logic/searchtypes/events/EventHandler';
 import { AggregationType, AggregationResult } from 'views/components/aggregationbuilder/AggregationBuilderPropTypes';
 import type { VisualizationComponentProps } from 'views/components/aggregationbuilder/AggregationBuilder';
 import { makeVisualization, retrieveChartData } from 'views/components/aggregationbuilder/AggregationBuilder';
 import useChartData from 'views/components/visualizations/useChartData';
+import useEvents from 'views/components/visualizations/useEvents';
 
 import XYPlot from '../XYPlot';
 
@@ -38,19 +38,15 @@ const ScatterVisualization = makeVisualization(({
   height,
 }: VisualizationComponentProps) => {
   const rows = useMemo(() => retrieveChartData(data), [data]);
-  const chartDataResult = useChartData(rows, {
+  const _chartDataResult = useChartData(rows, {
     widgetConfig: config,
     chartType: 'scatter',
     generator: seriesGenerator,
   });
-  const layout: { shapes?: Shapes } = {};
+  const { eventChartData, shapes } = useEvents(config, data.events);
 
-  if (config.eventAnnotation && data.events) {
-    const { eventChartData, shapes } = EventHandler.toVisualizationData(data.events);
-
-    chartDataResult.push(eventChartData);
-    layout.shapes = shapes;
-  }
+  const chartDataResult = eventChartData ? [..._chartDataResult, eventChartData] : _chartDataResult;
+  const layout: { shapes?: Shapes } = shapes ? { shapes } : {};
 
   return (
     <XYPlot config={config}

--- a/graylog2-web-interface/src/views/components/visualizations/scatter/ScatterVisualization.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/scatter/ScatterVisualization.tsx
@@ -30,9 +30,14 @@ const seriesGenerator = (type, name, labels, values) => ({ type, name, x: labels
 
 const setChartColor = (chart, colors) => ({ marker: { color: colors.get(chart.name) } });
 
-const ScatterVisualization = makeVisualization(({ config, data, effectiveTimerange, height }: VisualizationComponentProps) => {
+const ScatterVisualization = makeVisualization(({
+  config,
+  data,
+  effectiveTimerange,
+  height,
+}: VisualizationComponentProps) => {
   const rows = retrieveChartData(data);
-  const chartDataResult = chartData(config, rows, 'scatter', seriesGenerator);
+  const chartDataResult = chartData(rows, { widgetConfig: config, chartType: 'scatter', generator: seriesGenerator });
   const layout: { shapes?: Shapes } = {};
 
   if (config.eventAnnotation && data.events) {

--- a/graylog2-web-interface/src/views/components/visualizations/scatter/ScatterVisualization.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/scatter/ScatterVisualization.tsx
@@ -15,6 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
+import { useMemo } from 'react';
 import PropTypes from 'prop-types';
 
 import type { Shapes } from 'views/logic/searchtypes/events/EventHandler';
@@ -22,8 +23,8 @@ import EventHandler from 'views/logic/searchtypes/events/EventHandler';
 import { AggregationType, AggregationResult } from 'views/components/aggregationbuilder/AggregationBuilderPropTypes';
 import type { VisualizationComponentProps } from 'views/components/aggregationbuilder/AggregationBuilder';
 import { makeVisualization, retrieveChartData } from 'views/components/aggregationbuilder/AggregationBuilder';
+import useChartData from 'views/components/visualizations/useChartData';
 
-import { chartData } from '../ChartData';
 import XYPlot from '../XYPlot';
 
 const seriesGenerator = (type, name, labels, values) => ({ type, name, x: labels, y: values, mode: 'markers' });
@@ -36,8 +37,12 @@ const ScatterVisualization = makeVisualization(({
   effectiveTimerange,
   height,
 }: VisualizationComponentProps) => {
-  const rows = retrieveChartData(data);
-  const chartDataResult = chartData(rows, { widgetConfig: config, chartType: 'scatter', generator: seriesGenerator });
+  const rows = useMemo(() => retrieveChartData(data), [data]);
+  const chartDataResult = useChartData(rows, {
+    widgetConfig: config,
+    chartType: 'scatter',
+    generator: seriesGenerator,
+  });
   const layout: { shapes?: Shapes } = {};
 
   if (config.eventAnnotation && data.events) {

--- a/graylog2-web-interface/src/views/components/visualizations/useChartData.ts
+++ b/graylog2-web-interface/src/views/components/visualizations/useChartData.ts
@@ -1,0 +1,18 @@
+import { useContext, useMemo } from 'react';
+import type { Optional } from 'utility-types';
+
+import type { ChartDataConfig } from 'views/components/visualizations/ChartData';
+import { chartData } from 'views/components/visualizations/ChartData';
+import type { Rows } from 'views/logic/searchtypes/pivot/PivotHandler';
+import UserDateTimeContext from 'contexts/UserDateTimeContext';
+
+const useChartData = (rows: Rows, config: Optional<ChartDataConfig, 'formatTime'>) => {
+  const { formatTime } = useContext(UserDateTimeContext);
+
+  return useMemo(() => chartData(rows, {
+    formatTime,
+    ...config,
+  }), [config, formatTime, rows]);
+};
+
+export default useChartData;

--- a/graylog2-web-interface/src/views/components/visualizations/useEvents.ts
+++ b/graylog2-web-interface/src/views/components/visualizations/useEvents.ts
@@ -14,21 +14,20 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import { useContext, useMemo } from 'react';
-import type { Optional } from 'utility-types';
+import { useCallback, useContext } from 'react';
 
-import type { ChartDataConfig } from 'views/components/visualizations/ChartData';
-import { chartData } from 'views/components/visualizations/ChartData';
-import type { Rows } from 'views/logic/searchtypes/pivot/PivotHandler';
+import type { Event } from 'views/logic/searchtypes/events/EventHandler';
+import EventHandler from 'views/logic/searchtypes/events/EventHandler';
 import UserDateTimeContext from 'contexts/UserDateTimeContext';
+import type AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
 
-const useChartData = (rows: Rows, config: Optional<ChartDataConfig, 'formatTime'>) => {
+const useEvents = (config: AggregationWidgetConfig, events: Event[] | undefined) => {
   const { formatTime } = useContext(UserDateTimeContext);
+  const formatTimestamp = useCallback((timestamp: string) => formatTime(timestamp, 'internal'), [formatTime]);
 
-  return useMemo(() => chartData(rows, {
-    formatTime,
-    ...config,
-  }), [config, formatTime, rows]);
+  return (config.eventAnnotation && events)
+    ? EventHandler.toVisualizationData(events, formatTimestamp)
+    : { eventChartData: undefined, shapes: undefined };
 };
 
-export default useChartData;
+export default useEvents;

--- a/graylog2-web-interface/src/views/components/visualizations/worldmap/WorldMapVisualization.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/worldmap/WorldMapVisualization.tsx
@@ -21,17 +21,19 @@ import { flow, fromPairs, get, zip, isEmpty } from 'lodash';
 import type Viewport from 'views/logic/aggregationbuilder/visualizations/Viewport';
 import { AggregationType, AggregationResult } from 'views/components/aggregationbuilder/AggregationBuilderPropTypes';
 import type { VisualizationComponentProps } from 'views/components/aggregationbuilder/AggregationBuilder';
+import { makeVisualization, retrieveChartData } from 'views/components/aggregationbuilder/AggregationBuilder';
 import type { Rows } from 'views/logic/searchtypes/pivot/PivotHandler';
 import type Pivot from 'views/logic/aggregationbuilder/Pivot';
-import { makeVisualization, retrieveChartData } from 'views/components/aggregationbuilder/AggregationBuilder';
+import UserDateTimeContext from 'contexts/UserDateTimeContext';
 
 import MapVisualization from './MapVisualization';
 
+import type { ExtractedSeries, ChartData } from '../ChartData';
 import { extractSeries, formatSeries, getLeafsFromRows, getXLabelsFromLeafs } from '../ChartData';
 import transformKeys from '../TransformKeys';
 import RenderCompletionCallback from '../../widgets/RenderCompletionCallback';
 
-const _arrayToMap = ([name, x, y]) => ({ name, x, y });
+const _arrayToMap = ([name, x, y]: ChartData) => ({ name, x, y });
 const _lastKey = (keys) => keys[keys.length - 1];
 const _mergeObject = (prev, last) => ({ ...prev, ...last });
 
@@ -47,7 +49,7 @@ const _createSeriesWithoutMetric = (rows: Rows) => {
 };
 
 const _formatSeriesForMap = (rowPivots: Array<Pivot>) => {
-  return (result) => result.map(({ name, x, y }) => {
+  return (result: Array<ReturnType<typeof _arrayToMap>>) => result.map(({ name, x, y }) => {
     const keys = x.map((k) => k.slice(0, -1)
       .map((key, idx) => ({ [rowPivots[idx].field]: key }))
       .reduce(_mergeObject, {}));
@@ -59,18 +61,26 @@ const _formatSeriesForMap = (rowPivots: Array<Pivot>) => {
   });
 };
 
-const WorldMapVisualization = makeVisualization(({ config, data, editing, onChange, width, ...rest }: VisualizationComponentProps) => {
+const WorldMapVisualization = makeVisualization(({
+  config,
+  data,
+  editing,
+  onChange,
+  width,
+  ...rest
+}: VisualizationComponentProps) => {
   const { rowPivots } = config;
   const onRenderComplete = useContext(RenderCompletionCallback);
   const hasMetric = !isEmpty(config.series);
   const markerRadiusSize = !hasMetric ? 1 : undefined;
   const seriesExtractor = hasMetric ? extractSeries() : _createSeriesWithoutMetric;
+  const { formatTime } = useContext(UserDateTimeContext);
 
   const pipeline = flow([
-    transformKeys(config.rowPivots, config.columnPivots),
+    transformKeys(config.rowPivots, config.columnPivots, formatTime),
     seriesExtractor,
     formatSeries,
-    (results) => results.map(_arrayToMap),
+    (results: ExtractedSeries) => results.map(_arrayToMap),
     _formatSeriesForMap(rowPivots),
   ]);
 

--- a/graylog2-web-interface/src/views/components/visualizations/worldmap/__tests__/WorldMapVisualization.test.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/worldmap/__tests__/WorldMapVisualization.test.tsx
@@ -25,6 +25,7 @@ import Series from 'views/logic/aggregationbuilder/Series';
 import RenderCompletionCallback from 'views/components/widgets/RenderCompletionCallback';
 import type { AbsoluteTimeRange } from 'views/logic/queries/Query';
 import type { Rows } from 'views/logic/searchtypes/pivot/PivotHandler';
+import UserDateTimeProvider from 'contexts/UserDateTimeProvider';
 
 import WorldMapVisualization from '../WorldMapVisualization';
 
@@ -34,6 +35,12 @@ type MapVisualizationProps = HTMLAttributes & {
   onChange: (viewPort: Viewport) => void;
   onRenderComplete: () => void;
 };
+
+const SUT = (props: React.ComponentProps<typeof WorldMapVisualization>) => (
+  <UserDateTimeProvider tz="Europe/Berlin">
+    <WorldMapVisualization {...props} />
+  </UserDateTimeProvider>
+);
 
 describe('WorldMapVisualization', () => {
   const config = AggregationWidgetConfig.builder().visualization(WorldMapVisualization.type).build();
@@ -45,15 +52,15 @@ describe('WorldMapVisualization', () => {
 
   it('does not call onChange when not editing', () => {
     const onChange = jest.fn();
-    const wrapper = mount(<WorldMapVisualization config={config}
-                                                 data={{ chart: [] }}
-                                                 editing={false}
-                                                 effectiveTimerange={effectiveTimerange}
-                                                 fields={Immutable.List()}
-                                                 onChange={onChange}
-                                                 toggleEdit={() => {}}
-                                                 height={1024}
-                                                 width={800} />);
+    const wrapper = mount(<SUT config={config}
+                               data={{ chart: [] }}
+                               editing={false}
+                               effectiveTimerange={effectiveTimerange}
+                               fields={Immutable.List()}
+                               onChange={onChange}
+                               toggleEdit={() => {}}
+                               height={1024}
+                               width={800} />);
     const mapVisualization = wrapper.find('map-visualization');
 
     const { onChange: _onChange } = mapVisualization.at(0).props() as MapVisualizationProps;
@@ -67,15 +74,15 @@ describe('WorldMapVisualization', () => {
 
   it('does call onChange when editing', () => {
     const onChange = jest.fn();
-    const wrapper = mount(<WorldMapVisualization config={config}
-                                                 data={{ chart: [] }}
-                                                 editing
-                                                 effectiveTimerange={effectiveTimerange}
-                                                 fields={Immutable.List()}
-                                                 onChange={onChange}
-                                                 toggleEdit={() => {}}
-                                                 height={1024}
-                                                 width={800} />);
+    const wrapper = mount(<SUT config={config}
+                               data={{ chart: [] }}
+                               editing
+                               effectiveTimerange={effectiveTimerange}
+                               fields={Immutable.List()}
+                               onChange={onChange}
+                               toggleEdit={() => {}}
+                               height={1024}
+                               width={800} />);
     const mapVisualization = wrapper.find('map-visualization');
 
     const { onChange: _onChange } = mapVisualization.at(0).props() as MapVisualizationProps;
@@ -95,15 +102,15 @@ describe('WorldMapVisualization', () => {
     const renderCompletionCallback = jest.fn();
     const wrapper = mount((
       <RenderCompletionCallback.Provider value={renderCompletionCallback}>
-        <WorldMapVisualization config={config}
-                               data={{ chart: [] }}
-                               editing
-                               effectiveTimerange={effectiveTimerange}
-                               fields={Immutable.List()}
-                               onChange={() => {}}
-                               toggleEdit={() => {}}
-                               height={1024}
-                               width={800} />
+        <SUT config={config}
+             data={{ chart: [] }}
+             editing
+             effectiveTimerange={effectiveTimerange}
+             fields={Immutable.List()}
+             onChange={() => {}}
+             toggleEdit={() => {}}
+             height={1024}
+             width={800} />
       </RenderCompletionCallback.Provider>
     ));
 
@@ -137,15 +144,15 @@ describe('WorldMapVisualization', () => {
       values: { '37.751,-97.822': 25, '35.69,139.69': 6 },
     }];
     const wrapper = mount((
-      <WorldMapVisualization config={configWithMetric}
-                             data={data}
-                             editing
-                             effectiveTimerange={effectiveTimerange}
-                             fields={Immutable.List()}
-                             onChange={() => {}}
-                             toggleEdit={() => {}}
-                             height={1024}
-                             width={800} />
+      <SUT config={configWithMetric}
+           data={data}
+           editing
+           effectiveTimerange={effectiveTimerange}
+           fields={Immutable.List()}
+           onChange={() => {}}
+           toggleEdit={() => {}}
+           height={1024}
+           width={800} />
     ));
     const mapVisualization = wrapper.find('map-visualization');
 
@@ -166,15 +173,15 @@ describe('WorldMapVisualization', () => {
       values: { '37.751,-97.822': null, '35.69,139.69': null },
     }];
     const wrapper = mount((
-      <WorldMapVisualization config={configWithoutMetric}
-                             data={data}
-                             editing
-                             effectiveTimerange={effectiveTimerange}
-                             fields={Immutable.List()}
-                             onChange={() => {}}
-                             toggleEdit={() => {}}
-                             height={1024}
-                             width={800} />
+      <SUT config={configWithoutMetric}
+           data={data}
+           editing
+           effectiveTimerange={effectiveTimerange}
+           fields={Immutable.List()}
+           onChange={() => {}}
+           toggleEdit={() => {}}
+           height={1024}
+           width={800} />
     ));
     const mapVisualization = wrapper.find('map-visualization');
 

--- a/graylog2-web-interface/src/views/logic/searchtypes/events/EventHandler.test.ts
+++ b/graylog2-web-interface/src/views/logic/searchtypes/events/EventHandler.test.ts
@@ -15,11 +15,14 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import { groupBy } from 'lodash';
+import moment from 'moment-timezone';
 
 import type { Event } from './EventHandler';
 import EventHandler from './EventHandler';
 
-const groupByTimestamp = ((es) => groupBy(es, (e) => e.timestamp));
+const formatTimestamp = (timezone: string) => (timestamp: string) => moment(timestamp).tz(timezone).toISOString(true);
+
+const groupByTimestamp = ((es: Event[]) => groupBy(es, (e) => e.timestamp));
 
 describe('EventHandler convert', () => {
   const event: Event = {
@@ -31,13 +34,13 @@ describe('EventHandler convert', () => {
   };
 
   it('should convert events to chart data and shapes', () => {
-    const result = EventHandler.toVisualizationData([event]);
+    const result = EventHandler.toVisualizationData([event], formatTimestamp('UTC'));
 
     expect(result).toMatchSnapshot();
   });
 
   it('should convert events to char data', () => {
-    const result = EventHandler.toChartData(groupByTimestamp([event]), 'UTC');
+    const result = EventHandler.toChartData(groupByTimestamp([event]), formatTimestamp('UTC'));
 
     expect(result).toEqual({
       hovertemplate: '%{text}',
@@ -52,7 +55,7 @@ describe('EventHandler convert', () => {
   });
 
   it('should convert events to char data and use new timezone', () => {
-    const result = EventHandler.toChartData(groupByTimestamp([event]), 'CET');
+    const result = EventHandler.toChartData(groupByTimestamp([event]), formatTimestamp('CET'));
 
     expect(result).toEqual({
       hovertemplate: '%{text}',
@@ -67,7 +70,7 @@ describe('EventHandler convert', () => {
   });
 
   it('should group duplicate events by timestamp and convert events to char data', () => {
-    const result = EventHandler.toChartData(groupByTimestamp([event, event, event]), 'UTC');
+    const result = EventHandler.toChartData(groupByTimestamp([event, event, event]), formatTimestamp('UTC'));
 
     expect(result).toEqual({
       hovertemplate: '%{text}',
@@ -82,7 +85,7 @@ describe('EventHandler convert', () => {
   });
 
   it('should keep the color set by the user', () => {
-    const result = EventHandler.toChartData(groupByTimestamp([event]), 'UTC');
+    const result = EventHandler.toChartData(groupByTimestamp([event]), formatTimestamp('UTC'));
 
     expect(result).toEqual({
       hovertemplate: '%{text}',
@@ -97,7 +100,7 @@ describe('EventHandler convert', () => {
   });
 
   it('should convert events to shape data', () => {
-    const result = EventHandler.toShapeData([event.timestamp], 'UTC');
+    const result = EventHandler.toShapeData([event.timestamp], formatTimestamp('UTC'));
 
     expect(result[0]).toEqual({
       layer: 'below',
@@ -112,7 +115,7 @@ describe('EventHandler convert', () => {
   });
 
   it('should convert events to shape data with new timezone', () => {
-    const result = EventHandler.toShapeData([event.timestamp], 'CET');
+    const result = EventHandler.toShapeData([event.timestamp], formatTimestamp('CET'));
 
     expect(result[0]).toEqual({
       layer: 'below',


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Prior to this PR, the transformation pipeline for chart data was accessing the `CurrentUserStore` directly to extract the current user's timezone and apply it to timestamps in chart data.

This PR is now changing this to use the `UserDateTimeContext`. This also makes it possible to override the timezone through a context provider.

Fixes: https://github.com/Graylog2/graylog2-server/issues/11341

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.