### PR TITLE
Improving generating initial field name index. (4.2)

### DIFF
--- a/graylog2-web-interface/src/views/components/searchbar/completions/FieldNameCompletion.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/completions/FieldNameCompletion.test.tsx
@@ -17,6 +17,7 @@
 import { StoreMock as MockStore } from 'helpers/mocking';
 import asMock from 'helpers/mocking/AsMock';
 import * as Immutable from 'immutable';
+import { List as MockList } from 'immutable';
 
 import { ViewMetaData, ViewMetadataStore } from 'views/stores/ViewMetadataStore';
 import { FieldTypeMappingsList, FieldTypesStore, FieldTypesStoreState } from 'views/stores/FieldTypesStore';
@@ -26,7 +27,7 @@ import FieldNameCompletion from './FieldNameCompletion';
 jest.mock('views/stores/FieldTypesStore', () => ({
   FieldTypesStore: MockStore(
     'listen',
-    ['getInitialState', jest.fn(() => ({ all: [], queryFields: { get: () => [] } }))],
+    ['getInitialState', jest.fn(() => ({ all: [], queryFields: { get: () => MockList() } }))],
   ),
 }));
 
@@ -39,8 +40,11 @@ jest.mock('views/stores/ViewMetadataStore', () => ({
 const _createField = (name) => ({ name, type: { type: 'string' } });
 const dummyFields = ['source', 'message', 'timestamp'].map(_createField);
 
-const _createQueryFields = (fields) => ({ get: () => fields }) as unknown as Immutable.Map<string, FieldTypeMappingsList>;
-const _createFieldTypesStoreState = (fields): FieldTypesStoreState => ({ all: fields, queryFields: _createQueryFields(fields) });
+const _createQueryFields = (fields) => ({ get: () => Immutable.List(fields) }) as unknown as Immutable.Map<string, FieldTypeMappingsList>;
+const _createFieldTypesStoreState = (fields): FieldTypesStoreState => ({
+  all: fields,
+  queryFields: _createQueryFields(fields),
+});
 
 describe('FieldNameCompletion', () => {
   beforeEach(() => {
@@ -115,8 +119,8 @@ describe('FieldNameCompletion', () => {
 
     const queryFields = {
       get: (queryId, _default) => ({
-        query1: ['foo'].map(_createField),
-        query2: ['bar'].map(_createField),
+        query1: Immutable.List(['foo'].map(_createField)),
+        query2: Immutable.List(['bar'].map(_createField)),
       }[queryId] || _default),
     };
 

--- a/graylog2-web-interface/src/views/components/searchbar/completions/FieldNameCompletion.ts
+++ b/graylog2-web-interface/src/views/components/searchbar/completions/FieldNameCompletion.ts
@@ -88,8 +88,7 @@ class FieldNameCompletion implements Completer {
     if (this.activeQuery) {
       const currentQueryFields: FieldTypeMappingsList = queryFields.get(this.activeQuery, Immutable.List());
 
-      this.currentQueryFieldNames = currentQueryFields.map((fieldMapping) => fieldMapping.name)
-        .reduce((prev, cur) => ({ ...prev, [cur]: cur }), {});
+      this.currentQueryFieldNames = Object.fromEntries(currentQueryFields.map(({ name }) => [name, name]).toArray());
     }
   };
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is improving field names indexing performance in the field names completion class, which is happening every time the field types store is refreshed.

Prior to this PR, a `reduce` call was used, subsequently merging objects into each other. For large numbers of fields, this is creating excessive load. A simpler way using `Object.fromEntries` is now being used, which is creating the object from the given array in a linear way.

Refs #11930.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

As this issue results from users with performance issues for a high number of fields, I ingested messages adding up to a number of 25000 fields being present. After that, loading the initial search page was profiled. Before the change it took about 30s, afterwards less than 4s.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.