### PR TITLE
Using decimal/float representation of y values, showing x/y hovers.

### DIFF
--- a/graylog2-web-interface/src/views/components/visualizations/ChartData.ts
+++ b/graylog2-web-interface/src/views/components/visualizations/ChartData.ts
@@ -55,7 +55,12 @@ export type Generator = (type: string, name: string, labels: Array<string>, valu
 
 const _defaultKeyJoiner = (keys) => keys.join('-');
 
-const _defaultChartGenerator = (type, name, labels, values): ChartDefinition => ({ type, name, x: labels, y: values });
+const _defaultChartGenerator = (type, name, labels, values): ChartDefinition => ({
+  type,
+  name,
+  x: labels,
+  y: values,
+});
 
 export const flattenLeafs = (leafs: Array<Leaf>, matcher: (value: Value) => boolean = ({ source }) => source.endsWith('leaf')): Array<any> => {
   return flatten(leafs.map((l) => l.values.filter((value) => matcher(value)).map((v) => [l.key, v])));

--- a/graylog2-web-interface/src/views/components/visualizations/XYPlot.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/XYPlot.tsx
@@ -17,7 +17,6 @@
 
 import React, { useCallback, useContext } from 'react';
 import PropTypes from 'prop-types';
-import { merge } from 'lodash';
 
 import connect from 'stores/connect';
 import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
@@ -62,6 +61,13 @@ const yLegendPosition = (containerHeight: number) => {
   return -0.14;
 };
 
+type Layout = {
+  yaxis: { fixedrange?: boolean },
+  legend?: { y?: number },
+  showlegend: boolean,
+  hovermode: 'x',
+};
+
 const XYPlot = ({
   config,
   chartData,
@@ -74,18 +80,18 @@ const XYPlot = ({
   onZoom = OnZoom,
 }: Props) => {
   const { formatTime } = useContext(UserDateTimeContext);
-  const yaxis = { fixedrange: true, rangemode: 'tozero', tickformat: ',g' };
-  const defaultLayout: {
-    yaxis: { fixedrange?: boolean },
-    legend?: { y?: number },
-    showlegend: boolean,
-  } = { yaxis, showlegend: false };
+  const yaxis = { fixedrange: true, rangemode: 'tozero', tickformat: ',~r' };
+  const defaultLayout: Layout = {
+    yaxis,
+    showlegend: false,
+    hovermode: 'x',
+  };
 
   if (height) {
     defaultLayout.legend = { y: yLegendPosition(height) };
   }
 
-  const layout = merge({}, defaultLayout, plotLayout);
+  const layout = { ...defaultLayout, ...plotLayout };
   const viewType = useContext(ViewTypeContext);
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const _onZoom = useCallback(config.isTimeline

--- a/graylog2-web-interface/src/views/components/visualizations/__tests__/ChartData.test.simple.sourceMatcher.result.json
+++ b/graylog2-web-interface/src/views/components/visualizations/__tests__/ChartData.test.simple.sourceMatcher.result.json
@@ -1,42 +1,42 @@
 [
   {
-     "name":"index-count()",
-     "type":"scatter",
-     "x":[
-        "2018-05-24T14:03:00.000Z-PostsController"
-     ],
-     "y":[
-        2696
-     ]
+    "name": "index-count()",
+    "type": "scatter",
+    "x": [
+      "2018-05-24T14:03:00.000Z-PostsController"
+    ],
+    "y": [
+      2696
+    ]
   },
   {
-     "name":"index-sum(took_ms)",
-     "type":"scatter",
-     "x":[
-        "2018-05-24T14:03:00.000Z-PostsController"
-     ],
-     "y":[
-        239622
-     ]
+    "name": "index-sum(took_ms)",
+    "type": "scatter",
+    "x": [
+      "2018-05-24T14:03:00.000Z-PostsController"
+    ],
+    "y": [
+      239622
+    ]
   },
   {
-     "name":"edit-count()",
-     "type":"scatter",
-     "x":[
-        "2018-05-24T14:03:00.000Z-PostsController"
-     ],
-     "y":[
-        118
-     ]
+    "name": "edit-count()",
+    "type": "scatter",
+    "x": [
+      "2018-05-24T14:03:00.000Z-PostsController"
+    ],
+    "y": [
+      118
+    ]
   },
   {
-     "name":"edit-sum(took_ms)",
-     "type":"scatter",
-     "x":[
-        "2018-05-24T14:03:00.000Z-PostsController"
-     ],
-     "y":[
-        6580
-     ]
+    "name": "edit-sum(took_ms)",
+    "type": "scatter",
+    "x": [
+      "2018-05-24T14:03:00.000Z-PostsController"
+    ],
+    "y": [
+      6580
+    ]
   }
 ]

--- a/graylog2-web-interface/src/views/components/visualizations/__tests__/XYPlot.test.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/__tests__/XYPlot.test.tsx
@@ -122,6 +122,7 @@ describe('XYPlot', () => {
       yaxis: { fixedrange: true, rangemode: 'tozero', tickformat: ',g' },
       xaxis: { fixedrange: true },
       showlegend: false,
+      hovermode: 'x',
     });
 
     expect(genericPlot).toHaveProp('chartData', chartData);

--- a/graylog2-web-interface/src/views/components/visualizations/__tests__/XYPlot.test.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/__tests__/XYPlot.test.tsx
@@ -119,7 +119,7 @@ describe('XYPlot', () => {
     const genericPlot = wrapper.find('GenericPlot');
 
     expect(genericPlot).toHaveProp('layout', {
-      yaxis: { fixedrange: true, rangemode: 'tozero', tickformat: ',g' },
+      yaxis: { fixedrange: true, rangemode: 'tozero', tickformat: ',~r' },
       xaxis: { fixedrange: true },
       showlegend: false,
       hovermode: 'x',


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

In #11639, plotly.js was updated to v2.x. Starting with this release, two changes were made: hover templates defaulting to exponential notation and the `hovermode` defaulting to `closest`, showing only a single, unified tooltip on hover.

This PR is now restoring the original behavior by explicitly soecifying `hovermode` and `yhoverformat` for plots.

Fixes #11917.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.