### PR TITLE
Integration tests: GRAYLOG_TEST_WITH_RUNNING_ES_AND_MONGODB fixes

### DIFF
--- a/full-backend-tests/src/test/java/org/graylog/testing/utils/GelfInputUtils.java
+++ b/full-backend-tests/src/test/java/org/graylog/testing/utils/GelfInputUtils.java
@@ -1,4 +1,4 @@
- /*
+/*
  * Copyright (C) 2020 Graylog, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
@@ -16,22 +16,23 @@
  */
 package org.graylog.testing.utils;
 
- import com.google.common.collect.ImmutableMap;
- import io.restassured.specification.RequestSpecification;
- import org.graylog2.inputs.gelf.http.GELFHttpInput;
- import org.graylog2.rest.models.system.inputs.requests.InputCreateRequest;
- import org.slf4j.Logger;
- import org.slf4j.LoggerFactory;
+import com.google.common.collect.ImmutableMap;
+import io.restassured.specification.RequestSpecification;
+import org.graylog2.inputs.gelf.http.GELFHttpInput;
+import org.graylog2.rest.models.system.inputs.requests.InputCreateRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
- import java.util.ArrayList;
+import java.util.ArrayList;
 
- import static io.restassured.RestAssured.given;
+import static io.restassured.RestAssured.given;
 
 public final class GelfInputUtils {
 
     private static final Logger LOG = LoggerFactory.getLogger(GelfInputUtils.class);
 
-    private GelfInputUtils() { }
+    private GelfInputUtils() {
+    }
 
     public static void createGelfHttpInput(int mappedPort, int gelfHttpPort, RequestSpecification requestSpecification) {
 

--- a/graylog2-server/src/test/java/org/graylog/testing/completebackend/README.md
+++ b/graylog2-server/src/test/java/org/graylog/testing/completebackend/README.md
@@ -11,6 +11,9 @@ The following environment variables can be set to configure local execution:
 
   Setting this to "true" (ignoring case) will allow debugging the code under test running inside a container.
 
+- GRAYLOG_TEST_WITH_RUNNING_ES_AND_MONGODB
+    `true`|`false` if you want to start the test against your current dev instance of graylog&mongodb&elasticsearch. 
+
 # Local Execution
 
 Running `mvn verify` locally should execute the tests in the same way as on a CI server. 

--- a/graylog2-server/src/test/java/org/graylog/testing/containermatrix/ContainerMatrixTestEngine.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/containermatrix/ContainerMatrixTestEngine.java
@@ -137,7 +137,8 @@ public class ContainerMatrixTestEngine extends ContainerMatrixHierarchicalTestEn
     }
 
     protected boolean testAgainstRunningESMongoDB() {
-        return !isBlank(System.getenv("GRAYLOG_TEST_WITH_RUNNING_ES_AND_MONGODB"));
+        final String value = System.getenv("GRAYLOG_TEST_WITH_RUNNING_ES_AND_MONGODB");
+        return !isBlank(value) && Boolean.parseBoolean(value);
     }
 
     @Override


### PR DESCRIPTION
- Added GRAYLOG_TEST_WITH_RUNNING_ES_AND_MONGODB documentation and better parsing
- Do not create GELF input in IT if there is already one existing (useful in combination with the :point_up: flag)

## Motivation and Context
The `GRAYLOG_TEST_WITH_RUNNING_ES_AND_MONGODB` had no documentation in README and has been quite hard to discover and use. Additionally, its value parsing now handles boolean values, so it's easier to enable/disable the feature in tests.

Additionally, the gelf input utils verify, that there is already an input listening on the default gelf port. If yes, no additional input will be created. This prevents adding more and more inputs in case of running tests against existing developer instance.

## How Has This Been Tested?
The utils are heavily used in the integration tests, so any problem there would be discovered by the existing tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

