### PR TITLE
Allow bulk update of Grok patterns

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/grok/GrokPatternService.java
+++ b/graylog2-server/src/main/java/org/graylog2/grok/GrokPatternService.java
@@ -44,7 +44,7 @@ public interface GrokPatternService {
 
     GrokPattern update(GrokPattern pattern) throws ValidationException;
 
-    List<GrokPattern> saveAll(Collection<GrokPattern> patterns, boolean replace) throws ValidationException;
+    List<GrokPattern> saveAll(Collection<GrokPattern> patterns, boolean dropAllExisting, boolean replaceExisting) throws ValidationException;
 
     Map<String, Object> match(GrokPattern pattern, String sampleData) throws GrokException;
 

--- a/graylog2-server/src/main/java/org/graylog2/grok/GrokPatternService.java
+++ b/graylog2-server/src/main/java/org/graylog2/grok/GrokPatternService.java
@@ -32,6 +32,10 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public interface GrokPatternService {
+    enum ImportStrategy {
+        ABORT_ON_CONFLICT, REPLACE_ON_CONFLICT, DROP_ALL_EXISTING
+    }
+
     GrokPattern load(String patternId) throws NotFoundException;
 
     Optional<GrokPattern> loadByName(String name);
@@ -44,7 +48,7 @@ public interface GrokPatternService {
 
     GrokPattern update(GrokPattern pattern) throws ValidationException;
 
-    List<GrokPattern> saveAll(Collection<GrokPattern> patterns, boolean dropAllExisting, boolean replaceExisting) throws ValidationException;
+    List<GrokPattern> saveAll(Collection<GrokPattern> patterns, ImportStrategy importStrategy) throws ValidationException;
 
     Map<String, Object> match(GrokPattern pattern, String sampleData) throws GrokException;
 

--- a/graylog2-server/src/main/java/org/graylog2/grok/InMemoryGrokPatternService.java
+++ b/graylog2-server/src/main/java/org/graylog2/grok/InMemoryGrokPatternService.java
@@ -124,7 +124,17 @@ public class InMemoryGrokPatternService implements GrokPatternService {
 
     @Override
     public List<GrokPattern> saveAll(Collection<GrokPattern> patterns,
-                                     boolean replace) throws ValidationException {
+                                     boolean dropAllExisting, boolean replaceExisting) throws ValidationException {
+
+        if (!dropAllExisting && !replaceExisting) {
+            for (GrokPattern pattern : loadAll()) {
+                final boolean patternExists = patterns.stream().anyMatch(p -> p.name().equals(pattern.name()));
+                if (patternExists) {
+                    throw new ValidationException("Grok pattern " + pattern.name() + " already exists");
+                }
+            }
+        }
+
         try {
             if (!validateAll(patterns)) {
                 throw new ValidationException("Patterns invalid.");
@@ -133,7 +143,7 @@ public class InMemoryGrokPatternService implements GrokPatternService {
             throw new ValidationException("Invalid patterns.\n" + e.getMessage());
         }
 
-        if (replace) {
+        if (dropAllExisting) {
             deleteAll();
         }
 

--- a/graylog2-server/src/main/java/org/graylog2/grok/InMemoryGrokPatternService.java
+++ b/graylog2-server/src/main/java/org/graylog2/grok/InMemoryGrokPatternService.java
@@ -39,6 +39,9 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.regex.PatternSyntaxException;
 import java.util.stream.Collectors;
 
+import static org.graylog2.grok.GrokPatternService.ImportStrategy.ABORT_ON_CONFLICT;
+import static org.graylog2.grok.GrokPatternService.ImportStrategy.DROP_ALL_EXISTING;
+
 public class InMemoryGrokPatternService implements GrokPatternService {
     // poor man's id generator
     private final AtomicLong idGen = new AtomicLong(0);
@@ -124,9 +127,9 @@ public class InMemoryGrokPatternService implements GrokPatternService {
 
     @Override
     public List<GrokPattern> saveAll(Collection<GrokPattern> patterns,
-                                     boolean dropAllExisting, boolean replaceExisting) throws ValidationException {
+                                     ImportStrategy importStrategy) throws ValidationException {
 
-        if (!dropAllExisting && !replaceExisting) {
+        if (importStrategy == ABORT_ON_CONFLICT) {
             for (GrokPattern pattern : loadAll()) {
                 final boolean patternExists = patterns.stream().anyMatch(p -> p.name().equals(pattern.name()));
                 if (patternExists) {
@@ -143,7 +146,7 @@ public class InMemoryGrokPatternService implements GrokPatternService {
             throw new ValidationException("Invalid patterns.\n" + e.getMessage());
         }
 
-        if (dropAllExisting) {
+        if (importStrategy == DROP_ALL_EXISTING) {
             deleteAll();
         }
 

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/GrokResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/GrokResource.java
@@ -183,8 +183,15 @@ public class GrokResource extends RestResource {
     @ApiOperation("Add a list of new patterns")
     @AuditEvent(type = AuditEventTypes.GROK_PATTERN_IMPORT_CREATE)
     public Response bulkUpdatePatterns(@ApiParam(name = "patterns", required = true) @NotNull GrokPatternList patternList,
-                                       @ApiParam(name = "replace", value = "Replace all patterns with the new ones.")
-                                       @QueryParam("replace") @DefaultValue("false") boolean replace) throws ValidationException {
+                                       // deprecated. used to drop all existing patterns before import
+                                       @Deprecated @QueryParam("replace") @DefaultValue("false")
+                                               boolean deprecatedDropAllExisting,
+                                       @ApiParam(name = "drop-all-existing", value = "Drop all existing patterns before import.")
+                                       @QueryParam("drop-all-existing") @DefaultValue("false")
+                                               boolean dropAllExisting,
+                                       @ApiParam(name = "replace-existing", value = "Replace existing patterns with the same name.")
+                                       @QueryParam("replace-existing") @DefaultValue("false")
+                                               boolean replaceExisting) throws ValidationException {
         checkPermission(RestPermissions.INPUTS_CREATE);
 
         try {
@@ -195,7 +202,8 @@ public class GrokResource extends RestResource {
             throw new ValidationException("Invalid pattern. Did not save any patterns\n" + e.getMessage());
         }
 
-        grokPatternService.saveAll(patternList.patterns(), replace);
+        grokPatternService.saveAll(patternList.patterns(), deprecatedDropAllExisting || dropAllExisting,
+                replaceExisting);
         return Response.accepted().build();
     }
 
@@ -205,8 +213,16 @@ public class GrokResource extends RestResource {
     @ApiOperation("Add a list of new patterns")
     @AuditEvent(type = AuditEventTypes.GROK_PATTERN_IMPORT_CREATE)
     public Response bulkUpdatePatternsFromTextFile(@ApiParam(name = "patterns", required = true) @NotNull InputStream patternsFile,
-                                                   @ApiParam(name = "replace", value = "Replace all patterns with the new ones.")
-                                                   @QueryParam("replace") @DefaultValue("false") boolean replace) throws ValidationException, IOException {
+                                                   // deprecated. used to drop all existing patterns before import
+                                                   @Deprecated @QueryParam("replace") @DefaultValue("false")
+                                                           boolean deprecatedDropAllExisting,
+                                                   @ApiParam(name = "drop-all-existing", value = "Drop all existing patterns before import.")
+                                                   @QueryParam("drop-all-existing") @DefaultValue("false")
+                                                           boolean dropAllExisting,
+                                                   @ApiParam(name = "replace-existing", value = "Replace existing patterns with the same name.")
+                                                   @QueryParam("replace-existing") @DefaultValue("false")
+                                                           boolean replaceExisting
+    ) throws ValidationException, IOException {
         checkPermission(RestPermissions.INPUTS_CREATE);
 
         final List<GrokPattern> grokPatterns = readGrokPatterns(patternsFile);
@@ -220,7 +236,8 @@ public class GrokResource extends RestResource {
                 throw new ValidationException("Invalid pattern. Did not save any patterns\n" + e.getMessage());
             }
 
-            grokPatternService.saveAll(grokPatterns, replace);
+            grokPatternService.saveAll(grokPatterns, deprecatedDropAllExisting || dropAllExisting,
+                    replaceExisting);
         }
 
         return Response.accepted().build();

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/GrokResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/GrokResource.java
@@ -30,6 +30,7 @@ import org.graylog2.database.NotFoundException;
 import org.graylog2.database.PaginatedList;
 import org.graylog2.grok.GrokPattern;
 import org.graylog2.grok.GrokPatternService;
+import org.graylog2.grok.GrokPatternService.ImportStrategy;
 import org.graylog2.grok.PaginatedGrokPatternService;
 import org.graylog2.plugin.database.ValidationException;
 import org.graylog2.rest.models.PaginatedResponse;
@@ -182,16 +183,14 @@ public class GrokResource extends RestResource {
     @Timed
     @ApiOperation("Add a list of new patterns")
     @AuditEvent(type = AuditEventTypes.GROK_PATTERN_IMPORT_CREATE)
-    public Response bulkUpdatePatterns(@ApiParam(name = "patterns", required = true) @NotNull GrokPatternList patternList,
+    public Response bulkUpdatePatterns(@ApiParam(name = "patterns", required = true) @NotNull
+                                               GrokPatternList patternList,
                                        // deprecated. used to drop all existing patterns before import
                                        @Deprecated @QueryParam("replace") @DefaultValue("false")
                                                boolean deprecatedDropAllExisting,
-                                       @ApiParam(name = "drop-all-existing", value = "Drop all existing patterns before import.")
-                                       @QueryParam("drop-all-existing") @DefaultValue("false")
-                                               boolean dropAllExisting,
-                                       @ApiParam(name = "replace-existing", value = "Replace existing patterns with the same name.")
-                                       @QueryParam("replace-existing") @DefaultValue("false")
-                                               boolean replaceExisting) throws ValidationException {
+                                       @ApiParam(name = "import-strategy", value = "Strategy to apply when importing.")
+                                       @QueryParam("import-strategy")
+                                               ImportStrategy importStrategy) throws ValidationException {
         checkPermission(RestPermissions.INPUTS_CREATE);
 
         try {
@@ -202,8 +201,10 @@ public class GrokResource extends RestResource {
             throw new ValidationException("Invalid pattern. Did not save any patterns\n" + e.getMessage());
         }
 
-        grokPatternService.saveAll(patternList.patterns(), deprecatedDropAllExisting || dropAllExisting,
-                replaceExisting);
+        ImportStrategy resolvedStrategy = importStrategy != null ? importStrategy :
+                deprecatedDropAllExisting ? ImportStrategy.DROP_ALL_EXISTING : ImportStrategy.ABORT_ON_CONFLICT;
+
+        grokPatternService.saveAll(patternList.patterns(), resolvedStrategy);
         return Response.accepted().build();
     }
 
@@ -216,13 +217,9 @@ public class GrokResource extends RestResource {
                                                    // deprecated. used to drop all existing patterns before import
                                                    @Deprecated @QueryParam("replace") @DefaultValue("false")
                                                            boolean deprecatedDropAllExisting,
-                                                   @ApiParam(name = "drop-all-existing", value = "Drop all existing patterns before import.")
-                                                   @QueryParam("drop-all-existing") @DefaultValue("false")
-                                                           boolean dropAllExisting,
-                                                   @ApiParam(name = "replace-existing", value = "Replace existing patterns with the same name.")
-                                                   @QueryParam("replace-existing") @DefaultValue("false")
-                                                           boolean replaceExisting
-    ) throws ValidationException, IOException {
+                                                   @ApiParam(name = "import-strategy", value = "Strategy to apply when importing.")
+                                                   @QueryParam("import-strategy")
+                                                           ImportStrategy importStrategy) throws ValidationException, IOException {
         checkPermission(RestPermissions.INPUTS_CREATE);
 
         final List<GrokPattern> grokPatterns = readGrokPatterns(patternsFile);
@@ -236,8 +233,10 @@ public class GrokResource extends RestResource {
                 throw new ValidationException("Invalid pattern. Did not save any patterns\n" + e.getMessage());
             }
 
-            grokPatternService.saveAll(grokPatterns, deprecatedDropAllExisting || dropAllExisting,
-                    replaceExisting);
+            ImportStrategy resolvedStrategy = importStrategy != null ? importStrategy :
+                    deprecatedDropAllExisting ? ImportStrategy.DROP_ALL_EXISTING : ImportStrategy.ABORT_ON_CONFLICT;
+
+            grokPatternService.saveAll(grokPatterns, resolvedStrategy);
         }
 
         return Response.accepted().build();

--- a/graylog2-server/src/test/java/org/graylog2/grok/InMemoryGrokPatternServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/grok/InMemoryGrokPatternServiceTest.java
@@ -33,6 +33,7 @@ import java.util.concurrent.Executors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
 
 public class InMemoryGrokPatternServiceTest {
@@ -113,16 +114,20 @@ public class InMemoryGrokPatternServiceTest {
     @Test
     public void saveAll() throws Exception {
         Collection<GrokPattern> patterns = ImmutableList.of(GrokPattern.create("1", ".*"),
-                                                            GrokPattern.create("2", ".+"));
-        final List<GrokPattern> saved = service.saveAll(patterns, false);
+                GrokPattern.create("2", ".+"));
+        final List<GrokPattern> saved = service.saveAll(patterns, false, false);
         assertThat(saved).hasSize(2);
 
-        service.saveAll(patterns, false);
-        // should have added the patterns again
+        // should fail because already exists
+        assertThatThrownBy(() -> service.saveAll(patterns, false, false))
+                .isInstanceOf(ValidationException.class);
+
+        // should add the patterns again
+        service.saveAll(patterns, false, true);
         assertThat(service.loadAll()).hasSize(4);
 
         // replaced all patterns
-        service.saveAll(patterns, true);
+        service.saveAll(patterns, true, false);
         assertThat(service.loadAll()).hasSize(2);
     }
 
@@ -164,8 +169,8 @@ public class InMemoryGrokPatternServiceTest {
     @Test
     public void deleteAll() throws Exception {
         Collection<GrokPattern> patterns = ImmutableList.of(GrokPattern.create("1", ".*"),
-                                                            GrokPattern.create("2", ".+"));
-        final List<GrokPattern> saved = service.saveAll(patterns, false);
+                GrokPattern.create("2", ".+"));
+        final List<GrokPattern> saved = service.saveAll(patterns, false, false);
         assertThat(service.deleteAll()).isEqualTo(2);
         assertThat(service.loadAll()).isEmpty();
     }

--- a/graylog2-server/src/test/java/org/graylog2/grok/InMemoryGrokPatternServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/grok/InMemoryGrokPatternServiceTest.java
@@ -35,6 +35,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
+import static org.graylog2.grok.GrokPatternService.ImportStrategy.ABORT_ON_CONFLICT;
+import static org.graylog2.grok.GrokPatternService.ImportStrategy.DROP_ALL_EXISTING;
+import static org.graylog2.grok.GrokPatternService.ImportStrategy.REPLACE_ON_CONFLICT;
 
 public class InMemoryGrokPatternServiceTest {
 
@@ -115,19 +118,19 @@ public class InMemoryGrokPatternServiceTest {
     public void saveAll() throws Exception {
         Collection<GrokPattern> patterns = ImmutableList.of(GrokPattern.create("1", ".*"),
                 GrokPattern.create("2", ".+"));
-        final List<GrokPattern> saved = service.saveAll(patterns, false, false);
+        final List<GrokPattern> saved = service.saveAll(patterns, ABORT_ON_CONFLICT);
         assertThat(saved).hasSize(2);
 
         // should fail because already exists
-        assertThatThrownBy(() -> service.saveAll(patterns, false, false))
+        assertThatThrownBy(() -> service.saveAll(patterns, ABORT_ON_CONFLICT))
                 .isInstanceOf(ValidationException.class);
 
         // should add the patterns again
-        service.saveAll(patterns, false, true);
+        service.saveAll(patterns, REPLACE_ON_CONFLICT);
         assertThat(service.loadAll()).hasSize(4);
 
         // replaced all patterns
-        service.saveAll(patterns, true, false);
+        service.saveAll(patterns, DROP_ALL_EXISTING);
         assertThat(service.loadAll()).hasSize(2);
     }
 
@@ -170,7 +173,7 @@ public class InMemoryGrokPatternServiceTest {
     public void deleteAll() throws Exception {
         Collection<GrokPattern> patterns = ImmutableList.of(GrokPattern.create("1", ".*"),
                 GrokPattern.create("2", ".+"));
-        final List<GrokPattern> saved = service.saveAll(patterns, false, false);
+        final List<GrokPattern> saved = service.saveAll(patterns, ABORT_ON_CONFLICT);
         assertThat(service.deleteAll()).isEqualTo(2);
         assertThat(service.loadAll()).isEmpty();
     }

--- a/graylog2-server/src/test/java/org/graylog2/inputs/extractors/GrokExtractorTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/inputs/extractors/GrokExtractorTest.java
@@ -224,7 +224,7 @@ public class GrokExtractorTest {
         final EventBus clusterBus = new EventBus();
         final GrokPatternService grokPatternService = new InMemoryGrokPatternService(clusterEventBus);
         try {
-            grokPatternService.saveAll(patternSet, true);
+            grokPatternService.saveAll(patternSet, true, false);
         } catch (Exception e) {
             fail("Could not save grok patter: " + e.getMessage());
         }

--- a/graylog2-server/src/test/java/org/graylog2/inputs/extractors/GrokExtractorTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/inputs/extractors/GrokExtractorTest.java
@@ -41,6 +41,7 @@ import java.util.Map;
 import java.util.concurrent.Executors;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.graylog2.grok.GrokPatternService.ImportStrategy.DROP_ALL_EXISTING;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -224,7 +225,7 @@ public class GrokExtractorTest {
         final EventBus clusterBus = new EventBus();
         final GrokPatternService grokPatternService = new InMemoryGrokPatternService(clusterEventBus);
         try {
-            grokPatternService.saveAll(patternSet, true, false);
+            grokPatternService.saveAll(patternSet, DROP_ALL_EXISTING);
         } catch (Exception e) {
             fail("Could not save grok patter: " + e.getMessage());
         }

--- a/graylog2-server/src/test/java/org/graylog2/rest/resources/system/GrokResourceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/rest/resources/system/GrokResourceTest.java
@@ -94,7 +94,7 @@ public class GrokResourceTest {
         final ByteArrayInputStream inputStream = new ByteArrayInputStream(patterns.getBytes(StandardCharsets.UTF_8));
         final GrokPattern expectedPattern = GrokPattern.create("TEST_PATTERN_0", "Foo");
 
-        final Response response = grokResource.bulkUpdatePatternsFromTextFile(inputStream, true, false, false);
+        final Response response = grokResource.bulkUpdatePatternsFromTextFile(inputStream, true, null);
 
         assertThat(response.getStatusInfo()).isEqualTo(Response.Status.ACCEPTED);
         assertThat(response.hasEntity()).isFalse();
@@ -112,7 +112,7 @@ public class GrokResourceTest {
         final ByteArrayInputStream inputStream = new ByteArrayInputStream(patterns.getBytes(StandardCharsets.UTF_8));
         final GrokPattern expectedPattern = GrokPattern.create("TEST_PATTERN_0", "Foo");
 
-        final Response response = grokResource.bulkUpdatePatternsFromTextFile(inputStream, true, false, false);
+        final Response response = grokResource.bulkUpdatePatternsFromTextFile(inputStream, true, null);
 
         assertThat(response.getStatusInfo()).isEqualTo(Response.Status.ACCEPTED);
         assertThat(response.hasEntity()).isFalse();
@@ -130,7 +130,7 @@ public class GrokResourceTest {
         final ByteArrayInputStream inputStream = new ByteArrayInputStream(patterns.getBytes(StandardCharsets.UTF_8));
         final GrokPattern expectedPattern = GrokPattern.create("TEST_PATTERN_0", "Foo");
 
-        final Response response = grokResource.bulkUpdatePatternsFromTextFile(inputStream, true, false, false);
+        final Response response = grokResource.bulkUpdatePatternsFromTextFile(inputStream, true, null);
 
         assertThat(response.getStatusInfo()).isEqualTo(Response.Status.ACCEPTED);
         assertThat(response.hasEntity()).isFalse();
@@ -150,7 +150,7 @@ public class GrokResourceTest {
         expectedException.expect(ValidationException.class);
         expectedException.expectMessage("Invalid pattern. Did not save any patterns");
 
-        grokResource.bulkUpdatePatternsFromTextFile(inputStream, true, false, false);
+        grokResource.bulkUpdatePatternsFromTextFile(inputStream, true, null);
     }
 
     @Test
@@ -158,7 +158,7 @@ public class GrokResourceTest {
         final String patterns = "# Comment\nHAHAHAHA_THIS_IS_NO_GROK_PATTERN!$%§";
         final ByteArrayInputStream inputStream = new ByteArrayInputStream(patterns.getBytes(StandardCharsets.UTF_8));
 
-        final Response response = grokResource.bulkUpdatePatternsFromTextFile(inputStream, true, false, false);
+        final Response response = grokResource.bulkUpdatePatternsFromTextFile(inputStream, true, null);
 
         assertThat(response.getStatusInfo()).isEqualTo(Response.Status.ACCEPTED);
         assertThat(response.hasEntity()).isFalse();

--- a/graylog2-server/src/test/java/org/graylog2/rest/resources/system/GrokResourceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/rest/resources/system/GrokResourceTest.java
@@ -94,7 +94,7 @@ public class GrokResourceTest {
         final ByteArrayInputStream inputStream = new ByteArrayInputStream(patterns.getBytes(StandardCharsets.UTF_8));
         final GrokPattern expectedPattern = GrokPattern.create("TEST_PATTERN_0", "Foo");
 
-        final Response response = grokResource.bulkUpdatePatternsFromTextFile(inputStream, true);
+        final Response response = grokResource.bulkUpdatePatternsFromTextFile(inputStream, true, false, false);
 
         assertThat(response.getStatusInfo()).isEqualTo(Response.Status.ACCEPTED);
         assertThat(response.hasEntity()).isFalse();
@@ -112,7 +112,7 @@ public class GrokResourceTest {
         final ByteArrayInputStream inputStream = new ByteArrayInputStream(patterns.getBytes(StandardCharsets.UTF_8));
         final GrokPattern expectedPattern = GrokPattern.create("TEST_PATTERN_0", "Foo");
 
-        final Response response = grokResource.bulkUpdatePatternsFromTextFile(inputStream, true);
+        final Response response = grokResource.bulkUpdatePatternsFromTextFile(inputStream, true, false, false);
 
         assertThat(response.getStatusInfo()).isEqualTo(Response.Status.ACCEPTED);
         assertThat(response.hasEntity()).isFalse();
@@ -130,7 +130,7 @@ public class GrokResourceTest {
         final ByteArrayInputStream inputStream = new ByteArrayInputStream(patterns.getBytes(StandardCharsets.UTF_8));
         final GrokPattern expectedPattern = GrokPattern.create("TEST_PATTERN_0", "Foo");
 
-        final Response response = grokResource.bulkUpdatePatternsFromTextFile(inputStream, true);
+        final Response response = grokResource.bulkUpdatePatternsFromTextFile(inputStream, true, false, false);
 
         assertThat(response.getStatusInfo()).isEqualTo(Response.Status.ACCEPTED);
         assertThat(response.hasEntity()).isFalse();
@@ -150,7 +150,7 @@ public class GrokResourceTest {
         expectedException.expect(ValidationException.class);
         expectedException.expectMessage("Invalid pattern. Did not save any patterns");
 
-        grokResource.bulkUpdatePatternsFromTextFile(inputStream, true);
+        grokResource.bulkUpdatePatternsFromTextFile(inputStream, true, false, false);
     }
 
     @Test
@@ -158,7 +158,7 @@ public class GrokResourceTest {
         final String patterns = "# Comment\nHAHAHAHA_THIS_IS_NO_GROK_PATTERN!$%§";
         final ByteArrayInputStream inputStream = new ByteArrayInputStream(patterns.getBytes(StandardCharsets.UTF_8));
 
-        final Response response = grokResource.bulkUpdatePatternsFromTextFile(inputStream, true);
+        final Response response = grokResource.bulkUpdatePatternsFromTextFile(inputStream, true, false, false);
 
         assertThat(response.getStatusInfo()).isEqualTo(Response.Status.ACCEPTED);
         assertThat(response.hasEntity()).isFalse();

--- a/graylog2-web-interface/src/components/grok-patterns/BulkLoadPatternModal.jsx
+++ b/graylog2-web-interface/src/components/grok-patterns/BulkLoadPatternModal.jsx
@@ -57,6 +57,8 @@ class BulkLoadPatternModal extends React.Component {
 
   _onImportStrategyChange = (event) => this.setState({ importStrategy: event.target.value });
 
+  _resetImportStrategy = () => this.setState({ importStrategy: 'ABORT_ON_CONFLICT' });
+
   render() {
     return (
       <span>
@@ -65,6 +67,7 @@ class BulkLoadPatternModal extends React.Component {
         <BootstrapModalForm ref={(modal) => { this.modal = modal; }}
                             title="Import Grok patterns from file"
                             submitButtonText="Upload"
+                            onModalClose={this._resetImportStrategy}
                             formProps={{ onSubmit: this._onSubmit }}>
           <Input id="pattern-file"
                  type="file"

--- a/graylog2-web-interface/src/components/grok-patterns/BulkLoadPatternModal.jsx
+++ b/graylog2-web-interface/src/components/grok-patterns/BulkLoadPatternModal.jsx
@@ -31,7 +31,8 @@ class BulkLoadPatternModal extends React.Component {
     super(props);
 
     this.state = {
-      dropExistingPatterns: false,
+      replaceConflictingPatterns: false,
+      dropAllExistingPatterns: false,
     };
   }
 
@@ -39,13 +40,13 @@ class BulkLoadPatternModal extends React.Component {
     evt.preventDefault();
 
     const reader = new FileReader();
-    const { dropExistingPatterns } = this.state;
+    const { replaceConflictingPatterns, dropAllExistingPatterns } = this.state;
     const { onSuccess } = this.props;
 
     reader.onload = (loaded) => {
       const request = loaded.target.result;
 
-      GrokPatternsStore.bulkImport(request, dropExistingPatterns).then(() => {
+      GrokPatternsStore.bulkImport(request, replaceConflictingPatterns, dropAllExistingPatterns).then(() => {
         UserNotification.success('Grok Patterns imported successfully', 'Success!');
         this.modal.close();
         onSuccess();
@@ -71,11 +72,16 @@ class BulkLoadPatternModal extends React.Component {
                  label="Pattern file"
                  help="A file containing Grok patterns, one per line. Name and patterns should be separated by whitespace."
                  required />
+          <Input id="replace-conflicting-patterns-checkbox"
+                 type="checkbox"
+                 name="replace-conflicting"
+                 label="Replace existing patterns with the same name?"
+                 onChange={(e) => this.setState({ replaceConflictingPatterns: e.target.checked })} />
           <Input id="drop-existing-patterns-checkbox"
                  type="checkbox"
                  name="drop-existing"
                  label="Drop all existing patterns before import?"
-                 onChange={(e) => this.setState({ dropExistingPatterns: e.target.checked })} />
+                 onChange={(e) => this.setState({ dropAllExistingPatterns: e.target.checked })} />
         </BootstrapModalForm>
       </span>
     );

--- a/graylog2-web-interface/src/components/grok-patterns/BulkLoadPatternModal.jsx
+++ b/graylog2-web-interface/src/components/grok-patterns/BulkLoadPatternModal.jsx
@@ -31,8 +31,7 @@ class BulkLoadPatternModal extends React.Component {
     super(props);
 
     this.state = {
-      replaceConflictingPatterns: false,
-      dropAllExistingPatterns: false,
+      importStrategy: 'ABORT_ON_CONFLICT',
     };
   }
 
@@ -40,13 +39,13 @@ class BulkLoadPatternModal extends React.Component {
     evt.preventDefault();
 
     const reader = new FileReader();
-    const { replaceConflictingPatterns, dropAllExistingPatterns } = this.state;
+    const { importStrategy } = this.state;
     const { onSuccess } = this.props;
 
     reader.onload = (loaded) => {
       const request = loaded.target.result;
 
-      GrokPatternsStore.bulkImport(request, replaceConflictingPatterns, dropAllExistingPatterns).then(() => {
+      GrokPatternsStore.bulkImport(request, importStrategy).then(() => {
         UserNotification.success('Grok Patterns imported successfully', 'Success!');
         this.modal.close();
         onSuccess();
@@ -55,6 +54,8 @@ class BulkLoadPatternModal extends React.Component {
 
     reader.readAsText(this.patternFile.getInputDOMNode().files[0]);
   };
+
+  _onImportStrategyChange = (event) => this.setState({ importStrategy: event.target.value });
 
   render() {
     return (
@@ -72,16 +73,25 @@ class BulkLoadPatternModal extends React.Component {
                  label="Pattern file"
                  help="A file containing Grok patterns, one per line. Name and patterns should be separated by whitespace."
                  required />
-          <Input id="replace-conflicting-patterns-checkbox"
-                 type="checkbox"
-                 name="replace-conflicting"
-                 label="Replace existing patterns with the same name?"
-                 onChange={(e) => this.setState({ replaceConflictingPatterns: e.target.checked })} />
-          <Input id="drop-existing-patterns-checkbox"
-                 type="checkbox"
-                 name="drop-existing"
-                 label="Drop all existing patterns before import?"
-                 onChange={(e) => this.setState({ dropAllExistingPatterns: e.target.checked })} />
+          <Input id="abort-on-conflicting-patterns-radio"
+                 type="radio"
+                 name="import-strategy"
+                 value="ABORT_ON_CONFLICT"
+                 label="Abort import if a pattern with the same name already exists"
+                 defaultChecked
+                 onChange={(e) => this._onImportStrategyChange(e)} />
+          <Input id="replace-conflicting-patterns-radio"
+                 type="radio"
+                 name="import-strategy"
+                 value="REPLACE_ON_CONFLICT"
+                 label="Replace existing patterns with the same name"
+                 onChange={(e) => this._onImportStrategyChange(e)} />
+          <Input id="drop-existing-patterns-radio"
+                 type="radio"
+                 name="import-strategy"
+                 value="DROP_ALL_EXISTING"
+                 label="Drop all existing patterns before import"
+                 onChange={(e) => this._onImportStrategyChange(e)} />
         </BootstrapModalForm>
       </span>
     );

--- a/graylog2-web-interface/src/components/grok-patterns/BulkLoadPatternModal.jsx
+++ b/graylog2-web-interface/src/components/grok-patterns/BulkLoadPatternModal.jsx
@@ -27,21 +27,25 @@ class BulkLoadPatternModal extends React.Component {
     onSuccess: PropTypes.func.isRequired,
   };
 
-  state = {
-    replacePatterns: false,
-  };
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      dropExistingPatterns: false,
+    };
+  }
 
   _onSubmit = (evt) => {
     evt.preventDefault();
 
     const reader = new FileReader();
-    const { replacePatterns } = this.state;
+    const { dropExistingPatterns } = this.state;
     const { onSuccess } = this.props;
 
     reader.onload = (loaded) => {
       const request = loaded.target.result;
 
-      GrokPatternsStore.bulkImport(request, replacePatterns).then(() => {
+      GrokPatternsStore.bulkImport(request, dropExistingPatterns).then(() => {
         UserNotification.success('Grok Patterns imported successfully', 'Success!');
         this.modal.close();
         onSuccess();
@@ -67,11 +71,11 @@ class BulkLoadPatternModal extends React.Component {
                  label="Pattern file"
                  help="A file containing Grok patterns, one per line. Name and patterns should be separated by whitespace."
                  required />
-          <Input id="replace-patterns-checkbox"
+          <Input id="drop-existing-patterns-checkbox"
                  type="checkbox"
-                 name="replace"
-                 label="Replace all existing patterns?"
-                 onChange={(e) => this.setState({ replacePatterns: e.target.checked })} />
+                 name="drop-existing"
+                 label="Drop all existing patterns before import?"
+                 onChange={(e) => this.setState({ dropExistingPatterns: e.target.checked })} />
         </BootstrapModalForm>
       </span>
     );

--- a/graylog2-web-interface/src/stores/grok-patterns/GrokPatternsStore.ts
+++ b/graylog2-web-interface/src/stores/grok-patterns/GrokPatternsStore.ts
@@ -193,7 +193,7 @@ export const GrokPatternsStore = singletonStore(
         );
     },
 
-    bulkImport(patterns: string, replaceConflictingPatterns: boolean, dropAllExistingPatterns: boolean) {
+    bulkImport(patterns: string, importStrategy: string) {
       const failCallback = (error) => {
         let errorMessage = error.message;
         const errorBody = error.additional.body;
@@ -212,7 +212,7 @@ export const GrokPatternsStore = singletonStore(
           'Could not load Grok patterns');
       };
 
-      const promise = fetchPlainText('POST', `${this.URL}?replace-existing=${String(replaceConflictingPatterns)}&drop-all-existing=${String(dropAllExistingPatterns)}`, patterns);
+      const promise = fetchPlainText('POST', `${this.URL}?import-strategy=${importStrategy}`, patterns);
 
       promise.catch(failCallback);
 

--- a/graylog2-web-interface/src/stores/grok-patterns/GrokPatternsStore.ts
+++ b/graylog2-web-interface/src/stores/grok-patterns/GrokPatternsStore.ts
@@ -193,7 +193,7 @@ export const GrokPatternsStore = singletonStore(
         );
     },
 
-    bulkImport(patterns: string, dropExisting: boolean) {
+    bulkImport(patterns: string, replaceConflictingPatterns: boolean, dropAllExistingPatterns: boolean) {
       const failCallback = (error) => {
         let errorMessage = error.message;
         const errorBody = error.additional.body;
@@ -212,7 +212,7 @@ export const GrokPatternsStore = singletonStore(
           'Could not load Grok patterns');
       };
 
-      const promise = fetchPlainText('POST', `${this.URL}?replace=${String(dropExisting)}`, patterns);
+      const promise = fetchPlainText('POST', `${this.URL}?replace-existing=${String(replaceConflictingPatterns)}&drop-all-existing=${String(dropAllExistingPatterns)}`, patterns);
 
       promise.catch(failCallback);
 

--- a/graylog2-web-interface/src/stores/grok-patterns/GrokPatternsStore.ts
+++ b/graylog2-web-interface/src/stores/grok-patterns/GrokPatternsStore.ts
@@ -193,7 +193,7 @@ export const GrokPatternsStore = singletonStore(
         );
     },
 
-    bulkImport(patterns: string, replaceAll: boolean) {
+    bulkImport(patterns: string, dropExisting: boolean) {
       const failCallback = (error) => {
         let errorMessage = error.message;
         const errorBody = error.additional.body;
@@ -212,7 +212,7 @@ export const GrokPatternsStore = singletonStore(
           'Could not load Grok patterns');
       };
 
-      const promise = fetchPlainText('POST', `${this.URL}?replace=${String(replaceAll)}`, patterns);
+      const promise = fetchPlainText('POST', `${this.URL}?replace=${String(dropExisting)}`, patterns);
 
       promise.catch(failCallback);
 


### PR DESCRIPTION
Adds an option to update Grok patterns on bulk import if they already exist.

This effectively provides three options when performing bulk imports:
1. Abort import if there is a name conflict with any of the patterns already present in graylog. This is the default.
2. If there is a name conflict, update the pattern with that name in graylog with the new pattern provided in the import.
3. Drop all existing patterns in graylog before importing the new set of patterns.

The dialog for importing patterns now shows these options.

Before:
![image](https://user-images.githubusercontent.com/886541/155368337-caab1cb0-5535-45b4-a220-920f49afe504.png)

After:
![image](https://user-images.githubusercontent.com/886541/155368380-00045135-9c6e-48e5-9d5e-bb6bca2a7821.png)

Fixes https://github.com/Graylog2/graylog2-server/issues/11109