### PR TITLE
Fix Issue 11918: Duplicating and editing a widget leaves it in focused state

### DIFF
--- a/graylog2-web-interface/src/views/components/widgets/WidgetActionsMenu.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/WidgetActionsMenu.tsx
@@ -137,10 +137,10 @@ const _onDelete = async (widget: Widget, view: View, title: string) => {
   return result === true ? WidgetActions.remove(widget.id) : Promise.resolve();
 };
 
-const _onDuplicate = (widgetId: string, setFocusWidget: (widgetId: string) => void, title: string) => {
+const _onDuplicate = (widgetId: string, unsetWidgetFocusing: () => void, title: string) => {
   WidgetActions.duplicate(widgetId).then((newWidget) => {
     TitlesActions.set(TitleTypes.Widget, newWidget.id, `${title} (copy)`).then(() => {
-      setFocusWidget(undefined);
+      unsetWidgetFocusing();
     });
   });
 };
@@ -167,7 +167,7 @@ const WidgetActionsMenu = ({
   const [showExport, setShowExport] = useState(false);
   const [showMoveWidgetToTab, setShowMoveWidgetToTab] = useState(false);
 
-  const onDuplicate = useCallback(() => _onDuplicate(widget.id, setWidgetFocusing, title), [setWidgetFocusing, title, widget.id]);
+  const onDuplicate = useCallback(() => _onDuplicate(widget.id, unsetWidgetFocusing, title), [unsetWidgetFocusing, title, widget.id]);
   const onCopyToDashboard = useCallback((widgetId: string, dashboardId: string) => _onCopyToDashboard(view, setShowCopyToDashboard, widgetId, dashboardId), [view]);
   const onMoveWidgetToTab = useCallback((widgetId: string, queryId: string, keepCopy: boolean) => _onMoveWidgetToTab(view, setShowMoveWidgetToTab, widgetId, queryId, keepCopy), [view]);
   const onDelete = useCallback(() => _onDelete(widget, view?.view, title), [title, view?.view, widget]);


### PR DESCRIPTION
Now instead of `setWidgetFocusing(undefined) ` we use `unsetWidgetFocusing` to unfocus widgets on duplication 
fix #11918 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

