### PR TITLE
Change Set to OrderSet in ExportModal.tsx to keep order of the columns

### DIFF
--- a/graylog2-web-interface/src/views/components/export/ExportModal.tsx
+++ b/graylog2-web-interface/src/views/components/export/ExportModal.tsx
@@ -17,7 +17,7 @@
 import * as React from 'react';
 import { useContext, useState } from 'react';
 import type { List } from 'immutable';
-import { Set } from 'immutable';
+import { OrderedSet } from 'immutable';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { Field, Formik, Form } from 'formik';
@@ -39,7 +39,7 @@ import ExportSettings from './ExportSettings';
 import ExportStrategy from './ExportStrategy';
 import startDownload from './startDownload';
 
-const DEFAULT_FIELDS = Set([TIMESTAMP_FIELD, SOURCE_FIELD, MESSAGE_FIELD]);
+const DEFAULT_FIELDS = OrderedSet([TIMESTAMP_FIELD, SOURCE_FIELD, MESSAGE_FIELD]);
 
 const Content = styled.div`
   margin-left: 15px;
@@ -53,12 +53,12 @@ export type Props = {
   view: View,
 };
 
-const _getInitialWidgetFields = (selectedWidget: Widget): Set<string> => {
+const _getInitialWidgetFields = (selectedWidget: Widget): OrderedSet<string> => {
   if (selectedWidget.config.showMessageRow) {
-    return Set<string>(selectedWidget.config.fields).add(MESSAGE_FIELD).toSet();
+    return OrderedSet<string>(selectedWidget.config.fields).add(MESSAGE_FIELD).toOrderedSet();
   }
 
-  return Set(selectedWidget.config.fields);
+  return OrderedSet(selectedWidget.config.fields);
 };
 
 const _getInitialFields = (selectedWidget) => {
@@ -123,7 +123,7 @@ const ExportModal = ({ closeModal, view, directExportWidgetId, executionState }:
               <Modal.Body>
                 <Content>
                   {showWidgetSelection && (
-                  <Field name="selectedWidget">
+                  <Field name="selectedWidget" data-testid="selected-widget-field">
                     {({ field: { name, onChange } }) => {
                       const onChangeSelectWidget = ({ value }) => {
                         setSelectedFields(_getInitialFields(value));

--- a/graylog2-web-interface/src/views/components/export/ExportModal.tsx
+++ b/graylog2-web-interface/src/views/components/export/ExportModal.tsx
@@ -123,7 +123,7 @@ const ExportModal = ({ closeModal, view, directExportWidgetId, executionState }:
               <Modal.Body>
                 <Content>
                   {showWidgetSelection && (
-                  <Field name="selectedWidget" data-testid="selected-widget-field">
+                  <Field name="selectedWidget">
                     {({ field: { name, onChange } }) => {
                       const onChangeSelectWidget = ({ value }) => {
                         setSelectedFields(_getInitialFields(value));


### PR DESCRIPTION
fix #12006 

## Description
In `_getInitialWidgetFields` function, which map the Array of selected fields, instead of Immutable Set use OrderSet. 

## Motivation and Context
We used Immutable function Set to transform Array into Immutable Set structure. Immutable Set doesn't keep an order which was in the array. Due to that we had unexpected sorting order  in  input of selected fields. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

