### PR TITLE
Always register ViewResolvers as singletons

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/plugin/inject/Graylog2Module.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/inject/Graylog2Module.java
@@ -519,6 +519,6 @@ public abstract class Graylog2Module extends AbstractModule {
 
     protected void installViewResolver(String name,
                                        Class<? extends ViewResolver> resolverClass) {
-        viewResolverBinder().addBinding(name).to(resolverClass);
+        viewResolverBinder().addBinding(name).to(resolverClass).asEagerSingleton();
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Always register ViewResolvers as singletons.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Ensures that a single instance is instantiated at server-startup time, versus an additional instance each time the map is injected, which can cause initialization operations to be repeated each time ViewsResource methods accessed.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested to ensure that view resolvers are still properly injected into ViewsResource.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

