### PR TITLE
Ensure that widget keeps id when moved to another dashboard page.

### DIFF
--- a/graylog2-web-interface/src/views/logic/views/MoveWidgetToTab.ts
+++ b/graylog2-web-interface/src/views/logic/views/MoveWidgetToTab.ts
@@ -15,7 +15,6 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as Immutable from 'immutable';
-import uuid from 'uuid/v4';
 
 import type { QueryId } from 'views/logic/queries/Query';
 import type { WidgetId } from 'views/logic/views/types';
@@ -75,7 +74,7 @@ const _setWidgetTitle = (titlesMap: TitlesMap, widgetID: WidgetId, newTitle: str
 
 const _addWidgetToTab = (widget: Widget, targetQueryId: QueryId, dashboard: View, widgetTitle: string | undefined | null, oldPosition: WidgetPosition): View => {
   const viewState = dashboard.state.get(targetQueryId);
-  const newWidget = widget?.id ? widget : widget.toBuilder().id(uuid()).build();
+  const newWidget = widget?.id ? widget : widget.toBuilder().newId().build();
   const newWidgets = viewState.widgets.push(newWidget);
   const { widgetPositions } = viewState;
   const widgetPositionsMap = oldPosition ? {

--- a/graylog2-web-interface/src/views/logic/views/MoveWidgetToTab.ts
+++ b/graylog2-web-interface/src/views/logic/views/MoveWidgetToTab.ts
@@ -75,7 +75,7 @@ const _setWidgetTitle = (titlesMap: TitlesMap, widgetID: WidgetId, newTitle: str
 
 const _addWidgetToTab = (widget: Widget, targetQueryId: QueryId, dashboard: View, widgetTitle: string | undefined | null, oldPosition: WidgetPosition): View => {
   const viewState = dashboard.state.get(targetQueryId);
-  const newWidget = widget.toBuilder().id(uuid()).build();
+  const newWidget = widget?.id ? widget : widget.toBuilder().id(uuid()).build();
   const newWidgets = viewState.widgets.push(newWidget);
   const { widgetPositions } = viewState;
   const widgetPositionsMap = oldPosition ? {

--- a/graylog2-web-interface/src/views/logic/views/__snapshots__/MoveWidgetToTab.test.ts.snap
+++ b/graylog2-web-interface/src/views/logic/views/__snapshots__/MoveWidgetToTab.test.ts.snap
@@ -142,7 +142,7 @@ Object {
         "highlighting": Array [],
       },
       "positions": Immutable.Map {
-        "dead-beef": Object {
+        "b34c3c6f-c49d-41d3-a65a-f746134f8f3e": Object {
           "col": 0,
           "height": 4,
           "row": 1,
@@ -152,11 +152,11 @@ Object {
       "selected_fields": undefined,
       "titles": Immutable.Map {
         "widget": Immutable.Map {
-          "dead-beef": "Widget Title",
+          "b34c3c6f-c49d-41d3-a65a-f746134f8f3e": "Widget Title",
         },
       },
       "widget_mapping": Immutable.Map {
-        "dead-beef": Immutable.Set [
+        "b34c3c6f-c49d-41d3-a65a-f746134f8f3e": Immutable.Set [
           "dead-beef",
         ],
       },
@@ -179,7 +179,7 @@ Object {
             "visualization": "numeric",
           },
           "filter": undefined,
-          "id": "dead-beef",
+          "id": "b34c3c6f-c49d-41d3-a65a-f746134f8f3e",
           "query": null,
           "streams": Array [],
           "timerange": null,
@@ -220,7 +220,7 @@ Object {
         "highlighting": Array [],
       },
       "positions": Immutable.Map {
-        "dead-beef": Object {
+        "b34c3c6f-c49d-41d3-a65a-f746134f8f3e": Object {
           "col": 1,
           "height": 4,
           "row": 1,
@@ -230,11 +230,11 @@ Object {
       "selected_fields": undefined,
       "titles": Immutable.Map {
         "widget": Immutable.Map {
-          "dead-beef": "Widget Title",
+          "b34c3c6f-c49d-41d3-a65a-f746134f8f3e": "Widget Title",
         },
       },
       "widget_mapping": Immutable.Map {
-        "dead-beef": Immutable.Set [
+        "b34c3c6f-c49d-41d3-a65a-f746134f8f3e": Immutable.Set [
           "dead-beef",
         ],
       },
@@ -257,7 +257,7 @@ Object {
             "visualization": "numeric",
           },
           "filter": undefined,
-          "id": "dead-beef",
+          "id": "b34c3c6f-c49d-41d3-a65a-f746134f8f3e",
           "query": null,
           "streams": Array [],
           "timerange": null,
@@ -296,7 +296,7 @@ Object {
         "highlighting": Array [],
       },
       "positions": Immutable.Map {
-        "dead-beef": Object {
+        "b34c3c6f-c49d-41d3-a65a-f746134f8f3e": Object {
           "col": 0,
           "height": 4,
           "row": 1,
@@ -306,7 +306,7 @@ Object {
       "selected_fields": undefined,
       "titles": Immutable.Map {},
       "widget_mapping": Immutable.Map {
-        "dead-beef": Immutable.Set [
+        "b34c3c6f-c49d-41d3-a65a-f746134f8f3e": Immutable.Set [
           "dead-beef",
         ],
       },
@@ -329,7 +329,7 @@ Object {
             "visualization": "numeric",
           },
           "filter": undefined,
-          "id": "dead-beef",
+          "id": "b34c3c6f-c49d-41d3-a65a-f746134f8f3e",
           "query": null,
           "streams": Array [],
           "timerange": null,


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This change is making sure that when a widget is moved to a different dashboard page (without copying it), it will keep its id. This avoids any issues with referential integrity when the widget is referenced somewhere else by id (e.g. reporting).

Nothing changes when the widget is copied instead of being moved. The source widget will stay as is (keeping its id) and the new widget will get a new, random id. This way any references will stay intact, referencing the old widget.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.