### PR TITLE
Change _isRequire validation to accept false and 0 values in HighlightForm

### DIFF
--- a/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightForm.test.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightForm.test.tsx
@@ -67,13 +67,13 @@ describe('HighlightForm', () => {
   };
 
   it('should render for edit', async () => {
-    const { findByText, findByDisplayValue } = render(<HighlightFormWithContext onClose={() => {}} rule={rule} />);
+    const { findByText } = render(<HighlightFormWithContext onClose={() => {}} rule={rule} />);
 
     const form = await findByText('Edit Highlighting Rule');
-    const value = await findByDisplayValue(rule.value);
+    const input = await screen.findByLabelText('Value');
 
+    expect(input).toHaveValue(String(rule.value));
     expect(form).toBeInTheDocument();
-    expect(value).toBeInTheDocument();
   });
 
   it('should render for new', async () => {

--- a/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightForm.test.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightForm.test.tsx
@@ -43,6 +43,13 @@ const rule = HighlightingRule.builder()
   .value('noob')
   .build();
 
+const ruleWithValueFalse = rule.toBuilder()
+  .value(false)
+  .build();
+const ruleWithValueZero = rule.toBuilder()
+  .value(0)
+  .build();
+
 describe('HighlightForm', () => {
   const fieldTypes: FieldTypes = {
     all: Immutable.List([FieldTypeMapping.create('foob', FieldType.create('long', [Properties.Numeric]))]),
@@ -53,6 +60,11 @@ describe('HighlightForm', () => {
       <HighlightForm {...props} />
     </FieldTypesContext.Provider>
   );
+
+  const triggerSaveButtonClick = async () => {
+    const elem = await screen.findByText('Save');
+    fireEvent.click(elem);
+  };
 
   it('should render for edit', async () => {
     const { findByText, findByDisplayValue } = render(<HighlightFormWithContext onClose={() => {}} rule={rule} />);
@@ -84,11 +96,9 @@ describe('HighlightForm', () => {
   });
 
   it('should fire remove action when saving a existing rule', async () => {
-    const { findByText } = render(<HighlightFormWithContext onClose={() => {}} rule={rule} />);
+    render(<HighlightFormWithContext onClose={() => {}} rule={rule} />);
 
-    const elem = await findByText('Save');
-
-    fireEvent.click(elem);
+    await triggerSaveButtonClick();
 
     await waitFor(() => expect(HighlightingRulesActions.update)
       .toBeCalledWith(rule, { field: rule.field, value: rule.value, condition: rule.condition, color: rule.color }));
@@ -122,5 +132,23 @@ describe('HighlightForm', () => {
       .toBeCalledWith(rule, expect.objectContaining({
         color: expect.objectContaining({ gradient: 'Viridis' }),
       })));
+  });
+
+  it('should be able to click submit when has value 0 with type number', async () => {
+    render(<HighlightFormWithContext onClose={() => {}} rule={ruleWithValueZero} />);
+
+    await triggerSaveButtonClick();
+
+    await waitFor(() => expect(HighlightingRulesActions.update)
+      .toBeCalledWith(ruleWithValueZero, { field: ruleWithValueZero.field, value: '0', condition: ruleWithValueZero.condition, color: ruleWithValueZero.color }));
+  });
+
+  it('should be able to click submit when has value false  with type boolean', async () => {
+    render(<HighlightFormWithContext onClose={() => {}} rule={ruleWithValueFalse} />);
+
+    await triggerSaveButtonClick();
+
+    await waitFor(() => expect(HighlightingRulesActions.update)
+      .toBeCalledWith(ruleWithValueFalse, { field: ruleWithValueFalse.field, value: 'false', condition: ruleWithValueFalse.condition, color: ruleWithValueFalse.color }));
   });
 });

--- a/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightForm.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightForm.tsx
@@ -19,6 +19,7 @@ import { useContext } from 'react';
 import PropTypes from 'prop-types';
 import * as Immutable from 'immutable';
 import { Formik, Form, Field } from 'formik';
+import isNil from 'lodash/isNil';
 
 import { defaultCompare } from 'views/logic/DefaultCompare';
 import { Input, BootstrapModalWrapper, Button, Modal } from 'components/bootstrap';
@@ -46,7 +47,7 @@ type Props = {
   rule: HighlightingRule | null | undefined,
 };
 
-const _isRequired = (field) => (value) => {
+const _isRequired = (field) => (value: string) => {
   if (['', null, undefined].includes(value)) {
     return `${field} is required`;
   }
@@ -129,7 +130,7 @@ const HighlightForm = ({ onClose, rule }: Props) => {
             validateOnMount
             initialValues={{
               field: rule?.field,
-              value: rule?.value,
+              value: isNil(rule?.value) ? '' : String(rule?.value),
               condition: rule?.condition ?? 'equal',
               color: colorToObject(rule?.color),
             }}>

--- a/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightForm.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightForm.tsx
@@ -47,7 +47,7 @@ type Props = {
 };
 
 const _isRequired = (field) => (value) => {
-  if (!value || value === '') {
+  if (['', null, undefined].includes(value)) {
     return `${field} is required`;
   }
 

--- a/graylog2-web-interface/src/views/logic/views/formatting/highlighting/HighlightingRule.ts
+++ b/graylog2-web-interface/src/views/logic/views/formatting/highlighting/HighlightingRule.ts
@@ -36,7 +36,7 @@ export const ConditionLabelMap = {
   greater: '>',
 };
 
-export type Value = string;
+export type Value = string | number | boolean;
 export type Color = HighlightingColor;
 export type Condition = keyof typeof ConditionLabelMap;
 


### PR DESCRIPTION
fix #11985 

## Description
Change `_isRequire` rule to recognize only `""`, `undefined`, `null` as unfilled.

## Motivation and Context
When the user highlights some field with a `false` or  `0` value the form recognizes this value as not filled. Due to that we see an error that field is required

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

