### PR TITLE
Render plugable components in query validation error explanation and adjust query validation type.

### DIFF
--- a/graylog2-web-interface/src/components/bootstrap/BootstrapModalForm.jsx
+++ b/graylog2-web-interface/src/components/bootstrap/BootstrapModalForm.jsx
@@ -91,7 +91,6 @@ class BootstrapModalForm extends React.Component {
     const { onSubmitForm } = this.props;
 
     if (typeof onSubmitForm === 'function') {
-      event.preventDefault();
       onSubmitForm(event);
     }
   };
@@ -136,7 +135,9 @@ class BootstrapModalForm extends React.Component {
           </Modal.Body>
           <Modal.Footer>
             <Button type="button" onClick={this.onModalCancel}>{cancelButtonText}</Button>
-            <Button type="submit" disabled={submitButtonDisabled} bsStyle="primary">{submitButtonText}</Button>
+            {/* We are not using type=submit here, because when this form is being rendered inside another form */}
+            {/* the submit button can influence the parent form, event though this form is in a portal */}
+            <Button type="button" onClick={this.submit} disabled={submitButtonDisabled} bsStyle="primary">{submitButtonText}</Button>
           </Modal.Footer>
         </form>
       </BootstrapModalWrapper>

--- a/graylog2-web-interface/src/components/bootstrap/BootstrapModalForm.jsx
+++ b/graylog2-web-interface/src/components/bootstrap/BootstrapModalForm.jsx
@@ -136,7 +136,7 @@ class BootstrapModalForm extends React.Component {
           <Modal.Footer>
             <Button type="button" onClick={this.onModalCancel}>{cancelButtonText}</Button>
             {/* We are not using type=submit here, because when this form is being rendered inside another form */}
-            {/* the submit button can influence the parent form, event though this form is in a portal */}
+            {/* the submit button can influence the parent form, even though this form is in a portal */}
             <Button type="button" onClick={this.submit} disabled={submitButtonDisabled} bsStyle="primary">{submitButtonText}</Button>
           </Modal.Footer>
         </form>

--- a/graylog2-web-interface/src/util/DocsHelper.js
+++ b/graylog2-web-interface/src/util/DocsHelper.js
@@ -47,6 +47,7 @@ class DocsHelper {
       UNKNOWN_FIELD: 'query-language#unknown-field',
       PARSE_EXCEPTION: 'query-language#parse-exception',
       INVALID_OPERATOR: 'query-language#invalid-operator',
+      UNDECLARED_PARAMETER: 'query-language#undeclared-parameter',
     },
     SEARCH_QUERY_LANGUAGE: 'query-language',
     STREAMS: 'streams',

--- a/graylog2-web-interface/src/views/components/searchbar/queryvalidation/QueryValidation.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/queryvalidation/QueryValidation.test.tsx
@@ -24,6 +24,9 @@ import SearchExecutionState from 'views/logic/search/SearchExecutionState';
 import FormWarningsContext from 'contexts/FormWarningsContext';
 import type { QueryValidationState } from 'views/components/searchbar/queryvalidation/types';
 import { validationError } from 'fixtures/queryValidationState';
+import usePluginEntities from 'views/logic/usePluginEntities';
+
+import asMock from '../../../../../test/helpers/mocking/AsMock';
 
 jest.mock('views/stores/QueriesStore', () => ({
   QueriesActions: {
@@ -47,6 +50,7 @@ jest.mock('views/stores/SearchExecutionStateStore', () => ({
   },
 }));
 
+jest.mock('views/logic/usePluginEntities');
 jest.mock('logic/rest/FetchProvider', () => jest.fn(() => Promise.resolve()));
 jest.mock('logic/datetimes/DateTime', () => ({}));
 
@@ -108,5 +112,17 @@ describe('QueryValidation', () => {
 
     await screen.findByText('ParseException');
     await screen.findByTitle('ParseException documentation');
+  });
+
+  it('renders plugable validation explanation', async () => {
+    const ExampleComponent = ({ validationState }: { validationState: QueryValidationState }) => (
+      <>Plugable validation explanation for {validationState.explanations.map(({ errorType }) => errorType).join()}</>
+    );
+    asMock(usePluginEntities).mockImplementation((entityKey) => (entityKey === 'views.elements.validationErrorExplanation' ? [ExampleComponent] : []));
+    render(<SUT error={validationError} />);
+
+    await openExplanation();
+
+    await screen.findByText('Plugable validation explanation for ParseException');
   });
 });

--- a/graylog2-web-interface/src/views/components/searchbar/queryvalidation/QueryValidation.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/queryvalidation/QueryValidation.test.tsx
@@ -101,7 +101,7 @@ describe('QueryValidation', () => {
     await openExplanation();
 
     await screen.findByText('Error');
-    await screen.findByText('ParseException');
+    await screen.findByText('Parse Exception');
     await screen.findByText(/Cannot parse 'source: '/);
   });
 
@@ -110,19 +110,19 @@ describe('QueryValidation', () => {
 
     await openExplanation();
 
-    await screen.findByText('ParseException');
-    await screen.findByTitle('ParseException documentation');
+    await screen.findByText('Parse Exception');
+    await screen.findByTitle('Parse Exception documentation');
   });
 
   it('renders plugable validation explanation', async () => {
     const ExampleComponent = ({ validationState }: { validationState: QueryValidationState }) => (
-      <>Plugable validation explanation for {validationState.explanations.map(({ errorType }) => errorType).join()}</>
+      <>Plugable validation explanation for {validationState.explanations.map(({ errorTitle }) => errorTitle).join()}</>
     );
     asMock(usePluginEntities).mockImplementation((entityKey) => (entityKey === 'views.elements.validationErrorExplanation' ? [ExampleComponent] : []));
     render(<SUT error={validationError} />);
 
     await openExplanation();
 
-    await screen.findByText('Plugable validation explanation for ParseException');
+    await screen.findByText('Plugable validation explanation for Parse Exception');
   });
 });

--- a/graylog2-web-interface/src/views/components/searchbar/queryvalidation/QueryValidation.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/queryvalidation/QueryValidation.tsx
@@ -97,15 +97,10 @@ const shakeAnimation = keyframes`
   }
 `;
 
-const StyledPopover = styled(Popover)(({ $shaking }) => {
-  if ($shaking) {
-    return css`
-      animation: ${shakeAnimation} 0.82s cubic-bezier(0.36, 0.07, 0.19, 0.97) both;
-    `;
-  }
-
-  return '';
-});
+const StyledPopover = styled(Popover)(({ $shaking }) => css`
+  z-index: 2;
+  animation: ${$shaking ? css`${shakeAnimation} 0.82s cubic-bezier(0.36, 0.07, 0.19, 0.97) both` : 'none'};
+`);
 
 const ExplanationTitle = ({ title }: { title: string }) => (
   <Title>

--- a/graylog2-web-interface/src/views/components/searchbar/queryvalidation/QueryValidation.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/queryvalidation/QueryValidation.tsx
@@ -211,8 +211,8 @@ const QueryValidation = () => {
                                      text={<DocumentationIcon name="lightbulb" />} />
                 </Explanation>
               ))}
-              {/* eslint-disable-next-line react/no-array-index-key */}
               {plugableValidationExplanation?.map((PlugableExplanation, index) => (
+                // eslint-disable-next-line react/no-array-index-key
                 <PlugableExplanation validationState={validationState} key={index} />),
               )}
             </div>

--- a/graylog2-web-interface/src/views/components/searchbar/queryvalidation/QueryValidation.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/queryvalidation/QueryValidation.tsx
@@ -30,6 +30,7 @@ import DocsHelper from 'util/DocsHelper';
 import QueryValidationActions from 'views/actions/QueryValidationActions';
 import FormWarningsContext from 'contexts/FormWarningsContext';
 import type { QueryValidationState } from 'views/components/searchbar/queryvalidation/types';
+import usePluginEntities from 'views/logic/usePluginEntities';
 
 const Container = styled.div`
   margin-right: 5px;
@@ -160,6 +161,7 @@ const getErrorDocumentationLink = (errorType: string) => {
 };
 
 const QueryValidation = () => {
+  const plugableValidationExplanation = usePluginEntities('views.elements.validationErrorExplanation');
   const [shakingPopover, shake] = useShakeTemporarily();
   const [showExplanation, toggleShow] = useTriggerIfErrorsPersist(shake);
 
@@ -209,17 +211,15 @@ const QueryValidation = () => {
                                      text={<DocumentationIcon name="lightbulb" />} />
                 </Explanation>
               ))}
+              {plugableValidationExplanation.map((PlugableExplanation) => {
+                return <PlugableExplanation explanations={explanations} />;
+              })}
             </div>
           </StyledPopover>
         </Overlay>
       )}
     </>
   );
-};
-
-QueryValidation.defaultProps = {
-  filter: undefined,
-  streams: undefined,
 };
 
 export default QueryValidation;

--- a/graylog2-web-interface/src/views/components/searchbar/queryvalidation/QueryValidation.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/queryvalidation/QueryValidation.tsx
@@ -149,11 +149,11 @@ const useTriggerIfErrorsPersist = (trigger: () => void) => {
 
 const getErrorDocumentationLink = (errorType: string) => {
   switch (errorType) {
-    case 'Unknown field':
+    case 'UNKNOWN_FIELD':
       return DocsHelper.PAGES.SEARCH_QUERY_ERRORS.UNKNOWN_FIELD;
-    case 'ParseException':
+    case 'PARSE_EXCEPTION':
       return DocsHelper.PAGES.SEARCH_QUERY_ERRORS.PARSE_EXCEPTION;
-    case 'Invalid operator':
+    case 'INVALID_OPERATOR':
       return DocsHelper.PAGES.SEARCH_QUERY_ERRORS.INVALID_OPERATOR;
     default:
       return DocsHelper.PAGES.SEARCH_QUERY_LANGUAGE;
@@ -203,11 +203,11 @@ const QueryValidation = () => {
                          title={<ExplanationTitle title={StringUtils.capitalizeFirstLetter(status.toLocaleLowerCase())} />}
                          $shaking={shakingPopover}>
             <div role="alert">
-              {explanations.map(({ errorType, errorMessage }) => (
+              {explanations.map(({ errorType, errorTitle, errorMessage }) => (
                 <Explanation key={errorMessage}>
-                  <span><b>{errorType}</b>: {errorMessage}</span>
+                  <span><b>{errorTitle}</b>: {errorMessage}</span>
                   <DocumentationLink page={getErrorDocumentationLink(errorType)}
-                                     title={`${errorType} documentation`}
+                                     title={`${errorTitle} documentation`}
                                      text={<DocumentationIcon name="lightbulb" />} />
                 </Explanation>
               ))}

--- a/graylog2-web-interface/src/views/components/searchbar/queryvalidation/QueryValidation.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/queryvalidation/QueryValidation.tsx
@@ -155,6 +155,8 @@ const getErrorDocumentationLink = (errorType: string) => {
       return DocsHelper.PAGES.SEARCH_QUERY_ERRORS.PARSE_EXCEPTION;
     case 'INVALID_OPERATOR':
       return DocsHelper.PAGES.SEARCH_QUERY_ERRORS.INVALID_OPERATOR;
+    case 'UNDECLARED_PARAMETER':
+      return DocsHelper.PAGES.SEARCH_QUERY_ERRORS.UNDECLARED_PARAMETER;
     default:
       return DocsHelper.PAGES.SEARCH_QUERY_LANGUAGE;
   }

--- a/graylog2-web-interface/src/views/components/searchbar/queryvalidation/QueryValidation.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/queryvalidation/QueryValidation.tsx
@@ -212,7 +212,9 @@ const QueryValidation = () => {
                 </Explanation>
               ))}
               {/* eslint-disable-next-line react/no-array-index-key */}
-              {plugableValidationExplanation.map((PlugableExplanation, index) => <PlugableExplanation validationState={validationState} key={index} />)}
+              {plugableValidationExplanation?.map((PlugableExplanation, index) => (
+                <PlugableExplanation validationState={validationState} key={index} />),
+              )}
             </div>
           </StyledPopover>
         </Overlay>

--- a/graylog2-web-interface/src/views/components/searchbar/queryvalidation/QueryValidation.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/queryvalidation/QueryValidation.tsx
@@ -211,9 +211,8 @@ const QueryValidation = () => {
                                      text={<DocumentationIcon name="lightbulb" />} />
                 </Explanation>
               ))}
-              {plugableValidationExplanation.map((PlugableExplanation) => {
-                return <PlugableExplanation explanations={explanations} />;
-              })}
+              {/* eslint-disable-next-line react/no-array-index-key */}
+              {plugableValidationExplanation.map((PlugableExplanation, index) => <PlugableExplanation validationState={validationState} key={index} />)}
             </div>
           </StyledPopover>
         </Overlay>

--- a/graylog2-web-interface/src/views/components/searchbar/queryvalidation/types.ts
+++ b/graylog2-web-interface/src/views/components/searchbar/queryvalidation/types.ts
@@ -18,10 +18,12 @@ export type QueryValidationState = {
   status: 'OK' | 'ERROR' | 'WARNING',
   explanations: Array<{
     errorType: string,
+    errorTitle: string,
     errorMessage: string,
     beginLine: number,
     endLine: number,
     beginColumn: number,
     endColumn: number,
+    relatedProperty?: string,
   }> | undefined
 }

--- a/graylog2-web-interface/src/views/components/searchbar/queryvalidation/validateQuery.ts
+++ b/graylog2-web-interface/src/views/components/searchbar/queryvalidation/validateQuery.ts
@@ -63,18 +63,22 @@ export const validateQuery = ({
     if (result) {
       const explanations = result.explanations?.map(({
         error_type: errorType,
+        error_title: errorTitle,
         error_message: errorMessage,
         begin_line: beginLine,
         end_line: endLine,
         begin_column: beginColumn,
         end_column: endColumn,
+        related_property: relatedProperty,
       }) => ({
         errorMessage,
         errorType,
+        errorTitle,
         beginLine: beginLine ? beginLine - 1 : 0,
         endLine: endLine ? endLine - 1 : 0,
         beginColumn,
         endColumn,
+        relatedProperty,
       }));
 
       return ({

--- a/graylog2-web-interface/src/views/types.ts
+++ b/graylog2-web-interface/src/views/types.ts
@@ -45,6 +45,7 @@ import type { Message } from 'views/components/messagelist/Types';
 import type { ValuePath } from 'views/logic/valueactions/ValueActionHandler';
 import type WidgetPosition from 'views/logic/widgets/WidgetPosition';
 import type MessagesWidgetConfig from 'views/logic/widgets/MessagesWidgetConfig';
+import type { QueryValidationState } from 'views/components/searchbar/queryvalidation/types';
 
 export type BackendWidgetPosition = {
   id: string,
@@ -250,6 +251,7 @@ declare module 'graylog-web-plugin/plugin' {
     'views.components.widgets.messageDetails.contextProviders'?: Array<React.ComponentType<MessageDetailContextProviderProps>>,
     'views.elements.header'?: Array<React.ComponentType>;
     'views.elements.queryBar'?: Array<React.ComponentType>;
+    'views.elements.validationErrorExplanation'?: Array<React.ComponentType<{ explanations: QueryValidationState['explanations'] }>>;
     'views.export.formats'?: Array<ExportFormat>;
     'views.hooks.confirmDeletingDashboard'?: Array<(view: View) => Promise<boolean | null>>,
     'views.hooks.confirmDeletingDashboardPage'?: Array<(dashboardId: string, queryId: string, widgetIds: { [queryId: string]: Array<string> }) => Promise<boolean | null>>,

--- a/graylog2-web-interface/src/views/types.ts
+++ b/graylog2-web-interface/src/views/types.ts
@@ -251,7 +251,7 @@ declare module 'graylog-web-plugin/plugin' {
     'views.components.widgets.messageDetails.contextProviders'?: Array<React.ComponentType<MessageDetailContextProviderProps>>,
     'views.elements.header'?: Array<React.ComponentType>;
     'views.elements.queryBar'?: Array<React.ComponentType>;
-    'views.elements.validationErrorExplanation'?: Array<React.ComponentType<{ explanations: QueryValidationState['explanations'] }>>;
+    'views.elements.validationErrorExplanation'?: Array<React.ComponentType<{ validationState: QueryValidationState }>>;
     'views.export.formats'?: Array<ExportFormat>;
     'views.hooks.confirmDeletingDashboard'?: Array<(view: View) => Promise<boolean | null>>,
     'views.hooks.confirmDeletingDashboardPage'?: Array<(dashboardId: string, queryId: string, widgetIds: { [queryId: string]: Array<string> }) => Promise<boolean | null>>,

--- a/graylog2-web-interface/test/fixtures/queryValidationState.ts
+++ b/graylog2-web-interface/test/fixtures/queryValidationState.ts
@@ -21,7 +21,8 @@ import type { QueryValidationState } from 'views/components/searchbar/queryvalid
 export const validationError: QueryValidationState = {
   status: 'ERROR',
   explanations: [{
-    errorType: 'ParseException',
+    errorType: 'PARSE_EXCEPTION',
+    errorTitle: 'Parse Exception',
     errorMessage: "Cannot parse 'source: '",
     beginLine: 1,
     endLine: 1,


### PR DESCRIPTION
**_Please note: This PR needs to be merged after: https://github.com/Graylog2/graylog2-server/pull/12192_**

## Description
<!--- Describe your changes in detail -->
## Motivation and Context

With this PR it will be possible to render plugable components inside the query validation error explanation. This allows rendering components for plugin specific errors.

We are also updating the query validation state type based on the changes we implemented with 