### PR TITLE
Validate search query on parameter changes.

### DIFF
--- a/graylog2-web-interface/src/views/components/DashboardSearchBar.tsx
+++ b/graylog2-web-interface/src/views/components/DashboardSearchBar.tsx
@@ -41,6 +41,7 @@ import useParameters from 'views/hooks/useParameters';
 import debounceWithPromise from 'views/logic/debounceWithPromise';
 import validateQuery from 'views/components/searchbar/queryvalidation/validateQuery';
 import { isNoTimeRangeOverride } from 'views/typeGuards/timeRange';
+import ValidateOnParameterChange from 'views/components/searchbar/ValidateOnParameterChange';
 
 import TimeRangeInput from './searchbar/TimeRangeInput';
 import type { DashboardFormValues } from './DashboardSearchBarForm';
@@ -132,6 +133,7 @@ const DashboardSearchBar = ({ config, globalOverride, disableSearch = false, onE
 
                   return (
                     <>
+                      <ValidateOnParameterChange parameters={parameters} parameterBindings={parameterBindings} />
                       <TopRow>
                         <StyledTimeRangeInput disabled={disableSearch}
                                               onChange={(nextTimeRange) => setFieldValue('timerange', nextTimeRange)}

--- a/graylog2-web-interface/src/views/components/SearchBar.tsx
+++ b/graylog2-web-interface/src/views/components/SearchBar.tsx
@@ -52,6 +52,7 @@ import useParameters from 'views/hooks/useParameters';
 import debounceWithPromise from 'views/logic/debounceWithPromise';
 import validateQuery from 'views/components/searchbar/queryvalidation/validateQuery';
 
+import ValidateOnParameterChange from './searchbar/ValidateOnParameterChange';
 import SearchBarForm from './searchbar/SearchBarForm';
 
 type Props = {
@@ -152,6 +153,7 @@ const SearchBar = ({
 
                   return (
                     <>
+                      <ValidateOnParameterChange parameterBindings={parameterBindings} parameters={parameters} />
                       <TopRow>
                         <Col md={5}>
                           <TimeRangeInput disabled={disableSearch}

--- a/graylog2-web-interface/src/views/components/WidgetQueryControls.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetQueryControls.tsx
@@ -43,6 +43,7 @@ import FormWarningsProvider from 'contexts/FormWarningsProvider';
 import useParameters from 'views/hooks/useParameters';
 import debounceWithPromise from 'views/logic/debounceWithPromise';
 import validateQuery from 'views/components/searchbar/queryvalidation/validateQuery';
+import ValidateOnParameterChange from 'views/components/searchbar/ValidateOnParameterChange';
 
 import TimeRangeOverrideInfo from './searchbar/WidgetTimeRangeOverride';
 import TimeRangeInput from './searchbar/TimeRangeInput';
@@ -152,6 +153,7 @@ const WidgetQueryControls = ({ availableStreams, globalOverride }: Props) => {
           return (
             <>
               <PropagateDisableSubmissionState formKey="widget-query-controls" disableSubmission={disableSearchSubmit} />
+              <ValidateOnParameterChange parameters={parameters} parameterBindings={parameterBindings} />
               <WidgetTopRow>
                 <Col md={6}>
                   {!hasTimeRangeOverride && (

--- a/graylog2-web-interface/src/views/components/searchbar/ValidateOnParameterChange.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/ValidateOnParameterChange.test.tsx
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import * as Immutable from 'immutable';
+import { render, waitFor } from 'wrappedTestingLibrary';
+import { Formik, Form } from 'formik';
+
+import ValueParameter from 'views/logic/parameters/ValueParameter';
+import ParameterBinding from 'views/logic/parameters/ParameterBinding';
+
+import ValidateOnParameterChange from './ValidateOnParameterChange';
+
+describe('ValidateOnParameterChange', () => {
+  type SUTProps = React.ComponentProps<typeof ValidateOnParameterChange> & { onValidate: () => void };
+  const SUT = ({ onValidate, parameters, parameterBindings }: SUTProps) => (
+    <Formik validate={onValidate} onSubmit={() => {}} initialValues={{}} validateOnMount={false}>
+      <Form>
+        <ValidateOnParameterChange parameterBindings={parameterBindings} parameters={parameters} />
+      </Form>
+    </Formik>
+  );
+
+  const simpleParameters = Immutable.fromJS({
+    foo: ValueParameter.create('source', 'Source parameter', 'The value that source should have', 'string', undefined, false, ParameterBinding.empty()),
+  });
+
+  it('should not trigger form validation on mount', async () => {
+    const onValidateMock = jest.fn();
+    render(<SUT parameterBindings={undefined} parameters={undefined} onValidate={onValidateMock} />);
+
+    expect(onValidateMock).not.toHaveBeenCalled();
+  });
+
+  it('should trigger validation when parameters change', async () => {
+    const parameterBindings = Immutable.Map({ source: new ParameterBinding('value', 'example.org') });
+
+    const onValidateMock = jest.fn();
+    const { rerender } = render(<SUT parameterBindings={parameterBindings} parameters={simpleParameters} onValidate={onValidateMock} />);
+
+    const updatedParameters = Immutable.fromJS({
+      foo: ValueParameter.create('source', 'Source parameter', 'The value that source should have', 'string', 'default value', false, ParameterBinding.empty()),
+    });
+    rerender(<SUT parameterBindings={parameterBindings} parameters={updatedParameters} onValidate={onValidateMock} />);
+
+    await waitFor(() => expect(onValidateMock).toHaveBeenCalledTimes(1));
+  });
+
+  it('should trigger validation when parameter bindings change', async () => {
+    const onValidateMock = jest.fn();
+    const { rerender } = render(<SUT parameterBindings={undefined} parameters={simpleParameters} onValidate={onValidateMock} />);
+
+    const parameterBindings = Immutable.Map({ source: new ParameterBinding('value', 'example.org') });
+    rerender(<SUT parameterBindings={parameterBindings} parameters={simpleParameters} onValidate={onValidateMock} />);
+
+    await waitFor(() => expect(onValidateMock).toHaveBeenCalledTimes(1));
+  });
+});

--- a/graylog2-web-interface/src/views/components/searchbar/ValidateOnParameterChange.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/ValidateOnParameterChange.tsx
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 import type * as Immutable from 'immutable';
 import { useFormikContext } from 'formik';
 import { useEffect, useRef } from 'react';

--- a/graylog2-web-interface/src/views/components/searchbar/ValidateOnParameterChange.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/ValidateOnParameterChange.tsx
@@ -1,0 +1,28 @@
+import type * as Immutable from 'immutable';
+import { useFormikContext } from 'formik';
+import { useEffect, useRef } from 'react';
+
+import type { ParameterBindings } from 'views/logic/search/SearchExecutionState';
+import type Parameter from 'views/logic/parameters/Parameter';
+
+type Props = {
+  parameters: Immutable.Set<Parameter> | undefined,
+  parameterBindings: ParameterBindings | undefined,
+}
+
+const ValidateFormOnParameterChange = ({ parameterBindings, parameters }: Props) => {
+  const { validateForm } = useFormikContext();
+  const mounted = useRef(false);
+
+  useEffect(() => {
+    if (mounted.current) {
+      validateForm();
+    } else {
+      mounted.current = true;
+    }
+  }, [validateForm, parameterBindings, parameters]);
+
+  return null;
+};
+
+export default ValidateFormOnParameterChange;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Recently we implemented the search query validation. When an error in a query exists we disable the submit and display an error explanation. This currently results in a bug when working with parameters, because we display an error for undeclared parameters, but we do not validate the query again, when a parameter gets declared or when a user adds parameter bindings.