### PR TITLE
Add new test case for ExportModal.test.tsx, add triggerFormSubmit, refactor eslint error

### DIFF
--- a/graylog2-web-interface/src/views/components/export/ExportModal.test.tsx
+++ b/graylog2-web-interface/src/views/components/export/ExportModal.test.tsx
@@ -203,11 +203,12 @@ describe('ExportModal', () => {
     );
   });
 
-  it('initial fields should be  in the same direction as in widgetConfig where are more than 8 fields', async () => {
+  it('initial fields should keep order when there are more than 8 fields in widget config', async () => {
+    const fieldList = [
+      'timestamp', 'source', 'gl2_processing_timestamp', 'streams', 'gl2_accounted_message_size', 'controller', 'ingest_time', 'gl2_receive_timestamp', 'user_id',
+    ];
     const widgetConfig = new MessagesWidgetConfig(
-      [
-        'timestamp', 'source', 'gl2_processing_timestamp', 'streams', 'gl2_accounted_message_size', 'controller', 'ingest_time', 'gl2_receive_timestamp', 'user_id',
-      ],
+      fieldList,
       false,
       false,
       [],
@@ -231,9 +232,7 @@ describe('ExportModal', () => {
     expect(exportSearchTypeMessages).toHaveBeenCalledWith(
       {
         ...payload,
-        fields_in_order: [
-          'timestamp', 'source', 'gl2_processing_timestamp', 'streams', 'gl2_accounted_message_size', 'controller', 'ingest_time', 'gl2_receive_timestamp', 'user_id',
-        ],
+        fields_in_order: fieldList,
       },
       'search-id',
       'search-type-id-1',

--- a/graylog2-web-interface/src/views/components/export/ExportModal.test.tsx
+++ b/graylog2-web-interface/src/views/components/export/ExportModal.test.tsx
@@ -15,7 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { render, fireEvent, waitFor } from 'wrappedTestingLibrary';
+import { render, fireEvent, waitFor, screen } from 'wrappedTestingLibrary';
 import * as Immutable from 'immutable';
 import selectEvent from 'react-select-event';
 import type { Optional } from 'utility-types';
@@ -75,6 +75,13 @@ const pluginExports: PluginRegistration = {
 
 describe('ExportModal', () => {
   // Prepare expected payload
+
+  const triggerFormSubmit = () => {
+    const submitButton = screen.getByTestId('download-button');
+
+    fireEvent.click(submitButton);
+  };
+
   const payload = {
     fields_in_order: ['level', 'http_method', 'message'],
     limit: undefined,
@@ -130,11 +137,9 @@ describe('ExportModal', () => {
       ],
       execution_state: executionState,
     };
-    const { getByTestId } = render(<SimpleExportModal />);
+    render(<SimpleExportModal />);
 
-    const submitButton = getByTestId('download-button');
-
-    fireEvent.click(submitButton);
+    triggerFormSubmit();
 
     await waitFor(() => expect(exportSearchMessages).toHaveBeenCalledWith(
       expectedPayload,
@@ -145,13 +150,11 @@ describe('ExportModal', () => {
   });
 
   it('should show loading indicator after starting download', async () => {
-    const { getByTestId, findByText, getAllByText } = render(<SimpleExportModal />);
+    const { findByText, getAllByText } = render(<SimpleExportModal />);
 
     expect(getAllByText('Start Download')).toHaveLength(2);
 
-    const submitButton = getByTestId('download-button');
-
-    fireEvent.click(submitButton);
+    triggerFormSubmit();
 
     await findByText('Downloading...');
 
@@ -160,11 +163,9 @@ describe('ExportModal', () => {
 
   it('should be closed after finishing download', async () => {
     const closeModalStub = jest.fn();
-    const { getByTestId } = render(<SimpleExportModal closeModal={closeModalStub} />);
+    render(<SimpleExportModal closeModal={closeModalStub} />);
 
-    const submitButton = getByTestId('download-button');
-
-    fireEvent.click(submitButton);
+    triggerFormSubmit();
 
     await waitFor(() => expect(closeModalStub).toHaveBeenCalledTimes(1));
   });
@@ -181,11 +182,9 @@ describe('ExportModal', () => {
       .toBuilder()
       .state(viewStateMap)
       .build();
-    const { getByTestId } = render(<SimpleExportModal view={view} />);
+    render(<SimpleExportModal view={view} />);
 
-    const submitButton = getByTestId('download-button');
-
-    fireEvent.click(submitButton);
+    triggerFormSubmit();
 
     await waitFor(() => expect(exportSearchTypeMessages).toHaveBeenCalledTimes(1));
 
@@ -204,16 +203,55 @@ describe('ExportModal', () => {
     );
   });
 
+  it('initial fields should be  in the same direction as in widgetConfig where are more than 8 fields', async () => {
+    const widgetConfig = new MessagesWidgetConfig(
+      [
+        'timestamp', 'source', 'gl2_processing_timestamp', 'streams', 'gl2_accounted_message_size', 'controller', 'ingest_time', 'gl2_receive_timestamp', 'user_id',
+      ],
+      false,
+      false,
+      [],
+      []);
+    const widgetWithoutMessageRow = messagesWidget().toBuilder().config(widgetConfig).build();
+    const viewStateMap: ViewStateMap = Immutable.Map({
+      'query-id-1': stateWithOneWidget(messagesWidget()).toBuilder()
+        .widgets(Immutable.List([widgetWithoutMessageRow]))
+        .build(),
+    });
+    const view = viewWithoutWidget(View.Type.Search)
+      .toBuilder()
+      .state(viewStateMap)
+      .build();
+    render(<SimpleExportModal view={view} />);
+
+    triggerFormSubmit();
+
+    await waitFor(() => expect(exportSearchTypeMessages).toHaveBeenCalledTimes(1));
+
+    expect(exportSearchTypeMessages).toHaveBeenCalledWith(
+      {
+        ...payload,
+        fields_in_order: [
+          'timestamp', 'source', 'gl2_processing_timestamp', 'streams', 'gl2_accounted_message_size', 'controller', 'ingest_time', 'gl2_receive_timestamp', 'user_id',
+        ],
+      },
+      'search-id',
+      'search-type-id-1',
+      'text/csv',
+      'Widget-1-search-result.csv',
+    );
+  });
+
   describe('on search page', () => {
     const SearchExportModal = (props) => (
       <SimpleExportModal viewType={View.Type.Search} {...props} />
     );
 
     it('should not show widget selection when no widget exists', () => {
-      const { queryByText } = render(<SearchExportModal />);
+      const { queryByText, getByText } = render(<SearchExportModal />);
 
       // should not show widget selection but settings form
-      expect(queryByText(/Define the fields for your file./)).not.toBeNull();
+      expect(getByText(/Define the fields for your file./)).not.toBeNull();
       // should not show info about selected widget
       expect(queryByText(/The following settings are based on the message table:/)).toBeNull();
       // should not allow widget selection
@@ -221,11 +259,9 @@ describe('ExportModal', () => {
     });
 
     it('should export all messages with default fields when no widget exists', async () => {
-      const { getByTestId } = render(<SearchExportModal />);
+      render(<SearchExportModal />);
 
-      const submitButton = getByTestId('download-button');
-
-      fireEvent.click(submitButton);
+      triggerFormSubmit();
 
       await waitFor(() => expect(exportSearchMessages).toHaveBeenCalledTimes(1));
 
@@ -245,22 +281,20 @@ describe('ExportModal', () => {
     });
 
     it('preselect messages widget when only one exists', () => {
-      const { queryByText } = render(<SearchExportModal view={viewWithOneWidget(View.Type.Search)} />);
+      const { queryByText, getByText } = render(<SearchExportModal view={viewWithOneWidget(View.Type.Search)} />);
 
       // should not show widget selection but settings form
-      expect(queryByText(/Define the fields for your file./)).not.toBeNull();
+      expect(getByText(/Define the fields for your file./)).not.toBeNull();
       // should show info about selected widget
-      expect(queryByText(/The following settings are based on the message table:/)).not.toBeNull();
+      expect(getByText(/The following settings are based on the message table:/)).not.toBeNull();
       // should not allow widget selection
       expect(queryByText('Select different message table')).toBeNull();
     });
 
     it('should export messages related to preselected widget', async () => {
-      const { getByTestId } = render(<SearchExportModal view={viewWithOneWidget(View.Type.Search)} />);
+      render(<SearchExportModal view={viewWithOneWidget(View.Type.Search)} />);
 
-      const submitButton = getByTestId('download-button');
-
-      fireEvent.click(submitButton);
+      triggerFormSubmit();
       await waitFor(() => expect(exportSearchTypeMessages).toHaveBeenCalledTimes(1));
 
       expect(exportSearchTypeMessages).toHaveBeenCalledWith(
@@ -273,35 +307,33 @@ describe('ExportModal', () => {
     });
 
     it('show widget selection if more than one exists', async () => {
-      const { getByLabelText, queryByText } = render(<SearchExportModal view={viewWithMultipleWidgets(View.Type.Search)} />);
+      const { getByLabelText, getByText } = render(<SearchExportModal view={viewWithMultipleWidgets(View.Type.Search)} />);
 
       const select = getByLabelText('Select message table');
 
-      expect(queryByText(/Please select a message table to adopt its fields./)).not.toBeNull();
+      expect(getByText(/Please select a message table to adopt its fields./)).not.toBeNull();
 
       await selectEvent.openMenu(select);
 
-      expect(queryByText('Widget 1')).not.toBeNull();
-      expect(queryByText('Widget 2')).not.toBeNull();
+      expect(getByText('Widget 1')).not.toBeNull();
+      expect(getByText('Widget 2')).not.toBeNull();
     });
 
     it('preselect widget on direct export', () => {
-      const { queryByText } = render(<SearchExportModal view={viewWithMultipleWidgets(View.Type.Search)} directExportWidgetId="widget-id-1" />);
+      const { queryByText, getByText } = render(<SearchExportModal view={viewWithMultipleWidgets(View.Type.Search)} directExportWidgetId="widget-id-1" />);
 
       // should not show widget selection but settings form
-      expect(queryByText(/Define the fields for your file./)).not.toBeNull();
+      expect(getByText(/Define the fields for your file./)).not.toBeNull();
       // should show info about selected widget
-      expect(queryByText(/The following settings are based on the message table:/)).not.toBeNull();
+      expect(getByText(/The following settings are based on the message table:/)).not.toBeNull();
       // should not allow widget selection
       expect(queryByText('Select different message table')).toBeNull();
     });
 
     it('should export widget messages on direct export', async () => {
-      const { getByTestId } = render(<SearchExportModal view={viewWithMultipleWidgets(View.Type.Search)} directExportWidgetId="widget-id-1" />);
+      render(<SearchExportModal view={viewWithMultipleWidgets(View.Type.Search)} directExportWidgetId="widget-id-1" />);
 
-      const submitButton = getByTestId('download-button');
-
-      fireEvent.click(submitButton);
+      triggerFormSubmit();
       await waitFor(() => expect(exportSearchTypeMessages).toHaveBeenCalledTimes(1));
 
       expect(exportSearchTypeMessages).toHaveBeenCalledWith(
@@ -320,27 +352,27 @@ describe('ExportModal', () => {
     );
 
     it('show warning when no messages widget exists', () => {
-      const { queryByText } = render(<DashboardExportModal view={viewWithoutWidget(View.Type.Dashboard)} />);
+      const { getByText } = render(<DashboardExportModal view={viewWithoutWidget(View.Type.Dashboard)} />);
 
-      expect(queryByText('You need to create a message table widget to export its result.')).not.toBeNull();
+      expect(getByText('You need to create a message table widget to export its result.')).not.toBeNull();
     });
 
     it('does not preselect widget when only one exists', () => {
-      const { queryByText } = render(<DashboardExportModal view={viewWithOneWidget(View.Type.Dashboard)} />);
+      const { getByText } = render(<DashboardExportModal view={viewWithOneWidget(View.Type.Dashboard)} />);
 
-      expect(queryByText(/Please select the message table you want to export the search results for./)).not.toBeNull();
+      expect(getByText(/Please select the message table you want to export the search results for./)).not.toBeNull();
     });
 
     it('show widget selection if more than one exists', async () => {
-      const { queryByText, getByLabelText } = render(<DashboardExportModal view={viewWithMultipleWidgets(View.Type.Dashboard)} />);
+      const { getByText, getByLabelText } = render(<DashboardExportModal view={viewWithMultipleWidgets(View.Type.Dashboard)} />);
       const select = getByLabelText('Select message table');
 
-      expect(queryByText(/Please select the message table you want to export the search results for./)).not.toBeNull();
+      expect(getByText(/Please select the message table you want to export the search results for./)).not.toBeNull();
 
       await selectEvent.openMenu(select);
 
-      expect(queryByText('Widget 1')).not.toBeNull();
-      expect(queryByText('Widget 2')).not.toBeNull();
+      expect(getByText('Widget 1')).not.toBeNull();
+      expect(getByText('Widget 2')).not.toBeNull();
     });
 
     it('show widget selection with widgets from all dashboard pages', async () => {
@@ -355,32 +387,30 @@ describe('ExportModal', () => {
         .state(Immutable.Map({ 'query-id-1': stateWithOneWidget(messagesWidget()), 'query-id-2': secondViewState }))
         .build();
 
-      const { queryByText, getByLabelText } = render(<DashboardExportModal view={complexView} />);
+      const { getByText, getByLabelText } = render(<DashboardExportModal view={complexView} />);
       const select = getByLabelText('Select message table');
 
       await selectEvent.openMenu(select);
 
-      expect(queryByText('Widget 1')).not.toBeNull();
-      expect(queryByText('Widget 2')).not.toBeNull();
+      expect(getByText('Widget 1')).not.toBeNull();
+      expect(getByText('Widget 2')).not.toBeNull();
     });
 
     it('preselect widget on direct widget export', () => {
-      const { queryByText } = render(<DashboardExportModal view={viewWithMultipleWidgets(View.Type.Dashboard)} directExportWidgetId="widget-id-1" />);
+      const { queryByText, getByText } = render(<DashboardExportModal view={viewWithMultipleWidgets(View.Type.Dashboard)} directExportWidgetId="widget-id-1" />);
 
       // should not show widget selection but settings form
-      expect(queryByText(/Define the fields for your file./)).not.toBeNull();
+      expect(getByText(/Define the fields for your file./)).not.toBeNull();
       // should show info about selected widget
-      expect(queryByText(/You are currently exporting the search results for the message table:/)).not.toBeNull();
+      expect(getByText(/You are currently exporting the search results for the message table:/)).not.toBeNull();
       // should not allow widget selection
       expect(queryByText('Select different message table')).toBeNull();
     });
 
     it('should export widget messages on direct export', async () => {
-      const { getByTestId } = render(<DashboardExportModal view={viewWithMultipleWidgets(View.Type.Search)} directExportWidgetId="widget-id-1" />);
+      render(<DashboardExportModal view={viewWithMultipleWidgets(View.Type.Search)} directExportWidgetId="widget-id-1" />);
 
-      const submitButton = getByTestId('download-button');
-
-      fireEvent.click(submitButton);
+      triggerFormSubmit();
       await waitFor(() => expect(exportSearchTypeMessages).toHaveBeenCalledTimes(1));
 
       expect(exportSearchTypeMessages).toHaveBeenCalledWith(


### PR DESCRIPTION
## Description
- Add a new test case to check the column order while exporting. In some cases, while data transforming (f.e. if you use Immutable Set with more than 8 items) the sorting might not be as in the initial array
- add `triggerFormSubmit` fn to reuse login in  several test cases 
- refactor elint error recording to `queryBy*`, `getBy*` usage
## Motivation and Context

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

