### PR TITLE
Fix/highlighting bool message field in a dashboard/issue (backport of #12188 for 4.1)

### DIFF
--- a/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightForm.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightForm.tsx
@@ -47,7 +47,7 @@ type Props = {
 };
 
 const _isRequired = (field) => (value) => {
-  if (!value || value === '') {
+  if (['', null, undefined].includes(value)) {
     return `${field} is required`;
   }
 


### PR DESCRIPTION
**This is a backport of https://github.com/Graylog2/graylog2-server/pull/12188 for 4.1**

## Description
Change `_isRequire` rule to recognize only `""`, `undefined`, `null` as unfilled.

## Motivation and Context
When the user highlights some field with a `false` or  `0` value the form recognizes this value as not filled. Due to that we see an error that field is required

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.