### PR TITLE
Support credentials in URLs for MS Edge. (backport of #12194 for 4.1)

### DIFF
--- a/graylog2-web-interface/src/util/URLUtils.ts
+++ b/graylog2-web-interface/src/util/URLUtils.ts
@@ -97,7 +97,7 @@ const URLUtils = {
   areCredentialsInURLSupported(): boolean {
     const browser = URLUtils.parser.getBrowser();
 
-    return browser.name !== 'IE' && browser.name !== 'Edge';
+    return browser.name !== 'IE';
   },
   isValidURL(str: string) {
     let isValid = true;


### PR DESCRIPTION
**This is a backport of https://github.com/Graylog2/graylog2-server/pull/12194 for 4.1**

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Prior to this change, when generating URLs from the frontend that directly link to the API (e.g. for downloading exports, reports, etc.), it was checked if the browser supports embedding crendentials in the URL. This check was written at a time when MS Edge was not based on Chromium yet. Therefore it was assuming that it does not support it.

This has changed, therefore the check for Edge is removed. The whole logic will vanish with the introduction of session cookies, therefore a further revamp is not necessary.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.