### PR TITLE
Add render-error id to the error message

### DIFF
--- a/graylog2-web-interface/src/pages/RuntimeErrorPage.jsx
+++ b/graylog2-web-interface/src/pages/RuntimeErrorPage.jsx
@@ -77,7 +77,7 @@ class RuntimeErrorPage extends React.Component {
             </ToggleDetails>
           </dt>
           <dt>
-            <pre className="content">
+            <pre className="content" id="render-error">
               <div className="pull-right">
                 <ClipboardButton title={<Icon name="copy" fixedWidth />}
                                  bsSize="sm"


### PR DESCRIPTION
During the report generation the backend needs to know if a FE error occurred. In that case, we can prematurely terminate the waiting logic and correctly propagate the FE exception and its stacktrace. This PR adds an unique ID so we can recognize the error in the page easily. 

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
This PR completes changes started in https://github.com/Graylog2/graylog-plugin-enterprise/pull/3240

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

