### PR TITLE
Wait for node balancer recognition period before triggering "HALTING" lifecycle

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/system/shutdown/GracefulShutdown.java
+++ b/graylog2-server/src/main/java/org/graylog2/system/shutdown/GracefulShutdown.java
@@ -39,7 +39,6 @@ import static org.graylog2.audit.AuditEventTypes.NODE_SHUTDOWN_COMPLETE;
 @Singleton
 public class GracefulShutdown implements Runnable {
     private static final Logger LOG = LoggerFactory.getLogger(GracefulShutdown.class);
-    private static final int SLEEP_SECS = 1;
 
     private final Configuration configuration;
     private final BufferSynchronizerService bufferSynchronizerService;
@@ -96,12 +95,6 @@ public class GracefulShutdown implements Runnable {
 
         // Trigger a lifecycle change. Some services are listening for those and will halt operation accordingly.
         serverStatus.shutdown();
-
-        /*
-         * Wait a second to give for example the calling REST call some time to respond
-         * to the client. Using a latch or something here might be a bit over-engineered.
-         */
-        Uninterruptibles.sleepUninterruptibly(SLEEP_SECS, TimeUnit.SECONDS);
 
         // Stop REST API service to avoid changes from outside.
         jerseyService.stopAsync();

--- a/graylog2-server/src/main/java/org/graylog2/system/shutdown/GracefulShutdown.java
+++ b/graylog2-server/src/main/java/org/graylog2/system/shutdown/GracefulShutdown.java
@@ -84,8 +84,7 @@ public class GracefulShutdown implements Runnable {
     private void doRun(boolean exit) {
         LOG.info("Graceful shutdown initiated.");
 
-        // Trigger a lifecycle change. Some services are listening for those and will halt operation accordingly.
-        serverStatus.shutdown();
+        serverStatus.overrideLoadBalancerDead();
 
         // Give possible load balancers time to recognize state change. State is DEAD because of HALTING.
         LOG.info("Node status: [{}]. Waiting <{}sec> for possible load balancers to recognize state change.",
@@ -94,6 +93,9 @@ public class GracefulShutdown implements Runnable {
         Uninterruptibles.sleepUninterruptibly(configuration.getLoadBalancerRecognitionPeriodSeconds(), TimeUnit.SECONDS);
 
         activityWriter.write(new Activity("Graceful shutdown initiated.", GracefulShutdown.class));
+
+        // Trigger a lifecycle change. Some services are listening for those and will halt operation accordingly.
+        serverStatus.shutdown();
 
         /*
          * Wait a second to give for example the calling REST call some time to respond


### PR DESCRIPTION
During shutdown, at first, set the load balancer status to "DEAD" and then pause for the configured load balancer recognition period. Only after that trigger the lifecycle change to "HALTING".

Previously, we would start with triggering the lifecycle change to "HALTING" prior to pausing for load balancer recognition. This would set the load balancer status to "DEAD" but at the same time, any service listening for the lifecycle change to "HALTING" would already take action and potentially shut down.

While in most cases this shouldn't be a problem, it is e.g. for the server-side of the cloud forwarder which runs as a service and stops accepting messages when server shutdown is detected. With this change, the load balancer status is set now set to "DEAD" ahead of time.