### PR TITLE
Hotfix for never-expiring session validity #12220

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/models/system/sessions/responses/DefaultSessionResponseFactory.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/system/sessions/responses/DefaultSessionResponseFactory.java
@@ -50,7 +50,7 @@ public class DefaultSessionResponseFactory implements SessionResponseFactory {
 
     protected Date getValidUntil(Session session) {
         if(session.getTimeout() < 0) { // means "session never expires", which is not possible in cookie-based auth
-            return new DateTime().plus(Years.years(10)).toDate(); // careful, later we convert the date to seconds as int and it may overflow for too big values
+            return new DateTime(DateTimeZone.UTC ).plus(Years.years(10)).toDate(); // careful, later we convert the date to seconds as int and it may overflow for too big values
         } else {
             return new DateTime(session.getLastAccessTime(), DateTimeZone.UTC).plus(session.getTimeout()).toDate();
         }

--- a/graylog2-server/src/main/java/org/graylog2/rest/models/system/sessions/responses/DefaultSessionResponseFactory.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/system/sessions/responses/DefaultSessionResponseFactory.java
@@ -22,6 +22,7 @@ import org.apache.shiro.session.Session;
 import org.apache.shiro.subject.Subject;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
+import org.joda.time.Years;
 
 import javax.inject.Inject;
 import java.util.Date;
@@ -48,7 +49,11 @@ public class DefaultSessionResponseFactory implements SessionResponseFactory {
     }
 
     protected Date getValidUntil(Session session) {
-        return new DateTime(session.getLastAccessTime(), DateTimeZone.UTC).plus(session.getTimeout()).toDate();
+        if(session.getTimeout() < 0) { // means "session never expires", which is not possible in cookie-based auth
+            return new DateTime().plus(Years.years(10)).toDate(); // careful, later we convert the date to seconds as int and it may overflow for too big values
+        } else {
+            return new DateTime(session.getLastAccessTime(), DateTimeZone.UTC).plus(session.getTimeout()).toDate();
+        }
     }
 
     protected Subject getSubjectFromSession(Session session) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
With the implementation of the cookie auth in #11788 we encountered a bug #12220 that prevents log-in for never expiring sessions. 

Cookies generally don't allow unlimited TTL, they always require a `maxAge` value. The common workaround is to set this value to the very distant future. This PR does exactly that - for never-expiring session configuration it sets the cookie to be valid for 10 years from the moment of login. It's rather a workaround and we should think about removing the non-expiring functionality generally, as we can't implement it correctly.

## Motivation and Context
Fixes #12220 

## How Has This Been Tested?
**TODO** add an integration test!

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

