### PR TITLE
Improve fetching of query field value suggestions.

### DIFF
--- a/graylog2-web-interface/src/views/components/searchbar/completions/FieldValueCompletion.test.ts
+++ b/graylog2-web-interface/src/views/components/searchbar/completions/FieldValueCompletion.test.ts
@@ -356,11 +356,20 @@ describe('FieldValueCompletion', () => {
       expect(result).toEqual(false);
     });
 
-    it('returns true if current token is a keyword and ends with :', async () => {
+    it('returns true if current token is a keyword and ends with ":"', async () => {
       const completer = new FieldValueCompletion();
       const result = completer.shouldShowCompletions(1, [[{ type: 'keyword', value: 'http_method:', index: 0, start: 0 }, null]]);
 
       expect(result).toEqual(true);
+    });
+
+    it('returns false if current token is a keyword that ends with ":" which is already followed by a term', async () => {
+      const completer = new FieldValueCompletion();
+      const result = completer.shouldShowCompletions(1, [[
+        { type: 'keyword', value: 'http_method:', index: 0, start: 0 },
+        { type: 'term', value: 'POST' }, null]]);
+
+      expect(result).toEqual(false);
     });
 
     it('returns true if current token is a keyword in a complex query and ends with :', async () => {

--- a/graylog2-web-interface/src/views/components/searchbar/completions/FieldValueCompletion.ts
+++ b/graylog2-web-interface/src/views/components/searchbar/completions/FieldValueCompletion.ts
@@ -201,10 +201,13 @@ class FieldValueCompletion implements Completer {
     }
 
     const previousToken = currentLineTokens[currentTokenIndex - 1];
+    const nextToken = currentLineTokens[currentTokenIndex + 1];
+
     const currentTokenIsFieldName = currentToken?.type === 'keyword' && currentToken?.value.endsWith(':');
     const currentTokenIsFieldValue = currentToken?.type === 'term' && previousToken?.type === 'keyword';
+    const nextTokenIsTerm = nextToken?.type === 'term';
 
-    return currentTokenIsFieldName || currentTokenIsFieldValue;
+    return (currentTokenIsFieldName || currentTokenIsFieldValue) && !nextTokenIsTerm;
   };
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

In some cases we display suggestions for field values in the search query, e.g. for query strings like:
`http_method:` and `http_method:POS`

After every query string change we check if we should open the query input autocomplete (we are calling `shouldShowCompletions` of every defined completer class). Opening the autocomplete triggers the actual fetching of completions (we are calling `getCompletions` of every defined completer class).

This PR is improving the logic by:
- not calling `getCompletions` on the initial render
- making sure `shouldShowCompletions` of the `FieldValueCompleter` does not return true for a query string  like `http_method:POST` where `http_method` is the currently selected token.


This change is fixing https://github.com/Graylog2/graylog2-server/issues/12165. In this case the problem occurred when using the field value action "Add to query" (only) while the query string is empty. In this case the ace editor behaves unexpected, because it defines the added field name as the currently selected token. When using the field value action "Add to query" while the query string is not empty the field value will be defined as the current token.

Fixes #12165

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
