### PR TITLE
Do no throw errors for invalid dates.

### DIFF
--- a/graylog2-web-interface/src/contexts/UserDateTimeProvider.test.tsx
+++ b/graylog2-web-interface/src/contexts/UserDateTimeProvider.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 /*
  * Copyright (C) 2020 Graylog, Inc.
  *
@@ -34,7 +35,7 @@ jest.useFakeTimers()
 describe('DateTimeProvider', () => {
   const user = alice.toBuilder().timezone('Europe/Berlin').build();
   const invalidDate = '2020-00-00T04:00:00.000Z';
-  const expectErrorForInvalidDate = (action: () => any) => expect(action).toThrowError(`Date time ${invalidDate} is not valid.`);
+  const expectErrorForInvalidDate = () => expect(console.error).toHaveBeenCalledWith(`Date time ${invalidDate} is not valid.`);
 
   const renderSUT = (currentUser: User = user, tzOverride = undefined) => {
     let contextValue;
@@ -55,6 +56,16 @@ describe('DateTimeProvider', () => {
 
     return contextValue;
   };
+
+  const original = console.error;
+
+  beforeEach(() => {
+    console.error = jest.fn();
+  });
+
+  afterEach(() => {
+    console.error = original;
+  });
 
   describe('userTimezone value should', () => {
     it('provide user timezone', () => {
@@ -77,9 +88,10 @@ describe('DateTimeProvider', () => {
       expect(formatTime('2021-03-27T14:32:31.894Z')).toBe('2021-03-27 15:32:31');
     });
 
-    it('throw an error for an invalid date', () => {
+    it('log an error for an invalid date', () => {
       const { formatTime } = renderSUT();
-      expectErrorForInvalidDate(() => formatTime(invalidDate));
+      formatTime(invalidDate);
+      expectErrorForInvalidDate();
     });
 
     it('respect timezone override', () => {
@@ -98,9 +110,10 @@ describe('DateTimeProvider', () => {
       expect(result.format(DATE_TIME_FORMATS.internal)).toBe('2021-03-27T15:32:31.894+01:00');
     });
 
-    it('throw an error for an invalid date', () => {
+    it('log an error for an invalid date', () => {
       const { toUserTimezone } = renderSUT();
-      expectErrorForInvalidDate(() => toUserTimezone(invalidDate));
+      toUserTimezone(invalidDate);
+      expectErrorForInvalidDate();
     });
 
     it('respect timezone override', () => {

--- a/graylog2-web-interface/src/util/DateTime.test.ts
+++ b/graylog2-web-interface/src/util/DateTime.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 /*
  * Copyright (C) 2020 Graylog, Inc.
  *
@@ -51,7 +52,17 @@ describe('DateTime utils', () => {
   const moscowTZ = 'Europe/Moscow';
 
   const invalidDate = '2020-00-00T04:00:00.000Z';
-  const expectErrorForInvalidDate = (action: () => any) => expect(action).toThrowError(`Date time ${invalidDate} is not valid.`);
+
+  const expectErrorForInvalidDate = (message = `Date time ${invalidDate} is not valid.`) => expect(console.error).toHaveBeenCalledWith(message);
+  const original = console.error;
+
+  beforeEach(() => {
+    console.error = jest.fn();
+  });
+
+  afterEach(() => {
+    console.error = original;
+  });
 
   describe('toDateObject', () => {
     it.each(exampleUTCInput)('should transform %s to moment object', (type: any, input) => {
@@ -70,11 +81,14 @@ describe('DateTime utils', () => {
     });
 
     it('should validate date based on defined format', () => {
-      expect(() => toDateObject('2020-01-01T10:00:00.000Z', ['date'])).toThrowError('Date time 2020-01-01T10:00:00.000Z is not valid. Expected formats: YYYY-MM-DD.');
+      toDateObject('2020-01-01T10:00:00.000Z', ['date']);
+
+      expect(console.error).toHaveBeenCalledWith('Date time 2020-01-01T10:00:00.000Z is not valid. Expected formats: YYYY-MM-DD.');
     });
 
     it('should throw an error for an invalid date', () => {
-      expectErrorForInvalidDate(() => toDateObject(invalidDate));
+      toDateObject(invalidDate);
+      expectErrorForInvalidDate();
     });
   });
 
@@ -91,12 +105,14 @@ describe('DateTime utils', () => {
       expect(parseFromIsoString(exampleBerlinTime, moscowTZ).format(DATE_TIME_FORMATS.internal)).toBe('2020-01-01T12:00:00.000+03:00');
     });
 
-    it('should throw an error when provided date string is not an ISO 8601 date', () => {
-      expect(() => parseFromIsoString('2020-01-01T04:00:00.000')).toThrow(new Error('Date time 2020-01-01T04:00:00.000 is not valid. Expected formats: YYYY-MM-DDTHH:mm:ss.SSSZ.'));
+    it('should log an error when provided date string is not an ISO 8601 date', () => {
+      parseFromIsoString('2020-01-01T04:00:00.000');
+      expectErrorForInvalidDate('Date time 2020-01-01T04:00:00.000 is not valid. Expected formats: YYYY-MM-DDTHH:mm:ss.SSSZ.');
     });
 
     it('should throw an error for an invalid date', () => {
-      expectErrorForInvalidDate(() => parseFromIsoString(invalidDate));
+      parseFromIsoString(invalidDate);
+      expectErrorForInvalidDate('Date time 2020-00-00T04:00:00.000Z is not valid. Expected formats: YYYY-MM-DDTHH:mm:ss.SSSZ.');
     });
   });
 
@@ -120,7 +136,8 @@ describe('DateTime utils', () => {
     });
 
     it('should throw an error for an invalid date', () => {
-      expectErrorForInvalidDate(() => adjustFormat(invalidDate));
+      adjustFormat(invalidDate);
+      expectErrorForInvalidDate();
     });
   });
 
@@ -134,7 +151,8 @@ describe('DateTime utils', () => {
     });
 
     it('should throw an error for an invalid date', () => {
-      expectErrorForInvalidDate(() => formatAsBrowserTime(invalidDate));
+      formatAsBrowserTime(invalidDate);
+      expectErrorForInvalidDate();
     });
   });
 
@@ -144,7 +162,8 @@ describe('DateTime utils', () => {
     });
 
     it('should throw an error for an invalid date', () => {
-      expectErrorForInvalidDate(() => relativeDifference(invalidDate));
+      relativeDifference(invalidDate);
+      expectErrorForInvalidDate();
     });
   });
 });

--- a/graylog2-web-interface/src/util/DateTime.ts
+++ b/graylog2-web-interface/src/util/DateTime.ts
@@ -42,7 +42,8 @@ const validateDateTime = (dateTime: Moment, originalDateTime: DateTime, addition
       errorMessage = `${errorMessage} ${additionalInfo}`;
     }
 
-    throw new Error(errorMessage);
+    // eslint-disable-next-line no-console
+    console.error(errorMessage);
   }
 
   return dateTime;


### PR DESCRIPTION

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Before this change we were throwing an error when providing an invalid date for the `DateTime` utils.
This "fail early" approach makes the usage of invalid dates more obvious, but it introduced bugs like: https://github.com/Graylog2/graylog2-server/issues/12193

We are now just tracking an error in the console instead. 

Fixes: https://github.com/Graylog2/graylog2-server/issues/12193