### PR TITLE
Display milliseconds for all date times on search page.

### DIFF
--- a/graylog2-web-interface/src/views/components/TypeSpecificValue.tsx
+++ b/graylog2-web-interface/src/views/components/TypeSpecificValue.tsx
@@ -57,7 +57,7 @@ const TypeSpecificValue = ({ field, value, render = defaultComponent, type = Fie
   }
 
   switch (type.type) {
-    case 'date': return <Timestamp dateTime={value} render={render} field={field} />;
+    case 'date': return <Timestamp dateTime={value} render={render} field={field} format="complete" />;
     case 'boolean': return <Component value={String(value)} field={field} />;
     default: return _formatValue(field, value, truncate, render, type);
   }

--- a/graylog2-web-interface/src/views/components/WidgetQueryControls.test.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetQueryControls.test.tsx
@@ -129,7 +129,7 @@ describe('WidgetQueryControls', () => {
   describe('displays if global override is set', () => {
     const resetTimeRangeButtonTitle = /reset global override/i;
     const resetQueryButtonTitle = /reset global filter/i;
-    const timeRangeOverrideInfo = '2020-01-01T10:00:00.850Z - 2020-01-02T10:00:00.000Z';
+    const timeRangeOverrideInfo = '2019-10-10 12:26:31 - 2019-10-10 12:26:31';
     const queryOverrideInfo = globalOverrideWithQuery.query.query_string;
 
     it('shows preview of global override time range', async () => {

--- a/graylog2-web-interface/src/views/components/WidgetQueryControls.test.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetQueryControls.test.tsx
@@ -23,10 +23,13 @@ import { GlobalOverrideActions } from 'views/stores/GlobalOverrideStore';
 import { SearchActions } from 'views/stores/SearchStore';
 import type GlobalOverride from 'views/logic/search/GlobalOverride';
 import Widget from 'views/logic/widgets/Widget';
-import mockComponent from 'helpers/mocking/MockComponent';
 
 import WidgetQueryControls from './WidgetQueryControls';
 import WidgetContext from './contexts/WidgetContext';
+
+jest.mock('hooks/useUserDateTime');
+jest.mock('views/components/searchbar/queryvalidation/QueryValidation', () => mockComponent('QueryValidation'));
+jest.mock('views/components/searchbar/QueryInput', () => ({ value = '' }: { value: string }) => <span>{value}</span>);
 
 jest.mock('views/stores/WidgetStore', () => ({
   WidgetActions: {
@@ -65,9 +68,6 @@ jest.mock('moment', () => {
 
   return Object.assign(() => mockMoment('2019-10-10T12:26:31.146Z'), mockMoment);
 });
-
-jest.mock('views/components/searchbar/queryvalidation/QueryValidation', () => mockComponent('QueryValidation'));
-jest.mock('views/components/searchbar/QueryInput', () => ({ value = '' }: { value: string }) => <span>{value}</span>);
 
 jest.mock('views/stores/SearchConfigStore', () => ({
   SearchConfigActions: {

--- a/graylog2-web-interface/src/views/components/WidgetQueryControls.test.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetQueryControls.test.tsx
@@ -23,6 +23,7 @@ import { GlobalOverrideActions } from 'views/stores/GlobalOverrideStore';
 import { SearchActions } from 'views/stores/SearchStore';
 import type GlobalOverride from 'views/logic/search/GlobalOverride';
 import Widget from 'views/logic/widgets/Widget';
+import mockComponent from 'helpers/mocking/MockComponent';
 
 import WidgetQueryControls from './WidgetQueryControls';
 import WidgetContext from './contexts/WidgetContext';

--- a/graylog2-web-interface/src/views/components/messagelist/MessageDetail.tsx
+++ b/graylog2-web-interface/src/views/components/messagelist/MessageDetail.tsx
@@ -117,7 +117,7 @@ const MessageDetail = ({
     const rawTimestamp = fields.timestamp;
 
     timestamp.push(<dt key={`dt-${rawTimestamp}`}>Timestamp</dt>);
-    timestamp.push(<dd key={`dd-${rawTimestamp}`}><Timestamp dateTime={rawTimestamp} /></dd>);
+    timestamp.push(<dd key={`dd-${rawTimestamp}`}><Timestamp dateTime={rawTimestamp} format="complete" /></dd>);
   }
 
   const messageTitle = _formatMessageTitle(index, id);

--- a/graylog2-web-interface/src/views/components/messagelist/MessageDetail.tsx
+++ b/graylog2-web-interface/src/views/components/messagelist/MessageDetail.tsx
@@ -16,7 +16,7 @@
  */
 import PropTypes from 'prop-types';
 import * as React from 'react';
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import Immutable from 'immutable';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 
@@ -83,6 +83,7 @@ const MessageDetail = ({
   const { fields, index, id, decoration_stats: decorationStats } = message;
   const { gl2_source_node, gl2_source_input } = fields;
   const { isLocalNode } = useIsLocalNode(gl2_source_node);
+  const additionalContext = useMemo(() => ({ isLocalNode }), [isLocalNode]);
 
   const _toggleShowOriginal = () => {
     setShowOriginal(!showOriginal);
@@ -123,7 +124,7 @@ const MessageDetail = ({
   const messageTitle = _formatMessageTitle(index, id);
 
   return (
-    <AdditionalContext.Provider value={{ isLocalNode }}>
+    <AdditionalContext.Provider value={additionalContext}>
       <MessageDetailProviders message={message}>
         <>
           <Row className="row-sm">

--- a/graylog2-web-interface/src/views/components/searchbar/WidgetTimeRangeOverride.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/WidgetTimeRangeOverride.tsx
@@ -20,6 +20,8 @@ import styled from 'styled-components';
 import type { TimeRange } from 'views/logic/queries/Query';
 import { Button } from 'components/bootstrap';
 import timerangeToString from 'views/logic/queries/TimeRangeToString';
+import type { DateTime } from 'util/DateTime';
+import useUserDateTime from 'hooks/useUserDateTime';
 
 import TimeRangeButton from './TimeRangeButton';
 
@@ -62,16 +64,22 @@ type Props = {
   value: TimeRange,
 };
 
-const WidgetTimeRangeOverride = ({ value, onReset }: Props) => (
-  <Wrapper>
-    <TimeRangeButton disabled />
-    <TimeRangeInfo>
-      <TimeRangeString>{timerangeToString(value)}</TimeRangeString>
-      <ResetButton bsSize="xs" bsStyle="primary" onClick={onReset} data-testid="reset-global-time-range">
-        Reset Global Override
-      </ResetButton>
-    </TimeRangeInfo>
-  </Wrapper>
-);
+const WidgetTimeRangeOverride = ({ value, onReset }: Props) => {
+  const { formatTime } = useUserDateTime();
+  const localTimeWithMS = timerangeToString(value, (dateTime: DateTime) => formatTime(dateTime, 'complete'));
+  const internalTime = timerangeToString(value, (dateTime: DateTime) => formatTime(dateTime, 'internal'));
+
+  return (
+    <Wrapper>
+      <TimeRangeButton disabled />
+      <TimeRangeInfo>
+        <TimeRangeString title={internalTime}>{localTimeWithMS}</TimeRangeString>
+        <ResetButton bsSize="xs" bsStyle="primary" onClick={onReset} data-testid="reset-global-time-range">
+          Reset Global Override
+        </ResetButton>
+      </TimeRangeInfo>
+    </Wrapper>
+  );
+};
 
 export default WidgetTimeRangeOverride;

--- a/graylog2-web-interface/src/views/components/widgets/TimerangeInfo.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/TimerangeInfo.tsx
@@ -25,6 +25,7 @@ import { useStore } from 'stores/connect';
 import { SearchStore } from 'views/stores/SearchStore';
 import { GlobalOverrideStore } from 'views/stores/GlobalOverrideStore';
 import useUserDateTime from 'hooks/useUserDateTime';
+import type { DateTime } from 'util/DateTime';
 
 type Props = {
   className?: string,
@@ -47,15 +48,17 @@ const TimerangeInfo = ({ className, widget, activeQuery, widgetId }: Props) => {
   const { result, widgetMapping } = useStore(SearchStore);
   const globalOverride = useStore(GlobalOverrideStore);
 
+  const toLocalTimeWithMS = (dateTime: DateTime) => formatTime(dateTime, 'complete');
+  const toInternalTime = (dateTime: DateTime) => formatTime(dateTime, 'internal');
   const globalTimerangeString = globalOverride?.timerange
-    ? `Global Override: ${timerangeToString(globalOverride.timerange, formatTime)}` : undefined;
+    ? `Global Override: ${timerangeToString(globalOverride.timerange, toLocalTimeWithMS)}` : undefined;
 
-  const configuredTimerange = timerangeToString(widget.timerange || DEFAULT_TIMERANGE, formatTime);
+  const configuredTimerange = timerangeToString(widget.timerange || DEFAULT_TIMERANGE, toLocalTimeWithMS);
 
   const searchTypeId = widgetId ? widgetMapping?.get(widgetId)?.first() : undefined;
 
   const effectiveTimerange = (activeQuery && searchTypeId) ? getEffectiveWidgetTimerange(result, activeQuery, searchTypeId) : undefined;
-  const effectiveTimerangeString = effectiveTimerange ? timerangeToString(effectiveTimerange, formatTime) : 'Effective widget time range is currently not available.';
+  const effectiveTimerangeString = effectiveTimerange ? timerangeToString(effectiveTimerange, toInternalTime) : 'Effective widget time range is currently not available.';
 
   return (
     <Wrapper className={className}>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

With https://github.com/Graylog2/graylog2-server/pull/11994 we unified the format of most timestamps in the UI (`YYYY-MM-DD HH:mm:ss`). One unintentional change was that we no longer display milliseconds for timestamps in the message table widget.

With this PR we are reverting this change. We are also making sure we:

- we display milliseconds for the widget time range info, which will be displayed on dashboards after configuring a time range in the dashboard search bar.
![image](https://user-images.githubusercontent.com/46300478/156748775-4b5b1a79-127b-451d-b78d-038df4084834.png)

- we display the time range override in the widget edit mode in the user time zone. This time range override is also visible  after configuring a time range in the dashboard search bar.
![image](https://user-images.githubusercontent.com/46300478/156749052-7a4c6010-270a-4895-8ade-9f89a4e0e83e.png)

