### PR TITLE
Proper version of EleasticsearchException is handled in clusterHealth…

### DIFF
--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/ClusterAdapterES7.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/ClusterAdapterES7.java
@@ -266,16 +266,15 @@ public class ClusterAdapterES7 implements ClusterAdapter {
 
     private Optional<ClusterHealthResponse> clusterHealth(Collection<String> indices) {
         final String[] indicesAry = indices.toArray(new String[0]);
-        if (!indices.isEmpty() && !indicesExist(indicesAry)) {
-            return Optional.empty();
-        }
-        final ClusterHealthRequest request = new ClusterHealthRequest(indicesAry)
-                .timeout(TimeValue.timeValueSeconds(Ints.saturatedCast(requestTimeout.toSeconds())))
-                .indicesOptions(IndicesOptions.lenientExpand());
-
         try {
+            if (!indices.isEmpty() && !indicesExist(indicesAry)) {
+                return Optional.empty();
+            }
+            final ClusterHealthRequest request = new ClusterHealthRequest(indicesAry)
+                    .timeout(TimeValue.timeValueSeconds(Ints.saturatedCast(requestTimeout.toSeconds())))
+                    .indicesOptions(IndicesOptions.lenientExpand());
             return Optional.of(client.execute((c, requestOptions) -> c.cluster().health(request, requestOptions)));
-        } catch (ElasticsearchException e) {
+        } catch (org.graylog.shaded.elasticsearch7.org.elasticsearch.ElasticsearchException e) {
             if (LOG.isDebugEnabled()) {
                 LOG.error("{} ({})", e.getMessage(), Optional.ofNullable(e.getCause()).map(Throwable::getMessage).orElse("n/a"), e);
             } else {

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/ClusterAdapterES7Test.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/ClusterAdapterES7Test.java
@@ -19,12 +19,16 @@ package org.graylog.storage.elasticsearch7;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.joschi.jadconfig.util.Duration;
 import com.google.common.io.Resources;
+import org.graylog.shaded.elasticsearch7.org.elasticsearch.ElasticsearchException;
 import org.graylog.storage.elasticsearch7.cat.CatApi;
+import org.graylog2.indexer.indices.HealthStatus;
 import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -71,6 +75,13 @@ class ClusterAdapterES7Test {
         mockNodesResponse();
 
         assertThat(this.clusterAdapter.nodeIdToName("foobar")).isEmpty();
+    }
+
+    @Test
+    void returnsEmptyOptionalForHealthWhenElasticsearchExceptionThrown() {
+        when(client.execute(any())).thenThrow(new ElasticsearchException("Exception"));
+        final Optional<HealthStatus> healthStatus = clusterAdapter.health(Collections.singletonList("foo_index"));
+        assertThat(healthStatus).isEmpty();
     }
 
     private void mockNodesResponse() throws IOException {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
ClusterAdapterES7 class was not catching proper version of ElasticsearchException in its clusterHealth() method.

Relates to #10869


## Motivation and Context
ClusterAdapterES7 class was not catching proper version of ElasticsearchException in its clusterHealth() method.
indicesExist() invocation was not part of try-catch block. 
As a result, IndexerClusterResource.clusterHealth() method was not returning error with nice, "Couldn't read Elasticsearch cluster health" message. There was another side effect - Periodicals like IndexerClusterCheckerThread did not stop its doRun() method execution after health check invocation in a clean way.

## How Has This Been Tested?
Tested with ES 7.10.2 running on docker.
ES has to be stopped with "docker stop" command.
Invoke [graylog_url]/api/system/indexer/cluster/health REST call.
After the changes, you will receive the following response : {"type":"ApiError","message":"Couldn't read Elasticsearch cluster health"}
Before, it was : {"type":"ApiError","message":"An error occurred: "}


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

