### PR TITLE
Using proper time range when search has not results.

### DIFF
--- a/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/views/searchtypes/pivots/ESPivotTest.java
+++ b/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/views/searchtypes/pivots/ESPivotTest.java
@@ -376,12 +376,10 @@ public class ESPivotTest {
     }
 
     @Test
-    public void searchResultForAllMessagesIncludesPivotTimerangeForNoDocuments() throws InvalidRangeParametersException {
+    public void searchResultForAllMessagesIncludesPivotTimerangeForNoDocuments() {
         when(queryResult.getTotal()).thenReturn(0L);
-        final TimeRange pivotRange = mock(TimeRange.class);
+        final TimeRange pivotRange = AbsoluteRange.create(DateTime.parse("1970-01-01T00:00:00.000Z"), DateTime.parse("2020-01-09T15:44:25.408Z"));
         when(query.effectiveTimeRange(pivot)).thenReturn(pivotRange);
-        when(pivotRange.getFrom()).thenReturn(DateTime.parse("1970-01-01T00:00:00.000Z"));
-        when(pivotRange.getTo()).thenReturn(DateTime.parse("2020-01-09T15:44:25.408Z"));
         final SearchType.Result result = this.esPivot.doExtractResult(job, query, pivot, queryResult, aggregations, queryContext);
         final PivotResult pivotResult = (PivotResult) result;
 

--- a/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/views/searchtypes/pivots/ESPivotTest.java
+++ b/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/views/searchtypes/pivots/ESPivotTest.java
@@ -26,19 +26,9 @@ import io.searchbox.core.search.aggregation.MaxAggregation;
 import io.searchbox.core.search.aggregation.MetricAggregation;
 import io.searchbox.core.search.aggregation.MinAggregation;
 import org.assertj.core.api.AbstractCharSequenceAssert;
-import org.graylog.shaded.elasticsearch6.org.elasticsearch.index.query.QueryBuilders;
-import org.graylog.shaded.elasticsearch6.org.elasticsearch.search.aggregations.AggregationBuilders;
-import org.graylog.shaded.elasticsearch6.org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.graylog.plugins.views.search.Query;
 import org.graylog.plugins.views.search.SearchJob;
 import org.graylog.plugins.views.search.SearchType;
-import org.graylog.storage.elasticsearch6.views.ESGeneratedQueryContext;
-import org.graylog.storage.elasticsearch6.views.searchtypes.pivot.ESPivot;
-import org.graylog.storage.elasticsearch6.views.searchtypes.pivot.ESPivotBucketSpecHandler;
-import org.graylog.storage.elasticsearch6.views.searchtypes.pivot.ESPivotSeriesSpecHandler;
-import org.graylog.storage.elasticsearch6.views.searchtypes.pivot.buckets.ESTimeHandler;
-import org.graylog.storage.elasticsearch6.views.searchtypes.pivot.buckets.ESValuesHandler;
-import org.graylog.storage.elasticsearch6.views.searchtypes.pivot.series.ESCountHandler;
 import org.graylog.plugins.views.search.searchtypes.pivot.BucketSpec;
 import org.graylog.plugins.views.search.searchtypes.pivot.Pivot;
 import org.graylog.plugins.views.search.searchtypes.pivot.PivotResult;
@@ -47,9 +37,20 @@ import org.graylog.plugins.views.search.searchtypes.pivot.buckets.AutoInterval;
 import org.graylog.plugins.views.search.searchtypes.pivot.buckets.Time;
 import org.graylog.plugins.views.search.searchtypes.pivot.buckets.Values;
 import org.graylog.plugins.views.search.searchtypes.pivot.series.Count;
+import org.graylog.shaded.elasticsearch6.org.elasticsearch.index.query.QueryBuilders;
+import org.graylog.shaded.elasticsearch6.org.elasticsearch.search.aggregations.AggregationBuilders;
+import org.graylog.shaded.elasticsearch6.org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.graylog.storage.elasticsearch6.views.ESGeneratedQueryContext;
+import org.graylog.storage.elasticsearch6.views.searchtypes.pivot.ESPivot;
+import org.graylog.storage.elasticsearch6.views.searchtypes.pivot.ESPivotBucketSpecHandler;
+import org.graylog.storage.elasticsearch6.views.searchtypes.pivot.ESPivotSeriesSpecHandler;
+import org.graylog.storage.elasticsearch6.views.searchtypes.pivot.buckets.ESTimeHandler;
+import org.graylog.storage.elasticsearch6.views.searchtypes.pivot.buckets.ESValuesHandler;
+import org.graylog.storage.elasticsearch6.views.searchtypes.pivot.series.ESCountHandler;
 import org.graylog2.plugin.indexer.searches.timeranges.AbsoluteRange;
 import org.graylog2.plugin.indexer.searches.timeranges.InvalidRangeParametersException;
 import org.graylog2.plugin.indexer.searches.timeranges.RelativeRange;
+import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeUtils;
 import org.junit.After;
@@ -376,15 +377,12 @@ public class ESPivotTest {
 
     @Test
     public void searchResultForAllMessagesIncludesPivotTimerangeForNoDocuments() throws InvalidRangeParametersException {
-        DateTimeUtils.setCurrentMillisFixed(1578584665408L);
-        final long documentCount = 0;
-        when(queryResult.getTotal()).thenReturn(documentCount);
-        final MetricAggregation mockMetricAggregation = createTimestampRangeAggregations(null, null);
-        when(queryResult.getAggregations()).thenReturn(mockMetricAggregation);
-        when(query.effectiveTimeRange(pivot)).thenReturn(RelativeRange.create(0));
-
+        when(queryResult.getTotal()).thenReturn(0L);
+        final TimeRange pivotRange = mock(TimeRange.class);
+        when(query.effectiveTimeRange(pivot)).thenReturn(pivotRange);
+        when(pivotRange.getFrom()).thenReturn(DateTime.parse("1970-01-01T00:00:00.000Z"));
+        when(pivotRange.getTo()).thenReturn(DateTime.parse("2020-01-09T15:44:25.408Z"));
         final SearchType.Result result = this.esPivot.doExtractResult(job, query, pivot, queryResult, aggregations, queryContext);
-
         final PivotResult pivotResult = (PivotResult) result;
 
         assertThat(pivotResult.effectiveTimerange()).isEqualTo(AbsoluteRange.create(

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivots/ESPivotTest.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivots/ESPivotTest.java
@@ -53,6 +53,7 @@ import org.graylog.storage.elasticsearch7.views.searchtypes.pivot.series.ESCount
 import org.graylog2.plugin.indexer.searches.timeranges.AbsoluteRange;
 import org.graylog2.plugin.indexer.searches.timeranges.InvalidRangeParametersException;
 import org.graylog2.plugin.indexer.searches.timeranges.RelativeRange;
+import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeUtils;
 import org.junit.After;
@@ -384,20 +385,17 @@ public class ESPivotTest {
 
     @Test
     public void searchResultForAllMessagesIncludesPivotTimerangeForNoDocuments() throws InvalidRangeParametersException {
-        DateTimeUtils.setCurrentMillisFixed(1578584665408L);
-        final long documentCount = 0;
-        returnDocumentCount(queryResult, documentCount);
-        final Aggregations mockMetricAggregation = createTimestampRangeAggregations(0d, 0d);
-        when(queryResult.getAggregations()).thenReturn(mockMetricAggregation);
-        when(query.effectiveTimeRange(pivot)).thenReturn(RelativeRange.create(0));
-
+        returnDocumentCount(queryResult, 0);
+        final TimeRange pivotRange = mock(TimeRange.class);
+        when(query.effectiveTimeRange(pivot)).thenReturn(pivotRange);
+        when(pivotRange.getFrom()).thenReturn(DateTime.parse("1970-01-01T00:00:00.000Z"));
+        when(pivotRange.getTo()).thenReturn(DateTime.parse("2020-01-09T15:44:25.408Z"));
         final SearchType.Result result = this.esPivot.doExtractResult(job, query, pivot, queryResult, aggregations, queryContext);
-
         final PivotResult pivotResult = (PivotResult) result;
-
         assertThat(pivotResult.effectiveTimerange()).isEqualTo(AbsoluteRange.create(
                 DateTime.parse("1970-01-01T00:00:00.000Z"),
                 DateTime.parse("2020-01-09T15:44:25.408Z")
         ));
     }
+
 }

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivots/ESPivotTest.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivots/ESPivotTest.java
@@ -386,10 +386,8 @@ public class ESPivotTest {
     @Test
     public void searchResultForAllMessagesIncludesPivotTimerangeForNoDocuments() throws InvalidRangeParametersException {
         returnDocumentCount(queryResult, 0);
-        final TimeRange pivotRange = mock(TimeRange.class);
+        final TimeRange pivotRange = AbsoluteRange.create(DateTime.parse("1970-01-01T00:00:00.000Z"), DateTime.parse("2020-01-09T15:44:25.408Z"));
         when(query.effectiveTimeRange(pivot)).thenReturn(pivotRange);
-        when(pivotRange.getFrom()).thenReturn(DateTime.parse("1970-01-01T00:00:00.000Z"));
-        when(pivotRange.getTo()).thenReturn(DateTime.parse("2020-01-09T15:44:25.408Z"));
         final SearchType.Result result = this.esPivot.doExtractResult(job, query, pivot, queryResult, aggregations, queryContext);
         final PivotResult pivotResult = (PivotResult) result;
         assertThat(pivotResult.effectiveTimerange()).isEqualTo(AbsoluteRange.create(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes #12236.
After this change, we start using proper time range in the search response when search has not results.
Aggregations are not used to fetch time range in that situation, but time range from the pivot is used instead.

## Motivation and Context
It has been discovered in #12236.

When we have no results in search response, we still used to obtain time range from aggregations, namely **"timestamp-min"** and **"timestamp-max"**. Those aggregations behaved differently in different versions of ES. The most problematic approach was visible in ES7, when they contained +/- Infinity, resulting in extremely strange time range used:

> from: "292278994-08-17T07:12:55.807Z"
> to: "-292275055-05-16T16:47:04.192Z"

In ES6 everything seemed to work, but I changed the code there to have the same approach used in both places.

## How Has This Been Tested?
1. Go to search.
2. Create a search that will return no results, either by using proper input time range, stream or query text itself.
3. The time range in Message Count widget should match the one from the input, even if there are not results.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

