### PR TITLE
Disable search highlighter for scroll queries (#12225) (4.2 backport)

### DIFF
--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/SearchRequestFactory.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/SearchRequestFactory.java
@@ -91,13 +91,13 @@ public class SearchRequestFactory {
 
         applySortingIfPresent(searchSourceBuilder, searchCommand);
 
-        applyHighlighting(searchSourceBuilder);
+        applyHighlighting(searchSourceBuilder, searchCommand);
 
         return searchSourceBuilder;
     }
 
-    private void applyHighlighting(SearchSourceBuilder searchSourceBuilder) {
-        if (allowHighlighting) {
+    private void applyHighlighting(SearchSourceBuilder searchSourceBuilder, SearchCommand searchCommand) {
+        if (allowHighlighting && searchCommand.highlight()) {
             final HighlightBuilder highlightBuilder = new HighlightBuilder()
                     .requireFieldMatch(false)
                     .field("*")

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/SearchRequestFactoryTest.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/SearchRequestFactoryTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.graylog2.utilities.AssertJsonPath.assertJsonPath;
 
 class SearchRequestFactoryTest {
@@ -51,5 +52,18 @@ class SearchRequestFactoryTest {
             request.jsonPathAsListOf("$.query.bool.filter..range.timestamp.to", String.class)
                     .containsExactly("2020-07-23 11:08:32.243");
         });
+    }
+
+    @Test
+    void scrollSearchDoesNotHighlgiht() {
+        final SearchSourceBuilder search = this.searchRequestFactory.create(ScrollCommand.builder()
+                .indices(Collections.singleton("graylog_0"))
+                .range(AbsoluteRange.create(
+                        DateTime.parse("2020-07-23T11:03:32.243Z"),
+                        DateTime.parse("2020-07-23T11:08:32.243Z")
+                ))
+                .build());
+
+        assertThat(search.toString()).doesNotContain("\"highlight\":");
     }
 }


### PR DESCRIPTION
Our use cases for scroll queries are:
 - Archinving
 - Alerting
 - CSV log export

Unconditionally activating highlighting makes no sense,
is more expensive and might also cause errors on big documents,
if they exceed `index.highlight.max_analyzed_offset`

(cherry picked from commit 3bb5207c60bfdd8c0f31886eb499d6a6dddd9a48)
