### PR TITLE
Fix for "add to query" and time format

### DIFF
--- a/graylog2-web-interface/src/views/logic/valueactions/AddToQueryHandler.ts
+++ b/graylog2-web-interface/src/views/logic/valueactions/AddToQueryHandler.ts
@@ -26,7 +26,7 @@ export default class AddToQueryHandler extends QueryManipulationHandler {
   formatTimestampForES = (value: string) => {
     const utc = moment(value).tz('UTC');
 
-    return `"${utc.format('YYYY-MM-DD hh:mm:ss.SSS')}"`;
+    return `"${utc.format('YYYY-MM-DDThh:mm:ss.SSS[Z]')}"`;
   };
 
   formatNewQuery = (oldQuery: string, field: string, value: string, type: FieldType) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

fixes #11429

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When you add a timestamp (see issue #11429) via the context menu, the string is not formatted to correctly to UTC. This PR fixes the issue

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

