### PR TITLE
Fix a problem with a random rotation strategy order

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchConfiguration.java
@@ -17,21 +17,21 @@
 package org.graylog2.configuration;
 
 import com.github.joschi.jadconfig.Parameter;
-import com.github.joschi.jadconfig.converters.StringSetConverter;
+import com.github.joschi.jadconfig.converters.StringListConverter;
 import com.github.joschi.jadconfig.util.Duration;
 import com.github.joschi.jadconfig.validators.PositiveDurationValidator;
 import com.github.joschi.jadconfig.validators.PositiveIntegerValidator;
 import com.github.joschi.jadconfig.validators.PositiveLongValidator;
 import com.github.joschi.jadconfig.validators.StringNotBlankValidator;
-import com.google.common.collect.Sets;
 import org.graylog2.configuration.validators.RotationStrategyValidator;
 import org.graylog2.indexer.rotation.strategies.MessageCountRotationStrategy;
 import org.graylog2.indexer.rotation.strategies.SizeBasedRotationStrategy;
 import org.graylog2.indexer.rotation.strategies.TimeBasedRotationStrategy;
 import org.joda.time.Period;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Locale;
-import java.util.Set;
 
 public class ElasticsearchConfiguration {
     public static final String DEFAULT_EVENTS_INDEX_PREFIX = "default_events_index_prefix";
@@ -86,9 +86,8 @@ public class ElasticsearchConfiguration {
     @Parameter(value = "retention_strategy", required = true)
     private String retentionStrategy = "delete";
 
-    @Parameter(value = "enabled_index_rotation_strategies", converter = StringSetConverter.class, validators = RotationStrategyValidator.class)
-    private Set<String> enabledRotationStrategies = Sets.newHashSet(
-            MessageCountRotationStrategy.NAME, SizeBasedRotationStrategy.NAME, TimeBasedRotationStrategy.NAME);
+    @Parameter(value = "enabled_index_rotation_strategies", converter = StringListConverter.class, validators = RotationStrategyValidator.class)
+    private List<String> enabledRotationStrategies = Arrays.asList(TimeBasedRotationStrategy.NAME, MessageCountRotationStrategy.NAME, SizeBasedRotationStrategy.NAME);
 
     @Deprecated // Should be removed in Graylog 3.0
     @Parameter(value = "rotation_strategy")
@@ -170,7 +169,7 @@ public class ElasticsearchConfiguration {
         return templateName;
     }
 
-    public Set<String> getEnabledRotationStrategies() {
+    public List<String> getEnabledRotationStrategies() {
         return enabledRotationStrategies;
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/configuration/validators/RotationStrategyValidator.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/validators/RotationStrategyValidator.java
@@ -23,10 +23,11 @@ import org.graylog2.indexer.rotation.strategies.MessageCountRotationStrategy;
 import org.graylog2.indexer.rotation.strategies.SizeBasedRotationStrategy;
 import org.graylog2.indexer.rotation.strategies.TimeBasedRotationStrategy;
 
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-public class RotationStrategyValidator implements Validator<Set<String>> {
+public class RotationStrategyValidator implements Validator<List<String>> {
     Set<String> VALID_STRATEGIES = Sets.newHashSet(
             MessageCountRotationStrategy.NAME, SizeBasedRotationStrategy.NAME, TimeBasedRotationStrategy.NAME);
 
@@ -34,7 +35,7 @@ public class RotationStrategyValidator implements Validator<Set<String>> {
     // The set of valid rotation strategies must
     // - contain only names of supported strategies
     // - not be empty
-    public void validate(String parameter, Set<String> value) throws ValidationException {
+    public void validate(String parameter, List<String> value) throws ValidationException {
         if (value == null || value.isEmpty()) {
             throw new ValidationException("Parameter " + parameter + " should be non-empty list");
         }
@@ -43,6 +44,10 @@ public class RotationStrategyValidator implements Validator<Set<String>> {
                 .filter(s -> !VALID_STRATEGIES.contains(s))
                 .collect(Collectors.toSet()).isEmpty()) {
             throw new ValidationException("Parameter " + parameter + " contains invalid values: " + value);
+        }
+
+        if (value.stream().distinct().count() != value.size()) {
+            throw new ValidationException("Parameter " + parameter + " contains duplicate values: " + value);
         }
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/models/system/indices/RotationStrategies.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/system/indices/RotationStrategies.java
@@ -22,21 +22,22 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 import org.graylog.autovalue.WithBeanGetter;
 
-import java.util.Set;
+import java.util.List;
 
 @AutoValue
 @WithBeanGetter
 @JsonAutoDetect
 public abstract class RotationStrategies {
     @JsonProperty
-    public abstract int total();
+    public int total() {
+        return strategies().size();
+    }
 
     @JsonProperty
-    public abstract Set<RotationStrategyDescription> strategies();
+    public abstract List<RotationStrategyDescription> strategies();
 
     @JsonCreator
-    public static RotationStrategies create(@JsonProperty("total") int total,
-                                            @JsonProperty("strategies") Set<RotationStrategyDescription> strategies) {
-        return new AutoValue_RotationStrategies(total, strategies);
+    public static RotationStrategies create(@JsonProperty("strategies") List<RotationStrategyDescription> strategies) {
+        return new AutoValue_RotationStrategies(strategies);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indices/RotationStrategyResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indices/RotationStrategyResource.java
@@ -42,6 +42,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -79,7 +80,7 @@ public class RotationStrategyResource extends RestResource {
                 .stream()
                 .filter(this::isEnabledRotationStrategy)
                 .map(this::getRotationStrategyDescription)
-                .collect(Collectors.toSet());
+                .collect(Collectors.toCollection(LinkedHashSet::new));
 
         return RotationStrategies.create(strategies.size(), strategies);
     }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indices/RotationStrategyResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indices/RotationStrategyResource.java
@@ -42,9 +42,8 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import static java.util.Objects.requireNonNull;
@@ -76,13 +75,13 @@ public class RotationStrategyResource extends RestResource {
     @ApiOperation(value = "List available rotation strategies",
                   notes = "This resource returns a list of all available rotation strategies on this Graylog node.")
     public RotationStrategies list() {
-        final Set<RotationStrategyDescription> strategies = rotationStrategies.keySet()
+        final List<RotationStrategyDescription> strategies = rotationStrategies.keySet()
                 .stream()
                 .filter(this::isEnabledRotationStrategy)
                 .map(this::getRotationStrategyDescription)
-                .collect(Collectors.toCollection(LinkedHashSet::new));
+                .collect(Collectors.toList());
 
-        return RotationStrategies.create(strategies.size(), strategies);
+        return RotationStrategies.create(strategies);
     }
 
     @GET

--- a/graylog2-server/src/test/java/org/graylog2/indexer/rotation/strategies/RotationStrategyValidatorTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/rotation/strategies/RotationStrategyValidatorTest.java
@@ -21,8 +21,8 @@ import org.graylog2.configuration.validators.RotationStrategyValidator;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashSet;
 
 public class RotationStrategyValidatorTest {
     private final RotationStrategyValidator validator = new RotationStrategyValidator();
@@ -38,31 +38,38 @@ public class RotationStrategyValidatorTest {
     @Test
     void emptySet() {
         Assertions.assertThrows(ValidationException.class, () -> {
-            validator.validate(PARAM, new HashSet<>());
+            validator.validate(PARAM, new ArrayList<>());
+        });
+    }
+
+    @Test
+    void duplicates() {
+        Assertions.assertThrows(ValidationException.class, () -> {
+            validator.validate(PARAM, Arrays.asList("1", "1"));
         });
     }
 
     @Test
     void invalidStrategy() {
         Assertions.assertThrows(ValidationException.class, () -> {
-            validator.validate(PARAM, new HashSet<>(Arrays.asList("invalid-strategy")));
+            validator.validate(PARAM, Arrays.asList("invalid-strategy"));
         });
         Assertions.assertThrows(ValidationException.class, () -> {
-            validator.validate(PARAM, new HashSet<>(Arrays.asList(
+            validator.validate(PARAM, Arrays.asList(
                     TimeBasedRotationStrategy.NAME,
-                    "invalid-strategy")));
+                    "invalid-strategy"));
         });
     }
 
     @Test
     void validStrategy() throws ValidationException {
-        validator.validate(PARAM, new HashSet<>(Arrays.asList(
+        validator.validate(PARAM, Arrays.asList(
                 TimeBasedRotationStrategy.NAME
-        )));
-        validator.validate(PARAM, new HashSet<>(Arrays.asList(
+        ));
+        validator.validate(PARAM, Arrays.asList(
                 TimeBasedRotationStrategy.NAME,
                 SizeBasedRotationStrategy.NAME,
                 MessageCountRotationStrategy.NAME
-        )));
+        ));
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes #12246
Rotation strategies are returned in the same order in /system/indices/rotation/strategies endpoint.
TimeBasedRotationStrategy is the first/default one if nothing is configured in graylog.conf file.
Validator for "enabled_index_rotation_strategies" will not allow to put duplicates in this property.

## Motivation and Context
Every time the Create Index Set page was opened, the Index Rotation Configuration gets randomly selected from provided 3 options. It was caused by the fact that back-end returned the strategies in random order.

## How Has This Been Tested?
   1. Open the System -> Indices page
   2. Click on the Create Index Set button
   3. Verify which rotation strategy is selected
   4. Refresh the page and verify again what strategy is pre-selected now


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

