### PR TITLE
Create default absolute time range in date time picker based on user time zone.

### DIFF
--- a/graylog2-web-interface/src/views/components/searchbar/TimeRangeInput.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/TimeRangeInput.test.tsx
@@ -29,6 +29,8 @@ jest.mock('stores/configurations/ConfigurationsStore', () => ({
   },
 }));
 
+jest.mock('hooks/useUserDateTime');
+
 describe('TimeRangeInput', () => {
   const defaultTimeRange = { type: 'relative', range: 300 };
 

--- a/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TimeRangeDropdown.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TimeRangeDropdown.test.tsx
@@ -40,6 +40,8 @@ jest.mock('stores/tools/ToolsStore', () => ({
   testNaturalDate: jest.fn(),
 }));
 
+jest.mock('hooks/useUserDateTime');
+
 const defaultProps = {
   currentTimeRange: {
     type: 'relative',

--- a/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TimeRangeDropdown.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TimeRangeDropdown.tsx
@@ -15,7 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { useCallback, useState, useContext } from 'react';
+import { useCallback, useState } from 'react';
 import { Form, Formik } from 'formik';
 import styled, { css } from 'styled-components';
 import moment from 'moment';
@@ -31,7 +31,6 @@ import type { RelativeTimeRangeClassified } from 'views/components/searchbar/dat
 import validateTimeRange from 'views/components/TimeRangeValidation';
 import type { DateTimeFormats, DateTime } from 'util/DateTime';
 import { toDateObject } from 'util/DateTime';
-import UserDateTimeContext from 'contexts/UserDateTimeContext';
 import useUserDateTime from 'hooks/useUserDateTime';
 
 import migrateTimeRangeToNewType from './migrateTimeRangeToNewType';

--- a/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TimerangeDropdown.relativeTimeRange.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TimerangeDropdown.relativeTimeRange.test.tsx
@@ -35,6 +35,7 @@ jest.mock('views/stores/SearchConfigStore', () => ({
   ),
 }));
 
+jest.mock('hooks/useUserDateTime');
 jest.mock('stores/tools/ToolsStore', () => ({}));
 
 const defaultProps = {

--- a/graylog2-web-interface/src/views/components/widgets/Widget.aggregations.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/Widget.aggregations.test.tsx
@@ -52,6 +52,7 @@ const mockedUnixTime = 1577836800000; // 2020-01-01 00:00:00.000
 
 jest.mock('./WidgetHeader', () => 'widget-header');
 jest.mock('./WidgetColorContext', () => ({ children }) => children);
+jest.mock('hooks/useUserDateTime');
 
 const MockWidgetStoreState = Immutable.Map();
 


### PR DESCRIPTION
_Please note: This PR needs to be merged together with https://github.com/Graylog2/graylog-plugin-enterprise/pull/3283_

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Before this change the default time range in the date time picker was not based on the user time zone.
You can test this by selecting a dashboard, opening the date time picker in the search bar and selecting the "absolute" tab. Of course you need to be logged in with a user who has a configured time zone.

![image](https://user-images.githubusercontent.com/46300478/157273942-4d939641-4c62-4142-a3b4-a7731a55240f.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

/jenkins-pr-deps https://github.com/Graylog2/graylog-plugin-enterprise/pull/3283