### PR TITLE
Fixing bug which resulted in multiple search creations and executions.

### DIFF
--- a/graylog2-web-interface/src/views/hooks/BindSearchParamsFromQuery.test.ts
+++ b/graylog2-web-interface/src/views/hooks/BindSearchParamsFromQuery.test.ts
@@ -63,6 +63,12 @@ describe('BindSearchParamsFromQuery should', () => {
     expect(QueriesActions.update).not.toHaveBeenCalled();
   });
 
+  it('not update query when query is already up to date', async () => {
+    await bindSearchParamsFromQuery(defaultInput);
+
+    expect(QueriesActions.update).not.toHaveBeenCalled();
+  });
+
   it('update query string with provided query param', async () => {
     const input = {
       ...defaultInput,

--- a/graylog2-web-interface/src/views/hooks/BindSearchParamsFromQuery.test.ts
+++ b/graylog2-web-interface/src/views/hooks/BindSearchParamsFromQuery.test.ts
@@ -34,10 +34,6 @@ jest.mock('views/stores/QueriesStore', () => ({
 describe('BindSearchParamsFromQuery should', () => {
   const query = Query.builder()
     .id(MOCK_VIEW_QUERY_ID)
-    .filter(Immutable.Map({
-      type: 'or',
-      filters: Immutable.List(),
-    }))
     .build();
   const search = Search.create()
     .toBuilder()

--- a/graylog2-web-interface/src/views/hooks/BindSearchParamsFromQuery.test.ts
+++ b/graylog2-web-interface/src/views/hooks/BindSearchParamsFromQuery.test.ts
@@ -32,7 +32,13 @@ jest.mock('views/stores/QueriesStore', () => ({
 }));
 
 describe('BindSearchParamsFromQuery should', () => {
-  const query = Query.builder().id(MOCK_VIEW_QUERY_ID).build();
+  const query = Query.builder()
+    .id(MOCK_VIEW_QUERY_ID)
+    .filter(Immutable.Map({
+      type: 'or',
+      filters: Immutable.List(),
+    }))
+    .build();
   const search = Search.create()
     .toBuilder()
     .queries([query])

--- a/graylog2-web-interface/src/views/logic/NormalizeSearchURLQueryParams.test.ts
+++ b/graylog2-web-interface/src/views/logic/NormalizeSearchURLQueryParams.test.ts
@@ -19,12 +19,17 @@ import * as Immutable from 'immutable';
 import normalizeSearchURLQueryParams from './NormalizeSearchURLQueryParams';
 
 describe('NormalizeSearchURLQueryParams', () => {
+  const emptyFilter = Immutable.Map({
+    type: 'or',
+    filters: Immutable.List(),
+  });
+
   it('should normalize relative time range with only a start', async () => {
     const result = normalizeSearchURLQueryParams({ rangetype: 'relative', relative: '600' });
 
     expect(result).toEqual({
       queryString: undefined,
-      streamsFilter: null,
+      streamsFilter: emptyFilter,
       timeRange: { type: 'relative', range: 600 },
     });
   });
@@ -34,7 +39,7 @@ describe('NormalizeSearchURLQueryParams', () => {
 
     expect(result).toEqual({
       queryString: undefined,
-      streamsFilter: null,
+      streamsFilter: emptyFilter,
       timeRange: { type: 'relative', from: 600 },
     });
   });
@@ -44,7 +49,7 @@ describe('NormalizeSearchURLQueryParams', () => {
 
     expect(result).toEqual({
       queryString: undefined,
-      streamsFilter: null,
+      streamsFilter: emptyFilter,
       timeRange: { type: 'relative', from: 600, to: 300 },
     });
   });
@@ -58,7 +63,7 @@ describe('NormalizeSearchURLQueryParams', () => {
 
     expect(result).toEqual({
       queryString: undefined,
-      streamsFilter: null,
+      streamsFilter: emptyFilter,
       timeRange: { type: 'absolute', from: '2020-01-01T10:00:00.850Z', to: '2020-01-02T10:00:00.000Z' },
     });
   });
@@ -68,7 +73,7 @@ describe('NormalizeSearchURLQueryParams', () => {
 
     expect(result).toEqual({
       queryString: undefined,
-      streamsFilter: null,
+      streamsFilter: emptyFilter,
       timeRange: { type: 'keyword', keyword: 'yesterday' },
     });
   });
@@ -81,7 +86,7 @@ describe('NormalizeSearchURLQueryParams', () => {
         query_string: 'http_method:GET',
         type: 'elasticsearch',
       },
-      streamsFilter: null,
+      streamsFilter: emptyFilter,
       timeRange: undefined,
     });
   });

--- a/graylog2-web-interface/src/views/logic/NormalizeSearchURLQueryParams.test.ts
+++ b/graylog2-web-interface/src/views/logic/NormalizeSearchURLQueryParams.test.ts
@@ -19,17 +19,12 @@ import * as Immutable from 'immutable';
 import normalizeSearchURLQueryParams from './NormalizeSearchURLQueryParams';
 
 describe('NormalizeSearchURLQueryParams', () => {
-  const emptyFilter = Immutable.Map({
-    type: 'or',
-    filters: Immutable.List(),
-  });
-
   it('should normalize relative time range with only a start', async () => {
     const result = normalizeSearchURLQueryParams({ rangetype: 'relative', relative: '600' });
 
     expect(result).toEqual({
       queryString: undefined,
-      streamsFilter: emptyFilter,
+      streamsFilter: null,
       timeRange: { type: 'relative', range: 600 },
     });
   });
@@ -39,7 +34,7 @@ describe('NormalizeSearchURLQueryParams', () => {
 
     expect(result).toEqual({
       queryString: undefined,
-      streamsFilter: emptyFilter,
+      streamsFilter: null,
       timeRange: { type: 'relative', from: 600 },
     });
   });
@@ -49,7 +44,7 @@ describe('NormalizeSearchURLQueryParams', () => {
 
     expect(result).toEqual({
       queryString: undefined,
-      streamsFilter: emptyFilter,
+      streamsFilter: null,
       timeRange: { type: 'relative', from: 600, to: 300 },
     });
   });
@@ -63,7 +58,7 @@ describe('NormalizeSearchURLQueryParams', () => {
 
     expect(result).toEqual({
       queryString: undefined,
-      streamsFilter: emptyFilter,
+      streamsFilter: null,
       timeRange: { type: 'absolute', from: '2020-01-01T10:00:00.850Z', to: '2020-01-02T10:00:00.000Z' },
     });
   });
@@ -73,7 +68,7 @@ describe('NormalizeSearchURLQueryParams', () => {
 
     expect(result).toEqual({
       queryString: undefined,
-      streamsFilter: emptyFilter,
+      streamsFilter: null,
       timeRange: { type: 'keyword', keyword: 'yesterday' },
     });
   });
@@ -86,7 +81,7 @@ describe('NormalizeSearchURLQueryParams', () => {
         query_string: 'http_method:GET',
         type: 'elasticsearch',
       },
-      streamsFilter: emptyFilter,
+      streamsFilter: null,
       timeRange: undefined,
     });
   });

--- a/graylog2-web-interface/src/views/logic/queries/Query.test.ts
+++ b/graylog2-web-interface/src/views/logic/queries/Query.test.ts
@@ -16,7 +16,7 @@
  */
 import { List, Map, Set } from 'immutable';
 
-import { filtersToStreamSet } from './Query';
+import Query, { filtersToStreamSet } from './Query';
 
 describe('Query', () => {
   describe('filtersToStreamSet', () => {
@@ -67,6 +67,15 @@ describe('Query', () => {
         '5c2e07eeba33a9681ad6070a',
         '5d2d9649e117dc4df84cf83c',
       ]));
+    });
+  });
+
+  describe('equality check', () => {
+    it('does not differentiate between a filter which is `undefined` and a filter which is `null`', () => {
+      const queryWithUndefinedFilter = Query.builder().build();
+      const queryWithNullFilter = Query.builder().filter(null).build();
+
+      expect(queryWithUndefinedFilter.equals(queryWithNullFilter)).toBe(true);
     });
   });
 });

--- a/graylog2-web-interface/src/views/logic/queries/Query.ts
+++ b/graylog2-web-interface/src/views/logic/queries/Query.ts
@@ -56,7 +56,11 @@ const _streamFilters = (selectedStreams: Array<string>) => {
 };
 
 export const filtersForQuery = (streams: Array<string> | null | undefined): FilterType | null | undefined => {
-  const streamFilters = _streamFilters(streams ?? []);
+  if (!streams || streams.length === 0) {
+    return null;
+  }
+
+  const streamFilters = _streamFilters(streams);
 
   return Immutable.Map({
     type: 'or',
@@ -147,13 +151,12 @@ export default class Query {
     const { id, query, timerange, filter, searchTypes } = this._value;
 
     // eslint-disable-next-line @typescript-eslint/no-use-before-define
-    const builder = Query.builder()
+    return Query.builder()
       .id(id)
       .query(query)
       .timerange(timerange)
+      .filter(filter)
       .searchTypes(searchTypes);
-
-    return filter ? builder.filter(filter) : builder;
   }
 
   equals(other: any): boolean {

--- a/graylog2-web-interface/src/views/logic/queries/Query.ts
+++ b/graylog2-web-interface/src/views/logic/queries/Query.ts
@@ -119,6 +119,8 @@ export type TimeRange = RelativeTimeRange | AbsoluteTimeRange | KeywordTimeRange
 
 export type NoTimeRangeOverride = {};
 
+const isNullish = (o: any) => (o === null || o === undefined);
+
 export default class Query {
   private _value: InternalState;
 
@@ -151,12 +153,14 @@ export default class Query {
     const { id, query, timerange, filter, searchTypes } = this._value;
 
     // eslint-disable-next-line @typescript-eslint/no-use-before-define
-    return Query.builder()
+    const builder = Query.builder()
       .id(id)
       .query(query)
       .timerange(timerange)
       .filter(filter)
       .searchTypes(searchTypes);
+
+    return filter ? builder.filter(filter) : builder;
   }
 
   equals(other: any): boolean {
@@ -171,7 +175,7 @@ export default class Query {
     if (this.id !== other.id
       || !isDeepEqual(this.query, other.query)
       || !isDeepEqual(this.timerange, other.timerange)
-      || !isDeepEqual(this.filter, other.filter)
+      || !((isNullish(this.filter) && isNullish(other.filter)) || isDeepEqual(this.filter, other.filter))
       || !isDeepEqual(this.searchTypes, other.searchTypes)) {
       return false;
     }

--- a/graylog2-web-interface/src/views/logic/queries/Query.ts
+++ b/graylog2-web-interface/src/views/logic/queries/Query.ts
@@ -56,11 +56,7 @@ const _streamFilters = (selectedStreams: Array<string>) => {
 };
 
 export const filtersForQuery = (streams: Array<string> | null | undefined): FilterType | null | undefined => {
-  if (!streams || streams.length === 0) {
-    return null;
-  }
-
-  const streamFilters = _streamFilters(streams);
+  const streamFilters = _streamFilters(streams ?? []);
 
   return Immutable.Map({
     type: 'or',
@@ -149,6 +145,7 @@ export default class Query {
   // eslint-disable-next-line @typescript-eslint/no-use-before-define
   toBuilder(): Builder {
     const { id, query, timerange, filter, searchTypes } = this._value;
+
     // eslint-disable-next-line @typescript-eslint/no-use-before-define
     const builder = Query.builder()
       .id(id)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is fixing a bug which caused multiple search creations and executions when opening the search page and when executing a search. This affected the following requests:
- `/views/search/metadata`
- `http://localhost:8080/api/views/search`
- `/api/views/search/[search-id]/execute`

Before this change the deep equal check inside `BindSearchParamsFromQuery` always returned false, because the filter of the existing query was `null` and filter of the possible new query was `undefined`. Of course, only when no query filter has been defined.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
