### PR TITLE
Fix validation of enterprise params without license

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/errors/MissingEnterpriseLicenseException.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/errors/MissingEnterpriseLicenseException.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.views.search.errors;
+
+import com.google.common.collect.ImmutableSet;
+import org.graylog.plugins.views.search.elasticsearch.QueryParam;
+
+import java.util.Optional;
+
+public class MissingEnterpriseLicenseException extends IllegalStateException {
+
+    private ImmutableSet<QueryParam> queryParams;
+
+    public MissingEnterpriseLicenseException(final String message) {
+        super(message);
+    }
+
+    public MissingEnterpriseLicenseException(String s, ImmutableSet<QueryParam> queryParams) {
+        this(s);
+        this.queryParams = queryParams;
+    }
+    
+    public ImmutableSet<QueryParam> getQueryParams() {
+        return Optional.ofNullable(queryParams).orElse(ImmutableSet.of());
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/errors/UnboundParameterError.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/errors/UnboundParameterError.java
@@ -39,7 +39,7 @@ public class UnboundParameterError extends QueryError {
     }
 
     @JsonIgnore
-    public Set<QueryParam> allUnknownParametersNames() {
+    public Set<QueryParam> allUnknownParameters() {
         return allUnknownParameters;
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/ValidationTypeDTO.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/ValidationTypeDTO.java
@@ -28,6 +28,7 @@ public enum ValidationTypeDTO {
     QUERY_PARSING_ERROR(ValidationType.QUERY_PARSING_ERROR),
     UNKNOWN_FIELD(ValidationType.UNKNOWN_FIELD),
     INVALID_OPERATOR(ValidationType.INVALID_OPERATOR),
+    MISSING_LICENSE(ValidationType.MISSING_LICENSE),
     ;
 
     private final ValidationType internalType;

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/validation/QueryValidationServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/validation/QueryValidationServiceImpl.java
@@ -21,7 +21,9 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.lucene.queryparser.classic.ParseException;
 import org.graylog.plugins.views.search.ParameterProvider;
 import org.graylog.plugins.views.search.Query;
+import org.graylog.plugins.views.search.elasticsearch.QueryParam;
 import org.graylog.plugins.views.search.elasticsearch.QueryStringDecorators;
+import org.graylog.plugins.views.search.errors.MissingEnterpriseLicenseException;
 import org.graylog.plugins.views.search.errors.SearchException;
 import org.graylog.plugins.views.search.errors.UnboundParameterError;
 import org.graylog.plugins.views.search.rest.MappedFieldTypeDTO;
@@ -34,6 +36,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -66,6 +69,14 @@ public class QueryValidationServiceImpl implements QueryValidationService {
             decoratedQuery(req);
         } catch (SearchException searchException) {
             return ValidationResponse.error(toExplanation(searchException));
+        } catch (MissingEnterpriseLicenseException licenseException) {
+            return ValidationResponse.error(
+                    paramsToValidationErrors(
+                            licenseException.getQueryParams(),
+                            ValidationType.MISSING_LICENSE,
+                            param -> "Search parameter used without enterprise license: " + param.name()
+                    ));
+
         }
 
         try {
@@ -86,27 +97,32 @@ public class QueryValidationServiceImpl implements QueryValidationService {
     private List<ValidationMessage> toExplanation(SearchException searchException) {
         if (searchException.error() instanceof UnboundParameterError) {
             final UnboundParameterError error = (UnboundParameterError) searchException.error();
-
-            return
-                    error.allUnknownParametersNames().stream()
-                            .flatMap(param -> {
-                                final String errorMessage = "Unbound required parameter used: " + param.name();
-                                return param.positions()
-                                        .stream()
-                                        .map(
-                                                p -> ValidationMessage.builder(ValidationType.UNDECLARED_PARAMETER)
-                                                        .errorMessage(errorMessage)
-                                                        .beginLine(p.line())
-                                                        .endLine(p.line())
-                                                        .beginColumn(p.beginColumn())
-                                                        .endColumn(p.endColumn())
-                                                        .relatedProperty(param.name())
-                                                        .build()
-                                        );
-                            })
-                            .collect(Collectors.toList());
+            return paramsToValidationErrors(
+                    error.allUnknownParameters(),
+                    ValidationType.UNDECLARED_PARAMETER,
+                    param -> "Unbound required parameter used: " + param.name()
+            );
         }
         return Collections.singletonList(ValidationMessage.fromException(searchException));
+    }
+
+    private List<ValidationMessage> paramsToValidationErrors(final Set<QueryParam> params, final ValidationType errorType, final Function<QueryParam, String> messageBuilder) {
+        return params.stream()
+                .flatMap(param -> {
+                    final String errorMessage = messageBuilder.apply(param);
+                    return param.positions()
+                            .stream()
+                            .map(p -> ValidationMessage.builder(errorType)
+                                    .errorMessage(errorMessage)
+                                    .beginLine(p.line())
+                                    .endLine(p.line())
+                                    .beginColumn(p.beginColumn())
+                                    .endColumn(p.endColumn())
+                                    .relatedProperty(param.name())
+                                    .build()
+                            );
+                })
+                .collect(Collectors.toList());
     }
 
     private List<ValidationMessage> toExplanation(final ParseException parseException) {

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/validation/ValidationType.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/validation/ValidationType.java
@@ -21,4 +21,5 @@ public enum ValidationType {
     QUERY_PARSING_ERROR,
     UNKNOWN_FIELD,
     INVALID_OPERATOR,
+    MISSING_LICENSE,
 }


### PR DESCRIPTION
Adapted query validation logic to catch https://github.com/Graylog2/graylog2-server/issues/12271

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
/jenkins-pr-deps Graylog2/graylog-plugin-enterprise#3303
Fixes #12271
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/4102775/158182882-49d5c78c-f4e4-43b2-8b8d-798a7ca42121.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

