### PR TITLE
Upped Timeout for Report Generation in Integration Tests

### DIFF
--- a/graylog2-server/src/test/resources/org/graylog/testing/graylognode/Dockerfile
+++ b/graylog2-server/src/test/resources/org/graylog/testing/graylognode/Dockerfile
@@ -24,6 +24,7 @@ RUN \
   echo "export GRAYLOG_UID=${GRAYLOG_UID}"         >> /etc/profile.d/graylog.sh && \
   echo "export GRAYLOG_GID=${GRAYLOG_GID}"         >> /etc/profile.d/graylog.sh && \
   echo "export GRAYLOG_REPORT_DISABLE_SANDBOX=true" >> /etc/profile.d/graylog.sh && \
+  echo "export GRAYLOG_REPORT_GENERATION_TIMEOUT_SECONDS=600" >> /etc/profile.d/graylog.sh && \
   echo "export PATH=${GRAYLOG_HOME}/bin:${PATH}"   >> /etc/profile.d/graylog.sh && \
   apt-get update  > /dev/null && \
   apt-get install --no-install-recommends --assume-yes \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

If Jenkins is under high load, sometimes report generation takes longer than the default 180 seconds so we set a higher timeout in the Dockerfile for integration testing.

The Dockerfile is part of the regular graylog2-server, so this is an additional change with enterprise PR #3289

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

