### PR TITLE
Expose ES index UUID

### DIFF
--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/IndicesAdapterES6.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/IndicesAdapterES6.java
@@ -689,9 +689,15 @@ public class IndicesAdapterES6 implements IndicesAdapter {
 
     private String getIndexState(String index) {
         final State request = new State.Builder().indices(index).withMetadata().build();
-
         final JestResult response = JestUtils.execute(jestClient, request, () -> "Failed to get index metadata");
-
         return response.getJsonObject().path("metadata").path("indices").path(index).path("state").asText();
+    }
+
+    @Override
+    public String getIndexId(String index) {
+        final State request = new State.Builder().indices(index).withMetadata().build();
+        final JestResult response = JestUtils.execute(jestClient, request, () -> "Failed to get index metadata");
+        return response.getJsonObject().path("metadata").path("indices").path(index)
+                .path("settings").path("index").path("uuid").asText();
     }
 }

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/IndicesAdapterES7.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/IndicesAdapterES7.java
@@ -518,4 +518,13 @@ public class IndicesAdapterES7 implements IndicesAdapter {
             throw new IllegalStateException("Unable to parse invalid index state: " + state);
         }
     }
+
+    @Override
+    public String getIndexId(String index) {
+        final GetSettingsRequest request = new GetSettingsRequest().indices(index)
+                .indicesOptions(IndicesOptions.fromOptions(true, true, true, true));
+        final GetSettingsResponse response = client.execute((c, requestOptions) -> c.indices().getSettings(request, requestOptions),
+                "Unable to retrieve settings for index/alias " + index);
+        return response.getSetting(index, "index.uuid");
+    }
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
@@ -351,4 +351,11 @@ public class Indices {
     public IndexRangeStats indexRangeStatsOfIndex(String index) {
         return indicesAdapter.indexRangeStatsOfIndex(index);
     }
+
+    /**
+     * Returns ES UUID of the index; null if it does not exist
+     */
+    public String getIndexId(String indexName) {
+        return indicesAdapter.getIndexId(indexName);
+    }
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/indices/IndicesAdapter.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indices/IndicesAdapter.java
@@ -106,4 +106,6 @@ public interface IndicesAdapter {
     boolean isOpen(String index);
 
     boolean isClosed(String index);
+
+    String getIndexId(String index);
 }


### PR DESCRIPTION
ES assigns a UUID to each index. This information is useful e.g. to resolve situations where an index name is re-used. 

We expose the UUID via `Indices.getIndexId()`