### PR TITLE
Remove condition which block search button when are undeclared params

### DIFF
--- a/graylog2-web-interface/src/views/components/WithSearchStatus.tsx
+++ b/graylog2-web-interface/src/views/components/WithSearchStatus.tsx
@@ -28,7 +28,7 @@ const _disableSearch = (undeclaredParameters, parameterBindings, usedParameters)
   const bindingsMap = getParameterBindingsAsMap(parameterBindings);
   const missingValues = usedParameters.filter((param) => (param.needsBinding && !param.optional)).map((p) => bindingsMap.get(p.name)).filter((value) => !trim(value));
 
-  return undeclaredParameters.size > 0 || missingValues.size > 0;
+  return missingValues.size > 0;
 };
 
 type SearchStatusProps = {


### PR DESCRIPTION
Fixes: #12261 

## Description
In the current implementation, we block submit button when we have at least one undeclared parameter in `SearchMetadataStore`. 
```
const _disableSearch = (undeclaredParameters, parameterBindings, usedParameters) => {
  const bindingsMap = getParameterBindingsAsMap(parameterBindings);
  const missingValues = usedParameters.filter((param) => (param.needsBinding && !param.optional)).map((p) => bindingsMap.get(p.name)).filter((value) => !trim(value));

  return undeclaredParameters.size > 0 || missingValues.size > 0;
};
....
  {
    searchMetadata: SearchMetadataStore,
    executionState: SearchExecutionStateStore,
    configurations: SearchConfigStore,
  },
  ({ searchMetadata, executionState, configurations }) => ({
    isDisabled: _disableSearch(searchMetadata.undeclared, executionState.parameterBindings, searchMetadata.used),
    config: configurations.searchesClusterConfig,
  }),
....
```

When the user removes the parameter from the search input we don't update the `SearchMetadataStore`. That is why the condition `undeclaredParameters.size > 0` would be always `true` and the search button will be disabled. In other words, since we got one undeclared parameter in the metadata - the search button will be always blocked.
I decided to remove condition `undeclaredParameters.size > 0` from the  code. In this case, the user will be able to click the search button, after removing the undeclared param from the input and update the search. That wouldn't be a problem for our logic, because form validation handles the case of using undeclared param in the search input. 



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

/jenkins-pr-deps https://github.com/Graylog2/graylog-plugin-enterprise/pull/3321