### PR TITLE
Add support for checking resolved view permissions

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/ViewResolver.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/ViewResolver.java
@@ -21,10 +21,21 @@ import java.util.Set;
 
 /**
  * View Resolvers provide a way that plugins can provide custom sources for looking up views.
+ *
+ * Each resolvable view must also have a corresponding {@link org.graylog.plugins.views.search.Search} saved in the
+ * database. The ViewResolver methods pertaining to search records must be implemented in order for runtime
+ * operation of views to work correctly.
+ *
+ * See https://github.com/Graylog2/graylog2-server/pull/12280 and
+ * https://github.com/Graylog2/graylog2-server/pull/12287 for more information.
  */
 public interface ViewResolver {
     Optional<ViewDTO> get(String id);
 
+    /**
+     * @param searchId A search id.
+     * @return the corresponding {@link ViewDTO} for supplied searchId.
+     */
     Set<ViewDTO> getBySearchId(String searchId);
 
     /**

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/ViewResolver.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/ViewResolver.java
@@ -25,6 +25,8 @@ import java.util.Set;
 public interface ViewResolver {
     Optional<ViewDTO> get(String id);
 
+    Set<ViewDTO> getBySearchId(String searchId);
+
     /**
      * @return A set of all search ids referenced by resolvable views.
      * The search ids must be returned to prevent the searches from being automatically deleted by periodically by

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/ViewService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/ViewService.java
@@ -205,7 +205,7 @@ public class ViewService extends PaginatedDbService<ViewDTO> {
         return viewWithRequirements;
     }
 
-    private ViewDTO requirementsForView(ViewDTO view) {
+    public ViewDTO requirementsForView(ViewDTO view) {
         return viewRequirementsFactory.create(view)
                 .rebuildRequirements(ViewDTO::requires, (v, newRequirements) -> v.toBuilder().requires(newRequirements).build());
     }

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/SearchDomainTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/SearchDomainTest.java
@@ -21,6 +21,7 @@ import org.graylog.plugins.views.search.db.SearchDbService;
 import org.graylog.plugins.views.search.errors.PermissionException;
 import org.graylog.plugins.views.search.permissions.SearchUser;
 import org.graylog.plugins.views.search.views.ViewDTO;
+import org.graylog.plugins.views.search.views.ViewResolver;
 import org.graylog.plugins.views.search.views.ViewService;
 import org.junit.Before;
 import org.junit.Rule;
@@ -32,8 +33,11 @@ import org.mockito.junit.MockitoRule;
 
 import javax.ws.rs.ForbiddenException;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -68,7 +72,7 @@ public class SearchDomainTest {
     public void setUp() throws Exception {
         allSearchesInDb.clear();
         when(dbService.streamAll()).thenReturn(allSearchesInDb.stream());
-        sut = new SearchDomain(dbService, executionGuard, viewService);
+        sut = new SearchDomain(dbService, executionGuard, viewService, new HashMap<>());
     }
 
     @Test
@@ -149,6 +153,23 @@ public class SearchDomainTest {
     }
 
     @Test
+    public void includesSearchesPermittedViaResolvedView() {
+        Search permittedSearch = Search.builder().id(UUID.randomUUID().toString()).owner("someone else").build();
+        allSearchesInDb.add(permittedSearch);
+        when(dbService.get(permittedSearch.id())).thenReturn(Optional.of(permittedSearch));
+        final SearchUser searchUser = mock(SearchUser.class);
+        final ViewDTO viewDTO = mock(ViewDTO.class);
+        when(searchUser.canReadView(viewDTO)).thenReturn(true);
+
+        // Prepare test ViewResolver that returns a view that should be permitted.
+        final SearchDomain searchDomain = new SearchDomain(dbService, executionGuard, viewService,
+                testViewResolvers(viewDTO));
+
+        List<Search> result = searchDomain.getAllForUser(searchUser, searchUser::canReadView);
+        assertThat(result).containsExactly(permittedSearch);
+    }
+
+    @Test
     public void listIsEmptyIfNoSearchesPermitted() {
         mockSearchWithOwner("someone else");
         mockSearchWithOwner("someone else");
@@ -196,5 +217,35 @@ public class SearchDomainTest {
         allSearchesInDb.add(search);
         when(dbService.get(search.id())).thenReturn(Optional.of(search));
         return search;
+    }
+
+    private HashMap<String, ViewResolver> testViewResolvers(ViewDTO viewDTO) {
+        final HashMap<String, ViewResolver> viewResolvers = new HashMap<>();
+        viewResolvers.put("test-resolver", new TestViewResolver(viewDTO));
+        return viewResolvers;
+    }
+
+    private static class TestViewResolver implements ViewResolver {
+
+        private final ViewDTO viewDTO;
+
+        public TestViewResolver(ViewDTO viewDTO) {
+            this.viewDTO = viewDTO;
+        }
+
+        @Override
+        public Optional<ViewDTO> get(String id) {
+            return Optional.empty();
+        }
+
+        @Override
+        public Set<String> getSearchIds() {
+            return Collections.emptySet();
+        }
+
+        @Override
+        public Set<ViewDTO> getBySearchId(String searchId) {
+            return Collections.singleton(viewDTO);
+        }
     }
 }

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/db/SearchesCleanUpJobTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/db/SearchesCleanUpJobTest.java
@@ -204,5 +204,10 @@ public class SearchesCleanUpJobTest {
         public Set<String> getSearchIds() {
             return Collections.singleton(IN_USE_RESOLVER_SEARCH_ID);
         }
+
+        @Override
+        public Set<ViewDTO> getBySearchId(String searchId) {
+            return Collections.emptySet();
+        }
     }
 }

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/ViewsResourceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/ViewsResourceTest.java
@@ -225,6 +225,10 @@ public class ViewsResourceTest {
         public Set<String> getSearchIds() {
             return null;
         }
-    }
 
+        @Override
+        public Set<ViewDTO> getBySearchId(String searchId) {
+            return Collections.emptySet();
+        }
+    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The `SearchDomain hasReadPermissionFor()` method is responsible for verifying that the current user is authorized to view the search record for the provided `ViewDTO`. Support for external view resolvers was added in https://github.com/Graylog2/graylog2-server/pull/12089. However, when implemented, support for authorizing search access for resolved views was not added, so resolved views were not accessible for non-admin users.

This PR adjusts the `SearchDomain hasReadPermissionFor()` logic to also query search records for resolved views, which subsequently allows permissions checks to be completed for them. 

/jenkins-pr-deps https://github.com/Graylog2/graylog-plugin-enterprise/pull/3315

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This is needed to fix a bug for Graylog Security. See https://github.com/Graylog2/graylog-plugin-enterprise/pull/3315.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

