### PR TITLE
Better validation error for empty lookup param

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/errors/EmptyParameterError.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/errors/EmptyParameterError.java
@@ -22,14 +22,14 @@ import org.graylog.plugins.views.search.elasticsearch.QueryParam;
 import javax.annotation.Nonnull;
 
 public class EmptyParameterError extends QueryError {
-    private final QueryParam param;
+    private final QueryParam parameterUsage;
 
-    public EmptyParameterError(@Nonnull Query query, String description, QueryParam param) {
+    public EmptyParameterError(@Nonnull Query query, String description, QueryParam parameterUsage) {
         super(query, description);
-        this.param = param;
+        this.parameterUsage = parameterUsage;
     }
 
-    public QueryParam getParam() {
-        return param;
+    public QueryParam getParameterUsage() {
+        return parameterUsage;
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/errors/EmptyParameterError.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/errors/EmptyParameterError.java
@@ -17,11 +17,19 @@
 package org.graylog.plugins.views.search.errors;
 
 import org.graylog.plugins.views.search.Query;
+import org.graylog.plugins.views.search.elasticsearch.QueryParam;
 
 import javax.annotation.Nonnull;
 
 public class EmptyParameterError extends QueryError {
-    public EmptyParameterError(@Nonnull Query query, String description) {
+    private final QueryParam param;
+
+    public EmptyParameterError(@Nonnull Query query, String description, QueryParam param) {
         super(query, description);
+        this.param = param;
+    }
+
+    public QueryParam getParam() {
+        return param;
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/ValidationTypeDTO.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/ValidationTypeDTO.java
@@ -25,6 +25,7 @@ import java.util.Locale;
 public enum ValidationTypeDTO {
 
     UNDECLARED_PARAMETER(ValidationType.UNDECLARED_PARAMETER),
+    EMPTY_PARAMETER(ValidationType.EMPTY_PARAMETER),
     QUERY_PARSING_ERROR(ValidationType.QUERY_PARSING_ERROR),
     UNKNOWN_FIELD(ValidationType.UNKNOWN_FIELD),
     INVALID_OPERATOR(ValidationType.INVALID_OPERATOR),

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/validation/QueryValidationServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/validation/QueryValidationServiceImpl.java
@@ -23,6 +23,7 @@ import org.graylog.plugins.views.search.ParameterProvider;
 import org.graylog.plugins.views.search.Query;
 import org.graylog.plugins.views.search.elasticsearch.QueryParam;
 import org.graylog.plugins.views.search.elasticsearch.QueryStringDecorators;
+import org.graylog.plugins.views.search.errors.EmptyParameterError;
 import org.graylog.plugins.views.search.errors.MissingEnterpriseLicenseException;
 import org.graylog.plugins.views.search.errors.SearchException;
 import org.graylog.plugins.views.search.errors.UnboundParameterError;
@@ -102,6 +103,12 @@ public class QueryValidationServiceImpl implements QueryValidationService {
                     ValidationType.UNDECLARED_PARAMETER,
                     param -> "Unbound required parameter used: " + param.name()
             );
+        } else if (searchException.error() instanceof EmptyParameterError) {
+            final EmptyParameterError error = (EmptyParameterError) searchException.error();
+            return paramsToValidationErrors(
+                    Collections.singleton(error.getParam()),
+                    ValidationType.EMPTY_PARAMETER,
+                    param -> error.description());
         }
         return Collections.singletonList(ValidationMessage.fromException(searchException));
     }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/validation/QueryValidationServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/validation/QueryValidationServiceImpl.java
@@ -69,7 +69,7 @@ public class QueryValidationServiceImpl implements QueryValidationService {
             // but we want to trigger the decorators as well, because they may trigger additional exceptions
             decoratedQuery(req);
         } catch (SearchException searchException) {
-            return ValidationResponse.error(toExplanation(searchException));
+            return convert(searchException);
         } catch (MissingEnterpriseLicenseException licenseException) {
             return ValidationResponse.error(
                     paramsToValidationErrors(
@@ -77,7 +77,6 @@ public class QueryValidationServiceImpl implements QueryValidationService {
                             ValidationType.MISSING_LICENSE,
                             param -> "Search parameter used without enterprise license: " + param.name()
                     ));
-
         }
 
         try {
@@ -95,22 +94,22 @@ public class QueryValidationServiceImpl implements QueryValidationService {
         }
     }
 
-    private List<ValidationMessage> toExplanation(SearchException searchException) {
+    private ValidationResponse convert(SearchException searchException) {
         if (searchException.error() instanceof UnboundParameterError) {
             final UnboundParameterError error = (UnboundParameterError) searchException.error();
-            return paramsToValidationErrors(
+            return ValidationResponse.error(paramsToValidationErrors(
                     error.allUnknownParameters(),
                     ValidationType.UNDECLARED_PARAMETER,
                     param -> "Unbound required parameter used: " + param.name()
-            );
+            ));
         } else if (searchException.error() instanceof EmptyParameterError) {
             final EmptyParameterError error = (EmptyParameterError) searchException.error();
-            return paramsToValidationErrors(
-                    Collections.singleton(error.getParam()),
+            return ValidationResponse.warning(paramsToValidationErrors(
+                    Collections.singleton(error.getParameterUsage()),
                     ValidationType.EMPTY_PARAMETER,
-                    param -> error.description());
+                    param -> error.description()));
         }
-        return Collections.singletonList(ValidationMessage.fromException(searchException));
+        return ValidationResponse.error(Collections.singletonList(ValidationMessage.fromException(searchException)));
     }
 
     private List<ValidationMessage> paramsToValidationErrors(final Set<QueryParam> params, final ValidationType errorType, final Function<QueryParam, String> messageBuilder) {

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/validation/ValidationType.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/validation/ValidationType.java
@@ -18,6 +18,7 @@ package org.graylog.plugins.views.search.validation;
 
 public enum ValidationType {
     UNDECLARED_PARAMETER,
+    EMPTY_PARAMETER,
     QUERY_PARSING_ERROR,
     UNKNOWN_FIELD,
     INVALID_OPERATOR,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR does two things, both related to the validation of enterprise params:

* Handling of empty lookup params with correct type and query positions highlighted
* Change validation errors of empty params to WARNING instead of ERROR


## Motivation and Context
/jenkins-pr-deps Graylog2/graylog-plugin-enterprise#3316
Fixes https://github.com/Graylog2/graylog-plugin-enterprise/issues/3297 (makes the problem more obvious and provides better error messages)

## How Has This Been Tested?
Added integration test (see the related PR in the enterprise repo)


## Screenshots (if appropriate):
![Peek 2022-03-16 07-54](https://user-images.githubusercontent.com/4102775/158547847-dc36c936-40f2-4aab-8a95-54fb71ffe71e.gif)
(:point_up: old screenshot, now it will be only yellow warning, not red error)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

