### PR TITLE
Notification is presented if any active writing index is blocked.

### DIFF
--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/IndicesAdapterES6.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/IndicesAdapterES6.java
@@ -68,6 +68,7 @@ import org.graylog.shaded.elasticsearch6.org.elasticsearch.search.aggregations.b
 import org.graylog.shaded.elasticsearch6.org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.graylog.shaded.elasticsearch6.org.elasticsearch.search.sort.FieldSortBuilder;
 import org.graylog.shaded.elasticsearch6.org.elasticsearch.search.sort.SortBuilders;
+import org.graylog.storage.elasticsearch6.blocks.JestBlockSettingsParser;
 import org.graylog.storage.elasticsearch6.indices.GetSingleAlias;
 import org.graylog.storage.elasticsearch6.jest.JestUtils;
 import org.graylog2.indexer.ElasticsearchException;
@@ -78,6 +79,7 @@ import org.graylog2.indexer.indices.IndexMoveResult;
 import org.graylog2.indexer.indices.IndexSettings;
 import org.graylog2.indexer.indices.Indices;
 import org.graylog2.indexer.indices.IndicesAdapter;
+import org.graylog2.indexer.indices.blocks.IndicesBlockStatus;
 import org.graylog2.indexer.indices.stats.IndexStatistics;
 import org.graylog2.indexer.searches.IndexRangeStats;
 import org.graylog2.jackson.TypeReferences;
@@ -569,6 +571,16 @@ public class IndicesAdapterES6 implements IndicesAdapter {
         final JestResult jestResult = JestUtils.execute(jestClient, request, () -> "Couldn't check stats of indices " + indices);
 
         return jestResult.getJsonObject().path("indices");
+    }
+
+    @Override
+    public IndicesBlockStatus getIndicesBlocksStatus(final List<String> indices) {
+        final GetSettings request = new GetSettings.Builder()
+                .addIndex(indices)
+                .build();
+        final JestResult jestResult = JestUtils.execute(jestClient, request, () -> "Couldn't check settings of indices " + indices);
+        final JestBlockSettingsParser blockSettingsParser = new JestBlockSettingsParser();
+        return blockSettingsParser.parseBlockSettings(jestResult, indices);
     }
 
     @Override

--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/blocks/JestBlockSettingsParser.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/blocks/JestBlockSettingsParser.java
@@ -1,0 +1,43 @@
+package org.graylog.storage.elasticsearch6.blocks;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.searchbox.client.JestResult;
+import org.graylog2.indexer.indices.blocks.IndicesBlockStatus;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+
+public class JestBlockSettingsParser {
+
+    static final Collection<String> POSSIBLE_BLOCKS = Arrays.asList("read_only", "read_only_allow_delete", "read", "write", "metadata");
+    static final String BLOCK_SETTINGS_PREFIX = "index.blocks.";
+
+    public IndicesBlockStatus parseBlockSettings(final JestResult jestResult, final List<String> indices) {
+        final IndicesBlockStatus indicesBlockStatus = new IndicesBlockStatus();
+        if (indices == null || indices.isEmpty() || jestResult == null) {
+            return indicesBlockStatus;
+        }
+        final JsonNode jsonObject = jestResult.getJsonObject();
+        if (jsonObject != null && !jsonObject.isMissingNode()) {
+            for (String indexName : indices) {
+                Collection<String> blocks = new LinkedList<>();
+                for (String possibleBlock : POSSIBLE_BLOCKS) {
+                    final JsonNode blockElem = jsonObject.path(indexName).path("settings").path("index").path("blocks").path(possibleBlock);
+                    if (!blockElem.isMissingNode()) {
+                        if ((blockElem.isBoolean() && blockElem.asBoolean()) ||
+                                (blockElem.isTextual() && blockElem.asText().contains("true"))
+                        ) {
+                            blocks.add(BLOCK_SETTINGS_PREFIX + possibleBlock);
+                        }
+                    }
+                }
+                if (!blocks.isEmpty()) {
+                    indicesBlockStatus.addIndexBlocks(indexName, blocks);
+                }
+            }
+        }
+        return indicesBlockStatus;
+    }
+}

--- a/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/blocks/JestBlockSettingsParserTest.java
+++ b/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/blocks/JestBlockSettingsParserTest.java
@@ -1,0 +1,139 @@
+package org.graylog.storage.elasticsearch6.blocks;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.searchbox.client.JestResult;
+import org.graylog2.indexer.indices.blocks.IndicesBlockStatus;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class JestBlockSettingsParserTest {
+
+    private JestBlockSettingsParser toTest;
+    private JestResult jestResult;
+    private ObjectMapper mapper = new ObjectMapper();
+
+    @Before
+    public void setUp() {
+        toTest = new JestBlockSettingsParser();
+        jestResult = mock(JestResult.class);
+    }
+
+    @Test
+    public void noBlockedIndicesIdentifiedIfEmptyResponseParsed() throws Exception {
+        when(jestResult.getJsonObject()).thenReturn(mapper.readTree("{}"));
+        final IndicesBlockStatus indicesBlockStatus = toTest.parseBlockSettings(jestResult, Collections.singletonList("graylog_0"));
+        assertNotNull(indicesBlockStatus);
+        assertEquals(0, indicesBlockStatus.countBlockedIndices());
+    }
+
+    @Test
+    public void noBlockedIndicesIdentifiedIfEmptyListOfIndicesProvided() {
+        final IndicesBlockStatus indicesBlockStatus = toTest.parseBlockSettings(jestResult, Collections.emptyList());
+        assertNotNull(indicesBlockStatus);
+        assertEquals(0, indicesBlockStatus.countBlockedIndices());
+    }
+
+    @Test
+    public void noBlockedIndicesIdentifiedIfNullListOfIndicesProvided() {
+        final IndicesBlockStatus indicesBlockStatus = toTest.parseBlockSettings(jestResult, null);
+        assertNotNull(indicesBlockStatus);
+        assertEquals(0, indicesBlockStatus.countBlockedIndices());
+    }
+
+    @Test
+    public void noBlockedIndicesIdentifiedIfFalseBlockPresent() throws Exception {
+        String json = "{\n" +
+                "  \"graylog_0\": {\n" +
+                "    \"settings\": {\n" +
+                "      \"index\": {\n" +
+                "        \"blocks\": {\n" +
+                "          \"read_only\": \"false\"\n" +
+                "        }\n" +
+                "      }\n" +
+                "    }\n" +
+                "  }  \n" +
+                "}";
+        when(jestResult.getJsonObject()).thenReturn(mapper.readTree(json));
+        final IndicesBlockStatus indicesBlockStatus = toTest.parseBlockSettings(jestResult, Collections.singletonList("graylog_0"));
+        assertNotNull(indicesBlockStatus);
+        assertEquals(0, indicesBlockStatus.countBlockedIndices());
+    }
+
+    @Test
+    public void blockedIndicesIdentifiedIfFalseBlockPresent() throws Exception {
+        String json = "{\n" +
+                "  \"graylog_0\": {\n" +
+                "    \"settings\": {\n" +
+                "      \"index\": {\n" +
+                "        \"blocks\": {\n" +
+                "          \"read_only\": \"true\"\n" +
+                "        }\n" +
+                "      }\n" +
+                "    }\n" +
+                "  }  \n" +
+                "}";
+        when(jestResult.getJsonObject()).thenReturn(mapper.readTree(json));
+        final IndicesBlockStatus indicesBlockStatus = toTest.parseBlockSettings(jestResult, Collections.singletonList("graylog_0"));
+        assertNotNull(indicesBlockStatus);
+        final Set<String> blockedIndices = indicesBlockStatus.getBlockedIndices();
+        assertEquals(1, indicesBlockStatus.countBlockedIndices());
+        assertTrue(blockedIndices.contains("graylog_0"));
+        Collection<String> indexBlocks = indicesBlockStatus.getIndexBlocks("graylog_0");
+        assertEquals(1, indexBlocks.size());
+        assertTrue(indexBlocks.contains("index.blocks.read_only"));
+    }
+
+    @Test
+    public void blockedIndicesIdentifiedAmongUnblockedOnes() throws Exception {
+        String json = "{\n" +
+                "  \"graylog_0\": {\n" +
+                "    \"settings\": {\n" +
+                "      \"index\": {\n" +
+                "        \"blocks\": {\n" +
+                "          \"read_only\": \"true\"\n" +
+                "        }\n" +
+                "      }\n" +
+                "    }\n" +
+                "  },  \n" +
+                "  \"unblocked1\": {\n" +
+                "    \"settings\": {\n" +
+                "      \"index\": {\n" +
+                "        \"blocks\": {\n" +
+                "          \"read_only\": \"false\"\n" +
+                "        }\n" +
+                "      }\n" +
+                "    }\n" +
+                "  },  \n" +
+                "  \"unblocked2\": {\n" +
+                "    \"settings\": {\n" +
+                "      \"index\": {\n" +
+                "        \"blocks\": {\n" +
+                "          \"read_only\": false\n" +
+                "        }\n" +
+                "      }\n" +
+                "    }\n" +
+                "  }  \n" +
+
+                "}";
+        when(jestResult.getJsonObject()).thenReturn(mapper.readTree(json));
+        final IndicesBlockStatus indicesBlockStatus = toTest.parseBlockSettings(jestResult, Arrays.asList("graylog_0", "unblocked1", "unblocked2"));
+        assertNotNull(indicesBlockStatus);
+        final Set<String> blockedIndices = indicesBlockStatus.getBlockedIndices();
+        assertEquals(1, indicesBlockStatus.countBlockedIndices());
+        assertTrue(blockedIndices.contains("graylog_0"));
+        Collection<String> indexBlocks = indicesBlockStatus.getIndexBlocks("graylog_0");
+        assertEquals(1, indexBlocks.size());
+        assertTrue(indexBlocks.contains("index.blocks.read_only"));
+    }
+}

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/IndicesAdapterES7.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/IndicesAdapterES7.java
@@ -361,7 +361,7 @@ public class IndicesAdapterES7 implements IndicesAdapter {
 
         return client.execute((c, requestOptions) -> {
             final GetSettingsResponse settingsResponse = c.indices().getSettings(getSettingsRequest, requestOptions);
-            final BlockSettingsParser blockSettingsParser = new BlockSettingsParser(); //TODO: make it a bean?
+            final BlockSettingsParser blockSettingsParser = new BlockSettingsParser();
             return blockSettingsParser.parseBlockSettings(settingsResponse);
         });
     }

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/IndicesAdapterES7.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/IndicesAdapterES7.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.github.joschi.jadconfig.util.Duration;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import org.apache.logging.log4j.util.Strings;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequest;
@@ -57,6 +58,7 @@ import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.b
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.metrics.Max;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.metrics.Min;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.graylog.storage.elasticsearch7.blocks.BlockSettingsParser;
 import org.graylog.storage.elasticsearch7.cat.CatApi;
 import org.graylog.storage.elasticsearch7.cluster.ClusterStateApi;
 import org.graylog.storage.elasticsearch7.stats.StatsApi;
@@ -66,6 +68,7 @@ import org.graylog2.indexer.indices.IndexMoveResult;
 import org.graylog2.indexer.indices.IndexSettings;
 import org.graylog2.indexer.indices.Indices;
 import org.graylog2.indexer.indices.IndicesAdapter;
+import org.graylog2.indexer.indices.blocks.IndicesBlockStatus;
 import org.graylog2.indexer.indices.stats.IndexStatistics;
 import org.graylog2.indexer.searches.IndexRangeStats;
 import org.graylog2.plugin.Message;
@@ -347,6 +350,20 @@ public class IndicesAdapterES7 implements IndicesAdapter {
     @Override
     public JsonNode getIndexStats(Collection<String> indices) {
         return statsApi.indexStatsWithDocsAndStore(indices);
+    }
+
+    @Override
+    public IndicesBlockStatus getIndicesBlocksStatus(final List<String> indices) {
+        final GetSettingsRequest getSettingsRequest = new GetSettingsRequest()
+                .indices(indices.toArray(new String[]{}))
+                .indicesOptions(IndicesOptions.fromOptions(false, true, true, true))
+                .names(Strings.EMPTY_ARRAY);
+
+        return client.execute((c, requestOptions) -> {
+            final GetSettingsResponse settingsResponse = c.indices().getSettings(getSettingsRequest, requestOptions);
+            final BlockSettingsParser blockSettingsParser = new BlockSettingsParser(); //TODO: make it a bean?
+            return blockSettingsParser.parseBlockSettings(settingsResponse);
+        });
     }
 
     @Override

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/blocks/BlockSettingsParser.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/blocks/BlockSettingsParser.java
@@ -1,0 +1,36 @@
+package org.graylog.storage.elasticsearch7.blocks;
+
+import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.admin.indices.settings.get.GetSettingsResponse;
+import org.graylog.shaded.elasticsearch7.org.elasticsearch.common.collect.ImmutableOpenMap;
+import org.graylog.shaded.elasticsearch7.org.elasticsearch.common.settings.Settings;
+import org.graylog2.indexer.indices.blocks.IndicesBlockStatus;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class BlockSettingsParser {
+
+    static final String BLOCK_SETTINGS_PREFIX = "index.blocks.";
+
+    public IndicesBlockStatus parseBlockSettings(final GetSettingsResponse settingsResponse) {
+        IndicesBlockStatus result = new IndicesBlockStatus();
+        final ImmutableOpenMap<String, Settings> indexToSettingsMap = settingsResponse.getIndexToSettings();
+        final String[] indicesInResponse = indexToSettingsMap.keys().toArray(String.class);
+        for (String index : indicesInResponse) {
+            final Settings blockSettings = indexToSettingsMap.get(index).getByPrefix(BLOCK_SETTINGS_PREFIX);
+
+            if (!blockSettings.isEmpty()) {
+                final Set<String> blockSettingsNames = blockSettings.names();
+                final Set<String> blockSettingsSetToTrue = blockSettingsNames.stream()
+                        .filter(s -> blockSettings.getAsBoolean(s, false))
+                        .map(s -> BLOCK_SETTINGS_PREFIX + s)
+                        .collect(Collectors.toSet());
+                if (!blockSettingsSetToTrue.isEmpty()) {
+                    result.addIndexBlocks(index, blockSettingsSetToTrue);
+                }
+            }
+        }
+
+        return result;
+    }
+}

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/blocks/BlockSettingsParserTest.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/blocks/BlockSettingsParserTest.java
@@ -1,0 +1,89 @@
+package org.graylog.storage.elasticsearch7.blocks;
+
+import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.admin.indices.settings.get.GetSettingsResponse;
+import org.graylog.shaded.elasticsearch7.org.elasticsearch.common.collect.ImmutableOpenMap;
+import org.graylog.shaded.elasticsearch7.org.elasticsearch.common.settings.Settings;
+import org.graylog2.indexer.indices.blocks.IndicesBlockStatus;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collection;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class BlockSettingsParserTest {
+
+    private BlockSettingsParser toTest;
+
+    @Before
+    public void setUp() {
+        toTest = new BlockSettingsParser();
+    }
+
+    @Test
+    public void noBlockedIndicesIdentifiedIfEmptyResponseParsed() {
+        GetSettingsResponse emptyResponse = new GetSettingsResponse(ImmutableOpenMap.of(), ImmutableOpenMap.of());
+        final IndicesBlockStatus indicesBlockStatus = toTest.parseBlockSettings(emptyResponse);
+        assertNotNull(indicesBlockStatus);
+        assertEquals(0, indicesBlockStatus.countBlockedIndices());
+    }
+
+    @Test
+    public void noBlockedIndicesIdentifiedIfEmptySettingsPresent() {
+        ImmutableOpenMap.Builder<String, Settings> settingsBuilder = new ImmutableOpenMap.Builder<>();
+        settingsBuilder.put("index_0", Settings.builder().build());
+        GetSettingsResponse emptySettingsResponse = new GetSettingsResponse(settingsBuilder.build(), ImmutableOpenMap.of());
+        final IndicesBlockStatus indicesBlockStatus = toTest.parseBlockSettings(emptySettingsResponse);
+        assertNotNull(indicesBlockStatus);
+        assertEquals(0, indicesBlockStatus.countBlockedIndices());
+    }
+
+    @Test
+    public void parserProperlyResponseWithMultipleIndicesWithDifferentBlockSettings() {
+        ImmutableOpenMap.Builder<String, Settings> settingsBuilder = new ImmutableOpenMap.Builder<>();
+        settingsBuilder.put("index_with_no_block_settings", Settings.builder().put("lalala", 42).build());
+        settingsBuilder.put("index_with_false_block_setting", Settings.builder().put("index.blocks.read_only", false).build());
+        settingsBuilder.put("index_with_true_block_setting", Settings.builder().put("index.blocks.read_only", true).build());
+        settingsBuilder.put("index_with_multiple_true_block_settings", Settings.builder()
+                .put("index.blocks.read_only", true)
+                .put("index.blocks.read_only_allow_delete", true)
+                .build());
+        settingsBuilder.put("index_with_mixed_block_settings", Settings.builder()
+                .put("index.blocks.read_only", false)
+                .put("index.blocks.read_only_allow_delete", true)
+                .build());
+        GetSettingsResponse settingsResponse = new GetSettingsResponse(settingsBuilder.build(), ImmutableOpenMap.of());
+        final IndicesBlockStatus indicesBlockStatus = toTest.parseBlockSettings(settingsResponse);
+        assertNotNull(indicesBlockStatus);
+        assertEquals(3, indicesBlockStatus.countBlockedIndices());
+        final Set<String> blockedIndices = indicesBlockStatus.getBlockedIndices();
+
+        assertFalse(blockedIndices.contains("index_with_no_block_settings"));
+        assertFalse(blockedIndices.contains("index_with_false_block_setting"));
+
+        assertTrue(blockedIndices.contains("index_with_true_block_setting"));
+        Collection<String> indexBlocks = indicesBlockStatus.getIndexBlocks("index_with_true_block_setting");
+        assertEquals(1, indexBlocks.size());
+        assertTrue(indexBlocks.contains("index.blocks.read_only"));
+
+        assertTrue(blockedIndices.contains("index_with_multiple_true_block_settings"));
+        indexBlocks = indicesBlockStatus.getIndexBlocks("index_with_multiple_true_block_settings");
+        assertEquals(2, indexBlocks.size());
+        assertTrue(indexBlocks.contains("index.blocks.read_only"));
+        assertTrue(indexBlocks.contains("index.blocks.read_only_allow_delete"));
+
+        assertTrue(blockedIndices.contains("index_with_mixed_block_settings"));
+        indexBlocks = indicesBlockStatus.getIndexBlocks("index_with_mixed_block_settings");
+        assertEquals(1, indexBlocks.size());
+        assertFalse(indexBlocks.contains("index.blocks.read_only"));
+        assertTrue(indexBlocks.contains("index.blocks.read_only_allow_delete"));
+
+
+    }
+
+
+}

--- a/graylog2-server/src/main/java/org/graylog2/bindings/PeriodicalBindings.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/PeriodicalBindings.java
@@ -29,6 +29,7 @@ import org.graylog2.periodical.ClusterIdGeneratorPeriodical;
 import org.graylog2.periodical.ContentPackLoaderPeriodical;
 import org.graylog2.periodical.ESVersionCheckPeriodical;
 import org.graylog2.periodical.GarbageCollectionWarningThread;
+import org.graylog2.periodical.IndexBlockCheck;
 import org.graylog2.periodical.IndexRangesCleanupPeriodical;
 import org.graylog2.periodical.IndexRetentionThread;
 import org.graylog2.periodical.IndexRotationThread;
@@ -50,6 +51,7 @@ public class PeriodicalBindings extends AbstractModule {
         periodicalBinder.addBinding().to(ContentPackLoaderPeriodical.class);
         periodicalBinder.addBinding().to(GarbageCollectionWarningThread.class);
         periodicalBinder.addBinding().to(IndexerClusterCheckerThread.class);
+        periodicalBinder.addBinding().to(IndexBlockCheck.class);
         periodicalBinder.addBinding().to(IndexRetentionThread.class);
         periodicalBinder.addBinding().to(IndexRotationThread.class);
         periodicalBinder.addBinding().to(NodePingThread.class);

--- a/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
@@ -24,12 +24,13 @@ import com.google.common.eventbus.EventBus;
 import org.graylog2.audit.AuditActor;
 import org.graylog2.audit.AuditEventSender;
 import org.graylog2.indexer.ElasticsearchException;
+import org.graylog2.indexer.IgnoreIndexTemplate;
 import org.graylog2.indexer.IndexMappingFactory;
 import org.graylog2.indexer.IndexNotFoundException;
 import org.graylog2.indexer.IndexSet;
-import org.graylog2.indexer.IgnoreIndexTemplate;
 import org.graylog2.indexer.IndexTemplateNotFoundException;
 import org.graylog2.indexer.indexset.IndexSetConfig;
+import org.graylog2.indexer.indices.blocks.IndicesBlockStatus;
 import org.graylog2.indexer.indices.events.IndicesClosedEvent;
 import org.graylog2.indexer.indices.events.IndicesDeletedEvent;
 import org.graylog2.indexer.indices.events.IndicesReopenedEvent;
@@ -80,6 +81,10 @@ public class Indices {
         this.auditEventSender = auditEventSender;
         this.eventBus = eventBus;
         this.indicesAdapter = indicesAdapter;
+    }
+
+    public IndicesBlockStatus getIndicesBlocksStatus(final List<String> indices) {
+        return indicesAdapter.getIndicesBlocksStatus(indices);
     }
 
     public void move(String source, String target) {

--- a/graylog2-server/src/main/java/org/graylog2/indexer/indices/IndicesAdapter.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indices/IndicesAdapter.java
@@ -18,6 +18,7 @@ package org.graylog2.indexer.indices;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.github.joschi.jadconfig.util.Duration;
+import org.graylog2.indexer.indices.blocks.IndicesBlockStatus;
 import org.graylog2.indexer.indices.stats.IndexStatistics;
 import org.graylog2.indexer.searches.IndexRangeStats;
 import org.joda.time.DateTime;
@@ -83,6 +84,8 @@ public interface IndicesAdapter {
     Optional<IndexStatistics> getIndexStats(String index);
 
     JsonNode getIndexStats(Collection<String> index);
+
+    IndicesBlockStatus getIndicesBlocksStatus(List<String> indices);
 
     boolean exists(String indexName) throws IOException;
 

--- a/graylog2-server/src/main/java/org/graylog2/indexer/indices/blocks/IndicesBlockStatus.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indices/blocks/IndicesBlockStatus.java
@@ -1,0 +1,36 @@
+package org.graylog2.indexer.indices.blocks;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class IndicesBlockStatus {
+
+    private Map<String, Collection<String>> blocksPerIndex = new HashMap<>();
+
+    public void addIndexBlocks(final String indexName, final Collection<String> blockTypes) {
+        blocksPerIndex.put(indexName, blockTypes);
+    }
+
+    public Collection<String> getIndexBlocks(final String indexName) {
+        return blocksPerIndex.get(indexName);
+    }
+
+    public int countBlockedIndices() {
+        return blocksPerIndex.size();
+    }
+
+    public Set<String> getBlockedIndices() {
+        return blocksPerIndex.keySet();
+    }
+
+    public List<String[]> toBlockDetails() {
+        return blocksPerIndex.entrySet()
+                .stream()
+                .map(entry -> new String[]{entry.getKey(), String.join(", ", entry.getValue())})
+                .collect(Collectors.toList());
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/notifications/Notification.java
+++ b/graylog2-server/src/main/java/org/graylog2/notifications/Notification.java
@@ -65,6 +65,7 @@ public interface Notification extends Persisted {
         OUTPUT_FAILING,
         INDEX_RANGES_RECALCULATION,
         GENERIC,
+        ES_INDEX_BLOCKED,
         ES_NODE_DISK_WATERMARK_LOW,
         ES_NODE_DISK_WATERMARK_HIGH,
         ES_NODE_DISK_WATERMARK_FLOOD_STAGE,

--- a/graylog2-server/src/main/java/org/graylog2/periodical/IndexBlockCheck.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/IndexBlockCheck.java
@@ -1,0 +1,119 @@
+package org.graylog2.periodical;
+
+import org.graylog2.indexer.IndexSetRegistry;
+import org.graylog2.indexer.cluster.Cluster;
+import org.graylog2.indexer.indices.Indices;
+import org.graylog2.indexer.indices.blocks.IndicesBlockStatus;
+import org.graylog2.notifications.Notification;
+import org.graylog2.notifications.NotificationService;
+import org.graylog2.plugin.periodical.Periodical;
+import org.graylog2.plugin.system.NodeId;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import java.util.ArrayList;
+import java.util.List;
+
+public class IndexBlockCheck extends Periodical {
+    private static final Logger LOG = LoggerFactory.getLogger(IndexRotationThread.class);
+
+    private final NotificationService notificationService;
+    private final IndexSetRegistry indexSetRegistry;
+    private final Cluster cluster;
+    private final Indices indices;
+    private final NodeId nodeId;
+
+    @Inject
+    public IndexBlockCheck(final NotificationService notificationService,
+                           final IndexSetRegistry indexSetRegistry,
+                           final Cluster cluster,
+                           final Indices indices,
+                           final NodeId nodeId) {
+        this.notificationService = notificationService;
+        this.indexSetRegistry = indexSetRegistry;
+        this.cluster = cluster;
+        this.indices = indices;
+        this.nodeId = nodeId;
+    }
+
+    @Override
+    public void doRun() {
+        if (cluster.isConnected()) {
+            final IndicesBlockStatus indicesBlockStatus = indices.getIndicesBlocksStatus(getAllActiveWriteIndices());
+            if (indicesBlockStatus.countBlockedIndices() > 0) {
+                indicesBlockedProblemNotification("Indices blocked", indicesBlockStatus.countBlockedIndices() + " indices are blocked.", indicesBlockStatus);
+            } else {
+                notificationService.fixed(Notification.Type.ES_INDEX_BLOCKED);
+            }
+        } else {
+            LOG.debug("Elasticsearch cluster isn't healthy. Skipping index block check.");
+        }
+    }
+
+    private List<String> getAllActiveWriteIndices() {
+        List<String> activeWriteIndices = new ArrayList<>();
+        indexSetRegistry.forEach((indexSet) -> {
+            try {
+                final String activeWriteIndex = indexSet.getActiveWriteIndex();
+                if (activeWriteIndex != null) {
+                    activeWriteIndices.add(activeWriteIndex);
+                }
+            } catch (Exception e) {
+                LOG.error("Couldn't perform index block check for index set : " + indexSet, e);
+            }
+        });
+        return activeWriteIndices;
+    }
+
+    private void indicesBlockedProblemNotification(final String title, final String description, final IndicesBlockStatus indicesBlockStatus) {
+        final Notification notification = notificationService.buildNow()
+                .addNode(nodeId.toString())
+                .addType(Notification.Type.ES_INDEX_BLOCKED)
+                .addSeverity(Notification.Severity.URGENT)
+                .addDetail("title", title)
+                .addDetail("description", description)
+                .addDetail("blockDetails", indicesBlockStatus.toBlockDetails());
+        notificationService.publishIfFirst(notification);
+    }
+
+    @Override
+    protected Logger getLogger() {
+        return LOG;
+    }
+
+    @Override
+    public boolean runsForever() {
+        return false;
+    }
+
+    @Override
+    public boolean stopOnGracefulShutdown() {
+        return true;
+    }
+
+    @Override
+    public boolean leaderOnly() {
+        return true;
+    }
+
+    @Override
+    public boolean startOnThisNode() {
+        return true;
+    }
+
+    @Override
+    public boolean isDaemon() {
+        return true;
+    }
+
+    @Override
+    public int getInitialDelaySeconds() {
+        return 0;
+    }
+
+    @Override
+    public int getPeriodSeconds() {
+        return 30;
+    }
+}

--- a/graylog2-web-interface/src/logic/notifications/NotificationsFactory.js
+++ b/graylog2-web-interface/src/logic/notifications/NotificationsFactory.js
@@ -132,6 +132,23 @@ class NotificationsFactory {
           description: notification.details.description,
         };
 
+      case 'es_index_blocked':
+        return {
+          title: notification.details.title,
+          description: (
+            <span>
+              {notification.details.description}<br/>
+              {notification.details.blockDetails?.length>0 &&
+                <ul>
+                  {notification.details.blockDetails.map((line) => <li>
+                    {line[0]}: {line[1]}
+                  </li>)}
+                </ul>
+              }
+            </span>
+          ),
+        };
+
       case 'index_ranges_recalculation':
         return {
           title: 'Index ranges recalculation required',


### PR DESCRIPTION
## Description
fixes #10930
Notification is presented if any active writing index is blocked.
Notification contains name of blocked index (i.e. graylog_0) and name of block (i.e. index.blocks.read), so that the admin can easily fix the problem with proper REST call.

## Motivation and Context
In #10930 it was suggested that notification should be presented if index.blocks.read_only_allow_delete is set to true.
This PR generalizes a problem : notification is presented if any active writing index is blocked, with any of index.blocks.* type of blocks. Because of that, admin can react quickly when the block is present and prevent losing important data, which otherwise could not be ingested, without any clear indication that there is a problem.

As presented on the screenshot, notification contains all the necessary information needed to fix the problem with proper REST call.


The solution does not contain any tool for automatic or semi-automatic removal of the blocks.
It may be a good idea to introduce it and improve the comfort of block removal even more, but it definitely requires more discussions about how to do it.

## How Has This Been Tested?
1. Block any active write index with the following (or similar) REST call:
```
http://localhost:9200/unused_0/_settings
{
  "index.blocks.read_only": true
}
```
2. Check if notification is present.
3. Remove all the blocks with  the following (or similar) REST call:
```
http://localhost:9200/unused_0/_settings
{
  "index.blocks.read_only": null
}
```
4. Check if notification is gone.

## Screenshots (if appropriate):
![Screenshot 2022-03-16 at 13-01-31 Graylog - System overview](https://user-images.githubusercontent.com/100699120/158585597-80426300-6cbf-441d-a157-4c0d65ea363a.png)
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

