### PR TITLE
fix: rerender multi select when value changes

### DIFF
--- a/graylog2-web-interface/src/components/common/Select.tsx
+++ b/graylog2-web-interface/src/components/common/Select.tsx
@@ -566,7 +566,7 @@ class Select<OptionValue> extends React.Component<Props<OptionValue>, State> {
       return <CreatableSelect {...selectProps} />;
     }
 
-    return <ReactSelect {...selectProps} />;
+    return <ReactSelect key={value} {...selectProps} />;
   }
 }
 

--- a/graylog2-web-interface/src/components/common/Select.tsx
+++ b/graylog2-web-interface/src/components/common/Select.tsx
@@ -443,11 +443,11 @@ class Select<OptionValue> extends React.Component<Props<OptionValue>, State> {
 
   // Using ReactSelect.Creatable now needs to get values as objects or they are not display
   // This method takes care of formatting a string value into options react-select supports.
-  _formatInputValue = (value: OptionValue): Array<Option> => {
+  _formatInputValue = (value: OptionValue): Array<Option> | string => {
     const { options, displayKey, valueKey, delimiter, allowCreate } = this.props;
 
     if (value === undefined || value === null || (typeof value === 'string' && value === '')) {
-      return undefined;
+      return '';
     }
 
     if (allowCreate && typeof value === 'string') {
@@ -566,7 +566,7 @@ class Select<OptionValue> extends React.Component<Props<OptionValue>, State> {
       return <CreatableSelect {...selectProps} />;
     }
 
-    return <ReactSelect key={value} {...selectProps} />;
+    return <ReactSelect {...selectProps} />;
   }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When clearing values from the `<Select />` component the inner state would not update to the newly provided value(s) when they were passed as a prop in a "controlled" manner.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It makes sure the `<Select />` rerenders on value change. It might not be the most ideal way of solving it, but while digging deeper into the component and `react-select` itself it was hard to spot where it went wrong.

I believe it had something to do with `react-select`'s `StateManager`, since it didn't update its value to the passed prop.

The solution is to add a `key` prop based on the value so `react-select` forces a rerender.

Fixes: https://github.com/Graylog2/graylog2-server/issues/12265
Fixes: https://github.com/Graylog2/graylog2-server/issues/12259

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually in the browser

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

