### PR TITLE
Avoid passing `undefined` value to react-select.

### DIFF
--- a/graylog2-web-interface/src/components/common/Select.tsx
+++ b/graylog2-web-interface/src/components/common/Select.tsx
@@ -447,7 +447,7 @@ class Select<OptionValue> extends React.Component<Props<OptionValue>, State> {
     const { options, displayKey, valueKey, delimiter, allowCreate } = this.props;
 
     if (value === undefined || value === null || (typeof value === 'string' && value === '')) {
-      return '';
+      return [];
     }
 
     if (allowCreate && typeof value === 'string') {

--- a/graylog2-web-interface/src/components/common/Select.tsx
+++ b/graylog2-web-interface/src/components/common/Select.tsx
@@ -17,10 +17,10 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import type { Theme as SelectTheme } from 'react-select';
+import ReactSelect, { components as Components, createFilter } from 'react-select';
 import { isEqual } from 'lodash';
 import type { DefaultTheme } from 'styled-components';
 import { withTheme } from 'styled-components';
-import ReactSelect, { components as Components, createFilter } from 'react-select';
 import CreatableSelect from 'react-select/creatable';
 
 import { themePropTypes } from 'theme';
@@ -447,7 +447,7 @@ class Select<OptionValue> extends React.Component<Props<OptionValue>, State> {
     const { options, displayKey, valueKey, delimiter, allowCreate } = this.props;
 
     if (value === undefined || value === null || (typeof value === 'string' && value === '')) {
-      return undefined;
+      return '';
     }
 
     if (allowCreate && typeof value === 'string') {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is avoiding to pass `undefined` to `react-select`, as it would effectively turn it into an uncontrolled component, leading to the component not clearing its value when the state change was triggered externally. Instead, we are passing an empty array.

Fixes #12263 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.