### PR TITLE
Async forcemerge request that still blocks as all other index operations

### DIFF
--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/jest/JestFuture.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/jest/JestFuture.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.storage.elasticsearch6.jest;
+
+import com.github.joschi.jadconfig.util.Duration;
+import io.searchbox.client.JestResultHandler;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+
+public class JestFuture<T> implements JestResultHandler<T> {
+
+    private final CompletableFuture<T> future;
+
+    public JestFuture() {
+        future = new CompletableFuture<>();
+    }
+
+    @Override
+    public void completed(T result) {
+        future.complete(result);
+    }
+
+    @Override
+    public void failed(Exception ex) {
+        future.completeExceptionally(ex);
+    }
+
+    public T getBlocking(Duration timeout) throws ExecutionException, InterruptedException, TimeoutException {
+        return future.get(timeout.getQuantity(), timeout.getUnit());
+    }
+}

--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/jest/JestUtils.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/jest/JestUtils.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import io.searchbox.action.Action;
 import io.searchbox.client.JestClient;
 import io.searchbox.client.JestResult;
+import io.searchbox.client.JestResultHandler;
 import io.searchbox.client.http.JestHttpClient;
 import org.apache.http.client.config.RequestConfig;
 import org.graylog2.indexer.ElasticsearchException;
@@ -83,6 +84,20 @@ public class JestUtils {
             return ((JestHttpClient) client).execute(request, requestConfig);
         } else {
             return client.execute(request);
+        }
+    }
+
+
+    public static <T extends JestResult> void executeAsync(JestClient client, RequestConfig requestConfig,
+                                                           Action<T> request, JestResultHandler<T> resultHandler) {
+        try {
+            if (client instanceof JestHttpClient) {
+                ((JestHttpClient) client).executeAsync(request, resultHandler, requestConfig);
+            } else {
+                client.executeAsync(request, resultHandler);
+            }
+        } catch (IOException e) {
+            resultHandler.failed(e);
         }
     }
 

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/FutureActionListener.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/FutureActionListener.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.storage.elasticsearch7;
+
+import com.github.joschi.jadconfig.util.Duration;
+import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.ActionListener;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+
+public class FutureActionListener<T> implements ActionListener<T> {
+
+    private final CompletableFuture<T> future;
+
+    public FutureActionListener() {
+        this.future = new CompletableFuture<T>();
+    }
+
+    @Override
+    public void onResponse(T result) {
+        future.complete(result);
+    }
+
+    @Override
+    public void onFailure(Exception e) {
+        future.completeExceptionally(e);
+    }
+
+    public T getBlocking(Duration timeout) throws ExecutionException, InterruptedException, TimeoutException {
+        return future.get(timeout.getQuantity(), timeout.getUnit());
+    }
+}


### PR DESCRIPTION
This is an attempt to fix issue described in https://github.com/Graylog2/graylog2-server/issues/12025. It assumes, that the forcemerge operations consume all threads from the ES client thread pool, blocking all other ES operations. To prevent that, the forcemerge behind index optimization is triggered as an async call. To keep the app logic and structure, this call is then blocking the caller thread and waits till the forcemerge finishes (SystemJob implementations block generally and their running/blocking time is exposed as a metric). Generally, for each optimize job, it frees one thread from the ES client thread pool yet still blocks one in the app. 


Additionally, under the original issue, I have mentioned several config settings that I believe may add to the problem if kept in the default settings. 

## Motivation and Context
Hopefully it fixes #12025

## How Has This Been Tested?
Manually tested that the index rotation and optimization works. IndicesIT to ensure that nothing else breaks. Performance-wise I was unable to test the benefit and verify our assumptions so far. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

