### PR TITLE
Don't exclude the MapWidgetModule when running the migrations command

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/commands/Server.java
+++ b/graylog2-server/src/main/java/org/graylog2/commands/Server.java
@@ -181,15 +181,9 @@ public class Server extends ServerBootstrap {
                 new GRNTypesModule(),
                 new SecurityModule(),
                 new PrometheusMetricsModule(),
-                new ClusterConfigValidatorModule()
+                new ClusterConfigValidatorModule(),
+                new MapWidgetModule()
         );
-
-        if (!isMigrationCommand()) {
-            modules.add(
-                    new MapWidgetModule()
-            );
-        }
-
         return modules.build();
     }
 


### PR DESCRIPTION
The ClusterConfigValidatorModule introduced a dependency,
through the GeoIpResolverConfigValidator which breaks the migration command.

```
2022-03-17 16:05:09,624 ERROR: org.graylog2.bootstrap.CmdLineTool - Guice error (more detail on log level debug): No implementation for org.graylog.plugins.map.geoip.GeoIpResolverFactory was bound.
Exception in thread "main" com.google.inject.CreationException: Unable to create injector, see the following errors:

1) [Guice/MissingImplementation]: No implementation for GeoIpResolverFactory was bound.

Requested by:
1  : GeoIpVendorResolverService.<init>(GeoIpVendorResolverService.java:33)
      \_ for 1st parameter
     at GeoIpResolverConfigValidator.<init>(GeoIpResolverConfigValidator.java:48)
      \_ for 1st parameter
     at PluginModule.addClusterConfigValidator(PluginModule.java:391)

```

I actuall forgot why I excluded that module in the first place :-( 
It's simpler to just bind it.
