### PR TITLE
Do not hide search results when search refresh hook sets an error, but display overlay.

### DIFF
--- a/graylog2-web-interface/src/views/components/SearchResult.test.tsx
+++ b/graylog2-web-interface/src/views/components/SearchResult.test.tsx
@@ -17,7 +17,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { act } from 'react-dom/test-utils';
-import { render } from 'wrappedTestingLibrary';
+import { render, screen } from 'wrappedTestingLibrary';
 
 import { simpleFields, simpleQueryFields } from 'fixtures/fields';
 import asMock from 'helpers/mocking/AsMock';
@@ -76,18 +76,20 @@ describe('SearchResult', () => {
   });
 
   const initialFieldTypes = { all: simpleFields(), queryFields: simpleQueryFields('aQueryId') };
-  const SimpleSearchResult = ({ fieldTypes }) => (
+  const SimpleSearchResult = ({ fieldTypes, hasErrors }) => (
     <FieldTypesContext.Provider value={fieldTypes}>
-      <SearchResult hasErrors={false} />
+      <SearchResult hasErrors={hasErrors} />
     </FieldTypesContext.Provider>
   );
 
   SimpleSearchResult.propTypes = {
     fieldTypes: PropTypes.object,
+    hasErrors: PropTypes.bool,
   };
 
   SimpleSearchResult.defaultProps = {
     fieldTypes: initialFieldTypes,
+    hasErrors: false,
   };
 
   it('should show spinner with undefined fields', () => {
@@ -120,5 +122,17 @@ describe('SearchResult', () => {
     const { getByText } = render(<SimpleSearchResult />);
 
     expect(getByText('Create a new widget by selecting a widget type in the left sidebar section "Create".')).not.toBeNull();
+  });
+
+  it('should display overlay when hasErrors prop is true', () => {
+    render(<SimpleSearchResult hasErrors />);
+
+    expect(screen.getByTestId('disable-results-overlay')).toBeInTheDocument();
+  });
+
+  it('should not display overlay when hasErrors prop is false', () => {
+    render(<SimpleSearchResult />);
+
+    expect(screen.queryByTestId('disable-results-overlay')).not.toBeInTheDocument();
   });
 });

--- a/graylog2-web-interface/src/views/components/SearchResult.tsx
+++ b/graylog2-web-interface/src/views/components/SearchResult.tsx
@@ -17,6 +17,7 @@
 import * as React from 'react';
 import { useContext } from 'react';
 import styled, { css } from 'styled-components';
+import chroma from 'chroma-js';
 
 import Spinner from 'components/common/Spinner';
 import Query from 'views/components/Query';
@@ -30,6 +31,18 @@ import WidgetFocusContext from 'views/components/contexts/WidgetFocusContext';
 const StyledRow = styled(Row)(({ $hasFocusedWidget }: { $hasFocusedWidget: boolean }) => css`
   height: ${$hasFocusedWidget ? '100%' : 'auto'};
   overflow: ${$hasFocusedWidget ? 'auto' : 'visible'};
+  position: relative;
+`);
+
+const DisabledSearchOverlay = styled.div(({ theme }) => css`
+  background: ${chroma(theme.colors.brand.tertiary).alpha(0.25).css()};
+
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 2;
 `);
 
 const StyledCol = styled(Col)`
@@ -49,19 +62,17 @@ type Props = {
 const SearchResult = React.memo(({ hasErrors }: Props) => {
   const fieldTypes = useContext(FieldTypesContext);
   const { focusedWidget } = useContext(WidgetFocusContext);
+  const hasFocusedWidget = !!focusedWidget?.id;
 
   if (!fieldTypes) {
     return <Spinner />;
   }
 
-  const hasFocusedWidget = !!focusedWidget?.id;
-
-  const content = hasErrors ? null : <Query />;
-
   return (
     <StyledRow $hasFocusedWidget={hasFocusedWidget}>
+      {(hasErrors && !hasFocusedWidget) && <DisabledSearchOverlay />}
       <StyledCol>
-        {content}
+        <Query />
         <SearchLoadingIndicator />
       </StyledCol>
     </StyledRow>

--- a/graylog2-web-interface/src/views/components/SearchResult.tsx
+++ b/graylog2-web-interface/src/views/components/SearchResult.tsx
@@ -34,7 +34,7 @@ const StyledRow = styled(Row)(({ $hasFocusedWidget }: { $hasFocusedWidget: boole
   position: relative;
 `);
 
-const DisabledSearchOverlay = styled.div(({ theme }) => css`
+const DisableResultsOverlay = styled.div(({ theme }) => css`
   background: ${chroma(theme.colors.brand.tertiary).alpha(0.25).css()};
 
   position: absolute;
@@ -70,7 +70,7 @@ const SearchResult = React.memo(({ hasErrors }: Props) => {
 
   return (
     <StyledRow $hasFocusedWidget={hasFocusedWidget}>
-      {(hasErrors && !hasFocusedWidget) && <DisabledSearchOverlay />}
+      {(hasErrors && !hasFocusedWidget) && <DisableResultsOverlay data-testid="disable-results-overlay" />}
       <StyledCol>
         <Query />
         <SearchLoadingIndicator />


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Before this change we were hiding the search results, when a search refresh hooks sets an error. This is currently the case for parameter errors, e.g. when a parameter needs to be declared.

This can be confusing for users, but it can also result in disappearing changes, when editing a widget, as described in https://github.com/Graylog2/graylog-plugin-enterprise/issues/3281.

This solution is not fixing all related problems, for example if you remove a parameter on a dashboard, which is being used in a widget query, we display the "Undeclared parameter" warning, but it is still not possible to remove the parameter name from the widget query. In every case it is an improvement.

Before: 
![image](https://user-images.githubusercontent.com/46300478/158847227-bdb113d0-9378-42b3-a07a-7c95211e5e39.png)

After:
![image](https://user-images.githubusercontent.com/46300478/158847434-e63854b3-f516-4e71-ad45-34b8cfbab558.png)


Fixes https://github.com/Graylog2/graylog-plugin-enterprise/issues/3281