### PR TITLE
Update search URL params when selecting a time range in histogram.

### DIFF
--- a/graylog2-web-interface/src/views/hooks/SyncWithQueryParameters.test.tsx
+++ b/graylog2-web-interface/src/views/hooks/SyncWithQueryParameters.test.tsx
@@ -35,6 +35,7 @@ jest.mock('views/actions/QueriesActions', () => ({
   QueriesActions: {
     update: mockAction(),
     query: mockAction(),
+    timerange: mockAction(),
   },
 }));
 
@@ -199,6 +200,7 @@ describe('SyncWithQueryParameters', () => {
 
       expect(QueriesActions.update.completed.listen).toHaveBeenCalled();
       expect(QueriesActions.query.completed.listen).toHaveBeenCalled();
+      expect(QueriesActions.timerange.completed.listen).toHaveBeenCalled();
     });
   });
 });

--- a/graylog2-web-interface/src/views/hooks/SyncWithQueryParameters.ts
+++ b/graylog2-web-interface/src/views/hooks/SyncWithQueryParameters.ts
@@ -98,7 +98,7 @@ export const useSyncWithQueryParameters = (query: string) => {
   useEffect(() => syncWithQueryParameters(query, history.replace), []);
 
   useActionListeners(
-    [QueriesActions.update.completed, QueriesActions.query.completed],
+    [QueriesActions.update.completed, QueriesActions.query.completed, QueriesActions.timerange.completed],
     () => syncWithQueryParameters(query),
     [query],
   );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

_Please note, we need to create a backport for this bugfix._

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

As described in https://github.com/Graylog2/graylog2-server/issues/11388 the search URL params are currently not being updated, when selecting a time range by dragging over a histogram.

There are a few linter warnings in the related files, which I did not fixed, to ensure we do not introduce new bugs with this bugfix.

Fixes https://github.com/Graylog2/graylog2-server/issues/11388

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

