### PR TITLE
Update identifier for query validation parsing error type.

### DIFF
--- a/graylog2-web-interface/src/util/DocsHelper.js
+++ b/graylog2-web-interface/src/util/DocsHelper.js
@@ -45,7 +45,7 @@ class DocsHelper {
     ROLLING_ES_UPGRADE: 'rolling-es-upgrade',
     SEARCH_QUERY_ERRORS: {
       UNKNOWN_FIELD: 'query-language#unknown-field',
-      PARSE_EXCEPTION: 'query-language#parse-exception',
+      QUERY_PARSING_ERROR: 'query-language#parse-exception',
       INVALID_OPERATOR: 'query-language#invalid-operator',
       UNDECLARED_PARAMETER: 'query-language#undeclared-parameter',
     },

--- a/graylog2-web-interface/src/views/components/searchbar/queryvalidation/QueryValidation.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/queryvalidation/QueryValidation.tsx
@@ -146,8 +146,8 @@ const getErrorDocumentationLink = (errorType: string) => {
   switch (errorType) {
     case 'UNKNOWN_FIELD':
       return DocsHelper.PAGES.SEARCH_QUERY_ERRORS.UNKNOWN_FIELD;
-    case 'PARSE_EXCEPTION':
-      return DocsHelper.PAGES.SEARCH_QUERY_ERRORS.PARSE_EXCEPTION;
+    case 'QUERY_PARSING_ERROR':
+      return DocsHelper.PAGES.SEARCH_QUERY_ERRORS.QUERY_PARSING_ERROR;
     case 'INVALID_OPERATOR':
       return DocsHelper.PAGES.SEARCH_QUERY_ERRORS.INVALID_OPERATOR;
     case 'UNDECLARED_PARAMETER':

--- a/graylog2-web-interface/test/fixtures/queryValidationState.ts
+++ b/graylog2-web-interface/test/fixtures/queryValidationState.ts
@@ -21,7 +21,7 @@ import type { QueryValidationState } from 'views/components/searchbar/queryvalid
 export const validationError: QueryValidationState = {
   status: 'ERROR',
   explanations: [{
-    errorType: 'PARSE_EXCEPTION',
+    errorType: 'QUERY_PARSING_ERROR',
     errorTitle: 'Parse Exception',
     errorMessage: "Cannot parse 'source: '",
     beginLine: 1,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR is updating the identifier we use in the frontend for the query validation parsing error type.
This is necessary, because we changed the id in the backend recently.

Based on this identifier we display error type specific documentation links.
