### PR TITLE
Handle query parsing error for event definition listing

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/events/rest/EventDefinitionsResource.java
+++ b/graylog2-server/src/main/java/org/graylog/events/rest/EventDefinitionsResource.java
@@ -110,7 +110,12 @@ public class EventDefinitionsResource extends RestResource implements PluginRest
     public PaginatedResponse<EventDefinitionDto> list(@ApiParam(name = "page") @QueryParam("page") @DefaultValue("1") int page,
                                                       @ApiParam(name = "per_page") @QueryParam("per_page") @DefaultValue("50") int perPage,
                                                       @ApiParam(name = "query") @QueryParam("query") @DefaultValue("") String query) {
-        final SearchQuery searchQuery = searchQueryParser.parse(query);
+        SearchQuery searchQuery;
+        try {
+            searchQuery = searchQueryParser.parse(query);
+        } catch (IllegalArgumentException e) {
+            throw new BadRequestException("Invalid argument in search query: " + e.getMessage());
+        }
         final PaginatedList<EventDefinitionDto> result = dbService.searchPaginated(searchQuery, event -> {
             return isPermitted(RestPermissions.EVENT_DEFINITIONS_READ, event.id());
         }, "title", page, perPage);

--- a/graylog2-web-interface/src/stores/event-definitions/EventDefinitionsStore.js
+++ b/graylog2-web-interface/src/stores/event-definitions/EventDefinitionsStore.js
@@ -136,6 +136,9 @@ export const EventDefinitionsStore = singletonStore(
         this.propagateChanges();
 
         return response;
+      }).catch((error) => {
+        UserNotification.error(`Fetching event definitions failed with status: ${error}`,
+          'Could not retrieve event definitions');
       });
 
       EventDefinitionsActions.listPaginated.promise(promise);


### PR DESCRIPTION
Catch query parsing error in the backend and display the
error in the frontend.

Previously, a search in the event definitions list for
an invalid id (not a valid mongoDB id) would result
in a 500 error which was also not handled by the frontend.

Fixes #12266 