### PR TITLE
Validation code refactored. 

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/ViewsBindings.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/ViewsBindings.java
@@ -92,6 +92,9 @@ import org.graylog.plugins.views.search.searchtypes.pivot.series.SumOfSquares;
 import org.graylog.plugins.views.search.searchtypes.pivot.series.Variance;
 import org.graylog.plugins.views.search.validation.QueryValidationService;
 import org.graylog.plugins.views.search.validation.QueryValidationServiceImpl;
+import org.graylog.plugins.views.search.validation.subvalidators.LuceneQuerySubValidator;
+import org.graylog.plugins.views.search.validation.subvalidators.UnknownFieldsIdentifier;
+import org.graylog.plugins.views.search.validation.subvalidators.ValidationExplanationCreator;
 import org.graylog.plugins.views.search.views.RequiresParameterSupport;
 import org.graylog.plugins.views.search.views.ViewRequirements;
 import org.graylog.plugins.views.search.views.widgets.aggregation.AggregationConfigDTO;
@@ -181,6 +184,9 @@ public class ViewsBindings extends ViewsModule {
 
         bind(SearchJobService.class).to(InMemorySearchJobService.class).in(Scopes.SINGLETON);
         bind(MappedFieldTypesService.class).to(MappedFieldTypesServiceImpl.class).in(Scopes.SINGLETON);
+        bind(UnknownFieldsIdentifier.class).in(Scopes.SINGLETON);
+        bind(ValidationExplanationCreator.class).in(Scopes.SINGLETON);
+        bind(LuceneQuerySubValidator.class).in(Scopes.SINGLETON);
         bind(QueryValidationService.class).to(QueryValidationServiceImpl.class).in(Scopes.SINGLETON);
         bind(ChunkDecorator.class).to(LegacyChunkDecorator.class);
         bind(MessagesExporter.class).to(DecoratingMessagesExporter.class);

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/elasticsearch/QueryStringDecorators.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/elasticsearch/QueryStringDecorators.java
@@ -19,12 +19,25 @@ package org.graylog.plugins.views.search.elasticsearch;
 import org.graylog.plugins.views.search.ParameterProvider;
 import org.graylog.plugins.views.search.Query;
 import org.graylog.plugins.views.search.engine.QueryStringDecorator;
+import org.graylog.plugins.views.search.errors.EmptyParameterError;
+import org.graylog.plugins.views.search.errors.MissingEnterpriseLicenseException;
+import org.graylog.plugins.views.search.errors.SearchException;
+import org.graylog.plugins.views.search.errors.UnboundParameterError;
+import org.graylog.plugins.views.search.validation.QueryValidationService;
+import org.graylog.plugins.views.search.validation.ValidationMessage;
+import org.graylog.plugins.views.search.validation.ValidationRequest;
+import org.graylog.plugins.views.search.validation.ValidationResponse;
+import org.graylog.plugins.views.search.validation.ValidationType;
 
 import javax.inject.Inject;
 import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
 import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
-public class QueryStringDecorators implements QueryStringDecorator {
+public class QueryStringDecorators implements QueryStringDecorator, QueryValidationService {
     private final Set<QueryStringDecorator> queryDecorators;
 
     public static class Fake extends QueryStringDecorators {
@@ -42,5 +55,62 @@ public class QueryStringDecorators implements QueryStringDecorator {
     public String decorate(String queryString, ParameterProvider job, Query query) {
         return this.queryDecorators.isEmpty() ? queryString : this.queryDecorators.stream()
                 .reduce(queryString, (prev, decorator) -> decorator.decorate(prev, job, query), String::concat);
+    }
+
+    @Override
+    public ValidationResponse validate(final ValidationRequest req) {
+        //TODO: instead of centralized exception handling we have to switch to proper validation in each QueryStringDecorator (effectively : QueryStringParameterSubstitution)
+        try {
+            ParameterProvider parameterProvider = (name) -> req.parameters().stream().filter(p -> Objects.equals(p.name(), name)).findFirst();
+            final Query query = Query.builder().query(req.query()).timerange(req.timerange()).build();
+            this.decorate(req.getCombinedQueryWithFilter(), parameterProvider, query);
+        } catch (SearchException searchException) {
+            return convert(searchException);
+        } catch (MissingEnterpriseLicenseException licenseException) {
+            return ValidationResponse.error(paramsToValidationErrors(
+                            licenseException.getQueryParams(),
+                            ValidationType.MISSING_LICENSE,
+                            param -> "Search parameter used without enterprise license: " + param.name()
+                    )
+            );
+        }
+        return ValidationResponse.ok();
+    }
+
+    private ValidationResponse convert(SearchException searchException) {
+        if (searchException.error() instanceof UnboundParameterError) {
+            final UnboundParameterError error = (UnboundParameterError) searchException.error();
+            return ValidationResponse.error(paramsToValidationErrors(
+                    error.allUnknownParameters(),
+                    ValidationType.UNDECLARED_PARAMETER,
+                    param -> "Unbound required parameter used: " + param.name()
+            ));
+        } else if (searchException.error() instanceof EmptyParameterError) {
+            final EmptyParameterError error = (EmptyParameterError) searchException.error();
+            return ValidationResponse.warning(paramsToValidationErrors(
+                    Collections.singleton(error.getParameterUsage()),
+                    ValidationType.EMPTY_PARAMETER,
+                    param -> error.description()));
+        }
+        return ValidationResponse.error(Collections.singletonList(ValidationMessage.fromException(searchException)));
+    }
+
+    private List<ValidationMessage> paramsToValidationErrors(final Set<QueryParam> params, final ValidationType errorType, final Function<QueryParam, String> messageBuilder) {
+        return params.stream()
+                .flatMap(param -> {
+                    final String errorMessage = messageBuilder.apply(param);
+                    return param.positions()
+                            .stream()
+                            .map(p -> ValidationMessage.builder(errorType)
+                                    .errorMessage(errorMessage)
+                                    .beginLine(p.line())
+                                    .endLine(p.line())
+                                    .beginColumn(p.beginColumn())
+                                    .endColumn(p.endColumn())
+                                    .relatedProperty(param.name())
+                                    .build()
+                            );
+                })
+                .collect(Collectors.toList());
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/validation/QueryValidationServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/validation/QueryValidationServiceImpl.java
@@ -16,47 +16,28 @@
  */
 package org.graylog.plugins.views.search.validation;
 
-import com.google.common.collect.Streams;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.lucene.queryparser.classic.ParseException;
-import org.graylog.plugins.views.search.ParameterProvider;
-import org.graylog.plugins.views.search.Query;
-import org.graylog.plugins.views.search.elasticsearch.QueryParam;
 import org.graylog.plugins.views.search.elasticsearch.QueryStringDecorators;
-import org.graylog.plugins.views.search.errors.EmptyParameterError;
-import org.graylog.plugins.views.search.errors.MissingEnterpriseLicenseException;
-import org.graylog.plugins.views.search.errors.SearchException;
-import org.graylog.plugins.views.search.errors.UnboundParameterError;
-import org.graylog.plugins.views.search.rest.MappedFieldTypeDTO;
-import org.graylog2.indexer.fieldtypes.MappedFieldTypesService;
+import org.graylog.plugins.views.search.validation.subvalidators.LuceneQuerySubValidator;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import java.util.Collections;
-import java.util.List;
-import java.util.Locale;
-import java.util.Objects;
-import java.util.Set;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 @Singleton
 public class QueryValidationServiceImpl implements QueryValidationService {
 
-    private final LuceneQueryParser luceneQueryParser;
-    private final MappedFieldTypesService mappedFieldTypesService;
-    private final QueryStringDecorators queryStringDecorators;
+    private final LuceneQuerySubValidator luceneQuerySubValidator;
+    private final QueryStringDecorators queryStringDecoratorsSubValidator;
 
     @Inject
-    public QueryValidationServiceImpl(LuceneQueryParser luceneQueryParser, MappedFieldTypesService mappedFieldTypesService, QueryStringDecorators queryStringDecorators) {
-        this.luceneQueryParser = luceneQueryParser;
-        this.mappedFieldTypesService = mappedFieldTypesService;
-        this.queryStringDecorators = queryStringDecorators;
+    public QueryValidationServiceImpl(final LuceneQuerySubValidator luceneQuerySubValidator,
+                                      final QueryStringDecorators queryStringDecoratorsSubValidator) {
+        this.luceneQuerySubValidator = luceneQuerySubValidator;
+        this.queryStringDecoratorsSubValidator = queryStringDecoratorsSubValidator;
     }
 
     @Override
-    public ValidationResponse validate(ValidationRequest req) {
+    public ValidationResponse validate(final ValidationRequest req) {
         // caution, there are two validation steps!
         // the validation uses query with _non_replaced parameters, as is, to be able to track the exact positions of errors
         final String rawQuery = req.query().queryString();
@@ -65,128 +46,12 @@ public class QueryValidationServiceImpl implements QueryValidationService {
             return ValidationResponse.ok();
         }
 
-        try {
-            // but we want to trigger the decorators as well, because they may trigger additional exceptions
-            decoratedQuery(req);
-        } catch (SearchException searchException) {
-            return convert(searchException);
-        } catch (MissingEnterpriseLicenseException licenseException) {
-            return ValidationResponse.error(
-                    paramsToValidationErrors(
-                            licenseException.getQueryParams(),
-                            ValidationType.MISSING_LICENSE,
-                            param -> "Search parameter used without enterprise license: " + param.name()
-                    ));
-        }
-
-        try {
-            final ParsedQuery parsedQuery = luceneQueryParser.parse(rawQuery);
-            final List<ParsedTerm> unknownFields = getUnknownFields(req, parsedQuery);
-            final List<ParsedTerm> invalidOperators = parsedQuery.invalidOperators();
-            final List<ValidationMessage> explanations = getExplanations(unknownFields, invalidOperators);
-
-            return explanations.isEmpty()
-                    ? ValidationResponse.ok()
-                    : ValidationResponse.warning(explanations);
-
-        } catch (ParseException e) {
-            return ValidationResponse.error(toExplanation(e));
+        final ValidationResponse validationResponse = queryStringDecoratorsSubValidator.validate(req);
+        if (!validationResponse.status().equals(ValidationStatus.OK)) {
+            return validationResponse;
+        } else {
+            return luceneQuerySubValidator.validate(req);
         }
     }
 
-    private ValidationResponse convert(SearchException searchException) {
-        if (searchException.error() instanceof UnboundParameterError) {
-            final UnboundParameterError error = (UnboundParameterError) searchException.error();
-            return ValidationResponse.error(paramsToValidationErrors(
-                    error.allUnknownParameters(),
-                    ValidationType.UNDECLARED_PARAMETER,
-                    param -> "Unbound required parameter used: " + param.name()
-            ));
-        } else if (searchException.error() instanceof EmptyParameterError) {
-            final EmptyParameterError error = (EmptyParameterError) searchException.error();
-            return ValidationResponse.warning(paramsToValidationErrors(
-                    Collections.singleton(error.getParameterUsage()),
-                    ValidationType.EMPTY_PARAMETER,
-                    param -> error.description()));
-        }
-        return ValidationResponse.error(Collections.singletonList(ValidationMessage.fromException(searchException)));
-    }
-
-    private List<ValidationMessage> paramsToValidationErrors(final Set<QueryParam> params, final ValidationType errorType, final Function<QueryParam, String> messageBuilder) {
-        return params.stream()
-                .flatMap(param -> {
-                    final String errorMessage = messageBuilder.apply(param);
-                    return param.positions()
-                            .stream()
-                            .map(p -> ValidationMessage.builder(errorType)
-                                    .errorMessage(errorMessage)
-                                    .beginLine(p.line())
-                                    .endLine(p.line())
-                                    .beginColumn(p.beginColumn())
-                                    .endColumn(p.endColumn())
-                                    .relatedProperty(param.name())
-                                    .build()
-                            );
-                })
-                .collect(Collectors.toList());
-    }
-
-    private List<ValidationMessage> toExplanation(final ParseException parseException) {
-        return Collections.singletonList(ValidationMessage.fromException(parseException));
-    }
-
-    private List<ValidationMessage> getExplanations(List<ParsedTerm> unknownFields, List<ParsedTerm> invalidOperators) {
-
-
-        final Stream<ValidationMessage> unknownFieldsStream = unknownFields.stream().map(f -> {
-            final ValidationMessage.Builder message = ValidationMessage.builder(ValidationType.UNKNOWN_FIELD)
-                    .relatedProperty(f.getRealFieldName())
-                    .errorMessage("Query contains unknown field: " + f.getRealFieldName());
-
-            f.keyToken().ifPresent(t -> {
-                message.beginLine(t.beginLine());
-                message.beginColumn(t.beginColumn());
-                message.endLine(t.endLine());
-                message.endColumn(t.endColumn());
-            });
-
-            return message.build();
-        });
-
-        final Stream<ValidationMessage> invalidOperatorsStream = invalidOperators.stream()
-                .map(term -> {
-                    final String errorMessage = String.format(Locale.ROOT, "Query contains invalid operator \"%s\". All AND / OR / NOT operators have to be written uppercase", term.value());
-                    final ValidationMessage.Builder message = ValidationMessage.builder(ValidationType.INVALID_OPERATOR)
-                            .errorMessage(errorMessage);
-                    term.keyToken().ifPresent(t -> {
-                        message.beginLine(t.beginLine());
-                        message.beginColumn(t.beginColumn());
-                        message.endLine(t.endLine());
-                        message.endColumn(t.endColumn());
-                    });
-                    return message.build();
-                });
-
-        return Streams.concat(unknownFieldsStream, invalidOperatorsStream)
-                .distinct()
-                .collect(Collectors.toList());
-    }
-
-    private List<ParsedTerm> getUnknownFields(ValidationRequest req, ParsedQuery query) {
-        final Set<String> availableFields = mappedFieldTypesService.fieldTypesByStreamIds(req.streams(), req.timerange())
-                .stream()
-                .map(MappedFieldTypeDTO::name)
-                .collect(Collectors.toSet());
-
-        return query.terms().stream()
-                .filter(t -> !t.isDefaultField())
-                .filter(term -> !availableFields.contains(term.getRealFieldName()))
-                .collect(Collectors.toList());
-    }
-
-    private String decoratedQuery(ValidationRequest req) {
-        ParameterProvider parameterProvider = (name) -> req.parameters().stream().filter(p -> Objects.equals(p.name(), name)).findFirst();
-        final Query query = Query.builder().query(req.query()).timerange(req.timerange()).build();
-        return this.queryStringDecorators.decorate(req.getCombinedQueryWithFilter(), parameterProvider, query);
-    }
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/validation/subvalidators/LuceneQuerySubValidator.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/validation/subvalidators/LuceneQuerySubValidator.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog.plugins.views.search.validation.subvalidators;
 
 import org.graylog.plugins.views.search.validation.LuceneQueryParser;

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/validation/subvalidators/LuceneQuerySubValidator.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/validation/subvalidators/LuceneQuerySubValidator.java
@@ -1,0 +1,50 @@
+package org.graylog.plugins.views.search.validation.subvalidators;
+
+import org.graylog.plugins.views.search.validation.LuceneQueryParser;
+import org.graylog.plugins.views.search.validation.ParsedQuery;
+import org.graylog.plugins.views.search.validation.ParsedTerm;
+import org.graylog.plugins.views.search.validation.QueryValidationService;
+import org.graylog.plugins.views.search.validation.ValidationMessage;
+import org.graylog.plugins.views.search.validation.ValidationRequest;
+import org.graylog.plugins.views.search.validation.ValidationResponse;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.util.List;
+
+@Singleton
+public class LuceneQuerySubValidator implements QueryValidationService {
+
+    private final LuceneQueryParser luceneQueryParser;
+    private final UnknownFieldsIdentifier unknownFieldsIdentifier;
+    private final ValidationExplanationCreator validationExplanationCreator;
+
+    @Inject
+    public LuceneQuerySubValidator(final LuceneQueryParser luceneQueryParser,
+                                   final UnknownFieldsIdentifier unknownFieldsIdentifier,
+                                   final ValidationExplanationCreator validationExplanationCreator) {
+        this.luceneQueryParser = luceneQueryParser;
+        this.unknownFieldsIdentifier = unknownFieldsIdentifier;
+        this.validationExplanationCreator = validationExplanationCreator;
+    }
+
+    @Override
+    public ValidationResponse validate(final ValidationRequest req) {
+        try {
+            final String rawQuery = req.query().queryString();
+            final ParsedQuery parsedQuery = luceneQueryParser.parse(rawQuery);
+            final List<ParsedTerm> unknownFields = unknownFieldsIdentifier.identifyUnknownFields(req, parsedQuery.terms());
+            final List<ParsedTerm> invalidOperators = parsedQuery.invalidOperators();
+            final List<ValidationMessage> verificationExplanations = validationExplanationCreator.getVerificationExplanations(unknownFields, invalidOperators);
+            if (verificationExplanations.isEmpty()) {
+                return ValidationResponse.ok();
+            } else {
+                return ValidationResponse.warning(verificationExplanations);
+            }
+        } catch (Exception e) {
+            return ValidationResponse.error(validationExplanationCreator.getExceptionExplanations(e));
+        }
+    }
+
+
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/validation/subvalidators/UnknownFieldsIdentifier.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/validation/subvalidators/UnknownFieldsIdentifier.java
@@ -1,0 +1,40 @@
+package org.graylog.plugins.views.search.validation.subvalidators;
+
+import org.graylog.plugins.views.search.rest.MappedFieldTypeDTO;
+import org.graylog.plugins.views.search.validation.ParsedTerm;
+import org.graylog.plugins.views.search.validation.ValidationRequest;
+import org.graylog2.indexer.fieldtypes.MappedFieldTypesService;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Singleton
+public class UnknownFieldsIdentifier {
+
+    private final MappedFieldTypesService mappedFieldTypesService;
+
+    @Inject
+    public UnknownFieldsIdentifier(final MappedFieldTypesService mappedFieldTypesService) {
+        this.mappedFieldTypesService = mappedFieldTypesService;
+    }
+
+    public List<ParsedTerm> identifyUnknownFields(final ValidationRequest req, final Collection<ParsedTerm> parsedQueryTerms) {
+        if (req == null || parsedQueryTerms == null) {
+            return Collections.emptyList();
+        }
+        final Set<String> availableFields = mappedFieldTypesService.fieldTypesByStreamIds(req.streams(), req.timerange())
+                .stream()
+                .map(MappedFieldTypeDTO::name)
+                .collect(Collectors.toSet());
+
+        return parsedQueryTerms.stream()
+                .filter(t -> !t.isDefaultField())
+                .filter(term -> !availableFields.contains(term.getRealFieldName()))
+                .collect(Collectors.toList());
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/validation/subvalidators/UnknownFieldsIdentifier.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/validation/subvalidators/UnknownFieldsIdentifier.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog.plugins.views.search.validation.subvalidators;
 
 import org.graylog.plugins.views.search.rest.MappedFieldTypeDTO;

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/validation/subvalidators/ValidationExplanationCreator.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/validation/subvalidators/ValidationExplanationCreator.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog.plugins.views.search.validation.subvalidators;
 
 import com.google.common.collect.Streams;

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/validation/subvalidators/ValidationExplanationCreator.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/validation/subvalidators/ValidationExplanationCreator.java
@@ -1,0 +1,58 @@
+package org.graylog.plugins.views.search.validation.subvalidators;
+
+import com.google.common.collect.Streams;
+import org.graylog.plugins.views.search.validation.ParsedTerm;
+import org.graylog.plugins.views.search.validation.ValidationMessage;
+import org.graylog.plugins.views.search.validation.ValidationType;
+
+import javax.inject.Singleton;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Singleton
+public class ValidationExplanationCreator {
+
+    public List<ValidationMessage> getExceptionExplanations(final Exception e) {
+        return Collections.singletonList(ValidationMessage.fromException(e));
+    }
+
+    public List<ValidationMessage> getVerificationExplanations(final List<ParsedTerm> unknownFields,
+                                                               final List<ParsedTerm> invalidOperators) {
+
+        final Stream<ValidationMessage> unknownFieldsStream = unknownFields.stream().map(term -> {
+            final ValidationMessage.Builder messageBuilder = getErrorMessageBuilder((t) -> "Query contains unknown field: " + term.getRealFieldName(),
+                    ValidationType.UNKNOWN_FIELD,
+                    term);
+            messageBuilder.relatedProperty(term.getRealFieldName());
+            return messageBuilder.build();
+        });
+
+        final Stream<ValidationMessage> invalidOperatorsStream = invalidOperators.stream().map(term -> {
+            final ValidationMessage.Builder message = getErrorMessageBuilder((t) -> String.format(Locale.ROOT, "Query contains invalid operator \"%s\". All AND / OR / NOT operators have to be written uppercase", t.value()),
+                    ValidationType.INVALID_OPERATOR,
+                    term);
+            return message.build();
+        });
+
+        return Streams.concat(unknownFieldsStream, invalidOperatorsStream)
+                .distinct()
+                .collect(Collectors.toList());
+    }
+
+    private ValidationMessage.Builder getErrorMessageBuilder(final Function<ParsedTerm, String> errorMessageFunction, final ValidationType validationType, final ParsedTerm parsedTerm) {
+        final ValidationMessage.Builder message = ValidationMessage.builder(validationType)
+                .errorMessage(errorMessageFunction.apply(parsedTerm));
+
+        parsedTerm.keyToken().ifPresent(t -> {
+            message.beginLine(t.beginLine());
+            message.beginColumn(t.beginColumn());
+            message.endLine(t.endLine());
+            message.endColumn(t.endColumn());
+        });
+        return message;
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/MessagesResourceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/MessagesResourceTest.java
@@ -22,7 +22,6 @@ import com.google.common.eventbus.EventBus;
 import org.graylog.plugins.views.search.SearchDomain;
 import org.graylog.plugins.views.search.SearchExecutionGuard;
 import org.graylog.plugins.views.search.elasticsearch.QueryStringDecorators;
-import org.graylog.plugins.views.search.elasticsearch.QueryStringParser;
 import org.graylog.plugins.views.search.errors.PermissionException;
 import org.graylog.plugins.views.search.export.AuditContext;
 import org.graylog.plugins.views.search.export.CommandFactory;
@@ -34,6 +33,9 @@ import org.graylog.plugins.views.search.permissions.SearchUser;
 import org.graylog.plugins.views.search.validation.LuceneQueryParser;
 import org.graylog.plugins.views.search.validation.QueryValidationService;
 import org.graylog.plugins.views.search.validation.QueryValidationServiceImpl;
+import org.graylog.plugins.views.search.validation.subvalidators.LuceneQuerySubValidator;
+import org.graylog.plugins.views.search.validation.subvalidators.UnknownFieldsIdentifier;
+import org.graylog.plugins.views.search.validation.subvalidators.ValidationExplanationCreator;
 import org.graylog2.plugin.database.users.User;
 import org.graylog2.shared.bindings.GuiceInjectorHolder;
 import org.junit.jupiter.api.BeforeEach;
@@ -79,8 +81,7 @@ public class MessagesResourceTest {
         SearchDomain searchDomain = mock(SearchDomain.class);
 
         final QueryValidationServiceImpl validationService = new QueryValidationServiceImpl(
-                new LuceneQueryParser(),
-                (streamIds, timeRange) -> Collections.emptySet(),
+                new LuceneQuerySubValidator(new LuceneQueryParser(), new UnknownFieldsIdentifier((streamIds, timeRange) -> Collections.emptySet()), new ValidationExplanationCreator()),
                 new QueryStringDecorators(Collections.emptySet()));
 
         sut = new MessagesTestResource(exporter, commandFactory, searchDomain, executionGuard, permittedStreams, mock(ObjectMapper.class), eventBus, validationService);

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/validation/QueryValidationServiceImplTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/validation/QueryValidationServiceImplTest.java
@@ -16,12 +16,13 @@
  */
 package org.graylog.plugins.views.search.validation;
 
-import edu.emory.mathcs.backport.java.util.Collections;
 import org.graylog.plugins.views.search.elasticsearch.ElasticsearchQueryString;
 import org.graylog.plugins.views.search.elasticsearch.QueryStringDecorators;
 import org.graylog.plugins.views.search.validation.subvalidators.LuceneQuerySubValidator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/validation/QueryValidationServiceImplTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/validation/QueryValidationServiceImplTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog.plugins.views.search.validation;
 
 import edu.emory.mathcs.backport.java.util.Collections;

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/validation/QueryValidationServiceImplTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/validation/QueryValidationServiceImplTest.java
@@ -1,0 +1,61 @@
+package org.graylog.plugins.views.search.validation;
+
+import edu.emory.mathcs.backport.java.util.Collections;
+import org.graylog.plugins.views.search.elasticsearch.ElasticsearchQueryString;
+import org.graylog.plugins.views.search.elasticsearch.QueryStringDecorators;
+import org.graylog.plugins.views.search.validation.subvalidators.LuceneQuerySubValidator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+public class QueryValidationServiceImplTest {
+
+    private QueryValidationServiceImpl toTest;
+    private LuceneQuerySubValidator luceneQuerySubValidator;
+    private QueryStringDecorators queryStringDecoratorsSubValidator;
+    private ValidationRequest validationRequest;
+
+    @BeforeEach
+    public void setUp() {
+        luceneQuerySubValidator = mock(LuceneQuerySubValidator.class);
+        queryStringDecoratorsSubValidator = mock(QueryStringDecorators.class);
+        validationRequest = mock(ValidationRequest.class);
+        when(validationRequest.query()).thenReturn(ElasticsearchQueryString.of("nevermind"));
+
+        toTest = new QueryValidationServiceImpl(luceneQuerySubValidator, queryStringDecoratorsSubValidator);
+    }
+
+    @Test
+    public void returnsOkResponseOnEmptyQuery() {
+        when(validationRequest.query()).thenReturn(ElasticsearchQueryString.of(""));
+        final ValidationResponse validationResponse = toTest.validate(validationRequest);
+        assertEquals(ValidationStatus.OK, validationResponse.status());
+    }
+
+    @Test
+    public void returnsQueryDecoratorsValidationResponseIfItIsNotOk() {
+        final ValidationResponse queryStringDecoratorsValidationResponse = ValidationResponse.create(ValidationStatus.ERROR,
+                Collections.singletonList(ValidationMessage.builder(ValidationType.MISSING_LICENSE)
+                        .errorMessage("It is sooo wrong!").build()));
+        when(queryStringDecoratorsSubValidator.validate(validationRequest)).thenReturn(queryStringDecoratorsValidationResponse);
+        final ValidationResponse validationResponse = toTest.validate(validationRequest);
+        assertEquals(queryStringDecoratorsValidationResponse, validationResponse);
+        verifyNoInteractions(luceneQuerySubValidator);
+    }
+
+    @Test
+    public void returnsLuceneValidationResponseIfQueryDecoratorsValidationIsOk() {
+        final ValidationResponse queryStringDecoratorsValidationResponse = ValidationResponse.create(ValidationStatus.OK, Collections.emptyList());
+        final ValidationResponse luceneValidationResponse = ValidationResponse.create(ValidationStatus.ERROR,
+                Collections.singletonList(ValidationMessage.builder(ValidationType.QUERY_PARSING_ERROR)
+                        .errorMessage("It is sooo wrong!").build()));
+        when(queryStringDecoratorsSubValidator.validate(validationRequest)).thenReturn(queryStringDecoratorsValidationResponse);
+        when(luceneQuerySubValidator.validate(validationRequest)).thenReturn(luceneValidationResponse);
+        final ValidationResponse validationResponse = toTest.validate(validationRequest);
+        assertEquals(luceneValidationResponse, validationResponse);
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/validation/subvalidators/LuceneQuerySubValidatorTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/validation/subvalidators/LuceneQuerySubValidatorTest.java
@@ -1,0 +1,100 @@
+package org.graylog.plugins.views.search.validation.subvalidators;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.lucene.queryparser.classic.ParseException;
+import org.graylog.plugins.views.search.elasticsearch.ElasticsearchQueryString;
+import org.graylog.plugins.views.search.validation.LuceneQueryParser;
+import org.graylog.plugins.views.search.validation.ParsedQuery;
+import org.graylog.plugins.views.search.validation.ParsedTerm;
+import org.graylog.plugins.views.search.validation.ValidationMessage;
+import org.graylog.plugins.views.search.validation.ValidationRequest;
+import org.graylog.plugins.views.search.validation.ValidationResponse;
+import org.graylog.plugins.views.search.validation.ValidationStatus;
+import org.graylog.plugins.views.search.validation.ValidationType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class LuceneQuerySubValidatorTest {
+
+    private LuceneQueryParser luceneQueryParser;
+    private UnknownFieldsIdentifier unknownFieldsIdentifier;
+    private ValidationExplanationCreator validationExplanationCreator;
+    private ValidationRequest validationRequest;
+    private ParsedQuery parsedQuery;
+
+    private LuceneQuerySubValidator toTest;
+
+    private final String queryString = "search";
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        luceneQueryParser = mock(LuceneQueryParser.class);
+        unknownFieldsIdentifier = mock(UnknownFieldsIdentifier.class);
+        validationExplanationCreator = mock(ValidationExplanationCreator.class);
+        validationRequest = mock(ValidationRequest.class);
+        parsedQuery = mock(ParsedQuery.class);
+
+        when(validationRequest.query()).thenReturn(ElasticsearchQueryString.of(queryString));
+        when(luceneQueryParser.parse(queryString)).thenReturn(parsedQuery);
+        when(luceneQueryParser.parse(queryString)).thenReturn(parsedQuery);
+
+        toTest = new LuceneQuerySubValidator(luceneQueryParser, unknownFieldsIdentifier, validationExplanationCreator);
+    }
+
+    @Test
+    public void returnsErrorOnParsingException() throws Exception {
+        when(luceneQueryParser.parse(queryString)).thenThrow(new ParseException("Gosh..."));
+        when(validationExplanationCreator.getExceptionExplanations(any()))
+                .thenReturn(Collections.singletonList(ValidationMessage.builder(ValidationType.QUERY_PARSING_ERROR).errorMessage("Oh noes!").build()));
+
+        final ValidationResponse validationResponse = toTest.validate(validationRequest);
+        assertEquals(ValidationStatus.ERROR, validationResponse.status());
+        final List<ValidationMessage> explanations = validationResponse.explanations();
+        assertEquals(1, explanations.size());
+        assertEquals(ValidationType.QUERY_PARSING_ERROR, explanations.get(0).validationType());
+        assertEquals("Oh noes!", explanations.get(0).errorMessage());
+
+    }
+
+    @Test
+    public void returnsOkOnNoProblems() throws Exception {
+        final ImmutableList<ParsedTerm> parsedQueryTerms = ImmutableList.of(ParsedTerm.create("field", "value"));
+        when(unknownFieldsIdentifier.identifyUnknownFields(validationRequest, parsedQueryTerms)).thenReturn(Collections.emptyList());
+        when(parsedQuery.invalidOperators()).thenReturn(Collections.emptyList());
+        when(parsedQuery.terms()).thenReturn(parsedQueryTerms);
+        when(validationExplanationCreator.getVerificationExplanations(argThat(List::isEmpty), argThat(List::isEmpty))).thenReturn(Collections.emptyList());
+
+        final ValidationResponse validationResponse = toTest.validate(validationRequest);
+        assertEquals(ValidationStatus.OK, validationResponse.status());
+    }
+
+    @Test
+    public void returnsWarningOnNoProblems() throws Exception {
+        final ImmutableList<ParsedTerm> parsedQueryTerms = ImmutableList.of(ParsedTerm.create("field", "value"));
+        final List<ParsedTerm> invalidOperators = Collections.singletonList(ParsedTerm.create("invalidOperator", "val"));
+        final List<ParsedTerm> unknownFields = Collections.singletonList(ParsedTerm.create("unknownField", "nvmd"));
+        when(unknownFieldsIdentifier.identifyUnknownFields(validationRequest, parsedQueryTerms)).thenReturn(unknownFields);
+        when(parsedQuery.invalidOperators()).thenReturn(invalidOperators);
+        when(parsedQuery.terms()).thenReturn(parsedQueryTerms);
+        final ValidationMessage unknownFieldMsg = ValidationMessage.builder(ValidationType.UNKNOWN_FIELD).errorMessage("No!").build();
+        final ValidationMessage invalidOperatorMsg = ValidationMessage.builder(ValidationType.INVALID_OPERATOR).errorMessage("No, please stop typing wrong queries!").build();
+        when(validationExplanationCreator.getVerificationExplanations(unknownFields, invalidOperators)).thenReturn(
+                Arrays.asList(unknownFieldMsg, invalidOperatorMsg));
+
+        final ValidationResponse validationResponse = toTest.validate(validationRequest);
+        assertEquals(ValidationStatus.WARNING, validationResponse.status());
+        assertTrue(validationResponse.explanations().contains(unknownFieldMsg));
+        assertTrue(validationResponse.explanations().contains(invalidOperatorMsg));
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/validation/subvalidators/LuceneQuerySubValidatorTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/validation/subvalidators/LuceneQuerySubValidatorTest.java
@@ -80,7 +80,7 @@ public class LuceneQuerySubValidatorTest {
     }
 
     @Test
-    public void returnsWarningOnNoProblems() throws Exception {
+    public void returnsWarningOnValidationProblems() throws Exception {
         final ImmutableList<ParsedTerm> parsedQueryTerms = ImmutableList.of(ParsedTerm.create("field", "value"));
         final List<ParsedTerm> invalidOperators = Collections.singletonList(ParsedTerm.create("invalidOperator", "val"));
         final List<ParsedTerm> unknownFields = Collections.singletonList(ParsedTerm.create("unknownField", "nvmd"));

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/validation/subvalidators/LuceneQuerySubValidatorTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/validation/subvalidators/LuceneQuerySubValidatorTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog.plugins.views.search.validation.subvalidators;
 
 import com.google.common.collect.ImmutableList;

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/validation/subvalidators/UnknownFieldsIdentifierTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/validation/subvalidators/UnknownFieldsIdentifierTest.java
@@ -1,0 +1,68 @@
+package org.graylog.plugins.views.search.validation.subvalidators;
+
+import org.graylog.plugins.views.search.rest.MappedFieldTypeDTO;
+import org.graylog.plugins.views.search.validation.ParsedTerm;
+import org.graylog.plugins.views.search.validation.ValidationRequest;
+import org.graylog2.indexer.fieldtypes.FieldTypes;
+import org.graylog2.indexer.fieldtypes.MappedFieldTypesService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class UnknownFieldsIdentifierTest {
+
+    private UnknownFieldsIdentifier toTest;
+    private MappedFieldTypesService mappedFieldTypesService;
+    private MappedFieldTypeDTO existingFieldTypeDTO;
+    private ValidationRequest validationRequest;
+
+    @BeforeEach
+    public void setUp() {
+        validationRequest = mock(ValidationRequest.class);
+        mappedFieldTypesService = mock(MappedFieldTypesService.class);
+        existingFieldTypeDTO = MappedFieldTypeDTO.create("existingField", FieldTypes.Type.builder().type("date").build());
+        when(mappedFieldTypesService.fieldTypesByStreamIds(any(), any())).thenReturn(Collections.singleton(existingFieldTypeDTO));
+
+        toTest = new UnknownFieldsIdentifier(mappedFieldTypesService);
+    }
+
+    @Test
+    public void returnsEmptyListOnNullRequest() {
+        final List<ParsedTerm> result = toTest.identifyUnknownFields(null, Collections.emptyList());
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void returnsEmptyListOnNullTerms() {
+        final List<ParsedTerm> result = toTest.identifyUnknownFields(validationRequest, null);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void identifiesUnknownFields() {
+
+        final ParsedTerm unknownField = ParsedTerm.create("unknownField", "lalala");
+        Collection<ParsedTerm> parsedQueryTerms = Arrays.asList(
+                ParsedTerm.create("existingField", "papapa"),
+                unknownField,
+                ParsedTerm.create(ParsedTerm.DEFAULT_FIELD, "123")
+        );
+
+        final List<ParsedTerm> result = toTest.identifyUnknownFields(validationRequest, parsedQueryTerms);
+        assertNotNull(result);
+        assertEquals(1, result.size());
+        assertTrue(result.contains(unknownField));
+
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/validation/subvalidators/UnknownFieldsIdentifierTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/validation/subvalidators/UnknownFieldsIdentifierTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog.plugins.views.search.validation.subvalidators;
 
 import org.graylog.plugins.views.search.rest.MappedFieldTypeDTO;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
QueryValidationServiceImpl class split to number of classes, so that each class has one responsibility. Unit tests added.
It is just part of the task, related to graylog2-server only.

## Motivation and Context
#12291 issue shows initial motivation.

Some important points from discussions:
"The only way how I can validate the params is to let the decoration run, ignore the results and catch exceptions it produces. All the information about the params is then propagated back in the exception classes. And since I catch the exceptions in the server2 code, I can't even use the type of the parameters."

"The best solution would be probably to have one shared validation interface, two implementations, one in the server and one in the enterprise code, both providing lists of validation problems. The server would then merge it all together and deliver the validation info."

"If our validation code would be pluggable, we could also provide a parameter validator in enterprise which would take a look at query strings, parameters and bindings which would return validation errors about undeclared parameters, missing bindings, etc."


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

