### PR TITLE
Allow ignoring 403 when fetching response.

### DIFF
--- a/graylog2-web-interface/src/logic/rest/FetchProvider.ts
+++ b/graylog2-web-interface/src/logic/rest/FetchProvider.ts
@@ -168,6 +168,12 @@ export class Builder {
     return this;
   }
 
+  ignoreUnauthorized() {
+    this.errorHandler = (error) => onServerError(error, () => {});
+
+    return this;
+  }
+
   noSessionExtension() {
     this.options = {
       ...this.options,


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is adding an `ignoreUnauthorized` method to the `Builder` class of the `FetchProvider` module. This allows consumers of it to ignore 403s occurring when fetching a response, which would otherwise be reported through `ErrorsActions.report` by default, leading to an error page in most cases.

A use case for this would be an API where a 403 response can be expected, but does not necessarily indicate a general permissions problem. E.g. optional functionality which is offered when a user has the corresponding permissions, which is just not shown/disabled if not.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.