### PR TITLE
Fixing serialization of execution state for export jobs.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/ExecutionState.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/ExecutionState.java
@@ -31,17 +31,20 @@ import java.util.Map;
 @JsonAutoDetect
 @JsonDeserialize(builder = ExecutionState.Builder.class)
 public abstract class ExecutionState {
+    @JsonProperty
+    public abstract ImmutableMap<String, Parameter.Binding> parameterBindings();
 
-    public abstract ImmutableMap<String,  Parameter.Binding> parameterBindings();
-
+    @JsonProperty
     public abstract ImmutableMap<String, ExecutionStateGlobalOverride> queries();
 
+    @JsonProperty
     public abstract ExecutionStateGlobalOverride globalOverride();
 
+    @JsonProperty
     public abstract ImmutableMap<String, Object> additionalParameters();
 
     public static ExecutionState empty() {
-       return builder().build();
+        return builder().build();
     }
 
     public static Builder builder() {
@@ -66,10 +69,10 @@ public abstract class ExecutionState {
         @JsonProperty
         public abstract ImmutableMap.Builder<String, ExecutionStateGlobalOverride> queriesBuilder();
 
-        public abstract ImmutableMap.Builder<String,  Parameter.Binding> parameterBindingsBuilder();
+        public abstract ImmutableMap.Builder<String, Parameter.Binding> parameterBindingsBuilder();
 
         @JsonProperty("parameter_bindings")
-        public Builder withParameterBindings(Map<String,  Parameter.Binding> values) {
+        public Builder withParameterBindings(Map<String, Parameter.Binding> values) {
             values.forEach((s, o) -> parameterBindingsBuilder().put(s, o));
             return this;
         }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/ExecutionStateGlobalOverride.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/ExecutionStateGlobalOverride.java
@@ -25,6 +25,7 @@ import com.google.common.collect.ImmutableSet;
 import org.graylog.plugins.views.search.engine.BackendQuery;
 import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
 
+import javax.annotation.Nullable;
 import java.util.Optional;
 
 @AutoValue
@@ -76,16 +77,16 @@ public abstract class ExecutionStateGlobalOverride {
         }
 
         @JsonProperty
-        public abstract Builder timerange(TimeRange timerange);
+        public abstract Builder timerange(@Nullable TimeRange timerange);
 
         @JsonProperty
-        public abstract Builder query(BackendQuery query);
+        public abstract Builder query(@Nullable BackendQuery query);
 
         @JsonProperty
-        public abstract Builder limit(Integer limit);
+        public abstract Builder limit(@Nullable Integer limit);
 
         @JsonProperty
-        public abstract Builder offset(Integer offset);
+        public abstract Builder offset(@Nullable Integer offset);
 
         @JsonProperty
         public abstract Builder keepSearchTypes(ImmutableSet<String> keepSearchTypes);


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is fixing (de-)serialization for the `ExecutionState`/`ExecutionStateGlobalOverride` classes. They were missing required annotations for properties which are nullable (for deserialization) or should be serialized.

Missing these lead to exporting searches/search types containing parameters to fail. The reason for this is that the created export job was missing the parameter bindings due to them not being serialized properly.

Fixes Graylog2/graylog-plugin-enterprise#3327

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.