### PR TITLE
Provide injectable flag indicating if server is in development.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/bootstrap/CmdLineTool.java
+++ b/graylog2-server/src/main/java/org/graylog2/bootstrap/CmdLineTool.java
@@ -68,14 +68,15 @@ import org.graylog2.plugin.Version;
 import org.graylog2.plugin.system.NodeIdPersistenceException;
 import org.graylog2.shared.UI;
 import org.graylog2.shared.bindings.GuiceInjectorHolder;
+import org.graylog2.shared.bindings.IsDevelopmentBindings;
 import org.graylog2.shared.bindings.PluginBindings;
 import org.graylog2.shared.metrics.MetricRegistryFactory;
 import org.graylog2.shared.plugins.ChainingClassLoader;
 import org.graylog2.shared.plugins.PluginLoader;
 import org.graylog2.shared.utilities.ExceptionUtils;
+import org.graylog2.storage.SearchVersion;
 import org.graylog2.storage.UnsupportedSearchException;
 import org.graylog2.storage.versionprobe.ElasticsearchProbeException;
-import org.graylog2.storage.SearchVersion;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -205,7 +206,8 @@ public abstract class CmdLineTool implements CliCommand {
     /**
      * Things that have to run before the guice injector is created.
      * This call happens *after* the configuration file has been parsed.
-     * @param plugins  The already loaded plugins
+     *
+     * @param plugins The already loaded plugins
      */
     protected void beforeInjectorCreation(Set<Plugin> plugins) {
     }
@@ -292,6 +294,7 @@ public abstract class CmdLineTool implements CliCommand {
         beforeInjectorCreation(plugins);
 
         injector = setupInjector(
+                new IsDevelopmentBindings(),
                 new NamedConfigParametersModule(jadConfig.getConfigurationBeans()),
                 new PluginBindings(plugins),
                 binder -> binder.bind(MetricRegistry.class).toInstance(metricRegistry)

--- a/graylog2-server/src/main/java/org/graylog2/bootstrap/ServerBootstrap.java
+++ b/graylog2-server/src/main/java/org/graylog2/bootstrap/ServerBootstrap.java
@@ -49,6 +49,7 @@ import org.graylog2.plugin.inputs.MessageInput;
 import org.graylog2.plugin.system.NodeId;
 import org.graylog2.shared.bindings.GenericBindings;
 import org.graylog2.shared.bindings.GenericInitializerBindings;
+import org.graylog2.shared.bindings.IsDevelopmentBindings;
 import org.graylog2.shared.bindings.SchedulerBindings;
 import org.graylog2.shared.bindings.ServerStatusBindings;
 import org.graylog2.shared.bindings.SharedPeriodicalBindings;
@@ -137,6 +138,7 @@ public abstract class ServerBootstrap extends CmdLineTool {
 
     private Injector getPreflightInjector(List<PreflightCheckModule> preflightCheckModules) {
         final Injector injector = Guice.createInjector(
+                new IsDevelopmentBindings(),
                 new NamedConfigParametersModule(jadConfig.getConfigurationBeans()),
                 new ServerStatusBindings(capabilities()),
                 new ConfigurationModule(configuration),
@@ -168,9 +170,9 @@ public abstract class ServerBootstrap extends CmdLineTool {
         final NodeId nodeId = injector.getInstance(NodeId.class);
         final String systemInformation = Tools.getSystemInformation();
         final Map<String, Object> auditEventContext = ImmutableMap.of(
-            "version", version.toString(),
-            "java", systemInformation,
-            "node_id", nodeId.toString()
+                "version", version.toString(),
+                "java", systemInformation,
+                "node_id", nodeId.toString()
         );
         auditEventSender.success(AuditActor.system(nodeId), NODE_STARTUP_INITIATE, auditEventContext);
 

--- a/graylog2-server/src/main/java/org/graylog2/shared/bindings/IsDevelopmentBindings.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/bindings/IsDevelopmentBindings.java
@@ -1,0 +1,13 @@
+package org.graylog2.shared.bindings;
+
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import com.google.inject.name.Names;
+import org.graylog2.shared.bindings.providers.IsDevelopmentServerProvider;
+
+public class IsDevelopmentBindings implements Module {
+    @Override
+    public void configure(Binder binder) {
+        binder.bind(Boolean.class).annotatedWith(Names.named("isDevelopmentServer")).toProvider(IsDevelopmentServerProvider.class);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/shared/bindings/IsDevelopmentBindings.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/bindings/IsDevelopmentBindings.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog2.shared.bindings;
 
 import com.google.inject.Binder;

--- a/graylog2-server/src/main/java/org/graylog2/shared/bindings/RestApiBindings.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/bindings/RestApiBindings.java
@@ -21,9 +21,8 @@ import org.graylog2.plugin.inject.Graylog2Module;
 import org.graylog2.rest.resources.RestResourcesModule;
 import org.graylog2.shared.rest.resources.RestResourcesSharedModule;
 import org.graylog2.shared.security.ShiroSecurityBinding;
-import org.graylog2.web.DevelopmentIndexHtmlGenerator;
 import org.graylog2.web.IndexHtmlGenerator;
-import org.graylog2.web.ProductionIndexHtmlGenerator;
+import org.graylog2.web.IndexHtmlGeneratorProvider;
 import org.graylog2.web.resources.WebResourcesModule;
 
 import javax.ws.rs.container.DynamicFeature;
@@ -38,16 +37,8 @@ public class RestApiBindings extends Graylog2Module {
         jerseyExceptionMapperBinder();
         jerseyAdditionalComponentsBinder();
 
-        // In development mode we use an external process to provide the web interface.
-        // To avoid errors because of missing production web assets, we use a different implementation for
-        // generating the "index.html" page.
-        final String development = System.getenv("DEVELOPMENT");
-        if (development == null || development.equalsIgnoreCase("false")) {
-            bind(IndexHtmlGenerator.class).to(ProductionIndexHtmlGenerator.class).asEagerSingleton();
-        } else {
-            bind(IndexHtmlGenerator.class).to(DevelopmentIndexHtmlGenerator.class).asEagerSingleton();
-        }
-
+        bind(IndexHtmlGenerator.class).toProvider(IndexHtmlGeneratorProvider.class);
+        
         // Install all resource modules
         install(new WebResourcesModule());
         install(new RestResourcesModule());

--- a/graylog2-server/src/main/java/org/graylog2/shared/bindings/providers/IsDevelopmentServerProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/bindings/providers/IsDevelopmentServerProvider.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog2.shared.bindings.providers;
 
 import javax.inject.Provider;

--- a/graylog2-server/src/main/java/org/graylog2/shared/bindings/providers/IsDevelopmentServerProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/bindings/providers/IsDevelopmentServerProvider.java
@@ -1,0 +1,17 @@
+package org.graylog2.shared.bindings.providers;
+
+import javax.inject.Provider;
+
+public class IsDevelopmentServerProvider implements Provider<Boolean> {
+    private final boolean isDevelopmentServer;
+
+    public IsDevelopmentServerProvider() {
+        final String development = System.getenv("DEVELOPMENT");
+        this.isDevelopmentServer = !(development == null || development.equalsIgnoreCase("false"));
+    }
+
+    @Override
+    public Boolean get() {
+        return this.isDevelopmentServer;
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/web/IndexHtmlGeneratorProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/web/IndexHtmlGeneratorProvider.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog2.web;
 
 import javax.inject.Inject;

--- a/graylog2-server/src/main/java/org/graylog2/web/IndexHtmlGeneratorProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/web/IndexHtmlGeneratorProvider.java
@@ -1,0 +1,23 @@
+package org.graylog2.web;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Provider;
+
+public class IndexHtmlGeneratorProvider implements Provider<IndexHtmlGenerator> {
+    private final Provider<? extends IndexHtmlGenerator> indexHtmlGeneratorProvider;
+
+    @Inject
+    public IndexHtmlGeneratorProvider(Provider<DevelopmentIndexHtmlGenerator> developmentIndexHtmlGeneratorProvider,
+                                      Provider<ProductionIndexHtmlGenerator> productionIndexHtmlGeneratorProvider,
+                                      @Named("isDevelopmentServer") Boolean isDevelopmentServer) {
+        this.indexHtmlGeneratorProvider = isDevelopmentServer
+                ? developmentIndexHtmlGeneratorProvider
+                : productionIndexHtmlGeneratorProvider;
+    }
+
+    @Override
+    public IndexHtmlGenerator get() {
+        return indexHtmlGeneratorProvider.get();
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/web/IndexHtmlGeneratorProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/web/IndexHtmlGeneratorProvider.java
@@ -27,6 +27,9 @@ public class IndexHtmlGeneratorProvider implements Provider<IndexHtmlGenerator> 
     public IndexHtmlGeneratorProvider(Provider<DevelopmentIndexHtmlGenerator> developmentIndexHtmlGeneratorProvider,
                                       Provider<ProductionIndexHtmlGenerator> productionIndexHtmlGeneratorProvider,
                                       @Named("isDevelopmentServer") Boolean isDevelopmentServer) {
+        // In development mode we use an external process to provide the web interface.
+        // To avoid errors because of missing production web assets, we use a different implementation for
+        // generating the "index.html" page.
         this.indexHtmlGeneratorProvider = isDevelopmentServer
                 ? developmentIndexHtmlGeneratorProvider
                 : productionIndexHtmlGeneratorProvider;


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR provides an injectable (as "isDevelopmentServer") boolean that indicates if the Graylog server is run in development (through the `DEVELOPMENT` system property). The flag can then be used to change the server's behavior depending on if it's run in development or not, e.g. if it should provide frontend assets or not.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.