### PR TITLE
Add new date time format for date time utils to display only hour and minute.

### DIFF
--- a/graylog2-web-interface/src/util/DateTime.ts
+++ b/graylog2-web-interface/src/util/DateTime.ts
@@ -31,6 +31,7 @@ export const DATE_TIME_FORMATS = {
   internal: 'YYYY-MM-DDTHH:mm:ss.SSSZ', // ISO 8601, internal default, not really nice to read. Mostly used communication with the API.
   internalIndexer: 'YYYY-MM-DDTHH:mm:ss.SSS[Z]', // ISO 8601, used for ES search queries, when a timestamp has to be reformatted
   date: 'YYYY-MM-DD',
+  hourAndMinute: 'HH:mm',
 };
 
 const DEFAULT_OUTPUT_TZ = 'UTC';


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

With this PR we are adding a new format for the date time utils to display only the hour and minute of a time stamp.
