### PR TITLE
Proper permissions checking for resolved views

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/permissions/SearchUser.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/permissions/SearchUser.java
@@ -22,25 +22,34 @@ import org.graylog.plugins.views.search.rest.PermittedStreams;
 import org.graylog.plugins.views.search.rest.ViewsRestPermissions;
 import org.graylog.plugins.views.search.views.ViewDTO;
 import org.graylog.plugins.views.search.views.ViewLike;
+import org.graylog.plugins.views.search.views.ViewResolver;
+import org.graylog.plugins.views.search.views.ViewResolverDecoder;
 import org.graylog2.plugin.database.users.User;
 import org.graylog2.shared.security.RestPermissions;
 import org.joda.time.DateTimeZone;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.util.Map;
 import java.util.Optional;
 import java.util.function.BiPredicate;
 import java.util.function.Predicate;
 
 public class SearchUser implements SearchPermissions, StreamPermissions, ViewPermissions {
+    private static final Logger LOG = LoggerFactory.getLogger(SearchUser.class);
     private final User currentUser;
     private final Predicate<String> isPermitted;
     private final BiPredicate<String, String> isPermittedEntity;
     private final UserStreams userStreams;
+    private final Map<String, ViewResolver> viewResolvers;
 
-    public SearchUser(User currentUser, Predicate<String> isPermitted, BiPredicate<String, String> isPermittedEntity, PermittedStreams permittedStreams) {
+    public SearchUser(User currentUser, Predicate<String> isPermitted, BiPredicate<String, String> isPermittedEntity,
+                      PermittedStreams permittedStreams, Map<String, ViewResolver> viewResolvers) {
         this.currentUser = currentUser;
         this.isPermitted = isPermitted;
         this.isPermittedEntity = isPermittedEntity;
         this.userStreams = new UserStreams(this, permittedStreams);
+        this.viewResolvers = viewResolvers;
     }
 
     public Optional<DateTimeZone> timeZone() {
@@ -53,6 +62,21 @@ public class SearchUser implements SearchPermissions, StreamPermissions, ViewPer
 
     public boolean canReadView(ViewLike view) {
         final String viewId = view.id();
+
+        // If a resolved view id is provided, delegate the permissions check to the resolver.
+        final ViewResolverDecoder decoder = new ViewResolverDecoder(viewId);
+        if (decoder.isResolverViewId()) {
+            final ViewResolver viewResolver = viewResolvers.get(decoder.getResolverName());
+            if (viewResolver != null) {
+                return viewResolver.canReadView(viewId, isPermitted, isPermittedEntity);
+            } else {
+                // Resolved view could not be found, so permissions cannot be checked.
+                LOG.info("View resolver [{}] could not be found.", decoder.getResolverName());
+                return false;
+            }
+        }
+
+        // Proceed to standard views permission check.
         return isPermitted(ViewsRestPermissions.VIEW_READ, viewId)
                 || (view.type().equals(ViewDTO.Type.DASHBOARD) && isPermitted(RestPermissions.DASHBOARDS_READ, viewId));
     }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/ViewResolver.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/ViewResolver.java
@@ -18,6 +18,8 @@ package org.graylog.plugins.views.search.views;
 
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.BiPredicate;
+import java.util.function.Predicate;
 
 /**
  * View Resolvers provide a way that plugins can provide custom sources for looking up views.
@@ -44,4 +46,22 @@ public interface ViewResolver {
      * {@link org.graylog.plugins.views.search.db.SearchesCleanUpJob}.
      */
     Set<String> getSearchIds();
+
+    /**
+     * A method to return whether the current user is authorized to read the current view and its related objects
+     * (such as the backing {@link org.graylog.plugins.views.search.Search} record).
+     *
+     * This method accepts two permissions tester predicates, to allow each implementation to perform any combination
+     * of permission checks needed.
+     *
+     * @param viewId                  The id of the view.
+     * @param permissionTester        A predicate, which tests a single string permission parameter.
+     *                                For example, is the user authorized to read a view based on having of a
+     *                                particular permission?
+     * @param entityPermissionsTester A bi-predicate which tests two parameters (the permission to test and the id of
+     *                                the entity). For example, is the user authorized to read a view based on having
+     *                                a particular permission and/or having access to a particular entity?
+     */
+    boolean canReadView(String viewId, Predicate<String> permissionTester,
+                        BiPredicate<String, String> entityPermissionsTester);
 }

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/SearchDomainTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/SearchDomainTest.java
@@ -39,6 +39,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.function.BiPredicate;
+import java.util.function.Predicate;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
@@ -241,6 +243,11 @@ public class SearchDomainTest {
         @Override
         public Set<String> getSearchIds() {
             return Collections.emptySet();
+        }
+
+        @Override
+        public boolean canReadView(String viewId, Predicate<String> permissionTester, BiPredicate<String, String> entityPermissionsTester) {
+            return false;
         }
 
         @Override

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/db/SearchesCleanUpJobTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/db/SearchesCleanUpJobTest.java
@@ -39,6 +39,8 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.BiPredicate;
+import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -208,6 +210,11 @@ public class SearchesCleanUpJobTest {
         @Override
         public Set<ViewDTO> getBySearchId(String searchId) {
             return Collections.emptySet();
+        }
+
+        @Override
+        public boolean canReadView(String viewId, Predicate<String> permissionTester, BiPredicate<String, String> entityPermissionsTester) {
+            return false;
         }
     }
 }

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/permissions/SearchUserTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/permissions/SearchUserTest.java
@@ -18,10 +18,11 @@ package org.graylog.plugins.views.search.permissions;
 
 import org.graylog.plugins.views.search.Search;
 import org.graylog.plugins.views.search.rest.PermittedStreams;
-import org.graylog.plugins.views.search.rest.TestSearchUser;
 import org.graylog2.plugin.database.users.User;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+
+import java.util.HashMap;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -35,7 +36,8 @@ class SearchUserTest {
     }
 
     private SearchUser searchUser(String username) {
-        return new SearchUser(mockUser(username), (perm) -> true, (perm, id) -> true, Mockito.mock(PermittedStreams.class));
+        return new SearchUser(mockUser(username), (perm) -> true, (perm, id) -> true, Mockito.mock(PermittedStreams.class),
+                new HashMap<>());
     }
 
     @Test

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/TestSearchUser.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/TestSearchUser.java
@@ -22,8 +22,8 @@ import org.graylog.plugins.views.search.permissions.SearchUser;
 import org.graylog2.plugin.database.users.User;
 import org.mockito.Mockito;
 
+import java.util.HashMap;
 import java.util.Optional;
-import java.util.function.Consumer;
 
 import static org.graylog2.shared.security.RestPermissions.DASHBOARDS_READ;
 import static org.graylog2.shared.security.RestPermissions.STREAMS_READ;
@@ -78,8 +78,8 @@ public class TestSearchUser {
                 Optional.ofNullable(user).orElseGet(() -> Mockito.mock(User.class)),
                 permission -> verifyPermission(permissions, permission),
                 (permission, entityid) -> verifyPermission(permissions, permission, entityid),
-                new PermittedStreams(knownStreamIDs::stream)
-        );
+                new PermittedStreams(knownStreamIDs::stream),
+                new HashMap<>());
     }
 
     private Boolean verifyPermission(ImmutableMap<String, Boolean> permissions, String permission, String entityId) {

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/ViewsResourceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/ViewsResourceTest.java
@@ -51,6 +51,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.BiPredicate;
+import java.util.function.Predicate;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -229,6 +231,11 @@ public class ViewsResourceTest {
         @Override
         public Set<ViewDTO> getBySearchId(String searchId) {
             return Collections.emptySet();
+        }
+
+        @Override
+        public boolean canReadView(String viewId, Predicate<String> permissionTester, BiPredicate<String, String> entityPermissionsTester) {
+            return false;
         }
     }
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Add proper view resolver permissions checks that support view resolver-specific permissions checks and no longer require global `views:read:*` access.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The previous attempt to check resolved view permissions (in https://github.com/Graylog2/graylog2-server/pull/12287) was not complete, because it required users to have global views read permissions (`views:read:*`) in order to access any resolved views. This is not acceptable, because global view access cannot be required to access specific resolved views. Also, a view resolver might require that another particular permission be checked in order to validate access to the view (which completely depends on the view resolver implementation).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
See testing comment in linked PR.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [*] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

