### PR TITLE
Reset time based rotation strategy after leader change

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/periodical/IndexRotationThread.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/IndexRotationThread.java
@@ -24,6 +24,7 @@ import org.graylog2.indexer.indexset.IndexSetConfig;
 import org.graylog2.indexer.indices.HealthStatus;
 import org.graylog2.indexer.indices.Indices;
 import org.graylog2.indexer.indices.TooManyAliasesException;
+import org.graylog2.indexer.rotation.strategies.TimeBasedRotationStrategy;
 import org.graylog2.notifications.Notification;
 import org.graylog2.notifications.NotificationService;
 import org.graylog2.plugin.indexer.rotation.RotationStrategy;
@@ -64,6 +65,19 @@ public class IndexRotationThread extends Periodical {
         this.indices = indices;
         this.nodeId = nodeId;
         this.rotationStrategyMap = rotationStrategyMap;
+    }
+
+    @Override
+    public void initialize() {
+        // The time based index rotation strategy has state which needs to be reset in case this periodical gets
+        // re-used due to a leader change.
+        // This is by no means ideal, but easier than to remove state from the rotation strategy without changing its
+        // behaviour.
+        final Provider<RotationStrategy> rotationStrategyProvider =
+                rotationStrategyMap.get(TimeBasedRotationStrategy.class.getCanonicalName());
+        if (rotationStrategyProvider != null) {
+            ((TimeBasedRotationStrategy) rotationStrategyProvider.get()).reset();
+        }
     }
 
     @Override


### PR DESCRIPTION
The time-based rotation strategy remembers the last time an index was rotated in order to calculate the next rotation point.

When a node loses the leader state, it will stop being responsible for index rotation. The time-based rotation strategy, however, because it is a singleton, will still reference the last rotation times.

If for any reason, the node becomes leader again after a while, it will be unaware of any previous index rotations and will make a rotation decision based on stale data. If any rotations have happened in between, triggered by the other node, the now new leader will immediately rotate the index.

This is a rare scenario to happen, so I don't think this is critical. But nevertheless good to fix.

The proper way to fix this would be to remove the state from the rotation strategy. This might however introduce slightly different behaviour for some rotation periods. Also, changing the logic of the rotation strategy itself is a delicate undertaking, which is why I opted for a low-risk solution.

