### PR TITLE
Support config of sidecars on Darwin and FreeBSD

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/migrations/V20180212165000_AddDefaultCollectors.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/migrations/V20180212165000_AddDefaultCollectors.java
@@ -83,6 +83,44 @@ public class V20180212165000_AddDefaultCollectors extends Migration {
                         "  logs: /var/lib/graylog-sidecar/collectors/filebeat/log"
         );
         ensureCollector(
+                "filebeat",
+                "exec",
+                "darwin",
+                "/usr/share/filebeat/bin/filebeat",
+                "-c  %s",
+                "test config -c %s",
+                beatsPreambel +
+                        "filebeat.inputs:\n" +
+                        "- input_type: log\n" +
+                        "  paths:\n" +
+                        "    - /var/log/*.log\n" +
+                        "  type: log\n" +
+                        "output.logstash:\n" +
+                        "   hosts: [\"192.168.1.1:5044\"]\n" +
+                        "path:\n" +
+                        "  data: /var/lib/graylog-sidecar/collectors/filebeat/data\n" +
+                        "  logs: /var/lib/graylog-sidecar/collectors/filebeat/log"
+        );
+        ensureCollector(
+                "filebeat",
+                "exec",
+                "freebsd",
+                "/usr/share/filebeat/bin/filebeat",
+                "-c  %s",
+                "test config -c %s",
+                beatsPreambel +
+                        "filebeat.inputs:\n" +
+                        "- input_type: log\n" +
+                        "  paths:\n" +
+                        "    - /var/log/*.log\n" +
+                        "  type: log\n" +
+                        "output.logstash:\n" +
+                        "   hosts: [\"192.168.1.1:5044\"]\n" +
+                        "path:\n" +
+                        "  data: /var/lib/graylog-sidecar/collectors/filebeat/data\n" +
+                        "  logs: /var/lib/graylog-sidecar/collectors/filebeat/log"
+        );
+        ensureCollector(
                 "winlogbeat",
                 "svc",
                 "windows",

--- a/graylog2-web-interface/src/components/sidecars/configuration-forms/CollectorForm.jsx
+++ b/graylog2-web-interface/src/components/sidecars/configuration-forms/CollectorForm.jsx
@@ -149,6 +149,8 @@ const CollectorForm = createReactClass({
 
     options.push({ value: 'linux', label: 'Linux' });
     options.push({ value: 'windows', label: 'Windows' });
+    options.push({ value: 'darwin', label: 'Darwin' });
+    options.push({ value: 'freebsd', label: 'FreeBSD' });
 
     return options;
   },


### PR DESCRIPTION
Adds missing validation and config options for Darwin and FreeBSD.

They were already supported, but it was not possible to configure them.

Fixes https://github.com/Graylog2/collector-sidecar/issues/377