### PR TITLE
backport graylog-plugin-enterprise/issues/3418 to 4.3 

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/shared/security/AccessTokenAuthToken.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/security/AccessTokenAuthToken.java
@@ -66,7 +66,7 @@ public final class AccessTokenAuthToken implements HostAuthenticationToken {
     @Override
     public String toString() {
         return MoreObjects.toStringHelper(this)
-                .add("token", token)
+                .add("hashcode", hashCode())
                 .add("host", host)
                 .toString();
     }

--- a/graylog2-server/src/main/java/org/graylog2/shared/security/SessionIdToken.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/security/SessionIdToken.java
@@ -74,7 +74,7 @@ public final class SessionIdToken implements HostAuthenticationToken, RemoteAddr
     @Override
     public String toString() {
         return MoreObjects.toStringHelper(this)
-                .add("sessionId", sessionId)
+                .add("hashcode", hashCode())
                 .add("host", host)
                 .toString();
     }


### PR DESCRIPTION
See https://github.com/Graylog2/graylog-plugin-enterprise/issues/3418

Note: @patrickmann had created the initial round of backports (all mentioned in the original issue https://github.com/Graylog2/graylog-plugin-enterprise/issues/3418), but it appears that the `4.3` backport was missed, so I am creating it now.