### PR TITLE
Always execute search, when pressing enter in search bar form.

### DIFF
--- a/graylog2-web-interface/src/views/actions/QueriesActions.ts
+++ b/graylog2-web-interface/src/views/actions/QueriesActions.ts
@@ -34,6 +34,7 @@ type QueriesActionsType = RefluxActions<{
   remove: (queryId: QueryId) => Promise<QueriesList>,
   timerange: (queryId: QueryId, newTimeRange: TimeRange) => Promise<QueriesList>,
   update: (queryId: QueryId, query: Query) => Promise<QueriesList>,
+  forceUpdate: (queryId: QueryId, query: Query) => Promise<QueriesList>,
 }>;
 
 // eslint-disable-next-line import/prefer-default-export
@@ -48,5 +49,6 @@ export const QueriesActions: QueriesActionsType = singletonActions(
     remove: { asyncResult: true },
     timerange: { asyncResult: true },
     update: { asyncResult: true },
+    forceUpdate: { asyncResult: true },
   }),
 );

--- a/graylog2-web-interface/src/views/components/DashboardSearchBar.test.tsx
+++ b/graylog2-web-interface/src/views/components/DashboardSearchBar.test.tsx
@@ -69,6 +69,10 @@ const config = {
 describe('DashboardSearchBar', () => {
   const onExecute = jest.fn();
 
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('should render the DashboardSearchBar', async () => {
     render(<DashboardSearchBar onExecute={onExecute} config={config} />);
 
@@ -84,7 +88,7 @@ describe('DashboardSearchBar', () => {
     await screen.findByText('No Override');
   });
 
-  it('should refresh search when button is clicked', async () => {
+  it('should call onExecute when there are no changes', async () => {
     render(<DashboardSearchBar onExecute={onExecute} config={config} />);
 
     const searchButton = await screen.findByTitle('Perform search');
@@ -93,7 +97,7 @@ describe('DashboardSearchBar', () => {
 
     userEvent.click(searchButton);
 
-    await waitFor(() => expect(SearchActions.refresh).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(onExecute).toHaveBeenCalledTimes(1));
   });
 
   it('should call onExecute and set global override when search is performed', async () => {
@@ -112,6 +116,7 @@ describe('DashboardSearchBar', () => {
     userEvent.click(searchButton);
 
     await waitFor(() => expect(GlobalOverrideActions.set).toHaveBeenCalledWith({ type: 'relative', from: 300 }, ''));
+    await waitFor(() => expect(onExecute).toHaveBeenCalledTimes(1));
   }, applyTimeoutMultiplier(10000));
 
   it('should hide the save and load controls if a widget is being edited', async () => {

--- a/graylog2-web-interface/src/views/components/DashboardSearchBar.test.tsx
+++ b/graylog2-web-interface/src/views/components/DashboardSearchBar.test.tsx
@@ -67,14 +67,12 @@ const config = {
 };
 
 describe('DashboardSearchBar', () => {
-  const onExecute = jest.fn();
-
   afterEach(() => {
     jest.clearAllMocks();
   });
 
   it('should render the DashboardSearchBar', async () => {
-    render(<DashboardSearchBar onExecute={onExecute} config={config} />);
+    render(<DashboardSearchBar config={config} />);
 
     await screen.findByLabelText('Open Time Range Selector');
     await screen.findByLabelText('Search Time Range, Opens Time Range Selector On Click');
@@ -83,13 +81,13 @@ describe('DashboardSearchBar', () => {
   });
 
   it('defaults to no override being selected', async () => {
-    render(<DashboardSearchBar onExecute={onExecute} config={config} />);
+    render(<DashboardSearchBar config={config} />);
 
     await screen.findByText('No Override');
   });
 
-  it('should call onExecute when there are no changes', async () => {
-    render(<DashboardSearchBar onExecute={onExecute} config={config} />);
+  it('should call SearchActions.refresh on submit when there are no changes', async () => {
+    render(<DashboardSearchBar config={config} />);
 
     const searchButton = await screen.findByTitle('Perform search');
 
@@ -97,11 +95,11 @@ describe('DashboardSearchBar', () => {
 
     userEvent.click(searchButton);
 
-    await waitFor(() => expect(onExecute).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(SearchActions.refresh).toHaveBeenCalledTimes(1));
   });
 
-  it('should call onExecute and set global override when search is performed', async () => {
-    render(<DashboardSearchBar onExecute={onExecute} config={config} />);
+  it('should call SearchActions.refresh and set global override on submit when there are changes', async () => {
+    render(<DashboardSearchBar config={config} />);
 
     const timeRangeInput = await screen.findByText(/no override/i);
 
@@ -116,7 +114,7 @@ describe('DashboardSearchBar', () => {
     userEvent.click(searchButton);
 
     await waitFor(() => expect(GlobalOverrideActions.set).toHaveBeenCalledWith({ type: 'relative', from: 300 }, ''));
-    await waitFor(() => expect(onExecute).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(SearchActions.refresh).toHaveBeenCalledTimes(1));
   }, applyTimeoutMultiplier(10000));
 
   it('should hide the save and load controls if a widget is being edited', async () => {
@@ -131,7 +129,7 @@ describe('DashboardSearchBar', () => {
 
     render(
       <WidgetFocusContext.Provider value={widgetFocusContext}>
-        <DashboardSearchBar onExecute={onExecute} config={config} />
+        <DashboardSearchBar config={config} />
       </WidgetFocusContext.Provider>,
     );
 
@@ -154,7 +152,7 @@ describe('DashboardSearchBar', () => {
 
     render(
       <WidgetFocusContext.Provider value={widgetFocusContext}>
-        <DashboardSearchBar onExecute={onExecute} config={config} />
+        <DashboardSearchBar config={config} />
       </WidgetFocusContext.Provider>,
     );
 

--- a/graylog2-web-interface/src/views/components/DashboardSearchBar.tsx
+++ b/graylog2-web-interface/src/views/components/DashboardSearchBar.tsx
@@ -42,6 +42,7 @@ import debounceWithPromise from 'views/logic/debounceWithPromise';
 import validateQuery from 'views/components/searchbar/queryvalidation/validateQuery';
 import { isNoTimeRangeOverride } from 'views/typeGuards/timeRange';
 import ValidateOnParameterChange from 'views/components/searchbar/ValidateOnParameterChange';
+import { SearchActions } from 'views/stores/SearchStore';
 
 import TimeRangeInput from './searchbar/TimeRangeInput';
 import type { DashboardFormValues } from './DashboardSearchBarForm';
@@ -54,7 +55,6 @@ type Props = {
     query: QueryString,
   },
   disableSearch?: boolean,
-  onExecute: () => Promise<void>,
 };
 
 const TopRow = styled.div(({ theme }) => css`
@@ -95,9 +95,9 @@ const SearchButtonAndQuery = styled.div`
 
 const debouncedValidateQuery = debounceWithPromise(validateQuery, 350);
 
-const DashboardSearchBar = ({ config, globalOverride, disableSearch = false, onExecute: performSearch }: Props) => {
+const DashboardSearchBar = ({ config, globalOverride, disableSearch = false }: Props) => {
   const submitForm = useCallback(({ timerange, queryString }) => GlobalOverrideActions.set(timerange, queryString)
-    .then(() => performSearch()), [performSearch]);
+    .then(() => SearchActions.refresh()), []);
 
   const { parameterBindings, parameters } = useParameters();
   const _validateQueryString = useCallback((values: DashboardFormValues) => {
@@ -198,7 +198,6 @@ const DashboardSearchBar = ({ config, globalOverride, disableSearch = false, onE
 
 DashboardSearchBar.propTypes = {
   disableSearch: PropTypes.bool,
-  onExecute: PropTypes.func.isRequired,
 };
 
 DashboardSearchBar.defaultProps = {

--- a/graylog2-web-interface/src/views/components/Search.test.tsx
+++ b/graylog2-web-interface/src/views/components/Search.test.tsx
@@ -89,8 +89,10 @@ jest.mock('views/components/common/WindowLeaveMessage', () => jest.fn(mockCompon
 jest.mock('views/components/WithSearchStatus', () => (x) => x);
 jest.mock('views/components/SearchBar', () => mockComponent('SearchBar'));
 
-jest.mock('views/components/DashboardSearchBar', () => ({ onExecute }: { onExecute: (view: View) => Promise<void> }) => (
-  <button type="button" onClick={() => onExecute({ search: {} } as View)}>Execute Query</button>
+const mockRefreshSearch = () => SearchActions.refresh();
+
+jest.mock('views/components/DashboardSearchBar', () => () => (
+  <button type="button" onClick={mockRefreshSearch}>Execute Query</button>
 ));
 
 jest.mock('views/stores/SearchMetadataStore');

--- a/graylog2-web-interface/src/views/components/Search.tsx
+++ b/graylog2-web-interface/src/views/components/Search.tsx
@@ -212,11 +212,10 @@ const Search = () => {
                               <IfInteractive>
                                 <HeaderElements />
                                 <IfDashboard>
-                                  {!editingWidget
-                                  && <DashboardSearchBarWithStatus onExecute={refreshIfNotUndeclared} />}
+                                  {!editingWidget && <DashboardSearchBarWithStatus />}
                                 </IfDashboard>
                                 <IfSearch>
-                                  <SearchBarWithStatus onExecute={refreshIfNotUndeclared} />
+                                  <SearchBarWithStatus />
                                 </IfSearch>
 
                                 <QueryBarElements />

--- a/graylog2-web-interface/src/views/components/SearchBar.test.tsx
+++ b/graylog2-web-interface/src/views/components/SearchBar.test.tsx
@@ -107,7 +107,7 @@ describe('SearchBar', () => {
     expect(metaButtons).not.toBeNull();
   });
 
-  it('should update query when search is performed', async () => {
+  it('should refresh search, when search is performed and there are no changes.', async () => {
     render(<SearchBar config={config} />);
 
     const searchButton = await screen.findByTitle('Perform search');

--- a/graylog2-web-interface/src/views/components/SearchBar.tsx
+++ b/graylog2-web-interface/src/views/components/SearchBar.tsx
@@ -144,7 +144,11 @@ const SearchBar = ({
   const streams = filtersToStreamSet(queryFilters.get(id, Immutable.Map())).toJS();
   const limitDuration = moment.duration(config.query_time_range_limit).asSeconds() ?? 0;
 
-  const _onSubmit = (values: SearchBarFormValues) => onSubmit(values, currentQuery);
+  const _onSubmit = (values: SearchBarFormValues, ...rest) => {
+    console.log({ rest });
+
+    return onSubmit(values, currentQuery);
+  };
 
   return (
     <WidgetFocusContext.Consumer>

--- a/graylog2-web-interface/src/views/components/SearchBar.tsx
+++ b/graylog2-web-interface/src/views/components/SearchBar.tsx
@@ -99,7 +99,7 @@ const defaultOnSubmit = ({ timerange, streams, queryString }, currentQuery: Quer
     .build();
 
   if (!currentQuery.equals(newQuery)) {
-    return QueriesActions.update(newQuery.id, newQuery);
+    return QueriesActions.forceUpdate(newQuery.id, newQuery);
   }
 
   return SearchActions.refresh();

--- a/graylog2-web-interface/src/views/components/SearchBar.tsx
+++ b/graylog2-web-interface/src/views/components/SearchBar.tsx
@@ -52,6 +52,7 @@ import useParameters from 'views/hooks/useParameters';
 import debounceWithPromise from 'views/logic/debounceWithPromise';
 import validateQuery from 'views/components/searchbar/queryvalidation/validateQuery';
 import PluggableSearchBarControls from 'views/components/searchbar/PluggableSearchBarControls';
+import { SearchActions } from 'views/stores/SearchStore';
 
 import ValidateOnParameterChange from './searchbar/ValidateOnParameterChange';
 import SearchBarForm from './searchbar/SearchBarForm';
@@ -97,7 +98,11 @@ const defaultOnSubmit = ({ timerange, streams, queryString }, currentQuery: Quer
     .query(createElasticsearchQueryString(queryString))
     .build();
 
-  return QueriesActions.update(newQuery.id, newQuery);
+  if (!currentQuery.equals(newQuery)) {
+    return QueriesActions.update(newQuery.id, newQuery);
+  }
+
+  return SearchActions.refresh();
 };
 
 const defaultProps = {

--- a/graylog2-web-interface/src/views/components/SearchBar.tsx
+++ b/graylog2-web-interface/src/views/components/SearchBar.tsx
@@ -144,11 +144,7 @@ const SearchBar = ({
   const streams = filtersToStreamSet(queryFilters.get(id, Immutable.Map())).toJS();
   const limitDuration = moment.duration(config.query_time_range_limit).asSeconds() ?? 0;
 
-  const _onSubmit = (values: SearchBarFormValues, ...rest) => {
-    console.log({ rest });
-
-    return onSubmit(values, currentQuery);
-  };
+  const _onSubmit = (values: SearchBarFormValues) => onSubmit(values, currentQuery);
 
   return (
     <WidgetFocusContext.Consumer>

--- a/graylog2-web-interface/src/views/components/WidgetQueryControls.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetQueryControls.tsx
@@ -84,7 +84,11 @@ const _onSubmit = (values, widget: Widget) => {
   const { timerange, streams, queryString } = values;
   const newWidget = updateWidgetSearchControls(widget, { timerange, streams, queryString });
 
-  return WidgetActions.update(widget.id, newWidget);
+  if (!widget.equals(newWidget)) {
+    return WidgetActions.update(widget.id, newWidget);
+  }
+
+  return SearchActions.refresh();
 };
 
 const _resetTimeRangeOverride = () => GlobalOverrideActions.resetTimeRange().then(SearchActions.refresh);

--- a/graylog2-web-interface/src/views/components/WithSearchStatus.tsx
+++ b/graylog2-web-interface/src/views/components/WithSearchStatus.tsx
@@ -37,24 +37,21 @@ const _disableSearch = (_undeclaredParameters: Immutable.Set<string>, parameterB
 type SearchStatusProps = {
   config: SearchesConfig;
   disableSearch?: boolean;
-  onExecute: () => void;
 }
 
 type WrapperProps = {
   config: SearchesConfig;
   isDisabled: boolean;
-  onExecute: () => void;
 };
 
 type ResultProps = {
   config?: SearchesConfig;
   isDisabled?: boolean;
-  onExecute: () => void;
 };
 
 const WithSearchStatus = (Component: React.ComponentType<Partial<SearchStatusProps>>): React.ComponentType<ResultProps> => connect(
-  ({ config, isDisabled, onExecute }: WrapperProps) => {
-    return <Component disableSearch={isDisabled} onExecute={onExecute} config={config} />;
+  ({ config, isDisabled }: WrapperProps) => {
+    return <Component disableSearch={isDisabled} config={config} />;
   },
   {
     searchMetadata: SearchMetadataStore,

--- a/graylog2-web-interface/src/views/components/searchbar/SearchButton.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/SearchButton.test.tsx
@@ -17,37 +17,43 @@
 import * as React from 'react';
 import { render, screen, fireEvent } from 'wrappedTestingLibrary';
 
-import { SearchActions } from 'views/stores/SearchStore';
 import SearchButton from 'views/components/searchbar/SearchButton';
 
-jest.mock('views/stores/SearchStore', () => ({
-  SearchActions: {
-    refresh: jest.fn(),
-  },
-}));
-
 describe('SearchButton', () => {
+  const onFormSubmit = jest.fn().mockImplementation((e) => e.preventDefault());
+
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  it('should perform refresh when not dirty', () => {
-    render(<SearchButton />);
+  const SUT = ({ disabled, dirty }: { dirty?: boolean, disabled?: boolean}) => (
+    <form onSubmit={onFormSubmit}>
+      <SearchButton disabled={disabled} dirty={dirty} />
+    </form>
+  );
 
-    const button = screen.getByTitle('Perform search');
+  SUT.defaultProps = {
+    dirty: false,
+    disabled: false,
+  };
+
+  it('should trigger form submit refresh when dirty', () => {
+    render(<SUT dirty />);
+
+    const button = screen.getByTitle('Perform search (changes were made after last search execution)');
 
     fireEvent.click(button);
 
-    expect(SearchActions.refresh).toHaveBeenCalledTimes(1);
+    expect(onFormSubmit).toHaveBeenCalledTimes(1);
   });
 
-  it('should not perform refresh when not dirty and disabled', () => {
-    render(<SearchButton disabled />);
+  it('should trigger form submit refresh when not dirty', () => {
+    render(<SUT />);
 
     const button = screen.getByTitle('Perform search');
 
     fireEvent.click(button);
 
-    expect(SearchActions.refresh).not.toHaveBeenCalled();
+    expect(onFormSubmit).toHaveBeenCalledTimes(1);
   });
 });

--- a/graylog2-web-interface/src/views/components/searchbar/SearchButton.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/SearchButton.tsx
@@ -49,16 +49,10 @@ type Props = {
   dirty: boolean,
 };
 
-const onButtonClick = (e: MouseEvent, disabled: Boolean, onClick?: () => void) => {
+const onButtonClick = (e: MouseEvent, disabled: Boolean) => {
   if (disabled) {
     e.preventDefault();
     QueryValidationActions.displayValidationErrors();
-
-    return;
-  }
-
-  if (typeof onClick === 'function') {
-    onClick();
   }
 };
 
@@ -88,7 +82,9 @@ const CleanSearchButton = ({ disabled, glyph, className }: { disabled: boolean, 
 const SearchButton = ({ dirty, disabled, ...rest }: Props) => {
   const className = disabled ? 'disabled' : '';
 
-  return dirty ? <DirtySearchButton className={className} disabled={disabled} {...rest} /> : <CleanSearchButton className={className} disabled={disabled} {...rest} />;
+  return dirty
+    ? <DirtySearchButton className={className} disabled={disabled} {...rest} />
+    : <CleanSearchButton className={className} disabled={disabled} {...rest} />;
 };
 
 SearchButton.defaultProps = {

--- a/graylog2-web-interface/src/views/components/searchbar/SearchButton.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/SearchButton.tsx
@@ -20,7 +20,6 @@ import styled, { css } from 'styled-components';
 
 import { Button } from 'components/bootstrap';
 import { Icon } from 'components/common';
-import { SearchActions } from 'views/stores/SearchStore';
 import QueryValidationActions from 'views/actions/QueryValidationActions';
 import type { IconName } from 'components/common/Icon';
 
@@ -63,21 +62,25 @@ const onButtonClick = (e: MouseEvent, disabled: Boolean, onClick?: () => void) =
   }
 };
 
+const COMMON_PROPS = {
+  type: 'submit',
+  bsStyle: 'success',
+};
+
 const DirtySearchButton = ({ glyph, className, disabled }: { disabled: boolean, glyph: IconName, className: string }) => (
-  <DirtyButton type="submit"
-               bsStyle="success"
-               onClick={(e) => onButtonClick(e, disabled)}
+  <DirtyButton onClick={(e) => onButtonClick(e, disabled)}
                title="Perform search (changes were made after last search execution)"
-               className={className}>
+               className={className}
+               {...COMMON_PROPS}>
     <Icon name={glyph} />
   </DirtyButton>
 );
 
 const CleanSearchButton = ({ disabled, glyph, className }: { disabled: boolean, glyph: IconName, className: string }) => (
-  <StyledButton bsStyle="success"
-                onClick={(e) => onButtonClick(e, disabled, SearchActions.refresh)}
+  <StyledButton onClick={(e) => onButtonClick(e, disabled)}
                 title="Perform search"
-                className={className}>
+                className={className}
+                {...COMMON_PROPS}>
     <Icon name={glyph} />
   </StyledButton>
 );

--- a/graylog2-web-interface/src/views/components/widgets/EditWidgetFrame.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/EditWidgetFrame.test.tsx
@@ -22,6 +22,7 @@ import MockStore from 'helpers/mocking/StoreMock';
 import { WidgetActions } from 'views/stores/WidgetStore';
 import { SearchActions } from 'views/stores/SearchStore';
 import Widget from 'views/logic/widgets/Widget';
+import { createElasticsearchQueryString } from 'views/logic/queries/Query';
 
 import EditWidgetFrame from './EditWidgetFrame';
 
@@ -37,7 +38,7 @@ jest.mock('views/stores/WidgetStore', () => ({
 jest.mock('views/stores/SearchStore', () => ({
   SearchStore: MockStore(['getInitialState', () => ({ search: { parameters: [] } })]),
   SearchActions: {
-    refresh: jest.fn(),
+    refresh: jest.fn(() => Promise.resolve()),
   },
 }));
 
@@ -73,6 +74,8 @@ describe('EditWidgetFrame', () => {
     const widget = Widget.builder()
       .id('deadbeef')
       .type('dummy')
+      .query(createElasticsearchQueryString())
+      .timerange({ type: 'relative', from: 300 })
       .config({})
       .build();
     const renderSUT = () => render((
@@ -86,7 +89,7 @@ describe('EditWidgetFrame', () => {
       </ViewTypeContext.Provider>
     ));
 
-    it('performs search when clicking on search button', async () => {
+    it('refreshes search after clicking on search button, when there are no changes', async () => {
       renderSUT();
       const searchButton = screen.getByTitle(/Perform search/);
 
@@ -102,7 +105,6 @@ describe('EditWidgetFrame', () => {
 
       expect(reactSelect).not.toBeNull();
 
-      // Flow is not parsing the jest assertion before
       if (reactSelect) {
         await selectEvent.select(reactSelect, 'PFLog');
       }

--- a/graylog2-web-interface/src/views/logic/widgets/Widget.ts
+++ b/graylog2-web-interface/src/views/logic/widgets/Widget.ts
@@ -19,6 +19,7 @@ import uuid from 'uuid/v4';
 
 import type { QueryString, TimeRange } from 'views/logic/queries/Query';
 import { singleton } from 'logic/singleton';
+import isDeepEqual from 'stores/isDeepEqual';
 
 export type WidgetState = {
   id: string;
@@ -75,6 +76,23 @@ class Widget {
   // eslint-disable-next-line class-methods-use-this
   get isExportable() {
     return false;
+  }
+
+  equals(other: any): boolean {
+    if (other === undefined) {
+      return false;
+    }
+
+    if (!(other instanceof Widget)) {
+      return false;
+    }
+
+    return this.id === other.id
+      && this.filter === other.filter
+      && isDeepEqual(this.config, other.config)
+      && isDeepEqual(this.timerange, other.timerange)
+      && isDeepEqual(this.query, other.query)
+      && isDeepEqual(this.streams, other.streams);
   }
 
   duplicate(newId: string): Widget {

--- a/graylog2-web-interface/src/views/stores/QueriesStore.ts
+++ b/graylog2-web-interface/src/views/stores/QueriesStore.ts
@@ -93,6 +93,17 @@ export const QueriesStore: QueriesStoreType = singletonStore(
 
       return promise;
     },
+
+    // Similar to the update action, but it is skipping the equality check.
+    forceUpdate(queryId: QueryId, query: Query) {
+      const newQueries = this.queries.set(queryId, query);
+      const promise: Promise<QueriesList> = this._propagateQueryChange(newQueries).then(() => newQueries);
+
+      QueriesActions.forceUpdate.promise(promise);
+
+      return promise;
+    },
+
     update(queryId: QueryId, query: Query) {
       const newQueries = this.queries.set(queryId, query);
       const promise: Promise<QueriesList> = this.queries.get(queryId).equals(query)

--- a/graylog2-web-interface/src/views/stores/SearchStore.ts
+++ b/graylog2-web-interface/src/views/stores/SearchStore.ts
@@ -139,6 +139,13 @@ export const SearchStore: Store<SearchStoreState> = singletonStore(
       return promise;
     },
 
+    refresh() {
+      const promise = Promise.resolve();
+      SearchActions.refresh.promise(promise);
+
+      return promise;
+    },
+
     trackJobStatus(job: SearchJobResult, search: Search) {
       return new Bluebird((resolve) => {
         if (job && job.execution.done) {


### PR DESCRIPTION
**Please note**, this PR needs to be merged together with https://github.com/Graylog2/graylog-plugin-enterprise/pull/3451

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Before this change we were not reexecuting the search on enter press (in the query input or streams select), when the form values did not changed.

This was only the case when clicking on the search submit button. The reason, when there is no change:
- the search submit button did not triggered a form submit, but `SearchActions.refresh`, which triggered the rexecution.
- pressing enter in e.g. the query input triggered a search submit, which updates the query. Updating the current query also triggers a search submit, but only when the query actually changed.

With this PR we are:
- always submitting the search form, when clicking on the search submit button.
- we are triggering a search execution on form submit, even when the query did not changed.

This PR is fixing the behaviour the the search page and widget edit mode.

We should create a backport for this change.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

/jenkins-pr-deps https://github.com/Graylog2/graylog-plugin-enterprise/pull/3451