### PR TITLE
use analyzer#normalize method for value-tokens detection

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/validation/LuceneQueryParser.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/validation/LuceneQueryParser.java
@@ -22,9 +22,11 @@ import org.apache.lucene.search.Query;
 
 public class LuceneQueryParser {
     private final TermCollectingQueryParser parser;
+    private final StandardAnalyzer analyzer;
 
     public LuceneQueryParser() {
-        this.parser = new TermCollectingQueryParser(ParsedTerm.DEFAULT_FIELD, new StandardAnalyzer());
+        analyzer = new StandardAnalyzer();
+        this.parser = new TermCollectingQueryParser(ParsedTerm.DEFAULT_FIELD, analyzer);
         this.parser.setSplitOnWhitespace(true);
     }
 
@@ -33,7 +35,7 @@ public class LuceneQueryParser {
         final ParsedQuery.Builder builder = ParsedQuery.builder().query(query);
 
         builder.tokensBuilder().addAll(this.parser.getTokens());
-        final TermCollectingQueryVisitor visitor = new TermCollectingQueryVisitor(this.parser.getTokens());
+        final TermCollectingQueryVisitor visitor = new TermCollectingQueryVisitor(this.parser.getTokens(), analyzer);
         parsed.visit(visitor);
         builder.termsBuilder().addAll(visitor.getParsedTerms());
         return builder.build();

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/elasticsearch/parser/LuceneQueryParserTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/elasticsearch/parser/LuceneQueryParserTest.java
@@ -209,4 +209,14 @@ class LuceneQueryParserTest {
         assertThat(loremTerm.keyToken().get().image()).isEqualTo("lorem");
         assertThat(loremTerm.valueToken().get().image()).isEqualTo("ipsum");
     }
+
+    @Test
+    void testValueTokenAnalyzed() throws ParseException {
+        // we are using standard analyzer in the parser, which means that values are processed by the lowercase filter
+        // This can lead to mismatches in equals during the value token recognition. This tests ensures that
+        // uppercase values are correctly recognized and assigned
+        final ParsedQuery query = parser.parse("foo:BAR");
+        final ParsedTerm term = query.terms().iterator().next();
+        assertThat(term.valueToken().get().image()).isEqualTo("BAR");
+    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
When we detect value-tokens during the lucene query parsing, we are using the standard analyzer. The analyzer itself uses a lowercase filter => tokens are lowercase in some parts of the logic. To be able to correctly detect value tokens, we need to use the very same approach for values. 

## Description
Added the analyzer to the TermCollectingQueryVisitor, which detects value tokens.

## Motivation and Context
Fixes value detection (=correct validation positions) for queries with uppercase values (`foo:BAR`)

## How Has This Been Tested?
Added unit test

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

