### PR TITLE
Remove UI support for the GRAYLOG_API_URL environment variable

### DIFF
--- a/graylog2-web-interface/src/util/AppConfig.ts
+++ b/graylog2-web-interface/src/util/AppConfig.ts
@@ -18,7 +18,6 @@ import * as Immutable from 'immutable';
 
 declare global {
   const DEVELOPMENT: boolean | undefined;
-  const GRAYLOG_API_URL: string | undefined;
   const FEATURES: string | undefined;
   const IS_CLOUD: boolean | undefined;
 }
@@ -52,12 +51,6 @@ const getEnabledFeatures = () => {
 const AppConfig = {
   features: getEnabledFeatures(),
   gl2ServerUrl() {
-    if (typeof (GRAYLOG_API_URL) !== 'undefined') {
-      // The GRAYLOG_API_URL variable will be set by webpack via the DefinePlugin.
-      // eslint-disable-next-line no-undef
-      return GRAYLOG_API_URL;
-    }
-
     return appConfig().gl2ServerUrl;
   },
 

--- a/graylog2-web-interface/webpack.config.js
+++ b/graylog2-web-interface/webpack.config.js
@@ -228,8 +228,6 @@ if (TARGET === 'start') {
     plugins: [
       new webpack.DefinePlugin({
         DEVELOPMENT: true,
-        // Keep old env to avoid breaking developer setups
-        GRAYLOG_API_URL: JSON.stringify(process.env.GRAYLOG_API_URL || process.env.GRAYLOG_HTTP_PUBLISH_URI),
         IS_CLOUD: process.env.IS_CLOUD,
       }),
       new CopyWebpackPlugin({ patterns: [{ from: 'config.js' }] }),


### PR DESCRIPTION
The GRAYLOG_API_URL environment variable was used for two development
features:

- Configuring the proxy backend for the development web server
  (devServer.js)
- Configuring the backend URL for the user interface (AppConfig.ts)

The latter will break cookie authentication when GRAYLOG_API_URL is set
because the URL might point to a different host than the web interface.
That prevents the cookie to be used for requests to the backend due to
the same-origin policy.

This commit removes the handling of the environment variable in the UI.

The development web server proxy backend can still be configured using
the variable.