### PR TITLE
Fix parsing of invalid search operators

### DIFF
--- a/full-backend-tests/src/test/java/org/graylog/plugins/views/QueryValidationResourceIT.java
+++ b/full-backend-tests/src/test/java/org/graylog/plugins/views/QueryValidationResourceIT.java
@@ -18,7 +18,6 @@ package org.graylog.plugins.views;
 
 import io.restassured.response.ValidatableResponse;
 import io.restassured.specification.RequestSpecification;
-import org.checkerframework.checker.units.qual.A;
 import org.graylog.testing.completebackend.GraylogBackend;
 import org.graylog.testing.containermatrix.annotations.ContainerMatrixTest;
 import org.graylog.testing.containermatrix.annotations.ContainerMatrixTestsConfiguration;

--- a/full-backend-tests/src/test/java/org/graylog/plugins/views/QueryValidationResourceIT.java
+++ b/full-backend-tests/src/test/java/org/graylog/plugins/views/QueryValidationResourceIT.java
@@ -19,6 +19,8 @@ package org.graylog.plugins.views;
 import io.restassured.response.ValidatableResponse;
 import io.restassured.specification.RequestSpecification;
 import org.graylog.testing.completebackend.GraylogBackend;
+import org.graylog.testing.containermatrix.MongodbServer;
+import org.graylog.testing.containermatrix.SearchServer;
 import org.graylog.testing.containermatrix.annotations.ContainerMatrixTest;
 import org.graylog.testing.containermatrix.annotations.ContainerMatrixTestsConfiguration;
 import org.graylog.testing.utils.GelfInputUtils;
@@ -33,7 +35,7 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.core.IsEqual.equalTo;
 
-@ContainerMatrixTestsConfiguration(serverLifecycle = CLASS)
+@ContainerMatrixTestsConfiguration(serverLifecycle = CLASS, mongoVersions = MongodbServer.MONGO4, searchVersions = SearchServer.OS1)
 public class QueryValidationResourceIT {
 
     private final RequestSpecification requestSpec;

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/validation/ImmutableToken.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/validation/ImmutableToken.java
@@ -17,6 +17,7 @@
 package org.graylog.plugins.views.search.validation;
 
 import com.google.auto.value.AutoValue;
+import org.apache.lucene.queryparser.classic.QueryParserConstants;
 
 @AutoValue
 public abstract class ImmutableToken {
@@ -53,5 +54,10 @@ public abstract class ImmutableToken {
 
     public boolean matches(int tokenType, String tokenValue) {
         return kind() == tokenType && image().equals(tokenValue);
+    }
+
+
+    public boolean isInvalidOperator() {
+        return kind() == QueryParserConstants.TERM && ("and".equals(image()) || "or".equals(image()) || "not".equals(image()));
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/validation/LuceneQueryParser.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/validation/LuceneQueryParser.java
@@ -21,12 +21,12 @@ import org.apache.lucene.queryparser.classic.ParseException;
 import org.apache.lucene.search.Query;
 
 public class LuceneQueryParser {
-    private final TermCollectingQueryParser parser;
+    private final TokenCollectingQueryParser parser;
     private final StandardAnalyzer analyzer;
 
     public LuceneQueryParser() {
         analyzer = new StandardAnalyzer();
-        this.parser = new TermCollectingQueryParser(ParsedTerm.DEFAULT_FIELD, analyzer);
+        this.parser = new TokenCollectingQueryParser(ParsedTerm.DEFAULT_FIELD, analyzer);
         this.parser.setSplitOnWhitespace(true);
     }
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/validation/ParsedQuery.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/validation/ParsedQuery.java
@@ -18,8 +18,6 @@ package org.graylog.plugins.views.search.validation;
 
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
-import org.apache.lucene.queryparser.classic.Token;
 
 import javax.validation.constraints.NotNull;
 import java.util.List;
@@ -40,14 +38,13 @@ public abstract class ParsedQuery {
 
     public Set<String> allFieldNames() {
         return terms().stream()
-                .filter(t -> !t.isInvalidOperator())
                 .map(ParsedTerm::getRealFieldName)
                 .collect(Collectors.toSet());
     }
 
-    public List<ParsedTerm> invalidOperators() {
-        return terms().stream()
-                .filter(ParsedTerm::isInvalidOperator)
+    public List<ImmutableToken> invalidOperators() {
+        return tokens().stream()
+                .filter(ImmutableToken::isInvalidOperator)
                 .collect(Collectors.toList());
     }
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/validation/ParsedTerm.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/validation/ParsedTerm.java
@@ -17,13 +17,8 @@
 package org.graylog.plugins.views.search.validation;
 
 import com.google.auto.value.AutoValue;
-import com.google.common.collect.ImmutableList;
-import org.apache.lucene.queryparser.classic.Token;
 
-import javax.annotation.Nullable;
 import javax.validation.constraints.NotNull;
-import java.util.Collections;
-import java.util.List;
 import java.util.Optional;
 
 @AutoValue
@@ -55,10 +50,6 @@ public abstract class ParsedTerm {
 
     public boolean isDefaultField() {
         return field().equals(DEFAULT_FIELD);
-    }
-
-    public boolean isInvalidOperator() {
-        return isDefaultField() && ("and".equals(value()) || "or".equals(value()) || "not".equals(value()));
     }
 
     public String getRealFieldName() {

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/validation/TokenCollectingQueryParser.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/validation/TokenCollectingQueryParser.java
@@ -21,9 +21,9 @@ import org.apache.lucene.queryparser.classic.QueryParser;
 
 import java.util.List;
 
-public class TermCollectingQueryParser extends QueryParser {
+public class TokenCollectingQueryParser extends QueryParser {
 
-    public TermCollectingQueryParser(String defaultFieldName, Analyzer analyzer) {
+    public TokenCollectingQueryParser(String defaultFieldName, Analyzer analyzer) {
         super(new CollectingQueryParserTokenManager(defaultFieldName, analyzer));
         init(defaultFieldName, analyzer);
     }

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/elasticsearch/parser/LuceneQueryParserTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/elasticsearch/parser/LuceneQueryParserTest.java
@@ -73,11 +73,9 @@ class LuceneQueryParserTest {
     void unknownTerm() throws ParseException {
         final ParsedQuery query = parser.parse("foo:bar and");
         assertThat(query.allFieldNames()).contains("foo");
-        assertThat(query.invalidOperators().stream().map(ParsedTerm::value).collect(Collectors.toSet())).contains("and");
+        assertThat(query.invalidOperators().stream().map(ImmutableToken::image).collect(Collectors.toSet())).contains("and");
 
-        final ParsedTerm term = query.invalidOperators().iterator().next();
-        assertThat(term.keyToken()).isPresent();
-        final ImmutableToken token = term.keyToken().get();
+        final ImmutableToken token = query.invalidOperators().iterator().next();
         assertThat(token.beginColumn()).isEqualTo(8);
         assertThat(token.beginLine()).isEqualTo(1);
         assertThat(token.endColumn()).isEqualTo(11);
@@ -94,15 +92,15 @@ class LuceneQueryParserTest {
         {
             final ParsedQuery queryWithAnd = parser.parse("foo:bar and");
             assertThat(queryWithAnd.invalidOperators()).isNotEmpty();
-            final ParsedTerm invalidOperator = queryWithAnd.invalidOperators().iterator().next();
-            assertThat(invalidOperator.value()).isEqualTo("and");
+            final ImmutableToken invalidOperator = queryWithAnd.invalidOperators().iterator().next();
+            assertThat(invalidOperator.image()).isEqualTo("and");
         }
 
         {
             final ParsedQuery queryWithOr = parser.parse("foo:bar or");
             assertThat(queryWithOr.invalidOperators()).isNotEmpty();
-            final ParsedTerm invalidOperator = queryWithOr.invalidOperators().iterator().next();
-            assertThat(invalidOperator.value()).isEqualTo("or");
+            final ImmutableToken invalidOperator = queryWithOr.invalidOperators().iterator().next();
+            assertThat(invalidOperator.image()).isEqualTo("or");
         }
     }
 
@@ -136,9 +134,8 @@ class LuceneQueryParserTest {
     void testLongStringOfInvalidTokens() throws ParseException {
         final ParsedQuery query = parser.parse("and and and or or or");
         assertThat(query.invalidOperators().size()).isEqualTo(6);
-        assertThat(query.invalidOperators().stream().allMatch(op -> op.keyToken().isPresent())).isTrue();
-        assertThat(query.invalidOperators().stream().allMatch(op -> {
-            final String tokenValue = op.keyToken().map(ImmutableToken::image).get();
+        assertThat(query.invalidOperators().stream().allMatch(token -> {
+            final String tokenValue = token.image();
             return tokenValue.equals("or") || tokenValue.equals("and");
         })).isTrue();
     }


### PR DESCRIPTION
There was a bug in our detection of invalid operators that used terms, not parsed tokens. Tokens have more knowledge of the context and reflect the quoted text, so they are the correct place to look for invalid operators. 

<!--- Provide a general summary of your changes in the Title above -->

## Description
Before:
![image](https://user-images.githubusercontent.com/4102775/162255129-fe16d913-413d-4ba6-9bf2-b1f60158aea7.png)

After:
![image](https://user-images.githubusercontent.com/4102775/162256279-bd71d0a3-eeb1-4dc5-8448-a465f8c1f468.png)

## How Has This Been Tested?
Added integration test

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

