### PR TITLE
Fuzzy operator does not break query validation anymore.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/validation/TermCollectingQueryVisitor.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/validation/TermCollectingQueryVisitor.java
@@ -18,11 +18,10 @@ package org.graylog.plugins.views.search.validation;
 
 import com.google.common.collect.Streams;
 import org.apache.lucene.analysis.Analyzer;
-import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.queryparser.classic.QueryParserConstants;
-import org.apache.lucene.search.AutomatonQuery;
 import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.FuzzyQuery;
 import org.apache.lucene.search.PrefixQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.QueryVisitor;
@@ -31,9 +30,7 @@ import org.apache.lucene.search.TermRangeQuery;
 import org.apache.lucene.search.WildcardQuery;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
-import java.util.Locale;
 import java.util.stream.Stream;
 
 public class TermCollectingQueryVisitor extends QueryVisitor {
@@ -120,6 +117,8 @@ public class TermCollectingQueryVisitor extends QueryVisitor {
             processTerms(((WildcardQuery) query).getTerm());
         } else if (query instanceof PrefixQuery) {
             processTerms(((PrefixQuery) query).getPrefix());
+        } else if (query instanceof FuzzyQuery) {
+            processTerms(((FuzzyQuery) query).getTerm());
         } else {
             throw new IllegalArgumentException("Unrecognized query type: " + query.getClass().getName());
         }

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/elasticsearch/parser/LuceneQueryParserTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/elasticsearch/parser/LuceneQueryParserTest.java
@@ -23,7 +23,6 @@ import org.graylog.plugins.views.search.validation.ParsedQuery;
 import org.graylog.plugins.views.search.validation.ParsedTerm;
 import org.junit.jupiter.api.Test;
 
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -218,5 +217,13 @@ class LuceneQueryParserTest {
         final ParsedQuery query = parser.parse("foo:BAR");
         final ParsedTerm term = query.terms().iterator().next();
         assertThat(term.valueToken().get().image()).isEqualTo("BAR");
+    }
+
+    @Test
+    void testFuzzyQuery() throws ParseException {
+        final ParsedQuery query = parser.parse("fuzzy~");
+        final ParsedTerm term = query.terms().iterator().next();
+        assertThat(term.field()).isEqualTo("_default_");
+        assertThat(term.value()).isEqualTo("fuzzy");
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes #12425.

## Description
Description with screenshot is provided in the #12425 issue.

## Motivation and Context
After this fix, you can safely type "logni~" and you will get results with "login" text, fuzziness works!

## How Has This Been Tested?
Type a fuzzy query string (i.e. smth~) in the search bar and notice the error is shown on the bottom of the screen.

## Screenshots (if appropriate):
see #12425

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

