### PR TITLE
Added workaround for reporting binaries in IT Tests in Docker on M1 OSX

### DIFF
--- a/graylog2-server/src/test/java/org/graylog/testing/graylognode/NodeContainerFactory.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/graylognode/NodeContainerFactory.java
@@ -190,6 +190,15 @@ public class NodeContainerFactory {
             if (!containerFileExists(container, containerPath)) {
                 LOG.error("Mandatory file {} does not exist in container at {}", filename, containerPath);
             }
+            // fix to duplicate files for Docker on OSX, system.arch is aarch64 instead or arm64
+            if(filename.endsWith("_arm64")) {
+                final String aarch64Path = containerPath.replaceAll("_arm64", "_aarch64");
+                container.copyFileToContainer(MountableFile.forHostPath(originalPath), aarch64Path);
+                if (!containerFileExists(container, aarch64Path)) {
+                    LOG.error("Mandatory file {} does not exist in container at {}", filename, aarch64Path);
+                }
+
+            }
         });
 
         return container;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
In Docker on M1 OSX, the architecture is aarch64 instead of arm64 on ARM Linux on other platforms. The compiled binaries are working, so we just duplicate the files.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

