### PR TITLE
Fuzzy operator does not break query validation anymore (4.3)

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/validation/TermCollectingQueryVisitor.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/validation/TermCollectingQueryVisitor.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Streams;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.queryparser.classic.QueryParserConstants;
 import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.FuzzyQuery;
 import org.apache.lucene.search.PrefixQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.QueryVisitor;
@@ -92,6 +93,8 @@ public class TermCollectingQueryVisitor extends QueryVisitor {
             processTerms(((WildcardQuery) query).getTerm());
         } else if (query instanceof PrefixQuery) {
             processTerms(((PrefixQuery) query).getPrefix());
+        } else if (query instanceof FuzzyQuery) {
+            processTerms(((FuzzyQuery) query).getTerm());
         } else {
             throw new IllegalArgumentException("Unrecognized query type: " + query.getClass().getName());
         }

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/elasticsearch/parser/LuceneQueryParserTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/elasticsearch/parser/LuceneQueryParserTest.java
@@ -23,7 +23,6 @@ import org.graylog.plugins.views.search.validation.ParsedQuery;
 import org.graylog.plugins.views.search.validation.ParsedTerm;
 import org.junit.jupiter.api.Test;
 
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -182,5 +181,13 @@ class LuceneQueryParserTest {
     void testEmptyQueryNewlines() {
         assertThatThrownBy(() -> parser.parse("\n\n\n"))
                 .hasMessageContaining("Cannot parse '\n\n\n': Encountered \"<EOF>\" at line 4, column 0.");
+    }
+
+    @Test
+    void testFuzzyQuery() throws ParseException {
+        final ParsedQuery query = parser.parse("fuzzy~");
+        final ParsedTerm term = query.terms().iterator().next();
+        assertThat(term.field()).isEqualTo("_default_");
+        assertThat(term.value()).isEqualTo("fuzzy");
     }
 }


### PR DESCRIPTION
Backporting PR #12428, fixing issue #12425 on 4.3.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

