### PR TITLE
Show empty field select for newly created sort in aggregation. (backport of #12427 for 4.2)

### DIFF
--- a/graylog2-web-interface/src/views/components/aggregationwizard/sort/SortConfiguration.test.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/sort/SortConfiguration.test.tsx
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import { render, screen } from 'wrappedTestingLibrary';
+
+import WidgetConfigForm from 'views/components/aggregationwizard/WidgetConfigForm';
+import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
+
+import SortConfiguration from './SortConfiguration';
+
+describe('SortConfiguration', () => {
+  it('should show empty field for new sorts', async () => {
+    const onSubmit = jest.fn();
+    const validate = jest.fn();
+    const config = AggregationWidgetConfig.builder().build();
+
+    render((
+      <WidgetConfigForm initialValues={{ sort: [{ id: 'foobar' }] }}
+                        onSubmit={onSubmit}
+                        validate={validate}
+                        config={config}>
+        <SortConfiguration index={0} />
+      </WidgetConfigForm>
+    ));
+
+    await screen.findByLabelText('Select field for sorting');
+
+    expect(screen.queryByText('-1')).not.toBeInTheDocument();
+  });
+});

--- a/graylog2-web-interface/src/views/components/aggregationwizard/sort/SortConfiguration.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/sort/SortConfiguration.tsx
@@ -20,11 +20,7 @@ import { Field, useFormikContext } from 'formik';
 import Select from 'components/common/Select';
 import { Input } from 'components/bootstrap';
 
-import {
-  GroupByFormValues,
-  MetricFormValues,
-  WidgetConfigFormValues,
-} from '../WidgetConfigForm';
+import type { GroupByFormValues, MetricFormValues, WidgetConfigFormValues } from '../WidgetConfigForm';
 
 type Props = {
   index: number,
@@ -60,8 +56,18 @@ type Option = {
 const Sort = React.memo(({ index }: Props) => {
   const { values, setFieldValue } = useFormikContext<WidgetConfigFormValues>();
   const { metrics = [], groupBy: { groupings = [] } = {} } = values;
-  const metricsOptions: Array<OptionValue> = metrics.map(formatSeries).map(({ field, label }) => ({ type: 'metric', field, label }));
-  const rowPivotOptions: Array<OptionValue> = groupings.filter((grouping) => (grouping.direction === 'row')).map(formatGrouping).map((groupBy) => ({ type: 'groupBy', field: groupBy, label: groupBy }));
+  const metricsOptions: Array<OptionValue> = metrics.map(formatSeries)
+    .map(({ field, label }) => ({
+      type: 'metric',
+      field,
+      label,
+    }));
+  const rowPivotOptions: Array<OptionValue> = groupings.filter((grouping) => (grouping.direction === 'row'))
+    .map(formatGrouping).map((groupBy) => ({
+      type: 'groupBy',
+      field: groupBy,
+      label: groupBy,
+    }));
   const options = [
     ...metricsOptions,
     ...rowPivotOptions,
@@ -70,7 +76,8 @@ const Sort = React.memo(({ index }: Props) => {
   const numberIndexedOptions: Array<Option> = options.map((option, idx) => ({ label: option.label, value: idx }));
 
   const currentSort = values.sort[index];
-  const selectedOption = currentSort ? options.findIndex((option) => (option.type === currentSort.type && option.field === currentSort.field)) : undefined;
+  const optionIndex = options.findIndex((option) => (option.type === currentSort.type && option.field === currentSort.field));
+  const selectedOption = optionIndex > -1 ? optionIndex : undefined;
 
   return (
     <div data-testid={`sort-element-${index}`}>


### PR DESCRIPTION
_Please note, this is a backport of #12427 for 4.2_

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Before this PR, when adding a new sort to an aggregation, the field select showed a value of `-1`. This was due to an incorrect lookup of the current field's value in the component.

This change is now fixing this, showing an empty select for a new sort.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.