### PR TITLE
Center value in number visualization properly. (backport of #12424 for 4.3)

### DIFF
--- a/graylog2-web-interface/src/views/components/visualizations/number/AutoFontSizer.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/number/AutoFontSizer.tsx
@@ -15,7 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import React, { useEffect, useRef, useState } from 'react';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
 /**
  * This component will calculate the largest possible font size for the provided child.
@@ -26,10 +26,15 @@ import styled from 'styled-components';
 const TOLERANCE = 0.05;
 const CHILD_SIZE_RATIO = 0.8; // Proportion of the child size in relation to the container
 
-const FontSize = styled.div<{ fontSize: number }>`
+const FontSize = styled.div<{ fontSize: number, $center: boolean }>`
   height: 100%;
   width: 100%;
-  font-size: ${(props) => `${props.fontSize}px`};
+  font-size: ${(props) => css`${props.fontSize}px`};
+  ${(props) => (props.$center ? css`
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  ` : '')}
 `;
 
 type ElementWithDimensions = {
@@ -42,6 +47,7 @@ type Props = {
   target?: React.Ref<any> | ElementWithDimensions,
   height: number,
   width: number,
+  center?: boolean,
 };
 
 const _multiplierForElement = (element, targetWidth, targetHeight) => {
@@ -84,13 +90,13 @@ const useAutoFontSize = (target, _container, height, width) => {
   return fontSize;
 };
 
-const AutoFontSizer = ({ children, target, height, width }: Props) => {
+const AutoFontSizer = ({ children, target, height, width, center }: Props) => {
   const _container = useRef<HTMLElement | undefined>();
   const fontSize = useAutoFontSize(target, _container, height, width);
   const _mixedContainer: { current } = _container;
 
   return (
-    <FontSize fontSize={fontSize} ref={_mixedContainer}>
+    <FontSize $center={center} fontSize={fontSize} ref={_mixedContainer}>
       {children}
     </FontSize>
   );
@@ -98,6 +104,7 @@ const AutoFontSizer = ({ children, target, height, width }: Props) => {
 
 AutoFontSizer.defaultProps = {
   target: null,
+  center: false,
 };
 
 export default AutoFontSizer;

--- a/graylog2-web-interface/src/views/components/visualizations/number/NumberVisualization.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/number/NumberVisualization.tsx
@@ -56,12 +56,8 @@ const SingleItemGrid = styled.div`
 `;
 
 const NumberBox = styled(ElementDimensions)`
-  display: flex;
-  justify-content: center;
-  align-items: center;
   height: 100%;
   width: 100%;
-  text-align: center;
   padding-bottom: 10px;
 `;
 
@@ -124,7 +120,7 @@ const NumberVisualization = ({ config, currentView, fields, data }: Props) => {
     <Container>
       <NumberBox resizeDelay={20}>
         {({ height, width }) => (
-          <AutoFontSizer height={height} width={width}>
+          <AutoFontSizer height={height} width={width} center>
             <CustomHighlighting field={field} value={value}>
               <Value field={field}
                      type={fieldTypeFor(field, fields)}


### PR DESCRIPTION
_Please note, this is a backport of #12424 for 4.3_

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Prior to this PR, the number visualization of the search did not properly center the values it displays. Values were slightly misaligned towards the top of the widget.

This change is now making sure that values in a number visualization are always centered vertically and horizontally.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
Before:

![image](https://user-images.githubusercontent.com/41929/162393689-fd93ec09-aa28-495a-8dce-3d2bfb56ae80.png)

![image](https://user-images.githubusercontent.com/41929/162393870-9c875793-e00c-4d74-9266-c0c02f0b93cc.png)

After:

![image](https://user-images.githubusercontent.com/41929/162394031-32783309-48d2-499c-af87-541250d49195.png)

![image](https://user-images.githubusercontent.com/41929/162393953-d9894de8-50e7-4df5-bc98-e9d00da58420.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
