### PR TITLE
Separating linter/lockfile housekeeping jobs.

### DIFF
--- a/.github/workflows/updating-lockfile.yml
+++ b/.github/workflows/updating-lockfile.yml
@@ -1,8 +1,8 @@
-name: Fix linter hints
+name: Updating yarn lockfile
 
 on:
   schedule:
-    - cron: '0 */8 * * *'
+    - cron: '0 */12 * * *'
 
 jobs:
   build:
@@ -22,18 +22,13 @@ jobs:
           path: ~/.cache/yarn
       - name: Install dependencies
         run: yarn install
-      - name: Resetting lockfile
-        run: git checkout yarn.lock
-      - name: Run lint --fix
-        continue-on-error: true
-        run: yarn lint --fix
       - name: Create/Update Pull Request
         uses: Graylog2/create-pull-request@7380612b49221684fefa025244f2ef4008ae50ad
         with:
-          title: Fixing linter hints automatically
-          body: This PR was created by a job that is running periodically to find and fix linter hints.
-          author: Dr. Lint-a-lot <garybot2@graylog.com>
-          branch: fix/linter-hints
-          committer: Dr. Lint-a-lot <garybot2@graylog.com>
-          commit-message: Running lint --fix
+          title: Updating yarn lockfile
+          body: This PR was created by a job that is running periodically to update the yarn lockfile after transitive dependencies have been updated.
+          author: Gary Bot <garybot2@graylog.com>
+          branch: update-yarn-lockfile
+          committer: Gary Bot <garybot2@graylog.com>
+          commit-message: Updating yarn lockfile
           delete-branch: true


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Prior to this change, the auto-fixing linter job was also committing changes to the yarn lockfile whenever they existed. This was unintuitive.

This change is now resetting the yarn lockfile, making sure it is not part of the generated PR. In addition, it is adding a second job which is solely generating PRs for updating the yarn lockfile.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.