### PR TITLE
Log cause of failed preflight check

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/bootstrap/preflight/PreflightCheckService.java
+++ b/graylog2-server/src/main/java/org/graylog2/bootstrap/preflight/PreflightCheckService.java
@@ -26,8 +26,8 @@ import java.util.Map;
 public class PreflightCheckService {
     private static final Logger LOG = LoggerFactory.getLogger(PreflightCheckService.class);
 
-    private Map<String, PreflightCheck> preflightChecks;
-    private boolean skipPreflightChecks;
+    private final Map<String, PreflightCheck> preflightChecks;
+    private final boolean skipPreflightChecks;
 
     @Inject
     public PreflightCheckService(Map<String, PreflightCheck> preflightChecks,
@@ -36,11 +36,22 @@ public class PreflightCheckService {
         this.skipPreflightChecks = skipPreflightChecks;
     }
 
-    public void runChecks() {
+    /**
+     * Performs preflight checks. In case of a failure, logs the cause of it.
+     *
+     * @throws PreflightCheckException If a preflight check failed.
+     */
+    public void runChecks() throws PreflightCheckException {
         if (skipPreflightChecks) {
             LOG.info("Skipping preflight checks");
             return;
         }
-        preflightChecks.values().forEach(PreflightCheck::runCheck);
+
+        try {
+            preflightChecks.values().forEach(PreflightCheck::runCheck);
+        } catch (PreflightCheckException e) {
+            LOG.error("Preflight check failed with error: {}", e.getLocalizedMessage());
+            throw e;
+        }
     }
 }


### PR DESCRIPTION
A failing preflight check was not logged but only written to STDERR.

This leads to the server stopping without any indication whatsoever of what might have caused it if you look only at the log file.

This PR adds the missing logging.

Steps to reproduce (prior to applying this PR):

* Start the server with a functioning journal
* Make the journal directory unwritable, e.g. with `chmod u-w journal`
* Start graylog again and notice that it stops again with the last line of the log file being something like ```2022-04-12 10:33:09,112 INFO : org.graylog2.bootstrap.preflight.SearchDbPreflightCheck - Connected to (Elastic/Open)Search version <Elasticsearch:7.10.2>```