### PR TITLE
Revert changes in `BootstrapModalForm` and reimplement `type="submit"` for submit button. (backport of #12465 for 4.3)

### DIFF
--- a/graylog2-web-interface/src/components/bootstrap/BootstrapModalForm.jsx
+++ b/graylog2-web-interface/src/components/bootstrap/BootstrapModalForm.jsx
@@ -91,6 +91,7 @@ class BootstrapModalForm extends React.Component {
     const { onSubmitForm } = this.props;
 
     if (typeof onSubmitForm === 'function') {
+      event.preventDefault();
       onSubmitForm(event);
     }
   };
@@ -135,9 +136,7 @@ class BootstrapModalForm extends React.Component {
           </Modal.Body>
           <Modal.Footer>
             <Button type="button" onClick={this.onModalCancel}>{cancelButtonText}</Button>
-            {/* We are not using type=submit here, because when this form is being rendered inside another form */}
-            {/* the submit button can influence the parent form, even though this form is in a portal */}
-            <Button type="button" onClick={this.submit} disabled={submitButtonDisabled} bsStyle="primary">{submitButtonText}</Button>
+            <Button type="submit" disabled={submitButtonDisabled} bsStyle="primary">{submitButtonText}</Button>
           </Modal.Footer>
         </form>
       </BootstrapModalWrapper>


### PR DESCRIPTION
_Please note, this PR is a backport of #12465 for 4.3 and should be merged together with https://github.com/Graylog2/graylog-plugin-enterprise/pull/3463_

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

With https://github.com/Graylog2/graylog2-server/pull/12189 we changed the way the `BootstrapModalForm` is being submitted. Instead of using `type="submit"` for the submit button we called the `onSubmit` action directly. Before the mentioned change, the form submit could influence a parent form, when using formik, by setting its `isSubmitting` attribute. This problem occurred when declaring a parameter, by clicking on the "declare parameter" button in the query validation popover.

Changing the way we submit the form resulted in other problems (https://github.com/Graylog2/graylog2-server/issues/12314 and https://github.com/Graylog2/graylog2-server/issues/12462). Fortunately it is possible to avoid this behaviour by stopping the event propagation.

There is a linter error I did not fixed, to avoid introducing further bugs.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)