### PR TITLE
Added reworded OS Deprecation Warning (backport of #12470)

### DIFF
--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/ElasticsearchFilterDeprecationWarningsInterceptor.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/ElasticsearchFilterDeprecationWarningsInterceptor.java
@@ -31,6 +31,7 @@ public class ElasticsearchFilterDeprecationWarningsInterceptor implements HttpRe
     private String[] messagesToFilter = {
             "setting was deprecated in Elasticsearch",
             "but in a future major version, direct access to system indices and their aliases will not be allowed",
+            "but in a future major version, direct access to system indices will be prevented by default",
             "in epoch time formats is deprecated and will not be supported in the next major version of Elasticsearch",
             org.graylog.shaded.elasticsearch7.org.elasticsearch.common.joda.JodaDeprecationPatterns.USE_NEW_FORMAT_SPECIFIERS
     };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
Opensearch slightly reworded a deprecation warning that we are filtering, so the filter is not working for the new message format and the logs get polluted. This PR adds the reworded message.

backport of #12470 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

