### PR TITLE
HTTP event notification with basic auth or API key

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/events/contentpack/entities/HttpEventNotificationConfigEntity.java
+++ b/graylog2-server/src/main/java/org/graylog/events/contentpack/entities/HttpEventNotificationConfigEntity.java
@@ -26,7 +26,6 @@ import org.graylog.events.notifications.types.HTTPEventNotificationConfig;
 import org.graylog2.contentpacks.model.entities.EntityDescriptor;
 import org.graylog2.contentpacks.model.entities.references.ValueReference;
 
-import javax.annotation.Nullable;
 import java.util.Map;
 
 @AutoValue
@@ -37,21 +36,6 @@ public abstract class HttpEventNotificationConfigEntity implements EventNotifica
     public static final String TYPE_NAME = "http-notification-v1";
 
     private static final String FIELD_URL = "url";
-    private static final String FIELD_BASIC_AUTH = "basic_auth";
-    private static final String FIELD_APIKEY = "apikey";
-    private static final String FIELD_APIKEY_VALUE = "apikey_value";
-
-    @JsonProperty(FIELD_BASIC_AUTH)
-    @Nullable
-    public abstract String basicAuth();
-
-    @JsonProperty(FIELD_APIKEY)
-    @Nullable
-    public abstract String apiKey();
-
-    @JsonProperty(FIELD_APIKEY_VALUE)
-    @Nullable
-    public abstract String apiKeyValue();
 
     @JsonProperty(FIELD_URL)
     public abstract ValueReference url();
@@ -63,22 +47,13 @@ public abstract class HttpEventNotificationConfigEntity implements EventNotifica
     public abstract Builder toBuilder();
 
     @AutoValue.Builder
-    public abstract static class Builder implements EventNotificationConfigEntity.Builder<Builder> {
+    public static abstract class Builder implements EventNotificationConfigEntity.Builder<Builder> {
 
         @JsonCreator
         public static Builder create() {
             return new AutoValue_HttpEventNotificationConfigEntity.Builder()
                     .type(TYPE_NAME);
         }
-
-        @JsonProperty(FIELD_BASIC_AUTH)
-        public abstract Builder basicAuth(String basicAuth);
-
-        @JsonProperty(FIELD_APIKEY)
-        public abstract Builder apiKey(String apiKey);
-
-        @JsonProperty(FIELD_APIKEY_VALUE)
-        public abstract Builder apiKeyValue(String apiKeyValue);
 
         @JsonProperty(FIELD_URL)
         public abstract Builder url(ValueReference url);
@@ -89,9 +64,6 @@ public abstract class HttpEventNotificationConfigEntity implements EventNotifica
     @Override
     public EventNotificationConfig toNativeEntity(Map<String, ValueReference> parameters, Map<EntityDescriptor, Object> nativeEntities) {
         return HTTPEventNotificationConfig.builder()
-                .basicAuth(basicAuth())
-                .apiKey(apiKey())
-                .apiKeyValue(apiKeyValue())
                 .url(url().asString(parameters))
                 .build();
     }

--- a/graylog2-server/src/main/java/org/graylog/events/contentpack/entities/HttpEventNotificationConfigEntity.java
+++ b/graylog2-server/src/main/java/org/graylog/events/contentpack/entities/HttpEventNotificationConfigEntity.java
@@ -26,6 +26,7 @@ import org.graylog.events.notifications.types.HTTPEventNotificationConfig;
 import org.graylog2.contentpacks.model.entities.EntityDescriptor;
 import org.graylog2.contentpacks.model.entities.references.ValueReference;
 
+import javax.annotation.Nullable;
 import java.util.Map;
 
 @AutoValue
@@ -36,6 +37,21 @@ public abstract class HttpEventNotificationConfigEntity implements EventNotifica
     public static final String TYPE_NAME = "http-notification-v1";
 
     private static final String FIELD_URL = "url";
+    private static final String FIELD_BASIC_AUTH = "basic_auth";
+    private static final String FIELD_APIKEY = "apikey";
+    private static final String FIELD_APIKEY_VALUE = "apikey_value";
+
+    @JsonProperty(FIELD_BASIC_AUTH)
+    @Nullable
+    public abstract String basicAuth();
+
+    @JsonProperty(FIELD_APIKEY)
+    @Nullable
+    public abstract String apiKey();
+
+    @JsonProperty(FIELD_APIKEY_VALUE)
+    @Nullable
+    public abstract String apiKeyValue();
 
     @JsonProperty(FIELD_URL)
     public abstract ValueReference url();
@@ -47,13 +63,22 @@ public abstract class HttpEventNotificationConfigEntity implements EventNotifica
     public abstract Builder toBuilder();
 
     @AutoValue.Builder
-    public static abstract class Builder implements EventNotificationConfigEntity.Builder<Builder> {
+    public abstract static class Builder implements EventNotificationConfigEntity.Builder<Builder> {
 
         @JsonCreator
         public static Builder create() {
             return new AutoValue_HttpEventNotificationConfigEntity.Builder()
                     .type(TYPE_NAME);
         }
+
+        @JsonProperty(FIELD_BASIC_AUTH)
+        public abstract Builder basicAuth(String basicAuth);
+
+        @JsonProperty(FIELD_APIKEY)
+        public abstract Builder apiKey(String apiKey);
+
+        @JsonProperty(FIELD_APIKEY_VALUE)
+        public abstract Builder apiKeyValue(String apiKeyValue);
 
         @JsonProperty(FIELD_URL)
         public abstract Builder url(ValueReference url);
@@ -64,6 +89,9 @@ public abstract class HttpEventNotificationConfigEntity implements EventNotifica
     @Override
     public EventNotificationConfig toNativeEntity(Map<String, ValueReference> parameters, Map<EntityDescriptor, Object> nativeEntities) {
         return HTTPEventNotificationConfig.builder()
+                .basicAuth(basicAuth())
+                .apiKey(apiKey())
+                .apiKeyValue(apiKeyValue())
                 .url(url().asString(parameters))
                 .build();
     }

--- a/graylog2-server/src/main/java/org/graylog/events/notifications/EventNotificationConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/events/notifications/EventNotificationConfig.java
@@ -50,6 +50,9 @@ public interface EventNotificationConfig extends ContentPackable<EventNotificati
     @JsonIgnore
     ValidationResult validate();
 
+    @JsonIgnore
+    default EventNotificationConfig prepareConfigUpdate(EventNotificationConfig newConfig) {return newConfig;}
+
     class FallbackNotificationConfig implements EventNotificationConfig {
         @Override
         public String type() {

--- a/graylog2-server/src/main/java/org/graylog/events/notifications/NotificationResourceHandler.java
+++ b/graylog2-server/src/main/java/org/graylog/events/notifications/NotificationResourceHandler.java
@@ -88,6 +88,10 @@ public class NotificationResourceHandler {
         return dto;
     }
 
+    /**
+     * Allow subclass to modify the DTO prior to update or test execution.
+     * Mainly intended for handling encrypted values, which are not available to the UI.
+     */
     private NotificationDto prepareUpdate(NotificationDto newDto) {
         if (newDto.id() == null) {
             // It's not an update
@@ -189,11 +193,12 @@ public class NotificationResourceHandler {
      * @throws InternalServerErrorException if the notification definition failed to be executed
      */
     public void test(NotificationDto notificationDto, String userName) throws NotFoundException, InternalServerErrorException {
-        final EventNotification.Factory eventNotificationFactory = eventNotificationFactories.get(notificationDto.config().type());
+        NotificationDto dto = prepareUpdate(notificationDto);
+        final EventNotification.Factory eventNotificationFactory = eventNotificationFactories.get(dto.config().type());
         if (eventNotificationFactory == null) {
-            throw new NotFoundException("Couldn't find factory for notification type <" + notificationDto.config().type() + ">");
+            throw new NotFoundException("Couldn't find factory for notification type <" + dto.config().type() + ">");
         }
-        final EventNotificationContext notificationContext = NotificationTestData.getDummyContext(notificationDto, userName);
+        final EventNotificationContext notificationContext = NotificationTestData.getDummyContext(dto, userName);
         final EventNotification eventNotification = eventNotificationFactory.create();
         try {
             eventNotification.execute(notificationContext);

--- a/graylog2-server/src/main/java/org/graylog/events/notifications/NotificationResourceHandler.java
+++ b/graylog2-server/src/main/java/org/graylog/events/notifications/NotificationResourceHandler.java
@@ -109,7 +109,7 @@ public class NotificationResourceHandler {
         // Grab the old record so we can revert to it if something goes wrong
         final Optional<NotificationDto> oldDto = notificationService.get(updatedDto.id());
 
-        final NotificationDto dto = notificationService.save(updatedDto);
+        final NotificationDto dto = notificationService.save(prepareUpdate(updatedDto));
 
         LOG.debug("Updated notification definition <{}/{}>", dto.id(), dto.title());
 

--- a/graylog2-server/src/main/java/org/graylog/events/notifications/types/HTTPEventNotification.java
+++ b/graylog2-server/src/main/java/org/graylog/events/notifications/types/HTTPEventNotification.java
@@ -145,7 +145,7 @@ public class HTTPEventNotification implements EventNotification {
     }
 
     private String getBasicAuthHeaderValue(HTTPEventNotificationConfig config) {
-        if (config.basicAuth() == null) {
+        if (config.basicAuth() == null || (!config.basicAuth().isSet())) {
             return null;
         }
         String credentials = encryptedValueService.decrypt(config.basicAuth());
@@ -153,7 +153,7 @@ public class HTTPEventNotification implements EventNotification {
     }
 
     private  String getApiKeyValue(HTTPEventNotificationConfig config) {
-        if (config.apiKeyValue() == null) {
+        if (config.apiKeyValue() == null || (!config.apiKeyValue().isSet())) {
             return null;
         }
         return encryptedValueService.decrypt(config.apiKeyValue());

--- a/graylog2-server/src/main/java/org/graylog/events/notifications/types/HTTPEventNotification.java
+++ b/graylog2-server/src/main/java/org/graylog/events/notifications/types/HTTPEventNotification.java
@@ -30,6 +30,7 @@ import org.graylog.events.notifications.EventNotification;
 import org.graylog.events.notifications.EventNotificationContext;
 import org.graylog.events.notifications.EventNotificationModelData;
 import org.graylog.events.notifications.EventNotificationService;
+import org.graylog.events.notifications.NotificationDto;
 import org.graylog.events.notifications.NotificationTestData;
 import org.graylog.events.notifications.PermanentEventNotificationException;
 import org.graylog.events.notifications.TemporaryEventNotificationException;
@@ -144,7 +145,7 @@ public class HTTPEventNotification implements EventNotification {
     }
 
     private String getBasicAuthHeaderValue(HTTPEventNotificationConfig config) {
-        if (config.basicAuth() == null || (!config.basicAuth().isSet())) {
+        if (config.basicAuth() == null || !config.basicAuth().isSet()) {
             return null;
         }
         String credentials = encryptedValueService.decrypt(config.basicAuth());
@@ -152,7 +153,7 @@ public class HTTPEventNotification implements EventNotification {
     }
 
     private  String getApiKeyValue(HTTPEventNotificationConfig config) {
-        if (config.apiSecret() == null || (!config.apiSecret().isSet())) {
+        if (config.apiSecret() == null || !config.apiSecret().isSet()) {
             return null;
         }
         return encryptedValueService.decrypt(config.apiSecret());

--- a/graylog2-server/src/main/java/org/graylog/events/notifications/types/HTTPEventNotification.java
+++ b/graylog2-server/src/main/java/org/graylog/events/notifications/types/HTTPEventNotification.java
@@ -43,7 +43,6 @@ import org.slf4j.LoggerFactory;
 import javax.inject.Inject;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.Base64;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 

--- a/graylog2-server/src/main/java/org/graylog/events/notifications/types/HTTPEventNotification.java
+++ b/graylog2-server/src/main/java/org/graylog/events/notifications/types/HTTPEventNotification.java
@@ -152,9 +152,9 @@ public class HTTPEventNotification implements EventNotification {
     }
 
     private  String getApiKeyValue(HTTPEventNotificationConfig config) {
-        if (config.apiKeyValue() == null || (!config.apiKeyValue().isSet())) {
+        if (config.apiSecret() == null || (!config.apiSecret().isSet())) {
             return null;
         }
-        return encryptedValueService.decrypt(config.apiKeyValue());
+        return encryptedValueService.decrypt(config.apiSecret());
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/events/notifications/types/HTTPEventNotificationConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/events/notifications/types/HTTPEventNotificationConfig.java
@@ -81,10 +81,10 @@ public abstract class HTTPEventNotificationConfig implements EventNotificationCo
             validation.addError(FIELD_URL, "HTTP Notification url cannot be empty.");
         }
         if (Strings.isNullOrEmpty(apiKey()) && (apiSecret() != null && apiSecret().isSet())) {
-            validation.addError(FIELD_API_KEY, "HTTP Notification cannot specify API key value without API key");
+            validation.addError(FIELD_API_KEY, "HTTP Notification cannot specify API secret without API key");
         }
-        if (!Strings.isNullOrEmpty(apiKey()) && (apiSecret() == null || !apiSecret().isSet())) {
-            validation.addError(FIELD_API_SECRET, "HTTP Notification cannot specify API key without API key value");
+        if (!Strings.isNullOrEmpty(apiKey()) && (apiSecret() == null || (!apiSecret().isSet()) && !apiSecret().isKeepValue())) {
+            validation.addError(FIELD_API_SECRET, "HTTP Notification cannot specify API key without API secret");
         }
 
         return validation;

--- a/graylog2-server/src/main/java/org/graylog/events/notifications/types/HTTPEventNotificationConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/events/notifications/types/HTTPEventNotificationConfig.java
@@ -94,14 +94,29 @@ public abstract class HTTPEventNotificationConfig implements EventNotificationCo
     @JsonIgnore
     public EventNotificationConfig prepareConfigUpdate(@Nonnull EventNotificationConfig newConfig) {
         final HTTPEventNotificationConfig newHttpConfig = (HTTPEventNotificationConfig) newConfig;
-        if (newHttpConfig.basicAuth() != null && newHttpConfig.basicAuth().isDeleteValue()) {
-            return newHttpConfig.toBuilder().basicAuth(null).build();
+        EncryptedValue newBasicAuth = newHttpConfig.basicAuth();
+        if (newHttpConfig.basicAuth() != null) {
+            if (newHttpConfig.basicAuth().isKeepValue()) {
+                // If the client secret should be kept, use the value from the existing config
+                newBasicAuth = basicAuth();
+            }
+            else if (newHttpConfig.basicAuth().isDeleteValue()) {
+                newBasicAuth = EncryptedValue.createUnset();
+            }
         }
-        if (newHttpConfig.apiKeyValue() != null && newHttpConfig.apiKeyValue().isKeepValue()) {
-            // If the client secret should be kept, use the value from the existing config
-            return newHttpConfig.toBuilder().apiKeyValue(apiKeyValue()).build();
+
+        EncryptedValue newApiKeyValue = newHttpConfig.apiKeyValue();
+        if (newHttpConfig.apiKeyValue() != null) {
+            if (newHttpConfig.apiKeyValue().isKeepValue()) {
+                // If the client secret should be kept, use the value from the existing config
+                newApiKeyValue = apiKeyValue();
+            }
+            else if (newHttpConfig.apiKeyValue().isDeleteValue()) {
+                newApiKeyValue = EncryptedValue.createUnset();
+            }
         }
-        return newHttpConfig;
+
+        return newHttpConfig.toBuilder().apiKeyValue(newApiKeyValue).basicAuth(newBasicAuth).build();
     }
 
     @AutoValue.Builder

--- a/graylog2-server/src/main/java/org/graylog/events/notifications/types/HTTPEventNotificationConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/events/notifications/types/HTTPEventNotificationConfig.java
@@ -115,8 +115,11 @@ public abstract class HTTPEventNotificationConfig implements EventNotificationCo
 
     @Override
     public EventNotificationConfigEntity toContentPackEntity(EntityDescriptorIds entityDescriptorIds) {
-       return HttpEventNotificationConfigEntity.builder()
-           .url(ValueReference.of(url()))
-           .build();
+        return HttpEventNotificationConfigEntity.builder()
+                .basicAuth(basicAuth())
+                .apiKey(apiKey())
+                .apiKeyValue(apiKeyValue())
+                .url(ValueReference.of(url()))
+                .build();
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/events/notifications/types/HTTPEventNotificationConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/events/notifications/types/HTTPEventNotificationConfig.java
@@ -83,7 +83,7 @@ public abstract class HTTPEventNotificationConfig implements EventNotificationCo
         if (Strings.isNullOrEmpty(apiKey()) && (apiKeyValue() != null) && apiKeyValue().isSet()) {
             validation.addError(FIELD_APIKEY, "HTTP Notification cannot specify API key value without API key");
         }
-        if (!Strings.isNullOrEmpty(apiKey()) && (apiKeyValue() == null)) {
+        if (!Strings.isNullOrEmpty(apiKey()) && (apiKeyValue() == null) || !apiKeyValue().isSet()) {
             validation.addError(FIELD_APIKEY_VALUE, "HTTP Notification cannot specify API key without API key value");
         }
 

--- a/graylog2-server/src/main/java/org/graylog/events/notifications/types/HTTPEventNotificationConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/events/notifications/types/HTTPEventNotificationConfig.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
+import joptsimple.internal.Strings;
 import org.graylog.events.contentpack.entities.EventNotificationConfigEntity;
 import org.graylog.events.contentpack.entities.HttpEventNotificationConfigEntity;
 import org.graylog.events.event.EventDto;
@@ -32,6 +33,8 @@ import org.graylog2.contentpacks.EntityDescriptorIds;
 import org.graylog2.contentpacks.model.entities.references.ValueReference;
 import org.graylog2.plugin.rest.ValidationResult;
 
+import javax.annotation.Nullable;
+
 @AutoValue
 @JsonTypeName(HTTPEventNotificationConfig.TYPE_NAME)
 @JsonDeserialize(builder = HTTPEventNotificationConfig.Builder.class)
@@ -39,6 +42,21 @@ public abstract class HTTPEventNotificationConfig implements EventNotificationCo
     public static final String TYPE_NAME = "http-notification-v1";
 
     private static final String FIELD_URL = "url";
+    private static final String FIELD_BASIC_AUTH = "basic_auth";
+    private static final String FIELD_APIKEY = "apikey";
+    private static final String FIELD_APIKEY_VALUE = "apikey_value";
+
+    @JsonProperty(FIELD_BASIC_AUTH)
+    @Nullable
+    public abstract String basicAuth();
+
+    @JsonProperty(FIELD_APIKEY)
+    @Nullable
+    public abstract String apiKey();
+
+    @JsonProperty(FIELD_APIKEY_VALUE)
+    @Nullable
+    public abstract String apiKeyValue();
 
     @JsonProperty(FIELD_URL)
     public abstract String url();
@@ -59,6 +77,12 @@ public abstract class HTTPEventNotificationConfig implements EventNotificationCo
         if (url().isEmpty()) {
             validation.addError(FIELD_URL, "HTTP Notification url cannot be empty.");
         }
+        if (Strings.isNullOrEmpty(apiKey()) && !Strings.isNullOrEmpty(apiKeyValue())) {
+            validation.addError(FIELD_APIKEY, "HTTP Notification cannot specify API key value without API key");
+        }
+        if (!Strings.isNullOrEmpty(apiKey()) && Strings.isNullOrEmpty(apiKeyValue())) {
+            validation.addError(FIELD_APIKEY, "HTTP Notification cannot specify API key without API key value");
+        }
 
         return validation;
     }
@@ -70,6 +94,18 @@ public abstract class HTTPEventNotificationConfig implements EventNotificationCo
             return new AutoValue_HTTPEventNotificationConfig.Builder()
                     .type(TYPE_NAME);
         }
+
+        @JsonProperty(FIELD_BASIC_AUTH)
+        @Nullable
+        public abstract Builder basicAuth(String basicAuth);
+
+        @JsonProperty(FIELD_APIKEY)
+        @Nullable
+        public abstract Builder apiKey(String apiKey);
+
+        @JsonProperty(FIELD_APIKEY_VALUE)
+        @Nullable
+        public abstract Builder apiKeyValue(String apiKeyValue);
 
         @JsonProperty(FIELD_URL)
         public abstract Builder url(String url);

--- a/graylog2-server/src/main/java/org/graylog/events/notifications/types/HTTPEventNotificationConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/events/notifications/types/HTTPEventNotificationConfig.java
@@ -45,20 +45,20 @@ public abstract class HTTPEventNotificationConfig implements EventNotificationCo
 
     private static final String FIELD_URL = "url";
     private static final String FIELD_BASIC_AUTH = "basic_auth";
-    private static final String FIELD_APIKEY = "apikey";
-    private static final String FIELD_APIKEY_VALUE = "apikey_value";
+    private static final String FIELD_API_KEY = "api_key";
+    private static final String FIELD_API_SECRET = "api_secret";
 
     @JsonProperty(FIELD_BASIC_AUTH)
     @Nullable
     public abstract EncryptedValue basicAuth();
 
-    @JsonProperty(FIELD_APIKEY)
+    @JsonProperty(FIELD_API_KEY)
     @Nullable
     public abstract String apiKey();
 
-    @JsonProperty(FIELD_APIKEY_VALUE)
+    @JsonProperty(FIELD_API_SECRET)
     @Nullable
-    public abstract EncryptedValue apiKeyValue();
+    public abstract EncryptedValue apiSecret();
 
     @JsonProperty(FIELD_URL)
     public abstract String url();
@@ -80,11 +80,11 @@ public abstract class HTTPEventNotificationConfig implements EventNotificationCo
         if (url().isEmpty()) {
             validation.addError(FIELD_URL, "HTTP Notification url cannot be empty.");
         }
-        if (Strings.isNullOrEmpty(apiKey()) && (apiKeyValue() != null) && apiKeyValue().isSet()) {
-            validation.addError(FIELD_APIKEY, "HTTP Notification cannot specify API key value without API key");
+        if (Strings.isNullOrEmpty(apiKey()) && (apiSecret() != null && apiSecret().isSet())) {
+            validation.addError(FIELD_API_KEY, "HTTP Notification cannot specify API key value without API key");
         }
-        if (!Strings.isNullOrEmpty(apiKey()) && (apiKeyValue() == null) || !apiKeyValue().isSet()) {
-            validation.addError(FIELD_APIKEY_VALUE, "HTTP Notification cannot specify API key without API key value");
+        if (!Strings.isNullOrEmpty(apiKey()) && (apiSecret() == null || !apiSecret().isSet())) {
+            validation.addError(FIELD_API_SECRET, "HTTP Notification cannot specify API key without API key value");
         }
 
         return validation;
@@ -105,18 +105,18 @@ public abstract class HTTPEventNotificationConfig implements EventNotificationCo
             }
         }
 
-        EncryptedValue newApiKeyValue = newHttpConfig.apiKeyValue();
-        if (newHttpConfig.apiKeyValue() != null) {
-            if (newHttpConfig.apiKeyValue().isKeepValue()) {
+        EncryptedValue newApiKeyValue = newHttpConfig.apiSecret();
+        if (newHttpConfig.apiSecret() != null) {
+            if (newHttpConfig.apiSecret().isKeepValue()) {
                 // If the client secret should be kept, use the value from the existing config
-                newApiKeyValue = apiKeyValue();
+                newApiKeyValue = apiSecret();
             }
-            else if (newHttpConfig.apiKeyValue().isDeleteValue()) {
+            else if (newHttpConfig.apiSecret().isDeleteValue()) {
                 newApiKeyValue = EncryptedValue.createUnset();
             }
         }
 
-        return newHttpConfig.toBuilder().apiKeyValue(newApiKeyValue).basicAuth(newBasicAuth).build();
+        return newHttpConfig.toBuilder().apiSecret(newApiKeyValue).basicAuth(newBasicAuth).build();
     }
 
     @AutoValue.Builder
@@ -130,11 +130,11 @@ public abstract class HTTPEventNotificationConfig implements EventNotificationCo
         @JsonProperty(FIELD_BASIC_AUTH)
         public abstract Builder basicAuth(EncryptedValue basicAuth);
 
-        @JsonProperty(FIELD_APIKEY)
+        @JsonProperty(FIELD_API_KEY)
         public abstract Builder apiKey(String apiKey);
 
-        @JsonProperty(FIELD_APIKEY_VALUE)
-        public abstract Builder apiKeyValue(EncryptedValue apiKeyValue);
+        @JsonProperty(FIELD_API_SECRET)
+        public abstract Builder apiSecret(EncryptedValue apiKeyValue);
 
         @JsonProperty(FIELD_URL)
         public abstract Builder url(String url);

--- a/graylog2-server/src/main/java/org/graylog/events/notifications/types/HTTPEventNotificationConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/events/notifications/types/HTTPEventNotificationConfig.java
@@ -81,7 +81,7 @@ public abstract class HTTPEventNotificationConfig implements EventNotificationCo
             validation.addError(FIELD_APIKEY, "HTTP Notification cannot specify API key value without API key");
         }
         if (!Strings.isNullOrEmpty(apiKey()) && Strings.isNullOrEmpty(apiKeyValue())) {
-            validation.addError(FIELD_APIKEY, "HTTP Notification cannot specify API key without API key value");
+            validation.addError(FIELD_APIKEY_VALUE, "HTTP Notification cannot specify API key without API key value");
         }
 
         return validation;

--- a/graylog2-server/src/main/java/org/graylog/events/notifications/types/HTTPEventNotificationConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/events/notifications/types/HTTPEventNotificationConfig.java
@@ -124,6 +124,9 @@ public abstract class HTTPEventNotificationConfig implements EventNotificationCo
         @JsonCreator
         public static Builder create() {
             return new AutoValue_HTTPEventNotificationConfig.Builder()
+                    .basicAuth(EncryptedValue.createUnset())
+                    .apiSecret(EncryptedValue.createUnset())
+                    .apiKey("")
                     .type(TYPE_NAME);
         }
 

--- a/graylog2-server/src/test/java/org/graylog/events/notifications/NotificationDtoTest.java
+++ b/graylog2-server/src/test/java/org/graylog/events/notifications/NotificationDtoTest.java
@@ -38,6 +38,14 @@ public class NotificationDtoTest {
                 .build();
     }
 
+    private NotificationDto getHttpNotification(HTTPEventNotificationConfig config) {
+        return NotificationDto.builder()
+                .title("Foobar")
+                .description("")
+                .config(config)
+                .build();
+    }
+
     private NotificationDto getEmailNotification() {
         return NotificationDto.builder()
                 .title("Foobar")
@@ -105,7 +113,7 @@ public class NotificationDtoTest {
         final NotificationDto emptyNotification = getEmailNotification().toBuilder().config(emptyConfig).build();
         final ValidationResult validationResult = emptyNotification.validate();
         assertThat(validationResult.failed()).isTrue();
-        assertThat(validationResult.getErrors().size()).isEqualTo(3);
+        assertThat(validationResult.getErrors()).hasSize(3);
         assertThat(validationResult.getErrors()).containsOnlyKeys("subject", "body", "recipients");
     }
 
@@ -127,7 +135,26 @@ public class NotificationDtoTest {
 
         final ValidationResult validationResult = validNotification.validate();
         assertThat(validationResult.failed()).isFalse();
-        assertThat(validationResult.getErrors().size()).isEqualTo(0);
+        assertThat(validationResult.getErrors()).isEmpty();
+    }
+
+    @Test
+    public void testValidateHttpNotificationWithApiKey() {
+        HTTPEventNotificationConfig httpConfig = HTTPEventNotificationConfig.Builder.create()
+                .url("http://localhost")
+                .apiKey("xxx")
+                .build();
+        NotificationDto notification = getHttpNotification(httpConfig);
+        ValidationResult validationResult = notification.validate();
+        assertThat(validationResult.getErrors()).containsOnlyKeys("apikey_value");
+
+        httpConfig = HTTPEventNotificationConfig.Builder.create()
+                .url("http://localhost")
+                .apiKeyValue("xxx")
+                .build();
+        notification = getHttpNotification(httpConfig);
+        validationResult = notification.validate();
+        assertThat(validationResult.getErrors()).containsOnlyKeys("apikey");
     }
 
     @Test
@@ -136,7 +163,7 @@ public class NotificationDtoTest {
 
         final ValidationResult validationResult = validNotification.validate();
         assertThat(validationResult.failed()).isFalse();
-        assertThat(validationResult.getErrors().size()).isEqualTo(0);
+        assertThat(validationResult.getErrors()).isEmpty();
     }
 
     @Test
@@ -145,6 +172,6 @@ public class NotificationDtoTest {
 
         final ValidationResult validationResult = validNotification.validate();
         assertThat(validationResult.failed()).isFalse();
-        assertThat(validationResult.getErrors().size()).isEqualTo(0);
+        assertThat(validationResult.getErrors()).isEmpty();
     }
 }

--- a/graylog2-server/src/test/java/org/graylog/events/notifications/NotificationDtoTest.java
+++ b/graylog2-server/src/test/java/org/graylog/events/notifications/NotificationDtoTest.java
@@ -147,15 +147,15 @@ public class NotificationDtoTest {
                 .build();
         NotificationDto notification = getHttpNotification(httpConfig);
         ValidationResult validationResult = notification.validate();
-        assertThat(validationResult.getErrors()).containsOnlyKeys("apikey_value");
+        assertThat(validationResult.getErrors()).containsOnlyKeys("api_secret");
 
         httpConfig = HTTPEventNotificationConfig.Builder.create()
                 .url("http://localhost")
-                .apiKeyValue(EncryptedValue.builder().value("xxx").salt("123").isDeleteValue(false).isKeepValue(false).build())
+                .apiSecret(EncryptedValue.builder().value("xxx").salt("123").isDeleteValue(false).isKeepValue(false).build())
                 .build();
         notification = getHttpNotification(httpConfig);
         validationResult = notification.validate();
-        assertThat(validationResult.getErrors()).containsOnlyKeys("apikey");
+        assertThat(validationResult.getErrors()).containsOnlyKeys("api_key");
     }
 
     @Test

--- a/graylog2-server/src/test/java/org/graylog/events/notifications/NotificationDtoTest.java
+++ b/graylog2-server/src/test/java/org/graylog/events/notifications/NotificationDtoTest.java
@@ -21,6 +21,7 @@ import org.graylog.events.legacy.LegacyAlarmCallbackEventNotificationConfig;
 import org.graylog.events.notifications.types.EmailEventNotificationConfig;
 import org.graylog.events.notifications.types.HTTPEventNotificationConfig;
 import org.graylog2.plugin.rest.ValidationResult;
+import org.graylog2.security.encryption.EncryptedValue;
 import org.junit.Test;
 
 import java.util.HashMap;
@@ -150,7 +151,7 @@ public class NotificationDtoTest {
 
         httpConfig = HTTPEventNotificationConfig.Builder.create()
                 .url("http://localhost")
-                .apiKeyValue("xxx")
+                .apiKeyValue(EncryptedValue.builder().value("xxx").salt("123").isDeleteValue(false).isKeepValue(false).build())
                 .build();
         notification = getHttpNotification(httpConfig);
         validationResult = notification.validate();

--- a/graylog2-web-interface/src/components/common/URLWhiteListInput.tsx
+++ b/graylog2-web-interface/src/components/common/URLWhiteListInput.tsx
@@ -35,9 +35,10 @@ type Props = {
   labelClassName: string,
   wrapperClassName: string,
   urlType: React.ComponentProps<typeof URLWhiteListFormModal>['urlType'],
+  autofocus: boolean,
 };
 
-const URLWhiteListInput = ({ label, onChange, validationMessage, validationState, url, onValidationChange, labelClassName, wrapperClassName, urlType }: Props) => {
+const URLWhiteListInput = ({ label, onChange, validationMessage, validationState, url, onValidationChange, labelClassName, wrapperClassName, urlType, autofocus }: Props) => {
   const [isWhitelisted, setIsWhitelisted] = useState(false);
   const [currentValidationState, setCurrentValidationState] = useState(validationState);
   const [ownValidationMessage, setOwnValidationMessage] = useState(validationMessage);
@@ -116,7 +117,7 @@ const URLWhiteListInput = ({ label, onChange, validationMessage, validationState
            name="url"
            label={label}
            ref={urlInputRef}
-           autoFocus
+           autoFocus={autofocus}
            required
            onChange={onChange}
            help={helpMessage}
@@ -128,6 +129,7 @@ const URLWhiteListInput = ({ label, onChange, validationMessage, validationState
 };
 
 URLWhiteListInput.propTypes = {
+  autofocus: PropTypes.bool,
   label: PropTypes.string.isRequired,
   onChange: PropTypes.func.isRequired,
   validationState: PropTypes.string,
@@ -143,6 +145,7 @@ URLWhiteListInput.propTypes = {
 };
 
 URLWhiteListInput.defaultProps = {
+  autofocus: true,
   url: '',
   validationState: '',
   validationMessage: '',

--- a/graylog2-web-interface/src/components/event-notifications/event-notification-details/HttpNotificationDetails.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-details/HttpNotificationDetails.jsx
@@ -21,7 +21,12 @@ import { ReadOnlyFormGroup } from 'components/common';
 
 const HttpNotificationDetails = ({ notification }) => {
   return (
-    <ReadOnlyFormGroup label="URL" value={notification.config.url} />
+    <>
+      <ReadOnlyFormGroup label="URL" value={notification.config.url} />
+      <ReadOnlyFormGroup label="Basic Authentication" value={notification.config.basic_auth?.is_set ? '******' : null} />
+      <ReadOnlyFormGroup label="API Key" value={notification.config.api_key} />
+      <ReadOnlyFormGroup label="API Secret" value={notification.config.api_secret?.is_set ? '******' : null} />
+    </>
   );
 };
 

--- a/graylog2-web-interface/src/components/event-notifications/event-notification-form/EventNotificationForm.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-form/EventNotificationForm.jsx
@@ -133,7 +133,8 @@ class EventNotificationForm extends React.Component {
                    help={lodash.get(validation, 'errors.title[0]', 'Title to identify this Notification.')}
                    value={notification.title}
                    onChange={this.handleChange}
-                   required />
+                   required
+                   autoFocus />
 
             <Input id="notification-description"
                    name="description"

--- a/graylog2-web-interface/src/components/event-notifications/event-notification-types/HttpNotificationForm.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-types/HttpNotificationForm.jsx
@@ -17,10 +17,17 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import lodash from 'lodash';
+import styled from 'styled-components';
 
 import { URLWhiteListInput } from 'components/common';
-import { Button, Col, Input, Row } from 'components/bootstrap';
+import { Button, Col, ControlLabel, Input, Row } from 'components/bootstrap';
 import * as FormsUtils from 'util/FormsUtils';
+
+const StyledButton = styled(Button)`
+  clear: both;
+  display: block;
+  margin-bottom: 15px;
+`;
 
 class HttpNotificationForm extends React.Component {
   static propTypes = {
@@ -43,6 +50,10 @@ class HttpNotificationForm extends React.Component {
     this.state = {
       api_secret: '',
       basic_auth: '',
+      reset: {
+        api_secret: false,
+        basic_auth: false,
+      },
     };
   }
 
@@ -90,11 +101,19 @@ class HttpNotificationForm extends React.Component {
   };
 
   resetSecret = (attribute) => {
+    const { reset } = this.state;
+    reset[attribute] = true;
+    this.setState({ reset });
+
     this.propagateChange(attribute, { delete_value: true });
     this.setState({ [attribute]: '' });
   };
 
   undoResetSecret = (attribute) => {
+    const { reset } = this.state;
+    reset[attribute] = false;
+    this.setState({ reset });
+
     this.propagateChange(attribute, { keep_value: true });
     this.setState({ [attribute]: '******' });
   };
@@ -102,8 +121,7 @@ class HttpNotificationForm extends React.Component {
   render() {
     const { config, validation } = this.props;
     const { api_secret, basic_auth } = config;
-    const basicAuthColumnSize = basic_auth?.keep_value || basic_auth?.delete_value ? 10 : 12;
-    const apiSecretColumnSize = api_secret?.keep_value || api_secret?.delete_value ? 10 : 12;
+    const { reset } = this.state;
 
     return (
       <>
@@ -114,62 +132,66 @@ class HttpNotificationForm extends React.Component {
                            onValidationChange={this.onValidationChange}
                            url={config.url} />
         <Row>
-          <Col md={basicAuthColumnSize}>
-            <Input id="basicAuth"
-                   onChange={this.handleSecretInputChange}
-                   label="Basic Authentication"
-                   type="password"
-                   name="basic_auth"
-                   value={this.state.basic_auth || ''} />
+          <Col md={12}>
+            {basic_auth?.keep_value ? (
+              <>
+                <ControlLabel>Basic Authentication</ControlLabel>
+                <StyledButton bsStyle="danger" type="button" onClick={() => { this.resetSecret('basic_auth'); }}>
+                  Reset Secret
+                </StyledButton>
+              </>
+            ) : (
+              <Input id="basicAuth"
+                     label="Basic Authentication"
+                     name="basic_auth"
+                     type="password"
+                     onChange={this.handleSecretInputChange}
+                     value={this.state.basic_auth || ''}
+                     buttonAfter={reset.basic_auth ? (
+                       <Button type="button" onClick={() => { this.undoResetSecret('basic_auth'); }}>
+                         Undo Reset
+                       </Button>
+                     ) : undefined} />
+            )}
           </Col>
-          {basic_auth?.keep_value === true && (
-            <Col md={2}>
-              <Button bsStyle="danger" type="button" onClick={() => { this.resetSecret('basic_auth'); }}>
-                Reset Secret
-              </Button>
-            </Col>
-          )}
-          {basic_auth?.delete_value === true && (
-            <Col md={2}>
-              <Button type="button" onClick={() => { this.undoResetSecret('basic_auth'); }}>
-                Undo Reset
-              </Button>
-            </Col>
-          )}
         </Row>
-        <Input id="api_key"
-               name="api_key"
-               label="API Key"
-               type="text"
-               onChange={this.handleChange}
-               bsStyle={validation.errors.api_key ? 'error' : null}
-               help={lodash.get(validation, 'errors.api_key[0]', 'The API Key.')}
-               value={config.api_key} />
         <Row>
-          <Col md={apiSecretColumnSize}>
-            <Input id="api_secret"
-                   name="api_secret"
-                   label="API Secret"
-                   type="password"
-                   onChange={this.handleSecretInputChange}
-                   bsStyle={validation.errors.api_secret ? 'error' : null}
-                   help={lodash.get(validation, 'errors.api_secret[0]', 'The API Secret')}
-                   value={this.state.api_secret || ''} />
+          <Col md={12}>
+            <Input id="api_key"
+                   name="api_key"
+                   label="API Key"
+                   type="text"
+                   onChange={this.handleChange}
+                   bsStyle={validation.errors.api_key ? 'error' : null}
+                   help={lodash.get(validation, 'errors.api_key[0]', 'The API Key.')}
+                   value={config.api_key} />
           </Col>
-          {api_secret?.keep_value === true && (
-            <Col md={2}>
-              <Button bsStyle="danger" type="button" onClick={() => { this.resetSecret('api_secret'); }}>
-                Reset Secret
-              </Button>
-            </Col>
-          )}
-          {api_secret?.delete_value === true && (
-            <Col md={2}>
-              <Button type="button" onClick={() => { this.undoResetSecret('api_secret'); }}>
-                Undo Reset
-              </Button>
-            </Col>
-          )}
+        </Row>
+        <Row>
+          <Col md={12}>
+            {api_secret?.keep_value ? (
+              <>
+                <ControlLabel>API Secret</ControlLabel>
+                <StyledButton bsStyle="danger" type="button" onClick={() => { this.resetSecret('api_secret'); }}>
+                  Reset Secret
+                </StyledButton>
+              </>
+            ) : (
+              <Input id="apiSecret"
+                     label="API Secret"
+                     name="api_secret"
+                     type="password"
+                     onChange={this.handleSecretInputChange}
+                     bsStyle={validation.errors.api_secret ? 'error' : null}
+                     help={lodash.get(validation, 'errors.api_secret[0]', 'The API Secret')}
+                     value={this.state.api_secret || ''}
+                     buttonAfter={reset.api_secret ? (
+                       <Button type="button" onClick={() => { this.undoResetSecret('api_secret'); }}>
+                         Undo Reset
+                       </Button>
+                     ) : undefined} />
+            )}
+          </Col>
         </Row>
       </>
     );

--- a/graylog2-web-interface/src/components/event-notifications/event-notification-types/HttpNotificationForm.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-types/HttpNotificationForm.jsx
@@ -19,6 +19,7 @@ import PropTypes from 'prop-types';
 import lodash from 'lodash';
 
 import { URLWhiteListInput } from 'components/common';
+import { Button, Col, Input, Row } from 'components/bootstrap';
 import * as FormsUtils from 'util/FormsUtils';
 
 class HttpNotificationForm extends React.Component {
@@ -31,7 +32,32 @@ class HttpNotificationForm extends React.Component {
 
   static defaultConfig = {
     url: '',
+    api_key: '',
+    api_secret: { keep_value: true },
+    basic_auth: { keep_value: true },
   };
+
+  constructor() {
+    super();
+
+    this.state = {
+      api_secret: '',
+      basic_auth: '',
+    };
+  }
+
+  componentDidMount() {
+    const { config, onChange } = this.props;
+    const nextConfig = lodash.cloneDeep(config);
+
+    nextConfig.basic_auth = config.basic_auth?.is_set ? { keep_value: true } : null;
+    nextConfig.api_secret = config.api_secret?.is_set ? { keep_value: true } : null;
+
+    onChange(nextConfig);
+
+    this.setState({ basic_auth: config.basic_auth.is_set ? '******' : '' });
+    this.setState({ api_secret: config.api_secret.is_set ? '******' : '' });
+  }
 
   propagateChange = (key, value) => {
     const { config, onChange } = this.props;
@@ -43,8 +69,18 @@ class HttpNotificationForm extends React.Component {
 
   handleChange = (event) => {
     const { name } = event.target;
+    const inputValue = FormsUtils.getValueFromInput(event.target);
 
-    this.propagateChange(name, FormsUtils.getValueFromInput(event.target));
+    this.propagateChange(name, inputValue);
+  };
+
+  handleSecretInputChange = (event) => {
+    const { name } = event.target;
+    const inputValue = FormsUtils.getValueFromInput(event.target);
+    const value = inputValue.length === 0 ? { delete_value: true } : { set_value: inputValue };
+
+    this.setState({ [name]: inputValue });
+    this.propagateChange(name, value);
   };
 
   onValidationChange = (validationState) => {
@@ -53,16 +89,89 @@ class HttpNotificationForm extends React.Component {
     setIsSubmitEnabled(validationState !== 'error');
   };
 
+  resetSecret = (attribute) => {
+    this.propagateChange(attribute, { delete_value: true });
+    this.setState({ [attribute]: '' });
+  };
+
+  undoResetSecret = (attribute) => {
+    this.propagateChange(attribute, { keep_value: true });
+    this.setState({ [attribute]: '******' });
+  };
+
   render() {
     const { config, validation } = this.props;
+    const { api_secret, basic_auth } = config;
+    const basicAuthColumnSize = basic_auth?.keep_value || basic_auth?.delete_value ? 10 : 12;
+    const apiSecretColumnSize = api_secret?.keep_value || api_secret?.delete_value ? 10 : 12;
 
     return (
-      <URLWhiteListInput label="URL"
-                         onChange={this.handleChange}
-                         validationState={validation.errors.url ? 'error' : null}
-                         validationMessage={lodash.get(validation, 'errors.url[0]', 'The URL to POST to when an Event occurs.')}
-                         onValidationChange={this.onValidationChange}
-                         url={config.url} />
+      <>
+        <URLWhiteListInput label="URL"
+                           onChange={this.handleChange}
+                           validationState={validation.errors.url ? 'error' : null}
+                           validationMessage={lodash.get(validation, 'errors.url[0]', 'The URL to POST to when an Event occurs.')}
+                           onValidationChange={this.onValidationChange}
+                           url={config.url} />
+        <Row>
+          <Col md={basicAuthColumnSize}>
+            <Input id="basicAuth"
+                   onChange={this.handleSecretInputChange}
+                   label="Basic Authentication"
+                   type="password"
+                   name="basic_auth"
+                   value={this.state.basic_auth || ''} />
+          </Col>
+          {basic_auth?.keep_value === true && (
+            <Col md={2}>
+              <Button bsStyle="danger" type="button" onClick={() => { this.resetSecret('basic_auth'); }}>
+                Reset Secret
+              </Button>
+            </Col>
+          )}
+          {basic_auth?.delete_value === true && (
+            <Col md={2}>
+              <Button type="button" onClick={() => { this.undoResetSecret('basic_auth'); }}>
+                Undo Reset
+              </Button>
+            </Col>
+          )}
+        </Row>
+        <Input id="api_key"
+               name="api_key"
+               label="API Key"
+               type="text"
+               onChange={this.handleChange}
+               bsStyle={validation.errors.api_key ? 'error' : null}
+               help={lodash.get(validation, 'errors.api_key[0]', 'The API Key.')}
+               value={config.api_key} />
+        <Row>
+          <Col md={apiSecretColumnSize}>
+            <Input id="api_secret"
+                   name="api_secret"
+                   label="API Secret"
+                   type="password"
+                   onChange={this.handleSecretInputChange}
+                   bsStyle={validation.errors.api_secret ? 'error' : null}
+                   help={lodash.get(validation, 'errors.api_secret[0]', 'The API Secret')}
+                   value={this.state.api_secret || ''} />
+          </Col>
+          {api_secret?.keep_value === true && (
+            <Col md={2}>
+              <Button bsStyle="danger" type="button" onClick={() => { this.resetSecret('api_secret'); }}>
+                Reset Secret
+              </Button>
+            </Col>
+          )}
+          {api_secret?.delete_value === true && (
+            <Col md={2}>
+              <Button type="button" onClick={() => { this.undoResetSecret('api_secret'); }}>
+                Undo Reset
+              </Button>
+            </Col>
+          )}
+        </Row>
+      </>
     );
   }
 }

--- a/graylog2-web-interface/src/components/event-notifications/event-notification-types/HttpNotificationForm.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-types/HttpNotificationForm.jsx
@@ -130,7 +130,8 @@ class HttpNotificationForm extends React.Component {
                            validationState={validation.errors.url ? 'error' : null}
                            validationMessage={lodash.get(validation, 'errors.url[0]', 'The URL to POST to when an Event occurs.')}
                            onValidationChange={this.onValidationChange}
-                           url={config.url} />
+                           url={config.url}
+                           autofocus={false} />
         <Row>
           <Col md={12}>
             {basic_auth?.keep_value ? (

--- a/graylog2-web-interface/src/components/event-notifications/event-notification-types/HttpNotificationForm.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-types/HttpNotificationForm.jsx
@@ -136,18 +136,19 @@ class HttpNotificationForm extends React.Component {
           <Col md={12}>
             {basic_auth?.keep_value ? (
               <>
-                <ControlLabel>Basic Authentication</ControlLabel>
+                <ControlLabel>Basic authentication</ControlLabel>
                 <StyledButton bsStyle="danger" type="button" onClick={() => { this.resetSecret('basic_auth'); }}>
                   Reset Secret
                 </StyledButton>
               </>
             ) : (
               <Input id="basicAuth"
-                     label="Basic Authentication"
+                     label={<span>Basic authentication <small className="text-muted">(Optional)</small></span>}
                      name="basic_auth"
                      type="password"
                      onChange={this.handleSecretInputChange}
                      value={this.state.basic_auth || ''}
+                     help="The Basic authentication string needs to follow this format: '<username>:<password>'."
                      buttonAfter={reset.basic_auth ? (
                        <Button type="button" onClick={() => { this.undoResetSecret('basic_auth'); }}>
                          Undo Reset
@@ -160,11 +161,11 @@ class HttpNotificationForm extends React.Component {
           <Col md={12}>
             <Input id="api_key"
                    name="api_key"
-                   label="API Key"
+                   label={<span>API Key <small className="text-muted">(Optional)</small></span>}
                    type="text"
                    onChange={this.handleChange}
                    bsStyle={validation.errors.api_key ? 'error' : null}
-                   help={lodash.get(validation, 'errors.api_key[0]', 'The API Key.')}
+                   help={lodash.get(validation, 'errors.api_key[0]', 'If an API secret is set, an API key must also be set.')}
                    value={config.api_key} />
           </Col>
         </Row>
@@ -179,12 +180,12 @@ class HttpNotificationForm extends React.Component {
               </>
             ) : (
               <Input id="apiSecret"
-                     label="API Secret"
+                     label={<span>API Secret <small className="text-muted">(Optional)</small></span>}
                      name="api_secret"
                      type="password"
                      onChange={this.handleSecretInputChange}
                      bsStyle={validation.errors.api_secret ? 'error' : null}
-                     help={lodash.get(validation, 'errors.api_secret[0]', 'The API Secret.')}
+                     help={lodash.get(validation, 'errors.api_secret[0]', 'If an API key is set, an API secret must also be set.')}
                      value={this.state.api_secret || ''}
                      buttonAfter={reset.api_secret ? (
                        <Button type="button" onClick={() => { this.undoResetSecret('api_secret'); }}>

--- a/graylog2-web-interface/src/components/event-notifications/event-notification-types/HttpNotificationForm.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-types/HttpNotificationForm.jsx
@@ -184,7 +184,7 @@ class HttpNotificationForm extends React.Component {
                      type="password"
                      onChange={this.handleSecretInputChange}
                      bsStyle={validation.errors.api_secret ? 'error' : null}
-                     help={lodash.get(validation, 'errors.api_secret[0]', 'The API Secret')}
+                     help={lodash.get(validation, 'errors.api_secret[0]', 'The API Secret.')}
                      value={this.state.api_secret || ''}
                      buttonAfter={reset.api_secret ? (
                        <Button type="button" onClick={() => { this.undoResetSecret('api_secret'); }}>

--- a/graylog2-web-interface/src/components/event-notifications/event-notification-types/HttpNotificationForm.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-types/HttpNotificationForm.jsx
@@ -137,7 +137,7 @@ class HttpNotificationForm extends React.Component {
             {basic_auth?.keep_value ? (
               <>
                 <ControlLabel>Basic authentication</ControlLabel>
-                <StyledButton bsStyle="danger" type="button" onClick={() => { this.resetSecret('basic_auth'); }}>
+                <StyledButton bsStyle="default" type="button" onClick={() => { this.resetSecret('basic_auth'); }}>
                   Reset Secret
                 </StyledButton>
               </>
@@ -174,7 +174,7 @@ class HttpNotificationForm extends React.Component {
             {api_secret?.keep_value ? (
               <>
                 <ControlLabel>API Secret</ControlLabel>
-                <StyledButton bsStyle="danger" type="button" onClick={() => { this.resetSecret('api_secret'); }}>
+                <StyledButton bsStyle="default" type="button" onClick={() => { this.resetSecret('api_secret'); }}>
                   Reset Secret
                 </StyledButton>
               </>


### PR DESCRIPTION
Customers sometimes need to provide a basic auth string or API key in the HTTP notification event request.

We offer the following options:
* basic auth: specified string will be added as a base64-encoded authorization header 
* API key: the provided key name and value will be added as a query parameter

![Screenshot 2022-04-29 at 11 57 45](https://user-images.githubusercontent.com/92227/165924374-88f269c8-71b7-4b32-b071-c52186f49446.png)

Resolves Graylog2/graylog-plugin-integrations#769