### PR TITLE
Fix ConfirmDialog close behaviour via `X` button (or pressing `ESC` or clicking on the background)

### DIFF
--- a/graylog2-web-interface/src/components/common/ConfirmDialog.tsx
+++ b/graylog2-web-interface/src/components/common/ConfirmDialog.tsx
@@ -35,7 +35,7 @@ const ConfirmDialog = ({
   btnConfirmText,
 }) => {
   return (
-    <Modal show={show}>
+    <Modal show={show} onHide={onCancel}>
       <Modal.Header closeButton>
         <Modal.Title>{title}</Modal.Title>
       </Modal.Header>

--- a/graylog2-web-interface/src/components/common/index.tsx
+++ b/graylog2-web-interface/src/components/common/index.tsx
@@ -26,6 +26,7 @@ export { default as Center } from './Center';
 export { default as ClipboardButton } from './ClipboardButton';
 export { default as ColorPicker } from './ColorPicker';
 export { default as ColorPickerPopover } from './ColorPickerPopover';
+export { default as ConfirmDialog } from './ConfirmDialog';
 export { default as ConfirmLeaveDialog } from './ConfirmLeaveDialog';
 export { default as ContentHeadRow } from './ContentHeadRow';
 export { default as ControlledTableList } from './ControlledTableList';


### PR DESCRIPTION
Fix `ConfirmDialog` close behaviour via `X` button (or pressing `ESC` or clicking on the background).

## Motivation and Context

The UX is broken when using the `ConfirmDialog` and pressing the `X` button on the right, top. This also affect the keyboard shortcut ESC and clicking on the background.

## Screenshots (if appropriate):

![Screenshot 2022-04-14 at 11 57 50](https://user-images.githubusercontent.com/92227/163361936-cca60541-101f-49ec-9a60-670cff09224a.png)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the code style of this project.

Fix #12479 