### PR TITLE
Fixing route prefixing after `urijs` update.

### DIFF
--- a/graylog2-web-interface/src/routing/Routes.test.ts
+++ b/graylog2-web-interface/src/routing/Routes.test.ts
@@ -77,4 +77,38 @@ describe('Routes', () => {
       expect(uri.hasQuery('interval', 'hour')).toBeTruthy();
     });
   });
+
+  describe('with `/` prefix', () => {
+    beforeAll(() => {
+      jest.resetModules();
+
+      window.appConfig = {
+        gl2AppPathPrefix: '/',
+      } as AppConfigs;
+
+      Routes = jest.requireActual('./Routes').default;
+    });
+
+    it('returns a route from constant', () => {
+      expect(Routes.SEARCH).toMatch('/search');
+    });
+
+    it('returns correct route for getting started page', () => {
+      expect(Routes.GETTING_STARTED).toMatch('/gettingstarted');
+    });
+
+    it('returns a route from function', () => {
+      expect(Routes.node('id')).toMatch('/system/nodes/id');
+    });
+
+    it('routes contain query parameters', () => {
+      const uri = URI(Routes.search('', { rangetype: 'relative', relative: 300 }, 'hour'));
+
+      expect(uri.path()).toMatch('/search');
+      expect(uri.hasQuery('q', '')).toBeTruthy();
+      expect(uri.hasQuery('rangetype', 'relative')).toBeTruthy();
+      expect(uri.hasQuery('relative', '300')).toBeTruthy();
+      expect(uri.hasQuery('interval', 'hour')).toBeTruthy();
+    });
+  });
 });

--- a/graylog2-web-interface/src/routing/Routes.ts
+++ b/graylog2-web-interface/src/routing/Routes.ts
@@ -254,19 +254,28 @@ const Routes = {
   filtered_metrics: (nodeId: string, filter: string) => `${Routes.SYSTEM.METRICS(nodeId)}?filter=${filter}`,
 } as const;
 
+const prefixUrlWithoutHostname = (url: string, prefix: string) => {
+  const uri = new URI(url);
+
+  return uri.directory(`${prefix}/${uri.directory()}`)
+    .normalizePath()
+    .resource();
+};
+
 const qualifyUrls = (routes, appPrefix): typeof routes => {
   const qualifiedRoutes = {};
 
   Object.keys(routes).forEach((routeName) => {
     switch (typeof routes[routeName]) {
       case 'string':
-        qualifiedRoutes[routeName] = new URI(`${appPrefix}/${routes[routeName]}`).normalizePath().resource();
+        qualifiedRoutes[routeName] = prefixUrlWithoutHostname(routes[routeName], appPrefix);
+
         break;
       case 'function':
         qualifiedRoutes[routeName] = (...params) => {
           const result = routes[routeName](...params);
 
-          return new URI(`${appPrefix}/${result}`).normalizePath().resource();
+          return prefixUrlWithoutHostname(result, appPrefix);
         };
 
         break;

--- a/graylog2-web-interface/src/routing/Routes.ts
+++ b/graylog2-web-interface/src/routing/Routes.ts
@@ -263,6 +263,10 @@ const prefixUrlWithoutHostname = (url: string, prefix: string) => {
 };
 
 const qualifyUrls = (routes, appPrefix): typeof routes => {
+  if (appPrefix === '/') {
+    return routes;
+  }
+
   const qualifiedRoutes = {};
 
   Object.keys(routes).forEach((routeName) => {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

In #12468 `urijs` was updated. With this version, the [parsing of URLs starting with a double slash](https://github.com/medialize/URI.js/blob/gh-pages/CHANGELOG.md#11911-april-3rd-2022) (e.g. `//search`) has changed, interpreting the first path of the path as hostname (in this example `search`). This led to application routes being messed up with when the application prefix is `/`, swallowing the first part of the path, e.g. turning `/gettingstarted` into `/`.

This has lead to a particularly bad condition, resulting in repeated redirection to `/` when trying to redirect to the getting started page after logging in.

This change is now fixing the way application routes are being prefixed and normalized. The `qualifyUrls` function in the `routing/Routes` module is now returning proper results for all prefixes again, by making use of the `URI#directory` function to set the directory path of a prefixed URL, making sure that a double-slash is not parsed as part of a scheme.

Although URL prefixing now works properly, a shortcut is added, which just returns the original routes when the prefix is exactly `/`, saving a few cycles.

Fixes #12476.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.