### PR TITLE
Do not show error on messages from Forwarder in show single message page

### DIFF
--- a/graylog2-web-interface/src/pages/ShowMessagePage.test.tsx
+++ b/graylog2-web-interface/src/pages/ShowMessagePage.test.tsx
@@ -31,6 +31,7 @@ const mockGetInput = jest.fn();
 const mockListNodes = jest.fn();
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const mockListStreams = jest.fn((..._args) => Promise.resolve([]));
+const mockPluginStoreExports = jest.fn();
 
 jest.mock('stores/nodes/NodesStore', () => ({
   NodesActions: { list: (...args) => mockListNodes(...args) },
@@ -53,6 +54,12 @@ jest.mock('stores/streams/StreamsStore', () => ({ listStreams: (...args) => mock
 jest.mock('views/logic/fieldtypes/useFieldTypes');
 jest.mock('routing/withParams', () => (x) => x);
 
+jest.mock('graylog-web-plugin/plugin', () => ({
+  PluginStore: {
+    exports: jest.fn((...args) => mockPluginStoreExports(...args)),
+  },
+}));
+
 type SimpleShowMessagePageProps = {
   index: string,
   messageId: string,
@@ -65,7 +72,7 @@ const SimpleShowMessagePage = ({ index, messageId }: SimpleShowMessagePageProps)
 
 describe('ShowMessagePage', () => {
   beforeEach(() => {
-    asMock(useFieldTypes).mockClear();
+    jest.clearAllMocks();
     asMock(useFieldTypes).mockReturnValue({ data: [] });
   });
 
@@ -118,5 +125,20 @@ describe('ShowMessagePage', () => {
     await screen.findByText(/SSH Brute Force/);
 
     expect(container).toMatchSnapshot();
+  });
+
+  it('does not fetch input when opening message from forwarder', async () => {
+    mockPluginStoreExports.mockReturnValue([{
+      isLocalNode: jest.fn(() => false),
+    }]);
+
+    mockLoadMessage.mockImplementation(() => Promise.resolve(message));
+    mockGetInput.mockImplementation(() => Promise.resolve());
+    mockListStreams.mockImplementation(() => Promise.resolve([]));
+
+    render(<SimpleShowMessagePage index="graylog_5" messageId="20f683d2-a874-11e9-8a11-0242ac130004" />);
+    await screen.findByText(/Deprecated field/);
+
+    expect(mockGetInput).not.toHaveBeenCalled();
   });
 });

--- a/graylog2-web-interface/src/pages/ShowMessagePage.tsx
+++ b/graylog2-web-interface/src/pages/ShowMessagePage.tsx
@@ -65,19 +65,22 @@ const useMessage = (index: string, messageId: string) => {
   const [inputs, setInputs] = useState<Immutable.Map<string, Input>>(Immutable.Map());
 
   useEffect(() => {
-    MessagesActions.loadMessage(index, messageId)
-      .then((_message) => {
-        setMessage(_message);
+    const fetchData = async () => {
+      const _message = await MessagesActions.loadMessage(index, messageId);
+      setMessage(_message);
 
-        return _message.source_input_id ? InputsActions.get(_message.source_input_id) : Promise.resolve();
-      })
-      .then((input) => {
+      if (_message.source_input_id) {
+        const input = await InputsActions.get(_message.source_input_id);
+
         if (input) {
           const newInputs = Immutable.Map({ [input.id]: input });
 
           setInputs(newInputs);
         }
-      });
+      }
+    };
+
+    fetchData();
   }, [index, messageId, setMessage, setInputs]);
 
   return { message, inputs };

--- a/graylog2-web-interface/src/pages/ShowMessagePage.tsx
+++ b/graylog2-web-interface/src/pages/ShowMessagePage.tsx
@@ -34,6 +34,7 @@ import StreamsStore from 'stores/streams/StreamsStore';
 import { InputsActions } from 'stores/inputs/InputsStore';
 import { MessagesActions } from 'stores/messages/MessagesStore';
 import { NodesActions } from 'stores/nodes/NodesStore';
+import { isLocalNode } from 'views/hooks/useIsLocalNode';
 
 type Props = {
   params: {
@@ -69,7 +70,7 @@ const useMessage = (index: string, messageId: string) => {
       const _message = await MessagesActions.loadMessage(index, messageId);
       setMessage(_message);
 
-      if (_message.source_input_id) {
+      if (_message.source_input_id && await isLocalNode(_message.fields.gl2_source_node)) {
         const input = await InputsActions.get(_message.source_input_id);
 
         if (input) {


### PR DESCRIPTION
Before these changes, opening the show single message page with a message coming from a Forwarder displayed an error, since we tried to fetch a local Input that actually belonged to a Forwarder.

To fix the issue we now use the `isLocalNode` function to decide whether the message was received on a local node directly (and we should therefore try to fetch the Input) or through a Forwarder.

Fixes https://github.com/Graylog2/graylog-plugin-enterprise/issues/3472