### PR TITLE
Implement pluggable search bar controls for dashboards and widget edit mode.

### DIFF
--- a/graylog2-web-interface/src/views/components/DashboardSearchBar.tsx
+++ b/graylog2-web-interface/src/views/components/DashboardSearchBar.tsx
@@ -46,6 +46,7 @@ import ValidateOnParameterChange from 'views/components/searchbar/ValidateOnPara
 import TimeRangeInput from './searchbar/TimeRangeInput';
 import type { DashboardFormValues } from './DashboardSearchBarForm';
 import DashboardSearchForm from './DashboardSearchBarForm';
+import PluggableSearchBarControls from './searchbar/PluggableSearchBarControls';
 
 type Props = {
   config: SearchesConfig,
@@ -56,6 +57,11 @@ type Props = {
   disableSearch?: boolean,
   onExecute: () => Promise<void>,
 };
+
+const Container = styled.div`
+  display: grid;
+  row-gap: 10px;
+`;
 
 const TopRow = styled.div(({ theme }) => css`
   display: flex;
@@ -132,7 +138,7 @@ const DashboardSearchBar = ({ config, globalOverride, disableSearch = false, onE
                   const disableSearchSubmit = disableSearch || isSubmitting || isValidating || !isValid;
 
                   return (
-                    <>
+                    <Container>
                       <ValidateOnParameterChange parameters={parameters} parameterBindings={parameterBindings} />
                       <TopRow>
                         <StyledTimeRangeInput disabled={disableSearch}
@@ -184,7 +190,8 @@ const DashboardSearchBar = ({ config, globalOverride, disableSearch = false, onE
                           </ViewActionsWrapper>
                         )}
                       </BottomRow>
-                    </>
+                      <PluggableSearchBarControls />
+                    </Container>
                   );
                 }}
               </DashboardSearchForm>

--- a/graylog2-web-interface/src/views/components/WidgetQueryControls.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetQueryControls.tsx
@@ -52,6 +52,12 @@ import SearchButton from './searchbar/SearchButton';
 import QueryInput from './searchbar/queryinput/AsyncQueryInput';
 import SearchBarForm, { normalizeSearchBarFormValues } from './searchbar/SearchBarForm';
 import WidgetQueryOverride from './WidgetQueryOverride';
+import PluggableSearchBarControls from './searchbar/PluggableSearchBarControls';
+
+const Container = styled.div`
+  display: grid;
+  row-gap: 10px;
+`;
 
 const SecondRow = styled.div`
   display: flex;
@@ -151,7 +157,7 @@ const WidgetQueryControls = ({ availableStreams, globalOverride }: Props) => {
           const disableSearchSubmit = isSubmitting || isValidatingQuery || !isValid;
 
           return (
-            <>
+            <Container>
               <PropagateDisableSubmissionState formKey="widget-query-controls" disableSubmission={disableSearchSubmit} />
               <ValidateOnParameterChange parameters={parameters} parameterBindings={parameterBindings} />
               <WidgetTopRow>
@@ -213,7 +219,8 @@ const WidgetQueryControls = ({ availableStreams, globalOverride }: Props) => {
                 {hasQueryOverride
                   && <WidgetQueryOverride value={globalOverride?.query} onReset={_resetQueryOverride} />}
               </SecondRow>
-            </>
+              <PluggableSearchBarControls />
+            </Container>
           );
         }}
       </SearchBarForm>

--- a/graylog2-web-interface/src/views/components/searchbar/PluggableSearchBarControls.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/PluggableSearchBarControls.test.tsx
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import { render, screen } from 'wrappedTestingLibrary';
+
+import asMock from 'helpers/mocking/AsMock';
+import usePluginEntities from 'views/logic/usePluginEntities';
+
+import PluggableSearchBarControls from './PluggableSearchBarControls';
+
+jest.mock('views/logic/usePluginEntities');
+jest.mock('hooks/useFeature', () => () => true);
+
+describe('PluggableSearchBarControls', () => {
+  const createPluggableSearchBarControl = (overrides = {}) => {
+    return () => ({
+      id: 'example-component',
+      placement: 'right',
+      component: () => <div>Example Component</div>,
+      ...overrides,
+    });
+  };
+
+  it('should render left search bar controls from plugins', () => {
+    const example = createPluggableSearchBarControl({ placement: 'left' });
+
+    asMock(usePluginEntities).mockImplementation((entityKey) => ({ 'views.components.searchBar': [example] }[entityKey]));
+    render(<PluggableSearchBarControls />);
+
+    expect(screen.getByText('Example Component')).toBeInTheDocument();
+  });
+
+  it('should render right search bar controls from plugins', () => {
+    const example = createPluggableSearchBarControl({ placement: 'right' });
+    asMock(usePluginEntities).mockImplementation((entityKey) => ({ 'views.components.searchBar': [example] }[entityKey]));
+    render(<PluggableSearchBarControls />);
+
+    expect(screen.getByText('Example Component')).toBeInTheDocument();
+  });
+
+  it('should render fallback for search bar filters', () => {
+    asMock(usePluginEntities).mockImplementation((entityKey) => ({ 'views.components.searchBar': [] }[entityKey]));
+    render(<PluggableSearchBarControls />);
+
+    expect(screen.getByText('Filters')).toBeInTheDocument();
+  });
+
+  it('should not render fallback when search bar filters are defined', () => {
+    const example = createPluggableSearchBarControl({ id: 'search-filters' });
+    asMock(usePluginEntities).mockImplementation((entityKey) => ({ 'views.components.searchBar': [example] }[entityKey]));
+    render(<PluggableSearchBarControls />);
+
+    expect(screen.queryByText('Filters')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

With https://github.com/Graylog2/graylog2-server/pull/12441 we are now displaying pluggable search bar controls for the search bar on the default search page.
With this PR we are also rendering the pluggable search bar controls for dashboards and the widget edit mode.

Fixes https://github.com/Graylog2/graylog-plugin-enterprise/issues/3401
