### PR TITLE
Add enterprise license as fixture

### DIFF
--- a/full-backend-tests/src/test/java/org/graylog/shared/system/stats/SystemStatsIT.java
+++ b/full-backend-tests/src/test/java/org/graylog/shared/system/stats/SystemStatsIT.java
@@ -23,6 +23,8 @@ import org.graylog.testing.containermatrix.SearchServer;
 import org.graylog.testing.containermatrix.annotations.ContainerMatrixTest;
 import org.graylog.testing.containermatrix.annotations.ContainerMatrixTestsConfiguration;
 import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -42,6 +44,7 @@ public class SystemStatsIT {
     }
 
     @ContainerMatrixTest
+    @DisabledOnOs(OS.MAC)
     void filesystemStats() {
         final Map<Object, Object> filesystems = given()
                 .spec(requestSpec)

--- a/graylog2-server/src/test/java/org/graylog/testing/completebackend/ContainerizedGraylogBackend.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/completebackend/ContainerizedGraylogBackend.java
@@ -17,6 +17,7 @@
 package org.graylog.testing.completebackend;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import org.apache.commons.lang3.StringUtils;
 import org.graylog.testing.containermatrix.MongodbServer;
 import org.graylog.testing.elasticsearch.SearchServerInstance;
 import org.graylog.testing.graylognode.ExecutableNotFoundException;
@@ -27,12 +28,16 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.Network;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.net.URL;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.stream.Collectors;
 
 public class ContainerizedGraylogBackend implements GraylogBackend, AutoCloseable {
     private static final Logger LOG = LoggerFactory.getLogger(GraylogBackend.class);
@@ -47,17 +52,17 @@ public class ContainerizedGraylogBackend implements GraylogBackend, AutoCloseabl
     public static ContainerizedGraylogBackend createStarted(SearchVersion esVersion, MongodbServer mongodbVersion,
                                                             int[] extraPorts, List<URL> mongoDBFixtures,
                                                             PluginJarsProvider pluginJarsProvider, MavenProjectDirProvider mavenProjectDirProvider,
-                                                            List<String> enabledFeatureFlags) {
+                                                            List<String> enabledFeatureFlags, boolean preImportLicense) {
 
         final ContainerizedGraylogBackend backend = new ContainerizedGraylogBackend();
-        backend.create(esVersion, mongodbVersion, extraPorts, mongoDBFixtures, pluginJarsProvider, mavenProjectDirProvider, enabledFeatureFlags);
+        backend.create(esVersion, mongodbVersion, extraPorts, mongoDBFixtures, pluginJarsProvider, mavenProjectDirProvider, enabledFeatureFlags, preImportLicense);
         return backend;
     }
 
     private void create(SearchVersion esVersion, MongodbServer mongodbVersion,
                         int[] extraPorts, List<URL> mongoDBFixtures,
                         PluginJarsProvider pluginJarsProvider, MavenProjectDirProvider mavenProjectDirProvider,
-                        List<String> enabledFeatureFlags) {
+                        List<String> enabledFeatureFlags, boolean preImportLicense) {
 
         final SearchServerInstanceFactory searchServerInstanceFactory = new SearchServerInstanceFactoryByVersion(esVersion);
         Network network = Network.newNetwork();
@@ -66,6 +71,10 @@ public class ContainerizedGraylogBackend implements GraylogBackend, AutoCloseabl
         MongoDBInstance mongoDB = MongoDBInstance.createStartedWithUniqueName(network, Lifecycle.CLASS, mongodbVersion);
         mongoDB.dropDatabase();
         mongoDB.importFixtures(mongoDBFixtures);
+
+        if(preImportLicense) {
+            createLicenses(mongoDB, "GRAYLOG_LICENSE_STRING", "GRAYLOG_SECURITY_LICENSE_STRING");
+        }
 
         try {
             // Wait for ES before starting the Graylog node to avoid any race conditions
@@ -92,6 +101,21 @@ public class ContainerizedGraylogBackend implements GraylogBackend, AutoCloseabl
             throw new RuntimeException(e);
         } finally {
             executor.shutdown();
+        }
+    }
+
+    private void createLicenses(MongoDBInstance mongoDBInstance, String... licenseStrs) {
+        try {
+            final List<String> licenses = Arrays.stream(licenseStrs).map(System::getenv).filter(p -> StringUtils.isNotBlank(p)).collect(Collectors.toList());
+            if(!licenses.isEmpty()) {
+                Class myClass = Class.forName("testing.completebackend.EnterpriseITUtils");
+                Method method = myClass.getDeclaredMethod("importLicense", MongoDBInstance.class, String.class);
+                for (String license : licenses) {
+                    method.invoke(null, mongoDBInstance, license);
+                }
+            }
+        } catch (NoSuchMethodException | ClassNotFoundException | InvocationTargetException | IllegalAccessException ex) {
+            LOG.error("Could not import license to Mongo: ", ex);
         }
     }
 

--- a/graylog2-server/src/test/java/org/graylog/testing/completebackend/ContainerizedGraylogBackend.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/completebackend/ContainerizedGraylogBackend.java
@@ -109,10 +109,8 @@ public class ContainerizedGraylogBackend implements GraylogBackend, AutoCloseabl
             final List<String> licenses = Arrays.stream(licenseStrs).map(System::getenv).filter(p -> StringUtils.isNotBlank(p)).collect(Collectors.toList());
             if(!licenses.isEmpty()) {
                 Class myClass = Class.forName("testing.completebackend.EnterpriseITUtils");
-                Method method = myClass.getDeclaredMethod("importLicense", MongoDBInstance.class, String.class);
-                for (String license : licenses) {
-                    method.invoke(null, mongoDBInstance, license);
-                }
+                Method method = myClass.getDeclaredMethod("importLicenses", MongoDBInstance.class, List.class);
+                method.invoke(null, mongoDBInstance, licenses);
             }
         } catch (NoSuchMethodException | ClassNotFoundException | InvocationTargetException | IllegalAccessException ex) {
             LOG.error("Could not import license to Mongo: ", ex);

--- a/graylog2-server/src/test/java/org/graylog/testing/completebackend/TestLicenseImporter.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/completebackend/TestLicenseImporter.java
@@ -1,0 +1,9 @@
+package org.graylog.testing.completebackend;
+
+import org.graylog.testing.mongodb.MongoDBInstance;
+
+import java.util.List;
+
+public interface TestLicenseImporter {
+    default void importLicenses(final MongoDBInstance mongoDBInstance, final List<String> licenses) {}
+}

--- a/graylog2-server/src/test/java/org/graylog/testing/completebackend/TestLicenseImporter.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/completebackend/TestLicenseImporter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog.testing.completebackend;
 
 import org.graylog.testing.mongodb.MongoDBInstance;

--- a/graylog2-server/src/test/java/org/graylog/testing/containermatrix/ContainerMatrixTestEngine.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/containermatrix/ContainerMatrixTestEngine.java
@@ -138,6 +138,16 @@ public class ContainerMatrixTestEngine extends ContainerMatrixHierarchicalTestEn
                 .collect(Collectors.toList());
     }
 
+    private boolean preImportLicense(Set<Class<?>> annotatedClasses) {
+        return annotatedClasses
+                .stream()
+                .map(aClass -> AnnotationSupport.findAnnotation(aClass, ContainerMatrixTestsConfiguration.class))
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .anyMatch(ContainerMatrixTestsConfiguration::preImportLicense);
+    }
+
+
     private List<URL> getMongoDBFixtures(Set<Class<?>> annotatedClasses) {
         final List<URL> urls = new LinkedList<>();
         for (Class<?> aClass : annotatedClasses) {

--- a/graylog2-server/src/test/java/org/graylog/testing/containermatrix/ContainerMatrixTestEngine.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/containermatrix/ContainerMatrixTestEngine.java
@@ -138,16 +138,6 @@ public class ContainerMatrixTestEngine extends ContainerMatrixHierarchicalTestEn
                 .collect(Collectors.toList());
     }
 
-    private boolean preImportLicense(Set<Class<?>> annotatedClasses) {
-        return annotatedClasses
-                .stream()
-                .map(aClass -> AnnotationSupport.findAnnotation(aClass, ContainerMatrixTestsConfiguration.class))
-                .filter(Optional::isPresent)
-                .map(Optional::get)
-                .anyMatch(ContainerMatrixTestsConfiguration::preImportLicense);
-    }
-
-
     private List<URL> getMongoDBFixtures(Set<Class<?>> annotatedClasses) {
         final List<URL> urls = new LinkedList<>();
         for (Class<?> aClass : annotatedClasses) {

--- a/graylog2-server/src/test/java/org/graylog/testing/containermatrix/annotations/ContainerMatrixTestsConfiguration.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/containermatrix/annotations/ContainerMatrixTestsConfiguration.java
@@ -81,7 +81,11 @@ public @interface ContainerMatrixTestsConfiguration {
      */
     String[] enabledFeatureFlags() default {};
 
-    // pre-import an existing GL license to avoid possible race conditions during tests, only works reliable with Lifecycle.CLASS
-    boolean defaultPreImportLicense = true;
-    boolean preImportLicense() default defaultPreImportLicense;
+    /**
+     * Import existing GL licenses directly into Mongo to avoid possible race conditions during tests,
+     * that occured if the licenses where imported via REST
+     * Disabling only works with Lifecycle.CLASS because a new container is spun up.
+     */
+    boolean defaultImportLicenses = true;
+    boolean importLicenses() default defaultImportLicenses;
 }

--- a/graylog2-server/src/test/java/org/graylog/testing/containermatrix/annotations/ContainerMatrixTestsConfiguration.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/containermatrix/annotations/ContainerMatrixTestsConfiguration.java
@@ -82,5 +82,6 @@ public @interface ContainerMatrixTestsConfiguration {
     String[] enabledFeatureFlags() default {};
 
     // pre-import an existing GL license to avoid possible race conditions during tests, only works reliable with Lifecycle.CLASS
-    boolean preImportLicense() default true;
+    boolean defaultPreImportLicense = true;
+    boolean preImportLicense() default defaultPreImportLicense;
 }

--- a/graylog2-server/src/test/java/org/graylog/testing/containermatrix/annotations/ContainerMatrixTestsConfiguration.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/containermatrix/annotations/ContainerMatrixTestsConfiguration.java
@@ -80,4 +80,7 @@ public @interface ContainerMatrixTestsConfiguration {
      * @return enabled feature flags
      */
     String[] enabledFeatureFlags() default {};
+
+    // pre-import an existing GL license to avoid possible race conditions during tests, only works reliable with Lifecycle.CLASS
+    boolean preImportLicense() default true;
 }

--- a/graylog2-server/src/test/java/org/graylog/testing/mongodb/MongoDBFixtureImporter.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/mongodb/MongoDBFixtureImporter.java
@@ -72,7 +72,7 @@ import java.util.stream.Collectors;
  * }
  * }</pre>
  */
-class MongoDBFixtureImporter {
+public class MongoDBFixtureImporter {
     private static final Logger LOG = LoggerFactory.getLogger(MongoDBFixtureImporter.class);
     private static final String FIELD_DATA = "data";
     private static final String FIELD_INDEX = "index";
@@ -91,7 +91,7 @@ class MongoDBFixtureImporter {
         this.resources = buildFixtureResources(fixtureResources, contextClass);
     }
 
-    MongoDBFixtureImporter(List<URL> fixtureResources) {
+    public MongoDBFixtureImporter(List<URL> fixtureResources) {
         this.resources = fixtureResources;
     }
 
@@ -125,7 +125,7 @@ class MongoDBFixtureImporter {
     }
 
     @SuppressWarnings("unchecked")
-    private void importData(MongoDatabase database, String jsonData) {
+    public void importData(MongoDatabase database, String jsonData) {
         final Document data = Document.parse(jsonData);
 
         for (final String collectionName : data.keySet()) {

--- a/graylog2-server/src/test/java/org/junit/jupiter/engine/descriptor/ContainerMatrixTestClassDescriptor.java
+++ b/graylog2-server/src/test/java/org/junit/jupiter/engine/descriptor/ContainerMatrixTestClassDescriptor.java
@@ -44,8 +44,14 @@ public class ContainerMatrixTestClassDescriptor extends ClassBasedTestDescriptor
     private final SearchVersion esVersion;
     private final MongodbServer mongoVersion;
     private final List<URL> mongoFixtures;
+    private final boolean preImportLicense;
 
-    public ContainerMatrixTestClassDescriptor(TestDescriptor parent, Class<?> testClass, JupiterConfiguration configuration, @Nullable SearchVersion esVersion, @Nullable MongodbServer mongoVersion, List<URL> mongoFixtures) {
+    public ContainerMatrixTestClassDescriptor(TestDescriptor parent, Class<?> testClass,
+                                              JupiterConfiguration configuration,
+                                              @Nullable SearchVersion esVersion,
+                                              @Nullable MongodbServer mongoVersion,
+                                              List<URL> mongoFixtures,
+                                              boolean preImportLicense) {
         super(
                 parent.getUniqueId().append(SEGMENT_TYPE, testClass.getName() + "_" + esVersion + "_" + mongoVersion),
                 testClass,
@@ -55,11 +61,16 @@ public class ContainerMatrixTestClassDescriptor extends ClassBasedTestDescriptor
         this.esVersion = esVersion;
         this.mongoVersion = mongoVersion;
         this.mongoFixtures = mongoFixtures;
+        this.preImportLicense = preImportLicense;
         setParent(parent);
     }
 
-    public ContainerMatrixTestClassDescriptor(TestDescriptor parent, Class<?> testClass, JupiterConfiguration configuration, List<URL> mongoFixtures) {
-        this(parent, testClass, configuration, null, null, mongoFixtures);
+    public ContainerMatrixTestClassDescriptor(TestDescriptor parent,
+                                              Class<?> testClass,
+                                              JupiterConfiguration configuration,
+                                              List<URL> mongoFixtures,
+                                              boolean preImportLicense) {
+        this(parent, testClass, configuration, null, null, mongoFixtures, preImportLicense);
     }
 
     private static Supplier<String> determineDisplayName(Class<?> testClass, @Nullable SearchVersion esVersion, @Nullable MongodbServer mongodbServer) {
@@ -105,5 +116,9 @@ public class ContainerMatrixTestClassDescriptor extends ClassBasedTestDescriptor
 
     public List<URL> getMongoFixtures() {
         return mongoFixtures;
+    }
+
+    public boolean isPreImportLicense() {
+        return preImportLicense;
     }
 }

--- a/graylog2-server/src/test/java/org/junit/jupiter/engine/discovery/ContainerMatrixClassSelectorResolver.java
+++ b/graylog2-server/src/test/java/org/junit/jupiter/engine/discovery/ContainerMatrixClassSelectorResolver.java
@@ -19,6 +19,7 @@ package org.junit.jupiter.engine.discovery;
 import org.graylog.testing.completebackend.Lifecycle;
 import org.graylog.testing.containermatrix.ContainerMatrixTestEngine;
 import org.graylog.testing.containermatrix.MongodbServer;
+import org.graylog.testing.containermatrix.annotations.ContainerMatrixTestsConfiguration;
 import org.graylog.testing.containermatrix.discovery.IsContainerMatrixTestClass;
 import org.graylog2.storage.SearchVersion;
 import org.junit.jupiter.engine.config.JupiterConfiguration;
@@ -28,6 +29,7 @@ import org.junit.jupiter.engine.descriptor.ContainerMatrixTestsDescriptor;
 import org.junit.jupiter.engine.descriptor.NestedClassTestDescriptor;
 import org.junit.jupiter.engine.discovery.predicates.IsNestedTestClass;
 import org.junit.jupiter.engine.discovery.predicates.IsTestClassWithTests;
+import org.junit.platform.commons.support.AnnotationSupport;
 import org.junit.platform.commons.util.ReflectionUtils;
 import org.junit.platform.engine.DiscoverySelector;
 import org.junit.platform.engine.TestDescriptor;
@@ -135,6 +137,11 @@ public class ContainerMatrixClassSelectorResolver implements SelectorResolver {
         return Optional.empty();
     }
 
+    private boolean preImportLicense(Class<?> aClass) {
+        Optional<ContainerMatrixTestsConfiguration> annotation = AnnotationSupport.findAnnotation(aClass, ContainerMatrixTestsConfiguration.class);
+        return annotation.isPresent() ? annotation.get().preImportLicense() : true;
+    }
+
     private ClassBasedTestDescriptor newClassTestDescriptor(TestDescriptor parent, Class<?> testClass) {
         Optional<ContainerMatrixTestsDescriptor> containerMatrixTestsDescriptor = findContainerMatrixTestsDescriptor(parent);
 
@@ -145,12 +152,20 @@ public class ContainerMatrixClassSelectorResolver implements SelectorResolver {
             return new ContainerMatrixTestClassDescriptor(
                     parent,
                     testClass,
-                    configuration, esVersion, mongoVersion, ContainerMatrixTestEngine.getMongoDBFixtures(Lifecycle.CLASS, testClass));
+                    configuration,
+                    esVersion,
+                    mongoVersion,
+                    ContainerMatrixTestEngine.getMongoDBFixtures(Lifecycle.CLASS, testClass),
+                    preImportLicense(testClass)
+            );
         } else {
             return new ContainerMatrixTestClassDescriptor(
                     parent,
                     testClass,
-                    configuration, ContainerMatrixTestEngine.getMongoDBFixtures(Lifecycle.CLASS, testClass));
+                    configuration,
+                    ContainerMatrixTestEngine.getMongoDBFixtures(Lifecycle.CLASS, testClass),
+                    preImportLicense(testClass)
+            );
 
         }
     }

--- a/graylog2-server/src/test/java/org/junit/jupiter/engine/discovery/ContainerMatrixClassSelectorResolver.java
+++ b/graylog2-server/src/test/java/org/junit/jupiter/engine/discovery/ContainerMatrixClassSelectorResolver.java
@@ -139,7 +139,7 @@ public class ContainerMatrixClassSelectorResolver implements SelectorResolver {
 
     private boolean preImportLicense(Class<?> aClass) {
         Optional<ContainerMatrixTestsConfiguration> annotation = AnnotationSupport.findAnnotation(aClass, ContainerMatrixTestsConfiguration.class);
-        return annotation.isPresent() ? annotation.get().preImportLicense() : ContainerMatrixTestsConfiguration.defaultPreImportLicense;
+        return annotation.isPresent() ? annotation.get().importLicenses() : ContainerMatrixTestsConfiguration.defaultImportLicenses;
     }
 
     private ClassBasedTestDescriptor newClassTestDescriptor(TestDescriptor parent, Class<?> testClass) {

--- a/graylog2-server/src/test/java/org/junit/jupiter/engine/discovery/ContainerMatrixClassSelectorResolver.java
+++ b/graylog2-server/src/test/java/org/junit/jupiter/engine/discovery/ContainerMatrixClassSelectorResolver.java
@@ -139,7 +139,7 @@ public class ContainerMatrixClassSelectorResolver implements SelectorResolver {
 
     private boolean preImportLicense(Class<?> aClass) {
         Optional<ContainerMatrixTestsConfiguration> annotation = AnnotationSupport.findAnnotation(aClass, ContainerMatrixTestsConfiguration.class);
-        return annotation.isPresent() ? annotation.get().preImportLicense() : true;
+        return annotation.isPresent() ? annotation.get().preImportLicense() : ContainerMatrixTestsConfiguration.defaultPreImportLicense;
     }
 
     private ClassBasedTestDescriptor newClassTestDescriptor(TestDescriptor parent, Class<?> testClass) {

--- a/graylog2-server/src/test/java/org/junit/platform/engine/support/hierarchical/ContainerMatrixHierarchicalTestEngine.java
+++ b/graylog2-server/src/test/java/org/junit/platform/engine/support/hierarchical/ContainerMatrixHierarchicalTestEngine.java
@@ -26,6 +26,7 @@ import org.graylog.testing.completebackend.PluginJarsProvider;
 import org.graylog.testing.completebackend.RunningGraylogBackend;
 import org.graylog.testing.containermatrix.ContainerMatrixTestEngine;
 import org.graylog.testing.containermatrix.MongodbServer;
+import org.graylog.testing.containermatrix.annotations.ContainerMatrixTestsConfiguration;
 import org.graylog2.storage.SearchVersion;
 import org.junit.jupiter.engine.descriptor.ContainerMatrixTestClassDescriptor;
 import org.junit.jupiter.engine.descriptor.ContainerMatrixTestWithRunningESMongoTestsDescriptor;
@@ -75,7 +76,7 @@ public abstract class ContainerMatrixHierarchicalTestEngine<C extends EngineExec
                 MavenProjectDirProvider mavenProjectDirProvider = instantiateFactory(containerMatrixTestsDescriptor.getMavenProjectDirProvider());
 
                 if (Lifecycle.VM.equals(containerMatrixTestsDescriptor.getLifecycle())) {
-                    try (ContainerizedGraylogBackend backend = ContainerizedGraylogBackend.createStarted(esVersion, mongoVersion, extraPorts, mongoDBFixtures, pluginJarsProvider, mavenProjectDirProvider, enabledFeatureFlags, true)) {
+                    try (ContainerizedGraylogBackend backend = ContainerizedGraylogBackend.createStarted(esVersion, mongoVersion, extraPorts, mongoDBFixtures, pluginJarsProvider, mavenProjectDirProvider, enabledFeatureFlags, ContainerMatrixTestsConfiguration.defaultPreImportLicense)) {
                         RequestSpecification specification = requestSpec(backend);
                         this.execute(request, ((ContainerMatrixTestsDescriptor) descriptor).getChildren(), backend, specification);
                     } catch (Exception exception) {
@@ -84,7 +85,7 @@ public abstract class ContainerMatrixHierarchicalTestEngine<C extends EngineExec
                 } else if (Lifecycle.CLASS.equals(containerMatrixTestsDescriptor.getLifecycle())) {
                     for (TestDescriptor td : containerMatrixTestsDescriptor.getChildren()) {
                         List<URL> fixtures = mongoDBFixtures;
-                        boolean preImportLicense = false;
+                        boolean preImportLicense = ContainerMatrixTestsConfiguration.defaultPreImportLicense;
                         if (td instanceof ContainerMatrixTestClassDescriptor) {
                             fixtures = ((ContainerMatrixTestClassDescriptor) td).getMongoFixtures();
                             preImportLicense = ((ContainerMatrixTestClassDescriptor) td).isPreImportLicense();

--- a/graylog2-server/src/test/java/org/junit/platform/engine/support/hierarchical/ContainerMatrixHierarchicalTestEngine.java
+++ b/graylog2-server/src/test/java/org/junit/platform/engine/support/hierarchical/ContainerMatrixHierarchicalTestEngine.java
@@ -76,7 +76,7 @@ public abstract class ContainerMatrixHierarchicalTestEngine<C extends EngineExec
                 MavenProjectDirProvider mavenProjectDirProvider = instantiateFactory(containerMatrixTestsDescriptor.getMavenProjectDirProvider());
 
                 if (Lifecycle.VM.equals(containerMatrixTestsDescriptor.getLifecycle())) {
-                    try (ContainerizedGraylogBackend backend = ContainerizedGraylogBackend.createStarted(esVersion, mongoVersion, extraPorts, mongoDBFixtures, pluginJarsProvider, mavenProjectDirProvider, enabledFeatureFlags, ContainerMatrixTestsConfiguration.defaultPreImportLicense)) {
+                    try (ContainerizedGraylogBackend backend = ContainerizedGraylogBackend.createStarted(esVersion, mongoVersion, extraPorts, mongoDBFixtures, pluginJarsProvider, mavenProjectDirProvider, enabledFeatureFlags, ContainerMatrixTestsConfiguration.defaultImportLicenses)) {
                         RequestSpecification specification = requestSpec(backend);
                         this.execute(request, ((ContainerMatrixTestsDescriptor) descriptor).getChildren(), backend, specification);
                     } catch (Exception exception) {
@@ -85,7 +85,7 @@ public abstract class ContainerMatrixHierarchicalTestEngine<C extends EngineExec
                 } else if (Lifecycle.CLASS.equals(containerMatrixTestsDescriptor.getLifecycle())) {
                     for (TestDescriptor td : containerMatrixTestsDescriptor.getChildren()) {
                         List<URL> fixtures = mongoDBFixtures;
-                        boolean preImportLicense = ContainerMatrixTestsConfiguration.defaultPreImportLicense;
+                        boolean preImportLicense = ContainerMatrixTestsConfiguration.defaultImportLicenses;
                         if (td instanceof ContainerMatrixTestClassDescriptor) {
                             fixtures = ((ContainerMatrixTestClassDescriptor) td).getMongoFixtures();
                             preImportLicense = ((ContainerMatrixTestClassDescriptor) td).isPreImportLicense();

--- a/graylog2-server/src/test/java/org/junit/platform/engine/support/hierarchical/ContainerMatrixHierarchicalTestEngine.java
+++ b/graylog2-server/src/test/java/org/junit/platform/engine/support/hierarchical/ContainerMatrixHierarchicalTestEngine.java
@@ -75,7 +75,7 @@ public abstract class ContainerMatrixHierarchicalTestEngine<C extends EngineExec
                 MavenProjectDirProvider mavenProjectDirProvider = instantiateFactory(containerMatrixTestsDescriptor.getMavenProjectDirProvider());
 
                 if (Lifecycle.VM.equals(containerMatrixTestsDescriptor.getLifecycle())) {
-                    try (ContainerizedGraylogBackend backend = ContainerizedGraylogBackend.createStarted(esVersion, mongoVersion, extraPorts, mongoDBFixtures, pluginJarsProvider, mavenProjectDirProvider, enabledFeatureFlags)) {
+                    try (ContainerizedGraylogBackend backend = ContainerizedGraylogBackend.createStarted(esVersion, mongoVersion, extraPorts, mongoDBFixtures, pluginJarsProvider, mavenProjectDirProvider, enabledFeatureFlags, true)) {
                         RequestSpecification specification = requestSpec(backend);
                         this.execute(request, ((ContainerMatrixTestsDescriptor) descriptor).getChildren(), backend, specification);
                     } catch (Exception exception) {
@@ -84,10 +84,12 @@ public abstract class ContainerMatrixHierarchicalTestEngine<C extends EngineExec
                 } else if (Lifecycle.CLASS.equals(containerMatrixTestsDescriptor.getLifecycle())) {
                     for (TestDescriptor td : containerMatrixTestsDescriptor.getChildren()) {
                         List<URL> fixtures = mongoDBFixtures;
+                        boolean preImportLicense = false;
                         if (td instanceof ContainerMatrixTestClassDescriptor) {
                             fixtures = ((ContainerMatrixTestClassDescriptor) td).getMongoFixtures();
+                            preImportLicense = ((ContainerMatrixTestClassDescriptor) td).isPreImportLicense();
                         }
-                        try (ContainerizedGraylogBackend backend = ContainerizedGraylogBackend.createStarted(esVersion, mongoVersion, extraPorts, fixtures, pluginJarsProvider, mavenProjectDirProvider, enabledFeatureFlags)) {
+                        try (ContainerizedGraylogBackend backend = ContainerizedGraylogBackend.createStarted(esVersion, mongoVersion, extraPorts, fixtures, pluginJarsProvider, mavenProjectDirProvider, enabledFeatureFlags, preImportLicense)) {
                             RequestSpecification specification = requestSpec(backend);
                             this.execute(request, Collections.singleton(td), backend, specification);
                         } catch (Exception exception) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Imports the license as a fixture and not via REST to prevent any race conditions during container startup.

/jenkins-pr-deps https://github.com/Graylog2/graylog-plugin-enterprise/pull/3495

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

