### PR TITLE
Adds missing rows prop to FormikFormGroup for textarea inputs

### DIFF
--- a/graylog2-web-interface/src/components/common/FormikFormGroup.tsx
+++ b/graylog2-web-interface/src/components/common/FormikFormGroup.tsx
@@ -40,6 +40,7 @@ type Props = {
   required?: boolean,
   bsSize?: 'large' | 'small' | 'xsmall',
   validate?: (any) => string | undefined,
+  rows?: number,
 };
 
 /** Displays the FormikInput with a specific layout */
@@ -70,6 +71,7 @@ FormikFormGroup.defaultProps = {
   maxLength: undefined,
   required: false,
   validate: () => undefined,
+  rows: undefined,
 };
 
 export default FormikFormGroup;


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
The `FormikFormGroup` component supports a `textarea` type but does not allow for a `rows` prop to be provided. This adds support for it. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The `FormikFormGroup` component supports a `textarea` type but does not allow for a `rows` prop to be provided. This adds support for it. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Created a FormikFormGroup with `type=textarea` and assigned a `row` value and saw the input properly displayed

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

