### PR TITLE
Map query tokens to subqueries

### DIFF
--- a/full-backend-tests/src/test/java/org/graylog/plugins/views/QueryValidationResourceIT.java
+++ b/full-backend-tests/src/test/java/org/graylog/plugins/views/QueryValidationResourceIT.java
@@ -95,7 +95,9 @@ public class QueryValidationResourceIT {
                 .body("{\"query\":\"unknown_field:(x OR y)\"}")
                 .post("/search/validate")
                 .then()
+                .log().ifStatusCodeMatches(not(200))
                 .statusCode(200);
+
         validatableResponse.assertThat().body("status", equalTo("WARNING"));
         validatableResponse.assertThat().body("explanations.error_message[0]", containsString("Query contains unknown field: unknown_field"));
     }
@@ -108,6 +110,7 @@ public class QueryValidationResourceIT {
                 .body("{\"query\":\"/ethernet[0-9]+/\"}")
                 .post("/search/validate")
                 .then()
+                .log().ifStatusCodeMatches(not(200))
                 .statusCode(200);
         validatableResponse.assertThat().body("status", equalTo("OK"));
     }
@@ -120,6 +123,7 @@ public class QueryValidationResourceIT {
                 .body("{\"query\":\"not(http_response_code:200)\"}")
                 .post("/search/validate")
                 .then()
+                .log().ifStatusCodeMatches(not(200))
                 .statusCode(200);
         validatableResponse.assertThat().body("status", equalTo("WARNING"));
         validatableResponse.assertThat().body("explanations.error_message[0]", containsString("Query contains invalid operator \"not\". All AND / OR / NOT operators have to be written uppercase"));
@@ -133,6 +137,7 @@ public class QueryValidationResourceIT {
                 .body("{\"query\":\"timestamp:AAA\"}")
                 .post("/search/validate")
                 .then()
+                .log().ifStatusCodeMatches(not(200))
                 .statusCode(200);
         validatableResponse.assertThat().body("status", equalTo("WARNING"));
         validatableResponse.assertThat().body("explanations.error_type[0]", equalTo("INVALID_VALUE_TYPE"));

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/QueryValidationResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/QueryValidationResource.java
@@ -113,15 +113,18 @@ public class QueryValidationResource extends RestResource implements PluginRestR
 
     private ValidationMessageDTO toExplanation(ValidationMessage message) {
         final ValidationTypeDTO validationType = convert(message.validationType());
-        return ValidationMessageDTO.create(
+        final ValidationMessageDTO.Builder builder = ValidationMessageDTO.builder(
                 validationType,
-                message.position().beginLine(),
-                message.position().beginColumn(),
-                message.position().endLine(),
-                message.position().endColumn(),
-                message.errorMessage(),
-                message.relatedProperty()
-        );
+                message.errorMessage());
+
+        message.relatedProperty().ifPresent(builder::relatedProperty);
+        message.position().ifPresent(queryPosition -> {
+            builder.beginLine(queryPosition.beginLine());
+            builder.beginColumn(queryPosition.beginColumn());
+            builder.endLine(queryPosition.endLine());
+            builder.endColumn(queryPosition.endColumn());
+        });
+        return builder.build();
     }
 
     private ValidationTypeDTO convert(ValidationType validationType) {

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/ValidationMessageDTO.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/ValidationMessageDTO.java
@@ -56,7 +56,35 @@ public abstract class ValidationMessageDTO {
     @JsonProperty
     public abstract String relatedProperty();
 
-    public static ValidationMessageDTO create(ValidationTypeDTO validationType, Integer beginLine, Integer beginColumn, Integer endLine, Integer endColumn, String errorMessage, String relatedProperty) {
-        return new AutoValue_ValidationMessageDTO(validationType, beginLine, beginColumn, endLine, endColumn, validationType.errorTitle(), errorMessage, relatedProperty);
+    public static ValidationMessageDTO.Builder builder(ValidationTypeDTO validationType, String errorMessage) {
+        return new AutoValue_ValidationMessageDTO.Builder()
+                .errorType(validationType)
+                .errorMessage(errorMessage);
+    }
+
+    @AutoValue.Builder
+    public abstract static class Builder {
+        public abstract Builder errorType(ValidationTypeDTO type);
+
+        public abstract Builder beginLine(int beginLine);
+
+        @Nullable
+        public abstract Builder beginColumn(int beginColumn);
+
+        @Nullable
+        public abstract Builder endLine(int endLine);
+
+        @Nullable
+        public abstract Builder endColumn(int endColumn);
+
+        @Nullable
+        public abstract Builder errorTitle(String errorTitle);
+
+        public abstract Builder errorMessage(String errorMessage);
+
+        @Nullable
+        public abstract Builder relatedProperty(String relatedProperty);
+
+        public abstract ValidationMessageDTO build();
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/validation/CollectingQueryParserTokenManager.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/validation/CollectingQueryParserTokenManager.java
@@ -30,7 +30,7 @@ public class CollectingQueryParserTokenManager extends QueryParserTokenManager {
 
     private final List<ImmutableToken> tokens = new LinkedList<>();
 
-    public CollectingQueryParserTokenManager(String f, Analyzer a) {
+    public CollectingQueryParserTokenManager() {
         super(new FastCharStream(new StringReader("")));
     }
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/validation/FixedBooleanQuery.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/validation/FixedBooleanQuery.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.views.search.validation;
+
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.QueryVisitor;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Spliterator;
+import java.util.function.Consumer;
+
+/**
+ * The default BooleanQuery from lucene uses Multiset implementations in the visit method. These lose the reference
+ * to the actual query instance and aggregate queries if they are the same. This breaks our terms detection in
+ * validation. So we have to provide this alternative class that iterates bool clauses with correct references
+ */
+public class FixedBooleanQuery extends Query implements Iterable<BooleanClause> {
+
+    private final BooleanQuery delegate;
+
+    public FixedBooleanQuery(BooleanQuery delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public String toString(String field) {
+        return delegate.toString(field);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return delegate.equals(obj);
+    }
+
+    @Override
+    public int hashCode() {
+        return delegate.hashCode();
+    }
+
+    @Override
+    public Iterator<BooleanClause> iterator() {
+        return delegate.iterator();
+    }
+
+    @Override
+    public void forEach(Consumer<? super BooleanClause> consumer) {
+        delegate.forEach(consumer);
+    }
+
+    @Override
+    public Spliterator<BooleanClause> spliterator() {
+        return delegate.spliterator();
+    }
+
+    /**
+     * This is the only purpose of this class - provide a simpler visit method that preserves the query reference
+     * to the underlying object. That reference is then used to obtain related query terms during validation.
+     */
+    @Override
+    public void visit(QueryVisitor visitor) {
+        delegate.clauses().forEach(c -> {
+            final QueryVisitor sub = visitor.getSubVisitor(c.getOccur(), delegate);
+            c.getQuery().visit(sub);
+        });
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/validation/LuceneQueryParser.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/validation/LuceneQueryParser.java
@@ -21,21 +21,19 @@ import org.apache.lucene.queryparser.classic.ParseException;
 import org.apache.lucene.search.Query;
 
 public class LuceneQueryParser {
-    private final TokenCollectingQueryParser parser;
-    private final StandardAnalyzer analyzer;
 
-    public LuceneQueryParser() {
-        analyzer = new StandardAnalyzer();
-        this.parser = new TokenCollectingQueryParser(ParsedTerm.DEFAULT_FIELD, analyzer);
-        this.parser.setSplitOnWhitespace(true);
-    }
+    public static final StandardAnalyzer ANALYZER = new StandardAnalyzer();
 
     public ParsedQuery parse(final String query) throws ParseException {
+        final TokenCollectingQueryParser parser = new TokenCollectingQueryParser(ParsedTerm.DEFAULT_FIELD, ANALYZER);
+        parser.setSplitOnWhitespace(true);
+
         final Query parsed = parser.parse(query);
         final ParsedQuery.Builder builder = ParsedQuery.builder().query(query);
 
-        builder.tokensBuilder().addAll(this.parser.getTokens());
-        final TermCollectingQueryVisitor visitor = new TermCollectingQueryVisitor(analyzer, this.parser.getTokenLookup());
+        builder.tokensBuilder().addAll(parser.getTokens());
+
+        final TermCollectingQueryVisitor visitor = new TermCollectingQueryVisitor(ANALYZER, parser.getTokenLookup());
         parsed.visit(visitor);
         builder.termsBuilder().addAll(visitor.getParsedTerms());
         return builder.build();

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/validation/LuceneQueryParser.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/validation/LuceneQueryParser.java
@@ -35,7 +35,7 @@ public class LuceneQueryParser {
         final ParsedQuery.Builder builder = ParsedQuery.builder().query(query);
 
         builder.tokensBuilder().addAll(this.parser.getTokens());
-        final TermCollectingQueryVisitor visitor = new TermCollectingQueryVisitor(this.parser.getTokens(), analyzer);
+        final TermCollectingQueryVisitor visitor = new TermCollectingQueryVisitor(analyzer, this.parser.getTokenLookup());
         parsed.visit(visitor);
         builder.termsBuilder().addAll(visitor.getParsedTerms());
         return builder.build();

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/validation/TermCollectingQueryVisitor.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/validation/TermCollectingQueryVisitor.java
@@ -30,6 +30,7 @@ import org.apache.lucene.search.WildcardQuery;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -37,7 +38,7 @@ public class TermCollectingQueryVisitor extends QueryVisitor {
 
     private final Analyzer analyzer;
     private final List<ParsedTerm> parsedTerms = new ArrayList<>();
-    private Map<Query, Collection<ImmutableToken>> tokenLookup;
+    private final Map<Query, Collection<ImmutableToken>> tokenLookup;
 
     public TermCollectingQueryVisitor(Analyzer analyzer, Map<Query, Collection<ImmutableToken>> tokenLookup) {
         this.analyzer = analyzer;
@@ -47,7 +48,7 @@ public class TermCollectingQueryVisitor extends QueryVisitor {
     @Override
     public void consumeTerms(Query query, Term... terms) {
         super.consumeTerms(query, terms);
-        final Collection<ImmutableToken> tokens = tokenLookup.get(query);
+        final Collection<ImmutableToken> tokens = tokenLookup.getOrDefault(query, Collections.emptySet());
         processTerms(tokens, terms);
     }
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/validation/TokenCollectingQueryParser.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/validation/TokenCollectingQueryParser.java
@@ -16,12 +16,25 @@
  */
 package org.graylog.plugins.views.search.validation;
 
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.queryparser.classic.ParseException;
 import org.apache.lucene.queryparser.classic.QueryParser;
+import org.apache.lucene.search.Query;
 
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 public class TokenCollectingQueryParser extends QueryParser {
+
+    private final Set<ImmutableToken> processedTokens = new HashSet<>();
+    private final Map<Query, Collection<ImmutableToken>> tokenLookup = new LinkedHashMap<>();
 
     public TokenCollectingQueryParser(String defaultFieldName, Analyzer analyzer) {
         super(new CollectingQueryParserTokenManager(defaultFieldName, analyzer));
@@ -30,5 +43,75 @@ public class TokenCollectingQueryParser extends QueryParser {
 
     public List<ImmutableToken> getTokens() {
         return ((CollectingQueryParserTokenManager) super.token_source).getTokens();
+    }
+
+    public Map<Query, Collection<ImmutableToken>> getTokenLookup() {
+        return tokenLookup;
+    }
+
+    @Override
+    protected Query newFieldQuery(Analyzer analyzer, String field, String queryText, boolean quoted) throws ParseException {
+        return saveQueryLookupTokens(super.newFieldQuery(analyzer, field, queryText, quoted));
+    }
+
+    @Override
+    protected Query newPrefixQuery(Term prefix) {
+        return saveQueryLookupTokens(super.newPrefixQuery(prefix));
+    }
+
+    @Override
+    protected Query newRegexpQuery(Term regexp) {
+        return saveQueryLookupTokens(super.newRegexpQuery(regexp));
+    }
+
+    @Override
+    protected Query newFuzzyQuery(Term term, float minimumSimilarity, int prefixLength) {
+        return saveQueryLookupTokens(super.newFuzzyQuery(term, minimumSimilarity, prefixLength));
+    }
+
+    @Override
+    protected Query newMatchAllDocsQuery() {
+        return saveQueryLookupTokens(super.newMatchAllDocsQuery());
+    }
+
+    @Override
+    protected Query newWildcardQuery(Term t) {
+        return saveQueryLookupTokens(super.newWildcardQuery(t));
+    }
+
+    @Override
+    protected Query newSynonymQuery(TermAndBoost[] terms) {
+        return saveQueryLookupTokens(super.newSynonymQuery(terms));
+    }
+
+    @Override
+    protected Query newGraphSynonymQuery(Iterator<Query> queries) {
+        return saveQueryLookupTokens(super.newGraphSynonymQuery(queries));
+    }
+
+    @Override
+    protected Query newTermQuery(Term term, float boost) {
+        return saveQueryLookupTokens(super.newTermQuery(term, boost));
+    }
+
+    @Override
+    protected Query newRangeQuery(String field, String part1, String part2, boolean startInclusive, boolean endInclusive) {
+        return saveQueryLookupTokens(super.newRangeQuery(field, part1, part2, startInclusive, endInclusive));
+    }
+
+    /**
+     * This method persists all newly discovered tokens that may be referenced in the query to a lookup for
+     * later processing. This is the only place that binds query and its tokens together.
+     *
+     * This would be also good place to collect all subqueries if needed for any feature.
+     */
+    private Query saveQueryLookupTokens(Query query) {
+        if (!tokenLookup.containsKey(query)) {
+            final List<ImmutableToken> tokens = ((CollectingQueryParserTokenManager) super.token_source).getTokens();
+            final Collection<ImmutableToken> subtract = CollectionUtils.subtract(tokens, processedTokens);
+            processedTokens.addAll(tokens);
+            tokenLookup.put(query, subtract);
+        }
+        return query;
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/validation/TokenCollectingQueryParser.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/validation/TokenCollectingQueryParser.java
@@ -43,7 +43,7 @@ public class TokenCollectingQueryParser extends QueryParser {
         this(new CollectingQueryParserTokenManager(defaultFieldName, analyzer), defaultFieldName, analyzer);
     }
 
-    private TokenCollectingQueryParser(CollectingQueryParserTokenManager collectingQueryParserTokenManager, String defaultFieldName, Analyzer analyzer) {
+    TokenCollectingQueryParser(CollectingQueryParserTokenManager collectingQueryParserTokenManager, String defaultFieldName, Analyzer analyzer) {
         super(collectingQueryParserTokenManager);
         this.tokenManager = collectingQueryParserTokenManager;
         this.init(defaultFieldName, analyzer);

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/validation/TokenCollectingQueryParser.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/validation/TokenCollectingQueryParser.java
@@ -40,7 +40,7 @@ public class TokenCollectingQueryParser extends QueryParser {
     private final Map<Query, Collection<ImmutableToken>> tokenLookup = new IdentityHashMap<>();
 
     public TokenCollectingQueryParser(String defaultFieldName, Analyzer analyzer) {
-        this(new CollectingQueryParserTokenManager(defaultFieldName, analyzer), defaultFieldName, analyzer);
+        this(new CollectingQueryParserTokenManager(), defaultFieldName, analyzer);
     }
 
     TokenCollectingQueryParser(CollectingQueryParserTokenManager collectingQueryParserTokenManager, String defaultFieldName, Analyzer analyzer) {

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/validation/ValidationMessage.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/validation/ValidationMessage.java
@@ -22,18 +22,18 @@ import org.graylog2.shared.utilities.ExceptionUtils;
 
 import javax.annotation.Nullable;
 import java.util.Locale;
+import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 @AutoValue
 public abstract class ValidationMessage {
 
-    public abstract QueryPosition position();
+    public abstract Optional<QueryPosition> position();
 
     public abstract String errorMessage();
 
-    @Nullable
-    public abstract String relatedProperty();
+    public abstract Optional<String> relatedProperty();
 
     public abstract ValidationStatus validationStatus();
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/validation/validators/FieldValueTypeValidator.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/validation/validators/FieldValueTypeValidator.java
@@ -87,9 +87,10 @@ public class FieldValueTypeValidator implements QueryValidator {
                             .map(MappedFieldTypeDTO::type)
                             .map(FieldTypes.Type::type);
                     return typeName.flatMap(type -> fieldTypeValidation.validateFieldValueType(term, type))
-                            .map(validation -> validation.toBuilder()
-                                    .position(decorated.backtrackPosition(validation.position()))
-                                    .build());
+                            .map(validation -> validation.position()
+                                    .map(decorated::backtrackPosition)
+                                    .map(backtrackedPosition -> validation.toBuilder().position(backtrackedPosition).build())
+                                    .orElse(validation));
                 })
                 .filter(Optional::isPresent)
                 .map(Optional::get)

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/elasticsearch/parser/LuceneQueryParserTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/elasticsearch/parser/LuceneQueryParserTest.java
@@ -182,4 +182,10 @@ class LuceneQueryParserTest {
         final List<ParsedTerm> fooTerms = parsedQuery.terms().stream().filter(t -> t.field().equals("foo")).collect(Collectors.toList());
         assertThat(fooTerms.get(0).keyToken()).isNotEqualTo(fooTerms.get(1).keyToken());
     }
+
+    @Test
+    void testOrQuery() throws ParseException {
+        final ParsedQuery query = parser.parse("unknown_field:(x OR y)");
+        System.out.println(query);
+    }
 }

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/elasticsearch/parser/LuceneQueryParserTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/elasticsearch/parser/LuceneQueryParserTest.java
@@ -23,6 +23,7 @@ import org.graylog.plugins.views.search.validation.ParsedQuery;
 import org.graylog.plugins.views.search.validation.ParsedTerm;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -172,5 +173,13 @@ class LuceneQueryParserTest {
         final ParsedTerm term = query.terms().iterator().next();
         assertThat(term.field()).isEqualTo("_default_");
         assertThat(term.value()).isEqualTo("fuzzy");
+    }
+
+    @Test
+    void testRepeatedQuery() throws ParseException {
+        final ParsedQuery parsedQuery = parser.parse("foo:bar AND foo:bar AND something:else");
+        assertThat(parsedQuery.terms().size()).isEqualTo(3);
+        final List<ParsedTerm> fooTerms = parsedQuery.terms().stream().filter(t -> t.field().equals("foo")).collect(Collectors.toList());
+        assertThat(fooTerms.get(0).keyToken()).isNotEqualTo(fooTerms.get(1).keyToken());
     }
 }

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/elasticsearch/parser/LuceneQueryParserTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/elasticsearch/parser/LuceneQueryParserTest.java
@@ -186,6 +186,9 @@ class LuceneQueryParserTest {
     @Test
     void testOrQuery() throws ParseException {
         final ParsedQuery query = parser.parse("unknown_field:(x OR y)");
-        System.out.println(query);
+        assertThat(query.terms().size()).isEqualTo(2);
+        assertThat(query.terms())
+                .extracting(ParsedTerm::field)
+                .containsOnly("unknown_field");
     }
 }

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/elasticsearch/parser/LuceneQueryParserTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/elasticsearch/parser/LuceneQueryParserTest.java
@@ -32,6 +32,13 @@ class LuceneQueryParserTest {
 
     private final LuceneQueryParser parser = new LuceneQueryParser();
 
+
+    @Test
+    void testSuperSimpleQuery() throws ParseException {
+        final ParsedQuery fields = parser.parse("foo:bar");
+        assertThat(fields.allFieldNames()).contains("foo");
+    }
+
     @Test
     void getFieldNamesSimple() throws ParseException {
         final ParsedQuery fields = parser.parse("foo:bar AND lorem:ipsum");

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/validation/LuceneQueryParserTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/validation/LuceneQueryParserTest.java
@@ -14,7 +14,7 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-package org.graylog.plugins.views.search.elasticsearch.parser;
+package org.graylog.plugins.views.search.validation;
 
 import org.apache.lucene.queryparser.classic.ParseException;
 import org.graylog.plugins.views.search.validation.ImmutableToken;

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/validation/LuceneQueryParserTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/validation/LuceneQueryParserTest.java
@@ -51,17 +51,17 @@ class LuceneQueryParserTest {
     void getFieldExistPosition() throws ParseException {
         final ParsedQuery fields = parser.parse("_exists_:lorem");
         assertThat(fields.allFieldNames()).contains("lorem");
-
-        fields.terms()
-                .forEach(term -> assertThat(term.keyToken())
-                        .hasValueSatisfying(t -> {
+        assertThat(fields.terms())
+                .hasSize(1)
+                .extracting(ParsedTerm::keyToken)
+                .hasOnlyOneElementSatisfying(term ->
+                        assertThat(term).hasValueSatisfying(t -> {
                             assertThat(t.beginLine()).isEqualTo(1);
                             assertThat(t.beginColumn()).isEqualTo(9);
                             assertThat(t.endLine()).isEqualTo(1);
                             assertThat(t.endColumn()).isEqualTo(14);
                         }));
     }
-
 
     @Test
     void getFieldNamesComplex() throws ParseException {
@@ -81,7 +81,6 @@ class LuceneQueryParserTest {
         assertThat(query.terms()).extracting(ParsedTerm::value).contains("500", "504");
     }
 
-
     @Test
     void testGtQuery() throws ParseException {
         final ParsedQuery query = parser.parse("http_response_code:>400");
@@ -91,7 +90,6 @@ class LuceneQueryParserTest {
     @Test
     void testMultilineQuery() throws ParseException {
         final ParsedQuery query = parser.parse("foo:bar AND\nlorem:ipsum");
-
 
         assertThat(query.tokens())
                 .anySatisfy(token -> {
@@ -124,7 +122,7 @@ class LuceneQueryParserTest {
                 "OR not_existing_field:test");
 
         assertThat(query.tokens())
-                .anySatisfy(token -> {
+                .anySatisfy( token -> {
                     assertThat(token.image()).isEqualTo("not_existing_field");
                     assertThat(token.beginLine()).isEqualTo(3);
                     assertThat(token.beginColumn()).isEqualTo(3);
@@ -139,7 +137,6 @@ class LuceneQueryParserTest {
                 .hasMessageContaining("Cannot parse 'foo:': Encountered \"<EOF>\" at line 1, column 4.");
     }
 
-
     @Test
     void testEmptyQueryNewlines() {
         assertThatThrownBy(() -> parser.parse("\n\n\n"))
@@ -152,6 +149,7 @@ class LuceneQueryParserTest {
         assertThat(query.terms().size()).isEqualTo(2);
 
         assertThat(query.terms())
+                .hasSize(2)
                 .anySatisfy(term -> {
                     assertThat(term.field()).isEqualTo("foo");
                     assertThat(term.keyToken()).map(ImmutableToken::image).hasValue("foo");
@@ -173,14 +171,14 @@ class LuceneQueryParserTest {
 
         assertThat(query.terms())
                 .extracting(ParsedTerm::valueToken)
-                .anySatisfy(token -> assertThat(token).map(ImmutableToken::image).hasValue("BAR"));
+                .hasOnlyOneElementSatisfying(token -> assertThat(token).map(ImmutableToken::image).hasValue("BAR"));
     }
 
     @Test
     void testFuzzyQuery() throws ParseException {
         final ParsedQuery query = parser.parse("fuzzy~");
         assertThat(query.terms())
-                .anySatisfy(term -> {
+                .hasOnlyOneElementSatisfying(term -> {
                     assertThat(term.field()).isEqualTo("_default_");
                     assertThat(term.value()).isEqualTo("fuzzy");
                 });

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/validation/TokenCollectingQueryParserTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/validation/TokenCollectingQueryParserTest.java
@@ -1,0 +1,105 @@
+package org.graylog.plugins.views.search.validation;
+
+import org.apache.lucene.index.Term;
+import org.apache.lucene.queryparser.classic.QueryParserConstants;
+import org.apache.lucene.queryparser.classic.Token;
+import org.apache.lucene.search.Query;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import static org.graylog.plugins.views.search.validation.LuceneQueryParser.ANALYZER;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+class TokenCollectingQueryParserTest {
+
+    private TokenCollectingQueryParser toTest;
+
+    private CollectingQueryParserTokenManager tokenManagerMock;
+    private List<ImmutableToken> collectedTokensSimulation;
+    private Term testTerm;
+
+    @BeforeEach
+    void setUp() {
+        tokenManagerMock = mock(CollectingQueryParserTokenManager.class);
+        collectedTokensSimulation = new ArrayList<>();
+        doReturn(collectedTokensSimulation).when(tokenManagerMock).getTokens();
+        toTest = new TokenCollectingQueryParser(tokenManagerMock, ParsedTerm.DEFAULT_FIELD, ANALYZER);
+
+        testTerm = new Term("x", "nvmd");
+    }
+
+    @Test
+    void testStoresNothingForQueryIfNoNewTokensCollected() {
+        collectedTokensSimulation.clear();
+        final Query query = toTest.newFuzzyQuery(testTerm, 1.0f, 2);
+        final Map<Query, Collection<ImmutableToken>> tokenLookup = toTest.getTokenLookup();
+        assertNull(tokenLookup.get(query));
+    }
+
+    @Test
+    void testStoresTokensForQuery() {
+        final ImmutableToken testToken = ImmutableToken.create(Token.newToken(QueryParserConstants.TERM, "blah"));
+        collectedTokensSimulation.add(testToken);
+
+        final Query query = toTest.newPrefixQuery(testTerm);
+
+        final Map<Query, Collection<ImmutableToken>> tokenLookup = toTest.getTokenLookup();
+        final Collection<ImmutableToken> queryTokens = tokenLookup.get(query);
+        assertEquals(1, queryTokens.size());
+        assertTrue(queryTokens.contains(testToken));
+    }
+
+    @Test
+    void testStoresTokensForMultipleQueries() {
+        final ImmutableToken testToken1 = ImmutableToken.create(Token.newToken(QueryParserConstants.TERM, "prefixToken"));
+        collectedTokensSimulation.add(testToken1);
+        final Query query1 = toTest.newPrefixQuery(testTerm);
+        final ImmutableToken testToken2 = ImmutableToken.create(Token.newToken(QueryParserConstants.TERM, "regexpToken"));
+        collectedTokensSimulation.add(testToken2);
+        final Query query2 = toTest.newRegexpQuery(testTerm);
+        final ImmutableToken testToken3_1 = ImmutableToken.create(Token.newToken(QueryParserConstants.TERM, "termToken1"));
+        final ImmutableToken testToken3_2 = ImmutableToken.create(Token.newToken(QueryParserConstants.TERM, "termToken2"));
+        collectedTokensSimulation.add(testToken3_1);
+        collectedTokensSimulation.add(testToken3_2);
+        final Query query3 = toTest.newTermQuery(testTerm, 1.0f);
+
+        final Map<Query, Collection<ImmutableToken>> tokenLookup = toTest.getTokenLookup();
+        final Collection<ImmutableToken> query1Tokens = tokenLookup.get(query1);
+        assertEquals(1, query1Tokens.size());
+        assertTrue(query1Tokens.contains(testToken1));
+        final Collection<ImmutableToken> query2Tokens = tokenLookup.get(query2);
+        assertEquals(1, query2Tokens.size());
+        assertTrue(query2Tokens.contains(testToken2));
+        final Collection<ImmutableToken> query3Tokens = tokenLookup.get(query3);
+        assertEquals(2, query3Tokens.size());
+        assertTrue(query3Tokens.contains(testToken3_1));
+        assertTrue(query3Tokens.contains(testToken3_2));
+    }
+
+    @Test
+    void testSeparatesTokensForTwoIdenticalQueries() {
+        final ImmutableToken testToken1 = ImmutableToken.create(Token.newToken(QueryParserConstants.TERM, "blah1"));
+        collectedTokensSimulation.add(testToken1);
+        final Query query1 = toTest.newPrefixQuery(testTerm);
+        final ImmutableToken testToken2 = ImmutableToken.create(Token.newToken(QueryParserConstants.TERM, "blah2"));
+        collectedTokensSimulation.add(testToken2);
+        final Query query2 = toTest.newPrefixQuery(testTerm);
+
+        final Map<Query, Collection<ImmutableToken>> tokenLookup = toTest.getTokenLookup();
+        final Collection<ImmutableToken> query1Tokens = tokenLookup.get(query1);
+        assertEquals(1, query1Tokens.size());
+        assertTrue(query1Tokens.contains(testToken1));
+        final Collection<ImmutableToken> query2Tokens = tokenLookup.get(query2);
+        assertEquals(1, query2Tokens.size());
+        assertTrue(query2Tokens.contains(testToken2));
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/validation/TokenCollectingQueryParserTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/validation/TokenCollectingQueryParserTest.java
@@ -28,10 +28,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.graylog.plugins.views.search.validation.LuceneQueryParser.ANALYZER;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 
@@ -58,7 +56,9 @@ class TokenCollectingQueryParserTest {
         collectedTokensSimulation.clear();
         final Query query = toTest.newFuzzyQuery(testTerm, 1.0f, 2);
         final Map<Query, Collection<ImmutableToken>> tokenLookup = toTest.getTokenLookup();
-        assertNull(tokenLookup.get(query));
+        assertThat(tokenLookup)
+                .isNotNull()
+                .hasSize(0);
     }
 
     @Test
@@ -70,8 +70,11 @@ class TokenCollectingQueryParserTest {
 
         final Map<Query, Collection<ImmutableToken>> tokenLookup = toTest.getTokenLookup();
         final Collection<ImmutableToken> queryTokens = tokenLookup.get(query);
-        assertEquals(1, queryTokens.size());
-        assertTrue(queryTokens.contains(testToken));
+        assertThat(queryTokens)
+                .isNotNull()
+                .hasSize(1)
+                .contains(testToken);
+
     }
 
     @Test
@@ -90,32 +93,42 @@ class TokenCollectingQueryParserTest {
 
         final Map<Query, Collection<ImmutableToken>> tokenLookup = toTest.getTokenLookup();
         final Collection<ImmutableToken> query1Tokens = tokenLookup.get(query1);
-        assertEquals(1, query1Tokens.size());
-        assertTrue(query1Tokens.contains(testToken1));
+        assertThat(query1Tokens)
+                .isNotNull()
+                .hasSize(1)
+                .contains(testToken1);
         final Collection<ImmutableToken> query2Tokens = tokenLookup.get(query2);
-        assertEquals(1, query2Tokens.size());
-        assertTrue(query2Tokens.contains(testToken2));
+        assertThat(query2Tokens)
+                .isNotNull()
+                .hasSize(1)
+                .contains(testToken2);
         final Collection<ImmutableToken> query3Tokens = tokenLookup.get(query3);
-        assertEquals(2, query3Tokens.size());
-        assertTrue(query3Tokens.contains(testToken3_1));
-        assertTrue(query3Tokens.contains(testToken3_2));
+        assertThat(query3Tokens)
+                .isNotNull()
+                .hasSize(2)
+                .contains(testToken3_1)
+                .contains(testToken3_2);
     }
 
     @Test
     void testSeparatesTokensForTwoIdenticalQueries() {
-        final ImmutableToken testToken1 = ImmutableToken.create(Token.newToken(QueryParserConstants.TERM, "blah1"));
+        final ImmutableToken testToken1 = ImmutableToken.create(Token.newToken(QueryParserConstants.TERM, "blah"));
         collectedTokensSimulation.add(testToken1);
         final Query query1 = toTest.newPrefixQuery(testTerm);
-        final ImmutableToken testToken2 = ImmutableToken.create(Token.newToken(QueryParserConstants.TERM, "blah2"));
+        final ImmutableToken testToken2 = ImmutableToken.create(Token.newToken(QueryParserConstants.TERM, "blah"));
         collectedTokensSimulation.add(testToken2);
         final Query query2 = toTest.newPrefixQuery(testTerm);
 
         final Map<Query, Collection<ImmutableToken>> tokenLookup = toTest.getTokenLookup();
         final Collection<ImmutableToken> query1Tokens = tokenLookup.get(query1);
-        assertEquals(1, query1Tokens.size());
-        assertTrue(query1Tokens.contains(testToken1));
+        assertThat(query1Tokens)
+                .isNotNull()
+                .hasSize(1)
+                .contains(testToken1);
         final Collection<ImmutableToken> query2Tokens = tokenLookup.get(query2);
-        assertEquals(1, query2Tokens.size());
-        assertTrue(query2Tokens.contains(testToken2));
+        assertThat(query2Tokens)
+                .isNotNull()
+                .hasSize(1)
+                .contains(testToken2);
     }
 }

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/validation/TokenCollectingQueryParserTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/validation/TokenCollectingQueryParserTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog.plugins.views.search.validation;
 
 import org.apache.lucene.index.Term;

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/validation/ValidationMessageTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/validation/ValidationMessageTest.java
@@ -17,6 +17,7 @@
 package org.graylog.plugins.views.search.validation;
 
 import org.apache.lucene.queryparser.classic.ParseException;
+import org.graylog.plugins.views.search.engine.QueryPosition;
 import org.graylog.plugins.views.search.validation.validators.ValidationErrors;
 import org.junit.jupiter.api.Test;
 
@@ -42,10 +43,12 @@ class ValidationMessageTest {
 
             final ValidationMessage validationMessage = errors.iterator().next();
 
-            assertThat(validationMessage.position().beginLine()).isEqualTo(1);
-            assertThat(validationMessage.position().endLine()).isEqualTo(1);
-            assertThat(validationMessage.position().beginColumn()).isEqualTo(0);
-            assertThat(validationMessage.position().endColumn()).isEqualTo(4);
+            assertThat(validationMessage.position()).hasValue(QueryPosition.builder()
+                    .beginLine(1)
+                    .beginColumn(0)
+                    .endLine(1)
+                    .endColumn(4)
+                    .build());
             assertThat(validationMessage.validationType()).isEqualTo(ValidationType.QUERY_PARSING_ERROR);
             assertThat(validationMessage.errorMessage()).startsWith("Cannot parse query, cause: incomplete query, query ended unexpectedly");
         }

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/validation/fields/UnknownFieldsIdentifierTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/validation/fields/UnknownFieldsIdentifierTest.java
@@ -65,6 +65,6 @@ public class UnknownFieldsIdentifierTest {
         assertEquals(1, result.size());
         final ValidationMessage unknownTerm = result.iterator().next();
         assertThat(unknownTerm.validationType()).isEqualTo(ValidationType.UNKNOWN_FIELD);
-        assertThat(unknownTerm.relatedProperty()).isEqualTo("unknownField");
+        assertThat(unknownTerm.relatedProperty()).hasValue("unknownField");
     }
 }

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/validation/validators/InvalidOperatorsValidatorTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/validation/validators/InvalidOperatorsValidatorTest.java
@@ -16,6 +16,8 @@
  */
 package org.graylog.plugins.views.search.validation.validators;
 
+import org.assertj.core.api.Assertions;
+import org.graylog.plugins.views.search.engine.QueryPosition;
 import org.graylog.plugins.views.search.validation.QueryValidator;
 import org.graylog.plugins.views.search.validation.TestValidationContext;
 import org.graylog.plugins.views.search.validation.ValidationContext;
@@ -27,6 +29,7 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 import java.util.Objects;
 
+import static org.assertj.core.api.Assertions.allOf;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class InvalidOperatorsValidatorTest {
@@ -51,13 +54,14 @@ class InvalidOperatorsValidatorTest {
 
         final ValidationMessage message = validation.iterator().next();
         assertThat(message.validationType()).isEqualTo(ValidationType.INVALID_OPERATOR);
-        assertThat(message.relatedProperty()).isEqualTo("and");
+        assertThat(message.relatedProperty()).hasValue("and");
 
-
-        assertThat(message.position().beginColumn()).isEqualTo(8);
-        assertThat(message.position().beginLine()).isEqualTo(1);
-        assertThat(message.position().endColumn()).isEqualTo(11);
-        assertThat(message.position().endLine()).isEqualTo(1);
+        assertThat(message.position()).hasValue(QueryPosition.builder()
+                .beginLine(1)
+                .beginColumn(8)
+                .endLine(1)
+                .endColumn(11)
+                .build());
     }
 
 
@@ -76,7 +80,7 @@ class InvalidOperatorsValidatorTest {
         assertThat(messages.size()).isEqualTo(1);
         final ValidationMessage message = messages.iterator().next();
         assertThat(message.validationType()).isEqualTo(ValidationType.INVALID_OPERATOR);
-        assertThat(message.relatedProperty()).isEqualTo("and");
+        assertThat(message.relatedProperty()).hasValue("and");
     }
 
 
@@ -88,7 +92,7 @@ class InvalidOperatorsValidatorTest {
         assertThat(messages.size()).isEqualTo(1);
         final ValidationMessage message = messages.iterator().next();
         assertThat(message.validationType()).isEqualTo(ValidationType.INVALID_OPERATOR);
-        assertThat(message.relatedProperty()).isEqualTo("or");
+        assertThat(message.relatedProperty()).hasValue("or");
     }
 
     @Test
@@ -99,7 +103,7 @@ class InvalidOperatorsValidatorTest {
         assertThat(messages.size()).isEqualTo(1);
         final ValidationMessage message = messages.iterator().next();
         assertThat(message.validationType()).isEqualTo(ValidationType.INVALID_OPERATOR);
-        assertThat(message.relatedProperty()).isEqualTo("not");
+        assertThat(message.relatedProperty()).hasValue("not");
     }
 
     @Test
@@ -119,7 +123,9 @@ class InvalidOperatorsValidatorTest {
         final List<ValidationMessage> messages = sut.validate(context);
         assertThat(messages.size()).isEqualTo(6);
         assertThat(messages.stream().allMatch(v -> v.validationType() == ValidationType.INVALID_OPERATOR)).isTrue();
-        assertThat(messages.stream().allMatch(v -> (Objects.equals(v.relatedProperty(), "or") || Objects.equals(v.relatedProperty(), "and")))).isTrue();
 
+        Assertions.assertThat(messages)
+                .extracting(v -> v.relatedProperty().orElse("invalid-property"))
+                .containsOnly("and", "or");
     }
 }


### PR DESCRIPTION
The lucene query parser doesn't provide any connection between parsed (sub)queries and tokens used. This PR adds such a connection, which is later used to map key and value tokens, used for validation highlighting in queries. 


## Motivation and Context
Fixes https://github.com/Graylog2/graylog-plugin-enterprise/issues/3491

## How Has This Been Tested?
It's refactoring, relies on existing tests covering the functionality.

## Screenshots (if appropriate):

For the query `timestamp:$param$ OR $param$ AND something` the assignments are:

```
Query timestamp:param(TermQuery) contains following tokens: timestamp,:,$param$,OR
Query _default_:param(TermQuery) contains following tokens: $param$,AND
Query _default_:something(TermQuery) contains following tokens: something
```
and after substitution (param=aaaa):

```
Query timestamp:aaaa(TermQuery) contains following tokens: timestamp,:,aaaa,OR
Query _default_:aaaa(TermQuery) contains following tokens: aaaa,AND
Query _default_:something(TermQuery) contains following tokens: something,
```

Note that due to the (not ideal) integration with existing lucene query parser, the tokens contain also AND/OR operators. This isn't problematic now for our usage, just wanted to mention that it's known and expected now.

![image](https://user-images.githubusercontent.com/4102775/165037714-ffcc17bc-4a63-4981-85ba-e2c7473ce97c.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

