### PR TITLE
Fixing usage of multiple reference dates for human readable duration.

### DIFF
--- a/graylog2-web-interface/src/views/logic/queries/TimeRangeToString.ts
+++ b/graylog2-web-interface/src/views/logic/queries/TimeRangeToString.ts
@@ -29,8 +29,9 @@ export const readableRange = (timerange: TimeRange, fieldName: 'range' | 'from' 
     return placeholder;
   }
 
-  const dateAgo = moment().subtract(rangeAsSeconds, 'seconds');
-  const rangeTimespan = moment.preciseDiff(moment(), dateAgo);
+  const reference = moment();
+  const dateAgo = moment(reference).subtract(rangeAsSeconds, 'seconds');
+  const rangeTimespan = moment.preciseDiff(reference, dateAgo);
 
   return `${rangeTimespan} ago`;
 };


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This change is fixing a subtle issue when creating a human-readable duration for a time range through the `readableRange` function.  Prior to this change, that function used two different reference dates when calculating the length of a duration by calling `moment()` repeatedly.  One call happened when declaring the `dateAgo` variable, the other when calculating the diff between current time (which is another `moment()` call) and `dateAgo`. When the first and the second call are across a secound boundary, this could lead to the calculation being slightly off.  E.g. when the first call is happening at `12:00:00.999` and the second one at `12:05:01.000`, the function would return `5 minutes 1 second ago`. This also results in test failures happening for timings like that where the test expects the literal string `5 minutes ago` while `5 minutes 1 second ago` is generated.

This change is now calling `moment()` only once and basing all calculations on it, preventing these kinds of overflows.


<!--- Provide a general summary of your changes in the Title above -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.