### PR TITLE
Version check only fetches necessary parts of the response.

### DIFF
--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/NodeAdapterES7.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/NodeAdapterES7.java
@@ -34,15 +34,19 @@ public class NodeAdapterES7 implements NodeAdapter {
         this.jsonApi = new PlainJsonApi(objectMapper, client);
     }
 
+    NodeAdapterES7(final PlainJsonApi jsonApi) {
+        this.jsonApi = jsonApi;
+    }
+
     @Override
     public Optional<SearchVersion> version() {
 
-        final Request request = new Request("GET", "/");
+        final Request request = new Request("GET", "/?filter_path=version.number,version.distribution");
         final Optional<JsonNode> resp = Optional.of(jsonApi.perform(request, "Unable to retrieve cluster information"));
 
         final Optional<String> version = resp.map(r -> r.path("version")).map(r -> r.path("number")).map(JsonNode::textValue);
 
-        final SearchVersion.Distribution distribution  = resp.map(r -> r.path("version")).map(r -> r.path("distribution")).map(JsonNode::textValue)
+        final SearchVersion.Distribution distribution = resp.map(r -> r.path("version")).map(r -> r.path("distribution")).map(JsonNode::textValue)
                 .map(d -> d.toUpperCase(Locale.ROOT))
                 .map(SearchVersion.Distribution::valueOf)
                 .orElse(SearchVersion.Distribution.ELASTICSEARCH);

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/NodeAdapterES7Test.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/NodeAdapterES7Test.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog.storage.elasticsearch7;
 
 import com.fasterxml.jackson.databind.JsonNode;

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/NodeAdapterES7Test.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/NodeAdapterES7Test.java
@@ -1,0 +1,66 @@
+package org.graylog.storage.elasticsearch7;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.zafarkhaja.semver.Version;
+import org.graylog.shaded.elasticsearch7.org.elasticsearch.client.Request;
+import org.graylog2.storage.SearchVersion;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+class NodeAdapterES7Test {
+
+    private NodeAdapterES7 toTest;
+    private PlainJsonApi jsonApiMock;
+    private Request request;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @BeforeEach
+    void setUp() {
+        jsonApiMock = mock(PlainJsonApi.class);
+        toTest = new NodeAdapterES7(jsonApiMock);
+        request = new Request("GET", "/?filter_path=version.number,version.distribution");
+    }
+
+    @Test
+    void testElasticsearchVersionFetching() throws IOException {
+        mockResponse("{\"version\" : " +
+                " {" +
+                "    \"number\" : \"7.10.2\"" +
+                " }" +
+                "}");
+
+        assertThat(toTest.version())
+                .isNotEmpty()
+                .contains(SearchVersion.create(SearchVersion.Distribution.ELASTICSEARCH, Version.valueOf("7.10.2")));
+
+    }
+
+    @Test
+    void testOpensearchVersionFetching() throws IOException {
+        mockResponse("{\"version\" : " +
+                "  {" +
+                "    \"distribution\" : \"opensearch\"," +
+                "    \"number\" : \"1.3.1\"" +
+                "  }" +
+                "}");
+
+        assertThat(toTest.version())
+                .isNotEmpty()
+                .contains(SearchVersion.create(SearchVersion.Distribution.OPENSEARCH, Version.valueOf("1.3.1")));
+
+    }
+
+    private void mockResponse(final String jsonResponseWithVersion) throws IOException {
+        JsonNode jsonNode = objectMapper.readTree(jsonResponseWithVersion);
+        doReturn(jsonNode).when(jsonApiMock).perform(eq(request), anyString());
+    }
+}


### PR DESCRIPTION
## Description
Version check only fetches necessary parts of the response, not the whole JSON. Unit tests for version check have been added.

## Motivation and Context
NodeAdapterES7 had no unit tests. I've added them.
NodeAdapterES7 used to grab the whole JSON, despite needing only 1-2 fields. "filter_path" request parameter has been used to limit the size of response.

## How Has This Been Tested?
Tested on Opensearch and Elasticsearch, with debugger and looking in the startup logs for messages like this one:
`Connected to (Elastic/Open)Search version <Elasticsearch:7.10.2>`

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

