### PR TITLE
Limit size of system_messages collection

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -25,5 +25,7 @@ The following API endpoints have been removed in 4.4.
 
 ## Behaviour Changes
 
-- The system messages collection in MongoDB will be created as a 50MB capped collection going forward.
-  This happens at creation, so existing system messages collections remain unconstrained.
+- The `system_messages` collection in MongoDB will be created as a 50MB capped collection going forward.
+  This happens at creation, so existing `system_messages` collections remain unconstrained.
+<br>You can manually convert your existing collection to a capped collection by following 
+these [instructions](https://www.mongodb.com/docs/manual/core/capped-collections/#convert-a-collection-to-capped).

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -22,3 +22,8 @@ The following API endpoints have been removed in 4.4.
 | Endpoint                                    | Description                 |
 | ------------------------------------------- | --------------------------- |
 | `PUT /example/placeholder`                  | TODO placeholder comment    |
+
+## Behaviour Changes
+
+- The system messages collection in MongoDB will be created as a 50MB capped collection going forward.
+  This happens at creation, so existing system messages collections remain unconstrained.

--- a/graylog2-server/src/main/java/org/graylog2/system/activities/SystemMessageServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/system/activities/SystemMessageServiceImpl.java
@@ -33,7 +33,7 @@ import java.util.List;
 import java.util.Map;
 
 public class SystemMessageServiceImpl extends PersistedServiceImpl implements SystemMessageService {
-    private static final int MAX_COLLECTION_BYTES = 5 * 1024 * 1024;
+    private static final int MAX_COLLECTION_BYTES = 50 * 1024 * 1024;
     private final int PER_PAGE = 30;
     @Inject
     public SystemMessageServiceImpl(MongoConnection mongoConnection) {

--- a/graylog2-server/src/main/java/org/graylog2/system/activities/SystemMessageServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/system/activities/SystemMessageServiceImpl.java
@@ -18,11 +18,14 @@ package org.graylog2.system.activities;
 
 import com.google.common.collect.Lists;
 import com.mongodb.BasicDBObject;
+import com.mongodb.BasicDBObjectBuilder;
 import com.mongodb.DBCollection;
 import com.mongodb.DBObject;
 import org.bson.types.ObjectId;
+import org.graylog2.database.CollectionName;
 import org.graylog2.database.MongoConnection;
 import org.graylog2.database.PersistedServiceImpl;
+import org.graylog2.indexer.IndexFailureImpl;
 import org.mongojack.DBSort;
 
 import javax.inject.Inject;
@@ -30,13 +33,22 @@ import java.util.List;
 import java.util.Map;
 
 public class SystemMessageServiceImpl extends PersistedServiceImpl implements SystemMessageService {
+    private static final int MAX_COLLECTION_BYTES = 5 * 1024 * 1024;
     private final int PER_PAGE = 30;
-
     @Inject
     public SystemMessageServiceImpl(MongoConnection mongoConnection) {
         super(mongoConnection);
-        final DBCollection collection = this.collection(SystemMessageImpl.class);
-        collection.createIndex(DBSort.desc("timestamp"));
+
+        // Make sure that the system messages collection is always created capped.
+        final String collectionName = SystemMessageImpl.class.getAnnotation(CollectionName.class).value();
+        if (!mongoConnection.getDatabase().collectionExists(collectionName)) {
+            final DBObject options = BasicDBObjectBuilder.start()
+                    .add("capped", true)
+                    .add("size", MAX_COLLECTION_BYTES)
+                    .get();
+            final DBCollection collection = mongoConnection.getDatabase().createCollection(collectionName, options);
+            collection.createIndex(DBSort.desc("timestamp"));
+        }
     }
 
     @Override


### PR DESCRIPTION
Mongo DB collection `system_messages` grows indefinitely. There is little point in storing years worth of old system messages. 
We now cap the size of collection, just as we do for e.g. `index_failures` collection.

**Note:** you cannot delete documents from a capped collection. Users will no longer be able trim the collection by deleting a subset of documents.

Resolves Graylog2/graylog2-server#6118