### PR TITLE
Reduce matrix for faster integration tests

### DIFF
--- a/graylog2-server/src/test/java/org/graylog/testing/containermatrix/SearchServer.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/containermatrix/SearchServer.java
@@ -24,9 +24,9 @@ import static org.graylog2.storage.SearchVersion.Distribution.OPENSEARCH;
 public enum SearchServer {
     ES7(ELASTICSEARCH, "7.10.2"),
     ES6(ELASTICSEARCH, "6.8.4"),
-    OS1(OPENSEARCH, "1.2.1");
+    OS1(OPENSEARCH, "1.3.1");
 
-    public static final SearchServer DEFAULT_VERSION = ES7;
+    public static final SearchServer DEFAULT_VERSION = OS1;
 
     private final SearchVersion searchVersion;
 

--- a/graylog2-server/src/test/java/org/graylog/testing/containermatrix/annotations/ContainerMatrixTestsConfiguration.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/containermatrix/annotations/ContainerMatrixTestsConfiguration.java
@@ -60,13 +60,13 @@ public @interface ContainerMatrixTestsConfiguration {
      * matrix rule
      * If no version is explicitly specified, then {@link SearchServer#DEFAULT_VERSION will be used by the tests}
      */
-    SearchServer[] searchVersions() default {SearchServer.OS1, SearchServer.ES6, SearchServer.ES7};
+    SearchServer[] searchVersions() default {SearchServer.ES7};
 
     /**
      * matrix rule
      * If no version is explicitly specified, then {@link MongodbServer#DEFAULT_VERSION will be used by the tests}
      */
-    MongodbServer[] mongoVersions() default {MongodbServer.MONGO3, MongodbServer.MONGO4};
+    MongodbServer[] mongoVersions() default {MongodbServer.MONGO4};
 
     // additional Parameter, gets concatenated for all tests below the above rules
     int[] extraPorts() default {};

--- a/graylog2-server/src/test/java/org/graylog/testing/containermatrix/annotations/ContainerMatrixTestsConfiguration.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/containermatrix/annotations/ContainerMatrixTestsConfiguration.java
@@ -60,13 +60,13 @@ public @interface ContainerMatrixTestsConfiguration {
      * matrix rule
      * If no version is explicitly specified, then {@link SearchServer#DEFAULT_VERSION will be used by the tests}
      */
-    SearchServer[] searchVersions() default {SearchServer.ES7};
+    SearchServer[] searchVersions() default {SearchServer.OS1, SearchServer.ES6, SearchServer.ES7};
 
     /**
      * matrix rule
      * If no version is explicitly specified, then {@link MongodbServer#DEFAULT_VERSION will be used by the tests}
      */
-    MongodbServer[] mongoVersions() default {MongodbServer.MONGO4};
+    MongodbServer[] mongoVersions() default {MongodbServer.MONGO3, MongodbServer.MONGO4};
 
     // additional Parameter, gets concatenated for all tests below the above rules
     int[] extraPorts() default {};

--- a/graylog2-server/src/test/java/org/graylog/testing/containermatrix/annotations/ContainerMatrixTestsConfiguration.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/containermatrix/annotations/ContainerMatrixTestsConfiguration.java
@@ -60,7 +60,7 @@ public @interface ContainerMatrixTestsConfiguration {
      * matrix rule
      * If no version is explicitly specified, then {@link SearchServer#DEFAULT_VERSION will be used by the tests}
      */
-    SearchServer[] searchVersions() default {SearchServer.ES7};
+    SearchServer[] searchVersions() default {SearchServer.OS1};
 
     /**
      * matrix rule


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Instead of testing a matrix of ES/OS and Mongo, we test with Mongo 4 and OpenSearch 1.3 per default.

Alternative version: #12569

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This reduces build time on Jenkins significantly. (Approx. 30-40min reduction)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

