### PR TITLE
Using correct field for pie chart legends.

### DIFF
--- a/graylog2-web-interface/src/views/components/visualizations/pie/PieVisualization.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/pie/PieVisualization.tsx
@@ -15,7 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import { union } from 'lodash';
 
 import { AggregationType, AggregationResult } from 'views/components/aggregationbuilder/AggregationBuilderPropTypes';
@@ -25,6 +25,8 @@ import PlotLegend from 'views/components/visualizations/PlotLegend';
 import useChartData from 'views/components/visualizations/useChartData';
 import type { Generator } from 'views/components/visualizations/ChartData';
 import type ColorMapper from 'views/components/visualizations/ColorMapper';
+import type Pivot from 'views/logic/aggregationbuilder/Pivot';
+import type Series from 'views/logic/aggregationbuilder/Series';
 
 import type { ChartConfig } from '../GenericPlot';
 import GenericPlot from '../GenericPlot';
@@ -85,12 +87,26 @@ const labelMapper = (data: Array<{ labels: Array<string> }>) => data.reduce((acc
   return union(acc, labels);
 }, []);
 
+const legendField = (columnPivots: Array<Pivot>, rowPivots: Array<Pivot>, series: Array<Series>, isFunction: boolean) => {
+  if (rowPivots.length === 1 && series.length === 1 && !isFunction) {
+    return rowPivots[0].field;
+  }
+
+  if (columnPivots.length === 1) {
+    return columnPivots[0].field;
+  }
+
+  return null;
+};
+
 const PieVisualization = makeVisualization(({ config, data }: VisualizationComponentProps) => {
   const rows = useMemo(() => retrieveChartData(data), [data]);
   const transformedData = useChartData(rows, { widgetConfig: config, chartType: 'pie', generator: _generateSeries });
+  const { columnPivots, rowPivots, series } = config;
+  const fieldMapper = useCallback((isFunction: boolean) => legendField(columnPivots, rowPivots, series, isFunction), [columnPivots, rowPivots, series]);
 
   return (
-    <PlotLegend config={config} chartData={transformedData} labelMapper={labelMapper} neverHide>
+    <PlotLegend config={config} chartData={transformedData} labelMapper={labelMapper} fieldMapper={fieldMapper} neverHide>
       <GenericPlot chartData={transformedData}
                    layout={{ showlegend: false }}
                    getChartColor={getChartColor}


### PR DESCRIPTION
**Note:** This should be backported to `4.3`.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is fixing an issue where the field name which is used for the legend of a pie chart is taken from the wrong pivot. It happens when there is both at least one row and at least one column pivot defined for a pie chart. In that case, the field name is taken from the row pivot instead of the column pivot. 

This PR is now making the field mapping strategy in the `PlotLegend` component overridable, defaulting to the one which matches the chart data for most visualizations and use the mirrored one for pie charts.

Fixes #12501.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.