### PR TITLE
Introduce a JsonSubTypePropertyDefaultValue annotation

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/jackson/DeserializationProblemHandlerModule.java
+++ b/graylog2-server/src/main/java/org/graylog2/jackson/DeserializationProblemHandlerModule.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.jackson;
+
+import com.fasterxml.jackson.core.Version;
+import com.fasterxml.jackson.databind.Module;
+import com.fasterxml.jackson.databind.deser.DeserializationProblemHandler;
+
+/**
+ * A Jackson {@link Module} that adds our custom {@link DeserializationProblemHandler} implementations
+ * to the object mapper.
+ */
+public class DeserializationProblemHandlerModule extends Module {
+    @Override
+    public String getModuleName() {
+        return "DeserializationProblemHandlerModule";
+    }
+
+    @Override
+    public Version version() {
+        return Version.unknownVersion();
+    }
+
+    @Override
+    public void setupModule(SetupContext context) {
+        context.addDeserializationProblemHandler(new MissingTypeIdDeserializationProblemHandler());
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/jackson/JsonSubTypePropertyDefaultValue.java
+++ b/graylog2-server/src/main/java/org/graylog2/jackson/JsonSubTypePropertyDefaultValue.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.jackson;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * An annotation that can be used to set a default logical type name for documents that are missing it.
+ * This can be useful to set a default type for old JSON documents when migrating data structures from an
+ * untyped to a typed version.
+ * <p>
+ * Example:
+ * <pre>{@code
+ *   @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "type")
+ *   @JsonSubTypes(@JsonSubTypes.Type(value = SubTypeA.class, name = "a"))
+ *   @JsonSubTypePropertyDefaultValue("a")
+ *   public @interface TestInterface {
+ *   }
+ * }</pre>
+ * The difference to the {@code defaultImpl} parameter for {@link JsonTypeInfo} is,
+ * that the default value is only used when the type attribute it's missing in a document. Using {@code defaultImpl}
+ * will use the given default implementation in all cases, even if a document contains a non-existent type name.
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface JsonSubTypePropertyDefaultValue {
+    String value();
+}

--- a/graylog2-server/src/main/java/org/graylog2/jackson/MissingTypeIdDeserializationProblemHandler.java
+++ b/graylog2-server/src/main/java/org/graylog2/jackson/MissingTypeIdDeserializationProblemHandler.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.jackson;
+
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.deser.DeserializationProblemHandler;
+import com.fasterxml.jackson.databind.jsontype.TypeIdResolver;
+
+import java.io.IOException;
+
+/**
+ * A {@link DeserializationProblemHandler} implementation that handles missing type IDs. The handler checks if
+ * the base type has a {@link JsonSubTypePropertyDefaultValue} annotation to select a default type ID.
+ *
+ * @see JsonSubTypePropertyDefaultValue
+ */
+public class MissingTypeIdDeserializationProblemHandler extends DeserializationProblemHandler {
+    @Override
+    public JavaType handleMissingTypeId(DeserializationContext ctxt,
+                                        JavaType baseType,
+                                        TypeIdResolver idResolver,
+                                        String failureMsg) throws IOException {
+        final JsonSubTypePropertyDefaultValue annotation = baseType.getRawClass().getAnnotation(JsonSubTypePropertyDefaultValue.class);
+        if (annotation == null) {
+            return super.handleMissingTypeId(ctxt, baseType, idResolver, failureMsg);
+        }
+        return idResolver.typeFromId(ctxt, annotation.value());
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/shared/bindings/providers/ObjectMapperProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/bindings/providers/ObjectMapperProvider.java
@@ -41,6 +41,7 @@ import org.graylog.grn.GRNKeyDeserializer;
 import org.graylog.grn.GRNRegistry;
 import org.graylog2.database.ObjectIdSerializer;
 import org.graylog2.jackson.AutoValueSubtypeResolver;
+import org.graylog2.jackson.DeserializationProblemHandlerModule;
 import org.graylog2.jackson.JodaTimePeriodKeyDeserializer;
 import org.graylog2.jackson.SemverDeserializer;
 import org.graylog2.jackson.SemverRequirementDeserializer;
@@ -118,6 +119,7 @@ public class ObjectMapperProvider implements Provider<ObjectMapper> {
                 .registerModule(new Jdk8Module())
                 .registerModule(new JavaTimeModule())
                 .registerModule(new MetricsModule(TimeUnit.SECONDS, TimeUnit.SECONDS, false))
+                .registerModule(new DeserializationProblemHandlerModule())
                 .registerModule(new SimpleModule("Graylog")
                         .addKeyDeserializer(Period.class, new JodaTimePeriodKeyDeserializer())
                         .addKeyDeserializer(GRN.class, new GRNKeyDeserializer(grnRegistry))

--- a/graylog2-server/src/test/java/org/graylog2/jackson/JsonSubTypePropertyDefaultValueTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/jackson/JsonSubTypePropertyDefaultValueTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.jackson;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.InvalidTypeIdException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class JsonSubTypePropertyDefaultValueTest {
+    static final String VALUE_WITHOUT_TYPE = "{\"test\":{\"a\":\"this is a\"}}";
+    static final String VALUE_A = "{\"test\":{\"type\":\"a\",\"a\":\"this is a\"}}";
+    static final String VALUE_B = "{\"test\":{\"type\":\"b\",\"b\":\"this is b\"}}";
+
+    ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        this.objectMapper = new ObjectMapper();
+    }
+
+    @Test
+    void deserializeWithoutActiveProblemHandlerModule() throws Exception {
+        final TestDocument docA = objectMapper.readValue(VALUE_A, TestDocument.class);
+        final TestDocument docB = objectMapper.readValue(VALUE_B, TestDocument.class);
+
+        assertThat(docA.test).isInstanceOf(TestClass.SubTypeA.class);
+        assertThat(docB.test).isInstanceOf(TestClass.SubTypeB.class);
+
+        // The problem handler is not active, so we expect this to throw an exception.
+        assertThatThrownBy(() -> objectMapper.readValue(VALUE_WITHOUT_TYPE, TestDocument.class))
+                .isInstanceOf(InvalidTypeIdException.class);
+    }
+
+    @Test
+    void deserializeWithActiveProblemHandlerModule() throws Exception {
+        objectMapper.registerModule(new DeserializationProblemHandlerModule());
+
+        final TestDocument docA = objectMapper.readValue(VALUE_A, TestDocument.class);
+        final TestDocument docB = objectMapper.readValue(VALUE_B, TestDocument.class);
+        // The problem handler is active, so this should not throw an exception
+        final TestDocument docWithoutType = objectMapper.readValue(VALUE_WITHOUT_TYPE, TestDocument.class);
+
+        assertThat(docA.test).isInstanceOf(TestClass.SubTypeA.class);
+        assertThat(docB.test).isInstanceOf(TestClass.SubTypeB.class);
+        assertThat(docWithoutType.test).isInstanceOf(TestClass.SubTypeA.class);
+    }
+
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "type")
+    @JsonSubTypes({
+            @JsonSubTypes.Type(value = TestClass.SubTypeA.class, name = "a"),
+            @JsonSubTypes.Type(value = TestClass.SubTypeB.class, name = "b"),
+    })
+    @JsonSubTypePropertyDefaultValue("a")
+    public interface TestClass {
+        class SubTypeA implements TestClass {
+            final String type;
+            final String a;
+
+            @JsonCreator
+            private SubTypeA(@JsonProperty("type") String type, @JsonProperty("a") String a) {
+                this.type = type;
+                this.a = a;
+            }
+        }
+
+        class SubTypeB implements TestClass {
+            final String type;
+            final String b;
+
+            @JsonCreator
+            private SubTypeB(@JsonProperty("type") String type, @JsonProperty("b") String b) {
+                this.type = type;
+                this.b = b;
+            }
+        }
+    }
+
+    public static class TestDocument {
+        final TestClass test;
+
+        @JsonCreator
+        private TestDocument(@JsonProperty("test") TestClass test) {
+            this.test = test;
+        }
+    }
+}


### PR DESCRIPTION
The annotation can be used for JsonSubTypes use cases to provide a
default type value for documents that are missing the field.

See the javadoc of the JsonSubTypePropertyDefaultValue annotation for
more details.