### PR TITLE
Reduce matrix on github/jenkins

### DIFF
--- a/graylog2-server/src/test/java/org/graylog/testing/containermatrix/ContainerMatrixTestEngine.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/containermatrix/ContainerMatrixTestEngine.java
@@ -82,7 +82,7 @@ public class ContainerMatrixTestEngine extends ContainerMatrixHierarchicalTestEn
     }
 
     private boolean isJenkinsOnGithub() {
-        String github_workspace = System.getenv("GITHUB_WORKSPACE");
+        String github_workspace = System.getenv("CI");
         return !StringUtils.isBlank(github_workspace);
     }
 

--- a/graylog2-server/src/test/java/org/graylog/testing/containermatrix/ContainerMatrixTestEngine.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/containermatrix/ContainerMatrixTestEngine.java
@@ -81,16 +81,21 @@ public class ContainerMatrixTestEngine extends ContainerMatrixHierarchicalTestEn
         return get(annotatedClasses, (ContainerMatrixTestsConfiguration annotation) -> Stream.of(annotation.pluginJarsProvider()));
     }
 
-    private boolean isJenkinsOnGithub() {
-        String github_workspace = System.getenv("CI");
-        return !StringUtils.isBlank(github_workspace);
+    private boolean isRunningInCI() {
+        String ci = System.getenv("CI");
+        return !StringUtils.isBlank(ci);
+    }
+
+    private boolean enableContainerMatrixOnCI() {
+        String force_matrix = System.getenv("ENABLE_CONTAINER_MATRIX_ON_CI");
+        return "true".equalsIgnoreCase(force_matrix);
     }
 
     private Set<SearchServer> getSearchServerVersions(Set<Class<?>> annotatedClasses) {
         return get(annotatedClasses, (ContainerMatrixTestsConfiguration annotation) -> {
             if (annotation.searchVersions().length == 0) {
                 return Stream.of(SearchServer.DEFAULT_VERSION);
-            } if (isJenkinsOnGithub()) {
+            } if (isRunningInCI() && !enableContainerMatrixOnCI()) {
                 return Stream.of(annotation.searchVersions()[0]);
             } else {
                 return Stream.of(annotation.searchVersions());
@@ -102,7 +107,7 @@ public class ContainerMatrixTestEngine extends ContainerMatrixHierarchicalTestEn
         return get(annotatedClasses, (ContainerMatrixTestsConfiguration annotation) -> {
             if (annotation.mongoVersions().length == 0) {
                 return Stream.of(MongodbServer.DEFAULT_VERSION);
-            } if (isJenkinsOnGithub()) {
+            } if (isRunningInCI() && !enableContainerMatrixOnCI()) {
                 return Stream.of(annotation.mongoVersions()[0]);
             } else {
                 return Stream.of(annotation.mongoVersions());

--- a/graylog2-server/src/test/java/org/graylog/testing/containermatrix/ContainerMatrixTestEngine.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/containermatrix/ContainerMatrixTestEngine.java
@@ -81,7 +81,7 @@ public class ContainerMatrixTestEngine extends ContainerMatrixHierarchicalTestEn
         return get(annotatedClasses, (ContainerMatrixTestsConfiguration annotation) -> Stream.of(annotation.pluginJarsProvider()));
     }
 
-    private boolean isRunningInCI() {
+    private boolean isRunningOnCI() {
         String ci = System.getenv("CI");
         return !StringUtils.isBlank(ci);
     }
@@ -95,7 +95,7 @@ public class ContainerMatrixTestEngine extends ContainerMatrixHierarchicalTestEn
         return get(annotatedClasses, (ContainerMatrixTestsConfiguration annotation) -> {
             if (annotation.searchVersions().length == 0) {
                 return Stream.of(SearchServer.DEFAULT_VERSION);
-            } if (isRunningInCI() && !enableContainerMatrixOnCI()) {
+            } if (isRunningOnCI() && !enableContainerMatrixOnCI()) {
                 return Stream.of(annotation.searchVersions()[0]);
             } else {
                 return Stream.of(annotation.searchVersions());
@@ -107,7 +107,7 @@ public class ContainerMatrixTestEngine extends ContainerMatrixHierarchicalTestEn
         return get(annotatedClasses, (ContainerMatrixTestsConfiguration annotation) -> {
             if (annotation.mongoVersions().length == 0) {
                 return Stream.of(MongodbServer.DEFAULT_VERSION);
-            } if (isRunningInCI() && !enableContainerMatrixOnCI()) {
+            } if (isRunningOnCI() && !enableContainerMatrixOnCI()) {
                 return Stream.of(annotation.mongoVersions()[0]);
             } else {
                 return Stream.of(annotation.mongoVersions());


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Alternative to #12543 - reduce testing time on Github/Jenkins.

- if there is no SearchServer/Mongo version defined, use the default version
- if you are on Github/Jenkins, only use the first defined version
- otherwise, use what's defined

This means you can still have a special version based configuration that is used on Github/Jenkins.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Reduce build times on Github/Jenkins by reducing the matrix for IT tests.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
