### PR TITLE
Always clear query validation explanations. (backport of #12516 for 4.3)

### DIFF
--- a/graylog2-web-interface/src/views/components/searchbar/queryvalidation/QueryValidation.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/queryvalidation/QueryValidation.test.tsx
@@ -129,7 +129,7 @@ describe('QueryValidation', () => {
   it('only displays current validation explanation', async () => {
     const multipleValidationErrors: QueryValidationState = {
       status: 'ERROR',
-      explanations: [validationErrorExplanation, { ...validationErrorExplanation, endColumn: 6 }],
+      explanations: [validationErrorExplanation, { ...validationErrorExplanation, id: 'validation-explanation-id-2' }],
     };
     const singleValidationError: QueryValidationState = {
       status: 'ERROR',

--- a/graylog2-web-interface/src/views/components/searchbar/queryvalidation/QueryValidation.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/queryvalidation/QueryValidation.test.tsx
@@ -23,7 +23,7 @@ import QueryValidation from 'views/components/searchbar/queryvalidation/QueryVal
 import SearchExecutionState from 'views/logic/search/SearchExecutionState';
 import FormWarningsContext from 'contexts/FormWarningsContext';
 import type { QueryValidationState } from 'views/components/searchbar/queryvalidation/types';
-import { validationError } from 'fixtures/queryValidationState';
+import { validationError, validationErrorExplanation } from 'fixtures/queryValidationState';
 import usePluginEntities from 'views/logic/usePluginEntities';
 
 import asMock from '../../../../../test/helpers/mocking/AsMock';
@@ -70,7 +70,7 @@ describe('QueryValidation', () => {
   };
 
   const SUT = ({ error, warning }: SUTProps) => (
-    <Formik onSubmit={() => {}} initialValues={{}} initialErrors={error ? { queryString: error } : {}}>
+    <Formik onSubmit={() => {}} initialValues={{}} initialErrors={error ? { queryString: error } : {}} enableReinitialize>
       <Form>
         <FormWarningsContext.Provider value={{ warnings: warning ? { queryString: warning } : {}, setFieldWarning: () => {} }}>
           <QueryValidation />
@@ -114,7 +114,7 @@ describe('QueryValidation', () => {
     await screen.findByTitle('Parse Exception documentation');
   });
 
-  it('renders plugable validation explanation', async () => {
+  it('renders pluggable validation explanation', async () => {
     const ExampleComponent = ({ validationState }: { validationState: QueryValidationState }) => (
       <>Plugable validation explanation for {validationState.explanations.map(({ errorTitle }) => errorTitle).join()}</>
     );
@@ -124,5 +124,25 @@ describe('QueryValidation', () => {
     await openExplanation();
 
     await screen.findByText('Plugable validation explanation for Parse Exception');
+  });
+
+  it('only displays current validation explanation', async () => {
+    const multipleValidationErrors: QueryValidationState = {
+      status: 'ERROR',
+      explanations: [validationErrorExplanation, validationErrorExplanation],
+    };
+    const singleValidationError: QueryValidationState = {
+      status: 'ERROR',
+      explanations: [validationErrorExplanation],
+    };
+
+    const { rerender } = render(<SUT error={multipleValidationErrors} />);
+    await openExplanation();
+
+    await waitFor(() => expect(screen.getAllByText('Parse Exception')).toHaveLength(2));
+
+    rerender(<SUT error={singleValidationError} />);
+
+    await waitFor(() => expect(screen.getAllByText('Parse Exception')).toHaveLength(1));
   });
 });

--- a/graylog2-web-interface/src/views/components/searchbar/queryvalidation/QueryValidation.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/queryvalidation/QueryValidation.test.tsx
@@ -129,7 +129,7 @@ describe('QueryValidation', () => {
   it('only displays current validation explanation', async () => {
     const multipleValidationErrors: QueryValidationState = {
       status: 'ERROR',
-      explanations: [validationErrorExplanation, validationErrorExplanation],
+      explanations: [validationErrorExplanation, { ...validationErrorExplanation, endColumn: 6 }],
     };
     const singleValidationError: QueryValidationState = {
       status: 'ERROR',

--- a/graylog2-web-interface/src/views/components/searchbar/queryvalidation/QueryValidation.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/queryvalidation/QueryValidation.tsx
@@ -200,8 +200,9 @@ const QueryValidation = () => {
                          title={<ExplanationTitle title={StringUtils.capitalizeFirstLetter(status.toLocaleLowerCase())} />}
                          $shaking={shakingPopover}>
             <div role="alert">
-              {explanations.map(({ errorType, errorTitle, errorMessage }) => (
-                <Explanation key={errorMessage}>
+              {explanations.map(({ errorType, errorTitle, errorMessage }, index) => (
+                // eslint-disable-next-line react/no-array-index-key
+                <Explanation key={index}>
                   <span><b>{errorTitle}</b>: {errorMessage}</span>
                   <DocumentationLink page={getErrorDocumentationLink(errorType)}
                                      title={`${errorTitle} documentation`}

--- a/graylog2-web-interface/src/views/components/searchbar/queryvalidation/QueryValidation.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/queryvalidation/QueryValidation.tsx
@@ -200,9 +200,8 @@ const QueryValidation = () => {
                          title={<ExplanationTitle title={StringUtils.capitalizeFirstLetter(status.toLocaleLowerCase())} />}
                          $shaking={shakingPopover}>
             <div role="alert">
-              {explanations.map(({ errorType, errorTitle, errorMessage }, index) => (
-                // eslint-disable-next-line react/no-array-index-key
-                <Explanation key={index}>
+              {explanations.map(({ errorType, errorTitle, errorMessage, beginLine, endLine, beginColumn, endColumn }) => (
+                <Explanation key={`${errorType}-${beginLine}-${endLine}-${beginColumn}-${endColumn}`}>
                   <span><b>{errorTitle}</b>: {errorMessage}</span>
                   <DocumentationLink page={getErrorDocumentationLink(errorType)}
                                      title={`${errorTitle} documentation`}

--- a/graylog2-web-interface/src/views/components/searchbar/queryvalidation/QueryValidation.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/queryvalidation/QueryValidation.tsx
@@ -200,8 +200,8 @@ const QueryValidation = () => {
                          title={<ExplanationTitle title={StringUtils.capitalizeFirstLetter(status.toLocaleLowerCase())} />}
                          $shaking={shakingPopover}>
             <div role="alert">
-              {explanations.map(({ errorType, errorTitle, errorMessage, beginLine, endLine, beginColumn, endColumn }) => (
-                <Explanation key={`${errorType}-${beginLine}-${endLine}-${beginColumn}-${endColumn}`}>
+              {explanations.map(({ errorType, errorTitle, errorMessage, id }) => (
+                <Explanation key={id}>
                   <span><b>{errorTitle}</b>: {errorMessage}</span>
                   <DocumentationLink page={getErrorDocumentationLink(errorType)}
                                      title={`${errorTitle} documentation`}

--- a/graylog2-web-interface/src/views/components/searchbar/queryvalidation/types.ts
+++ b/graylog2-web-interface/src/views/components/searchbar/queryvalidation/types.ts
@@ -17,6 +17,7 @@
 export type QueryValidationState = {
   status: 'OK' | 'ERROR' | 'WARNING',
   explanations: Array<{
+    id: string,
     errorType: string,
     errorTitle: string,
     errorMessage: string,

--- a/graylog2-web-interface/src/views/components/searchbar/queryvalidation/validateQuery.ts
+++ b/graylog2-web-interface/src/views/components/searchbar/queryvalidation/validateQuery.ts
@@ -24,6 +24,7 @@ import type Parameter from 'views/logic/parameters/Parameter';
 import type { ParameterBindings } from 'views/logic/search/SearchExecutionState';
 import type { QueryValidationState } from 'views/components/searchbar/queryvalidation/types';
 import { onSubmittingTimerange } from 'views/components/TimerangeForForm';
+import generateId from 'logic/generateId';
 
 export type ValidationQuery = {
   queryString: ElasticsearchQueryString | string,
@@ -71,6 +72,7 @@ export const validateQuery = ({
         end_column: endColumn,
         related_property: relatedProperty,
       }) => ({
+        id: generateId(),
         errorMessage,
         errorType,
         errorTitle,

--- a/graylog2-web-interface/src/views/components/searchbar/queryvalidation/validateQuery.ts
+++ b/graylog2-web-interface/src/views/components/searchbar/queryvalidation/validateQuery.ts
@@ -15,6 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import type * as Immutable from 'immutable';
+import uuid from 'uuid/v4';
 
 import UserNotification from 'util/UserNotification';
 import fetch from 'logic/rest/FetchProvider';
@@ -24,7 +25,6 @@ import type Parameter from 'views/logic/parameters/Parameter';
 import type { ParameterBindings } from 'views/logic/search/SearchExecutionState';
 import type { QueryValidationState } from 'views/components/searchbar/queryvalidation/types';
 import { onSubmittingTimerange } from 'views/components/TimerangeForForm';
-import generateId from 'logic/generateId';
 
 export type ValidationQuery = {
   queryString: ElasticsearchQueryString | string,
@@ -72,7 +72,7 @@ export const validateQuery = ({
         end_column: endColumn,
         related_property: relatedProperty,
       }) => ({
-        id: generateId(),
+        id: uuid(),
         errorMessage,
         errorType,
         errorTitle,

--- a/graylog2-web-interface/test/fixtures/queryValidationState.ts
+++ b/graylog2-web-interface/test/fixtures/queryValidationState.ts
@@ -17,16 +17,17 @@
 
 import type { QueryValidationState } from 'views/components/searchbar/queryvalidation/types';
 
+export const validationErrorExplanation = {
+  errorType: 'QUERY_PARSING_ERROR',
+  errorTitle: 'Parse Exception',
+  errorMessage: "Cannot parse 'source: '",
+  beginLine: 1,
+  endLine: 1,
+  beginColumn: 1,
+  endColumn: 5,
+};
 // eslint-disable-next-line import/prefer-default-export
 export const validationError: QueryValidationState = {
   status: 'ERROR',
-  explanations: [{
-    errorType: 'QUERY_PARSING_ERROR',
-    errorTitle: 'Parse Exception',
-    errorMessage: "Cannot parse 'source: '",
-    beginLine: 1,
-    endLine: 1,
-    beginColumn: 1,
-    endColumn: 5,
-  }],
+  explanations: [validationErrorExplanation],
 };

--- a/graylog2-web-interface/test/fixtures/queryValidationState.ts
+++ b/graylog2-web-interface/test/fixtures/queryValidationState.ts
@@ -18,6 +18,7 @@
 import type { QueryValidationState } from 'views/components/searchbar/queryvalidation/types';
 
 export const validationErrorExplanation = {
+  id: 'validation-explanation-id',
   errorType: 'QUERY_PARSING_ERROR',
   errorTitle: 'Parse Exception',
   errorMessage: "Cannot parse 'source: '",


### PR DESCRIPTION
_Please note: This is a backport of #12516 for 4.3._

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Before this change it was possible that old validation explanations were not being removed. This happen because we used the error message as a key for the list items. Because of recent changes this attribute is no longer a uniq one.
We are now using the index as a key, while this can be problematic in some cases, it is not a problem in this case because the list items have no state.

You can reproduce the bug by:
1. paste the following query: `GET or timestamp:"test test"`
2. open the query validation explanation
3. remove `GET or`

/jenkins-pr-deps https://github.com/Graylog2/graylog-plugin-enterprise/pull/3546