### PR TITLE
Using correct field for pie chart legends. (`4.2`)

### DIFF
--- a/graylog2-web-interface/src/views/components/Value.tsx
+++ b/graylog2-web-interface/src/views/components/Value.tsx
@@ -15,6 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
+import { useCallback, useMemo } from 'react';
 import styled from 'styled-components';
 
 import FieldType from 'views/logic/fieldtypes/FieldType';
@@ -40,8 +41,8 @@ const ValueActionTitle = styled.span`
 const defaultRenderer: ValueRenderer = ({ value }: ValueRendererProps) => value;
 
 const Value = ({ children, field, value, queryId, render = defaultRenderer, type = FieldType.Unknown }: Props) => {
-  const RenderComponent: ValueRenderer = render || ((props: ValueRendererProps) => props.value);
-  const Component = ({ value: componentValue }) => <RenderComponent field={field} value={componentValue} />;
+  const RenderComponent: ValueRenderer = useMemo(() => render ?? ((props: ValueRendererProps) => props.value), [render]);
+  const Component = useCallback(({ value: componentValue }) => <RenderComponent field={field} value={componentValue} />, [RenderComponent, field]);
   const element = <TypeSpecificValue field={field} value={value} type={type} render={Component} />;
 
   return (

--- a/graylog2-web-interface/src/views/components/visualizations/PlotLegend.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/PlotLegend.tsx
@@ -22,10 +22,8 @@ import { chunk } from 'lodash';
 
 import ColorPicker from 'components/common/ColorPicker';
 import Value from 'views/components/Value';
-import { useStore } from 'stores/connect';
 import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
 import ChartColorContext from 'views/components/visualizations/ChartColorContext';
-import { CurrentViewStateStore } from 'views/stores/CurrentViewStateStore';
 import { Popover } from 'components/graylog';
 import FieldType from 'views/logic/fieldtypes/FieldType';
 import { colors as defaultColors } from 'views/components/visualizations/Colors';
@@ -33,6 +31,7 @@ import { EVENT_COLOR, eventsDisplayName } from 'views/logic/searchtypes/events/E
 import WidgetFocusContext from 'views/components/contexts/WidgetFocusContext';
 import Series from 'views/logic/aggregationbuilder/Series';
 import Pivot from 'views/logic/aggregationbuilder/Pivot';
+import useCurrentQueryId from 'views/logic/queries/useCurrentQueryId';
 
 const ColorHint = styled.div(({ color }) => `
   cursor: pointer;
@@ -125,7 +124,7 @@ const PlotLegend = ({ children, config, chartData, labelMapper = defaultLabelMap
   const [colorPickerConfig, setColorPickerConfig] = useState<ColorPickerConfig | undefined>();
   const { rowPivots, columnPivots, series } = config;
   const labels: Array<string> = labelMapper(chartData);
-  const { activeQuery } = useStore(CurrentViewStateStore);
+  const activeQuery = useCurrentQueryId();
   const { colors, setColor } = useContext(ChartColorContext);
   const { focusedWidget } = useContext(WidgetFocusContext);
   const defaultFieldMapper = useCallback((isFunction: boolean) => legendField(columnPivots, rowPivots, series, !neverHide, isFunction), [columnPivots, neverHide, rowPivots, series]);

--- a/graylog2-web-interface/src/views/components/visualizations/pie/PieVisualization.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/pie/PieVisualization.tsx
@@ -15,16 +15,13 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { useCallback, useMemo } from 'react';
+import { useCallback } from 'react';
 import { union } from 'lodash';
 
 import { AggregationType, AggregationResult } from 'views/components/aggregationbuilder/AggregationBuilderPropTypes';
 import type { VisualizationComponentProps } from 'views/components/aggregationbuilder/AggregationBuilder';
 import { makeVisualization, retrieveChartData } from 'views/components/aggregationbuilder/AggregationBuilder';
 import PlotLegend from 'views/components/visualizations/PlotLegend';
-import useChartData from 'views/components/visualizations/useChartData';
-import type { Generator } from 'views/components/visualizations/ChartData';
-import type ColorMapper from 'views/components/visualizations/ColorMapper';
 import type Pivot from 'views/logic/aggregationbuilder/Pivot';
 import type Series from 'views/logic/aggregationbuilder/Series';
 

--- a/graylog2-web-interface/src/views/components/visualizations/pie/PieVisualization.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/pie/PieVisualization.tsx
@@ -120,4 +120,6 @@ PieVisualization.propTypes = {
   data: AggregationResult.isRequired,
 };
 
+PieVisualization.displayName = 'PieVisualization';
+
 export default PieVisualization;

--- a/graylog2-web-interface/src/views/components/visualizations/pie/__tests__/PieVisualization.test.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/pie/__tests__/PieVisualization.test.tsx
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import { render, screen } from 'wrappedTestingLibrary';
+import userEvent from '@testing-library/user-event';
+import * as Immutable from 'immutable';
+
+import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
+import Series from 'views/logic/aggregationbuilder/Series';
+import Pivot from 'views/logic/aggregationbuilder/Pivot';
+
+import { oneRowPivotOneColumnPivot, oneRowPivot } from './fixtures';
+
+import PieVisualization from '../PieVisualization';
+
+jest.mock('views/logic/queries/useCurrentQueryId', () => () => 'query1');
+
+const effectiveTimerange = { type: 'absolute', from: '2022-04-27T12:15:59.633Z', to: '2022-04-27T12:20:59.633Z' } as const;
+const SimplePieVisualization = (props: Pick<React.ComponentProps<typeof PieVisualization>, 'config' | 'data'>) => (
+  <PieVisualization effectiveTimerange={effectiveTimerange}
+                    fields={Immutable.List()}
+                    toggleEdit={() => {}}
+                    height={800}
+                    width={600}
+                    onChange={() => {}}
+                    {...props} />
+);
+
+describe('PieVisualization', () => {
+  it('should use correct field in legend for aggregations with one row pivot', async () => {
+    const config = AggregationWidgetConfig.builder()
+      .rowPivots([Pivot.create('action', 'string')])
+      .series([Series.forFunction('count()')])
+      .build();
+    render(<SimplePieVisualization config={config} data={oneRowPivot} />);
+    const legendItem = await screen.findByText('show');
+    await userEvent.click(legendItem);
+
+    await screen.findByText('action = show');
+  });
+
+  it('should use correct field in legend for aggregations with one row and one column pivot', async () => {
+    const config = AggregationWidgetConfig.builder()
+      .columnPivots([Pivot.create('controller', 'string')])
+      .rowPivots([Pivot.create('action', 'string')])
+      .series([Series.forFunction('count()')])
+      .build();
+    render(<SimplePieVisualization config={config} data={oneRowPivotOneColumnPivot} />);
+    const legendItem = await screen.findByText('show');
+    await userEvent.click(legendItem);
+
+    await screen.findByText('action = show');
+  });
+});

--- a/graylog2-web-interface/src/views/components/visualizations/pie/__tests__/fixtures.ts
+++ b/graylog2-web-interface/src/views/components/visualizations/pie/__tests__/fixtures.ts
@@ -1,0 +1,229 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import type { Rows } from 'views/logic/searchtypes/pivot/PivotHandler';
+
+type Fixture = { [key: string]: Rows };
+export const oneRowPivotOneColumnPivot: Fixture = {
+  chart: [
+    {
+      key: [
+        'index',
+      ],
+      values: [
+        {
+          key: [
+            'PostsController',
+            'count()',
+          ],
+          value: 6863,
+          rollup: false,
+          source: 'col-leaf',
+        },
+        {
+          key: [
+            'UsersController',
+            'count()',
+          ],
+          value: 475,
+          rollup: false,
+          source: 'col-leaf',
+        },
+        {
+          key: [
+            'count()',
+          ],
+          value: 7338,
+          rollup: true,
+          source: 'row-leaf',
+        },
+      ],
+      source: 'leaf',
+    },
+    {
+      key: [
+        'show',
+      ],
+      values: [
+        {
+          key: [
+            'PostsController',
+            'count()',
+          ],
+          value: 2276,
+          rollup: false,
+          source: 'col-leaf',
+        },
+        {
+          key: [
+            'count()',
+          ],
+          value: 2276,
+          rollup: true,
+          source: 'row-leaf',
+        },
+      ],
+      source: 'leaf',
+    },
+    {
+      key: [
+        'login',
+      ],
+      values: [
+        {
+          key: [
+            'LoginController',
+            'count()',
+          ],
+          value: 1925,
+          rollup: false,
+          source: 'col-leaf',
+        },
+        {
+          key: [
+            'count()',
+          ],
+          value: 1925,
+          rollup: true,
+          source: 'row-leaf',
+        },
+      ],
+      source: 'leaf',
+    },
+    {
+      key: [
+        'edit',
+      ],
+      values: [
+        {
+          key: [
+            'PostsController',
+            'count()',
+          ],
+          value: 340,
+          rollup: false,
+          source: 'col-leaf',
+        },
+        {
+          key: [
+            'count()',
+          ],
+          value: 340,
+          rollup: true,
+          source: 'row-leaf',
+        },
+      ],
+      source: 'leaf',
+    },
+    {
+      key: [],
+      values: [
+        {
+          key: [
+            'count()',
+          ],
+          value: 11879,
+          rollup: true,
+          source: 'row-inner',
+        },
+      ],
+      source: 'non-leaf',
+    },
+  ],
+};
+
+export const oneRowPivot: Fixture = {
+  chart: [
+    {
+      key: [
+        'index',
+      ],
+      values: [
+        {
+          key: [
+            'count()',
+          ],
+          value: 7482,
+          rollup: true,
+          source: 'row-leaf',
+        },
+      ],
+      source: 'leaf',
+    },
+    {
+      key: [
+        'show',
+      ],
+      values: [
+        {
+          key: [
+            'count()',
+          ],
+          value: 2211,
+          rollup: true,
+          source: 'row-leaf',
+        },
+      ],
+      source: 'leaf',
+    },
+    {
+      key: [
+        'login',
+      ],
+      values: [
+        {
+          key: [
+            'count()',
+          ],
+          value: 1865,
+          rollup: true,
+          source: 'row-leaf',
+        },
+      ],
+      source: 'leaf',
+    },
+    {
+      key: [
+        'edit',
+      ],
+      values: [
+        {
+          key: [
+            'count()',
+          ],
+          value: 323,
+          rollup: true,
+          source: 'row-leaf',
+        },
+      ],
+      source: 'leaf',
+    },
+    {
+      key: [],
+      values: [
+        {
+          key: [
+            'count()',
+          ],
+          value: 11881,
+          rollup: true,
+          source: 'row-inner',
+        },
+      ],
+      source: 'non-leaf',
+    },
+  ],
+};

--- a/graylog2-web-interface/src/views/logic/queries/useCurrentQueryId.ts
+++ b/graylog2-web-interface/src/views/logic/queries/useCurrentQueryId.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import { useStore } from 'stores/connect';
+import { CurrentViewStateStore } from 'views/stores/CurrentViewStateStore';
+
+const useCurrentQueryId = () => {
+  const { activeQuery } = useStore(CurrentViewStateStore);
+
+  return activeQuery;
+};
+
+export default useCurrentQueryId;


### PR DESCRIPTION
**Note:** This PR is a backport of #12545 to `4.2`.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is fixing an issue where the field name which is used for the legend of a pie chart is taken from the wrong pivot. It happens when there is both at least one row and at least one column pivot defined for a pie chart. In that case, the field name is taken from the row pivot instead of the column pivot. 

This PR is now making the field mapping strategy in the `PlotLegend` component overridable, defaulting to the one which matches the chart data for most visualizations and use the mirrored one for pie charts.

Fixes https://github.com/Graylog2/graylog2-server/issues/12510.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.