### PR TITLE
Add Enable Bulk Receiving option for HTTP Gelf input (4.3 backport)

### DIFF
--- a/graylog2-server/src/test/java/org/graylog2/inputs/transports/HttpTransportConfigTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/inputs/transports/HttpTransportConfigTest.java
@@ -16,19 +16,26 @@
  */
 package org.graylog2.inputs.transports;
 
+import org.graylog2.plugin.configuration.Configuration;
 import org.graylog2.plugin.configuration.ConfigurationRequest;
 import org.graylog2.plugin.configuration.fields.ConfigurationField;
+import org.junit.Assert;
 import org.junit.Test;
+
+import java.util.HashMap;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class HttpTransportConfigTest {
     @Test
-    public void testGetRequestedConfiguration() {
-        HttpTransport.Config config = new HttpTransport.Config();
-
+    public void testConfigDefaults() {
+        final HttpTransport.Config config = new HttpTransport.Config();
         final ConfigurationRequest requestedConfiguration = config.getRequestedConfiguration();
+        assertTrue(requestedConfiguration.containsField(HttpTransport.CK_ENABLE_BULK_RECEIVING));
+        assertEquals(ConfigurationField.Optional.OPTIONAL, requestedConfiguration.getField(HttpTransport.CK_ENABLE_BULK_RECEIVING).isOptional());
+        assertEquals(false, requestedConfiguration.getField(HttpTransport.CK_ENABLE_BULK_RECEIVING).getDefaultValue());
+
         assertTrue(requestedConfiguration.containsField(HttpTransport.CK_ENABLE_CORS));
         assertEquals(ConfigurationField.Optional.OPTIONAL, requestedConfiguration.getField(HttpTransport.CK_ENABLE_CORS).isOptional());
         assertEquals(true, requestedConfiguration.getField(HttpTransport.CK_ENABLE_CORS).getDefaultValue());
@@ -36,5 +43,21 @@ public class HttpTransportConfigTest {
         assertTrue(requestedConfiguration.containsField(HttpTransport.CK_MAX_CHUNK_SIZE));
         assertEquals(ConfigurationField.Optional.OPTIONAL, requestedConfiguration.getField(HttpTransport.CK_MAX_CHUNK_SIZE).isOptional());
         assertEquals(65536, requestedConfiguration.getField(HttpTransport.CK_MAX_CHUNK_SIZE).getDefaultValue());
+    }
+
+    @Test
+    public void maxChunkSize() {
+        final HashMap<String, Object> configMap = new HashMap<>();
+        configMap.put(HttpTransport.CK_MAX_CHUNK_SIZE, 10);
+        final Configuration config = new Configuration(configMap);
+        Assert.assertEquals(10, HttpTransport.parseMaxChunkSize(config));
+    }
+
+    @Test
+    public void maxChunkSizeDefault() {
+        final HashMap<String, Object> configMap = new HashMap<>();
+        configMap.put(HttpTransport.CK_MAX_CHUNK_SIZE, -10);
+        final Configuration config = new Configuration(configMap);
+        Assert.assertEquals(HttpTransport.DEFAULT_MAX_CHUNK_SIZE, HttpTransport.parseMaxChunkSize(config));
     }
 }


### PR DESCRIPTION
Backport https://github.com/Graylog2/graylog2-server/pull/11529 to the `4.3` branch for inclusion in the `4.3.0` major release.