### PR TITLE
Fixing swagger schema generation for enums.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/documentation/generator/Generator.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/documentation/generator/Generator.java
@@ -17,23 +17,10 @@
 package org.graylog2.shared.rest.documentation.generator;
 
 import com.fasterxml.jackson.annotation.JsonValue;
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonAnyFormatVisitor;
-import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonArrayFormatVisitor;
-import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonBooleanFormatVisitor;
-import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonIntegerFormatVisitor;
-import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonMapFormatVisitor;
-import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonNullFormatVisitor;
-import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonNumberFormatVisitor;
-import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonObjectFormatVisitor;
-import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonStringFormatVisitor;
 import com.fasterxml.jackson.module.jsonSchema.JsonSchema;
 import com.fasterxml.jackson.module.jsonSchema.JsonSchemaGenerator;
-import com.fasterxml.jackson.module.jsonSchema.customProperties.TitleSchemaFactoryWrapper;
 import com.fasterxml.jackson.module.jsonSchema.factories.SchemaFactoryWrapper;
-import com.fasterxml.jackson.module.jsonSchema.factories.VisitorContext;
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 import com.google.common.collect.ComparisonChain;
@@ -827,27 +814,28 @@ public class Generator {
 
         @JsonValue
         public Map<String, Object> jsonValue() {
-            ImmutableMap.Builder<String, Object> builder = ImmutableMap.<String, Object>builder()
-                    .put("name", name)
-                    .put("description", description)
-                    .put("required", isRequired)
-                    .put("paramType", getKind());
+            final HashMap<String, Object> result = new HashMap<String, Object>() {{
+                put("name", name);
+                put("description", description);
+                put("required", isRequired);
+                put("paramType", getKind());
 
-            if (defaultValue != null) {
-                builder = builder.put("defaultValue", defaultValue);
-            }
+                if (defaultValue != null) {
+                    put("defaultValue", defaultValue);
+                }
 
-            if (allowableValues != null) {
-                builder = builder.put("enum", allowableValues);
-            }
+                if (allowableValues != null) {
+                    put("enum", allowableValues);
+                }
 
-            if (typeSchema.type() == null || isObjectSchema(typeSchema.type())) {
-                builder = builder.put("type", typeSchema.name());
-            } else {
-                builder = builder.putAll(typeSchema.type());
-            }
+                if (typeSchema.type() == null || isObjectSchema(typeSchema.type())) {
+                    put("type", typeSchema.name());
+                } else {
+                    putAll(typeSchema.type());
+                }
+            }};
 
-            return builder.build();
+            return ImmutableMap.copyOf(result);
         }
 
         public enum Kind {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Prior to this PR, generating the swagger schema failed for enums under certain conditions, because the enum values were provided twice in the generated schema. This results in a map entry conflict during JSON serialization because of the usage of `ImmutableMap.Builder`, which does not allow keys to be set twice.

This change is now making sure that defining the `enum` field for a type schema twice does not lead to an exception, through the use of a plain `HashMap` when providing the JSON value.

Fixes Graylog2/graylog-plugin-enterprise#3529.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.