### PR TITLE
Mock `QueryInput` in `DashboardSearchBar.test` to reduce its runtime.

### DIFF
--- a/graylog2-web-interface/src/views/components/DashboardSearchBar.test.tsx
+++ b/graylog2-web-interface/src/views/components/DashboardSearchBar.test.tsx
@@ -27,6 +27,7 @@ import WidgetFocusContext from 'views/components/contexts/WidgetFocusContext';
 
 import DashboardSearchBar from './DashboardSearchBar';
 
+jest.mock('views/components/searchbar/queryinput/QueryInput', () => ({ value = '' }: { value: string }) => <span>{value}</span>);
 jest.mock('views/components/ViewActionsMenu', () => () => <span>View Actions</span>);
 jest.mock('hooks/useUserDateTime');
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

With this PR we are mocking the `QueryInput` in the `DashboardSearchBar.test`, because the test case `should call SearchActions.refresh and set global override on submit when there are changes` is a flaky test.

Here is an example of its failure: https://jenkins.ci.torch.sh/job/Graylog-Snapshots/job/graylog2-server/job/master/2200/console

This test case is the only test case in this file which takes so much time, improving the performance of the `QueryInput`, by reducing the amount of rerenders is not helping with the long runtime. Mocking this component is reducing the runtime by ~70%.