### PR TITLE
Avoiding calling `useMemo` outside of component.

### DIFF
--- a/graylog2-web-interface/src/views/components/datatable/DataTableEntry.tsx
+++ b/graylog2-web-interface/src/views/components/datatable/DataTableEntry.tsx
@@ -56,11 +56,13 @@ type Props = {
 
 const _c = (field, value, path, source) => ({ field, value, path, source });
 
-const _column = (field: string, value: any, selectedQuery: string, idx: number, type: FieldType, valuePath: ValuePath, source: string | undefined | null) => {
+type ColumnProps = { field: string, value: any, selectedQuery: string, type: FieldType, valuePath: ValuePath, source: string | undefined | null };
+
+const Column = ({ field, value, selectedQuery, type, valuePath, source }: ColumnProps) => {
   const additionalContextValue = useMemo(() => ({ valuePath }), [valuePath]);
 
   return (
-    <StyledTd isNumeric={type.isNumeric()} key={`${selectedQuery}-${field}=${value}-${idx}`}>
+    <StyledTd isNumeric={type.isNumeric()}>
       <AdditionalContext.Provider value={additionalContextValue}>
         <CustomHighlighting field={source ?? field} value={value}>
           {value !== null && value !== undefined
@@ -117,7 +119,16 @@ const DataTableEntry = ({ columnPivots, currentView, fields, series, columnPivot
   return (
     <tbody className={classes}>
       <tr className="fields-row">
-        {columns.map(({ field, value, path, source }, idx) => _column(field, value, activeQuery, idx, fieldTypeFor(columnNameToField(field, series), types), path.slice(), source))}
+        {columns.map(({ field, value, path, source }, idx) => (
+          // eslint-disable-next-line react/no-array-index-key
+          <Column key={`${activeQuery}-${field}=${value}-${idx}`}
+                  field={field}
+                  value={value}
+                  selectedQuery={activeQuery}
+                  type={fieldTypeFor(columnNameToField(field, series), types)}
+                  valuePath={path.slice()}
+                  source={source} />
+        ))}
       </tr>
     </tbody>
   );


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is turning the `_column` function into a separate component.  Prior to it, the `_column` function called `useMemo` after #12528 was introduced, which lead to it being called conditionally resulting in different numbers of calls between rerenders, leading to an exception being thrown.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.