### PR TITLE
chore: add claims string type to OidcBackendConfig and improve the KeyValueTable component

### DIFF
--- a/graylog2-web-interface/src/components/common/KeyValueTable.css
+++ b/graylog2-web-interface/src/components/common/KeyValueTable.css
@@ -1,8 +1,0 @@
-/*
- * Nesting a form-group inside a form-group breaks the margins of input fields.
- * We reset the margins in that case but scope it to the KeyValueTable component to avoid affecting others by accident.
- */
-.form-horizontal .form-group .key-value-table-component .form-group {
-    margin-left: 0;
-    margin-right: 0;
-}

--- a/graylog2-web-interface/src/components/common/KeyValueTable.jsx
+++ b/graylog2-web-interface/src/components/common/KeyValueTable.jsx
@@ -16,12 +16,17 @@
  */
 import PropTypes from 'prop-types';
 import React from 'react';
+import styled from 'styled-components';
 
 import { Button, Input, Table } from 'components/bootstrap';
 import ObjectUtils from 'util/ObjectUtils';
 
-// eslint-disable-next-line no-unused-vars
-import style from './KeyValueTable.css';
+const StyledDiv = styled.div`
+  .form-group {
+    margin-left: 0;
+    margin-right: 0;
+  }
+`;
 
 /**
  * KeyValueTable displays a table for all key-value pairs in a JS object. If the editable prop is set to true, it also
@@ -154,24 +159,28 @@ class KeyValueTable extends React.Component {
     return (
       <tr>
         <td>
-          <Input type="text"
-                 name="newKey"
-                 id="newKey"
-                 data-testid="newKey"
-                 bsSize="small"
-                 placeholder={this.props.headers[0]}
-                 value={this.state.newKey}
-                 onChange={this._bindValue} />
+          <StyledDiv>
+            <Input type="text"
+                   name="newKey"
+                   id="newKey"
+                   data-testid="newKey"
+                   bsSize="small"
+                   placeholder={this.props.headers[0]}
+                   value={this.state.newKey}
+                   onChange={this._bindValue} />
+          </StyledDiv>
         </td>
         <td>
-          <Input type="text"
-                 name="newValue"
-                 id="newValue"
-                 data-testid="newValue"
-                 bsSize="small"
-                 placeholder={this.props.headers[1]}
-                 value={this.state.newValue}
-                 onChange={this._bindValue} />
+          <StyledDiv>
+            <Input type="text"
+                   name="newValue"
+                   id="newValue"
+                   data-testid="newValue"
+                   bsSize="small"
+                   placeholder={this.props.headers[1]}
+                   value={this.state.newValue}
+                   onChange={this._bindValue} />
+          </StyledDiv>
         </td>
         <td>
           <Button bsStyle="success" bsSize="small" onClick={this._addRow} disabled={addRowDisabled}>Add</Button>

--- a/graylog2-web-interface/src/components/common/KeyValueTable.jsx
+++ b/graylog2-web-interface/src/components/common/KeyValueTable.jsx
@@ -50,15 +50,6 @@ class KeyValueTable extends React.Component {
     actionsSize: PropTypes.oneOf(['large', 'medium', 'small', 'xsmall']),
   };
 
-  static defaultProps = {
-    headers: ['Name', 'Value', 'Actions'],
-    editable: false,
-    actionsSize: 'xsmall',
-    className: '',
-    containerClassName: '',
-    onChange: () => {},
-  };
-
   constructor(props) {
     super(props);
 
@@ -205,5 +196,14 @@ class KeyValueTable extends React.Component {
     );
   }
 }
+
+KeyValueTable.defaultProps = {
+  headers: ['Name', 'Value', 'Actions'],
+  editable: false,
+  actionsSize: 'xsmall',
+  className: '',
+  containerClassName: '',
+  onChange: () => {},
+};
 
 export default KeyValueTable;

--- a/graylog2-web-interface/src/components/common/KeyValueTable.jsx
+++ b/graylog2-web-interface/src/components/common/KeyValueTable.jsx
@@ -16,17 +16,12 @@
  */
 import PropTypes from 'prop-types';
 import React from 'react';
-import styled, { css } from 'styled-components';
 
-import { Button, Input } from 'components/bootstrap';
+import { Button, Input, Table } from 'components/bootstrap';
 import ObjectUtils from 'util/ObjectUtils';
 
 // eslint-disable-next-line no-unused-vars
 import style from './KeyValueTable.css';
-
-const Tr = styled.tr(({ theme }) => css`
-  background-color: ${theme.colors.input.background} !important;
-`);
 
 /**
  * KeyValueTable displays a table for all key-value pairs in a JS object. If the editable prop is set to true, it also
@@ -104,7 +99,7 @@ class KeyValueTable extends React.Component {
 
   _formattedHeaders = (headers) => {
     return (
-      <Tr>
+      <tr>
         {headers.map((header, idx) => {
           const customStyle = {};
 
@@ -119,7 +114,7 @@ class KeyValueTable extends React.Component {
 
           return <th key={header} style={customStyle}>{header}</th>;
         })}
-      </Tr>
+      </tr>
     );
   };
 
@@ -140,11 +135,11 @@ class KeyValueTable extends React.Component {
       }
 
       return (
-        <Tr key={key}>
+        <tr key={key}>
           <td>{key}</td>
           <td>{pairs[key]}</td>
           {actionsColumn}
-        </Tr>
+        </tr>
       );
     });
   };
@@ -157,7 +152,7 @@ class KeyValueTable extends React.Component {
     const addRowDisabled = !this.state.newKey || !this.state.newValue;
 
     return (
-      <Tr>
+      <tr>
         <td>
           <Input type="text"
                  name="newKey"
@@ -181,7 +176,7 @@ class KeyValueTable extends React.Component {
         <td>
           <Button bsStyle="success" bsSize="small" onClick={this._addRow} disabled={addRowDisabled}>Add</Button>
         </td>
-      </Tr>
+      </tr>
     );
   };
 
@@ -189,13 +184,13 @@ class KeyValueTable extends React.Component {
     return (
       <div className="key-value-table-component">
         <div className={`table-responsive ${this.props.containerClassName}`}>
-          <table className={`table table-striped ${this.props.className}`}>
+          <Table className={`table table-striped ${this.props.className}`}>
             <thead>{this._formattedHeaders(this.props.headers)}</thead>
             <tbody>
               {this._formattedRows(this.props.pairs)}
               {this._newRow()}
             </tbody>
-          </table>
+          </Table>
         </div>
       </div>
     );

--- a/graylog2-web-interface/src/components/common/KeyValueTable.jsx
+++ b/graylog2-web-interface/src/components/common/KeyValueTable.jsx
@@ -16,12 +16,17 @@
  */
 import PropTypes from 'prop-types';
 import React from 'react';
+import styled, { css } from 'styled-components';
 
 import { Button, Input } from 'components/bootstrap';
 import ObjectUtils from 'util/ObjectUtils';
 
 // eslint-disable-next-line no-unused-vars
 import style from './KeyValueTable.css';
+
+const Tr = styled.tr(({ theme }) => css`
+  background-color: ${theme.colors.input.background} !important;
+`);
 
 /**
  * KeyValueTable displays a table for all key-value pairs in a JS object. If the editable prop is set to true, it also
@@ -93,7 +98,7 @@ class KeyValueTable extends React.Component {
 
   _formattedHeaders = (headers) => {
     return (
-      <tr>
+      <Tr>
         {headers.map((header, idx) => {
           const style = {};
 
@@ -108,7 +113,7 @@ class KeyValueTable extends React.Component {
 
           return <th key={header} style={style}>{header}</th>;
         })}
-      </tr>
+      </Tr>
     );
   };
 
@@ -129,11 +134,11 @@ class KeyValueTable extends React.Component {
       }
 
       return (
-        <tr key={key}>
+        <Tr key={key}>
           <td>{key}</td>
           <td>{pairs[key]}</td>
           {actionsColumn}
-        </tr>
+        </Tr>
       );
     });
   };
@@ -146,7 +151,7 @@ class KeyValueTable extends React.Component {
     const addRowDisabled = !this.state.newKey || !this.state.newValue;
 
     return (
-      <tr>
+      <Tr>
         <td>
           <Input type="text"
                  name="newKey"
@@ -170,7 +175,7 @@ class KeyValueTable extends React.Component {
         <td>
           <Button bsStyle="success" bsSize="small" onClick={this._addRow} disabled={addRowDisabled}>Add</Button>
         </td>
-      </tr>
+      </Tr>
     );
   };
 

--- a/graylog2-web-interface/src/components/common/KeyValueTable.jsx
+++ b/graylog2-web-interface/src/components/common/KeyValueTable.jsx
@@ -56,12 +56,17 @@ class KeyValueTable extends React.Component {
     actionsSize: 'xsmall',
     className: '',
     containerClassName: '',
+    onChange: () => {},
   };
 
-  state = {
-    newKey: '',
-    newValue: '',
-  };
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      newKey: '',
+      newValue: '',
+    };
+  }
 
   _onPairsChange = (newPairs) => {
     if (this.props.onChange) {
@@ -87,6 +92,7 @@ class KeyValueTable extends React.Component {
 
   _deleteRow = (key) => {
     return () => {
+      // eslint-disable-next-line no-alert
       if (window.confirm(`Are you sure you want to delete property '${key}'?`)) {
         const newPairs = ObjectUtils.clone(this.props.pairs);
 
@@ -100,7 +106,7 @@ class KeyValueTable extends React.Component {
     return (
       <Tr>
         {headers.map((header, idx) => {
-          const style = {};
+          const customStyle = {};
 
           // Hide last column or apply width so it sticks to the right
           if (idx === headers.length - 1) {
@@ -108,10 +114,10 @@ class KeyValueTable extends React.Component {
               return null;
             }
 
-            style.width = 75;
+            customStyle.width = 75;
           }
 
-          return <th key={header} style={style}>{header}</th>;
+          return <th key={header} style={customStyle}>{header}</th>;
         })}
       </Tr>
     );

--- a/graylog2-web-interface/src/logic/authentication/okta/types.ts
+++ b/graylog2-web-interface/src/logic/authentication/okta/types.ts
@@ -32,7 +32,7 @@ export interface OktaBackendConfig extends SharedBackendConfig {
 }
 export interface OidcBackendConfig extends SharedBackendConfig {
   baseUrl?: string;
-  claims?: string;
+  claims?: { [key: string]: string },
 }
 
 export type BackendConfig = OktaBackendConfig | OidcBackendConfig;
@@ -49,7 +49,7 @@ export interface OktaBackendConfigJson extends SharedBackendConfigJson {
 
 export interface OidcBackendConfigJson extends SharedBackendConfigJson {
   base_url: string;
-  claims: string;
+  claims: { [key: string]: string };
 }
 
 export type BackendConfigJson = OktaBackendConfigJson | OidcBackendConfigJson

--- a/graylog2-web-interface/src/logic/authentication/okta/types.ts
+++ b/graylog2-web-interface/src/logic/authentication/okta/types.ts
@@ -32,6 +32,7 @@ export interface OktaBackendConfig extends SharedBackendConfig {
 }
 export interface OidcBackendConfig extends SharedBackendConfig {
   baseUrl?: string;
+  claims?: string;
 }
 
 export type BackendConfig = OktaBackendConfig | OidcBackendConfig;
@@ -48,6 +49,7 @@ export interface OktaBackendConfigJson extends SharedBackendConfigJson {
 
 export interface OidcBackendConfigJson extends SharedBackendConfigJson {
   base_url: string;
+  claims: string;
 }
 
 export type BackendConfigJson = OktaBackendConfigJson | OidcBackendConfigJson


### PR DESCRIPTION
# Description

Introduce new string `claims` to `OidcBackendConfig` and `OidcBackendConfigJson`.

And improve the `KeyValueTable` component (fix the dark mode):

![Screenshot 2022-05-17 at 16 36 37](https://user-images.githubusercontent.com/92227/168837624-80adf49e-f0f2-4867-a385-6d02fa6ac410.png)

![Screenshot 2022-05-17 at 16 36 51](https://user-images.githubusercontent.com/92227/168837681-e21f0317-34a7-42a2-aded-65367aa05e2a.png)


# Types of changes
- [x] Chore

/jenkins-pr-deps https://github.com/Graylog2/graylog-plugin-enterprise/pull/3544