### PR TITLE
Feature/extend search page customization (#12600)

### DIFF
--- a/graylog2-web-interface/src/hooks/useSearchPageLayout.ts
+++ b/graylog2-web-interface/src/hooks/useSearchPageLayout.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+
+import { useContext } from 'react';
+
+import SearchPageLayoutContext, { DEFAULT_STATE } from 'views/components/contexts/SearchPageLayoutContext';
+
+export default function useSearchPageLayout() {
+  let context = useContext(SearchPageLayoutContext);
+
+  if (context === undefined) {
+    context = DEFAULT_STATE;
+  }
+
+  return context;
+}

--- a/graylog2-web-interface/src/pages/SecurityPage.tsx
+++ b/graylog2-web-interface/src/pages/SecurityPage.tsx
@@ -61,10 +61,10 @@ const LinkTo = () => {
 const SecurityPage = () => {
   return (
     <StyledAlert bsStyle="danger" className="tm">
-      <StyledH2>Invalid License for Analyst Tools</StyledH2>
-      <StyledH4>Analyst Tools are disabled</StyledH4>
+      <StyledH2>Invalid License for the Security plugin</StyledH2>
+      <StyledH4>Security plugin is disabled</StyledH4>
       <p>
-        Analyst Tools are disabled because a valid Graylog for Security license was not found{Routes.pluginRoute('SYSTEM_LICENSES', false) ? '' : ' and the enterprise plugin is not installed'}.
+        The security plugin is disabled because a valid Graylog for Security license was not found{Routes.pluginRoute('SYSTEM_LICENSES', false) ? '' : ' and the enterprise plugin is not installed'}.
       </p>
       {isCloud
         ? (<>Contact your Graylog account manager.</>)

--- a/graylog2-web-interface/src/routing/Routes.ts
+++ b/graylog2-web-interface/src/routing/Routes.ts
@@ -343,7 +343,7 @@ const getPluginRoute = (routeKey) => pluginRoute(routeKey, false);
  *
  */
 export const ENTERPRISE_ROUTE_DESCRIPTION = 'Enterprise';
-export const SECURITY_ROUTE_DESCRIPTION = 'Analyst Tools';
+export const SECURITY_ROUTE_DESCRIPTION = 'Security';
 
 const defaultExport = Object.assign(qualifiedRoutes, { pluginRoute, getPluginRoute, unqualified });
 

--- a/graylog2-web-interface/src/views/components/Search.tsx
+++ b/graylog2-web-interface/src/views/components/Search.tsx
@@ -50,9 +50,10 @@ import { ViewMetadataStore } from 'views/stores/ViewMetadataStore';
 import { AdditionalContext } from 'views/logic/ActionContext';
 import DefaultFieldTypesProvider from 'views/components/contexts/DefaultFieldTypesProvider';
 import InteractiveContext from 'views/components/contexts/InteractiveContext';
+import useSearchPageLayout from 'hooks/useSearchPageLayout';
 import HighlightingRulesProvider from 'views/components/contexts/HighlightingRulesProvider';
-import SearchPageLayoutProvider from 'views/components/contexts/SearchPageLayoutProvider';
 import usePluginEntities from 'views/logic/usePluginEntities';
+import SearchPagePreferencesProvider from 'views/components/contexts/SearchPagePreferencesProvider';
 import WidgetFocusProvider from 'views/components/contexts/WidgetFocusProvider';
 import WidgetFocusContext from 'views/components/contexts/WidgetFocusContext';
 import type SearchExecutionState from 'views/logic/search/SearchExecutionState';
@@ -170,6 +171,7 @@ const Search = () => {
     () => _refreshIfNotUndeclared(searchRefreshHooks, SearchExecutionStateStore.getInitialState(), setHasErrors),
     [searchRefreshHooks],
   );
+  const { sidebar: { isShown: showSidebar } } = useSearchPageLayout();
 
   useRefreshSearchOn([SearchActions.refresh, ViewActions.search], refreshIfNotUndeclared);
 
@@ -198,15 +200,17 @@ const Search = () => {
               </IfInteractive>
               <InteractiveContext.Consumer>
                 {(interactive) => (
-                  <SearchPageLayoutProvider>
+                  <SearchPagePreferencesProvider>
                     <DefaultFieldTypesProvider>
                       <ViewAdditionalContextProvider>
                         <HighlightingRulesProvider>
                           <GridContainer id="main-row" interactive={interactive}>
                             <IfInteractive>
+                              {showSidebar && (
                               <ConnectedSidebar>
                                 <FieldsOverview />
                               </ConnectedSidebar>
+                              )}
                             </IfInteractive>
                             <SearchArea>
                               <IfInteractive>
@@ -233,7 +237,7 @@ const Search = () => {
                         </HighlightingRulesProvider>
                       </ViewAdditionalContextProvider>
                     </DefaultFieldTypesProvider>
-                  </SearchPageLayoutProvider>
+                  </SearchPagePreferencesProvider>
                 )}
               </InteractiveContext.Consumer>
             </CurrentViewTypeProvider>

--- a/graylog2-web-interface/src/views/components/ViewActionsMenu.tsx
+++ b/graylog2-web-interface/src/views/components/ViewActionsMenu.tsx
@@ -30,7 +30,8 @@ import onSaveAsView from 'views/logic/views/OnSaveAsViewAction';
 import { ViewStore } from 'views/stores/ViewStore';
 import { SearchMetadataStore } from 'views/stores/SearchMetadataStore';
 import type SearchMetadata from 'views/logic/search/SearchMetadata';
-import * as Permissions from 'views/Permissions';
+import * as ViewPermissions from 'views/Permissions';
+import useSearchPageLayout from 'hooks/useSearchPageLayout';
 import View from 'views/logic/views/View';
 import type User from 'logic/users/User';
 import CurrentUserContext from 'contexts/CurrentUserContext';
@@ -41,13 +42,26 @@ import ViewPropertiesModal from './views/ViewPropertiesModal';
 import IfDashboard from './dashboard/IfDashboard';
 import BigDisplayModeConfiguration from './dashboard/BigDisplayModeConfiguration';
 
-const _isAllowedToEdit = (view: View, currentUser: User | undefined | null) => isPermitted(currentUser?.permissions, [Permissions.View.Edit(view.id)])
+const _isAllowedToEdit = (view: View, currentUser: User | undefined | null) => isPermitted(currentUser?.permissions, [ViewPermissions.View.Edit(view.id)])
   || (view.type === View.Type.Dashboard && isPermitted(currentUser?.permissions, [`dashboards:edit:${view.id}`]));
 
 const _hasUndeclaredParameters = (searchMetadata: SearchMetadata) => searchMetadata.undeclared.size > 0;
 
 const ViewActionsMenu = ({ view, isNewView, metadata }) => {
   const currentUser = useContext(CurrentUserContext);
+  const {
+    viewActions: {
+      save: {
+        isShown: showSaveButton,
+      }, saveAs: {
+        isShown: showSaveAsButton,
+      }, share: {
+        isShown: showShareButton,
+      }, actionsDropdown: {
+        isShown: showDropDownButton,
+      },
+    },
+  } = useSearchPageLayout();
   const [shareViewOpen, setShareViewOpen] = useState(false);
   const [debugOpen, setDebugOpen] = useState(false);
   const [saveAsViewOpen, setSaveAsViewOpen] = useState(false);
@@ -67,21 +81,28 @@ const ViewActionsMenu = ({ view, isNewView, metadata }) => {
 
   return (
     <ButtonGroup>
+      {showSaveButton && (
       <Button onClick={() => onSaveView(view)}
               disabled={isNewView || hasUndeclaredParameters || !allowedToEdit}
-              data-testid="dashboard-save-button">
+              title="Save dashboard">
         <Icon name="save" /> Save
       </Button>
+      )}
+      {showSaveAsButton && (
       <Button onClick={() => setSaveAsViewOpen(true)}
               disabled={hasUndeclaredParameters}
-              data-testid="dashboard-save-as-button">
+              title="Save as new dashboard">
         <Icon name="copy" /> Save as
       </Button>
+      )}
+      {showShareButton && (
       <ShareButton entityType="dashboard"
                    entityId={view.id}
                    onClick={() => setShareViewOpen(true)}
                    bsStyle="default"
                    disabledInfo={isNewView && 'Only saved dashboards can be shared.'} />
+      )}
+      {showDropDownButton && (
       <DropdownButton title={<Icon name="ellipsis-h" />} id="query-tab-actions-dropdown" pullRight noCaret>
         <MenuItem onSelect={() => setEditViewOpen(true)} disabled={isNewView || !allowedToEdit}>
           <Icon name="edit" /> Edit metadata
@@ -93,6 +114,7 @@ const ViewActionsMenu = ({ view, isNewView, metadata }) => {
           <BigDisplayModeConfiguration view={view} disabled={isNewView} />
         </IfDashboard>
       </DropdownButton>
+      )}
       {debugOpen && <DebugOverlay show onClose={() => setDebugOpen(false)} />}
       {saveAsViewOpen && (
         <ViewPropertiesModal show

--- a/graylog2-web-interface/src/views/components/contexts/SearchPageLayoutContext.test.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/SearchPageLayoutContext.test.tsx
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import { render } from 'wrappedTestingLibrary';
+
+import type { LayoutState } from 'views/components/contexts/SearchPageLayoutContext';
+import SearchPageLayoutContext, { SAVE_COPY } from 'views/components/contexts/SearchPageLayoutContext';
+
+describe('SearchPageConfigProvider', () => {
+  const SUT = (suppliedProviderOverrides : LayoutState = undefined) => {
+    let contextValue;
+
+    render(
+      <SearchPageLayoutContext.Provider value={suppliedProviderOverrides}>
+        <SearchPageLayoutContext.Consumer>
+          {(value) => {
+            contextValue = value;
+
+            return <div />;
+          }}
+        </SearchPageLayoutContext.Consumer>
+
+      </SearchPageLayoutContext.Provider>,
+    );
+
+    return contextValue;
+  };
+
+  it('provides the overridden provider state when supplied', () => {
+    const providerOverrides: LayoutState = {
+      sidebar: { isShown: false }, viewActions: SAVE_COPY,
+    };
+    const contextValue = SUT(providerOverrides);
+
+    expect(contextValue).toEqual(providerOverrides);
+  });
+});

--- a/graylog2-web-interface/src/views/components/contexts/SearchPageLayoutContext.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/SearchPageLayoutContext.tsx
@@ -14,19 +14,57 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
+
 import * as React from 'react';
 
-type SearchPageLayoutConfig = {
-  sidebar: {
-    isPinned: boolean,
-  },
+import { singleton } from 'logic/singleton';
+
+export interface ViewActions {
+  save: {
+    isShown: boolean,
+  };
+  saveAs: {
+    isShown: boolean,
+  };
+  share: {
+    isShown: boolean,
+  }
+  actionsDropdown: {
+    isShown: boolean,
+  }
+}
+
+export const FULL_MENU: ViewActions = {
+  save: { isShown: true },
+  saveAs: { isShown: true },
+  share: { isShown: true },
+  actionsDropdown: { isShown: true },
 };
 
-export type SearchPageLayout = {
-  config: SearchPageLayoutConfig,
-  actions: { toggleSidebarPinning: () => void },
+export const SAVE_COPY: ViewActions = {
+  save: { isShown: false },
+  saveAs: { isShown: true },
+  share: { isShown: false },
+  actionsDropdown: { isShown: false },
 };
 
-const SearchPageLayoutContext = React.createContext<SearchPageLayout | undefined>(undefined);
+export const BLANK: ViewActions = {
+  save: { isShown: false },
+  saveAs: { isShown: false },
+  share: { isShown: false },
+  actionsDropdown: { isShown: false },
+};
 
-export default SearchPageLayoutContext;
+export type LayoutState = {
+  sidebar: { isShown: boolean }
+  viewActions: ViewActions
+}
+
+export const DEFAULT_STATE: LayoutState = {
+  sidebar: { isShown: true },
+  viewActions: FULL_MENU,
+};
+
+const SearchPageLayoutContext = React.createContext<LayoutState>(DEFAULT_STATE);
+
+export default singleton('contexts.SearchPageLayout', () => SearchPageLayoutContext);

--- a/graylog2-web-interface/src/views/components/contexts/SearchPagePreferencesContext.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/SearchPagePreferencesContext.tsx
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+
+import { singleton } from 'logic/singleton';
+
+type SearchPagePreferencesConfig = {
+  sidebar: {
+    isPinned: boolean,
+  },
+};
+
+export type SearchPagePreferences = {
+  config: SearchPagePreferencesConfig,
+  actions: { toggleSidebarPinning: () => void },
+};
+
+const SearchPagePreferencesContext = React.createContext<SearchPagePreferences | undefined>(undefined);
+
+export default singleton('contexts.SearchPagePreferences', () => SearchPagePreferencesContext);

--- a/graylog2-web-interface/src/views/components/contexts/SearchPagePreferencesProvider.test.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/SearchPagePreferencesProvider.test.tsx
@@ -28,8 +28,8 @@ import { CurrentUserStore } from 'stores/users/CurrentUserStore';
 import type { UserJSON } from 'logic/users/User';
 import { PreferencesActions } from 'stores/users/PreferencesStore';
 
-import SearchPageLayoutContext from './SearchPageLayoutContext';
-import SearchPageLayoutProvider from './SearchPageLayoutProvider';
+import SearchPagePreferencesContext from './SearchPagePreferencesContext';
+import SearchPagePreferencesProvider from './SearchPagePreferencesProvider';
 
 jest.mock('stores/users/CurrentUserStore', () => ({
   CurrentUserStore: MockStore(),
@@ -48,16 +48,16 @@ jest.mock('logic/local-storage/Store', () => ({
   set: jest.fn(),
 }));
 
-describe('SearchPageLayoutProvider', () => {
+describe('SearchPagePreferencesProvider', () => {
   const SimpleProvider = ({ children }: { children: any }) => (
     <CurrentUserProvider>
       <CurrentUserPreferencesProvider>
         <CurrentViewTypeProvider type={View.Type.Search}>
-          <SearchPageLayoutProvider>
-            <SearchPageLayoutContext.Consumer>
+          <SearchPagePreferencesProvider>
+            <SearchPagePreferencesContext.Consumer>
               {children}
-            </SearchPageLayoutContext.Consumer>
-          </SearchPageLayoutProvider>
+            </SearchPagePreferencesContext.Consumer>
+          </SearchPagePreferencesProvider>
         </CurrentViewTypeProvider>
       </CurrentUserPreferencesProvider>
     </CurrentUserProvider>
@@ -65,9 +65,9 @@ describe('SearchPageLayoutProvider', () => {
 
   const ProviderWithToggleButton = () => (
     <SimpleProvider>
-      {(searchPageLayout) => {
-        if (!searchPageLayout) return '';
-        const { actions: { toggleSidebarPinning } } = searchPageLayout;
+      {(searchPagePreferences) => {
+        if (!searchPagePreferences) return '';
+        const { actions: { toggleSidebarPinning } } = searchPagePreferences;
 
         return (<button type="button" onClick={() => toggleSidebarPinning()}>Toggle sidebar pinning</button>);
       }}
@@ -86,29 +86,29 @@ describe('SearchPageLayoutProvider', () => {
     return consume;
   };
 
-  it('provides default search page layout with empty preference store', () => {
+  it('provides default search page preference state with empty preference store', () => {
     const consume = renderSUT();
 
-    expect(consume.mock.calls[0][0]?.config.sidebar.isPinned).toEqual(false);
+    expect(consume).toHaveBeenCalledWith(expect.objectContaining({ config: expect.objectContaining({ sidebar: expect.objectContaining({ isPinned: false }) }) }));
   });
 
-  it('provides default search page layout if user does not exists', () => {
+  it('provides default search page preference state if user does not exists', () => {
     asMock(CurrentUserStore.getInitialState).mockReturnValue({ currentUser: {} as UserJSON });
 
     const consume = renderSUT();
 
-    expect(consume.mock.calls[0][0]?.config.sidebar.isPinned).toEqual(false);
+    expect(consume).toHaveBeenCalledWith(expect.objectContaining({ config: expect.objectContaining({ sidebar: expect.objectContaining({ isPinned: false }) }) }));
   });
 
-  it('provides default search page layout if user has no preferences', () => {
+  it('provides default search page preference state if user has no preferences', () => {
     asMock(CurrentUserStore.getInitialState).mockReturnValue({ currentUser: { preferences: {} } as UserJSON });
 
     const consume = renderSUT();
 
-    expect(consume.mock.calls[0][0]?.config.sidebar.isPinned).toEqual(false);
+    expect(consume).toHaveBeenCalledWith(expect.objectContaining({ config: expect.objectContaining({ sidebar: expect.objectContaining({ isPinned: false }) }) }));
   });
 
-  it('provides search page layout based on user preferences', () => {
+  it('provides search page preferences based on user preferences', () => {
     asMock(CurrentUserStore.getInitialState).mockReturnValue({
       currentUser: {
         preferences: {
@@ -119,10 +119,10 @@ describe('SearchPageLayoutProvider', () => {
 
     const consume = renderSUT();
 
-    expect(consume.mock.calls[0][0]?.config.sidebar.isPinned).toEqual(true);
+    expect(consume).toHaveBeenCalledWith(expect.objectContaining({ config: expect.objectContaining({ sidebar: expect.objectContaining({ isPinned: true }) }) }));
   });
 
-  it('provides search page layout based on local storage for system admin', () => {
+  it('provides search page preference state based on local storage for system admin', () => {
     asMock(Store.get).mockImplementationOnce((key) => {
       if (key === 'searchSidebarIsPinned') return true;
 
@@ -139,10 +139,10 @@ describe('SearchPageLayoutProvider', () => {
 
     const consume = renderSUT();
 
-    expect(consume.mock.calls[0][0]?.config.sidebar.isPinned).toEqual(true);
+    expect(consume).toHaveBeenCalledWith(expect.objectContaining({ config: expect.objectContaining({ sidebar: expect.objectContaining({ isPinned: true }) }) }));
   });
 
-  it('should update user preferences on layout change', () => {
+  it('should update user preferences on state change', () => {
     asMock(CurrentUserStore.getInitialState).mockReturnValue({
       currentUser: {
         username: 'alice',
@@ -169,7 +169,7 @@ describe('SearchPageLayoutProvider', () => {
     );
   });
 
-  it('should update local storage on layout change for system admin', () => {
+  it('should update local storage on preference state change for system admin', () => {
     asMock(CurrentUserStore.getInitialState).mockReturnValue({
       currentUser: {
         id: 'local:admin',

--- a/graylog2-web-interface/src/views/components/contexts/SearchPagePreferencesProvider.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/SearchPagePreferencesProvider.tsx
@@ -17,35 +17,35 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 
-import SearchPageLayoutContext from './SearchPageLayoutContext';
-import SearchPageLayoutState from './SearchPageLayoutState';
+import SearchPagePreferencesContext from './SearchPagePreferencesContext';
+import SearchPagePreferencesState from './SearchPagePreferencesState';
 
 type Props = {
   children: React.ReactElement,
 };
 
-const SearchPageLayoutProvider = ({ children }: Props) => {
+const SearchPagePreferencesProvider = ({ children }: Props) => {
   return (
-    <SearchPageLayoutState>
-      {({ getLayoutState, setLayoutState }) => {
+    <SearchPagePreferencesState>
+      {({ getPreferenceState, setPreferenceState }) => {
         const config = {
-          sidebar: { isPinned: getLayoutState('sidebarIsPinned', false) },
+          sidebar: { isPinned: getPreferenceState('sidebarIsPinned', false) },
         };
-        const actions = { toggleSidebarPinning: () => setLayoutState('sidebarIsPinned', !config.sidebar.isPinned) };
+        const actions = { toggleSidebarPinning: () => setPreferenceState('sidebarIsPinned', !config.sidebar.isPinned) };
 
         return (
-          <SearchPageLayoutContext.Provider value={{ config, actions }}>
+          <SearchPagePreferencesContext.Provider value={{ config, actions }}>
             {children}
-          </SearchPageLayoutContext.Provider>
+          </SearchPagePreferencesContext.Provider>
         );
       }}
 
-    </SearchPageLayoutState>
+    </SearchPagePreferencesState>
   );
 };
 
-SearchPageLayoutProvider.propTypes = {
+SearchPagePreferencesProvider.propTypes = {
   children: PropTypes.node.isRequired,
 };
 
-export default SearchPageLayoutProvider;
+export default SearchPagePreferencesProvider;

--- a/graylog2-web-interface/src/views/components/contexts/SearchPagePreferencesState.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/SearchPagePreferencesState.tsx
@@ -26,9 +26,9 @@ import Store from 'logic/local-storage/Store';
 import { PreferencesActions } from 'stores/users/PreferencesStore';
 
 type Props = {
-  children: (layoutConsumer: {
-    setLayoutState: (stateKey: string, value: boolean) => void,
-    getLayoutState: (stateKey: string, defaultValue: boolean) => boolean,
+  children: (preferenceConsumer: {
+    setPreferenceState: (stateKey: string, value: boolean) => void,
+    getPreferenceState: (stateKey: string, defaultValue: boolean) => boolean,
   }) => React.ReactElement;
 };
 
@@ -72,7 +72,7 @@ const _updateUserSidebarPinningPref = (currentUser, userPreferences, viewType, n
   }
 };
 
-const SearchPageLayoutState = ({ children }: Props) => {
+const SearchPagePreferenceState = ({ children }: Props) => {
   const currentUser = useContext(CurrentUserContext);
   const userPreferences = useContext(UserPreferencesContext);
   const viewType = useContext(ViewTypeContext);
@@ -82,11 +82,11 @@ const SearchPageLayoutState = ({ children }: Props) => {
 
   const _onSidebarPinningChange = (newIsPinned) => _updateUserSidebarPinningPref(currentUser, userPreferences, viewType, newIsPinned);
 
-  const getLayoutState = (stateKey: string, defaultValue: boolean) => {
+  const getPreferenceState = (stateKey: string, defaultValue: boolean) => {
     return state[stateKey] ?? defaultValue;
   };
 
-  const setLayoutState = (stateKey: string, value: boolean) => {
+  const setPreferenceState = (stateKey: string, value: boolean) => {
     if (stateKey === 'sidebarIsPinned') {
       _onSidebarPinningChange(value);
     }
@@ -94,7 +94,7 @@ const SearchPageLayoutState = ({ children }: Props) => {
     setState({ ...state, [stateKey]: value });
   };
 
-  return children({ getLayoutState, setLayoutState });
+  return children({ getPreferenceState, setPreferenceState });
 };
 
-export default SearchPageLayoutState;
+export default SearchPagePreferenceState;

--- a/graylog2-web-interface/src/views/components/sidebar/ContentColumn.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/ContentColumn.tsx
@@ -17,7 +17,7 @@
 import * as React from 'react';
 import styled, { css } from 'styled-components';
 
-import type { SearchPageLayout } from 'views/components/contexts/SearchPageLayoutContext';
+import type { SearchPagePreferences } from 'views/components/contexts/SearchPagePreferencesContext';
 import type { ViewMetaData as ViewMetadata } from 'views/stores/ViewMetadataStore';
 import { IconButton } from 'components/common';
 import ViewTypeContext from 'views/components/contexts/ViewTypeContext';
@@ -26,7 +26,7 @@ import viewTitle from 'views/logic/views/ViewTitle';
 type Props = {
   children: React.ReactNode,
   closeSidebar: () => void,
-  searchPageLayout: SearchPageLayout | undefined | null,
+  searchPageLayout: SearchPagePreferences | undefined | null,
   sectionTitle: string,
   viewMetadata: ViewMetadata,
 };

--- a/graylog2-web-interface/src/views/components/sidebar/Sidebar.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/Sidebar.tsx
@@ -22,8 +22,8 @@ import styled, { css } from 'styled-components';
 
 import type { ViewMetaData as ViewMetadata } from 'views/stores/ViewMetadataStore';
 import type QueryResult from 'views/logic/QueryResult';
-import type { SearchPageLayout } from 'views/components/contexts/SearchPageLayoutContext';
-import SearchPageLayoutContext from 'views/components/contexts/SearchPageLayoutContext';
+import type { SearchPagePreferences } from 'views/components/contexts/SearchPagePreferencesContext';
+import SearchPagePreferencesContext from 'views/components/contexts/SearchPagePreferencesContext';
 
 import SidebarNavigation from './SidebarNavigation';
 import ContentColumn from './ContentColumn';
@@ -36,7 +36,7 @@ type Props = {
   children: React.ReactElement,
   queryId: string,
   results: QueryResult,
-  searchPageLayout?: SearchPageLayout,
+  searchPageLayout?: SearchPagePreferences,
   sections?: Array<SidebarSection>,
   viewMetadata: ViewMetadata,
 };
@@ -134,9 +134,9 @@ Sidebar.defaultProps = {
 };
 
 const SidebarWithContext = ({ children, ...props }: React.ComponentProps<typeof Sidebar>) => (
-  <SearchPageLayoutContext.Consumer>
+  <SearchPagePreferencesContext.Consumer>
     {(searchPageLayout) => <Sidebar {...props} searchPageLayout={searchPageLayout}>{children}</Sidebar>}
-  </SearchPageLayoutContext.Consumer>
+  </SearchPagePreferencesContext.Consumer>
 );
 
 export default SidebarWithContext;

--- a/graylog2-web-interface/src/views/types.ts
+++ b/graylog2-web-interface/src/views/types.ts
@@ -268,3 +268,17 @@ declare module 'graylog-web-plugin/plugin' {
     visualizationTypes?: Array<VisualizationType<any>>;
   }
 }
+export interface ViewActions {
+  save: {
+    isShown: boolean,
+  };
+  saveAs: {
+    isShown: boolean,
+  };
+  share: {
+    isShown: boolean,
+  }
+  actionsDropdown: {
+    isShown: boolean,
+  }
+}


### PR DESCRIPTION
# Backport of #12600 

This change is needed to allow for the customization of the `Search` components' layout.
The first iteration allows hiding the sideNav and defining which viewActionMenu buttons are displayed.

* Adds layout configuration context for the `Search` component.
* This refactors the `SearchPageConfigContext` component to SearchPageLayoutContext
and all the SearchPageLayout domain components to SearchPagePreferences. This was done to prevent confusion about the domains these components are acting upon.
* This refactors the `SearchPageLayoutContext` into multiple components
to be more in line with our current approach to managing contexts and hooks.
* Renames "Analyst Tools" back to "Security" for routing purposes.
* Wrap both new contexts in `singleton()`
* Match file name to default export in
* Rename `setPreferencesState` and `getPreferencesState` to
  `setPreference` and `getPreference`
* Rename button titles to be more specific in `ViewActionsMenu.tsx`
        - 'Save Button' -> 'Save dashboard'
        - 'Save As Button' -> 'Save as new dashboard'
* Removed the default provider and instead relies on the hook to
   provide logical defaults for the layout context.
* Updates some tests to use more explicit checks.
* Updates naming conventions to be easier to read.


/jenkins-pr-deps Graylog2/graylog-plugin-enterprise#3579
