### PR TITLE
Escape field value suggestions before adding them to query.

### DIFF
--- a/graylog2-web-interface/src/views/components/searchbar/completions/FieldValueCompletion.ts
+++ b/graylog2-web-interface/src/views/components/searchbar/completions/FieldValueCompletion.ts
@@ -22,6 +22,7 @@ import type { TimeRange, NoTimeRangeOverride } from 'views/logic/queries/Query';
 import type FieldTypeMapping from 'views/logic/fieldtypes/FieldTypeMapping';
 import { onSubmittingTimerange } from 'views/components/TimerangeForForm';
 import { isNoTimeRangeOverride } from 'views/typeGuards/timeRange';
+import { escape } from 'views/logic/queries/QueryHelper';
 
 import type { Completer, CompleterContext, FieldTypes } from '../SearchBarAutocompletions';
 import type { Token, Line, CompletionResult } from '../queryinput/ace-types';
@@ -86,7 +87,7 @@ class FieldValueCompletion implements Completer {
   };
 
   // eslint-disable-next-line class-methods-use-this
-  shouldFetchCompletions = (fieldName: string, fieldTypes: FieldTypes) => {
+  private readonly shouldFetchCompletions = (fieldName: string, fieldTypes: FieldTypes) => {
     if (!fieldName) {
       return false;
     }
@@ -102,7 +103,7 @@ class FieldValueCompletion implements Completer {
     return true;
   };
 
-  alreadyFetchedAllSuggestions(
+  private alreadyFetchedAllSuggestions(
     input: string | number,
     fieldName: string,
     streams: Array<string> | undefined,
@@ -127,7 +128,7 @@ class FieldValueCompletion implements Completer {
       && !furtherSuggestionsCount;
   }
 
-  filterExistingSuggestions(input: string | number) {
+  private filterExistingSuggestions(input: string | number) {
     if (this.previousSuggestions) {
       return this.previousSuggestions.completions.filter((completion) => completion.name.startsWith(String(input)));
     }
@@ -171,7 +172,7 @@ class FieldValueCompletion implements Completer {
 
       const completions = suggestions.map(({ value, occurrence }) => ({
         name: value,
-        value: value,
+        value: escape(value),
         score: occurrence,
         caption: completionCaption(value, input),
         meta: `${occurrence} hits`,


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

**Note:** This is a backport of #12668 to `4.3`.

Prior to this change, field value suggestions (existing field values which are suggested in the query input when a user is wring a query) were not escaped when the user selects one to be added to the query string. This could lead to invalid queries being produced (e.g. when the field contains a windows pathname).

This change is now adding escaping to those suggestions being produced by the field value completion. A more general solution in the `SearchBarAutoCompletions` class could be implemented at a later time, but as this change aims towards being integrated into the upcoming release, it tries to fix this issue in the least intrusive way.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.