### PR TITLE
Archiving deletion job

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -42,3 +42,5 @@ The following API endpoints have been removed in 4.4.
   This happens at creation, so existing `system_messages` collections remain unconstrained.
 <br>You can manually convert your existing collection to a capped collection by following 
 these [instructions](https://www.mongodb.com/docs/manual/core/capped-collections/#convert-a-collection-to-capped).
+- Introducing new archive config parameter retentionTime in days, which automatically deletes archives meeting the criteria.
+  Default value is set to 0 which will disable this feature.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -42,5 +42,6 @@ The following API endpoints have been removed in 4.4.
   This happens at creation, so existing `system_messages` collections remain unconstrained.
 <br>You can manually convert your existing collection to a capped collection by following 
 these [instructions](https://www.mongodb.com/docs/manual/core/capped-collections/#convert-a-collection-to-capped).
-- Introducing new archive config parameter retentionTime in days, which automatically deletes archives meeting the criteria.
-  Default value is set to 0 which will disable this feature.
+- Introducing new archive config parameter retentionTime in days. 
+  Archives exceeding the specified retentionTime are automatically deleted. 
+  By default the behavior is unchanged: archives are retained indefinitely. 


### PR DESCRIPTION
## Description
New config parameter retentionTime was added which accepts integer and deletes archives after specified number of days.
Default value is 0, which means the feature is turned off.
When value is changed the user will get a confirmation screen before proceeding with saving.

Documents issue: https://github.com/Graylog2/graylog-plugin-enterprise/issues/3514
