### PR TITLE
Bump okta SDK version to 8.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -142,7 +142,7 @@
         <netty.version>4.1.60.Final</netty.version>
         <netty-tcnative-boringssl-static.version>2.0.36.Final</netty-tcnative-boringssl-static.version>
         <okhttp.version>3.14.6</okhttp.version>
-        <okta-sdk.version>3.0.1</okta-sdk.version>
+        <okta-sdk.version>8.2.1</okta-sdk.version>
         <opencsv.version>2.3</opencsv.version>
         <os-platform-finder.version>1.2.3</os-platform-finder.version>
         <pkts.version>3.0.5</pkts.version>


### PR DESCRIPTION
Rev the okta SDK version to latest 8.2.1.
Amazingly I did not need to fix any breaking changes.

Resolves Graylog2/graylog-plugin-enterprise#3486

See https://github.com/okta/okta-sdk-java/releases