### PR TITLE
Remove public access modifier for search delete

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/db/SearchDbService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/db/SearchDbService.java
@@ -139,7 +139,13 @@ public class SearchDbService {
         );
     }
 
-    public void delete(String id) {
+    /**
+     * Searches should only be deleted directly by {@link SearchesCleanUpJob} if they are no longer referenced
+     * by any views. Do not directly delete searches when deleting views. The searches might still be referenced by
+     * other view copies (until those copies are modified, at which time a new search would be created).
+     * @param id A Search ID.
+     */
+    void delete(String id) {
         db.removeById(new ObjectId(id));
     }
 


### PR DESCRIPTION
Remove public access modifier for the `SearchDbService.delete` method. 

Searches should only be deleted directly by the [SearchesCleanUpJob](https://github.com/Graylog2/graylog2-server/blob/a8f277fe71f43beb0620a5e32a7619b0ce982879/graylog2-server/src/main/java/org/graylog/plugins/views/search/db/SearchesCleanUpJob.java) if they are no longer referenced by any views. Views are passively dereference searches as query changes are made by through the UI saving new copies of searches. The old copies are left around until SearchesCleanUpJob determines that they are no longer referenced.

There was recently a bug (see ) where searches were being explicitly deleted elsewhere. Changing this access modifier could prevent this from happening again in the future.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

