### PR TITLE
Hide request when license valid

### DIFF
--- a/graylog2-web-interface/src/components/enterprise/ProductLink.tsx
+++ b/graylog2-web-interface/src/components/enterprise/ProductLink.tsx
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 import * as React from 'react';
 import PropTypes from 'prop-types';
 

--- a/graylog2-web-interface/src/components/enterprise/ProductLink.tsx
+++ b/graylog2-web-interface/src/components/enterprise/ProductLink.tsx
@@ -1,0 +1,44 @@
+import * as React from 'react';
+import PropTypes from 'prop-types';
+
+import { Button, ButtonToolbar } from 'components/bootstrap';
+
+type Props = {
+  children: React.ReactNode,
+  href: string,
+  clusterId: string,
+}
+
+const ProductLink = ({ href, clusterId, children }: Props) => {
+  let hrefWithParam = href;
+
+  if (clusterId) {
+    hrefWithParam = `${hrefWithParam}?cluster_id=${clusterId}`;
+  }
+
+  return (
+    <ButtonToolbar>
+      <Button type="link"
+              target="_blank"
+              rel="noopener noreferrer"
+              href={hrefWithParam}
+              bsStyle="primary">
+        {children}
+      </Button>
+    </ButtonToolbar>
+  );
+};
+
+ProductLink.propTypes = {
+  children: PropTypes.node,
+  href: PropTypes.string,
+  clusterId: PropTypes.string,
+};
+
+ProductLink.defaultProps = {
+  children: null,
+  href: '',
+  clusterId: null,
+};
+
+export default ProductLink;

--- a/graylog2-web-interface/src/pages/EnterprisePage.jsx
+++ b/graylog2-web-interface/src/pages/EnterprisePage.jsx
@@ -16,13 +16,14 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-// eslint-disable-next-line no-restricted-imports
 import styled, { css } from 'styled-components';
+import { PluginStore } from 'graylog-web-plugin/plugin';
 
 import { useStore } from 'stores/connect';
 import { NodesStore } from 'stores/nodes/NodesStore';
 import { DocumentTitle, PageHeader, Spinner } from 'components/common';
-import { Button, ButtonToolbar, Col, Row } from 'components/bootstrap';
+import { Col, Row } from 'components/bootstrap';
+import ProductLink from 'components/enterprise/ProductLink';
 import { GraylogClusterOverview } from 'components/cluster';
 import PluginList from 'components/enterprise/PluginList';
 import HideOnCloud from 'util/conditional/HideOnCloud';
@@ -35,38 +36,6 @@ const EnterpriseProductLink = ({ children }) => {
       {children}
     </a>
   );
-};
-
-const ProductLink = ({ href, clusterId, children }) => {
-  let hrefWithParam = href;
-
-  if (clusterId) {
-    hrefWithParam = `${hrefWithParam}?cluster_id=${clusterId}`;
-  }
-
-  return (
-    <ButtonToolbar>
-      <Button type="link"
-              target="_blank"
-              rel="noopener noreferrer"
-              href={hrefWithParam}
-              bsStyle="primary">
-        {children}
-      </Button>
-    </ButtonToolbar>
-  );
-};
-
-ProductLink.propTypes = {
-  children: PropTypes.node,
-  href: PropTypes.string,
-  clusterId: PropTypes.string,
-};
-
-ProductLink.defaultProps = {
-  children: null,
-  href: '',
-  clusterId: null,
 };
 
 EnterpriseProductLink.propTypes = {
@@ -87,6 +56,8 @@ const GraylogEnterpriseHeader = styled.h2`
 
 const EnterprisePage = () => {
   const nodes = useStore(NodesStore);
+  const licensePlugin = PluginStore.exports('license');
+  const ProductLinkComponent = licensePlugin[0]?.EnterpriseProductLink || ProductLink;
 
   if (!nodes) {
     return <Spinner />;
@@ -120,9 +91,9 @@ const EnterprisePage = () => {
                   hours per year in collecting and analyzing log data to uncover the root cause of performance,
                   outage, and error issues.
                 </p>
-                <ProductLink href="https://go2.graylog.org/request-graylog-operations" clusterId={clusterId}>
+                <ProductLinkComponent href="https://go2.graylog.org/request-graylog-operations" clusterId={clusterId}>
                   Request now
-                </ProductLink>
+                </ProductLinkComponent>
               </BiggerFontSize>
             </Col>
             <Col md={6}>
@@ -134,9 +105,9 @@ const EnterprisePage = () => {
                   integrations with other security tools, SOAR capabilities, and numerous compliance reporting
                   features.
                 </p>
-                <ProductLink href="https://go2.graylog.org/request-graylog-security" clusterId={clusterId}>
+                <ProductLinkComponent href="https://go2.graylog.org/request-graylog-security" clusterId={clusterId}>
                   Request now
-                </ProductLink>
+                </ProductLinkComponent>
               </BiggerFontSize>
             </Col>
           </Row>

--- a/graylog2-web-interface/src/pages/EnterprisePage.jsx
+++ b/graylog2-web-interface/src/pages/EnterprisePage.jsx
@@ -105,7 +105,7 @@ const EnterprisePage = () => {
                   integrations with other security tools, SOAR capabilities, and numerous compliance reporting
                   features.
                 </p>
-                <ProductLinkComponent href="https://go2.graylog.org/request-graylog-security" clusterId={clusterId}>
+                <ProductLinkComponent href="https://go2.graylog.org/request-graylog-security" licenseSubject="/license/security" clusterId={clusterId}>
                   Request now
                 </ProductLinkComponent>
               </BiggerFontSize>


### PR DESCRIPTION
These changes load the `EntrepriseProductLink` and use it to render the `request link` when the enterprise plugin is installed that allows hiding the link when the license is valid.

fix Graylog2/graylog-plugin-enterprise#3606

/jenkins-pr-deps Graylog2/graylog-plugin-enterprise#3612

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

