### PR TITLE
chore: add bsClass to input props

### DIFF
--- a/graylog2-web-interface/src/components/bootstrap/Input.jsx
+++ b/graylog2-web-interface/src/components/bootstrap/Input.jsx
@@ -43,6 +43,7 @@ class Input extends React.Component {
       PropTypes.string,
     ]),
     labelClassName: PropTypes.string,
+    bsClass: PropTypes.string,
     bsStyle: PropTypes.oneOf(['success', 'warning', 'error']),
     formGroupClassName: PropTypes.string,
     value: PropTypes.oneOfType([
@@ -79,6 +80,7 @@ class Input extends React.Component {
     labelClassName: undefined,
     name: undefined,
     formGroupClassName: undefined,
+    bsClass: undefined,
     bsStyle: null,
     value: undefined,
     placeholder: '',

--- a/graylog2-web-interface/src/components/bootstrap/Input.jsx
+++ b/graylog2-web-interface/src/components/bootstrap/Input.jsx
@@ -96,6 +96,7 @@ class Input extends React.Component {
     return this.input;
   };
 
+  // eslint-disable-next-line react/no-unused-class-component-methods
   getValue = () => {
     const { type } = this.props;
 
@@ -112,6 +113,7 @@ class Input extends React.Component {
     }
   };
 
+  // eslint-disable-next-line react/no-unused-class-component-methods
   getChecked = () => {
     return this.getInputDOMNode().checked;
   };
@@ -124,6 +126,7 @@ class Input extends React.Component {
     );
   };
 
+  // eslint-disable-next-line class-methods-use-this
   _renderFormGroup = (
     id,
     validationState,


### PR DESCRIPTION
# Description

Add `bsClass` to input props.

# Motivation and Context

I need to pass the `bsClass` prop to the `Input` component to manipulate the checkbox height.

# Types of changes

- [x] Chore