### PR TITLE
fix: don't render inactive notifications

### DIFF
--- a/graylog2-web-interface/src/components/common/PublicNotifications.test.tsx
+++ b/graylog2-web-interface/src/components/common/PublicNotifications.test.tsx
@@ -47,6 +47,17 @@ const mockedNotifications = {
     isGlobal: true,
     isDismissible: true,
   },
+  '6075a2999f4efa083977b75c': {
+    title: 'Inactive alert',
+    shortMessage: 'inactive alert',
+    longMessage: 'inactive alert should be visible',
+    atLogin: true,
+    variant: 'danger',
+    hiddenTitle: false,
+    isActive: false,
+    isGlobal: true,
+    isDismissible: true,
+  },
 } as Notifications;
 const mockedConfigNotifications = {
   '607468afaaa2380afe0757f1': {
@@ -95,7 +106,7 @@ const beforeMock = () => {
 describe('PublicNotifications', () => {
   beforeEach(beforeMock);
 
-  it('should render notifications', () => {
+  it('should render all active notifications', () => {
     render(<PublicNotifications />);
 
     const alerts = screen.getAllByRole('alert');

--- a/graylog2-web-interface/src/components/common/PublicNotifications.tsx
+++ b/graylog2-web-interface/src/components/common/PublicNotifications.tsx
@@ -89,7 +89,11 @@ const PublicNotifications = ({ readFromConfig }: Props) => {
     };
 
     const notification = allNotification[notificationId];
-    const { variant, hiddenTitle, isDismissible, title, shortMessage, longMessage } = notification;
+    const { variant, hiddenTitle, isActive, isDismissible, title, shortMessage, longMessage } = notification;
+
+    if (!isActive) {
+      return null;
+    }
 
     const _dismiss = () => {
       return onDismissPublicNotification(notificationId);


### PR DESCRIPTION
# Description

Don't render notification when `isActive` is set to `false`.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

Issue: https://github.com/Graylog2/graylog-plugin-enterprise/issues/3477