### PR TITLE
Make content pack creation more robust

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -7,6 +7,12 @@ Please make sure to create a MongoDB database backup before starting the upgrade
 
 ## Breaking Changes
 
+The following public interfaces have changed in 4.4:
+
+| Interface                 | Breaking Change            |
+|---------------------------|----------------------------|
+| `EntityWithExcerptFacade` | New abstract method <br/>`String id(ExcerptClass nativeEntity)` |
+
 ## API Endpoint Deprecations
 
 The following API endpoints are deprecated beginning with 4.4.

--- a/graylog2-server/src/main/java/org/graylog/events/contentpack/facade/EventDefinitionFacade.java
+++ b/graylog2-server/src/main/java/org/graylog/events/contentpack/facade/EventDefinitionFacade.java
@@ -161,6 +161,11 @@ public class EventDefinitionFacade implements EntityFacade<EventDefinitionDto> {
     }
 
     @Override
+    public String id(EventDefinitionDto nativeEntity) {
+        return nativeEntity.id();
+    }
+
+    @Override
     public EntityExcerpt createExcerpt(EventDefinitionDto nativeEntity) {
         return EntityExcerpt.builder()
                 .id(ModelId.of(nativeEntity.id()))
@@ -172,7 +177,9 @@ public class EventDefinitionFacade implements EntityFacade<EventDefinitionDto> {
     @Override
     public Set<EntityExcerpt> listEntityExcerpts() {
         return eventDefinitionService.streamAll()
-                .map(this::createExcerpt)
+                .map(this::maybeCreateExcerpt)
+                .filter(Optional::isPresent)
+                .map(Optional::get)
                 .collect(Collectors.toSet());
     }
 

--- a/graylog2-server/src/main/java/org/graylog/events/contentpack/facade/NotificationFacade.java
+++ b/graylog2-server/src/main/java/org/graylog/events/contentpack/facade/NotificationFacade.java
@@ -33,6 +33,7 @@ import org.graylog2.contentpacks.model.entities.EntityV1;
 import org.graylog2.contentpacks.model.entities.NativeEntity;
 import org.graylog2.contentpacks.model.entities.NativeEntityDescriptor;
 import org.graylog2.contentpacks.model.entities.references.ValueReference;
+import org.graylog2.lookup.dto.LookupTableDto;
 import org.graylog2.plugin.database.users.User;
 import org.graylog2.shared.users.UserService;
 import org.slf4j.Logger;
@@ -114,6 +115,11 @@ public class NotificationFacade implements EntityFacade<NotificationDto> {
     }
 
     @Override
+    public String id(NotificationDto nativeEntity) {
+        return nativeEntity.id();
+    }
+
+    @Override
     public EntityExcerpt createExcerpt(NotificationDto nativeEntity) {
         return EntityExcerpt.builder()
                 .id(ModelId.of(nativeEntity.id()))
@@ -125,7 +131,9 @@ public class NotificationFacade implements EntityFacade<NotificationDto> {
     @Override
     public Set<EntityExcerpt> listEntityExcerpts() {
         return notificationService.streamAll()
-                .map(this::createExcerpt)
+                .map(this::maybeCreateExcerpt)
+                .filter(Optional::isPresent)
+                .map(Optional::get)
                 .collect(Collectors.toSet());
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/EntityWithExcerptFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/EntityWithExcerptFacade.java
@@ -28,12 +28,16 @@ import org.graylog2.contentpacks.model.entities.NativeEntity;
 import org.graylog2.contentpacks.model.entities.NativeEntityDescriptor;
 import org.graylog2.contentpacks.model.entities.references.ValueReference;
 import org.graylog2.plugin.indexer.searches.timeranges.InvalidRangeParametersException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
 public interface EntityWithExcerptFacade<EntityClass, ExcerptClass> {
+    Logger LOG = LoggerFactory.getLogger(EntityWithExcerptFacade.class);
+
     /**
      * Create an exportable model of a native entity referenced by an {@link EntityDescriptor}
      * including optional constraints.
@@ -92,6 +96,13 @@ public interface EntityWithExcerptFacade<EntityClass, ExcerptClass> {
     void delete(EntityClass nativeEntity);
 
     /**
+     * Return a unique ID - primarily for troubleshooting
+     * @param nativeEntity The native entity
+     * @return unique ID of the entity
+     */
+    String id(ExcerptClass nativeEntity);
+
+    /**
      * Create an excerpt (id, type, title) of a native entity for display purposes.
      *
      * @param nativeEntity The native entity to create an excerpt of
@@ -99,6 +110,23 @@ public interface EntityWithExcerptFacade<EntityClass, ExcerptClass> {
      * @see EntityExcerpt
      */
     EntityExcerpt createExcerpt(ExcerptClass nativeEntity);
+
+    /**
+     * Create an excerpt (id, type, title) of a native entity for display purposes, but catch
+     * and log any exceptions that arise.
+     *
+     * @param nativeEntity The native entity to create an excerpt of
+     * @return The entity excerpt of the native entity
+     * @see EntityExcerpt
+     */
+    default Optional<EntityExcerpt> maybeCreateExcerpt(ExcerptClass nativeEntity) {
+        try {
+            return Optional.of(createExcerpt(nativeEntity));
+        } catch (Exception e) {
+            LOG.error("Unable to extract {} {}: {}", nativeEntity.getClass().getSimpleName(), id(nativeEntity), e.getMessage());
+        }
+        return Optional.empty();
+    }
 
     /**
      * Create entity excerpts of all native entities of type {@code T}.

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/GrokPatternFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/GrokPatternFacade.java
@@ -23,6 +23,7 @@ import com.google.common.graph.Graph;
 import com.google.common.graph.GraphBuilder;
 import com.google.common.graph.ImmutableGraph;
 import com.google.common.graph.MutableGraph;
+import org.graylog.events.processor.EventDefinitionDto;
 import org.graylog2.contentpacks.EntityDescriptorIds;
 import org.graylog2.contentpacks.exceptions.DivergingEntityConfigurationException;
 import org.graylog2.contentpacks.model.ModelId;
@@ -114,6 +115,11 @@ public class GrokPatternFacade implements EntityFacade<GrokPattern> {
     }
 
     @Override
+    public String id(GrokPattern nativeEntity) {
+        return nativeEntity.id();
+    }
+
+    @Override
     public Optional<NativeEntity<GrokPattern>> findExisting(Entity entity, Map<String, ValueReference> parameters) {
         if (entity instanceof EntityV1) {
             return findExisting((EntityV1) entity);
@@ -151,7 +157,9 @@ public class GrokPatternFacade implements EntityFacade<GrokPattern> {
     @Override
     public Set<EntityExcerpt> listEntityExcerpts() {
         return grokPatternService.loadAll().stream()
-                .map(this::createExcerpt)
+                .map(this::maybeCreateExcerpt)
+                .filter(Optional::isPresent)
+                .map(Optional::get)
                 .collect(Collectors.toSet());
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/InputFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/InputFacade.java
@@ -48,6 +48,7 @@ import org.graylog2.contentpacks.model.entities.NativeEntityDescriptor;
 import org.graylog2.contentpacks.model.entities.references.ReferenceMap;
 import org.graylog2.contentpacks.model.entities.references.ValueReference;
 import org.graylog2.database.NotFoundException;
+import org.graylog2.grok.GrokPattern;
 import org.graylog2.grok.GrokPatternService;
 import org.graylog2.inputs.Input;
 import org.graylog2.inputs.InputService;
@@ -441,6 +442,11 @@ public class InputFacade implements EntityFacade<InputWithExtractors> {
     }
 
     @Override
+    public String id(InputWithExtractors nativeEntity) {
+        return nativeEntity.input().getId();
+    }
+
+    @Override
     public EntityExcerpt createExcerpt(InputWithExtractors inputWithExtractors) {
         return EntityExcerpt.builder()
                 .id(ModelId.of(inputWithExtractors.input().getId()))
@@ -448,12 +454,13 @@ public class InputFacade implements EntityFacade<InputWithExtractors> {
                 .title(inputWithExtractors.input().getTitle())
                 .build();
     }
-
     @Override
     public Set<EntityExcerpt> listEntityExcerpts() {
         return inputService.all().stream()
                 .map(InputWithExtractors::create)
-                .map(this::createExcerpt)
+                .map(this::maybeCreateExcerpt)
+                .filter(Optional::isPresent)
+                .map(Optional::get)
                 .collect(Collectors.toSet());
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/LookupCacheFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/LookupCacheFacade.java
@@ -150,6 +150,11 @@ public class LookupCacheFacade implements EntityFacade<CacheDto> {
     }
 
     @Override
+    public String id(CacheDto nativeEntity) {
+        return nativeEntity.id();
+    }
+
+    @Override
     public EntityExcerpt createExcerpt(CacheDto cacheDto) {
         return EntityExcerpt.builder()
                 .id(ModelId.of(cacheDto.id()))
@@ -161,7 +166,9 @@ public class LookupCacheFacade implements EntityFacade<CacheDto> {
     @Override
     public Set<EntityExcerpt> listEntityExcerpts() {
         return cacheService.findAll().stream()
-                .map(this::createExcerpt)
+                .map(this::maybeCreateExcerpt)
+                .filter(Optional::isPresent)
+                .map(Optional::get)
                 .collect(Collectors.toSet());
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/LookupDataAdapterFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/LookupDataAdapterFacade.java
@@ -36,6 +36,7 @@ import org.graylog2.contentpacks.model.entities.NativeEntityDescriptor;
 import org.graylog2.contentpacks.model.entities.references.ValueReference;
 import org.graylog2.jackson.TypeReferences;
 import org.graylog2.lookup.db.DBDataAdapterService;
+import org.graylog2.lookup.dto.CacheDto;
 import org.graylog2.lookup.dto.DataAdapterDto;
 import org.graylog2.plugin.PluginMetaData;
 import org.graylog2.plugin.lookup.LookupDataAdapterConfiguration;
@@ -150,6 +151,11 @@ public class LookupDataAdapterFacade implements EntityFacade<DataAdapterDto> {
     }
 
     @Override
+    public String id(DataAdapterDto nativeEntity) {
+        return nativeEntity.id();
+    }
+
+    @Override
     public EntityExcerpt createExcerpt(DataAdapterDto dataAdapterDto) {
         return EntityExcerpt.builder()
                 .id(ModelId.of(dataAdapterDto.id()))
@@ -161,7 +167,9 @@ public class LookupDataAdapterFacade implements EntityFacade<DataAdapterDto> {
     @Override
     public Set<EntityExcerpt> listEntityExcerpts() {
         return dataAdapterService.findAll().stream()
-                .map(this::createExcerpt)
+                .map(this::maybeCreateExcerpt)
+                .filter(Optional::isPresent)
+                .map(Optional::get)
                 .collect(Collectors.toSet());
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/LookupTableFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/LookupTableFacade.java
@@ -189,6 +189,11 @@ public class LookupTableFacade implements EntityFacade<LookupTableDto> {
     }
 
     @Override
+    public String id(LookupTableDto nativeEntity) {
+        return nativeEntity.id();
+    }
+
+    @Override
     public EntityExcerpt createExcerpt(LookupTableDto lookupTableDto) {
         return EntityExcerpt.builder()
                 .id(ModelId.of(lookupTableDto.id()))
@@ -200,7 +205,9 @@ public class LookupTableFacade implements EntityFacade<LookupTableDto> {
     @Override
     public Set<EntityExcerpt> listEntityExcerpts() {
         return lookupTableService.findAll().stream()
-                .map(this::createExcerpt)
+                .map(this::maybeCreateExcerpt)
+                .filter(Optional::isPresent)
+                .map(Optional::get)
                 .collect(Collectors.toSet());
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/OutputFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/OutputFacade.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
+import org.graylog.events.notifications.NotificationDto;
 import org.graylog2.contentpacks.EntityDescriptorIds;
 import org.graylog2.contentpacks.exceptions.ContentPackException;
 import org.graylog2.contentpacks.model.ModelId;
@@ -167,6 +168,11 @@ public class OutputFacade implements EntityFacade<Output> {
     }
 
     @Override
+    public String id(Output nativeEntity) {
+        return nativeEntity.getId();
+    }
+
+    @Override
     public EntityExcerpt createExcerpt(Output output) {
         return EntityExcerpt.builder()
                 .id(ModelId.of(output.getId()))
@@ -178,7 +184,9 @@ public class OutputFacade implements EntityFacade<Output> {
     @Override
     public Set<EntityExcerpt> listEntityExcerpts() {
         return outputService.loadAll().stream()
-                .map(this::createExcerpt)
+                .map(this::maybeCreateExcerpt)
+                .filter(Optional::isPresent)
+                .map(Optional::get)
                 .collect(Collectors.toSet());
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/PipelineFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/PipelineFacade.java
@@ -24,6 +24,7 @@ import com.google.common.graph.Graph;
 import com.google.common.graph.GraphBuilder;
 import com.google.common.graph.ImmutableGraph;
 import com.google.common.graph.MutableGraph;
+import org.graylog.events.notifications.NotificationDto;
 import org.graylog.plugins.pipelineprocessor.ast.Pipeline;
 import org.graylog.plugins.pipelineprocessor.ast.Stage;
 import org.graylog.plugins.pipelineprocessor.db.PipelineDao;
@@ -237,6 +238,11 @@ public class PipelineFacade implements EntityFacade<PipelineDao> {
     }
 
     @Override
+    public String id(PipelineDao nativeEntity) {
+        return nativeEntity.id();
+    }
+
+    @Override
     public EntityExcerpt createExcerpt(PipelineDao pipeline) {
         return EntityExcerpt.builder()
                 .id(ModelId.of(pipeline.id()))
@@ -248,7 +254,9 @@ public class PipelineFacade implements EntityFacade<PipelineDao> {
     @Override
     public Set<EntityExcerpt> listEntityExcerpts() {
         return pipelineService.loadAll().stream()
-                .map(this::createExcerpt)
+                .map(this::maybeCreateExcerpt)
+                .filter(Optional::isPresent)
+                .map(Optional::get)
                 .collect(Collectors.toSet());
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/PipelineRuleFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/PipelineRuleFacade.java
@@ -19,6 +19,7 @@ package org.graylog2.contentpacks.facades;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
+import org.graylog.events.notifications.NotificationDto;
 import org.graylog.plugins.pipelineprocessor.db.RuleDao;
 import org.graylog.plugins.pipelineprocessor.db.RuleService;
 import org.graylog2.contentpacks.EntityDescriptorIds;
@@ -121,6 +122,11 @@ public class PipelineRuleFacade implements EntityFacade<RuleDao> {
     }
 
     @Override
+    public String id(RuleDao nativeEntity) {
+        return nativeEntity.id();
+    }
+
+    @Override
     public Optional<NativeEntity<RuleDao>> findExisting(Entity entity, Map<String, ValueReference> parameters) {
         if (entity instanceof EntityV1) {
             return findExisting((EntityV1) entity, parameters);
@@ -164,7 +170,9 @@ public class PipelineRuleFacade implements EntityFacade<RuleDao> {
     @Override
     public Set<EntityExcerpt> listEntityExcerpts() {
         return ruleService.loadAll().stream()
-                .map(this::createExcerpt)
+                .map(this::maybeCreateExcerpt)
+                .filter(Optional::isPresent)
+                .map(Optional::get)
                 .collect(Collectors.toSet());
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/RootEntityFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/RootEntityFacade.java
@@ -17,6 +17,7 @@
 package org.graylog2.contentpacks.facades;
 
 import com.google.common.graph.Graph;
+import org.graylog.events.notifications.NotificationDto;
 import org.graylog2.contentpacks.EntityDescriptorIds;
 import org.graylog2.contentpacks.model.ModelType;
 import org.graylog2.contentpacks.model.ModelTypes;
@@ -51,6 +52,11 @@ public class RootEntityFacade implements EntityFacade<Void> {
 
     @Override
     public void delete(Void nativeEntity) {
+    }
+
+    @Override
+    public String id(Void nativeEntity) {
+        throw new UnsupportedOperationException("Unsupported operation for root entity");
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/SidecarCollectorConfigurationFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/SidecarCollectorConfigurationFacade.java
@@ -23,6 +23,7 @@ import com.google.common.graph.Graph;
 import com.google.common.graph.GraphBuilder;
 import com.google.common.graph.ImmutableGraph;
 import com.google.common.graph.MutableGraph;
+import org.graylog.events.notifications.NotificationDto;
 import org.graylog.plugins.sidecar.rest.models.Configuration;
 import org.graylog.plugins.sidecar.services.ConfigurationService;
 import org.graylog2.contentpacks.EntityDescriptorIds;
@@ -119,6 +120,11 @@ public class SidecarCollectorConfigurationFacade implements EntityFacade<Configu
     }
 
     @Override
+    public String id(Configuration nativeEntity) {
+        return nativeEntity.id();
+    }
+
+    @Override
     public EntityExcerpt createExcerpt(Configuration configuration) {
         return EntityExcerpt.builder()
                 .id(ModelId.of(configuration.id()))
@@ -130,7 +136,9 @@ public class SidecarCollectorConfigurationFacade implements EntityFacade<Configu
     @Override
     public Set<EntityExcerpt> listEntityExcerpts() {
         return configurationService.all().stream()
-                .map(this::createExcerpt)
+                .map(this::maybeCreateExcerpt)
+                .filter(Optional::isPresent)
+                .map(Optional::get)
                 .collect(Collectors.toSet());
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/SidecarCollectorFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/SidecarCollectorFacade.java
@@ -19,6 +19,7 @@ package org.graylog2.contentpacks.facades;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
+import org.graylog.events.notifications.NotificationDto;
 import org.graylog.plugins.sidecar.rest.models.Collector;
 import org.graylog.plugins.sidecar.services.CollectorService;
 import org.graylog2.contentpacks.EntityDescriptorIds;
@@ -138,6 +139,11 @@ public class SidecarCollectorFacade implements EntityFacade<Collector> {
     }
 
     @Override
+    public String id(Collector nativeEntity) {
+        return nativeEntity.id();
+    }
+
+    @Override
     public EntityExcerpt createExcerpt(Collector collector) {
         return EntityExcerpt.builder()
                 .id(ModelId.of(collector.id()))
@@ -149,7 +155,9 @@ public class SidecarCollectorFacade implements EntityFacade<Collector> {
     @Override
     public Set<EntityExcerpt> listEntityExcerpts() {
         return collectorService.all().stream()
-                .map(this::createExcerpt)
+                .map(this::maybeCreateExcerpt)
+                .filter(Optional::isPresent)
+                .map(Optional::get)
                 .collect(Collectors.toSet());
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/StreamFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/StreamFacade.java
@@ -25,6 +25,7 @@ import com.google.common.graph.ImmutableGraph;
 import com.google.common.graph.MutableGraph;
 import org.bson.types.ObjectId;
 import org.graylog.events.legacy.V20190722150700_LegacyAlertConditionMigration;
+import org.graylog.events.notifications.NotificationDto;
 import org.graylog2.alarmcallbacks.AlarmCallbackConfiguration;
 import org.graylog2.alarmcallbacks.AlarmCallbackConfigurationService;
 import org.graylog2.alerts.AlertService;
@@ -317,6 +318,11 @@ public class StreamFacade implements EntityFacade<Stream> {
     }
 
     @Override
+    public String id(Stream nativeEntity) {
+        return nativeEntity.getId();
+    }
+
+    @Override
     public EntityExcerpt createExcerpt(Stream stream) {
         return EntityExcerpt.builder()
                 .id(ModelId.of(stream.getId()))
@@ -328,7 +334,9 @@ public class StreamFacade implements EntityFacade<Stream> {
     @Override
     public Set<EntityExcerpt> listEntityExcerpts() {
         return streamService.loadAll().stream()
-                .map(this::createExcerpt)
+                .map(this::maybeCreateExcerpt)
+                .filter(Optional::isPresent)
+                .map(Optional::get)
                 .collect(Collectors.toSet());
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/UnsupportedEntityFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/UnsupportedEntityFacade.java
@@ -17,6 +17,7 @@
 package org.graylog2.contentpacks.facades;
 
 import com.google.common.graph.Graph;
+import org.graylog.events.notifications.NotificationDto;
 import org.graylog2.contentpacks.EntityDescriptorIds;
 import org.graylog2.contentpacks.model.entities.Entity;
 import org.graylog2.contentpacks.model.entities.EntityDescriptor;
@@ -53,6 +54,11 @@ public class UnsupportedEntityFacade implements EntityFacade<Void> {
 
     @Override
     public void delete(Void nativeEntity) {
+        throw new UnsupportedOperationException("Unsupported entity");
+    }
+
+    @Override
+    public String id(Void nativeEntity) {
         throw new UnsupportedOperationException("Unsupported entity");
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/UrlWhitelistFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/UrlWhitelistFacade.java
@@ -97,6 +97,11 @@ public class UrlWhitelistFacade implements EntityFacade<WhitelistEntry> {
     }
 
     @Override
+    public String id(WhitelistEntry nativeEntity) {
+        return nativeEntity.id();
+    }
+
+    @Override
     public EntityExcerpt createExcerpt(WhitelistEntry whitelistEntry) {
         return EntityExcerpt.builder()
                 .id(ModelId.of(whitelistEntry.id()))
@@ -110,7 +115,9 @@ public class UrlWhitelistFacade implements EntityFacade<WhitelistEntry> {
         return urlWhitelistService.getWhitelist()
                 .entries()
                 .stream()
-                .map(this::createExcerpt)
+                .map(this::maybeCreateExcerpt)
+                .filter(Optional::isPresent)
+                .map(Optional::get)
                 .collect(Collectors.toSet());
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/ViewFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/ViewFacade.java
@@ -68,7 +68,7 @@ public abstract class ViewFacade implements EntityWithExcerptFacade<ViewDTO, Vie
     protected final UserService userService;
 
     @Inject
-    public ViewFacade(ObjectMapper objectMapper,
+    protected ViewFacade(ObjectMapper objectMapper,
                       SearchDbService searchDbService,
                       ViewService viewService,
                       ViewSummaryService viewSummaryService,
@@ -158,8 +158,17 @@ public abstract class ViewFacade implements EntityWithExcerptFacade<ViewDTO, Vie
     }
 
     @Override
+    public String id(ViewSummaryDTO nativeEntity) {
+        return nativeEntity.id();
+    }
+
+    @Override
     public Set<EntityExcerpt> listEntityExcerpts() {
-        return getNativeViews().map(this::createExcerpt).collect(Collectors.toSet());
+        return getNativeViews()
+                .map(this::maybeCreateExcerpt)
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .collect(Collectors.toSet());
     }
 
     protected Stream<ViewSummaryDTO> getNativeViews() {


### PR DESCRIPTION
Content pack creation should be more robust in the face of serialization issues (see linked issue for details).

As a first step we simply catch and log exceptions, so content pack creation can still proceed; and it is easier to identify the offending entity.

Resolves #12684 
/jenkins-pr-deps Graylog2/graylog-plugin-enterprise#3616