### PR TITLE
Allow cloning of existing event definitions

### DIFF
--- a/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitionEntry.test.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitionEntry.test.tsx
@@ -41,6 +41,7 @@ describe('EventDefinitionEntry', () => {
     return (
       <CurrentUserContext.Provider value={currentUser}>
         <EventDefinitionEntry onDelete={() => {}}
+                              onCopy={() => {}}
                               onDisable={() => {}}
                               onEnable={() => {}}
                               context={{ scheduler: {} }}

--- a/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitionEntry.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitionEntry.tsx
@@ -77,10 +77,26 @@ const EventDefinitionEntry = ({
   const [showEntityShareModal, setShowEntityShareModal] = useState(false);
   const isScheduled = lodash.get(context, `scheduler.${eventDefinition.id}.is_scheduled`, true);
 
-  let toggle = <MenuItem onClick={onDisable(eventDefinition)}>Disable</MenuItem>;
+  const handleCopy = () => {
+    onCopy(eventDefinition);
+  };
+
+  const handleDelete = () => {
+    onDelete(eventDefinition);
+  };
+
+  const handleDisable = () => {
+    onDisable(eventDefinition);
+  };
+
+  const handleEnable = () => {
+    onEnable(eventDefinition);
+  };
+
+  let toggle = <MenuItem onClick={handleDisable}>Disable</MenuItem>;
 
   if (!isScheduled) {
-    toggle = <MenuItem onClick={onEnable(eventDefinition)}>Enable</MenuItem>;
+    toggle = <MenuItem onClick={handleEnable}>Enable</MenuItem>;
   }
 
   const actions = (
@@ -95,11 +111,11 @@ const EventDefinitionEntry = ({
       <ShareButton entityId={eventDefinition.id} entityType="event_definition" onClick={() => setShowEntityShareModal(true)} />
       <IfPermitted permissions={`eventdefinitions:delete:${eventDefinition.id}`}>
         <DropdownButton id="more-dropdown" title="More" pullRight>
-          <MenuItem onClick={onCopy(eventDefinition)}>Duplicate</MenuItem>
+          <MenuItem onClick={handleCopy}>Duplicate</MenuItem>
           <MenuItem divider />
           {toggle}
           <MenuItem divider />
-          <MenuItem onClick={onDelete(eventDefinition)}>Delete</MenuItem>
+          <MenuItem onClick={handleDelete}>Delete</MenuItem>
         </DropdownButton>
       </IfPermitted>
     </React.Fragment>

--- a/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitionEntry.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitionEntry.tsx
@@ -56,6 +56,7 @@ type Props = {
   onDisable: (EventDefinition) => void,
   onEnable: (EventDefinition) => void,
   onDelete: (EventDefinition) => void,
+  onCopy: (EventDefinition) => void,
 };
 
 const getConditionPlugin = (type: string) => PluginStore.exports('eventDefinitionTypes')
@@ -71,6 +72,7 @@ const EventDefinitionEntry = ({
   onDisable,
   onEnable,
   onDelete,
+  onCopy,
 }: Props) => {
   const [showEntityShareModal, setShowEntityShareModal] = useState(false);
   const isScheduled = lodash.get(context, `scheduler.${eventDefinition.id}.is_scheduled`, true);
@@ -93,6 +95,8 @@ const EventDefinitionEntry = ({
       <ShareButton entityId={eventDefinition.id} entityType="event_definition" onClick={() => setShowEntityShareModal(true)} />
       <IfPermitted permissions={`eventdefinitions:delete:${eventDefinition.id}`}>
         <DropdownButton id="more-dropdown" title="More" pullRight>
+          <MenuItem onClick={onCopy(eventDefinition)}>Duplicate</MenuItem>
+          <MenuItem divider />
           {toggle}
           <MenuItem divider />
           <MenuItem onClick={onDelete(eventDefinition)}>Delete</MenuItem>
@@ -102,7 +106,7 @@ const EventDefinitionEntry = ({
   );
 
   const plugin = getConditionPlugin(eventDefinition.config.type);
-  let titleSuffix = <>{plugin?.displayName ?? eventDefinition.config.type}</>;
+  let titleSuffix = <div>{plugin?.displayName ?? eventDefinition.config.type}</div>;
 
   if (!isScheduled) {
     titleSuffix = (<span>{titleSuffix} <Label bsStyle="warning">disabled</Label></span>);

--- a/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitions.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitions.jsx
@@ -50,7 +50,7 @@ class EventDefinitions extends React.Component {
     context: {},
   };
 
-  renderEmptyContent = () => {
+  static renderEmptyContent = () => {
     return (
       <Row>
         <Col md={6} mdOffset={3} lg={4} lgOffset={4}>

--- a/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitions.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitions.jsx
@@ -41,6 +41,7 @@ class EventDefinitions extends React.Component {
     onPageChange: PropTypes.func.isRequired,
     onQueryChange: PropTypes.func.isRequired,
     onDelete: PropTypes.func.isRequired,
+    onCopy: PropTypes.func.isRequired,
     onEnable: PropTypes.func.isRequired,
     onDisable: PropTypes.func.isRequired,
   };
@@ -70,7 +71,7 @@ class EventDefinitions extends React.Component {
   };
 
   render() {
-    const { eventDefinitions, context, pagination, query, onPageChange, onQueryChange, onDelete, onEnable, onDisable } = this.props;
+    const { eventDefinitions, context, pagination, query, onPageChange, onQueryChange, onDelete, onCopy, onEnable, onDisable } = this.props;
 
     if (pagination.grandTotal === 0) {
       return this.renderEmptyContent();
@@ -81,7 +82,8 @@ class EventDefinitions extends React.Component {
                             eventDefinition={definition}
                             onDisable={onDisable}
                             onEnable={onEnable}
-                            onDelete={onDelete} />
+                            onDelete={onDelete}
+                            onCopy={onCopy} />
     ));
 
     return (

--- a/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitionsContainer.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitionsContainer.jsx
@@ -63,6 +63,14 @@ class EventDefinitionsContainer extends React.Component {
     };
   };
 
+  handleCopy = (definition) => {
+    return () => {
+      if (window.confirm(`Are you sure you want to create a copy of "${definition.title}"?`)) {
+        EventDefinitionsActions.copy(definition);
+      }
+    };
+  };
+
   handleEnable = (definition) => {
     return () => {
       if (window.confirm(`Are you sure you want to enable "${definition.title}"?`)) {
@@ -94,6 +102,7 @@ class EventDefinitionsContainer extends React.Component {
                         onPageChange={this.handlePageChange}
                         onQueryChange={this.handleQueryChange}
                         onDelete={this.handleDelete}
+                        onCopy={this.handleCopy}
                         onEnable={this.handleEnable}
                         onDisable={this.handleDisable} />
     );

--- a/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitionsContainer.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitionsContainer.jsx
@@ -25,6 +25,13 @@ import {} from 'components/event-definitions/event-definition-types';
 
 import EventDefinitions from './EventDefinitions';
 
+const DIALOG_TYPES = {
+  COPY: 'copy',
+  DELETE: 'delete',
+  DISABLE: 'disable',
+  ENABLE: 'enable',
+};
+
 class EventDefinitionsContainer extends React.Component {
   static propTypes = {
     eventDefinitions: PropTypes.object.isRequired,
@@ -44,10 +51,10 @@ class EventDefinitionsContainer extends React.Component {
 
     this.state = {
       currentDefinition: null,
-      showCopyDialog: false,
-      showDeleteDialog: false,
-      showDisableDialog: false,
-      showEnableDialog: false,
+      dialogBody: '',
+      dialogTitle: '',
+      showDialog: false,
+      dialogType: null,
     };
   }
 
@@ -69,28 +76,76 @@ class EventDefinitionsContainer extends React.Component {
   };
 
   handleDelete = (definition) => {
-    this.setState({ showDeleteDialog: true, currentDefinition: definition });
+    this.setState({
+      showDialog: true,
+      dialogType: DIALOG_TYPES.DELETE,
+      dialogBody: `Are you sure you want to delete "${definition.title}"?`,
+      dialogTitle: 'Delete Event Definition',
+      currentDefinition: definition,
+    });
   };
 
   handleCopy = (definition) => {
-    this.setState({ showCopyDialog: true, currentDefinition: definition });
+    this.setState({
+      showDialog: true,
+      dialogType: DIALOG_TYPES.COPY,
+      dialogBody: `Are you sure you want to create a copy of "${definition.title}"?`,
+      dialogTitle: 'Copy Event Definition',
+      currentDefinition: definition,
+    });
   };
 
   handleEnable = (definition) => {
-    this.setState({ showEnableDialog: true, currentDefinition: definition });
+    this.setState({
+      showDialog: true,
+      dialogType: DIALOG_TYPES.ENABLE,
+      dialogBody: `Are you sure you want to enable "${definition.title}"?`,
+      dialogTitle: 'Enable Event Definition',
+      currentDefinition: definition,
+    });
   };
 
   handleDisable = (definition) => {
-    this.setState({ showDisableDialog: true, currentDefinition: definition });
+    this.setState({
+      showDialog: true,
+      dialogType: DIALOG_TYPES.DISABLE,
+      dialogBody: 'Disable Event Definition',
+      dialogTitle: `Are you sure you want to disable "${definition.title}"?`,
+      currentDefinition: definition,
+    });
+  };
+
+  handleConfirm = () => {
+    const { dialogType, currentDefinition } = this.state;
+
+    switch (dialogType) {
+      case 'copy':
+        EventDefinitionsActions.copy(currentDefinition);
+        this.handleClearState();
+        break;
+      case 'delete':
+        EventDefinitionsActions.delete(currentDefinition);
+        this.handleClearState();
+        break;
+      case 'enable':
+        EventDefinitionsActions.enable(currentDefinition);
+        this.handleClearState();
+        break;
+      case 'disable':
+        EventDefinitionsActions.disable(currentDefinition);
+        this.handleClearState();
+        break;
+      default:
+        break;
+    }
   };
 
   handleClearState = () => {
     this.setState({
-      showCopyDialog: false,
-      showDeleteDialog: false,
-      showDisableDialog: false,
-      showEnableDialog: false,
+      showDialog: false,
       currentDefinition: null,
+      dialogBody: '',
+      dialogTitle: '',
     });
   };
 
@@ -98,11 +153,9 @@ class EventDefinitionsContainer extends React.Component {
     const { eventDefinitions } = this.props;
 
     const {
-      currentDefinition,
-      showCopyDialog,
-      showDeleteDialog,
-      showDisableDialog,
-      showEnableDialog,
+      showDialog,
+      dialogBody,
+      dialogTitle,
     } = this.state;
 
     if (!eventDefinitions.eventDefinitions) {
@@ -121,55 +174,15 @@ class EventDefinitionsContainer extends React.Component {
                           onCopy={this.handleCopy}
                           onEnable={this.handleEnable}
                           onDisable={this.handleDisable} />
-        {showCopyDialog && (
+        {showDialog && (
         <ConfirmDialog id="copy-event-definition-dialog"
-                       title="Copy Event Definition"
+                       title={dialogTitle}
                        show
-                       onConfirm={() => {
-                         EventDefinitionsActions.copy(currentDefinition);
-                         this.handleClearState();
-                       }}
+                       onConfirm={this.handleConfirm}
                        onCancel={this.handleClearState}>
-          {`Are you sure you want to create a copy of "${currentDefinition?.title || ''}"?`}
+          {dialogBody}
         </ConfirmDialog>
         )}
-        {showDeleteDialog && (
-        <ConfirmDialog id="delete-event-definition-dialog"
-                       title="Delete Event Definition"
-                       show
-                       onConfirm={() => {
-                         EventDefinitionsActions.delete(currentDefinition);
-                         this.handleClearState();
-                       }}
-                       onCancel={this.handleClearState}>
-          {`Are you sure you want to delete "${currentDefinition?.title || ''}"?`}
-        </ConfirmDialog>
-        )}
-        {showDisableDialog && (
-        <ConfirmDialog id="disable-event-definition-dialog"
-                       title="Disable Event Definition"
-                       show
-                       onConfirm={() => {
-                         EventDefinitionsActions.disable(currentDefinition);
-                         this.handleClearState();
-                       }}
-                       onCancel={this.handleClearState}>
-          {`Are you sure you want to disable "${currentDefinition?.title || ''}"?`}
-        </ConfirmDialog>
-        )}
-        {showEnableDialog && (
-        <ConfirmDialog id="enable-event-definition-dialog"
-                       title="Enable Event Definition"
-                       show
-                       onConfirm={() => {
-                         EventDefinitionsActions.enable(currentDefinition);
-                         this.handleClearState();
-                       }}
-                       onCancel={this.handleClearState}>
-          {`Are you sure you want to enable "${currentDefinition?.title || ''}"?`}
-        </ConfirmDialog>
-        )}
-
       </>
 
     );

--- a/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitionsContainer.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitionsContainer.jsx
@@ -32,6 +32,25 @@ const DIALOG_TYPES = {
   ENABLE: 'enable',
 };
 
+const DIALOG_TEXT = {
+  [DIALOG_TYPES.COPY]: {
+    dialogTitle: 'Copy Event Definition',
+    dialogBody: (definitionTitle) => `Are you sure you want to create a copy of "${definitionTitle}"?`,
+  },
+  [DIALOG_TYPES.DELETE]: {
+    dialogTitle: 'Delete Event Definition',
+    dialogBody: (definitionTitle) => `Are you sure you want to delete "${definitionTitle}"?`,
+  },
+  [DIALOG_TYPES.DISABLE]: {
+    dialogTitle: 'Disable Event Definition',
+    dialogBody: (definitionTitle) => `Are you sure you want to disable "${definitionTitle}"?`,
+  },
+  [DIALOG_TYPES.ENABLE]: {
+    dialogTitle: 'Enable Event Definition',
+    dialogBody: (definitionTitle) => `Are you sure you want to enable "${definitionTitle}"?`,
+  },
+};
+
 class EventDefinitionsContainer extends React.Component {
   static propTypes = {
     eventDefinitions: PropTypes.object.isRequired,
@@ -51,8 +70,6 @@ class EventDefinitionsContainer extends React.Component {
 
     this.state = {
       currentDefinition: null,
-      dialogBody: '',
-      dialogTitle: '',
       showDialog: false,
       dialogType: null,
     };
@@ -75,44 +92,43 @@ class EventDefinitionsContainer extends React.Component {
     promise.finally(callback);
   };
 
-  handleDelete = (definition) => {
-    this.setState({
-      showDialog: true,
-      dialogType: DIALOG_TYPES.DELETE,
-      dialogBody: `Are you sure you want to delete "${definition.title}"?`,
-      dialogTitle: 'Delete Event Definition',
-      currentDefinition: definition,
-    });
-  };
+  handleAction = (action) => (definition) => {
+    switch (action) {
+      case DIALOG_TYPES.COPY:
+        this.setState({
+          showDialog: true,
+          dialogType: DIALOG_TYPES.COPY,
+          currentDefinition: definition,
+        });
 
-  handleCopy = (definition) => {
-    this.setState({
-      showDialog: true,
-      dialogType: DIALOG_TYPES.COPY,
-      dialogBody: `Are you sure you want to create a copy of "${definition.title}"?`,
-      dialogTitle: 'Copy Event Definition',
-      currentDefinition: definition,
-    });
-  };
+        break;
+      case DIALOG_TYPES.DELETE:
+        this.setState({
+          showDialog: true,
+          dialogType: DIALOG_TYPES.DELETE,
+          currentDefinition: definition,
+        });
 
-  handleEnable = (definition) => {
-    this.setState({
-      showDialog: true,
-      dialogType: DIALOG_TYPES.ENABLE,
-      dialogBody: `Are you sure you want to enable "${definition.title}"?`,
-      dialogTitle: 'Enable Event Definition',
-      currentDefinition: definition,
-    });
-  };
+        break;
+      case DIALOG_TYPES.ENABLE:
+        this.setState({
+          showDialog: true,
+          dialogType: DIALOG_TYPES.ENABLE,
+          currentDefinition: definition,
+        });
 
-  handleDisable = (definition) => {
-    this.setState({
-      showDialog: true,
-      dialogType: DIALOG_TYPES.DISABLE,
-      dialogBody: 'Disable Event Definition',
-      dialogTitle: `Are you sure you want to disable "${definition.title}"?`,
-      currentDefinition: definition,
-    });
+        break;
+      case DIALOG_TYPES.DISABLE:
+        this.setState({
+          showDialog: true,
+          dialogType: DIALOG_TYPES.DISABLE,
+          currentDefinition: definition,
+        });
+
+        break;
+      default:
+        break;
+    }
   };
 
   handleConfirm = () => {
@@ -144,8 +160,7 @@ class EventDefinitionsContainer extends React.Component {
     this.setState({
       showDialog: false,
       currentDefinition: null,
-      dialogBody: '',
-      dialogTitle: '',
+      dialogType: null,
     });
   };
 
@@ -153,9 +168,9 @@ class EventDefinitionsContainer extends React.Component {
     const { eventDefinitions } = this.props;
 
     const {
+      currentDefinition,
+      dialogType,
       showDialog,
-      dialogBody,
-      dialogTitle,
     } = this.state;
 
     if (!eventDefinitions.eventDefinitions) {
@@ -170,17 +185,17 @@ class EventDefinitionsContainer extends React.Component {
                           query={eventDefinitions.query}
                           onPageChange={this.handlePageChange}
                           onQueryChange={this.handleQueryChange}
-                          onDelete={this.handleDelete}
-                          onCopy={this.handleCopy}
-                          onEnable={this.handleEnable}
-                          onDisable={this.handleDisable} />
+                          onDelete={this.handleAction(DIALOG_TYPES.DELETE)}
+                          onCopy={this.handleAction(DIALOG_TYPES.COPY)}
+                          onEnable={this.handleAction(DIALOG_TYPES.ENABLE)}
+                          onDisable={this.handleAction(DIALOG_TYPES.DISABLE)} />
         {showDialog && (
         <ConfirmDialog id="copy-event-definition-dialog"
-                       title={dialogTitle}
+                       title={DIALOG_TEXT[dialogType].dialogTitle}
                        show
                        onConfirm={this.handleConfirm}
                        onCancel={this.handleClearState}>
-          {dialogBody}
+          {DIALOG_TEXT[dialogType].dialogBody(currentDefinition.title)}
         </ConfirmDialog>
         )}
       </>

--- a/graylog2-web-interface/src/stores/event-definitions/EventDefinitionsStore.js
+++ b/graylog2-web-interface/src/stores/event-definitions/EventDefinitionsStore.js
@@ -30,6 +30,7 @@ export const EventDefinitionsActions = singletonActions(
     listPaginated: { asyncResult: true },
     get: { asyncResult: true },
     create: { asyncResult: true },
+    copy: { asyncResult: true },
     update: { asyncResult: true },
     delete: { asyncResult: true },
     enable: { asyncResult: true },
@@ -196,6 +197,35 @@ export const EventDefinitionsStore = singletonStore(
       );
 
       EventDefinitionsActions.create.promise(promise);
+    },
+
+    copy(eventDefinitionToCopy) {
+      const { eventDefinition } = this.extractSchedulerInfo(eventDefinitionToCopy);
+      // Remove the id from the event definition to create a new copy
+      delete eventDefinition.id;
+      // Modify the title to indicate a copy
+      eventDefinition.title = `COPY-${eventDefinition.title}`;
+
+      const promise = fetch('POST', this.eventDefinitionsUrl({ query: { schedule: false } }), this.setAlertFlag(eventDefinition));
+
+      promise.then(
+        (response) => {
+          UserNotification.success('Event Definition copied successfully',
+            `Event Definition "${eventDefinition.title}" was created successfully.`);
+
+          this.refresh();
+
+          return response;
+        },
+        (error) => {
+          if (error.status !== 400 || !error.additional.body || !error.additional.body.failed) {
+            UserNotification.error(`Creating Event Definition "${eventDefinition.title}" failed with status: ${error}`,
+              'Could not save Event Definition');
+          }
+        },
+      );
+
+      EventDefinitionsActions.copy.promise(promise);
     },
 
     update(eventDefinitionId, updatedEventDefinition) {


### PR DESCRIPTION
Addresses  Issue  #8017

## Description
Allows for the duplication of an event definition through the dropdown menu on the event definitions list page.

It also includes updates to clear our Eslint errors and warnings. Specifically around switching to the use of our confirm modal rather than relying on `window.confirm`

NOTE: This is not a complete refactor, considering the scope of the functionality it seemed unreasonable to wholesale update to our modern practices. Instead an issue will be created and addressed next cycle to actually upgrade to TS and ReactQuery.

## Motivation and Context
To correct issue #8017 

## How Has This Been Tested?
Tested locally visually and unit tests ran.

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/3578720/169356102-a718eac8-de4b-4189-babe-6a3705a10de9.png)

![image](https://user-images.githubusercontent.com/3578720/169356149-cdd90f0f-32c1-4b85-b32c-9115ab8537d8.png)


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

