### PR TITLE
Updating security policy to remove need for maintenance.

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,13 +4,7 @@
 
 Graylog is addressing vulnerabilities in the product for the current and the previous releases (a release is anything that increases either the major or the minor version part, in a [semver](https://semver.org) understanding) of the last twelve months.
 
-For the current release (4.0) this means:
-
-| Version | Supported          |
-| ------- | ------------------ |
-| 4.0.x   | :white_check_mark: |
-| 3.3.x   | :white_check_mark: |
-| < 3.3.0 | :x:                |
+We highly recommend anyone using a version that is older than twelve months _or_ the last two releases to upgrade as soon as possible.
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
This change is solely updating the security policy in order to remove the overly specific version matrix which would require updates for every release.
