### PR TITLE
Query validation (Lucene Parser) takes into account leading-wildcard setting.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/validation/LuceneQueryParser.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/validation/LuceneQueryParser.java
@@ -20,13 +20,24 @@ import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.queryparser.classic.ParseException;
 import org.apache.lucene.search.Query;
 
+import javax.inject.Inject;
+import javax.inject.Named;
+
 public class LuceneQueryParser {
 
     public static final StandardAnalyzer ANALYZER = new StandardAnalyzer();
 
+    private final boolean allowLeadingWildcard;
+
+    @Inject
+    public LuceneQueryParser(@Named("allow_leading_wildcard_searches") final boolean allowLeadingWildcard) {
+        this.allowLeadingWildcard = allowLeadingWildcard;
+    }
+
     public ParsedQuery parse(final String query) throws ParseException {
         final TokenCollectingQueryParser parser = new TokenCollectingQueryParser(ParsedTerm.DEFAULT_FIELD, ANALYZER);
         parser.setSplitOnWhitespace(true);
+        parser.setAllowLeadingWildcard(allowLeadingWildcard);
 
         final Query parsed = parser.parse(query);
         final ParsedQuery.Builder builder = ParsedQuery.builder().query(query);

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/MessagesResourceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/MessagesResourceTest.java
@@ -34,7 +34,6 @@ import org.graylog.plugins.views.search.validation.QueryValidationService;
 import org.graylog.plugins.views.search.validation.QueryValidationServiceImpl;
 import org.graylog2.indexer.fieldtypes.MappedFieldTypesService;
 import org.graylog2.plugin.database.users.User;
-import org.graylog2.shared.bindings.GuiceInjectorHolder;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -77,7 +76,7 @@ public class MessagesResourceTest {
 
         final MappedFieldTypesService mappedFieldTypesService = (streamIds, timeRange) -> Collections.emptySet();
         final QueryValidationServiceImpl validationService = new QueryValidationServiceImpl(
-                new LuceneQueryParser(),
+                new LuceneQueryParser(false),
                 mappedFieldTypesService,
                 Collections.emptySet());
 

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/validation/LuceneQueryParserTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/validation/LuceneQueryParserTest.java
@@ -26,7 +26,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class LuceneQueryParserTest {
 
-    private final LuceneQueryParser parser = new LuceneQueryParser();
+    private final LuceneQueryParser parser = new LuceneQueryParser(false);
 
 
     @Test
@@ -203,5 +203,20 @@ class LuceneQueryParserTest {
         assertThat(query.terms())
                 .extracting(ParsedTerm::field)
                 .containsOnly("unknown_field");
+    }
+
+    @Test
+    void testLeadingWildcardsParsingDependsOnParserSettings() throws ParseException {
+        assertThatThrownBy(() -> parser.parse("foo:*bar"))
+                .isInstanceOf(ParseException.class);
+
+        assertThatThrownBy(() -> parser.parse("foo:?bar"))
+                .isInstanceOf(ParseException.class);
+
+        final LuceneQueryParser leadingWildcardsTolerantParser = new LuceneQueryParser(true);
+        assertThat(leadingWildcardsTolerantParser.parse("foo:*bar"))
+                .isNotNull();
+        assertThat(leadingWildcardsTolerantParser.parse("foo:?bar"))
+                .isNotNull();
     }
 }

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/validation/QueryValidationServiceImplTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/validation/QueryValidationServiceImplTest.java
@@ -29,7 +29,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class QueryValidationServiceImplTest {
 
     public static final MappedFieldTypesService FIELD_TYPES_SERVICE = (streamIds, timeRange) -> Collections.emptySet();
-    public static final LuceneQueryParser LUCENE_QUERY_PARSER = new LuceneQueryParser();
+    public static final LuceneQueryParser LUCENE_QUERY_PARSER = new LuceneQueryParser(false);
 
     @Test
     void validateNoMessages() {
@@ -111,7 +111,7 @@ class QueryValidationServiceImplTest {
                         .build());
 
         final QueryValidationServiceImpl service = new QueryValidationServiceImpl(
-                new LuceneQueryParser(),
+                new LuceneQueryParser(false),
                 FIELD_TYPES_SERVICE,
                 ImmutableSet.of(warningValidator, errorValidator));
 

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/validation/TestValidationContext.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/validation/TestValidationContext.java
@@ -30,7 +30,7 @@ import java.util.Set;
 
 public class TestValidationContext {
 
-    public static final LuceneQueryParser LUCENE_QUERY_PARSER = new LuceneQueryParser();
+    public static final LuceneQueryParser LUCENE_QUERY_PARSER = new LuceneQueryParser(false);
 
     private final String queryString;
     private final Set<MappedFieldTypeDTO> fields;

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/validation/ValidationMessageTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/validation/ValidationMessageTest.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 class ValidationMessageTest {
 
-    private final LuceneQueryParser luceneQueryParser = new LuceneQueryParser();
+    private final LuceneQueryParser luceneQueryParser = new LuceneQueryParser(false);
 
     @Test
     void fromException() {


### PR DESCRIPTION
Fixes #12725 

## Description
Query validation (Lucene Parser) takes into consideration so-called leading-wildcard setting from the config.

## Motivation and Context
Even if clients set allow_leading_wildcard_searches = true in the config, validation returned errors when a query with leading wildcard was used.

## How Has This Been Tested?
1. Change **allow_leading_wildcard_searches** flag to true or false, restart the server.
2. Enter some queries starting with * or ? (foo:*bar or ?hatver...)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

