### PR TITLE
Query validation (Lucene Parser) takes into consideration so-called l…

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/validation/LuceneQueryParser.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/validation/LuceneQueryParser.java
@@ -20,12 +20,17 @@ import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.queryparser.classic.ParseException;
 import org.apache.lucene.search.Query;
 
+import javax.inject.Inject;
+import javax.inject.Named;
+
 public class LuceneQueryParser {
     private final TermCollectingQueryParser parser;
 
-    public LuceneQueryParser() {
+    @Inject
+    public LuceneQueryParser(@Named("allow_leading_wildcard_searches") final boolean allowLeadingWildcard) {
         this.parser = new TermCollectingQueryParser(ParsedTerm.DEFAULT_FIELD, new StandardAnalyzer());
         this.parser.setSplitOnWhitespace(true);
+        this.parser.setAllowLeadingWildcard(allowLeadingWildcard);
     }
 
     public ParsedQuery parse(final String query) throws ParseException {

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/elasticsearch/parser/LuceneQueryParserTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/elasticsearch/parser/LuceneQueryParserTest.java
@@ -30,7 +30,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class LuceneQueryParserTest {
 
-    private final LuceneQueryParser parser = new LuceneQueryParser();
+    private final LuceneQueryParser parser = new LuceneQueryParser(false);
 
     @Test
     void getFieldNamesSimple() throws ParseException {
@@ -189,5 +189,20 @@ class LuceneQueryParserTest {
         final ParsedTerm term = query.terms().iterator().next();
         assertThat(term.field()).isEqualTo("_default_");
         assertThat(term.value()).isEqualTo("fuzzy");
+    }
+
+    @Test
+    void testLeadingWildcardsParsingDependsOnParserSettings() throws ParseException {
+        assertThatThrownBy(() -> parser.parse("foo:*bar"))
+                .isInstanceOf(ParseException.class);
+
+        assertThatThrownBy(() -> parser.parse("foo:?bar"))
+                .isInstanceOf(ParseException.class);
+
+        final LuceneQueryParser leadingWildcardsTolerantParser = new LuceneQueryParser(true);
+        assertThat(leadingWildcardsTolerantParser.parse("foo:*bar"))
+                .isNotNull();
+        assertThat(leadingWildcardsTolerantParser.parse("foo:?bar"))
+                .isNotNull();
     }
 }

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/MessagesResourceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/MessagesResourceTest.java
@@ -22,7 +22,6 @@ import com.google.common.eventbus.EventBus;
 import org.graylog.plugins.views.search.SearchDomain;
 import org.graylog.plugins.views.search.SearchExecutionGuard;
 import org.graylog.plugins.views.search.elasticsearch.QueryStringDecorators;
-import org.graylog.plugins.views.search.elasticsearch.QueryStringParser;
 import org.graylog.plugins.views.search.errors.PermissionException;
 import org.graylog.plugins.views.search.export.AuditContext;
 import org.graylog.plugins.views.search.export.CommandFactory;
@@ -79,7 +78,7 @@ public class MessagesResourceTest {
         SearchDomain searchDomain = mock(SearchDomain.class);
 
         final QueryValidationServiceImpl validationService = new QueryValidationServiceImpl(
-                new LuceneQueryParser(),
+                new LuceneQueryParser(false),
                 (streamIds, timeRange) -> Collections.emptySet(),
                 new QueryStringDecorators(Collections.emptySet()));
 

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/validation/ValidationMessageTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/validation/ValidationMessageTest.java
@@ -24,7 +24,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 class ValidationMessageTest {
 
-    private final LuceneQueryParser luceneQueryParser = new LuceneQueryParser();
+    private final LuceneQueryParser luceneQueryParser = new LuceneQueryParser(false);
 
     @Test
     void fromException() {


### PR DESCRIPTION
…eading-wildcard setting from the config (4.3).

Backporting to 4.3.
Original PR: #12726
Related commit in master: 8b85ff8586959deb9eb30f293d0901bd33e8fdcf


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

