### PR TITLE
Improve hostname retrieval in EventProcessorEventFactory

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/events/event/EventProcessorEventFactory.java
+++ b/graylog2-server/src/main/java/org/graylog/events/event/EventProcessorEventFactory.java
@@ -18,6 +18,7 @@ package org.graylog.events.event;
 
 import de.huxhorn.sulky.ulid.ULID;
 import org.graylog.events.processor.EventDefinition;
+import org.graylog.util.HostnameProvider;
 import org.graylog2.cluster.NodeNotFoundException;
 import org.graylog2.cluster.NodeService;
 import org.graylog2.plugin.system.NodeId;
@@ -31,6 +32,17 @@ public class EventProcessorEventFactory implements EventFactory {
     private final ULID ulid;
 
     @Inject
+    public EventProcessorEventFactory(ULID ulid, HostnameProvider hostnameProvider) {
+        this.ulid = ulid;
+        try {
+            this.source = hostnameProvider.get().canonicalHostname();
+        } catch (Exception e) {
+            throw new RuntimeException("Couldn't get local hostname", e);
+        }
+    }
+
+    // Used in some tests in another repository.
+    @Deprecated
     public EventProcessorEventFactory(ULID ulid, NodeService nodeService, NodeId nodeId) {
         this.ulid = ulid;
         try {

--- a/graylog2-server/src/main/java/org/graylog/util/Hostname.java
+++ b/graylog2-server/src/main/java/org/graylog/util/Hostname.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.util;
+
+import com.google.auto.value.AutoValue;
+
+import static java.util.Objects.requireNonNull;
+
+@AutoValue
+public abstract class Hostname {
+    public abstract String hostname();
+
+    public abstract String canonicalHostname();
+
+    public static Hostname create(String hostname, String canonicalHostname) {
+        return new AutoValue_Hostname(requireNonNull(hostname), requireNonNull(canonicalHostname));
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/util/Hostname.java
+++ b/graylog2-server/src/main/java/org/graylog/util/Hostname.java
@@ -18,12 +18,26 @@ package org.graylog.util;
 
 import com.google.auto.value.AutoValue;
 
+import java.net.InetAddress;
+
 import static java.util.Objects.requireNonNull;
 
 @AutoValue
 public abstract class Hostname {
+    /**
+     * Returns the short hostname.
+     *
+     * @return the hostname
+     * @see InetAddress#getHostName()
+     */
     public abstract String hostname();
 
+    /**
+     * Returns the full hostname.
+     *
+     * @return the hostname
+     * @see InetAddress#getCanonicalHostName()
+     */
     public abstract String canonicalHostname();
 
     public static Hostname create(String hostname, String canonicalHostname) {

--- a/graylog2-server/src/main/java/org/graylog/util/Hostname.java
+++ b/graylog2-server/src/main/java/org/graylog/util/Hostname.java
@@ -40,6 +40,13 @@ public abstract class Hostname {
      */
     public abstract String canonicalHostname();
 
+    /**
+     * Creates the hostname object.
+     *
+     * @param hostname          the short hostname, see: {@link InetAddress#getHostName()}
+     * @param canonicalHostname the full hostname, see: {@link InetAddress#getCanonicalHostName()}
+     * @return the newly created hostname object
+     */
     public static Hostname create(String hostname, String canonicalHostname) {
         return new AutoValue_Hostname(requireNonNull(hostname), requireNonNull(canonicalHostname));
     }

--- a/graylog2-server/src/main/java/org/graylog/util/HostnameProvider.java
+++ b/graylog2-server/src/main/java/org/graylog/util/HostnameProvider.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.util;
+
+import org.graylog2.plugin.Tools;
+
+import javax.inject.Provider;
+
+public class HostnameProvider implements Provider<Hostname> {
+    /**
+     * Returns the {@link Hostname} object for the local node.
+     *
+     * @return the hostname
+     * @throws RuntimeException when local hostname cannot be retrieved
+     */
+    @Override
+    public Hostname get() {
+        try {
+            return Hostname.create(Tools.getLocalHostname(), Tools.getLocalCanonicalHostname());
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
Previously we looked up the local Graylog node in MongoDB to get the
stored hostname. This can fail when MongoDB isn't reachable, or the node
is overloaded, and its entry in the "nodes" collection in the database is
gone.

This change introduces a Hostname class and a provider to retrieve the
local hostname without talking to the database.