### PR TITLE
Optimize populating of user dropdown

### DIFF
--- a/graylog2-web-interface/src/components/event-notifications/event-notification-types/EmailNotificationFormContainer.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-types/EmailNotificationFormContainer.jsx
@@ -50,7 +50,8 @@ class EmailNotificationFormContainer extends React.Component {
     const { currentUser } = this.props;
 
     if (isPermitted(currentUser.permissions, 'users:list')) {
-      UsersDomain.loadUsers().then((users) => this.setState({ users }));
+      const query = { include_permissions: false, include_sessions: false };
+      UsersDomain.loadUsers(query).then((users) => this.setState({ users }));
     } else {
       this.setState({ users: Immutable.List() });
     }

--- a/graylog2-web-interface/src/components/users/UserCreate/UserCreate.tsx
+++ b/graylog2-web-interface/src/components/users/UserCreate/UserCreate.tsx
@@ -124,7 +124,8 @@ const UserCreate = () => {
   const [selectedRoles, setSelectedRoles] = useState<Immutable.Set<DescriptiveItem>>(Immutable.Set([initialRole]));
 
   useEffect(() => {
-    UsersDomain.loadUsers().then(setUsers);
+    const query = { include_permissions: false, include_sessions: false };
+    UsersDomain.loadUsers(query).then(setUsers);
   }, []);
 
   const _onAssignRole = (roles: Immutable.Set<DescriptiveItem>) => {

--- a/graylog2-web-interface/src/stores/users/UsersStore.ts
+++ b/graylog2-web-interface/src/stores/users/UsersStore.ts
@@ -76,6 +76,11 @@ export type PaginatedUsers = PaginatedList<UserOverview> & {
   adminUser: UserOverview | null | undefined,
 };
 
+export type Query = {
+  include_permissions?: boolean;
+  include_sessions?: boolean;
+};
+
 export type ActionsType = {
   create: (user: UserCreate) => Promise<void>;
   load: (userId: string) => Promise<User>;
@@ -86,7 +91,7 @@ export type ActionsType = {
   createToken: (userId: string, tokenName: string) => Promise<Token>;
   loadTokens: (userId: string) => Promise<TokenSummary[]>;
   deleteToken: (userId: string, tokenId: string, tokenName: string) => Promise<void>;
-  loadUsers: () => Promise<Immutable.List<User>>;
+  loadUsers: (query?: Query) => Promise<Immutable.List<User>>;
   loadUsersPaginated: (pagination: Pagination) => Promise<PaginatedUsers>;
   setStatus: (userId: string, newStatus: AccountStatus) => Promise<void>;
 };
@@ -195,7 +200,7 @@ export const UsersStore = singletonStore('core.Users', () => Reflux.createStore(
     return promise;
   },
 
-  loadUsers(query = {}): Promise<Immutable.List<User>> {
+  loadUsers(query: Query = {}): Promise<Immutable.List<User>> {
     const url = usersUrl({ url: ApiRoutes.UsersApiController.list().url, query });
     const promise = fetch('GET', url).then(({
       users,

--- a/graylog2-web-interface/src/stores/users/UsersStore.ts
+++ b/graylog2-web-interface/src/stores/users/UsersStore.ts
@@ -17,6 +17,7 @@
 import Reflux from 'reflux';
 import * as Immutable from 'immutable';
 import type { $PropertyType, $Shape } from 'utility-types';
+import URI from 'urijs';
 
 import type { UserOverviewJSON, AccountStatus } from 'logic/users/UserOverview';
 import UserOverview from 'logic/users/UserOverview';
@@ -28,7 +29,6 @@ import PaginationURL from 'util/PaginationURL';
 import type { UserJSON } from 'logic/users/User';
 import User from 'logic/users/User';
 import type { PaginatedListJSON, Pagination, PaginatedList } from 'stores/PaginationTypes';
-import URI from 'urijs';
 
 export type PaginatedUsersResponse = PaginatedListJSON & {
   users: Array<UserOverviewJSON>;

--- a/graylog2-web-interface/src/stores/users/UsersStore.ts
+++ b/graylog2-web-interface/src/stores/users/UsersStore.ts
@@ -28,6 +28,7 @@ import PaginationURL from 'util/PaginationURL';
 import type { UserJSON } from 'logic/users/User';
 import User from 'logic/users/User';
 import type { PaginatedListJSON, Pagination, PaginatedList } from 'stores/PaginationTypes';
+import URI from 'urijs';
 
 export type PaginatedUsersResponse = PaginatedListJSON & {
   users: Array<UserOverviewJSON>;
@@ -88,6 +89,14 @@ export type ActionsType = {
   loadUsers: () => Promise<Immutable.List<User>>;
   loadUsersPaginated: (pagination: Pagination) => Promise<PaginatedUsers>;
   setStatus: (userId: string, newStatus: AccountStatus) => Promise<void>;
+};
+
+const usersUrl = ({ url = '', query = {} }) => {
+  const uri = new URI(url);
+
+  uri.query(query);
+
+  return qualifyUrl(uri.resource());
 };
 
 export const UsersActions = singletonActions(
@@ -186,8 +195,8 @@ export const UsersStore = singletonStore('core.Users', () => Reflux.createStore(
     return promise;
   },
 
-  loadUsers(): Promise<Immutable.List<User>> {
-    const url = qualifyUrl(ApiRoutes.UsersApiController.list().url);
+  loadUsers(query = {}): Promise<Immutable.List<User>> {
+    const url = usersUrl({ url: ApiRoutes.UsersApiController.list().url, query });
     const promise = fetch('GET', url).then(({
       users,
     }) => Immutable.List(users.map((user) => UserOverview.fromJSON(user))));


### PR DESCRIPTION
As described in #12453, creating an email notification can be slow when there are a lot of users. This is due to the amount of work required to build the full set of user objects, particularly computing the set of permissions assigned to each user. Since we are only interested in the list of user emails, we should avoid fetching extraneous data.

The same thing applies to the user creation form, which fetches existing users to ensure uniqueness.

This PR adds the following optional query parameters to the `api/users` endpoint:
- include_sessions (default: true): if false, do not check current session information for users
- include_permissions (default: true): if false, do not return any permissions data

By calling `api/users?include_permissions=false&include_sessions=false` we speed up populating the email dropdown significantly. Testing with 3000 users (each with a single team membership) and 1000 sessions we observed a speed-up of approximately 5x.

**Note**: the API change is backward compatible, since the new parameters are optional with default values that preserve the legacy behavior.