### PR TITLE
Check permission before loading enterprise traffic graph

### DIFF
--- a/graylog2-web-interface/src/components/cluster/GraylogClusterOverview.tsx
+++ b/graylog2-web-interface/src/components/cluster/GraylogClusterOverview.tsx
@@ -17,7 +17,7 @@
 /* eslint-disable react/no-find-dom-node */
 
 import * as React from 'react';
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useContext } from 'react';
 import PropTypes from 'prop-types';
 import { reduce } from 'lodash';
 import styled, { css } from 'styled-components';
@@ -29,9 +29,11 @@ import NumberUtils from 'util/NumberUtils';
 import { useStore } from 'stores/connect';
 import { Col, Row } from 'components/bootstrap';
 import { Spinner } from 'components/common';
+import CurrentUserContext from 'contexts/CurrentUserContext';
 import { ClusterTrafficActions, ClusterTrafficStore } from 'stores/cluster/ClusterTrafficStore';
 import { NodesStore } from 'stores/nodes/NodesStore';
 import { formatTrafficData } from 'util/TrafficUtils';
+import { isPermitted } from 'util/PermissionsMixin';
 
 import TrafficGraph from './TrafficGraph';
 
@@ -72,6 +74,7 @@ const GraylogClusterTrafficGraph = () => {
   const eventThrottler = useRef(new EventHandlersThrottler());
   const containerRef = useRef(null);
   const licensePlugin = PluginStore.exports('license');
+  const currentUser = useContext(CurrentUserContext);
 
   useEffect(() => {
     ClusterTrafficActions.getTraffic();
@@ -99,7 +102,7 @@ const GraylogClusterTrafficGraph = () => {
     };
   }, []);
 
-  const TrafficGraphComponent = licensePlugin[0]?.EnterpriseTrafficGraph || TrafficGraph;
+  const TrafficGraphComponent = (isPermitted(currentUser.permissions, ['licenses:read']) && licensePlugin[0]?.EnterpriseTrafficGraph) || TrafficGraph;
   let sumOutput = null;
   let trafficGraph = <Spinner />;
 


### PR DESCRIPTION
These changes check the current user for license read permission before loading the enterprise traffic graph

fix Graylog2/graylog-plugin-enterprise#3648

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

