### PR TITLE
Avoid unnecessary eager instantiation of production provider.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/web/IndexHtmlGeneratorProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/web/IndexHtmlGeneratorProvider.java
@@ -16,14 +16,17 @@
  */
 package org.graylog2.web;
 
+import com.google.common.base.Suppliers;
+
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Provider;
 import javax.inject.Singleton;
+import java.util.function.Supplier;
 
 @Singleton
 public class IndexHtmlGeneratorProvider implements Provider<IndexHtmlGenerator> {
-    private final IndexHtmlGenerator indexHtmlGenerator;
+    private final Supplier<IndexHtmlGenerator> indexHtmlGeneratorSupplier;
 
     @Inject
     public IndexHtmlGeneratorProvider(Provider<DevelopmentIndexHtmlGenerator> developmentIndexHtmlGeneratorProvider,
@@ -36,11 +39,11 @@ public class IndexHtmlGeneratorProvider implements Provider<IndexHtmlGenerator> 
                 ? developmentIndexHtmlGeneratorProvider
                 : productionIndexHtmlGeneratorProvider;
 
-        this.indexHtmlGenerator = indexHtmlGeneratorProvider.get();
+        this.indexHtmlGeneratorSupplier = Suppliers.memoize(indexHtmlGeneratorProvider::get);
     }
 
     @Override
     public IndexHtmlGenerator get() {
-        return indexHtmlGenerator;
+        return this.indexHtmlGeneratorSupplier.get();
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/web/IndexHtmlGeneratorProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/web/IndexHtmlGeneratorProvider.java
@@ -19,9 +19,11 @@ package org.graylog2.web;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Provider;
+import javax.inject.Singleton;
 
+@Singleton
 public class IndexHtmlGeneratorProvider implements Provider<IndexHtmlGenerator> {
-    private final Provider<? extends IndexHtmlGenerator> indexHtmlGeneratorProvider;
+    private final IndexHtmlGenerator indexHtmlGenerator;
 
     @Inject
     public IndexHtmlGeneratorProvider(Provider<DevelopmentIndexHtmlGenerator> developmentIndexHtmlGeneratorProvider,
@@ -30,13 +32,15 @@ public class IndexHtmlGeneratorProvider implements Provider<IndexHtmlGenerator> 
         // In development mode we use an external process to provide the web interface.
         // To avoid errors because of missing production web assets, we use a different implementation for
         // generating the "index.html" page.
-        this.indexHtmlGeneratorProvider = isDevelopmentServer
+        final Provider<? extends IndexHtmlGenerator> indexHtmlGeneratorProvider = isDevelopmentServer
                 ? developmentIndexHtmlGeneratorProvider
                 : productionIndexHtmlGeneratorProvider;
+
+        this.indexHtmlGenerator = indexHtmlGeneratorProvider.get();
     }
 
     @Override
     public IndexHtmlGenerator get() {
-        return indexHtmlGeneratorProvider.get();
+        return indexHtmlGenerator;
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/web/ProductionIndexHtmlGenerator.java
+++ b/graylog2-server/src/main/java/org/graylog2/web/ProductionIndexHtmlGenerator.java
@@ -23,7 +23,6 @@ import org.graylog2.configuration.HttpConfiguration;
 import org.graylog2.rest.RestTools;
 
 import javax.inject.Inject;
-import javax.inject.Singleton;
 import javax.ws.rs.core.MultivaluedMap;
 import java.io.IOException;
 import java.net.URI;
@@ -39,7 +38,6 @@ import static java.util.Objects.requireNonNull;
  *
  * This implementation throws an error when the web interface assets cannot be found in the classpath.
  */
-@Singleton
 public class ProductionIndexHtmlGenerator implements IndexHtmlGenerator {
     private final String template;
     private final List<String> cssFiles;


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

In #12349, the binding logic for the `IndexHtmlGenerator` interface was changed in a way that the provider is actually deciding which implementation to use for instantiation. 

For this, the provider requires providers for the two differing implementations to be injected.  Unfortunately, as the `ProductionIndexHtmlGenerator` provider was annotated as `@Singleton`, it is instantiated regardless if the server is in production or not. 

This leads to an instantiation of the `PluginAssets` class, trying to read the web assets at startup, even if the server is in development mode. This can lead to a startup failure if the web assets have not been built yet (which is totally valid for a server in development mode).

This PR is now removing the `@Singleton` annotation from the provider class for `ProductionIndexHtmlGenerator`, moving it to the `IndexHtmlGeneratorProvider` class instead. In addition, the provider is caching a created instance, retaining the desired effects:

  - only a single instance of the `IndexHtmlGenerator` implementation is
    created
  - in production mode, startup fails if the web assets have not been
    built before
  - in development mode, startup succeeds if the web assets have not
    been built before

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.