### PR TITLE
Relaxed plugin version constraint

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/constraints/PluginVersionConstraintChecker.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/constraints/PluginVersionConstraintChecker.java
@@ -39,6 +39,7 @@ public class PluginVersionConstraintChecker implements ConstraintChecker {
                 .map(PluginMetaData::getVersion)
                 .map(Version::toString)
                 .map(Semver::new)
+                .map(Semver::withClearedSuffixAndBuild)
                 .collect(Collectors.toSet());
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The existing implementation had troubles with `-SNAPSHOT` version of the plugin and failed in tests. Using `Semver::withClearedSuffixAndBuild` to clear the suffix helps and we are doing the same operation in other checkers as well. So it's consistent with the rest of the codebase.


## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

