### PR TITLE
Field becomes a property of the BucketSpec interface.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/BucketSpec.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/BucketSpec.java
@@ -42,15 +42,25 @@ public interface BucketSpec extends PivotSpec {
     @JsonProperty
     String type();
 
+    @JsonProperty
+    String field();
+
     @JsonAutoDetect
     class Fallback implements BucketSpec {
         @JsonProperty
         private String type;
+        @JsonProperty
+        private String field;
         private Map<String, Object> props = Maps.newHashMap();
 
         @Override
         public String type() {
             return type;
+        }
+
+        @Override
+        public String field() {
+            return field;
         }
 
         @JsonAnySetter
@@ -73,13 +83,14 @@ public interface BucketSpec extends PivotSpec {
             }
             Fallback fallback = (Fallback) o;
             return Objects.equals(type, fallback.type) &&
+                    Objects.equals(field, fallback.field) &&
                     Objects.equals(props, fallback.props);
         }
 
         @Override
         public int hashCode() {
 
-            return Objects.hash(type, props);
+            return Objects.hash(type, field, props);
         }
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/buckets/DateRangeBucket.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/buckets/DateRangeBucket.java
@@ -46,6 +46,7 @@ public abstract class DateRangeBucket implements BucketSpec {
     @Override
     public abstract String type();
 
+    @Override
     @JsonProperty
     public abstract String field();
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/buckets/Time.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/buckets/Time.java
@@ -34,6 +34,7 @@ public abstract class Time implements BucketSpec {
     @Override
     public abstract String type();
 
+    @Override
     @JsonProperty
     public abstract String field();
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/buckets/Values.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/buckets/Values.java
@@ -35,6 +35,7 @@ public abstract class Values implements BucketSpec {
     @Override
     public abstract String type();
 
+    @Override
     @JsonProperty
     public abstract String field();
 


### PR DESCRIPTION
## Description
Field becomes a property of the BucketSpec interface. Because of that you won't have to cast to implementing class instance if you want to access "field" property. Field has been already present in all of the implementations, so it has been safe to move it to the interface.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

