### PR TITLE
replace Jmte Engine instance with JmteEngineProvider

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/alerts/FormattedEmailAlertSender.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/FormattedEmailAlertSender.java
@@ -39,6 +39,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 import java.net.URI;
 import java.util.Collections;
 import java.util.HashMap;
@@ -85,7 +86,7 @@ public class FormattedEmailAlertSender implements AlertSender {
     public FormattedEmailAlertSender(EmailConfiguration configuration,
                                      NotificationService notificationService,
                                      NodeId nodeId,
-                                     Engine templateEngine) {
+                                     @Named("Email") Engine templateEngine) {
         this.configuration = requireNonNull(configuration, "configuration");
         this.notificationService = requireNonNull(notificationService, "notificationService");
         this.nodeId = requireNonNull(nodeId, "nodeId");

--- a/graylog2-server/src/main/java/org/graylog2/bindings/ServerBindings.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/ServerBindings.java
@@ -17,6 +17,7 @@
 package org.graylog2.bindings;
 
 import com.floreysoft.jmte.Engine;
+import com.floreysoft.jmte.NamedRenderer;
 import com.google.inject.Scopes;
 import com.google.inject.assistedinject.FactoryModuleBuilder;
 import com.google.inject.multibindings.Multibinder;
@@ -33,6 +34,7 @@ import org.graylog2.bindings.providers.DefaultStreamProvider;
 import org.graylog2.bindings.providers.MongoConnectionProvider;
 import org.graylog2.bindings.providers.SystemJobFactoryProvider;
 import org.graylog2.bindings.providers.SystemJobManagerProvider;
+import org.graylog2.bindings.providers.JmteEngineProvider;
 import org.graylog2.cluster.ClusterConfigServiceImpl;
 import org.graylog2.database.MongoConnection;
 import org.graylog2.events.ClusterEventBus;
@@ -168,7 +170,8 @@ public class ServerBindings extends Graylog2Module {
         bind(ClusterStatsModule.class).asEagerSingleton();
         bind(ClusterConfigService.class).to(ClusterConfigServiceImpl.class).asEagerSingleton();
         bind(GrokPatternRegistry.class).in(Scopes.SINGLETON);
-        bind(Engine.class).toInstance(Engine.createEngine());
+        Multibinder.newSetBinder(binder(), NamedRenderer.class);
+        bind(Engine.class).toProvider(JmteEngineProvider.class).asEagerSingleton();
         bind(ErrorPageGenerator.class).to(GraylogErrorPageGenerator.class).asEagerSingleton();
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/bindings/ServerBindings.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/ServerBindings.java
@@ -22,6 +22,7 @@ import com.google.inject.Scopes;
 import com.google.inject.assistedinject.FactoryModuleBuilder;
 import com.google.inject.multibindings.Multibinder;
 import com.google.inject.multibindings.OptionalBinder;
+import com.google.inject.name.Names;
 import org.apache.shiro.mgt.DefaultSecurityManager;
 import org.glassfish.grizzly.http.server.ErrorPageGenerator;
 import org.graylog2.Configuration;
@@ -35,6 +36,7 @@ import org.graylog2.bindings.providers.MongoConnectionProvider;
 import org.graylog2.bindings.providers.SystemJobFactoryProvider;
 import org.graylog2.bindings.providers.SystemJobManagerProvider;
 import org.graylog2.bindings.providers.JmteEngineProvider;
+import org.graylog2.bindings.providers.EmailJmteEngineProvider;
 import org.graylog2.cluster.ClusterConfigServiceImpl;
 import org.graylog2.database.MongoConnection;
 import org.graylog2.events.ClusterEventBus;
@@ -172,6 +174,7 @@ public class ServerBindings extends Graylog2Module {
         bind(GrokPatternRegistry.class).in(Scopes.SINGLETON);
         Multibinder.newSetBinder(binder(), NamedRenderer.class);
         bind(Engine.class).toProvider(JmteEngineProvider.class).asEagerSingleton();
+        bind(Engine.class).annotatedWith(Names.named("Email")).toProvider(JmteEngineProvider.class).asEagerSingleton();
         bind(ErrorPageGenerator.class).to(GraylogErrorPageGenerator.class).asEagerSingleton();
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/bindings/providers/EmailJmteEngineProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/providers/EmailJmteEngineProvider.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.bindings.providers;
+
+import com.floreysoft.jmte.Engine;
+import com.floreysoft.jmte.Renderer;
+import com.floreysoft.jmte.NamedRenderer;
+import com.floreysoft.jmte.RenderFormatInfo;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+import javax.inject.Singleton;
+
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+import com.google.common.html.HtmlEscapers;
+
+
+@Singleton
+public class EmailJmteEngineProvider implements Provider<Engine> {
+    private Engine engine = null;
+
+    @Inject
+    public EmailJmteEngineProvider(Set<NamedRenderer> renderers) {
+      engine = Engine.createEngine();
+
+      engine.registerRenderer(String.class, new HtmlSafeRenderer());
+
+      for (NamedRenderer renderer : renderers) {
+        engine.registerNamedRenderer(renderer);
+      }
+    }
+
+    @Override
+    public Engine get() {
+      return engine;
+    }
+
+    private static class HtmlSafeRenderer implements Renderer<String> {
+      @Override
+      public String render(String value, Locale locale, Map<String,Object> model) {
+        String o = HtmlEscapers.htmlEscaper().escape(value);
+        return o;
+      }
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/bindings/providers/JmteEngineProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/providers/JmteEngineProvider.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.bindings.providers;
+
+import com.floreysoft.jmte.Engine;
+import com.floreysoft.jmte.NamedRenderer;
+import com.floreysoft.jmte.RenderFormatInfo;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+import javax.inject.Singleton;
+
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+import com.google.common.html.HtmlEscapers;
+
+
+@Singleton
+public class JmteEngineProvider implements Provider<Engine> {
+    private Engine engine = null;
+
+    @Inject
+    public JmteEngineProvider(Set<NamedRenderer> renderers) {
+      engine = Engine.createEngine();
+
+      engine.registerNamedRenderer(new HtmlSafeRenderer());
+
+      for (NamedRenderer renderer : renderers) {
+        engine.registerNamedRenderer(renderer);
+      }
+    }
+
+    @Override
+    public Engine get() {
+      return engine;
+    }
+
+    private static class HtmlSafeRenderer implements NamedRenderer {
+      private String convert(Object o) {
+        if (o instanceof String) {
+          return HtmlEscapers.htmlEscaper().escape((String) o);
+        }
+        return null;
+      }
+
+      @Override
+      public String render(Object value, String parameters, Locale locale, Map<String,Object> model) {
+        String o = convert(value);
+        if (o == null) {
+          return null;
+        }
+        return o;
+      }
+
+      @Override
+      public String getName() {
+        return "htmlsafe";
+      }
+
+      @Override
+      public RenderFormatInfo getFormatInfo() {
+        return null;
+      }
+
+      @Override
+      public Class<?>[] getSupportedClasses() {
+        return new Class<?>[] { String.class };
+      }
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/alerts/FormattedEmailAlertSenderTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/alerts/FormattedEmailAlertSenderTest.java
@@ -17,6 +17,7 @@
 package org.graylog2.alerts;
 
 import com.floreysoft.jmte.Engine;
+import com.floreysoft.jmte.NamedRenderer;
 import org.graylog2.configuration.EmailConfiguration;
 import org.graylog2.notifications.NotificationService;
 import org.graylog2.plugin.Message;
@@ -24,6 +25,7 @@ import org.graylog2.plugin.alarms.AlertCondition;
 import org.graylog2.plugin.configuration.Configuration;
 import org.graylog2.plugin.streams.Stream;
 import org.graylog2.plugin.system.NodeId;
+import org.graylog2.bindings.providers.JmteEngineProvider;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.junit.Before;
@@ -35,6 +37,7 @@ import org.mockito.junit.MockitoRule;
 
 import java.net.URI;
 import java.util.Collections;
+import java.util.HashSet;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -236,5 +239,22 @@ public class FormattedEmailAlertSenderTest {
                 .containsSequence(
                         "Last messages accounting for this alert:\n",
                         message.toString());
+    }
+
+    @Test
+    public void buildBodyEscapeHtmlOrNot() throws Exception {
+        Engine templateEngine = new JmteEngineProvider(new HashSet<NamedRenderer>()).get();
+        FormattedEmailAlertSender emailAlertSender = new FormattedEmailAlertSender(new EmailConfiguration(), mockNotificationService, mockNodeId, templateEngine);
+        Configuration pluginConfig = new Configuration(Collections.<String, Object>singletonMap("body", "Test: ${stream.title;htmlsafe}${stream.title}"));
+        emailAlertSender.initialize(pluginConfig);
+
+        Stream stream = mock(Stream.class);
+        when(stream.getTitle()).thenReturn("<test>");
+
+        AlertCondition.CheckResult checkResult = mock(AbstractAlertCondition.CheckResult.class);
+
+        String body = emailAlertSender.buildBody(stream, checkResult, Collections.<Message>emptyList());
+
+        assertThat(body).isEqualTo("Test: &lt;test&gt;<test>");
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/alerts/FormattedEmailAlertSenderTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/alerts/FormattedEmailAlertSenderTest.java
@@ -26,6 +26,7 @@ import org.graylog2.plugin.configuration.Configuration;
 import org.graylog2.plugin.streams.Stream;
 import org.graylog2.plugin.system.NodeId;
 import org.graylog2.bindings.providers.JmteEngineProvider;
+import org.graylog2.bindings.providers.EmailJmteEngineProvider;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.junit.Before;
@@ -243,9 +244,9 @@ public class FormattedEmailAlertSenderTest {
 
     @Test
     public void buildBodyEscapeHtmlOrNot() throws Exception {
-        Engine templateEngine = new JmteEngineProvider(new HashSet<NamedRenderer>()).get();
+        Engine templateEngine = new EmailJmteEngineProvider(new HashSet<NamedRenderer>()).get();
         FormattedEmailAlertSender emailAlertSender = new FormattedEmailAlertSender(new EmailConfiguration(), mockNotificationService, mockNodeId, templateEngine);
-        Configuration pluginConfig = new Configuration(Collections.<String, Object>singletonMap("body", "Test: ${stream.title;htmlsafe}${stream.title}"));
+        Configuration pluginConfig = new Configuration(Collections.<String, Object>singletonMap("body", "Test: ${stream.title}"));
         emailAlertSender.initialize(pluginConfig);
 
         Stream stream = mock(Stream.class);
@@ -255,6 +256,6 @@ public class FormattedEmailAlertSenderTest {
 
         String body = emailAlertSender.buildBody(stream, checkResult, Collections.<Message>emptyList());
 
-        assertThat(body).isEqualTo("Test: &lt;test&gt;<test>");
+        assertThat(body).isEqualTo("Test: &lt;test&gt;");
     }
 }


### PR DESCRIPTION


## Description
plugins can add NamedRenderer to engine
add HtmlSafeRenderer to engine by default

## Motivation and Context
As mention in #11183, Jmte may cause some bug in html email notifications.
This change let us escape texts in html template when needed.

## How Has This Been Tested?
I add a test case to test the provider and the renderer.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

