### PR TITLE
Added factory method to GeoLocationInformation to create instance with null checks

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/map/geoip/GeoLocationInformation.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/map/geoip/GeoLocationInformation.java
@@ -18,6 +18,9 @@
 package org.graylog.plugins.map.geoip;
 
 import com.google.auto.value.AutoValue;
+import com.maxmind.geoip2.record.City;
+import com.maxmind.geoip2.record.Country;
+import com.maxmind.geoip2.record.Location;
 
 @AutoValue
 public abstract class GeoLocationInformation {
@@ -40,4 +43,48 @@ public abstract class GeoLocationInformation {
         return new AutoValue_GeoLocationInformation(latitude, longitude, countryIsoCode, countryName, cityName,
                 region, timeZone);
     }
+
+    /**
+     * A helper method that performs additional null checks when getting individual fields from location, country, and city objects.
+     *
+     * @param location geo-location information
+     * @param country  country information
+     * @param city     city information
+     * @param region   region name
+     * @return combined geo location information
+     */
+    @SuppressWarnings("complextity")
+    public static GeoLocationInformation create(Location location, Country country, City city, String region) {
+        final double longitude;
+        final double latitude;
+        final String timeZone;
+        final String countryIsoCode;
+        final String countryName;
+        final String cityName = city == null || city.getGeoNameId() == null ? "N/A" : city.getName();
+
+        if (location == null) {
+            longitude = 0;
+            latitude = 0;
+            timeZone = "N/A";
+        } else {
+            // Auto unboxing of null boxed-primitives will produce a NullPointerException--check for nulls.
+            longitude = location.getLongitude() == null ? 0 : location.getLongitude();
+            latitude = location.getLatitude() == null ? 0 : location.getLatitude();
+
+            timeZone = location.getTimeZone() == null ? "N/A" : location.getTimeZone();
+        }
+
+        if (country == null || country.getGeoNameId() == null) {
+            countryName = "N/A";
+            countryIsoCode = "N/A";
+
+        } else {
+            countryIsoCode = country.getIsoCode() == null ? "N/A" : country.getIsoCode();
+            countryName = country.getName() == null ? "N/A" : country.getName();
+        }
+
+        return create(latitude, longitude, countryIsoCode, countryName, cityName, region, timeZone);
+
+    }
+
 }

--- a/graylog2-server/src/test/java/org/graylog/plugins/map/geoip/GeoLocationInformationTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/map/geoip/GeoLocationInformationTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog.plugins.map.geoip;
 
 import com.maxmind.geoip2.record.City;

--- a/graylog2-server/src/test/java/org/graylog/plugins/map/geoip/GeoLocationInformationTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/map/geoip/GeoLocationInformationTest.java
@@ -1,0 +1,54 @@
+package org.graylog.plugins.map.geoip;
+
+import com.maxmind.geoip2.record.City;
+import com.maxmind.geoip2.record.Country;
+import com.maxmind.geoip2.record.Location;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+class GeoLocationInformationTest {
+
+    @Test
+    void testCreateWithNullLocation() {
+
+        Assertions.assertDoesNotThrow(() -> GeoLocationInformation.create(null, createCountry(), createCity(), "N/A"));
+
+    }
+
+    @Test
+    void testCreateWithNullLongLat() {
+
+        Assertions.assertDoesNotThrow(() -> GeoLocationInformation.create(new Location(), createCountry(), createCity(), "N/A"));
+
+    }
+
+    @Test
+    void testCreateWithNullCountry() {
+
+        Assertions.assertDoesNotThrow(() -> GeoLocationInformation.create(null, null, createCity(), "N/A"));
+
+    }
+
+    @Test
+    void testCreateWithNullCity() {
+
+        Assertions.assertDoesNotThrow(() -> GeoLocationInformation.create(null, createCountry(), null, "N/A"));
+
+    }
+
+    private static Country createCountry() {
+        Map<String, String> names = new HashMap<>();
+        names.put("en", "United States");
+
+        return new Country(Collections.singletonList("en"), null, 1, false, "US", names);
+    }
+
+    private static City createCity() {
+        return new City(Collections.singletonList("en"), null, null, new HashMap<>());
+    }
+
+}

--- a/graylog2-server/src/test/java/org/graylog/plugins/map/geoip/MaxMindIpLocationResolverTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/map/geoip/MaxMindIpLocationResolverTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog.plugins.map.geoip;
 
 import com.codahale.metrics.Timer;

--- a/graylog2-server/src/test/java/org/graylog/plugins/map/geoip/MaxMindIpLocationResolverTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/map/geoip/MaxMindIpLocationResolverTest.java
@@ -1,0 +1,165 @@
+package org.graylog.plugins.map.geoip;
+
+import com.codahale.metrics.Timer;
+import com.codahale.metrics.UniformReservoir;
+import com.maxmind.geoip2.exception.GeoIp2Exception;
+import com.maxmind.geoip2.model.CityResponse;
+import com.maxmind.geoip2.record.City;
+import com.maxmind.geoip2.record.Country;
+import com.maxmind.geoip2.record.Location;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class MaxMindIpLocationResolverTest {
+
+    private AutoCloseable mocks;
+
+    @Mock
+    private MaxMindIpLocationResolver resolver;
+
+    @BeforeAll
+    void init() {
+        mocks = MockitoAnnotations.openMocks(this);
+        Timer timer = new Timer(new UniformReservoir(1));
+        when(resolver.getTimer()).thenReturn(timer.time());
+        when(resolver.doGetGeoIpData(any(InetAddress.class))).thenCallRealMethod();
+
+    }
+
+    @AfterAll
+    void cleanUp() throws Exception {
+        mocks.close();
+    }
+
+
+    @Test
+    void testDoGetGeoIpData() throws IOException, GeoIp2Exception {
+
+        Country country = createCountry();
+        City city = createCity();
+        Location location = createLocation();
+        CityResponse cityResponse = createCityResponse(country, city, location);
+
+        when(resolver.getCityResponse(any(InetAddress.class))).thenReturn(cityResponse);
+
+        InetAddress address = InetAddress.getByName("localhost");
+        Optional<GeoLocationInformation> optInfo = resolver.doGetGeoIpData(address);
+
+        assertTrue(optInfo.isPresent());
+        GeoLocationInformation info = optInfo.get();
+        assertEquals(country.getName(), info.countryName());
+        assertEquals(country.getIsoCode(), info.countryIsoCode());
+        assertEquals(city.getName(), info.cityName());
+        assertEquals(location.getLatitude(), info.latitude());
+        assertEquals(location.getLongitude(), info.longitude());
+        assertEquals(location.getTimeZone(), info.timeZone());
+
+    }
+
+    @Test
+    void testCityResponseWithNullCountry() throws IOException, GeoIp2Exception {
+
+        CityResponse cityResponse = createCityResponse(null, createCity(), createLocation());
+
+        when(resolver.getCityResponse(any(InetAddress.class))).thenReturn(cityResponse);
+
+        InetAddress address = InetAddress.getByName("localhost");
+        Optional<GeoLocationInformation> optInfo = resolver.doGetGeoIpData(address);
+
+        assertTrue(optInfo.isPresent());
+        GeoLocationInformation info = optInfo.get();
+        assertEquals("N/A", info.countryName());
+        assertEquals("N/A", info.countryIsoCode());
+
+    }
+
+    @Test
+    void testCityResponseWithNullCity() throws IOException, GeoIp2Exception {
+
+        CityResponse cityResponse = createCityResponse(createCountry(), null, createLocation());
+
+        when(resolver.getCityResponse(any(InetAddress.class))).thenReturn(cityResponse);
+
+        InetAddress address = InetAddress.getByName("localhost");
+        Optional<GeoLocationInformation> optInfo = resolver.doGetGeoIpData(address);
+        assertTrue(optInfo.isPresent());
+        GeoLocationInformation info = optInfo.get();
+        assertEquals("N/A", info.cityName());
+
+    }
+
+    @Test
+    void testCityResponseWithNullLocation() throws IOException, GeoIp2Exception {
+
+        CityResponse cityResponse = createCityResponse(createCountry(), createCity(), null);
+
+        when(resolver.getCityResponse(any(InetAddress.class))).thenReturn(cityResponse);
+
+        InetAddress address = InetAddress.getByName("localhost");
+        Optional<GeoLocationInformation> optInfo = resolver.doGetGeoIpData(address);
+        assertNonNullLocation(optInfo);
+
+    }
+
+    @Test
+    void testCityResponseWithNullLongLat() throws IOException, GeoIp2Exception {
+
+        Location location = new Location(null, null, null, null, null, null, "America/Chicago");
+        CityResponse cityResponse = createCityResponse(createCountry(), createCity(), location);
+
+        when(resolver.getCityResponse(any(InetAddress.class))).thenReturn(cityResponse);
+
+        InetAddress address = InetAddress.getByName("localhost");
+        Optional<GeoLocationInformation> optInfo = resolver.doGetGeoIpData(address);
+        assertNonNullLocation(optInfo);
+
+    }
+
+    private void assertNonNullLocation(Optional<GeoLocationInformation> optInfo) {
+        assertTrue(optInfo.isPresent());
+        GeoLocationInformation info = optInfo.get();
+
+        assertEquals(0.0, info.latitude());
+        assertEquals(0.0, info.longitude());
+    }
+
+    private CityResponse createCityResponse(Country country, City city, Location location) {
+
+        return new CityResponse(city, null, country, location, null, null,
+                country, null, null, null);
+    }
+
+    private static Country createCountry() {
+        Map<String, String> names = new HashMap<>();
+        names.put("en", "Mali");
+
+        return new Country(Collections.singletonList("en"), null, 1, false, "US", names);
+    }
+
+    private static City createCity() {
+        final HashMap<String, String> names = new HashMap<>();
+        names.put("en", "Timbuktu");
+        return new City(Collections.singletonList("en"), 1, 1, names);
+    }
+
+    private static Location createLocation() {
+        return new Location(10, 10_000_000, 16.766945605833932, -3.003387490676568, 1, 1, "GMT");
+    }
+}


### PR DESCRIPTION
Updated MaxMindIpLocationResolver to use null-safe method to create GeoLocationInformation instance.
closes #12788 

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Addresses a NullPointerException error caused in MaxMind Geo IP Information loader when the returned object contains null longitude/latitude fields.

To address the issue, a new method was added to GeoLocationInformation to create an instance from a Location, Country, and City object.  All the parameters as well as the needed fields from each parameter are checked for null.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The error prevents the entire message from being processed.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
A new unit test was added to test that no exception is thrown if the MaxMind database reader returns null city response fields, or if any of the required response fields themselves have null fields.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

