### PR TITLE
Removed wrong log message when all aggregations are on columns on Pivot.

### DIFF
--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/views/searchtypes/pivot/ESPivot.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/views/searchtypes/pivot/ESPivot.java
@@ -50,8 +50,10 @@ import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.IdentityHashMap;
 import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -88,77 +90,79 @@ public class ESPivot implements ESSearchTypeHandler<Pivot> {
         final AggTypes aggTypes = new AggTypes();
         contextMap.put(pivot.id(), aggTypes);
 
-        // holds the last complete bucket aggregation into which subsequent buckets get added
-        AggregationBuilder previousAggregation = null;
-
         // add global rollup series if those were requested
         if (pivot.rollup()) {
             seriesStream(pivot, queryContext, "global rollup")
-                    .forEach(previousAggregation != null ? previousAggregation::subAggregation : searchSourceBuilder::aggregation);
+                    .forEach(searchSourceBuilder::aggregation);
         }
 
-        final Iterator<BucketSpec> rowBuckets = pivot.rowGroups().iterator();
-        while (rowBuckets.hasNext()) {
-            final BucketSpec bucketSpec = rowBuckets.next();
-
-            final String name = queryContext.nextName();
-            LOG.debug("Creating row group aggregation '{}' as {}", bucketSpec.type(), name);
-            final ESPivotBucketSpecHandler<? extends PivotSpec, ? extends Aggregation> handler = bucketHandlers.get(bucketSpec.type());
-            if (handler == null) {
-                throw new IllegalArgumentException("Unknown row_group type " + bucketSpec.type());
-            }
-            final Optional<AggregationBuilder> generatedAggregation = handler.createAggregation(name, pivot, bucketSpec, this, queryContext, query);
-            if (generatedAggregation.isPresent()) {
-                final AggregationBuilder aggregationBuilder = generatedAggregation.get();
-                // always insert the series for the final row group, or for each one if explicit rollup was requested
-                if (!rowBuckets.hasNext() || pivot.rollup()) {
-                    seriesStream(pivot, queryContext, !rowBuckets.hasNext() ? "leaf row" : "row rollup")
-                            .forEach(aggregationBuilder::subAggregation);
-                }
-                if (previousAggregation != null) {
-                    previousAggregation.subAggregation(aggregationBuilder);
-                } else {
-                    searchSourceBuilder.aggregation(aggregationBuilder);
-                }
-                previousAggregation = aggregationBuilder;
-            }
-        }
-        final Iterator<BucketSpec> colBuckets = pivot.columnGroups().iterator();
-        while (colBuckets.hasNext()) {
-            final BucketSpec bucketSpec = colBuckets.next();
-
-            final String name = queryContext.nextName();
-            LOG.debug("Creating column group aggregation '{}' as {}", bucketSpec.type(), name);
-            final ESPivotBucketSpecHandler<? extends PivotSpec, ? extends Aggregation> handler = bucketHandlers.get(bucketSpec.type());
-            if (handler == null) {
-                throw new IllegalArgumentException("Unknown column_group type " + bucketSpec.type());
-            }
-            final Optional<AggregationBuilder> generatedAggregation = handler.createAggregation(name, pivot, bucketSpec, this, queryContext, query);
-            if (generatedAggregation.isPresent()) {
-                final AggregationBuilder aggregationBuilder = generatedAggregation.get();
-                // always insert the series for the final row group, or for each one if explicit rollup was requested
-                if (!colBuckets.hasNext() || pivot.rollup()) {
-                    seriesStream(pivot, queryContext, !colBuckets.hasNext() ? "leaf column" : "column rollup")
-                            .forEach(aggregationBuilder::subAggregation);
-                }
-                if (previousAggregation != null) {
-                    previousAggregation.subAggregation(aggregationBuilder);
-                } else {
-                    searchSourceBuilder.aggregation(aggregationBuilder);
-                }
-                previousAggregation = aggregationBuilder;
-            }
+        final Optional<AggregationBuilder> rootBucketAggregation = doGenerateBucketAggregationsTree(query, pivot, queryContext);
+        if (rootBucketAggregation.isPresent()) {
+            searchSourceBuilder.aggregation(rootBucketAggregation.get());
+        } else {
+            LOG.debug("No aggregations generated for {}", pivot);
         }
 
         final MinAggregationBuilder startTimestamp = AggregationBuilders.min("timestamp-min").field("timestamp");
         final MaxAggregationBuilder endTimestamp = AggregationBuilders.max("timestamp-max").field("timestamp");
-
         searchSourceBuilder.aggregation(startTimestamp);
         searchSourceBuilder.aggregation(endTimestamp);
+    }
 
-        if (previousAggregation == null) {
-            LOG.debug("No aggregations generated for {}", pivot);
+    private Optional<AggregationBuilder> doGenerateBucketAggregationsTree(Query query,
+                                                                          Pivot pivot,
+                                                                          ESGeneratedQueryContext queryContext) {
+
+        //ordered from low-level to high-level aggregations
+        Deque<AggregationBuilder> bucketAggregationChain = new LinkedList<>();
+
+        final Iterator<BucketSpec> rowBuckets = pivot.rowGroups().iterator();
+        while (rowBuckets.hasNext()) {
+            final BucketSpec bucketSpec = rowBuckets.next();
+            final boolean isLastRowBucket = !rowBuckets.hasNext();
+            final Optional<AggregationBuilder> generateSingleBucketAggregation = doGenerateSingleBucketAggregation(bucketSpec, isLastRowBucket, "row", query, pivot, queryContext);
+            generateSingleBucketAggregation.ifPresent(bucketAggregationChain::addFirst);
         }
+
+        final Iterator<BucketSpec> columnBuckets = pivot.columnGroups().iterator();
+        while (columnBuckets.hasNext()) {
+            final BucketSpec bucketSpec = columnBuckets.next();
+            final boolean isLastColumnBucket = !columnBuckets.hasNext();
+            final Optional<AggregationBuilder> generateSingleBucketAggregation = doGenerateSingleBucketAggregation(bucketSpec, isLastColumnBucket, "column", query, pivot, queryContext);
+            generateSingleBucketAggregation.ifPresent(bucketAggregationChain::addFirst);
+        }
+
+        return bucketAggregationChain.stream()
+                .reduce((aggrLower, aggrHigher) -> {
+                    aggrHigher.subAggregation(aggrLower);
+                    return aggrHigher;
+                });
+
+    }
+
+    private Optional<AggregationBuilder> doGenerateSingleBucketAggregation(BucketSpec bucketSpec,
+                                                                           final boolean isLast,
+                                                                           final String reason,
+                                                                           final Query query,
+                                                                           Pivot pivot,
+                                                                           ESGeneratedQueryContext queryContext
+    ) {
+        final String name = queryContext.nextName();
+        LOG.debug("Creating " + reason + " group aggregation '{}' as {}", bucketSpec.type(), name);
+        final ESPivotBucketSpecHandler<? extends PivotSpec, ? extends Aggregation> handler = bucketHandlers.get(bucketSpec.type());
+        if (handler == null) {
+            throw new IllegalArgumentException("Unknown " + reason + "_group type " + bucketSpec.type());
+        }
+        final Optional<AggregationBuilder> generatedAggregation = handler.createAggregation(name, pivot, bucketSpec, this, queryContext, query);
+        if (generatedAggregation.isPresent()) {
+            final AggregationBuilder aggregationBuilder = generatedAggregation.get();
+            // always insert the series for the final row/column group, or for each one if explicit rollup was requested
+            if (isLast || pivot.rollup()) {
+                seriesStream(pivot, queryContext, isLast ? "leaf " + reason : reason + " rollup")
+                        .forEach(aggregationBuilder::subAggregation);
+            }
+        }
+        return generatedAggregation;
     }
 
     private Stream<AggregationBuilder> seriesStream(Pivot pivot, ESGeneratedQueryContext queryContext, String reason) {

--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/views/searchtypes/pivot/ESPivot.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/views/searchtypes/pivot/ESPivot.java
@@ -88,8 +88,6 @@ public class ESPivot implements ESSearchTypeHandler<Pivot> {
         final AggTypes aggTypes = new AggTypes();
         contextMap.put(pivot.id(), aggTypes);
 
-        // holds the initial level aggregation to be added to the query
-        AggregationBuilder topLevelAggregation = null;
         // holds the last complete bucket aggregation into which subsequent buckets get added
         AggregationBuilder previousAggregation = null;
 
@@ -112,9 +110,6 @@ public class ESPivot implements ESSearchTypeHandler<Pivot> {
             final Optional<AggregationBuilder> generatedAggregation = handler.createAggregation(name, pivot, bucketSpec, this, queryContext, query);
             if (generatedAggregation.isPresent()) {
                 final AggregationBuilder aggregationBuilder = generatedAggregation.get();
-                if (topLevelAggregation == null) {
-                    topLevelAggregation = aggregationBuilder;
-                }
                 // always insert the series for the final row group, or for each one if explicit rollup was requested
                 if (!rowBuckets.hasNext() || pivot.rollup()) {
                     seriesStream(pivot, queryContext, !rowBuckets.hasNext() ? "leaf row" : "row rollup")
@@ -161,7 +156,7 @@ public class ESPivot implements ESSearchTypeHandler<Pivot> {
         searchSourceBuilder.aggregation(startTimestamp);
         searchSourceBuilder.aggregation(endTimestamp);
 
-        if (topLevelAggregation == null) {
+        if (previousAggregation == null) {
             LOG.debug("No aggregations generated for {}", pivot);
         }
     }

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/ESPivot.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/ESPivot.java
@@ -53,8 +53,10 @@ import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.IdentityHashMap;
 import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -91,77 +93,79 @@ public class ESPivot implements ESSearchTypeHandler<Pivot> {
         final AggTypes aggTypes = new AggTypes();
         contextMap.put(pivot.id(), aggTypes);
 
-        // holds the last complete bucket aggregation into which subsequent buckets get added
-        AggregationBuilder previousAggregation = null;
-
         // add global rollup series if those were requested
         if (pivot.rollup()) {
             seriesStream(pivot, queryContext, "global rollup")
                     .forEach(searchSourceBuilder::aggregation);
         }
 
-        final Iterator<BucketSpec> rowBuckets = pivot.rowGroups().iterator();
-        while (rowBuckets.hasNext()) {
-            final BucketSpec bucketSpec = rowBuckets.next();
-
-            final String name = queryContext.nextName();
-            LOG.debug("Creating row group aggregation '{}' as {}", bucketSpec.type(), name);
-            final ESPivotBucketSpecHandler<? extends PivotSpec, ? extends Aggregation> handler = bucketHandlers.get(bucketSpec.type());
-            if (handler == null) {
-                throw new IllegalArgumentException("Unknown row_group type " + bucketSpec.type());
-            }
-            final Optional<AggregationBuilder> generatedAggregation = handler.createAggregation(name, pivot, bucketSpec, this, queryContext, query);
-            if (generatedAggregation.isPresent()) {
-                final AggregationBuilder aggregationBuilder = generatedAggregation.get();
-                // always insert the series for the final row group, or for each one if explicit rollup was requested
-                if (!rowBuckets.hasNext() || pivot.rollup()) {
-                    seriesStream(pivot, queryContext, !rowBuckets.hasNext() ? "leaf row" : "row rollup")
-                            .forEach(aggregationBuilder::subAggregation);
-                }
-                if (previousAggregation != null) {
-                    previousAggregation.subAggregation(aggregationBuilder);
-                } else {
-                    searchSourceBuilder.aggregation(aggregationBuilder);
-                }
-                previousAggregation = aggregationBuilder;
-            }
-        }
-        final Iterator<BucketSpec> colBuckets = pivot.columnGroups().iterator();
-        while (colBuckets.hasNext()) {
-            final BucketSpec bucketSpec = colBuckets.next();
-
-            final String name = queryContext.nextName();
-            LOG.debug("Creating column group aggregation '{}' as {}", bucketSpec.type(), name);
-            final ESPivotBucketSpecHandler<? extends PivotSpec, ? extends Aggregation> handler = bucketHandlers.get(bucketSpec.type());
-            if (handler == null) {
-                throw new IllegalArgumentException("Unknown column_group type " + bucketSpec.type());
-            }
-            final Optional<AggregationBuilder> generatedAggregation = handler.createAggregation(name, pivot, bucketSpec, this, queryContext, query);
-            if (generatedAggregation.isPresent()) {
-                final AggregationBuilder aggregationBuilder = generatedAggregation.get();
-                // always insert the series for the final row group, or for each one if explicit rollup was requested
-                if (!colBuckets.hasNext() || pivot.rollup()) {
-                    seriesStream(pivot, queryContext, !colBuckets.hasNext() ? "leaf column" : "column rollup")
-                            .forEach(aggregationBuilder::subAggregation);
-                }
-                if (previousAggregation != null) {
-                    previousAggregation.subAggregation(aggregationBuilder);
-                } else {
-                    searchSourceBuilder.aggregation(aggregationBuilder);
-                }
-                previousAggregation = aggregationBuilder;
-            }
+        final Optional<AggregationBuilder> rootBucketAggregation = doGenerateBucketAggregationsTree(query, pivot, queryContext);
+        if (rootBucketAggregation.isPresent()) {
+            searchSourceBuilder.aggregation(rootBucketAggregation.get());
+        } else {
+            LOG.debug("No aggregations generated for {}", pivot);
         }
 
         final MinAggregationBuilder startTimestamp = AggregationBuilders.min("timestamp-min").field("timestamp");
         final MaxAggregationBuilder endTimestamp = AggregationBuilders.max("timestamp-max").field("timestamp");
-
         searchSourceBuilder.aggregation(startTimestamp);
         searchSourceBuilder.aggregation(endTimestamp);
+    }
 
-        if (previousAggregation == null) {
-            LOG.debug("No aggregations generated for {}", pivot);
+    private Optional<AggregationBuilder> doGenerateBucketAggregationsTree(Query query,
+                                                                          Pivot pivot,
+                                                                          ESGeneratedQueryContext queryContext) {
+
+        //ordered from low-level to high-level aggregations
+        Deque<AggregationBuilder> bucketAggregationChain = new LinkedList<>();
+
+        final Iterator<BucketSpec> rowBuckets = pivot.rowGroups().iterator();
+        while (rowBuckets.hasNext()) {
+            final BucketSpec bucketSpec = rowBuckets.next();
+            final boolean isLastRowBucket = !rowBuckets.hasNext();
+            final Optional<AggregationBuilder> generateSingleBucketAggregation = doGenerateSingleBucketAggregation(bucketSpec, isLastRowBucket, "row", query, pivot, queryContext);
+            generateSingleBucketAggregation.ifPresent(bucketAggregationChain::addFirst);
         }
+
+        final Iterator<BucketSpec> columnBuckets = pivot.columnGroups().iterator();
+        while (columnBuckets.hasNext()) {
+            final BucketSpec bucketSpec = columnBuckets.next();
+            final boolean isLastColumnBucket = !columnBuckets.hasNext();
+            final Optional<AggregationBuilder> generateSingleBucketAggregation = doGenerateSingleBucketAggregation(bucketSpec, isLastColumnBucket, "column", query, pivot, queryContext);
+            generateSingleBucketAggregation.ifPresent(bucketAggregationChain::addFirst);
+        }
+
+        return bucketAggregationChain.stream()
+                .reduce((aggrLower, aggrHigher) -> {
+                    aggrHigher.subAggregation(aggrLower);
+                    return aggrHigher;
+                });
+
+    }
+
+    private Optional<AggregationBuilder> doGenerateSingleBucketAggregation(BucketSpec bucketSpec,
+                                                                           final boolean isLast,
+                                                                           final String reason,
+                                                                           final Query query,
+                                                                           Pivot pivot,
+                                                                           ESGeneratedQueryContext queryContext
+    ) {
+        final String name = queryContext.nextName();
+        LOG.debug("Creating " + reason + " group aggregation '{}' as {}", bucketSpec.type(), name);
+        final ESPivotBucketSpecHandler<? extends PivotSpec, ? extends Aggregation> handler = bucketHandlers.get(bucketSpec.type());
+        if (handler == null) {
+            throw new IllegalArgumentException("Unknown " + reason + "_group type " + bucketSpec.type());
+        }
+        final Optional<AggregationBuilder> generatedAggregation = handler.createAggregation(name, pivot, bucketSpec, this, queryContext, query);
+        if (generatedAggregation.isPresent()) {
+            final AggregationBuilder aggregationBuilder = generatedAggregation.get();
+            // always insert the series for the final row/column group, or for each one if explicit rollup was requested
+            if (isLast || pivot.rollup()) {
+                seriesStream(pivot, queryContext, isLast ? "leaf " + reason : reason + " rollup")
+                        .forEach(aggregationBuilder::subAggregation);
+            }
+        }
+        return generatedAggregation;
     }
 
     private Stream<AggregationBuilder> seriesStream(Pivot pivot, ESGeneratedQueryContext queryContext, String reason) {

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/ESPivot.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/ESPivot.java
@@ -91,8 +91,6 @@ public class ESPivot implements ESSearchTypeHandler<Pivot> {
         final AggTypes aggTypes = new AggTypes();
         contextMap.put(pivot.id(), aggTypes);
 
-        // holds the initial level aggregation to be added to the query
-        AggregationBuilder topLevelAggregation = null;
         // holds the last complete bucket aggregation into which subsequent buckets get added
         AggregationBuilder previousAggregation = null;
 
@@ -115,9 +113,6 @@ public class ESPivot implements ESSearchTypeHandler<Pivot> {
             final Optional<AggregationBuilder> generatedAggregation = handler.createAggregation(name, pivot, bucketSpec, this, queryContext, query);
             if (generatedAggregation.isPresent()) {
                 final AggregationBuilder aggregationBuilder = generatedAggregation.get();
-                if (topLevelAggregation == null) {
-                    topLevelAggregation = aggregationBuilder;
-                }
                 // always insert the series for the final row group, or for each one if explicit rollup was requested
                 if (!rowBuckets.hasNext() || pivot.rollup()) {
                     seriesStream(pivot, queryContext, !rowBuckets.hasNext() ? "leaf row" : "row rollup")
@@ -164,7 +159,7 @@ public class ESPivot implements ESSearchTypeHandler<Pivot> {
         searchSourceBuilder.aggregation(startTimestamp);
         searchSourceBuilder.aggregation(endTimestamp);
 
-        if (topLevelAggregation == null) {
+        if (previousAggregation == null) {
             LOG.debug("No aggregations generated for {}", pivot);
         }
     }


### PR DESCRIPTION
## Description
Removed wrong log message when all aggregations are on columns on Pivot.

While the first commit contains only bug fix, the second one provides some refactoring that became possible.

## Motivation and Context
The screenshot shows the situation - when you configure Pivot aggregations to contain columns only, there will be a "No aggregations generated for..." message sent to the log. It is a bug, aggregations are generated and there should be no information like that in the logs. 

## How Has This Been Tested?
Replicate configuration similar to the one present on the screenshot.
Check if there is no more debug-level log message present.

## Screenshots (if appropriate):
![Screenshot 2022-06-03 at 14-48-36 Graylog - Leading Wild Dashboard](https://user-images.githubusercontent.com/100699120/171857054-c767af01-0973-40ba-ae79-e2a5e0a2d9be.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

