### PR TITLE
Prevent divide-by-zero exceptions in preflight checks

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/shared/system/stats/os/OshiOsProbe.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/system/stats/os/OshiOsProbe.java
@@ -46,9 +46,9 @@ public class OshiOsProbe implements OsProbe {
         final Memory mem = Memory.create(
                 globalMemory.getTotal(),
                 globalMemory.getAvailable(),
-                (short) (globalMemory.getAvailable() * 100 / globalMemory.getTotal()),
+                safePercentage(globalMemory.getAvailable(), globalMemory.getTotal(), 0),
                 globalMemory.getTotal() - globalMemory.getAvailable(),
-                (short) ((globalMemory.getTotal() - globalMemory.getAvailable()) * 100 / globalMemory.getTotal()),
+                safePercentage(globalMemory.getTotal() - globalMemory.getAvailable(), globalMemory.getTotal(), 0),
                 globalMemory.getAvailable(),
                 globalMemory.getTotal() - globalMemory.getAvailable());
 
@@ -87,5 +87,9 @@ public class OshiOsProbe implements OsProbe {
                 proc,
                 mem,
                 swap);
+    }
+
+    private short safePercentage(long nominator, long denominator, int override) {
+        return (denominator == 0) ? (short) override : (short) (nominator * 100 / denominator);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/shared/system/stats/os/OshiOsProbe.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/system/stats/os/OshiOsProbe.java
@@ -66,6 +66,7 @@ public class OshiOsProbe implements OsProbe {
         short steal = (short) (ticks[TickType.STEAL.getIndex()] - prevTicks[TickType.STEAL.getIndex()]);
 
         final CentralProcessor.ProcessorIdentifier processorIdentifier = centralProcessor.getProcessorIdentifier();
+        final int totalSockets = centralProcessor.getPhysicalPackageCount() > 0 ? centralProcessor.getPhysicalPackageCount() : 1;
 
         final Processor proc = Processor.create(
                 processorIdentifier.getName(),
@@ -73,7 +74,7 @@ public class OshiOsProbe implements OsProbe {
                 ((int) processorIdentifier.getVendorFreq() / 1000000),
                 centralProcessor.getLogicalProcessorCount(),
                 centralProcessor.getPhysicalPackageCount(),
-                centralProcessor.getLogicalProcessorCount() / centralProcessor.getPhysicalPackageCount(),
+                centralProcessor.getLogicalProcessorCount() / totalSockets,
                 -1,
                 sys,
                 user,


### PR DESCRIPTION
Avoid blocking preflight on divide-by-zero exceptions. 

This just handles the divide by zero exceptions, without attempting to address the file system incompatibilities that are causing them. Not ideal, but if we are not even using a particular stat (e.g. percentage of unused inodes) then we should avoid blocking on it, when encountering some unexpected flavor of file system.

See linked issues for details.



Resolves #12820, #12818