### PR TITLE
Enabling reviewbot for all PRs.

### DIFF
--- a/.github/workflows/reviewbot.yml
+++ b/.github/workflows/reviewbot.yml
@@ -2,29 +2,23 @@ name: PR Review
 
 on:
   pull_request:
-    branches:
-      - 'reviewbot/**'
 
 jobs:
-  build:
+  linter:
+    name: Reviewbot
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: graylog2-web-interface
-
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Set up Yarn cache
-        uses: actions/cache@v2
+      - name: Set up JDK
+        uses: actions/setup-java@v2
         with:
-          key: ${{ runner.os }}-yarn-${{ hashFiles('graylog2-web-interface/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-          path: ~/.cache/yarn
-      - name: Install dependencies
-        run: yarn install
+          java-version: 8
+          distribution: temurin
+          cache: maven
+      - name: Compile with Maven / Install dependencies
+        run: mvn --fail-fast -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3 -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 compile
       - name: Reviewbot
         uses: Graylog2/reviewbot@v1
         with:


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is enabling reviewbot for all PRs. Previously, it was enabled only on selected branches (`reviewbot/...`) for testing. Now that it has matured, it is enabled for all PRs, replacing the previous, jenkins-based linter job.

Reviewbot is running linter jobs for files which have changed in this PR. Any linter hints related to the changed code will be returned as checks annotations, showing up in the "Files changed" section of the PR and the status check will fail. For now, merging the PR will not be blocked though. Linter hints can be acceptable, if they have not been introduced in this PR and fixing them is beyond the scope of it (e.g.  for a bugfix PR that should be as non-intrusive as possible).

If the current PR should not be checked for linter hints, adding `[review skip]`, `[no review]` or `[skip review]` will skip this check.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.