### PR TITLE
Search Filters usage in Widgets

### DIFF
--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/views/ElasticsearchBackend.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/views/ElasticsearchBackend.java
@@ -120,11 +120,10 @@ public class ElasticsearchBackend implements QueryBackend<ESGeneratedQueryContex
                 .filter(normalizedRootQuery);
 
         usedSearchFiltersToQueryStringsMapper.map(query.filters())
-                .forEach(searchFilterQueryString -> {
-                    final String decorated = this.queryStringDecorators.decorate(searchFilterQueryString, job, query);
-                    final QueryBuilder normalized = normalizeQueryString(decorated);
-                    boolQuery.filter(normalized);
-                });
+                .stream()
+                .map(searchFilterQueryString -> this.queryStringDecorators.decorate(searchFilterQueryString, job, query))
+                .map(this::normalizeQueryString)
+                .forEach(boolQuery::filter);
 
         // add the optional root query filters
         generateFilterClause(query.filter(), job, query)
@@ -171,11 +170,10 @@ public class ElasticsearchBackend implements QueryBackend<ESGeneratedQueryContex
             });
 
             usedSearchFiltersToQueryStringsMapper.map(searchType.filters())
-                    .forEach(searchFilterQueryString -> {
-                        final String decorated = this.queryStringDecorators.decorate(searchFilterQueryString, job, query);
-                        final QueryBuilder normalized = normalizeQueryString(decorated);
-                        searchTypeOverrides.must(normalized);
-                    });
+                    .stream()
+                    .map(searchFilterQueryString -> this.queryStringDecorators.decorate(searchFilterQueryString, job, query))
+                    .map(this::normalizeQueryString)
+                    .forEach(searchTypeOverrides::must);
 
             searchTypeSourceBuilder.query(searchTypeOverrides);
 

--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/views/ElasticsearchBackend.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/views/ElasticsearchBackend.java
@@ -170,6 +170,13 @@ public class ElasticsearchBackend implements QueryBackend<ESGeneratedQueryContex
                 searchTypeOverrides.must(normalizedSearchTypeQuery);
             });
 
+            usedSearchFiltersToQueryStringsMapper.map(searchType.filters())
+                    .forEach(searchFilterQueryString -> {
+                        final String decorated = this.queryStringDecorators.decorate(searchFilterQueryString, job, query);
+                        final QueryBuilder normalized = normalizeQueryString(decorated);
+                        searchTypeOverrides.must(normalized);
+                    });
+
             searchTypeSourceBuilder.query(searchTypeOverrides);
 
             final String type = searchType.type();

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackend.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackend.java
@@ -167,6 +167,13 @@ public class ElasticsearchBackend implements QueryBackend<ESGeneratedQueryContex
                 searchTypeOverrides.must(normalizedSearchTypeQuery);
             });
 
+            usedSearchFiltersToQueryStringsMapper.map(searchType.filters())
+                    .forEach(searchFilterQueryString -> {
+                        final String decorated = this.queryStringDecorators.decorate(searchFilterQueryString, job, query);
+                        final QueryBuilder normalized = normalizeQueryString(decorated);
+                        searchTypeOverrides.must(normalized);
+                    });
+
             searchTypeSourceBuilder.query(searchTypeOverrides);
 
             final String type = searchType.type();

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackend.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackend.java
@@ -118,11 +118,11 @@ public class ElasticsearchBackend implements QueryBackend<ESGeneratedQueryContex
                 .filter(normalizedRootQuery);
 
         usedSearchFiltersToQueryStringsMapper.map(query.filters())
-                .forEach(searchFilterQueryString -> {
-                    final String decorated = this.queryStringDecorators.decorate(searchFilterQueryString, job, query);
-                    final QueryBuilder normalized = normalizeQueryString(decorated);
-                    boolQuery.filter(normalized);
-                });
+                .stream()
+                .map(searchFilterQueryString -> this.queryStringDecorators.decorate(searchFilterQueryString, job, query))
+                .map(this::normalizeQueryString)
+                .forEach(boolQuery::filter);
+
 
         // add the optional root query filters
         generateFilterClause(query.filter(), job, query).map(boolQuery::filter);
@@ -168,11 +168,10 @@ public class ElasticsearchBackend implements QueryBackend<ESGeneratedQueryContex
             });
 
             usedSearchFiltersToQueryStringsMapper.map(searchType.filters())
-                    .forEach(searchFilterQueryString -> {
-                        final String decorated = this.queryStringDecorators.decorate(searchFilterQueryString, job, query);
-                        final QueryBuilder normalized = normalizeQueryString(decorated);
-                        searchTypeOverrides.must(normalized);
-                    });
+                    .stream()
+                    .map(searchFilterQueryString -> this.queryStringDecorators.decorate(searchFilterQueryString, job, query))
+                    .map(this::normalizeQueryString)
+                    .forEach(searchTypeOverrides::must);
 
             searchTypeSourceBuilder.query(searchTypeOverrides);
 

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackendGeneratedRequestTestBase.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackendGeneratedRequestTestBase.java
@@ -25,6 +25,7 @@ import org.graylog.plugins.views.search.SearchType;
 import org.graylog.plugins.views.search.elasticsearch.FieldTypesLookup;
 import org.graylog.plugins.views.search.elasticsearch.IndexLookup;
 import org.graylog.plugins.views.search.elasticsearch.QueryStringDecorators;
+import org.graylog.plugins.views.search.searchfilters.model.InlineQueryStringSearchFilter;
 import org.graylog.plugins.views.search.searchtypes.pivot.BucketSpec;
 import org.graylog.plugins.views.search.searchtypes.pivot.Pivot;
 import org.graylog.plugins.views.search.searchtypes.pivot.SeriesSpec;
@@ -57,6 +58,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
@@ -96,7 +98,10 @@ public class ElasticsearchBackendGeneratedRequestTestBase {
                 indexLookup,
                 new QueryStringDecorators(Optional.empty()),
                 (elasticsearchBackend, ssb, job, query) -> new ESGeneratedQueryContext(elasticsearchBackend, ssb, job, query, fieldTypesLookup),
-                usedSearchFilters -> Collections.emptySet(),
+                usedSearchFilters -> usedSearchFilters.stream()
+                        .filter(sf -> sf instanceof InlineQueryStringSearchFilter)
+                        .map(inlineSf -> ((InlineQueryStringSearchFilter) inlineSf).queryString())
+                        .collect(Collectors.toSet()),
                 false);
     }
 

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackendSearchTypeOverridesTest.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackendSearchTypeOverridesTest.java
@@ -28,6 +28,7 @@ import org.graylog.plugins.views.search.SearchType;
 import org.graylog.plugins.views.search.elasticsearch.ElasticsearchQueryString;
 import org.graylog.plugins.views.search.engine.SearchConfig;
 import org.graylog.plugins.views.search.filter.StreamFilter;
+import org.graylog.plugins.views.search.searchfilters.model.InlineQueryStringSearchFilter;
 import org.graylog.plugins.views.search.searchtypes.pivot.Pivot;
 import org.graylog.plugins.views.search.searchtypes.pivot.series.Average;
 import org.graylog.plugins.views.search.searchtypes.pivot.series.Max;
@@ -56,7 +57,6 @@ import java.util.stream.Collectors;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.graylog.storage.elasticsearch7.views.ViewsUtils.indicesOf;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class ElasticsearchBackendSearchTypeOverridesTest extends ElasticsearchBackendGeneratedRequestTestBase {
@@ -75,6 +75,7 @@ public class ElasticsearchBackendSearchTypeOverridesTest extends ElasticsearchBa
                             .series(Collections.singletonList(Average.builder().field("field1").build()))
                             .rollup(true)
                             .timerange(DerivedTimeRange.of(AbsoluteRange.create("2019-09-11T10:31:52.819Z", "2019-09-11T10:36:52.823Z")))
+                            .filters(Collections.singletonList(InlineQueryStringSearchFilter.create("Pivot1 local filter", "Pivot1 local filter", "local:filter")))
                             .build()
             );
             add(
@@ -91,6 +92,7 @@ public class ElasticsearchBackendSearchTypeOverridesTest extends ElasticsearchBa
                 .searchTypes(searchTypes)
                 .query(ElasticsearchQueryString.of("production:true"))
                 .filter(StreamFilter.ofId("stream1"))
+                .filters(Collections.singletonList(InlineQueryStringSearchFilter.create("Global filter", "Global filter", "global:filter")))
                 .timerange(timeRangeForTest())
                 .build();
 
@@ -110,12 +112,12 @@ public class ElasticsearchBackendSearchTypeOverridesTest extends ElasticsearchBa
         final DocumentContext pivot1 = parse(generatedRequest.get(0).source().toString());
         final DocumentContext pivot2 = parse(generatedRequest.get(1).source().toString());
 
-        assertThat(queryStrings(pivot1)).containsExactly("production:true");
+        assertThat(queryStrings(pivot1)).containsExactly("production:true", "global:filter", "local:filter");
         assertThat(timerangeFrom(pivot1)).containsExactly("2019-09-11 10:31:52.819");
         assertThat(timerangeTo(pivot1)).containsExactly("2019-09-11 10:36:52.823");
         assertThat(streams(pivot1)).containsExactly(Collections.singletonList("stream1"));
 
-        assertThat(queryStrings(pivot2)).containsExactly("production:true", "source:babbage");
+        assertThat(queryStrings(pivot2)).containsExactly("production:true", "global:filter", "source:babbage");
         assertThat(timerangeFrom(pivot2)).containsExactly("2018-08-23 08:02:00.247");
         assertThat(timerangeTo(pivot2)).containsExactly("2018-08-23 08:07:00.252");
         assertThat(streams(pivot2)).containsExactly(Collections.singletonList("stream1"));

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/SearchType.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/SearchType.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.google.common.collect.Maps;
 import org.graylog.plugins.views.search.engine.BackendQuery;
 import org.graylog.plugins.views.search.rest.SearchTypeExecutionState;
+import org.graylog.plugins.views.search.searchfilters.model.UsedSearchFilter;
 import org.graylog.plugins.views.search.timeranges.DerivedTimeRange;
 import org.graylog2.contentpacks.ContentPackable;
 import org.graylog2.contentpacks.EntityDescriptorIds;
@@ -34,6 +35,7 @@ import org.graylog2.contentpacks.model.entities.SearchTypeEntity;
 
 import javax.annotation.Nullable;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -55,6 +57,7 @@ import java.util.stream.Collectors;
 @JsonAutoDetect
 public interface SearchType extends ContentPackable<SearchTypeEntity>, Exportable {
     String TYPE_FIELD = "type";
+    String FIELD_SEARCH_FILTERS = "filters";
 
     @JsonProperty(TYPE_FIELD)
     String type();
@@ -68,6 +71,9 @@ public interface SearchType extends ContentPackable<SearchTypeEntity>, Exportabl
     @Nullable
     @JsonProperty("filter")
     Filter filter();
+
+    @JsonProperty(FIELD_SEARCH_FILTERS)
+    List<UsedSearchFilter> filters();
 
     @JsonProperty
     Optional<DerivedTimeRange> timerange();
@@ -122,6 +128,10 @@ public interface SearchType extends ContentPackable<SearchTypeEntity>, Exportabl
         private Filter filter;
 
         @Nullable
+        @JsonProperty(FIELD_SEARCH_FILTERS)
+        private List<UsedSearchFilter> filters;
+
+        @Nullable
         @JsonProperty
         private DerivedTimeRange timeRange;
 
@@ -150,6 +160,11 @@ public interface SearchType extends ContentPackable<SearchTypeEntity>, Exportabl
         @Override
         public Filter filter() {
             return filter;
+        }
+
+        @Override
+        public List<UsedSearchFilter> filters() {
+            return filters;
         }
 
         @Override

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/MessageList.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/MessageList.java
@@ -22,14 +22,13 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
 import org.graylog.plugins.views.search.Filter;
 import org.graylog.plugins.views.search.SearchType;
 import org.graylog.plugins.views.search.engine.BackendQuery;
 import org.graylog.plugins.views.search.rest.SearchTypeExecutionState;
+import org.graylog.plugins.views.search.searchfilters.model.UsedSearchFilter;
 import org.graylog.plugins.views.search.timeranges.DerivedTimeRange;
 import org.graylog.plugins.views.search.timeranges.OffsetRange;
 import org.graylog2.contentpacks.EntityDescriptorIds;
@@ -66,12 +65,17 @@ public abstract class MessageList implements SearchType {
     @JsonProperty
     public abstract String id();
 
+    @Override
     @JsonProperty
     public abstract Optional<String> name();
 
     @Nullable
     @Override
     public abstract Filter filter();
+
+    @Override
+    @JsonProperty(FIELD_SEARCH_FILTERS)
+    public abstract List<UsedSearchFilter> filters();
 
     @JsonProperty
     public abstract int limit();
@@ -100,6 +104,7 @@ public abstract class MessageList implements SearchType {
                 .type(NAME)
                 .limit(150)
                 .offset(0)
+                .filters(Collections.emptyList())
                 .streams(Collections.emptySet())
                 .decorators(Collections.emptyList())
                 .fields(Collections.emptyList());
@@ -124,6 +129,7 @@ public abstract class MessageList implements SearchType {
         @JsonCreator
         public static Builder createDefault() {
             return builder()
+                    .filters(Collections.emptyList())
                     .streams(Collections.emptySet());
         }
 
@@ -140,6 +146,9 @@ public abstract class MessageList implements SearchType {
 
         @JsonProperty
         public abstract Builder filter(@Nullable Filter filter);
+
+        @JsonProperty(FIELD_SEARCH_FILTERS)
+        public abstract Builder filters(List<UsedSearchFilter> filters);
 
         @JsonProperty
         public abstract Builder fields(List<String> fields);
@@ -250,6 +259,7 @@ public abstract class MessageList implements SearchType {
                 .limit(limit())
                 .offset(offset())
                 .filter(filter())
+                .filters(filters())
                 .id(id())
                 .name(name().orElse(null))
                 .query(query().orElse(null))

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/events/EventList.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/events/EventList.java
@@ -19,8 +19,6 @@ package org.graylog.plugins.views.search.searchtypes.events;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableSet;
@@ -28,6 +26,7 @@ import org.graylog.plugins.views.search.Filter;
 import org.graylog.plugins.views.search.SearchType;
 import org.graylog.plugins.views.search.engine.BackendQuery;
 import org.graylog.plugins.views.search.rest.SearchTypeExecutionState;
+import org.graylog.plugins.views.search.searchfilters.model.UsedSearchFilter;
 import org.graylog.plugins.views.search.timeranges.DerivedTimeRange;
 import org.graylog2.contentpacks.EntityDescriptorIds;
 import org.graylog2.contentpacks.model.entities.EventListEntity;
@@ -60,10 +59,15 @@ public abstract class EventList implements SearchType {
     @Override
     public abstract Filter filter();
 
+    @Override
+    @JsonProperty(FIELD_SEARCH_FILTERS)
+    public abstract List<UsedSearchFilter> filters();
+
     @JsonCreator
     public static Builder builder() {
         return new AutoValue_EventList.Builder()
                 .type(NAME)
+                .filters(Collections.emptyList())
                 .streams(Collections.emptySet());
     }
 
@@ -84,6 +88,7 @@ public abstract class EventList implements SearchType {
         @JsonCreator
         public static Builder createDefault() {
             return builder()
+                    .filters(Collections.emptyList())
                     .streams(Collections.emptySet());
         }
 
@@ -100,6 +105,9 @@ public abstract class EventList implements SearchType {
 
         @JsonProperty
         public abstract Builder filter(@Nullable Filter filter);
+
+        @JsonProperty(FIELD_SEARCH_FILTERS)
+        public abstract Builder filters(List<UsedSearchFilter> filters);
 
         @JsonProperty
         public abstract Builder query(@Nullable BackendQuery query);
@@ -160,6 +168,7 @@ public abstract class EventList implements SearchType {
         return EventListEntity.builder()
                 .streams(mappedStreams(entityDescriptorIds))
                 .filter(filter())
+                .filters(filters())
                 .id(id())
                 .name(name().orElse(null))
                 .query(query().orElse(null))

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/Pivot.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/Pivot.java
@@ -27,6 +27,7 @@ import org.graylog.plugins.views.search.Filter;
 import org.graylog.plugins.views.search.SearchType;
 import org.graylog.plugins.views.search.engine.BackendQuery;
 import org.graylog.plugins.views.search.rest.SearchTypeExecutionState;
+import org.graylog.plugins.views.search.searchfilters.model.UsedSearchFilter;
 import org.graylog.plugins.views.search.timeranges.DerivedTimeRange;
 import org.graylog.plugins.views.search.timeranges.OffsetRange;
 import org.graylog2.contentpacks.EntityDescriptorIds;
@@ -60,6 +61,7 @@ public abstract class Pivot implements SearchType {
     @JsonProperty
     public abstract String id();
 
+    @Override
     @JsonProperty
     public abstract Optional<String> name();
 
@@ -82,6 +84,10 @@ public abstract class Pivot implements SearchType {
     @Override
     public abstract Filter filter();
 
+    @Override
+    @JsonProperty(FIELD_SEARCH_FILTERS)
+    public abstract List<UsedSearchFilter> filters();
+
     public abstract Builder toBuilder();
 
     @Override
@@ -95,6 +101,7 @@ public abstract class Pivot implements SearchType {
                 .rowGroups(of())
                 .columnGroups(of())
                 .sort(of())
+                .filters(of())
                 .streams(Collections.emptySet());
     }
 
@@ -104,6 +111,7 @@ public abstract class Pivot implements SearchType {
         public static Builder createDefault() {
             return builder()
                     .sort(Collections.emptyList())
+                    .filters(Collections.emptyList())
                     .streams(Collections.emptySet());
         }
 
@@ -135,6 +143,9 @@ public abstract class Pivot implements SearchType {
 
         @JsonProperty
         public abstract Builder filter(@Nullable Filter filter);
+
+        @JsonProperty(FIELD_SEARCH_FILTERS)
+        public abstract Builder filters(List<UsedSearchFilter> filters);
 
         @JsonProperty
         @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "type", visible = true)
@@ -174,6 +185,7 @@ public abstract class Pivot implements SearchType {
                 .columnGroups(columnGroups())
                 .rowGroups(rowGroups())
                 .filter(filter())
+                .filters(filters())
                 .query(query().orElse(null))
                 .id(id())
                 .name(name().orElse(null))

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/WidgetDTO.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/WidgetDTO.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
 import org.graylog.autovalue.WithBeanGetter;
 import org.graylog.plugins.views.search.engine.BackendQuery;
+import org.graylog.plugins.views.search.searchfilters.model.UsedSearchFilter;
 import org.graylog2.contentpacks.ContentPackable;
 import org.graylog2.contentpacks.EntityDescriptorIds;
 import org.graylog2.contentpacks.model.ModelTypes;
@@ -32,6 +33,7 @@ import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
 
 import javax.annotation.Nullable;
 import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -43,6 +45,7 @@ public abstract class WidgetDTO implements ContentPackable<WidgetEntity> {
     public static final String FIELD_ID = "id";
     public static final String FIELD_TYPE = "type";
     public static final String FIELD_FILTER = "filter";
+    public static final String FIELD_SEARCH_FILTERS = "filters";
     public static final String FIELD_CONFIG = "config";
     public static final String FIELD_TIMERANGE = "timerange";
     public static final String FIELD_QUERY = "query";
@@ -58,6 +61,9 @@ public abstract class WidgetDTO implements ContentPackable<WidgetEntity> {
     @Nullable
     public abstract String filter();
 
+    @JsonProperty(FIELD_SEARCH_FILTERS)
+    public abstract List<UsedSearchFilter> filters();
+
     @JsonProperty(FIELD_TIMERANGE)
     public abstract Optional<TimeRange> timerange();
 
@@ -72,7 +78,7 @@ public abstract class WidgetDTO implements ContentPackable<WidgetEntity> {
 
     public static Builder builder() {
         return Builder.builder();
-    };
+    }
 
     @AutoValue.Builder
     public static abstract class Builder {
@@ -84,6 +90,9 @@ public abstract class WidgetDTO implements ContentPackable<WidgetEntity> {
 
         @JsonProperty(FIELD_FILTER)
         public abstract Builder filter(@Nullable String filter);
+
+        @JsonProperty(FIELD_SEARCH_FILTERS)
+        public abstract Builder filters(List<UsedSearchFilter> filters);
 
         @JsonProperty(FIELD_TIMERANGE)
         public abstract Builder timerange(@Nullable TimeRange timerange);
@@ -107,7 +116,9 @@ public abstract class WidgetDTO implements ContentPackable<WidgetEntity> {
 
         @JsonCreator
         static Builder builder() {
-            return new AutoValue_WidgetDTO.Builder().streams(Collections.emptySet());
+            return new AutoValue_WidgetDTO.Builder()
+                    .streams(Collections.emptySet())
+                    .filters(Collections.emptyList());
         }
     }
 
@@ -122,6 +133,7 @@ public abstract class WidgetDTO implements ContentPackable<WidgetEntity> {
                 .id(this.id())
                 .config(this.config())
                 .filter(this.filter())
+                .filters(this.filters())
                 .streams(mappedStreams)
                 .type(this.type());
         if (this.query().isPresent()) {

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/EventListEntity.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/EventListEntity.java
@@ -24,12 +24,14 @@ import com.google.auto.value.AutoValue;
 import org.graylog.plugins.views.search.Filter;
 import org.graylog.plugins.views.search.SearchType;
 import org.graylog.plugins.views.search.engine.BackendQuery;
+import org.graylog.plugins.views.search.searchfilters.model.UsedSearchFilter;
 import org.graylog.plugins.views.search.searchtypes.events.EventList;
 import org.graylog.plugins.views.search.timeranges.DerivedTimeRange;
 import org.graylog2.contentpacks.model.entities.references.ValueReference;
 
 import javax.annotation.Nullable;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -51,10 +53,15 @@ public abstract class EventListEntity implements SearchTypeEntity {
     @Override
     public abstract Filter filter();
 
+    @Override
+    @JsonProperty(FIELD_SEARCH_FILTERS)
+    public abstract List<UsedSearchFilter> filters();
+
     @JsonCreator
     public static Builder builder() {
         return new AutoValue_EventListEntity.Builder()
                 .type(NAME)
+                .filters(Collections.emptyList())
                 .streams(Collections.emptySet());
     }
 
@@ -70,6 +77,7 @@ public abstract class EventListEntity implements SearchTypeEntity {
         @JsonCreator
         public static Builder createDefault() {
             return builder()
+                    .filters(Collections.emptyList())
                     .streams(Collections.emptySet());
         }
 
@@ -86,14 +94,19 @@ public abstract class EventListEntity implements SearchTypeEntity {
         public abstract Builder filter(@Nullable Filter filter);
 
         @JsonProperty
+        public abstract Builder filters(List<UsedSearchFilter> filters);
+
+        @JsonProperty
         public abstract Builder query(@Nullable BackendQuery query);
 
         @JsonProperty
         public abstract Builder timerange(@Nullable DerivedTimeRange timeRange);
 
+        @Override
         @JsonProperty
         public abstract Builder streams(Set<String> streams);
 
+        @Override
         public abstract EventListEntity build();
     }
 
@@ -104,6 +117,7 @@ public abstract class EventListEntity implements SearchTypeEntity {
                 .streams(mappedStreams(nativeEntities))
                 .id(id())
                 .filter(filter())
+                .filters(filters())
                 .query(query().orElse(null))
                 .timerange(timerange().orElse(null))
                 .name(name().orElse(null))

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/MessageListEntity.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/MessageListEntity.java
@@ -26,6 +26,7 @@ import com.google.auto.value.AutoValue;
 import org.graylog.plugins.views.search.Filter;
 import org.graylog.plugins.views.search.SearchType;
 import org.graylog.plugins.views.search.engine.BackendQuery;
+import org.graylog.plugins.views.search.searchfilters.model.UsedSearchFilter;
 import org.graylog.plugins.views.search.searchtypes.MessageList;
 import org.graylog.plugins.views.search.searchtypes.Sort;
 import org.graylog.plugins.views.search.timeranges.DerivedTimeRange;
@@ -60,12 +61,17 @@ public abstract class MessageListEntity implements SearchTypeEntity {
     @JsonProperty
     public abstract String id();
 
+    @Override
     @JsonProperty
     public abstract Optional<String> name();
 
     @Nullable
     @Override
     public abstract Filter filter();
+
+    @Override
+    @JsonProperty(FIELD_SEARCH_FILTERS)
+    public abstract List<UsedSearchFilter> filters();
 
     @JsonProperty
     public abstract int limit();
@@ -86,6 +92,7 @@ public abstract class MessageListEntity implements SearchTypeEntity {
                 .limit(150)
                 .offset(0)
                 .streams(Collections.emptySet())
+                .filters(Collections.emptyList())
                 .decorators(Collections.emptyList());
     }
 
@@ -101,6 +108,7 @@ public abstract class MessageListEntity implements SearchTypeEntity {
         @JsonCreator
         public static Builder createDefault() {
             return builder()
+                    .filters(Collections.emptyList())
                     .streams(Collections.emptySet());
         }
 
@@ -115,6 +123,9 @@ public abstract class MessageListEntity implements SearchTypeEntity {
 
         @JsonProperty
         public abstract Builder filter(@Nullable Filter filter);
+
+        @JsonProperty
+        public abstract Builder filters(List<UsedSearchFilter> filters);
 
         @JsonProperty
         @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "type", visible = true)
@@ -132,6 +143,7 @@ public abstract class MessageListEntity implements SearchTypeEntity {
         @JsonProperty
         public abstract Builder query(@Nullable BackendQuery query);
 
+        @Override
         @JsonProperty
         public abstract Builder streams(Set<String> streams);
 
@@ -151,23 +163,25 @@ public abstract class MessageListEntity implements SearchTypeEntity {
 
         public abstract Builder decorators(List<Decorator> decorators);
 
+        @Override
         public abstract MessageListEntity build();
     }
 
     @Override
     public SearchType toNativeEntity(Map<String, ValueReference> parameters, Map<EntityDescriptor, Object> nativeEntities) {
-       return MessageList.builder()
-       .limit(limit())
-       .streams(mappedStreams(nativeEntities))
-       .id(id())
-       .offset(offset())
-       .decorators(decorators())
-       .timerange(timerange().orElse(null))
-       .filter(filter())
-       .name(name().orElse(null))
-       .type(type())
-       .query(query().orElse(null))
-       .sort(sort())
-       .build();
+        return MessageList.builder()
+                .limit(limit())
+                .streams(mappedStreams(nativeEntities))
+                .id(id())
+                .offset(offset())
+                .decorators(decorators())
+                .timerange(timerange().orElse(null))
+                .filter(filter())
+                .filters(filters())
+                .name(name().orElse(null))
+                .type(type())
+                .query(query().orElse(null))
+                .sort(sort())
+                .build();
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/PivotEntity.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/PivotEntity.java
@@ -26,6 +26,7 @@ import com.google.auto.value.AutoValue;
 import org.graylog.plugins.views.search.Filter;
 import org.graylog.plugins.views.search.SearchType;
 import org.graylog.plugins.views.search.engine.BackendQuery;
+import org.graylog.plugins.views.search.searchfilters.model.UsedSearchFilter;
 import org.graylog.plugins.views.search.searchtypes.pivot.BucketSpec;
 import org.graylog.plugins.views.search.searchtypes.pivot.Pivot;
 import org.graylog.plugins.views.search.searchtypes.pivot.SeriesSpec;
@@ -61,6 +62,7 @@ public abstract class PivotEntity implements SearchTypeEntity {
     @JsonProperty
     public abstract String id();
 
+    @Override
     @JsonProperty
     public abstract Optional<String> name();
 
@@ -83,6 +85,10 @@ public abstract class PivotEntity implements SearchTypeEntity {
     @Override
     public abstract Filter filter();
 
+    @Override
+    @JsonProperty(FIELD_SEARCH_FILTERS)
+    public abstract List<UsedSearchFilter> filters();
+
     public abstract Builder toBuilder();
 
     @Override
@@ -95,6 +101,7 @@ public abstract class PivotEntity implements SearchTypeEntity {
                 .type(NAME)
                 .rowGroups(of())
                 .columnGroups(of())
+                .filters(Collections.emptyList())
                 .sort(of())
                 .streams(Collections.emptySet());
     }
@@ -104,6 +111,7 @@ public abstract class PivotEntity implements SearchTypeEntity {
         @JsonCreator
         public static Builder createDefault() {
             return builder()
+                    .filters(Collections.emptyList())
                     .sort(Collections.emptyList())
                     .streams(Collections.emptySet());
         }
@@ -136,6 +144,9 @@ public abstract class PivotEntity implements SearchTypeEntity {
         public abstract Builder filter(@Nullable Filter filter);
 
         @JsonProperty
+        public abstract Builder filters(List<UsedSearchFilter> filters);
+
+        @JsonProperty
         @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "type", visible = true)
         @JsonSubTypes({
                 @JsonSubTypes.Type(name = AbsoluteRange.ABSOLUTE, value = AbsoluteRange.class),
@@ -151,9 +162,11 @@ public abstract class PivotEntity implements SearchTypeEntity {
         @JsonProperty
         public abstract Builder query(@Nullable BackendQuery query);
 
+        @Override
         @JsonProperty
         public abstract Builder streams(Set<String> streams);
 
+        @Override
         public abstract PivotEntity build();
     }
 
@@ -170,6 +183,7 @@ public abstract class PivotEntity implements SearchTypeEntity {
                 .rollup(rollup())
                 .query(query().orElse(null))
                 .filter(filter())
+                .filters(filters())
                 .type(type())
                 .id(id())
                 .build();

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/SearchTypeEntity.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/SearchTypeEntity.java
@@ -23,6 +23,7 @@ import com.google.common.collect.Maps;
 import org.graylog.plugins.views.search.Filter;
 import org.graylog.plugins.views.search.SearchType;
 import org.graylog.plugins.views.search.engine.BackendQuery;
+import org.graylog.plugins.views.search.searchfilters.model.UsedSearchFilter;
 import org.graylog.plugins.views.search.timeranges.DerivedTimeRange;
 import org.graylog2.contentpacks.NativeEntityConverter;
 import org.graylog2.contentpacks.exceptions.ContentPackException;
@@ -32,6 +33,7 @@ import org.graylog2.plugin.streams.Stream;
 
 import javax.annotation.Nullable;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -47,6 +49,7 @@ import java.util.stream.Collectors;
 @JsonAutoDetect
 public interface SearchTypeEntity extends NativeEntityConverter<SearchType> {
     String TYPE_FIELD = "type";
+    String FIELD_SEARCH_FILTERS = "filters";
 
     @JsonProperty(TYPE_FIELD)
     String type();
@@ -60,6 +63,9 @@ public interface SearchTypeEntity extends NativeEntityConverter<SearchType> {
     @Nullable
     @JsonProperty("filter")
     Filter filter();
+
+    @JsonProperty(FIELD_SEARCH_FILTERS)
+    List<UsedSearchFilter> filters();
 
     @JsonProperty
     Optional<DerivedTimeRange> timerange();
@@ -77,9 +83,9 @@ public interface SearchTypeEntity extends NativeEntityConverter<SearchType> {
     }
 
     interface Builder {
-        public abstract Builder streams(Set<String> streams);
+        Builder streams(Set<String> streams);
 
-        public abstract SearchTypeEntity build();
+        SearchTypeEntity build();
     }
 
     @JsonAutoDetect
@@ -99,6 +105,10 @@ public interface SearchTypeEntity extends NativeEntityConverter<SearchType> {
         @Nullable
         @JsonProperty
         private Filter filter;
+
+        @Nullable
+        @JsonProperty(FIELD_SEARCH_FILTERS)
+        private List<UsedSearchFilter> filters;
 
         @Nullable
         @JsonProperty
@@ -129,6 +139,11 @@ public interface SearchTypeEntity extends NativeEntityConverter<SearchType> {
         @Override
         public Filter filter() {
             return filter;
+        }
+
+        @Override
+        public List<UsedSearchFilter> filters() {
+            return filters;
         }
 
         @Override

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/WidgetEntity.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/WidgetEntity.java
@@ -24,6 +24,7 @@ import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
 import org.graylog.autovalue.WithBeanGetter;
 import org.graylog.plugins.views.search.engine.BackendQuery;
+import org.graylog.plugins.views.search.searchfilters.model.UsedSearchFilter;
 import org.graylog.plugins.views.search.searchtypes.pivot.BucketSpec;
 import org.graylog.plugins.views.search.searchtypes.pivot.PivotSort;
 import org.graylog.plugins.views.search.searchtypes.pivot.SeriesSpec;
@@ -70,6 +71,7 @@ public abstract class WidgetEntity implements NativeEntityConverter<WidgetDTO> {
     public static final String FIELD_ID = "id";
     public static final String FIELD_TYPE = "type";
     public static final String FIELD_FILTER = "filter";
+    public static final String FIELD_SEARCH_FILTERS = "filters";
     public static final String FIELD_CONFIG = "config";
     public static final String FIELD_TIMERANGE = "timerange";
     public static final String FIELD_QUERY = "query";
@@ -84,6 +86,9 @@ public abstract class WidgetEntity implements NativeEntityConverter<WidgetDTO> {
     @JsonProperty(FIELD_FILTER)
     @Nullable
     public abstract String filter();
+
+    @JsonProperty(FIELD_SEARCH_FILTERS)
+    public abstract List<UsedSearchFilter> filters();
 
     @JsonProperty(FIELD_TIMERANGE)
     public abstract Optional<TimeRange> timerange();
@@ -112,6 +117,9 @@ public abstract class WidgetEntity implements NativeEntityConverter<WidgetDTO> {
         @JsonProperty(FIELD_FILTER)
         public abstract Builder filter(@Nullable String filter);
 
+        @JsonProperty(FIELD_SEARCH_FILTERS)
+        public abstract Builder filters(List<UsedSearchFilter> filters);
+
         @JsonProperty(FIELD_TIMERANGE)
         public abstract Builder timerange(@Nullable TimeRange timerange);
 
@@ -133,7 +141,9 @@ public abstract class WidgetEntity implements NativeEntityConverter<WidgetDTO> {
 
         @JsonCreator
         static Builder builder() {
-            return new AutoValue_WidgetEntity.Builder().streams(Collections.emptySet());
+            return new AutoValue_WidgetEntity.Builder()
+                    .streams(Collections.emptySet())
+                    .filters(Collections.emptyList());
         }
     }
 
@@ -142,6 +152,7 @@ public abstract class WidgetEntity implements NativeEntityConverter<WidgetDTO> {
         final WidgetDTO.Builder widgetBuilder = WidgetDTO.builder()
                 .config(this.config())
                 .filter(this.filter())
+                .filters(this.filters())
                 .id(this.id())
                 .streams(this.streams().stream()
                         .map(id -> EntityDescriptor.create(id, ModelTypes.STREAM_V1))


### PR DESCRIPTION
## Description
Added filters field for Search Filters in proper model classes and their content pack equivalents (both in "widget" and "search type" families of model classes).
Search Filters from search types are now used by ES Backend during query generation.

Fixes #12848

## Motivation and Context
Front-end wants to be able to use search filters on each widget/search type level. 

## How Has This Been Tested?
As Front-end is not yet done, you have to invoke search execution REST call manually, adding "filters" part in both the query itself and nested "search types". You can observe that results for different "search types" differ, depending on used "filters". You can observe that filters from the query itself and its "search types" are combined.

The existing tests have been also upgraded to test this feature automatically.


/jenkins-pr-deps Graylog2/graylog-plugin-enterprise#3684

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
