### PR TITLE
Use ordered query set for consistent tab ordering. (backport to 4.3 from #12833)

### DIFF
--- a/full-backend-tests/src/test/java/org/graylog/plugins/views/SearchSyncIT.java
+++ b/full-backend-tests/src/test/java/org/graylog/plugins/views/SearchSyncIT.java
@@ -174,7 +174,7 @@ public class SearchSyncIT {
                 .accept("application/vnd.graylog.search.v2+json")
                 .contentType("application/vnd.graylog.search.v2+json")
                 .when()
-                .body(fixture("org/graylog/plugins/views/search-with-three-empty-queries.json"))
+                .body(fixture("org/graylog/plugins/views/search-with-three-empty-queries-v2.json"))
                 .post("/views/search")
                 .then()
                 .statusCode(201)

--- a/full-backend-tests/src/test/java/org/graylog/plugins/views/SearchSyncIT.java
+++ b/full-backend-tests/src/test/java/org/graylog/plugins/views/SearchSyncIT.java
@@ -153,6 +153,7 @@ public class SearchSyncIT {
     @ContainerMatrixTest
     void testThatQueryOrderStaysConsistentInV1() {
         given()
+                .config(sut.withGraylogBackendFailureConfig())
                 .spec(requestSpec)
                 .accept("application/json")
                 .contentType("application/json")
@@ -160,6 +161,7 @@ public class SearchSyncIT {
                 .body(fixture("org/graylog/plugins/views/search-with-three-empty-queries.json"))
                 .post("/views/search")
                 .then()
+                .log().ifStatusCodeMatches(not(201))
                 .statusCode(201)
                 .assertThat()
                 .body("queries*.id", contains("4966dd79-2c7d-4ba9-8f90-c84aea7b5c49",
@@ -170,6 +172,7 @@ public class SearchSyncIT {
     @ContainerMatrixTest
     void testThatQueryOrderStaysConsistentInV2() {
         given()
+                .config(sut.withGraylogBackendFailureConfig())
                 .spec(requestSpec)
                 .accept("application/vnd.graylog.search.v2+json")
                 .contentType("application/vnd.graylog.search.v2+json")
@@ -177,6 +180,7 @@ public class SearchSyncIT {
                 .body(fixture("org/graylog/plugins/views/search-with-three-empty-queries-v2.json"))
                 .post("/views/search")
                 .then()
+                .log().ifStatusCodeMatches(not(201))
                 .statusCode(201)
                 .assertThat()
                 .body("queries*.id", contains("4966dd79-2c7d-4ba9-8f90-c84aea7b5c49",

--- a/full-backend-tests/src/test/java/org/graylog/plugins/views/SearchSyncIT.java
+++ b/full-backend-tests/src/test/java/org/graylog/plugins/views/SearchSyncIT.java
@@ -39,6 +39,7 @@ import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.core.IsEqual.equalTo;
 
@@ -147,6 +148,40 @@ public class SearchSyncIT {
                 .body("execution.completed_exceptionally", equalTo(false))
                 .body("results.f1446410-a082-4871-b3bf-d69aa42d0c96.search_types", not(hasKey("f1446410-a082-4871-b3bf-d69aa42d0c97")))
                 .body("results.f1446410-a082-4871-b3bf-d69aa42d0c97.search_types", hasKey("01c76680-377b-4930-86e2-a55fdb867b58"));
+    }
+
+    @ContainerMatrixTest
+    void testThatQueryOrderStaysConsistentInV1() {
+        given()
+                .spec(requestSpec)
+                .accept("application/json")
+                .contentType("application/json")
+                .when()
+                .body(fixture("org/graylog/plugins/views/search-with-three-empty-queries.json"))
+                .post("/views/search")
+                .then()
+                .statusCode(201)
+                .assertThat()
+                .body("queries*.id", contains("4966dd79-2c7d-4ba9-8f90-c84aea7b5c49",
+                        "0d5b45b8-1f55-4b60-ad34-d086ddd5d8fa",
+                        "3eec6f5c-0f1b-41dc-bb95-3ebc6bb905f3"));
+    }
+
+    @ContainerMatrixTest
+    void testThatQueryOrderStaysConsistentInV2() {
+        given()
+                .spec(requestSpec)
+                .accept("application/vnd.graylog.search.v2+json")
+                .contentType("application/vnd.graylog.search.v2+json")
+                .when()
+                .body(fixture("org/graylog/plugins/views/search-with-three-empty-queries.json"))
+                .post("/views/search")
+                .then()
+                .statusCode(201)
+                .assertThat()
+                .body("queries*.id", contains("4966dd79-2c7d-4ba9-8f90-c84aea7b5c49",
+                        "0d5b45b8-1f55-4b60-ad34-d086ddd5d8fa",
+                        "3eec6f5c-0f1b-41dc-bb95-3ebc6bb905f3"));
     }
 
     private String executeStoredSearch(String searchId) {

--- a/full-backend-tests/src/test/java/org/graylog/testing/backenddriver/SearchDriver.java
+++ b/full-backend-tests/src/test/java/org/graylog/testing/backenddriver/SearchDriver.java
@@ -91,7 +91,7 @@ public class SearchDriver {
                 .build();
         SearchDTO s = SearchDTO.builder()
                 .id(new ObjectId().toHexString())
-                .queries(new LinkedHashSet<>(Collections.singleton(q)))
+                .queries(q)
                 .build();
 
         return JsonUtils.toJsonString(s);

--- a/full-backend-tests/src/test/java/org/graylog/testing/backenddriver/SearchDriver.java
+++ b/full-backend-tests/src/test/java/org/graylog/testing/backenddriver/SearchDriver.java
@@ -30,6 +30,8 @@ import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
 
 import static io.restassured.RestAssured.given;
@@ -89,7 +91,7 @@ public class SearchDriver {
                 .build();
         SearchDTO s = SearchDTO.builder()
                 .id(new ObjectId().toHexString())
-                .queries(ImmutableSet.of(q))
+                .queries(new LinkedHashSet<>(Collections.singleton(q)))
                 .build();
 
         return JsonUtils.toJsonString(s);

--- a/full-backend-tests/src/test/resources/org/graylog/plugins/views/search-with-three-empty-queries-v2.json
+++ b/full-backend-tests/src/test/resources/org/graylog/plugins/views/search-with-three-empty-queries-v2.json
@@ -11,7 +11,6 @@
         "from": 300
       },
       "streams": [],
-      "filters": [],
       "search_types": []
     },
     {
@@ -25,7 +24,6 @@
         "from": 300
       },
       "streams": [],
-      "filters": [],
       "search_types": []
     },
     {

--- a/full-backend-tests/src/test/resources/org/graylog/plugins/views/search-with-three-empty-queries-v2.json
+++ b/full-backend-tests/src/test/resources/org/graylog/plugins/views/search-with-three-empty-queries-v2.json
@@ -1,0 +1,44 @@
+{
+  "queries": [
+    {
+      "id": "4966dd79-2c7d-4ba9-8f90-c84aea7b5c49",
+      "query": {
+        "type": "elasticsearch",
+        "query_string": ""
+      },
+      "timerange": {
+        "type": "relative",
+        "from": 300
+      },
+      "streams": [],
+      "filters": [],
+      "search_types": []
+    },
+    {
+      "id": "0d5b45b8-1f55-4b60-ad34-d086ddd5d8fa",
+      "query": {
+        "type": "elasticsearch",
+        "query_string": ""
+      },
+      "timerange": {
+        "type": "relative",
+        "from": 300
+      },
+      "streams": [],
+      "filters": [],
+      "search_types": []
+    },
+    {
+      "id": "3eec6f5c-0f1b-41dc-bb95-3ebc6bb905f3",
+      "query": {
+        "type": "elasticsearch",
+        "query_string": ""
+      },
+      "timerange": {
+        "type": "relative",
+        "from": 300
+      },
+      "search_types": []
+    }
+  ]
+}

--- a/full-backend-tests/src/test/resources/org/graylog/plugins/views/search-with-three-empty-queries.json
+++ b/full-backend-tests/src/test/resources/org/graylog/plugins/views/search-with-three-empty-queries.json
@@ -11,7 +11,6 @@
         "from": 300
       },
       "filter": null,
-      "filters": [],
       "search_types": []
     },
     {
@@ -25,7 +24,6 @@
         "from": 300
       },
       "filter": null,
-      "filters": [],
       "search_types": []
     },
     {

--- a/full-backend-tests/src/test/resources/org/graylog/plugins/views/search-with-three-empty-queries.json
+++ b/full-backend-tests/src/test/resources/org/graylog/plugins/views/search-with-three-empty-queries.json
@@ -1,0 +1,44 @@
+{
+  "queries": [
+    {
+      "id": "4966dd79-2c7d-4ba9-8f90-c84aea7b5c49",
+      "query": {
+        "type": "elasticsearch",
+        "query_string": ""
+      },
+      "timerange": {
+        "type": "relative",
+        "from": 300
+      },
+      "filter": null,
+      "filters": [],
+      "search_types": []
+    },
+    {
+      "id": "0d5b45b8-1f55-4b60-ad34-d086ddd5d8fa",
+      "query": {
+        "type": "elasticsearch",
+        "query_string": ""
+      },
+      "timerange": {
+        "type": "relative",
+        "from": 300
+      },
+      "filter": null,
+      "filters": [],
+      "search_types": []
+    },
+    {
+      "id": "3eec6f5c-0f1b-41dc-bb95-3ebc6bb905f3",
+      "query": {
+        "type": "elasticsearch",
+        "query_string": ""
+      },
+      "timerange": {
+        "type": "relative",
+        "from": 300
+      },
+      "search_types": []
+    }
+  ]
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SearchDTO.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SearchDTO.java
@@ -27,6 +27,7 @@ import org.graylog.plugins.views.search.Query;
 import org.graylog.plugins.views.search.Search;
 
 import javax.annotation.Nullable;
+import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -71,6 +72,10 @@ public abstract class SearchDTO {
 
         @JsonProperty
         public abstract Builder queries(LinkedHashSet<QueryDTO> queries);
+
+        public Builder queries(QueryDTO... queries) {
+            return this.queries(new LinkedHashSet<>(Arrays.asList(queries)));
+        }
 
         @JsonProperty
         public abstract Builder parameters(Set<Parameter> parameters);

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SearchDTO.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SearchDTO.java
@@ -27,11 +27,11 @@ import org.graylog.plugins.views.search.Query;
 import org.graylog.plugins.views.search.Search;
 
 import javax.annotation.Nullable;
+import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 import static com.google.common.collect.ImmutableSet.of;
-import static com.google.common.collect.ImmutableSet.toImmutableSet;
 
 @AutoValue
 @JsonAutoDetect
@@ -42,7 +42,7 @@ public abstract class SearchDTO {
     public abstract String id();
 
     @JsonProperty
-    public abstract ImmutableSet<QueryDTO> queries();
+    public abstract LinkedHashSet<QueryDTO> queries();
 
     @JsonProperty
     public abstract Set<Parameter> parameters();
@@ -54,7 +54,7 @@ public abstract class SearchDTO {
                 .queries(search.queries()
                         .stream()
                         .map(QueryDTO::fromQuery)
-                        .collect(toImmutableSet()))
+                        .collect(Collectors.toCollection(LinkedHashSet::new)))
                 .build();
     }
 
@@ -70,7 +70,7 @@ public abstract class SearchDTO {
         public abstract String id();
 
         @JsonProperty
-        public abstract Builder queries(ImmutableSet<QueryDTO> queries);
+        public abstract Builder queries(LinkedHashSet<QueryDTO> queries);
 
         @JsonProperty
         public abstract Builder parameters(Set<Parameter> parameters);
@@ -80,7 +80,7 @@ public abstract class SearchDTO {
         @JsonCreator
         static Builder create() {
             return new AutoValue_SearchDTO.Builder()
-                    .queries(ImmutableSet.of())
+                    .queries(new LinkedHashSet<>())
                     .parameters(of());
         }
     }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SearchDTO.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SearchDTO.java
@@ -31,6 +31,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static com.google.common.collect.ImmutableSet.of;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 
 @AutoValue
 @JsonAutoDetect
@@ -41,7 +42,7 @@ public abstract class SearchDTO {
     public abstract String id();
 
     @JsonProperty
-    public abstract Set<QueryDTO> queries();
+    public abstract ImmutableSet<QueryDTO> queries();
 
     @JsonProperty
     public abstract Set<Parameter> parameters();
@@ -53,7 +54,7 @@ public abstract class SearchDTO {
                 .queries(search.queries()
                         .stream()
                         .map(QueryDTO::fromQuery)
-                        .collect(Collectors.toSet()))
+                        .collect(toImmutableSet()))
                 .build();
     }
 
@@ -69,7 +70,7 @@ public abstract class SearchDTO {
         public abstract String id();
 
         @JsonProperty
-        public abstract Builder queries(Set<QueryDTO> queries);
+        public abstract Builder queries(ImmutableSet<QueryDTO> queries);
 
         @JsonProperty
         public abstract Builder parameters(Set<Parameter> parameters);

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SearchDTOv2.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SearchDTOv2.java
@@ -27,6 +27,7 @@ import org.graylog.plugins.views.search.Query;
 import org.graylog.plugins.views.search.Search;
 
 import javax.annotation.Nullable;
+import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -71,6 +72,10 @@ public abstract class SearchDTOv2 {
 
         @JsonProperty
         public abstract Builder queries(LinkedHashSet<QueryDTOv2> queries);
+
+        public Builder queries(QueryDTOv2... queries) {
+            return this.queries(new LinkedHashSet<>(Arrays.asList(queries)));
+        }
 
         @JsonProperty
         public abstract Builder parameters(Set<Parameter> parameters);

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SearchDTOv2.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SearchDTOv2.java
@@ -31,6 +31,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static com.google.common.collect.ImmutableSet.of;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 
 @AutoValue
 @JsonAutoDetect
@@ -41,7 +42,7 @@ public abstract class SearchDTOv2 {
     public abstract String id();
 
     @JsonProperty
-    public abstract Set<QueryDTOv2> queries();
+    public abstract ImmutableSet<QueryDTOv2> queries();
 
     @JsonProperty
     public abstract Set<Parameter> parameters();
@@ -53,7 +54,7 @@ public abstract class SearchDTOv2 {
                 .queries(search.queries()
                         .stream()
                         .map(QueryDTOv2::fromQuery)
-                        .collect(Collectors.toSet()))
+                        .collect(toImmutableSet()))
                 .build();
     }
 
@@ -69,7 +70,7 @@ public abstract class SearchDTOv2 {
         public abstract String id();
 
         @JsonProperty
-        public abstract Builder queries(Set<QueryDTOv2> queries);
+        public abstract Builder queries(ImmutableSet<QueryDTOv2> queries);
 
         @JsonProperty
         public abstract Builder parameters(Set<Parameter> parameters);

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SearchDTOv2.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SearchDTOv2.java
@@ -27,11 +27,11 @@ import org.graylog.plugins.views.search.Query;
 import org.graylog.plugins.views.search.Search;
 
 import javax.annotation.Nullable;
+import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 import static com.google.common.collect.ImmutableSet.of;
-import static com.google.common.collect.ImmutableSet.toImmutableSet;
 
 @AutoValue
 @JsonAutoDetect
@@ -42,7 +42,7 @@ public abstract class SearchDTOv2 {
     public abstract String id();
 
     @JsonProperty
-    public abstract ImmutableSet<QueryDTOv2> queries();
+    public abstract LinkedHashSet<QueryDTOv2> queries();
 
     @JsonProperty
     public abstract Set<Parameter> parameters();
@@ -54,7 +54,7 @@ public abstract class SearchDTOv2 {
                 .queries(search.queries()
                         .stream()
                         .map(QueryDTOv2::fromQuery)
-                        .collect(toImmutableSet()))
+                        .collect(Collectors.toCollection(LinkedHashSet::new)))
                 .build();
     }
 
@@ -70,7 +70,7 @@ public abstract class SearchDTOv2 {
         public abstract String id();
 
         @JsonProperty
-        public abstract Builder queries(ImmutableSet<QueryDTOv2> queries);
+        public abstract Builder queries(LinkedHashSet<QueryDTOv2> queries);
 
         @JsonProperty
         public abstract Builder parameters(Set<Parameter> parameters);
@@ -80,7 +80,7 @@ public abstract class SearchDTOv2 {
         @JsonCreator
         static Builder create() {
             return new AutoValue_SearchDTOv2.Builder()
-                    .queries(ImmutableSet.of())
+                    .queries(new LinkedHashSet<>())
                     .parameters(of());
         }
     }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SearchResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SearchResource.java
@@ -103,6 +103,23 @@ public class SearchResource extends RestResource implements PluginRestResource {
         return Response.created(URI.create(result.id())).entity(result).build();
     }
 
+    @POST
+    @ApiOperation(value = "Create a search query", response = SearchDTO.class, code = 201)
+    @AuditEvent(type = ViewsAuditEventTypes.SEARCH_CREATE)
+    @Consumes({SEARCH_FORMAT_V2})
+    @Produces({SEARCH_FORMAT_V2})
+    public Response createSearchV2(@ApiParam SearchDTOv2 searchRequest, @Context SearchUser searchUser) {
+        final Search search = searchRequest.toSearch();
+
+        final Search saved = searchDomain.saveForUser(search, searchUser);
+        final SearchDTO result = SearchDTO.fromSearch(saved);
+        if (result == null || result.id() == null) {
+            return Response.serverError().build();
+        }
+        LOG.debug("Created new search object {}", result.id());
+        return Response.created(URI.create(result.id())).entity(result).build();
+    }
+
     @GET
     @ApiOperation(value = "Retrieve a search query")
     @Path("{id}")

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SearchResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SearchResource.java
@@ -104,7 +104,7 @@ public class SearchResource extends RestResource implements PluginRestResource {
     }
 
     @POST
-    @ApiOperation(value = "Create a search query", response = SearchDTO.class, code = 201)
+    @ApiOperation(value = "Create a search query", response = SearchDTOv2.class, code = 201)
     @AuditEvent(type = ViewsAuditEventTypes.SEARCH_CREATE)
     @Consumes({SEARCH_FORMAT_V2})
     @Produces({SEARCH_FORMAT_V2})
@@ -112,7 +112,7 @@ public class SearchResource extends RestResource implements PluginRestResource {
         final Search search = searchRequest.toSearch();
 
         final Search saved = searchDomain.saveForUser(search, searchUser);
-        final SearchDTO result = SearchDTO.fromSearch(saved);
+        final SearchDTOv2 result = SearchDTOv2.fromSearch(saved);
         if (result == null || result.id() == null) {
             return Response.serverError().build();
         }

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/SearchResourceExecutionTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/SearchResourceExecutionTest.java
@@ -321,7 +321,6 @@ public class SearchResourceExecutionTest {
     private SearchDTO mockSearchDTO() {
         return SearchDTO.Builder
                 .create()
-                .queries(ImmutableSet.of())
                 .build();
     }
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

**Note:** Backport to `4.3` from #12833 

With the introduction of the `SearchDTO` class, which is meant to decouple internal data structures from REST requests/responses, a simple `Set` was used for queries. Unfortunately, the implementation for the `Set` used during deserialization does not preserve insertion order, leading to a different order when this `SearchDTO` is returned back to the caller after saving. The order of the queries set is used in the frontend to order the query tabs, so it relies on a stable ordering.

Therefore, this PR is making the type of the `queries` property more specific, by defining it as `LinkedHashSet`, which does preserve insertion order.

Obviously, the approach of relying on the ordering of elements in the set is not ideal. It does not communicate the fact that insertion order defines tab order and any accidental change to the query order in this set will mess up the tab order as well. Instead, we should prospectively make the order of the `queries` set in the search irrelevant. The tab ordering should be a separate property in the view, providing an explicit ordering of query tabs by referencing their specific id.

Refs #7470.
Refs #12834.

Dependency on Enterprise Plugin PR not needed in the backport, as the file that needs change does not exist in 4.3

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.