### PR TITLE
fix(Graylog2/graylog-plugin-enterprise#3668): Adds new documentation URL

### DIFF
--- a/graylog2-web-interface/src/util/DocsHelper.js
+++ b/graylog2-web-interface/src/util/DocsHelper.js
@@ -32,6 +32,9 @@ class DocsHelper {
     ES_CLUSTER_UNAVAILABLE: 'elasticsearch#configuration',
     ES_OPEN_FILE_LIMITS: 'elasticsearch#configuration',
     EXTRACTORS: 'extractors',
+    ILLUMINATE: {
+      INSTALL: 'illuminate-installer',
+    },
     INDEXER_FAILURES: 'indexer-failures',
     INDEX_MODEL: 'index-model',
     LOAD_BALANCERS: 'load-balancers',


### PR DESCRIPTION
Adds Illuminate docs URL

## Description
Adds to DocsHelper the Illuminate installation docs URL.

## Motivation and Context
Added some basic directions to the page presented when navigating to Illuminate, and there isn't a bundle installed, to get users started with the tool.

## How Has This Been Tested?
Manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

