### PR TITLE
Fixing event definitions page when no event definitions exist.

### DIFF
--- a/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitionEntry.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitionEntry.tsx
@@ -36,7 +36,7 @@ import {
 
 import EventDefinitionDescription from './EventDefinitionDescription';
 
-type EventDefinition = {
+export type EventDefinition = {
   id: string,
   config: {
     type: string,
@@ -53,10 +53,10 @@ type Props = {
     },
   },
   eventDefinition: EventDefinition,
-  onDisable: (EventDefinition) => void,
-  onEnable: (EventDefinition) => void,
-  onDelete: (EventDefinition) => void,
-  onCopy: (EventDefinition) => void,
+  onDisable: (eventDefinition: EventDefinition) => void,
+  onEnable: (eventDefinition: EventDefinition) => void,
+  onDelete: (eventDefinition: EventDefinition) => void,
+  onCopy: (eventDefinition: EventDefinition) => void,
 };
 
 const getConditionPlugin = (type: string) => PluginStore.exports('eventDefinitionTypes')

--- a/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitions.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitions.jsx
@@ -32,6 +32,24 @@ import QueryHelper from 'components/common/QueryHelper';
 import styles from './EventDefinitions.css';
 import EventDefinitionEntry from './EventDefinitionEntry';
 
+const EmptyContent = () => (
+  <Row>
+    <Col md={6} mdOffset={3} lg={4} lgOffset={4}>
+      <EmptyEntity>
+        <p>
+          Create Event Definitions that are able to search, aggregate or correlate Messages and other
+          Events, allowing you to record significant Events in Graylog and alert on them.
+        </p>
+        <IfPermitted permissions="eventdefinitions:create">
+          <LinkContainer to={Routes.ALERTS.DEFINITIONS.CREATE}>
+            <Button bsStyle="success">Get Started!</Button>
+          </LinkContainer>
+        </IfPermitted>
+      </EmptyEntity>
+    </Col>
+  </Row>
+);
+
 class EventDefinitions extends React.Component {
   static propTypes = {
     eventDefinitions: PropTypes.array.isRequired,
@@ -50,31 +68,11 @@ class EventDefinitions extends React.Component {
     context: {},
   };
 
-  static renderEmptyContent = () => {
-    return (
-      <Row>
-        <Col md={6} mdOffset={3} lg={4} lgOffset={4}>
-          <EmptyEntity>
-            <p>
-              Create Event Definitions that are able to search, aggregate or correlate Messages and other
-              Events, allowing you to record significant Events in Graylog and alert on them.
-            </p>
-            <IfPermitted permissions="eventdefinitions:create">
-              <LinkContainer to={Routes.ALERTS.DEFINITIONS.CREATE}>
-                <Button bsStyle="success">Get Started!</Button>
-              </LinkContainer>
-            </IfPermitted>
-          </EmptyEntity>
-        </Col>
-      </Row>
-    );
-  };
-
   render() {
     const { eventDefinitions, context, pagination, query, onPageChange, onQueryChange, onDelete, onCopy, onEnable, onDisable } = this.props;
 
     if (pagination.grandTotal === 0) {
-      return this.renderEmptyContent();
+      return <EmptyContent />;
     }
 
     const items = eventDefinitions.map((definition) => (

--- a/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitions.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitions.jsx
@@ -50,73 +50,69 @@ const EmptyContent = () => (
   </Row>
 );
 
-class EventDefinitions extends React.Component {
-  static propTypes = {
-    eventDefinitions: PropTypes.array.isRequired,
-    context: PropTypes.object,
-    pagination: PropTypes.object.isRequired,
-    query: PropTypes.string.isRequired,
-    onPageChange: PropTypes.func.isRequired,
-    onQueryChange: PropTypes.func.isRequired,
-    onDelete: PropTypes.func.isRequired,
-    onCopy: PropTypes.func.isRequired,
-    onEnable: PropTypes.func.isRequired,
-    onDisable: PropTypes.func.isRequired,
-  };
-
-  static defaultProps = {
-    context: {},
-  };
-
-  render() {
-    const { eventDefinitions, context, pagination, query, onPageChange, onQueryChange, onDelete, onCopy, onEnable, onDisable } = this.props;
-
-    if (pagination.grandTotal === 0) {
-      return <EmptyContent />;
-    }
-
-    const items = eventDefinitions.map((definition) => (
-      <EventDefinitionEntry context={context}
-                            eventDefinition={definition}
-                            onDisable={onDisable}
-                            onEnable={onEnable}
-                            onDelete={onDelete}
-                            onCopy={onCopy} />
-    ));
-
-    return (
-      <Row>
-        <Col md={12}>
-          <SearchForm query={query}
-                      onSearch={onQueryChange}
-                      onReset={onQueryChange}
-                      searchButtonLabel="Find"
-                      placeholder="Find Event Definitions"
-                      wrapperClass={styles.inline}
-                      queryHelpComponent={<QueryHelper entityName="event definition" />}
-                      queryWidth={200}
-                      topMargin={0}
-                      useLoadingState>
-            <IfPermitted permissions="eventdefinitions:create">
-              <LinkContainer to={Routes.ALERTS.DEFINITIONS.CREATE}>
-                <Button bsStyle="success" className={styles.createButton}>Create Event Definition</Button>
-              </LinkContainer>
-            </IfPermitted>
-          </SearchForm>
-
-          <PaginatedList activePage={pagination.page}
-                         pageSize={pagination.pageSize}
-                         pageSizes={[10, 25, 50]}
-                         totalItems={pagination.total}
-                         onChange={onPageChange}>
-            <div className={styles.definitionList}>
-              <EntityList items={items} />
-            </div>
-          </PaginatedList>
-        </Col>
-      </Row>
-    );
+const EventDefinitions = ({ eventDefinitions, context, pagination, query, onPageChange, onQueryChange, onDelete, onCopy, onEnable, onDisable }) => {
+  if (pagination.grandTotal === 0) {
+    return <EmptyContent />;
   }
-}
+
+  const items = eventDefinitions.map((definition) => (
+    <EventDefinitionEntry context={context}
+                          eventDefinition={definition}
+                          onDisable={onDisable}
+                          onEnable={onEnable}
+                          onDelete={onDelete}
+                          onCopy={onCopy} />
+  ));
+
+  return (
+    <Row>
+      <Col md={12}>
+        <SearchForm query={query}
+                    onSearch={onQueryChange}
+                    onReset={onQueryChange}
+                    searchButtonLabel="Find"
+                    placeholder="Find Event Definitions"
+                    wrapperClass={styles.inline}
+                    queryHelpComponent={<QueryHelper entityName="event definition" />}
+                    queryWidth={200}
+                    topMargin={0}
+                    useLoadingState>
+          <IfPermitted permissions="eventdefinitions:create">
+            <LinkContainer to={Routes.ALERTS.DEFINITIONS.CREATE}>
+              <Button bsStyle="success" className={styles.createButton}>Create Event Definition</Button>
+            </LinkContainer>
+          </IfPermitted>
+        </SearchForm>
+
+        <PaginatedList activePage={pagination.page}
+                       pageSize={pagination.pageSize}
+                       pageSizes={[10, 25, 50]}
+                       totalItems={pagination.total}
+                       onChange={onPageChange}>
+          <div className={styles.definitionList}>
+            <EntityList items={items} />
+          </div>
+        </PaginatedList>
+      </Col>
+    </Row>
+  );
+};
+
+EventDefinitions.propTypes = {
+  eventDefinitions: PropTypes.array.isRequired,
+  context: PropTypes.object,
+  pagination: PropTypes.object.isRequired,
+  query: PropTypes.string.isRequired,
+  onPageChange: PropTypes.func.isRequired,
+  onQueryChange: PropTypes.func.isRequired,
+  onDelete: PropTypes.func.isRequired,
+  onCopy: PropTypes.func.isRequired,
+  onEnable: PropTypes.func.isRequired,
+  onDisable: PropTypes.func.isRequired,
+};
+
+EventDefinitions.defaultProps = {
+  context: undefined,
+};
 
 export default EventDefinitions;

--- a/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitions.test.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitions.test.tsx
@@ -1,0 +1,30 @@
+import * as React from 'react';
+import { render, screen } from 'wrappedTestingLibrary';
+
+import EventDefinitions from './EventDefinitions';
+
+const SUT = (props: Partial<React.ComponentProps<typeof EventDefinitions>>) => (
+  <EventDefinitions onDisable={jest.fn()}
+                    onDelete={jest.fn()}
+                    onCopy={jest.fn()}
+                    onEnable={jest.fn()}
+                    onPageChange={jest.fn()}
+                    query="*"
+                    onQueryChange={jest.fn()}
+                    pagination={{
+                      grandTotal: 0,
+                      page: 1,
+                      pageSize: 10,
+                      total: 0,
+                    }}
+                    eventDefinitions={[]}
+                    {...props} />
+);
+
+describe('EventDefinitions', () => {
+  it('renders special dialog when no event definitions are present', async () => {
+    render(<SUT />);
+
+    await screen.findByText('Looks like there is nothing here, yet!');
+  });
+});

--- a/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitions.test.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitions.test.tsx
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 import * as React from 'react';
 import { render, screen } from 'wrappedTestingLibrary';
 

--- a/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitions.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitions.tsx
@@ -30,6 +30,7 @@ import Routes from 'routing/Routes';
 import QueryHelper from 'components/common/QueryHelper';
 
 import styles from './EventDefinitions.css';
+import type { EventDefinition } from './EventDefinitionEntry';
 import EventDefinitionEntry from './EventDefinitionEntry';
 
 const EmptyContent = () => (
@@ -50,7 +51,25 @@ const EmptyContent = () => (
   </Row>
 );
 
-const EventDefinitions = ({ eventDefinitions, context, pagination, query, onPageChange, onQueryChange, onDelete, onCopy, onEnable, onDisable }) => {
+type Props = {
+  eventDefinitions: Array<EventDefinition>,
+  context?: React.ComponentProps<typeof EventDefinitionEntry>['context'],
+  pagination: {
+    grandTotal: number,
+    page: number,
+    pageSize: number,
+    total: number,
+  },
+  query: string,
+  onPageChange: (page: number, size: number) => void,
+  onQueryChange: (newQuery: string) => void,
+  onDelete: (eventDefinition: EventDefinition) => void,
+  onCopy: (eventDefinition: EventDefinition) => void,
+  onEnable: (eventDefinition: EventDefinition) => void,
+  onDisable: (eventDefinition: EventDefinition) => void,
+};
+
+const EventDefinitions = ({ eventDefinitions, context, pagination, query, onPageChange, onQueryChange, onDelete, onCopy, onEnable, onDisable }: Props) => {
   if (pagination.grandTotal === 0) {
     return <EmptyContent />;
   }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

In #12706 the `renderEmptyContent` function in the `EventDefinition` component was declared [static](https://github.com/Graylog2/graylog2-server/pull/12706/files#diff-d63bb8afd1773532c36f162acb5111a8895e2c48a315ca72abb6f1b2a70dea66R53).
Unfortunately, the actual call was not changed from [`this.renderEmptyContent()` to `EventDefinition.renderEmptyContent()`](https://github.com/Graylog2/graylog2-server/pull/12706/files#diff-d63bb8afd1773532c36f162acb5111a8895e2c48a315ca72abb6f1b2a70dea66R77).

This PR is now fixing that, but differently. Instead of using a function to render the content, it is wrapped in a small stateless component itself (in aec544b418d9754993c41612c4b8f9e749f4c3ec). In addition, the component is turned into a function component (7929068a8edf7a8b6ea0a8874871fd81b5b3d952), types it (244b6c5803a0d3c1f5598bc9ca3f26844267787b) and adds a simple test case (e20c7aa25c6b7165838c55ba04aa50db883ddd9d).

Fixes #12859.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.