### PR TITLE
Fix ES7 Warning Message Filter (backport to 4.3 from #12787)

### DIFF
--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/ElasticsearchFilterDeprecationWarningsInterceptor.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/ElasticsearchFilterDeprecationWarningsInterceptor.java
@@ -34,6 +34,7 @@ public class ElasticsearchFilterDeprecationWarningsInterceptor implements HttpRe
             "but in a future major version, directaccess to system indices and their aliases will not be allowed",
             "but in a future major version, direct access to system indices will be prevented by default",
             "in epoch time formats is deprecated and will not be supported in the next major version of Elasticsearch",
+            "parameter is deprecated because frozen indices have been deprecated.",
             org.graylog.shaded.elasticsearch7.org.elasticsearch.common.joda.JodaDeprecationPatterns.USE_NEW_FORMAT_SPECIFIERS
     };
 

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/ElasticsearchFilterDeprecationWarningsInterceptor.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/ElasticsearchFilterDeprecationWarningsInterceptor.java
@@ -31,6 +31,7 @@ public class ElasticsearchFilterDeprecationWarningsInterceptor implements HttpRe
     private String[] messagesToFilter = {
             "setting was deprecated in Elasticsearch",
             "but in a future major version, direct access to system indices and their aliases will not be allowed",
+            "but in a future major version, directaccess to system indices and their aliases will not be allowed",
             "but in a future major version, direct access to system indices will be prevented by default",
             "in epoch time formats is deprecated and will not be supported in the next major version of Elasticsearch",
             org.graylog.shaded.elasticsearch7.org.elasticsearch.common.joda.JodaDeprecationPatterns.USE_NEW_FORMAT_SPECIFIERS


### PR DESCRIPTION
In PR #11810 is stated, that the message _always had a space_ in it, I started out without it. Now #12786 shows a problem that the given message was not filtered. What I first thought to be a typo during development is probably slightly different messages in ES 7.x versions - even if _git blame_ tells otherwise.

The filter can now work with both messages.

fixes #12786 

**Note: backport from #12787**

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

