### PR TITLE
Implement error version for `HoverForHelp` component.

### DIFF
--- a/graylog2-web-interface/src/components/common/HoverForHelp.tsx
+++ b/graylog2-web-interface/src/components/common/HoverForHelp.tsx
@@ -17,6 +17,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
+import type { SizeProp } from '@fortawesome/fontawesome-svg-core';
 
 import { OverlayTrigger } from 'components/common';
 import { Popover } from 'components/bootstrap';
@@ -40,26 +41,40 @@ const StyledPopover = styled(Popover)(({ theme }) => css`
   }
 `);
 
+const StyledIcon = styled(Icon)<{ $type: Type }>(({ theme, $type }) => css`
+  color: ${$type === 'error' ? theme.colors.variant.danger : 'inherit'};
+`);
+
+const iconName = (type: Type) => {
+  switch (type) {
+    case 'error':
+      return 'circle-exclamation';
+    case 'info':
+    default:
+      return 'question-circle';
+  }
+};
+
+type Type = 'info' | 'error';
+
 type Props = {
   children: React.ReactNode,
   className?: string,
   id?: string,
   placement?: 'top' | 'right' | 'bottom' | 'left',
+  iconSize?: SizeProp
   pullRight?: boolean,
   title: string,
   testId?: string,
+  type?: 'info' | 'error',
 };
 
-const HoverForHelp = ({ children, className, title, id, pullRight, placement, testId }: Props) => (
+const HoverForHelp = ({ children, className, title, id, pullRight, placement, testId, type, iconSize }: Props) => (
   <OverlayTrigger trigger={['hover', 'focus']}
                   placement={placement}
-                  overlay={(
-                    <StyledPopover title={title} id={id}>
-                      {children}
-                    </StyledPopover>
-                  )}
+                  overlay={<StyledPopover title={title} id={id}>{children}</StyledPopover>}
                   testId={testId}>
-    <Icon className={`${className} ${pullRight ? 'pull-right' : ''}`} name="question-circle" />
+    <StyledIcon className={`${className} ${pullRight ? 'pull-right' : ''}`} name={iconName(type)} $type={type} size={iconSize} />
   </OverlayTrigger>
 );
 
@@ -79,6 +94,8 @@ HoverForHelp.defaultProps = {
   pullRight: true,
   placement: 'bottom',
   testId: undefined,
+  type: 'info',
+  iconSize: undefined,
 };
 
 /** @component */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is extending the `HoverForHelp` component in a way it can be used to display errors.
The `HoverForHelp` component displays an icon, which displays a help text when hovering over it.

![image](https://user-images.githubusercontent.com/46300478/172884168-949f0591-d692-497d-8d37-bf66a4507238.png)
