### PR TITLE
Implementation of persistent disabled state for search filters.

### DIFF
--- a/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/views/ElasticsearchBackendTest.java
+++ b/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/views/ElasticsearchBackendTest.java
@@ -115,7 +115,7 @@ public class ElasticsearchBackendTest {
     @Test
     public void generatedContextHasQueryThatIncludesSearchFilters() {
         final ImmutableList<UsedSearchFilter> usedSearchFilters = ImmutableList.of(
-                InlineQueryStringSearchFilter.create("", "", "method:GET"),
+                InlineQueryStringSearchFilter.builder().title("").description("").queryString("method:GET").build(),
                 ReferencedQueryStringSearchFilter.create("12345")
         );
         doReturn(ImmutableSet.of("method:GET", "method:POST")).when(usedSearchFiltersToQueryStringsMapper).map(usedSearchFilters);

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackendSearchTypeOverridesTest.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackendSearchTypeOverridesTest.java
@@ -75,7 +75,7 @@ public class ElasticsearchBackendSearchTypeOverridesTest extends ElasticsearchBa
                             .series(Collections.singletonList(Average.builder().field("field1").build()))
                             .rollup(true)
                             .timerange(DerivedTimeRange.of(AbsoluteRange.create("2019-09-11T10:31:52.819Z", "2019-09-11T10:36:52.823Z")))
-                            .filters(Collections.singletonList(InlineQueryStringSearchFilter.create("Pivot1 local filter", "Pivot1 local filter", "local:filter")))
+                            .filters(Collections.singletonList(InlineQueryStringSearchFilter.builder().title("Pivot1 local filter").description("Pivot1 local filter").queryString("local:filter").build()))
                             .build()
             );
             add(
@@ -92,7 +92,7 @@ public class ElasticsearchBackendSearchTypeOverridesTest extends ElasticsearchBa
                 .searchTypes(searchTypes)
                 .query(ElasticsearchQueryString.of("production:true"))
                 .filter(StreamFilter.ofId("stream1"))
-                .filters(Collections.singletonList(InlineQueryStringSearchFilter.create("Global filter", "Global filter", "global:filter")))
+                .filters(Collections.singletonList(InlineQueryStringSearchFilter.builder().title("Global filter").description("Global filter").queryString("global:filter").build()))
                 .timerange(timeRangeForTest())
                 .build();
 

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackendTest.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackendTest.java
@@ -114,7 +114,7 @@ public class ElasticsearchBackendTest {
     @Test
     public void generatedContextHasQueryThatIncludesSearchFilters() {
         final ImmutableList<UsedSearchFilter> usedSearchFilters = ImmutableList.of(
-                InlineQueryStringSearchFilter.create("", "", "method:GET"),
+                InlineQueryStringSearchFilter.builder().title("").description("").queryString("method:GET").build(),
                 ReferencedQueryStringSearchFilter.create("12345")
         );
         doReturn(ImmutableSet.of("method:GET", "method:POST")).when(usedSearchFiltersToQueryStringsMapper).map(usedSearchFilters);

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchfilters/model/InlineQueryStringSearchFilter.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchfilters/model/InlineQueryStringSearchFilter.java
@@ -19,12 +19,14 @@ package org.graylog.plugins.views.search.searchfilters.model;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
 
 import javax.annotation.Nullable;
 
 @AutoValue
 @JsonTypeName(UsedSearchFilter.INLINE_QUERY_STRING_SEARCH_FILTER)
+@JsonDeserialize(builder = InlineQueryStringSearchFilter.Builder.class)
 public abstract class InlineQueryStringSearchFilter implements UsedSearchFilter {
 
     @JsonProperty(TITLE_FIELD)
@@ -42,18 +44,40 @@ public abstract class InlineQueryStringSearchFilter implements UsedSearchFilter 
     @JsonProperty(value = NEGATION_FIELD, defaultValue = "false")
     public abstract boolean negation();
 
-    @JsonCreator
-    @SuppressWarnings("unused")
-    public static InlineQueryStringSearchFilter create(@JsonProperty(TITLE_FIELD) final String title,
-                                                       @JsonProperty(DESCRIPTION_FIELD) final String description,
-                                                       @JsonProperty(QUERY_STRING_FIELD) final String queryString,
-                                                       @JsonProperty(value = NEGATION_FIELD, defaultValue = "false") final boolean negation) {
-        return new AutoValue_InlineQueryStringSearchFilter(title, description, queryString, negation);
+    @Override
+    @JsonProperty(value = DISABLED_FIELD, defaultValue = "false")
+    public abstract boolean disabled();
+
+    public static Builder builder() {
+        return Builder.create();
     }
 
-    public static InlineQueryStringSearchFilter create(@JsonProperty(TITLE_FIELD) final String title,
-                                                       @JsonProperty(DESCRIPTION_FIELD) final String description,
-                                                       @JsonProperty(QUERY_STRING_FIELD) final String queryString) {
-        return new AutoValue_InlineQueryStringSearchFilter(title, description, queryString, false);
+    @AutoValue.Builder
+    public abstract static class Builder {
+
+        @JsonProperty(TITLE_FIELD)
+        public abstract Builder title(String title);
+
+        @JsonProperty(DESCRIPTION_FIELD)
+        public abstract Builder description(String description);
+
+        @JsonProperty(QUERY_STRING_FIELD)
+        public abstract Builder queryString(String queryString);
+
+        @JsonProperty(value = NEGATION_FIELD, defaultValue = "false")
+        public abstract Builder negation(boolean negation);
+
+        @JsonProperty(value = DISABLED_FIELD, defaultValue = "false")
+        public abstract Builder disabled(boolean disabled);
+
+        @JsonCreator
+        public static Builder create() {
+            return new AutoValue_InlineQueryStringSearchFilter.Builder()
+                    .disabled(false)
+                    .negation(false);
+        }
+
+        public abstract InlineQueryStringSearchFilter build();
     }
+
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchfilters/model/ReferencedQueryStringSearchFilter.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchfilters/model/ReferencedQueryStringSearchFilter.java
@@ -19,12 +19,14 @@ package org.graylog.plugins.views.search.searchfilters.model;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
 
 import javax.annotation.Nullable;
 
 @AutoValue
 @JsonTypeName(UsedSearchFilter.REFERENCED_SEARCH_FILTER)
+@JsonDeserialize(builder = ReferencedQueryStringSearchFilter.Builder.class)
 public abstract class ReferencedQueryStringSearchFilter implements ReferencedSearchFilter {
 
     @JsonProperty
@@ -47,24 +49,46 @@ public abstract class ReferencedQueryStringSearchFilter implements ReferencedSea
     @JsonProperty(value = NEGATION_FIELD, defaultValue = "false")
     public abstract boolean negation();
 
-    @JsonCreator
-    @SuppressWarnings("unused")
-    public static ReferencedQueryStringSearchFilter create(@JsonProperty("id") final String id,
-                                                           @JsonProperty(TITLE_FIELD) final String title,
-                                                           @JsonProperty(DESCRIPTION_FIELD) final String description,
-                                                           @JsonProperty(QUERY_STRING_FIELD) final String queryString,
-                                                           @JsonProperty(value = NEGATION_FIELD, defaultValue = "false") final boolean negation) {
-        return new AutoValue_ReferencedQueryStringSearchFilter(id, title, description, queryString, negation);
-    }
-
-    public static ReferencedQueryStringSearchFilter create(@JsonProperty("id") final String id,
-                                                           @JsonProperty(TITLE_FIELD) final String title,
-                                                           @JsonProperty(DESCRIPTION_FIELD) final String description,
-                                                           @JsonProperty(QUERY_STRING_FIELD) final String queryString) {
-        return new AutoValue_ReferencedQueryStringSearchFilter(id, title, description, queryString, false);
-    }
+    @Override
+    @JsonProperty(value = DISABLED_FIELD, defaultValue = "false")
+    public abstract boolean disabled();
 
     public static ReferencedQueryStringSearchFilter create(final String id) {
-        return new AutoValue_ReferencedQueryStringSearchFilter(id, null, null, null, false);
+        return builder().id(id).build();
+    }
+
+    public static Builder builder() {
+        return Builder.create();
+    }
+
+    @AutoValue.Builder
+    public abstract static class Builder {
+
+        @JsonProperty
+        public abstract Builder id(String id);
+
+        @JsonProperty(TITLE_FIELD)
+        public abstract Builder title(String title);
+
+        @JsonProperty(DESCRIPTION_FIELD)
+        public abstract Builder description(String description);
+
+        @JsonProperty(QUERY_STRING_FIELD)
+        public abstract Builder queryString(String queryString);
+
+        @JsonProperty(value = NEGATION_FIELD, defaultValue = "false")
+        public abstract Builder negation(boolean negation);
+
+        @JsonProperty(value = DISABLED_FIELD, defaultValue = "false")
+        public abstract Builder disabled(boolean disabled);
+
+        @JsonCreator
+        public static Builder create() {
+            return new AutoValue_ReferencedQueryStringSearchFilter.Builder()
+                    .disabled(false)
+                    .negation(false);
+        }
+
+        public abstract ReferencedQueryStringSearchFilter build();
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchfilters/model/UsedSearchFilter.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchfilters/model/UsedSearchFilter.java
@@ -36,9 +36,12 @@ public interface UsedSearchFilter {
     String DESCRIPTION_FIELD = "description";
     String QUERY_STRING_FIELD = "queryString";
     String NEGATION_FIELD = "negation";
+    String DISABLED_FIELD = "disabled";
 
     String INLINE_QUERY_STRING_SEARCH_FILTER = "inlineQueryString";
     String REFERENCED_SEARCH_FILTER = "referenced";
 
     boolean negation();
+
+    boolean disabled();
 }

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/QueryTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/QueryTest.java
@@ -243,7 +243,7 @@ public class QueryTest {
     @Test
     public void testHasReferencedSearchFiltersReturnsFalseWhenNoReferencedSearchFilters() {
         Query query = Query.builder()
-                .filters(Collections.singletonList(InlineQueryStringSearchFilter.create("title", "descr", "*")))
+                .filters(Collections.singletonList(InlineQueryStringSearchFilter.builder().title("title").description("descr").queryString("*").build()))
                 .build();
 
         assertThat(query.hasReferencedStreamFilters())
@@ -254,7 +254,7 @@ public class QueryTest {
     public void testHasReferencedSearchFiltersReturnsTrueWhenReferencedSearchFilterPresent() {
         Query query = Query.builder()
                 .filters(ImmutableList.of(
-                        InlineQueryStringSearchFilter.create("title", "descr", "*"),
+                        InlineQueryStringSearchFilter.builder().title("title").description("descr").queryString("*").build(),
                         ReferencedQueryStringSearchFilter.create("007")))
                 .build();
 
@@ -273,7 +273,7 @@ public class QueryTest {
     @Test
     public void testSavesSearchFiltersCollectionInContentPack() {
         final ImmutableList<UsedSearchFilter> originalSearchFilters = ImmutableList.of(
-                InlineQueryStringSearchFilter.create("title", "descr", "*"),
+                InlineQueryStringSearchFilter.builder().title("title").description("descr").queryString("*").build(),
                 ReferencedQueryStringSearchFilter.create("007")
         );
         Query queryWithFilters = Query.builder().filters(originalSearchFilters).build();

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/model/entities/QueryEntityTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/model/entities/QueryEntityTest.java
@@ -48,7 +48,7 @@ class QueryEntityTest {
     public void testLoadsSearchFiltersCollectionFromContentPack() {
 
         final ImmutableList<UsedSearchFilter> originalSearchFilters = ImmutableList.of(
-                InlineQueryStringSearchFilter.create("title", "descr", "*"),
+                InlineQueryStringSearchFilter.builder().title("title").description("descr").queryString("*").disabled(true).build(),
                 ReferencedQueryStringSearchFilter.create("42")
         );
         QueryEntity queryWithFilters = QueryEntity.Builder


### PR DESCRIPTION
## Description
Implementation of persistent disabled state for search filters.
Search Filters used in Searches have an additional flag - "disabled", to reflect that.

## Motivation and Context
Front-end wants to persist and retrieve disabled Search Filters as well. 

## How Has This Been Tested?
Via Rest API, by adding and removing "disabled" flag on filters.

/jenkins-pr-deps Graylog2/graylog-plugin-enterprise#3698

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

