### PR TITLE
Allow overwriting `TextOverflowEllipsis` style.

### DIFF
--- a/graylog2-web-interface/src/components/common/TextOverflowEllipsis.tsx
+++ b/graylog2-web-interface/src/components/common/TextOverflowEllipsis.tsx
@@ -24,6 +24,7 @@ const Wrapper = styled.div`
 `;
 
 type Props = {
+  className?: string,
   children: string,
   titleOverride?: string,
 };
@@ -32,13 +33,14 @@ type Props = {
  * Component that signals text overflow to users by using an ellipsis.
  * The parent component needs a concrete width.
  */
-const TextOverflowEllipsis = ({ children, titleOverride }: Props) => (
-  <Wrapper title={titleOverride || children}>
+const TextOverflowEllipsis = ({ children, titleOverride, className }: Props) => (
+  <Wrapper title={titleOverride || children} className={className}>
     {children}
   </Wrapper>
 );
 
 TextOverflowEllipsis.defaultProps = {
+  className: undefined,
   titleOverride: undefined,
 };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

With this PR it will be possible to overwrite the `TextOverflowEllipsis` styling, e.g. like this: `styled(TextOverflowEllipsis)`.

i also tried adding the `as` / `forwardedAs` prop, but had some strange TS problem, I could not resolve easily.