### PR TITLE
Add cron expression as a scheduler strategy

### DIFF
--- a/graylog-project-parent/pom.xml
+++ b/graylog-project-parent/pom.xml
@@ -727,6 +727,11 @@
                 <version>${pkts.version}</version>
                 <scope>test</scope>
             </dependency>
+            <dependency>
+                <groupId>com.cronutils</groupId>
+                <artifactId>cron-utils</artifactId>
+                <version>${cron-utils.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/graylog2-server/pom.xml
+++ b/graylog2-server/pom.xml
@@ -689,6 +689,19 @@
             <version>1.5.0</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>com.cronutils</groupId>
+            <artifactId>cron-utils</artifactId>
+            <exclusions>
+                <!-- Avoid warning about multiple SLF4J bindings on server startup -->
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-simple</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/graylog2-server/src/main/java/org/graylog/scheduler/JobSchedule.java
+++ b/graylog2-server/src/main/java/org/graylog/scheduler/JobSchedule.java
@@ -19,6 +19,7 @@ package org.graylog.scheduler;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import org.graylog.scheduler.clock.JobSchedulerClock;
 import org.joda.time.DateTime;
 import org.mongojack.DBQuery;
 import org.mongojack.DBUpdate;
@@ -51,10 +52,11 @@ public interface JobSchedule {
      *
      * @param lastExecutionTime the last execution time of a trigger
      * @param lastNextTime      the base time, chosen by the caller (mostly last nextTime)
+     * @param clock
      * @return filled optional with the next execution time, empty optional if there is no next execution time
      */
     @JsonIgnore
-    Optional<DateTime> calculateNextTime(DateTime lastExecutionTime, DateTime lastNextTime);
+    Optional<DateTime> calculateNextTime(DateTime lastExecutionTime, DateTime lastNextTime, JobSchedulerClock clock);
 
     /**
      * Returns a map with the schedule data. This can be used to update a MongoDB document with schedule
@@ -77,7 +79,7 @@ public interface JobSchedule {
         }
 
         @Override
-        public Optional<DateTime> calculateNextTime(DateTime lastExecutionTime, DateTime lastNextTime) {
+        public Optional<DateTime> calculateNextTime(DateTime lastExecutionTime, DateTime lastNextTime, JobSchedulerClock clock) {
             return Optional.empty();
         }
 

--- a/graylog2-server/src/main/java/org/graylog/scheduler/JobScheduleStrategies.java
+++ b/graylog2-server/src/main/java/org/graylog/scheduler/JobScheduleStrategies.java
@@ -50,7 +50,7 @@ public class JobScheduleStrategies {
         final DateTime lastNextTime = trigger.nextTime();
         final DateTime lastExecutionTime = trigger.lock().lastLockTime();
 
-        return trigger.schedule().calculateNextTime(lastExecutionTime, lastNextTime);
+        return trigger.schedule().calculateNextTime(lastExecutionTime, lastNextTime, clock);
     }
 
     /**
@@ -70,7 +70,7 @@ public class JobScheduleStrategies {
 
         // This is using nextTime to make sure we take the runtime into account and schedule at
         // exactly after the last nextTime.
-        final Optional<DateTime> optionalNextTime = schedule.calculateNextTime(lastExecutionTime, lastNextTime);
+        final Optional<DateTime> optionalNextTime = schedule.calculateNextTime(lastExecutionTime, lastNextTime, clock);
 
         if (!optionalNextTime.isPresent()) {
             return Optional.empty();
@@ -84,7 +84,7 @@ public class JobScheduleStrategies {
         //       advance, should probably use a different helper method.
         while (!nextTime.isAfter(now)) {
             LOG.debug("New nextTime <{}> is in the past, re-calculating again", nextTime);
-            nextTime = schedule.calculateNextTime(lastExecutionTime, nextTime).orElse(null);
+            nextTime = schedule.calculateNextTime(lastExecutionTime, nextTime, clock).orElse(null);
             if (nextTime == null) {
                 return Optional.empty();
             }

--- a/graylog2-server/src/main/java/org/graylog/scheduler/schedule/CronJobSchedule.java
+++ b/graylog2-server/src/main/java/org/graylog/scheduler/schedule/CronJobSchedule.java
@@ -62,21 +62,15 @@ public abstract class CronJobSchedule implements JobSchedule {
     }
 
     @Override
-    public Optional<DateTime> calculateNextTime(DateTime lastExecutionTime, DateTime lastNextTime, JobSchedulerClock clock) {
+    public Optional<DateTime> calculateNextTime(DateTime previousExecutionTime, DateTime lastNextTime, JobSchedulerClock clock) {
         final Cron cron = newCronParser().parse(cronExpression());
         final ExecutionTime executionTime = ExecutionTime.forCron(cron);
 
         ZonedDateTime zdt = getZonedDateTime(clock);
 
-        final Optional<ZonedDateTime> nextExecution = executionTime.nextExecution(zdt);
-
-        return nextExecution
-                .map(this::toDateTime)
-                .filter(t -> isBeforeLastExecution(t, lastExecutionTime));
-    }
-
-    private boolean isBeforeLastExecution(DateTime nextExecution, DateTime lastExecutionTime) {
-        return lastExecutionTime == null || nextExecution.isBefore(lastExecutionTime);
+        return executionTime
+                .nextExecution(zdt)
+                .map(this::toDateTime);
     }
 
     private ZonedDateTime getZonedDateTime(JobSchedulerClock clock) {

--- a/graylog2-server/src/main/java/org/graylog/scheduler/schedule/CronJobSchedule.java
+++ b/graylog2-server/src/main/java/org/graylog/scheduler/schedule/CronJobSchedule.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.scheduler.schedule;
+
+import com.cronutils.model.Cron;
+import com.cronutils.model.definition.CronDefinitionBuilder;
+import com.cronutils.model.time.ExecutionTime;
+import com.cronutils.parser.CronParser;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableMap;
+import org.graylog.scheduler.JobSchedule;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+
+import java.time.Clock;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.Map;
+import java.util.Optional;
+import java.util.TimeZone;
+
+import static com.cronutils.model.CronType.QUARTZ;
+
+@AutoValue
+@JsonTypeName(CronJobSchedule.TYPE_NAME)
+@JsonDeserialize(builder = CronJobSchedule.Builder.class)
+public abstract class CronJobSchedule implements JobSchedule {
+    public static final String TYPE_NAME = "cron";
+
+    public static final String FIELD_CRON_EXPRESSION = "cron_expression";
+    public static final String FIELD_TIMEZONE = "timezone";
+
+    @JsonProperty(FIELD_CRON_EXPRESSION)
+    public abstract String cronExpression();
+
+    @JsonProperty(value = FIELD_TIMEZONE, defaultValue = "UTC")
+    public abstract String timezone();
+
+    // TODO: do we need this clock?
+    private final Clock clock = Clock.systemDefaultZone();
+
+    @Override
+    public Optional<DateTime> calculateNextTime(DateTime lastExecutionTime, DateTime lastNextTime) {
+        CronParser parser = new CronParser(CronDefinitionBuilder.instanceDefinitionFor(QUARTZ));
+        final Cron cron = parser.parse(cronExpression());
+        final ExecutionTime executionTime = ExecutionTime.forCron(cron);
+        final ZonedDateTime now = ZonedDateTime.now(clock);
+
+        final ZoneId zoneId = ZoneId.of(timezone());
+        final Optional<ZonedDateTime> nextExecution = executionTime.nextExecution(now.withZoneSameInstant(zoneId));
+
+        return nextExecution.map(t -> {
+            final DateTimeZone tz = DateTimeZone.forTimeZone(TimeZone.getTimeZone(t.getZone()));
+            return new DateTime(t.toInstant().toEpochMilli(), tz);
+        });
+    }
+
+    @Override
+    public Optional<Map<String, Object>> toDBUpdate(String fieldPrefix) {
+        return Optional.of(ImmutableMap.of(
+                fieldPrefix + JobSchedule.TYPE_FIELD, type(),
+                fieldPrefix + FIELD_CRON_EXPRESSION, cronExpression(),
+                fieldPrefix + FIELD_TIMEZONE, timezone()
+        ));
+    }
+    public static CronJobSchedule.Builder builder() {
+        return CronJobSchedule.Builder.create();
+    }
+
+    public abstract CronJobSchedule.Builder toBuilder();
+
+    @AutoValue.Builder
+    public static abstract class Builder implements JobSchedule.Builder<Builder> {
+
+        @JsonCreator
+        public static Builder create() {
+            return new AutoValue_CronJobSchedule.Builder().type(TYPE_NAME);
+        }
+
+        @JsonProperty(FIELD_CRON_EXPRESSION)
+        public abstract Builder cronExpression(String cronExpression);
+
+        @JsonProperty(FIELD_TIMEZONE)
+        public abstract Builder timezone(String timezone);
+
+        abstract CronJobSchedule autoBuild();
+
+        public CronJobSchedule build() {
+            // Make sure the type name is correct!
+            type(TYPE_NAME);
+
+            return autoBuild();
+        }
+    }
+}
+
+
+

--- a/graylog2-server/src/main/java/org/graylog/scheduler/schedule/CronJobSchedule.java
+++ b/graylog2-server/src/main/java/org/graylog/scheduler/schedule/CronJobSchedule.java
@@ -31,7 +31,6 @@ import org.graylog.scheduler.clock.JobSchedulerClock;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 
-import javax.annotation.Nullable;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;

--- a/graylog2-server/src/main/java/org/graylog/scheduler/schedule/IntervalJobSchedule.java
+++ b/graylog2-server/src/main/java/org/graylog/scheduler/schedule/IntervalJobSchedule.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableMap;
 import org.graylog.scheduler.JobSchedule;
+import org.graylog.scheduler.clock.JobSchedulerClock;
 import org.joda.time.DateTime;
 
 import javax.validation.constraints.Min;
@@ -49,7 +50,7 @@ public abstract class IntervalJobSchedule implements JobSchedule {
 
     @JsonIgnore
     @Override
-    public Optional<DateTime> calculateNextTime(DateTime lastExecutionTime, DateTime lastNextTime) {
+    public Optional<DateTime> calculateNextTime(DateTime lastExecutionTime, DateTime lastNextTime, JobSchedulerClock clock) {
         return Optional.of(lastNextTime.plus(unit().toMillis(interval())));
     }
 

--- a/graylog2-server/src/main/java/org/graylog/scheduler/schedule/OnceJobSchedule.java
+++ b/graylog2-server/src/main/java/org/graylog/scheduler/schedule/OnceJobSchedule.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableMap;
 import org.graylog.scheduler.JobSchedule;
+import org.graylog.scheduler.clock.JobSchedulerClock;
 import org.joda.time.DateTime;
 
 import java.util.Map;
@@ -36,7 +37,7 @@ public abstract class OnceJobSchedule implements JobSchedule {
 
     @JsonIgnore
     @Override
-    public Optional<DateTime> calculateNextTime(DateTime lastExecutionTime, DateTime lastNextTime) {
+    public Optional<DateTime> calculateNextTime(DateTime lastExecutionTime, DateTime lastNextTime, JobSchedulerClock clock) {
         return Optional.empty();
     }
 

--- a/graylog2-server/src/test/java/org/graylog/scheduler/JobScheduleStrategiesTest.java
+++ b/graylog2-server/src/test/java/org/graylog/scheduler/JobScheduleStrategiesTest.java
@@ -16,9 +16,6 @@
  */
 package org.graylog.scheduler;
 
-import com.cronutils.builder.CronBuilder;
-import com.cronutils.model.Cron;
-import com.cronutils.model.definition.CronDefinitionBuilder;
 import org.graylog.events.JobSchedulerTestClock;
 import org.graylog.scheduler.schedule.CronJobSchedule;
 import org.graylog.scheduler.schedule.IntervalJobSchedule;
@@ -31,10 +28,6 @@ import org.junit.Test;
 
 import java.util.concurrent.TimeUnit;
 
-import static com.cronutils.model.CronType.QUARTZ;
-import static com.cronutils.model.field.expression.FieldExpressionFactory.always;
-import static com.cronutils.model.field.expression.FieldExpressionFactory.on;
-import static com.cronutils.model.field.expression.FieldExpressionFactory.questionMark;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class JobScheduleStrategiesTest {
@@ -96,27 +89,6 @@ public class JobScheduleStrategiesTest {
                     assertThat(dateTime.getZone()).isEqualTo(DateTimeZone.forID("Europe/Vienna"));
                     assertThat(dateTime.toString(DATE_FORMAT)).isEqualTo("14/06/2022 01:00:00");
                 });
-    }
-
-    @Test
-    public void nextTimeCronWithEndTime() {
-        final DateTime endTime = DateTime.parse("13/06/2022 00:00:00", DATE_FORMAT);
-
-        // TODO: do I have to manually assign the end time in the lock?
-        final JobTriggerLock lock = JobTriggerLock.builder().lastLockTime(endTime).build();
-
-        final JobTriggerDto trigger = JobTriggerDto.builderWithClock(clock)
-                .jobDefinitionId("abc-123")
-                .endTime(endTime)
-                .schedule(CronJobSchedule.builder()
-                        .cronExpression("0 0 1 * * ? *")
-                        .timezone("Europe/Vienna")
-                        .build())
-                .lock(lock)
-                .build();
-
-        // it should not be running anymore
-        assertThat(strategies.nextTime(trigger)).isNotPresent();
     }
 
     @Test

--- a/graylog2-server/src/test/java/org/graylog/scheduler/JobScheduleStrategiesTest.java
+++ b/graylog2-server/src/test/java/org/graylog/scheduler/JobScheduleStrategiesTest.java
@@ -19,12 +19,13 @@ package org.graylog.scheduler;
 import com.cronutils.builder.CronBuilder;
 import com.cronutils.model.Cron;
 import com.cronutils.model.definition.CronDefinitionBuilder;
-import org.apache.logging.log4j.core.util.CronExpression;
 import org.graylog.events.JobSchedulerTestClock;
 import org.graylog.scheduler.schedule.CronJobSchedule;
 import org.graylog.scheduler.schedule.IntervalJobSchedule;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -37,12 +38,17 @@ import static com.cronutils.model.field.expression.FieldExpressionFactory.questi
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class JobScheduleStrategiesTest {
+
+    public static final DateTimeFormatter DATE_FORMAT = DateTimeFormat.forPattern("dd/MM/yyyy HH:mm:ss");
+
     private JobSchedulerTestClock clock;
     private JobScheduleStrategies strategies;
 
     @Before
     public void setUp() throws Exception {
-        this.clock = new JobSchedulerTestClock(DateTime.now(DateTimeZone.UTC));
+        DateTime dateTime = DateTime.parse("13/06/2022 15:13:59", DATE_FORMAT);
+        DateTime dateTimeWithZone = dateTime.withZone(DateTimeZone.forID("UTC"));
+        this.clock = new JobSchedulerTestClock(dateTimeWithZone);
         this.strategies = new JobScheduleStrategies(clock);
     }
 
@@ -98,10 +104,9 @@ public class JobScheduleStrategiesTest {
 
         assertThat(nextFutureTime1)
                 .isNotNull()
-                .isGreaterThanOrEqualTo(clock.nowUTC())
-                .satisfies(dateTime -> {
-                    assertThat(dateTime.secondOfMinute().get()).isEqualTo(0);
-                    assertThat(dateTime.minuteOfHour().get()).isEqualTo(0);
+                .satisfies(dateTime ->  {
+                    assertThat(dateTime.getZone()).isEqualTo(DateTimeZone.forID("Europe/Vienna"));
+                    assertThat(dateTime.toString(DATE_FORMAT)).isEqualTo("14/06/2022 01:00:00");
                 });
     }
 

--- a/graylog2-server/src/test/java/org/graylog/scheduler/schedule/CronJobScheduleTest.java
+++ b/graylog2-server/src/test/java/org/graylog/scheduler/schedule/CronJobScheduleTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog.scheduler.schedule;
 
 import org.junit.jupiter.api.Test;

--- a/graylog2-server/src/test/java/org/graylog/scheduler/schedule/CronJobScheduleTest.java
+++ b/graylog2-server/src/test/java/org/graylog/scheduler/schedule/CronJobScheduleTest.java
@@ -1,0 +1,25 @@
+package org.graylog.scheduler.schedule;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+
+class CronJobScheduleTest {
+
+    @Test
+    void testCronExpressionValidationInvalid() {
+        assertThatThrownBy(() -> CronJobSchedule.builder().cronExpression("nonsense").build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Cron expression contains 1 parts but we expect one of [6, 7]");
+    }
+
+
+    @Test
+    void testCronExpressionValidationValid() {
+        final CronJobSchedule cronJobSchedule = CronJobSchedule.builder().cronExpression("0 0 1 * * ? *").build();
+        assertThat(cronJobSchedule.cronExpression()).isNotNull();
+        assertThat(cronJobSchedule.timezone()).isEqualTo("UTC"); // default timezone
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -165,6 +165,7 @@
         <validation-api.version>2.0.1.Final</validation-api.version>
         <zkclient.version>0.11</zkclient.version>
         <zookeeper.version>3.5.7</zookeeper.version>
+        <cron-utils.version>9.1.6</cron-utils.version>
 
         <!-- Test dependencies -->
         <apacheds-server.version>2.0.0-M24</apacheds-server.version>


### PR DESCRIPTION
So far we supported only once and interval strategies. For a future migration of the reporting to the generic scheduler, we'll need a strategy that allows configuration, that will be represented as a cron expression.

## Description
Added CronJobSchedule implementation of the JobSchedule strategy.

## Motivation and Context
Preparing infrastructure for the migration of reporting

## How Has This Been Tested?
Added unit tests to all new functionality

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

