### PR TITLE
Custom exception when ES batch size too large

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/BatchSizeTooLargeException.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/BatchSizeTooLargeException.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.indexer;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+public class BatchSizeTooLargeException extends ElasticsearchException {
+    public BatchSizeTooLargeException(String errorMessage) {
+        super(errorMessage);
+    }
+}


### PR DESCRIPTION
When ES throws an exception due to batch size too large we now generate a custom exception to improve code maintainability.