### PR TITLE
Fix/#10827 SharingDisabledPopover displays readable entity types

### DIFF
--- a/graylog2-web-interface/src/components/permissions/SharingDisabledPopover.tsx
+++ b/graylog2-web-interface/src/components/permissions/SharingDisabledPopover.tsx
@@ -28,11 +28,17 @@ const StyledHoverForHelp = styled((props) => <HoverForHelp {...props} />)`
   margin-left: 8px;
 `;
 
-const SharingDisabledPopover = ({ type, description }: Props) => (
-  <StyledHoverForHelp title="Sharing not possible" pullRight={false}>
-    {description || `Only owners of this ${type} are allowed to share it.`}
-  </StyledHoverForHelp>
-);
+const SharingDisabledPopover = ({ type, description }: Props) => {
+  const getReadableType = (_type: string) => {
+    return _type.replaceAll('_', ' ');
+  };
+
+  return (
+    <StyledHoverForHelp title="Sharing not possible" pullRight={false}>
+      {description || `Only owners of this ${getReadableType(type)} are allowed to share it.`}
+    </StyledHoverForHelp>
+  );
+};
 
 SharingDisabledPopover.defaultProps = {
   description: undefined,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
I added a new function getReadableType in SharingDisabledPopover to convert the entity type to a readable text which for now it only replaces the underscore (_) with a space

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
To avoid showing text in snake case because it is not very readable
<!--- If it fixes an open issue, please link to the issue here. -->
fix #10827

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

