### PR TITLE
Added Graylog Schema Enforcement check to GeoIpResolverEngine when selecting field name prefix to add to message

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/map/geoip/GeoIpResolverEngine.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/map/geoip/GeoIpResolverEngine.java
@@ -92,9 +92,9 @@ public class GeoIpResolverEngine {
                 continue;
             }
 
-            //IF the user has opted NOT to enforce the Graylog Schema, the key will likely not
-            //be in the field map--in such cases use the key (full field name) as the prefix
-            final String prefix = ipAddressFields.getOrDefault(key, key);
+            // IF the user has opted NOT to enforce the Graylog Schema, the key will likely not
+            // be in the field map--in such cases use the key (full field name) as the prefix.
+            final String prefix = enforceGraylogSchema ? ipAddressFields.getOrDefault(key, key) : key;
 
             if (ReservedIpChecker.getInstance().isReservedIpAddress(address.getHostAddress())) {
                 message.addField(prefix + "_reserved_ip", true);

--- a/graylog2-server/src/test/java/org/graylog/plugins/map/geoip/GeoIpResolverEngineTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/map/geoip/GeoIpResolverEngineTest.java
@@ -138,7 +138,7 @@ public class GeoIpResolverEngineTest {
         Assert.assertTrue(fieldNotFoundError, message.hasField(expectedFieldName));
 
         Boolean expectedValue = true;
-        String fieldValueError = String.format("Expected value for '%s' is '%s'", expectedFieldName, expectedValue);
+        String fieldValueError = String.format(Locale.ENGLISH, "Expected value for '%s' is '%s'", expectedFieldName, expectedValue);
         Assert.assertEquals(fieldValueError, expectedValue, message.getField(expectedFieldName));
     }
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Closes #12904 

Added Graylog Schema Enforcement check to GeoIpResolverEngine when selecting field name prefix to add to message.

If the user has opted not to enforce the Graylog Schema, we want to scan ALL fields for possible IP addresses, as well as add original field name as the prefix for the Geo message field.  For example, given the field `source_ip`, with Graylog Schema Enforcement Off, the field added for the **Country Name** should be `source_ip_geo_country` (with the original field name as the prefix).  However, with enforcement on, the field name should be `source_geo_country`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Without checking for schema enforcement on field prefix generation, the user's message fields will be modified in an unexpected/undesired way when enforcement is turned off.

## Testing Steps
1. Turn Graylog Schema Enforcement ON for the Geo-Location Processing and submit a message with IP fields (source_ip, destination_ip, host_ip).  Confirm that the _geo_ fields added to the message have a prefix that exclude the '_ip' token in the input field.  For example, for `source_ip`, the **City Name** should be in the field `source_geo_city`.
2. Turn Schema Enforcement OFF and submit a message with IP fields.  Confirm that the _geo_ fields added to the message have a prefix that is exactly the input field name.  For example, `source_ip` should have a city name field of `source_ip_geo_city`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added unit tests and tested manually end-to-end.
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

