### PR TITLE
Fix/#12916 Lookup table name is now encoded before being used as route param

### DIFF
--- a/graylog2-web-interface/src/components/lookup-tables/LUTTableEntry.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/LUTTableEntry.jsx
@@ -52,7 +52,7 @@ class LUTTableEntry extends React.Component {
         <tr>
           <td>
             {this.props.errors.table && (<ErrorPopover placement="right" errorText={this.props.errors.table} title="Lookup Table problem" />)}
-            <Link to={Routes.SYSTEM.LOOKUPTABLES.show(this.props.table.name)}>{this.props.table.title}</Link>
+            <Link to={Routes.SYSTEM.LOOKUPTABLES.show(encodeURIComponent(this.props.table.name))}>{this.props.table.title}</Link>
           </td>
           <td>{this.props.table.description}</td>
           <td>{this.props.table.name}</td>
@@ -65,7 +65,7 @@ class LUTTableEntry extends React.Component {
             <Link to={Routes.SYSTEM.LOOKUPTABLES.DATA_ADAPTERS.show(this.props.dataAdapter.name)}>{this.props.dataAdapter.title}</Link>
           </td>
           <td>
-            <LinkContainer to={Routes.SYSTEM.LOOKUPTABLES.edit(this.props.table.name)}>
+            <LinkContainer to={Routes.SYSTEM.LOOKUPTABLES.edit(encodeURIComponent(this.props.table.name))}>
               <Button bsSize="xsmall" bsStyle="info">Edit</Button>
             </LinkContainer>
           &nbsp;

--- a/graylog2-web-interface/src/components/lookup-tables/LookupTable.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/LookupTable.jsx
@@ -81,7 +81,7 @@ class LookupTable extends React.Component {
             <dt>Cache</dt>
             <dd><Link to={Routes.SYSTEM.LOOKUPTABLES.CACHES.show(this.props.cache.name)}>{this.props.cache.title}</Link></dd>
           </dl>
-          <LinkContainer to={Routes.SYSTEM.LOOKUPTABLES.edit(this.props.table.name)}>
+          <LinkContainer to={Routes.SYSTEM.LOOKUPTABLES.edit(encodeURIComponent(this.props.table.name))}>
             <Button bsStyle="success">Edit</Button>
           </LinkContainer>
           {

--- a/graylog2-web-interface/src/components/lookup-tables/LookupTable.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/LookupTable.jsx
@@ -30,11 +30,15 @@ class LookupTable extends React.Component {
     dataAdapter: PropTypes.object.isRequired,
   };
 
-  state = {
-    lookupKey: null,
-    lookupResult: null,
-    purgeKey: null,
-  };
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      lookupKey: null,
+      lookupResult: null,
+      purgeKey: null,
+    };
+  }
 
   _onChange = (event) => {
     this.setState({ lookupKey: FormsUtils.getValueFromInput(event.target) });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Now we are encoding the lookup table name before using it as route parameter and that is fixing the problem of using special characters like "#" or "/".

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fix https://github.com/Graylog2/graylog2-server/issues/12916

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

