### PR TITLE
Fix/#9051 GrokPatternFilter now displays regex errors

### DIFF
--- a/graylog2-web-interface/src/components/grok-patterns/GrokPatternFilter.jsx
+++ b/graylog2-web-interface/src/components/grok-patterns/GrokPatternFilter.jsx
@@ -109,30 +109,41 @@ class GrokPatternFilter extends React.Component {
   render() {
     const { activeListItem, patternFilter } = this.state;
     const { addToPattern, patterns } = this.props;
-    const regExp = RegExp(patternFilter, 'i');
+    let regExp;
+    let regExpError;
+
+    try {
+      regExp = RegExp(patternFilter, 'i');
+    } catch (error) {
+      regExpError = error?.message;
+    }
 
     this.shownListItems = [];
-    const patternsToDisplay = patterns.filter((displayedPattern) => regExp.test(displayedPattern.name))
-      .map((displayedPattern, index) => {
-        const active = index === activeListItem;
+    let patternsToDisplay = [];
 
-        this.shownListItems.push(displayedPattern.name);
+    if (!regExpError) {
+      patternsToDisplay = patterns.filter((displayedPattern) => regExp.test(displayedPattern.name))
+        .map((displayedPattern, index) => {
+          const active = index === activeListItem;
 
-        return (
-          <ListGroupItem id={`list-item-${index}`}
-                         header={displayedPattern.name}
-                         bsStyle={active ? 'info' : undefined}
-                         onKeyDown={this._onPatternFilterKeyDown}
-                         key={displayedPattern.name}>
-            <span className={GrokPatternFilterStyle.patternDisplay}>{displayedPattern.pattern}</span>
-            <span className={GrokPatternFilterStyle.addButton}>
-              <Button bsSize="xsmall" bsStyle="primary" onClick={() => { addToPattern(displayedPattern.name); }}>
-                Add
-              </Button>
-            </span>
-          </ListGroupItem>
-        );
-      });
+          this.shownListItems.push(displayedPattern.name);
+
+          return (
+            <ListGroupItem id={`list-item-${index}`}
+                           header={displayedPattern.name}
+                           bsStyle={active ? 'info' : undefined}
+                           onKeyDown={this._onPatternFilterKeyDown}
+                           key={displayedPattern.name}>
+              <span className={GrokPatternFilterStyle.patternDisplay}>{displayedPattern.pattern}</span>
+              <span className={GrokPatternFilterStyle.addButton}>
+                <Button bsSize="xsmall" bsStyle="primary" onClick={() => { addToPattern(displayedPattern.name); }}>
+                  Add
+                </Button>
+              </span>
+            </ListGroupItem>
+          );
+        });
+    }
 
     return (
       <>
@@ -143,8 +154,9 @@ class GrokPatternFilter extends React.Component {
                autoComplete="off"
                formGroupClassName={GrokPatternFilterStyle.filterFormGroup}
                onKeyDown={this._onPatternFilterKeyDown}
-               value={patternFilter} />
-        <ListGroup bsClass={GrokPatternFilterStyle.resultList}>{patternsToDisplay}</ListGroup>
+               value={patternFilter}
+               error={regExpError} />
+        {!regExpError && <ListGroup bsClass={GrokPatternFilterStyle.resultList}>{patternsToDisplay}</ListGroup>}
       </>
     );
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
GrokPatternFilter now displays regex errors instead of redirecting to an error page

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Before when there is a regex error like a single Backslash the user gets automatically redirected to an error page
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/Graylog2/graylog2-server/issues/9051

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

