### PR TITLE
Stopped asking for index block status when list of indices in empty

### DIFF
--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/IndicesAdapterES6.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/IndicesAdapterES6.java
@@ -575,6 +575,9 @@ public class IndicesAdapterES6 implements IndicesAdapter {
 
     @Override
     public IndicesBlockStatus getIndicesBlocksStatus(final List<String> indices) {
+        if (indices == null || indices.isEmpty()) {
+            throw new IllegalArgumentException("Expecting list of indices with at least one index present.");
+        }
         final GetSettings request = new GetSettings.Builder()
                 .addIndex(indices)
                 .build();

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/IndicesAdapterES7.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/IndicesAdapterES7.java
@@ -354,6 +354,9 @@ public class IndicesAdapterES7 implements IndicesAdapter {
 
     @Override
     public IndicesBlockStatus getIndicesBlocksStatus(final List<String> indices) {
+        if (indices == null || indices.isEmpty()) {
+            throw new IllegalArgumentException("Expecting list of indices with at least one index present.");
+        }
         final GetSettingsRequest getSettingsRequest = new GetSettingsRequest()
                 .indices(indices.toArray(new String[]{}))
                 .indicesOptions(IndicesOptions.fromOptions(false, true, true, true))

--- a/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
@@ -84,7 +84,11 @@ public class Indices {
     }
 
     public IndicesBlockStatus getIndicesBlocksStatus(final List<String> indices) {
-        return indicesAdapter.getIndicesBlocksStatus(indices);
+        if (indices == null || indices.isEmpty()) {
+            return new IndicesBlockStatus();
+        } else {
+            return indicesAdapter.getIndicesBlocksStatus(indices);
+        }
     }
 
     public void move(String source, String target) {

--- a/graylog2-server/src/test/java/org/graylog2/indexer/indices/IndicesTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/indices/IndicesTest.java
@@ -23,6 +23,7 @@ import org.graylog2.indexer.IndexMappingFactory;
 import org.graylog2.indexer.IndexTemplateNotFoundException;
 import org.graylog2.indexer.TestIndexSet;
 import org.graylog2.indexer.indexset.IndexSetConfig;
+import org.graylog2.indexer.indices.blocks.IndicesBlockStatus;
 import org.graylog2.indexer.retention.strategies.DeletionRetentionStrategy;
 import org.graylog2.indexer.retention.strategies.DeletionRetentionStrategyConfig;
 import org.graylog2.indexer.rotation.strategies.MessageCountRotationStrategy;
@@ -35,8 +36,11 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.ZonedDateTime;
+import java.util.Collections;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
@@ -107,6 +111,20 @@ class IndicesTest {
         assertThatCode(() -> underTest.ensureIndexTemplate(indexSetConfig("test",
                 "test-template", "custom")))
                 .doesNotThrowAnyException();
+    }
+
+    @Test
+    public void testGetIndicesBlocksStatusReturnsNoBlocksOnNullIndicesList() {
+        final IndicesBlockStatus indicesBlocksStatus = underTest.getIndicesBlocksStatus(null);
+        assertNotNull(indicesBlocksStatus);
+        assertEquals(0, indicesBlocksStatus.countBlockedIndices());
+    }
+
+    @Test
+    public void testGetIndicesBlocksStatusReturnsNoBlocksOnEmptyIndicesList() {
+        final IndicesBlockStatus indicesBlocksStatus = underTest.getIndicesBlocksStatus(Collections.emptyList());
+        assertNotNull(indicesBlocksStatus);
+        assertEquals(0, indicesBlocksStatus.countBlockedIndices());
     }
 
     private TestIndexSet indexSetConfig(String indexPrefix, String indexTemplaNameName, String indexTemplateType) {


### PR DESCRIPTION
## Description
Whenever there are mo "Active Write Indices" and GL is running against OpenSearch, checking "Index Block Status" in "IndexBlockCheck" periodical will end up with an exception.

It turns out that there is a subtle difference in API between OpenSearch (https://opensearch.org/docs/latest/opensearch/rest-api/index-apis/get-settings/#url-parameters) and ES (https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-get-settings.html#get-index-settings-api-path-params). ES interprets no indices in URL as "_all" option, OpenSearch breaks. 

From now on, with both search engines, we will simply not check index block status if no indices are provided as input.

## Motivation and Context
1. Avoiding error on OpenSearch.
2. Searching for blocks in all indices in Elasticsearch in case no indices provided was not the greatest idea anyway.

## How Has This Been Tested?
Unit test has been added.

## Stacktrace showing the problem:

`Caused by: org.graylog.shaded.elasticsearch7.org.elasticsearch.client.ResponseException: method [GET], host [[https://vpc-glc-pt-poc-dev-ue1-2vkowefd6qzahy3jtff57644wa.us-east-1.es.amazonaws.com:443](https://vpc-glc-pt-poc-dev-ue1-2vkowefd6qzahy3jtff57644wa.us-east-1.es.amazonaws.com/)], URI [/_settings?master_timeout=30s&ignore_throttled=false&ignore_unavailable=false&expand_wildcards=open%2Cclosed&allow_no_indices=true], status line [HTTP/1.1 401 Unauthorized]
{"Message":"Your request: '/_settings' is not allowed."}
	at org.graylog.shaded.elasticsearch7.org.elasticsearch.client.RestClient.convertResponse(RestClient.java:302) ~[?:?]
	at org.graylog.shaded.elasticsearch7.org.elasticsearch.client.RestClient.performRequest(RestClient.java:272) ~[?:?]
	at org.graylog.shaded.elasticsearch7.org.elasticsearch.client.RestClient.performRequest(RestClient.java:246) ~[?:?]
	at org.graylog.shaded.elasticsearch7.org.elasticsearch.client.RestHighLevelClient.internalPerformRequest(RestHighLevelClient.java:1613) ~[?:?]
	at org.graylog.shaded.elasticsearch7.org.elasticsearch.client.RestHighLevelClient.performRequest(RestHighLevelClient.java:1583) ~[?:?]
	at org.graylog.shaded.elasticsearch7.org.elasticsearch.client.RestHighLevelClient.performRequestAndParseEntity(RestHighLevelClient.java:1553) ~[?:?]
	at org.graylog.shaded.elasticsearch7.org.elasticsearch.client.IndicesClient.getSettings(IndicesClient.java:788) ~[?:?]
	at org.graylog.storage.elasticsearch7.IndicesAdapterES7.lambda$getIndicesBlocksStatus$20(IndicesAdapterES7.java:363) ~[?:?]
	at org.graylog.storage.elasticsearch7.ElasticsearchClient.execute(ElasticsearchClient.java:109) ~[?:?]
	... 11 more
2022-06-21 10:02:29,501 ERROR: org.graylog2.periodical.IndexRotationThread - Uncaught exception in Periodical
org.graylog.shaded.elasticsearch7.org.elasticsearch.ElasticsearchException: An error occurred:
	at org.graylog.storage.elasticsearch7.ElasticsearchClient.exceptionFrom(ElasticsearchClient.java:151) ~[?:?]
	at org.graylog.storage.elasticsearch7.ElasticsearchClient.execute(ElasticsearchClient.java:111) ~[?:?]
	at org.graylog.storage.elasticsearch7.ElasticsearchClient.execute(ElasticsearchClient.java:104) ~[?:?]
	at org.graylog.storage.elasticsearch7.IndicesAdapterES7.getIndicesBlocksStatus(IndicesAdapterES7.java:362) ~[?:?]
	at org.graylog2.indexer.indices.Indices.getIndicesBlocksStatus(Indices.java:87) ~[graylog.jar:?]
	at org.graylog2.periodical.IndexBlockCheck.doRun(IndexBlockCheck.java:59) ~[graylog.jar:?]
	at org.graylog2.plugin.periodical.Periodical.run(Periodical.java:94) [graylog.jar:?]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539) [?:?]
	at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:305) [?:?]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305) [?:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) [?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) [?:?]
	at java.lang.Thread.run(Thread.java:833) [?:?]
Caused by: org.graylog.shaded.elasticsearch7.org.elasticsearch.ElasticsearchStatusException: Unable to parse response body
	at org.graylog.shaded.elasticsearch7.org.elasticsearch.client.RestHighLevelClient.parseResponseException(RestHighLevelClient.java:1872) ~[?:?]
	at org.graylog.shaded.elasticsearch7.org.elasticsearch.client.RestHighLevelClient.internalPerformRequest(RestHighLevelClient.java:1626) ~[?:?]
	at org.graylog.shaded.elasticsearch7.org.elasticsearch.client.RestHighLevelClient.performRequest(RestHighLevelClient.java:1583) ~[?:?]
	at org.graylog.shaded.elasticsearch7.org.elasticsearch.client.RestHighLevelClient.performRequestAndParseEntity(RestHighLevelClient.java:1553) ~[?:?]
	at org.graylog.shaded.elasticsearch7.org.elasticsearch.client.IndicesClient.getSettings(IndicesClient.java:788) ~[?:?]
	at org.graylog.storage.elasticsearch7.IndicesAdapterES7.lambda$getIndicesBlocksStatus$20(IndicesAdapterES7.java:363) ~[?:?]
	at org.graylog.storage.elasticsearch7.ElasticsearchClient.execute(ElasticsearchClient.java:109) ~[?:?]
	... 11 more
	Suppressed: org.graylog.shaded.elasticsearch7.org.elasticsearch.common.ParsingException: Failed to parse object: expecting field with name [error] but found [Message]
		at org.graylog.shaded.elasticsearch7.org.elasticsearch.common.xcontent.XContentParserUtils.ensureFieldName(XContentParserUtils.java:50) ~[?:?]
		at org.graylog.shaded.elasticsearch7.org.elasticsearch.ElasticsearchException.failureFromXContent(ElasticsearchException.java:592) ~[?:?]
		at org.graylog.shaded.elasticsearch7.org.elasticsearch.rest.BytesRestResponse.errorFromXContent(BytesRestResponse.java:179) ~[?:?]
		at org.graylog.shaded.elasticsearch7.org.elasticsearch.client.RestHighLevelClient.parseEntity(RestHighLevelClient.java:1892) ~[?:?]
		at org.graylog.shaded.elasticsearch7.org.elasticsearch.client.RestHighLevelClient.parseResponseException(RestHighLevelClient.java:1869) ~[?:?]
		at org.graylog.shaded.elasticsearch7.org.elasticsearch.client.RestHighLevelClient.internalPerformRequest(RestHighLevelClient.java:1626) ~[?:?]
		at org.graylog.shaded.elasticsearch7.org.elasticsearch.client.RestHighLevelClient.performRequest(RestHighLevelClient.java:1583) ~[?:?]
		at org.graylog.shaded.elasticsearch7.org.elasticsearch.client.RestHighLevelClient.performRequestAndParseEntity(RestHighLevelClient.java:1553) ~[?:?]
		at org.graylog.shaded.elasticsearch7.org.elasticsearch.client.IndicesClient.getSettings(IndicesClient.java:788) ~[?:?]
		at org.graylog.storage.elasticsearch7.IndicesAdapterES7.lambda$getIndicesBlocksStatus$20(IndicesAdapterES7.java:363) ~[?:?]
		at org.graylog.storage.elasticsearch7.ElasticsearchClient.execute(ElasticsearchClient.java:109) ~[?:?]
		at org.graylog.storage.elasticsearch7.ElasticsearchClient.execute(ElasticsearchClient.java:104) ~[?:?]
		at org.graylog.storage.elasticsearch7.IndicesAdapterES7.getIndicesBlocksStatus(IndicesAdapterES7.java:362) ~[?:?]
		at org.graylog2.indexer.indices.Indices.getIndicesBlocksStatus(Indices.java:87) ~[graylog.jar:?]
		at org.graylog2.periodical.IndexBlockCheck.doRun(IndexBlockCheck.java:59) ~[graylog.jar:?]
		at org.graylog2.plugin.periodical.Periodical.run(Periodical.java:94) [graylog.jar:?]
		at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539) [?:?]
		at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:305) [?:?]
		at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305) [?:?]
		at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) [?:?]
		at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) [?:?]
		at java.lang.Thread.run(Thread.java:833) [?:?]
Caused by: org.graylog.shaded.elasticsearch7.org.elasticsearch.client.ResponseException: method [GET], host [[https://vpc-glc-pt-poc-dev-ue1-2vkowefd6qzahy3jtff57644wa.us-east-1.es.amazonaws.com:443](https://vpc-glc-pt-poc-dev-ue1-2vkowefd6qzahy3jtff57644wa.us-east-1.es.amazonaws.com/)], URI [/_settings?master_timeout=30s&ignore_throttled=false&ignore_unavailable=false&expand_wildcards=open%2Cclosed&allow_no_indices=true], status line [HTTP/1.1 401 Unauthorized]
{"Message":"Your request: '/_settings' is not allowed."}
	at org.graylog.shaded.elasticsearch7.org.elasticsearch.client.RestClient.convertResponse(RestClient.java:302) ~[?:?]
	at org.graylog.shaded.elasticsearch7.org.elasticsearch.client.RestClient.performRequest(RestClient.java:272) ~[?:?]
	at org.graylog.shaded.elasticsearch7.org.elasticsearch.client.RestClient.performRequest(RestClient.java:246) ~[?:?]
	at org.graylog.shaded.elasticsearch7.org.elasticsearch.client.RestHighLevelClient.internalPerformRequest(RestHighLevelClient.java:1613) ~[?:?]
	at org.graylog.shaded.elasticsearch7.org.elasticsearch.client.RestHighLevelClient.performRequest(RestHighLevelClient.java:1583) ~[?:?]
	at org.graylog.shaded.elasticsearch7.org.elasticsearch.client.RestHighLevelClient.performRequestAndParseEntity(RestHighLevelClient.java:1553) ~[?:?]
	at org.graylog.shaded.elasticsearch7.org.elasticsearch.client.IndicesClient.getSettings(IndicesClient.java:788) ~[?:?]
	at org.graylog.storage.elasticsearch7.IndicesAdapterES7.lambda$getIndicesBlocksStatus$20(IndicesAdapterES7.java:363) ~[?:?]
	at org.graylog.storage.elasticsearch7.ElasticsearchClient.execute(ElasticsearchClient.java:109) ~[?:?]
	... 11 more`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

