### PR TITLE
Correct behavior when _cat/nodes API from the search engine returns n…

### DIFF
--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/ClusterAdapterES6.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/ClusterAdapterES6.java
@@ -96,7 +96,7 @@ public class ClusterAdapterES6 implements ClusterAdapter {
                     try {
                         //try parsing the String, it may represent a Long value
                         setBuilder.add(NodeFileDescriptorStats.create(name, ip, host, Long.parseLong(fileDescriptorMax.asText())));
-                    } catch (Exception e) {
+                    } catch (NumberFormatException e) {
                         StringBuilder sb = new StringBuilder("{");
                         sb.append("name = ").append(name);
                         sb.append(", host = ").append(host);

--- a/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/ClusterAdapterES6Test.java
+++ b/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/ClusterAdapterES6Test.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog.storage.elasticsearch6;
 
 import com.fasterxml.jackson.databind.JsonNode;

--- a/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/ClusterAdapterES6Test.java
+++ b/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/ClusterAdapterES6Test.java
@@ -1,0 +1,105 @@
+package org.graylog.storage.elasticsearch6;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.joschi.jadconfig.util.Duration;
+import io.searchbox.client.JestClient;
+import io.searchbox.core.CatResult;
+import org.graylog2.indexer.cluster.health.NodeDiskUsageStats;
+import org.graylog2.indexer.cluster.health.NodeFileDescriptorStats;
+import org.graylog2.indexer.cluster.health.NodeRole;
+import org.graylog2.indexer.cluster.health.SIUnitParser;
+import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+class ClusterAdapterES6Test {
+
+    private final static String SAMPLE_CAT_NODES_RESPONSE = "{" +
+            "\"result\" : " +
+            "[" +
+            "{" +
+            "\"id\":\"nodeWithCorrectInfo\"," +
+            "\"name\":\"nodeWithCorrectInfo\"," +
+            "\"role\":\"dimr\"," +
+            "\"ip\":\"182.88.0.2\"," +
+            "\"fileDescriptorMax\":1048576," +
+            "\"diskUsed\":\"45gb\"," +
+            "\"diskTotal\":\"411.5gb\"," +
+            "\"diskUsedPercent\":\"10.95\"" +
+            "}," +
+            "{" +
+            "\"id\":\"nodeWithMissingDiskStatistics\"," +
+            "\"name\":\"nodeWithMissingDiskStatistics\"," +
+            "\"role\":\"dimr\"," +
+            "\"ip\":\"182.88.0.1\"" +
+            "}" +
+            "]" +
+            "}";
+
+    private ClusterAdapterES6 clusterAdapter;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        final JestClient jestClient = mock(JestClient.class);
+        final CatResult catResult = mock(CatResult.class);
+        final ObjectMapper objectMapper = new ObjectMapperProvider().get();
+        final JsonNode catApiJsonResponse = objectMapper.readTree(SAMPLE_CAT_NODES_RESPONSE);
+
+        doReturn(catResult).when(jestClient).execute(any());
+        doReturn(catApiJsonResponse).when(catResult).getJsonObject();
+        doReturn(true).when(catResult).isSucceeded();
+        
+        this.clusterAdapter = new ClusterAdapterES6(jestClient, Duration.minutes(1));
+    }
+
+    @Test
+    void testFileDescriptorStats() {
+        final Set<NodeFileDescriptorStats> nodeFileDescriptorStats = clusterAdapter.fileDescriptorStats();
+
+        assertThat(nodeFileDescriptorStats)
+                .hasSize(1)
+                .noneSatisfy(
+                        nodeDescr -> assertThat(nodeDescr.name()).isEqualTo("nodeWithMissingDiskStatistics")
+                )
+                .first()
+                .satisfies(
+                        nodeDescr -> {
+                            assertThat(nodeDescr.name()).isEqualTo("nodeWithCorrectInfo");
+                            assertThat(nodeDescr.ip()).isEqualTo("182.88.0.2");
+                            assertThat(nodeDescr.fileDescriptorMax()).isPresent();
+                            assertThat(nodeDescr.fileDescriptorMax().get()).isEqualTo(1048576L);
+                        }
+                );
+    }
+
+    @Test
+    void testDiskUsageStats() {
+        final Set<NodeDiskUsageStats> diskUsageStats = clusterAdapter.diskUsageStats();
+
+        assertThat(diskUsageStats)
+                .hasSize(1)
+                .noneSatisfy(
+                        diskStats -> assertThat(diskStats.name()).isEqualTo("nodeWithMissingDiskStatistics")
+                )
+                .first()
+                .satisfies(
+                        nodeDescr -> {
+                            assertThat(nodeDescr.name()).isEqualTo("nodeWithCorrectInfo");
+                            assertThat(nodeDescr.ip()).isEqualTo("182.88.0.2");
+                            assertThat(nodeDescr.roles()).isEqualTo(NodeRole.parseSymbolString("dimr"));
+                            assertThat(nodeDescr.diskUsed().getBytes()).isEqualTo(SIUnitParser.parseBytesSizeValue("45gb").getBytes());
+                            assertThat(nodeDescr.diskTotal().getBytes()).isEqualTo(SIUnitParser.parseBytesSizeValue("411.5gb").getBytes());
+                            assertThat(nodeDescr.diskUsedPercent()).isEqualTo(10.95d);
+                        }
+                );
+
+    }
+}

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/ClusterAdapterES7.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/ClusterAdapterES7.java
@@ -104,7 +104,14 @@ public class ClusterAdapterES7 implements ClusterAdapter {
     }
 
     private List<NodeResponse> nodes() {
-        return catApi.nodes();
+        final List<NodeResponse> allNodes = catApi.nodes();
+        final List<NodeResponse> nodesWithDiskStatistics = allNodes.stream().filter(NodeResponse::hasDiskStatistics).collect(Collectors.toList());
+        if (allNodes.size() != nodesWithDiskStatistics.size()) {
+            final List<NodeResponse> nodesWithMissingDiskStatistics = allNodes.stream().filter(nr -> !nr.hasDiskStatistics()).collect(Collectors.toList());
+            LOG.info("_cat/nodes API has returned " + nodesWithMissingDiskStatistics.size() + " nodes without disk statistics:");
+            nodesWithMissingDiskStatistics.forEach(node -> LOG.info(node.toString()));
+        }
+        return nodesWithDiskStatistics;
     }
 
     @Override

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/cat/NodeResponse.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/cat/NodeResponse.java
@@ -18,6 +18,7 @@ package org.graylog.storage.elasticsearch7.cat;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 
@@ -37,12 +38,16 @@ public abstract class NodeResponse {
 
     public abstract String ip();
 
+    @Nullable
     public abstract String diskUsed();
 
+    @Nullable
     public abstract String diskTotal();
 
+    @Nullable
     public abstract Double diskUsedPercent();
 
+    @Nullable
     public abstract Long fileDescriptorMax();
 
     @JsonCreator
@@ -51,10 +56,10 @@ public abstract class NodeResponse {
                                       @JsonProperty("role") String role,
                                       @JsonProperty("host") @Nullable String host,
                                       @JsonProperty("ip") String ip,
-                                      @JsonProperty("diskUsed") String diskUsed,
-                                      @JsonProperty("diskTotal") String diskTotal,
-                                      @JsonProperty("diskUsedPercent") Double diskUsedPercent,
-                                      @JsonProperty("fileDescriptorMax") Long fileDescriptorMax) {
+                                      @JsonProperty("diskUsed") @Nullable String diskUsed,
+                                      @JsonProperty("diskTotal") @Nullable String diskTotal,
+                                      @JsonProperty("diskUsedPercent") @Nullable Double diskUsedPercent,
+                                      @JsonProperty("fileDescriptorMax") @Nullable Long fileDescriptorMax) {
         return new AutoValue_NodeResponse(
                 id,
                 name,
@@ -66,5 +71,13 @@ public abstract class NodeResponse {
                 diskUsedPercent,
                 fileDescriptorMax
         );
+    }
+
+    @JsonIgnore
+    public boolean hasDiskStatistics() {
+        return diskUsed() != null &&
+                diskTotal() != null &&
+                diskUsedPercent() != null &&
+                fileDescriptorMax() != null;
     }
 }

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/ClusterAdapterES7Test.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/ClusterAdapterES7Test.java
@@ -21,18 +21,26 @@ import com.github.joschi.jadconfig.util.Duration;
 import com.google.common.io.Resources;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.ElasticsearchException;
 import org.graylog.storage.elasticsearch7.cat.CatApi;
+import org.graylog.storage.elasticsearch7.cat.NodeResponse;
+import org.graylog2.indexer.cluster.health.NodeDiskUsageStats;
+import org.graylog2.indexer.cluster.health.NodeFileDescriptorStats;
+import org.graylog2.indexer.cluster.health.NodeRole;
+import org.graylog2.indexer.cluster.health.SIUnitParser;
 import org.graylog2.indexer.indices.HealthStatus;
 import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.testcontainers.shaded.com.google.common.collect.ImmutableList;
 
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Optional;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -45,6 +53,25 @@ class ClusterAdapterES7Test {
     private ObjectMapper objectMapper = new ObjectMapperProvider().get();
 
     private ClusterAdapterES7 clusterAdapter;
+
+    private final static NodeResponse NODE_WITH_CORRECT_INFO = NodeResponse.create("nodeWithCorrectInfo",
+            "nodeWithCorrectInfo",
+            "dimr",
+            null,
+            "182.88.0.2",
+            "45gb",
+            "411.5gb",
+            10.95d,
+            1048576L);
+    private final static NodeResponse NODE_WITH_MISSING_DISK_STATISTICS = NodeResponse.create("nodeWithMissingDiskStatistics",
+            "nodeWithMissingDiskStatistics",
+            "dimr",
+            null,
+            "182.88.0.1",
+            null,
+            null,
+            null,
+            null);
 
     @BeforeEach
     void setUp() {
@@ -82,6 +109,51 @@ class ClusterAdapterES7Test {
         when(client.execute(any())).thenThrow(new ElasticsearchException("Exception"));
         final Optional<HealthStatus> healthStatus = clusterAdapter.health(Collections.singletonList("foo_index"));
         assertThat(healthStatus).isEmpty();
+    }
+
+    @Test
+    void testFileDescriptorStats() {
+        doReturn(ImmutableList.of(NODE_WITH_CORRECT_INFO, NODE_WITH_MISSING_DISK_STATISTICS)).when(catApi).nodes();
+        final Set<NodeFileDescriptorStats> nodeFileDescriptorStats = clusterAdapter.fileDescriptorStats();
+
+        assertThat(nodeFileDescriptorStats)
+                .hasSize(1)
+                .noneSatisfy(
+                        nodeDescr -> assertThat(nodeDescr.name()).isEqualTo("nodeWithMissingDiskStatistics")
+                )
+                .first()
+                .satisfies(
+                        nodeDescr -> {
+                            assertThat(nodeDescr.name()).isEqualTo("nodeWithCorrectInfo");
+                            assertThat(nodeDescr.ip()).isEqualTo("182.88.0.2");
+                            assertThat(nodeDescr.fileDescriptorMax()).isPresent();
+                            assertThat(nodeDescr.fileDescriptorMax().get()).isEqualTo(1048576L);
+                        }
+                );
+    }
+
+    @Test
+    void testDiskUsageStats() {
+        doReturn(ImmutableList.of(NODE_WITH_CORRECT_INFO, NODE_WITH_MISSING_DISK_STATISTICS)).when(catApi).nodes();
+        final Set<NodeDiskUsageStats> diskUsageStats = clusterAdapter.diskUsageStats();
+
+        assertThat(diskUsageStats)
+                .hasSize(1)
+                .noneSatisfy(
+                        diskStats -> assertThat(diskStats.name()).isEqualTo("nodeWithMissingDiskStatistics")
+                )
+                .first()
+                .satisfies(
+                        nodeDescr -> {
+                            assertThat(nodeDescr.name()).isEqualTo("nodeWithCorrectInfo");
+                            assertThat(nodeDescr.ip()).isEqualTo("182.88.0.2");
+                            assertThat(nodeDescr.roles()).isEqualTo(NodeRole.parseSymbolString("dimr"));
+                            assertThat(nodeDescr.diskUsed().getBytes()).isEqualTo(SIUnitParser.parseBytesSizeValue("45gb").getBytes());
+                            assertThat(nodeDescr.diskTotal().getBytes()).isEqualTo(SIUnitParser.parseBytesSizeValue("411.5gb").getBytes());
+                            assertThat(nodeDescr.diskUsedPercent()).isEqualTo(10.95d);
+                        }
+                );
+
     }
 
     private void mockNodesResponse() throws IOException {

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/cat/CatApiTest.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/cat/CatApiTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog.storage.elasticsearch7.cat;
 
 import com.fasterxml.jackson.core.type.TypeReference;

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/cat/CatApiTest.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/cat/CatApiTest.java
@@ -1,0 +1,70 @@
+package org.graylog.storage.elasticsearch7.cat;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.graylog.storage.elasticsearch7.ElasticsearchClient;
+import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class CatApiTest {
+
+    private final static String SAMPLE_CAT_NODES_RESPONSE = "[" +
+            "{" +
+            "\"id\":\"nodeWithCorrectInfo\"," +
+            "\"name\":\"nodeWithCorrectInfo\"," +
+            "\"role\":\"dimr\"," +
+            "\"ip\":\"182.88.0.2\"," +
+            "\"fileDescriptorMax\":\"1048576\"," +
+            "\"diskUsed\":\"45gb\"," +
+            "\"diskTotal\":\"411.5gb\"," +
+            "\"diskUsedPercent\":\"10.95\"" +
+            "}," +
+            "{" +
+            "\"id\":\"nodeWithMissingDiskStatistics\"," +
+            "\"name\":\"nodeWithMissingDiskStatistics\"," +
+            "\"role\":\"dimr\"," +
+            "\"ip\":\"182.88.0.1\"" +
+            "}" +
+            "]";
+
+    @Test
+    void testNodesMethodParsesAndReturnsEvenNodesThatMissDiskUsageInfo() throws Exception {
+        final ObjectMapper objectMapper = new ObjectMapperProvider().get();
+        final ElasticsearchClient client = mock(ElasticsearchClient.class);
+        final CatApi toTest = new CatApi(objectMapper, client);
+
+        when(client.execute(any(), anyString()))
+                .thenReturn(objectMapper.readValue(SAMPLE_CAT_NODES_RESPONSE, new TypeReference<List<NodeResponse>>() {}));
+
+        final List<NodeResponse> nodes = toTest.nodes();
+
+        assertThat(nodes)
+                .hasSize(2)
+                .contains(NodeResponse.create("nodeWithCorrectInfo",
+                        "nodeWithCorrectInfo",
+                        "dimr",
+                        null,
+                        "182.88.0.2",
+                        "45gb",
+                        "411.5gb",
+                        10.95d,
+                        1048576L))
+                .contains(NodeResponse.create("nodeWithMissingDiskStatistics",
+                        "nodeWithMissingDiskStatistics",
+                        "dimr",
+                        null,
+                        "182.88.0.1",
+                        null,
+                        null,
+                        null,
+                        null));
+    }
+}


### PR DESCRIPTION
…odes without disk/file statistics present.

## Description
Fixes #12858
It seems that "_cat/nodes" endpoint for ES can return nodes without populating disk/file related fields (i.e. diskUsage).
Our code assumed those fields are always present and is throwing an ugly NullPointerException in this case (please go to #12858 for full stacktrace).
This PR makes our code more tolerant to this kind of rare scenario. It excludes nodes that temporarily do not return their disk/file data from current "open file"/"disk usage" check (performed by IndexerClusterCheckerThread periodical).
It also logs basic information about those nodes.

## Motivation and Context
We do not want NullPointerException in the logs.
We do not want periodical to break because of one strange node, we want it to continue execution for other nodes in the cluster.
(We are also curious why some nodes do not have all the fields reported, maybe additional logging will give us a clue)

## How Has This Been Tested?
I have not been able to reproduce it on my local environment.
I have simulated the same scenario with unit test and verified they do not fail after the introduction of this fix.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

