### PR TITLE
All queries from documentation are tested for successful validation.

### DIFF
--- a/full-backend-tests/src/test/java/org/graylog/plugins/views/QueryValidationResourceIT.java
+++ b/full-backend-tests/src/test/java/org/graylog/plugins/views/QueryValidationResourceIT.java
@@ -51,8 +51,19 @@ public class QueryValidationResourceIT {
         int mappedPort = sut.mappedPortFor(GELF_HTTP_PORT);
         GelfInputUtils.createGelfHttpInput(mappedPort, GELF_HTTP_PORT, requestSpec);
         GelfInputUtils.postMessage(mappedPort,
-                "{\"short_message\":\"query-validation-test\", \"host\":\"example.org\", \"level\":3}",
+                "{\"short_message\":\"query-validation-test\", " +
+                        "\"host\":\"example.org\", " +
+                        "\"type\":\"ssh\", " +
+                        "\"source\":\"example.org\", " +
+                        "\"http_response_code\":200, " +
+                        "\"bytes\":42, " +
+                        "\"timestamp\": \"2019-07-23 09:53:08.175\", " +
+                        "\"otherDate\": \"2020-07-29T12:00:00.000-05:00\", " +
+                        "\"resource\": \"posts\", " +
+                        "\"always_find_me\": \"whatever\", " +
+                        "\"level\":3}",
                 requestSpec);
+
 
         // mainly because of the waiting logic
         final boolean isMessagePresent = SearchUtils.waitForMessage(requestSpec, "query-validation-test");
@@ -104,15 +115,7 @@ public class QueryValidationResourceIT {
 
     @ContainerMatrixTest
     void testRegexWithoutFieldName() {
-        final ValidatableResponse validatableResponse = given()
-                .spec(requestSpec)
-                .when()
-                .body("{\"query\":\"/ethernet[0-9]+/\"}")
-                .post("/search/validate")
-                .then()
-                .log().ifStatusCodeMatches(not(200))
-                .statusCode(200);
-        validatableResponse.assertThat().body("status", equalTo("OK"));
+        verifyQueryIsValidatedSuccessfully("/ethernet[0-9]+/");
     }
 
     @ContainerMatrixTest
@@ -145,16 +148,75 @@ public class QueryValidationResourceIT {
 
     @ContainerMatrixTest
     void testQuotedDefaultField() {
+        // if the validation correctly recognizes the quoted text, it should not warn about lowercase or
+        verifyQueryIsValidatedSuccessfully("\\\"A or B\\\"");
+    }
+
+
+    @ContainerMatrixTest
+    void testQueriesFromDocumentationAreValidatedSuccessfully() {
+        //Uses https://docs.graylog.org/docs/query-language as a source of documented queries (accessed 27.06.2022)
+        verifyQueryIsValidatedSuccessfully("ssh");
+        verifyQueryIsValidatedSuccessfully("ssh login");
+        verifyQueryIsValidatedSuccessfully("\\\"ssh login\\\"");
+        verifyQueryIsValidatedSuccessfully("type:ssh");
+        verifyQueryIsValidatedSuccessfully("type:(ssh OR login)");
+        verifyQueryIsValidatedSuccessfully("type:\\\"ssh login\\\" ");
+        verifyQueryIsValidatedSuccessfully("_exists_:type ");
+        verifyQueryIsValidatedSuccessfully("NOT _exists_:type ");
+        verifyQueryIsValidatedSuccessfully("/ethernet[0-9]+/");
+        verifyQueryIsValidatedSuccessfully("\\\"ssh login\\\" AND source:example.org");
+        verifyQueryIsValidatedSuccessfully("(\\\"ssh login\\\" AND (source:example.org OR source:another.example.org)) OR _exists_:always_find_me");
+        verifyQueryIsValidatedSuccessfully("\\\"ssh login\\\" AND NOT source:example.org");
+        verifyQueryIsValidatedSuccessfully("NOT example.org");
+        verifyQueryIsValidatedWithValidationError("source:*.org"); //expected leading wildcard validation error with default settings
+        verifyQueryIsValidatedSuccessfully("source:exam?le.org");
+        verifyQueryIsValidatedSuccessfully("source:exam?le.*");
+        verifyQueryIsValidatedSuccessfully("ssh logni~ ");
+        verifyQueryIsValidatedSuccessfully("source:exmaple.org~");
+        verifyQueryIsValidatedSuccessfully("source:exmaple.org~1 ");
+        verifyQueryIsValidatedSuccessfully("\\\"foo bar\\\"~5 ");
+        verifyQueryIsValidatedSuccessfully("http_response_code:[500 TO 504]");
+        verifyQueryIsValidatedSuccessfully("http_response_code:{400 TO 404}");
+        verifyQueryIsValidatedSuccessfully("bytes:{0 TO 64]");
+        verifyQueryIsValidatedSuccessfully("http_response_code:[0 TO 64}");
+        verifyQueryIsValidatedSuccessfully("http_response_code:>400");
+        verifyQueryIsValidatedSuccessfully("http_response_code:<400");
+        verifyQueryIsValidatedSuccessfully("http_response_code:>=400");
+        verifyQueryIsValidatedSuccessfully("http_response_code:<=400");
+        verifyQueryIsValidatedSuccessfully("http_response_code:(>=400 AND <500)");
+        verifyQueryIsValidatedSuccessfully("timestamp:[\\\"2019-07-23 09:53:08.175\\\" TO \\\"2019-07-23 09:53:08.575\\\"]");
+        verifyQueryIsValidatedSuccessfully("otherDate:[\\\"2019-07-23T09:53:08.175\\\" TO \\\"2019-07-23T09:53:08.575\\\"]");
+        verifyQueryIsValidatedSuccessfully("otherDate:[\\\"2020-07-29T12:00:00.000-05:00\\\" TO \\\"2020-07-30T15:13:00.000-05:00\\\"]");
+        verifyQueryIsValidatedSuccessfully("otherDate:[now-5d TO now-4d]");
+        verifyQueryIsValidatedSuccessfully("resource:\\/posts\\/45326");
+    }
+
+    private void verifyQueryIsValidatedSuccessfully(final String query) {
         given()
                 .spec(requestSpec)
                 .when()
-                .body("{\"query\": \"\\\"A or B\\\"\"}")
+                .body("{\"query\": \"" + query + "\"}")
                 .post("/search/validate")
                 .then()
                 .statusCode(200)
                 .log().ifStatusCodeMatches(not(200))
                 .log().ifValidationFails()
-                // if the validation correctly recognizes the quoted text, it should not warn about lowercase or
                 .assertThat().body("status", equalTo("OK"));
     }
+
+    private void verifyQueryIsValidatedWithValidationError(final String query) {
+        given()
+                .spec(requestSpec)
+                .when()
+                .body("{\"query\": \"" + query + "\"}")
+                .post("/search/validate")
+                .then()
+                .statusCode(200)
+                .log().ifStatusCodeMatches(not(200))
+                .log().ifValidationFails()
+                .assertThat().body("status", equalTo("ERROR"));
+    }
+
+
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/validation/FieldTypeValidationImpl.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/validation/FieldTypeValidationImpl.java
@@ -16,36 +16,77 @@
  */
 package org.graylog.plugins.views.search.validation;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.net.InetAddresses;
 import org.graylog.plugins.views.search.engine.QueryPosition;
-import org.joda.time.DateTime;
+import org.graylog2.plugin.Tools;
+import org.joda.time.format.DateTimeFormatter;
+import org.joda.time.format.ISODateTimeFormat;
 
+import java.util.Comparator;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 public class FieldTypeValidationImpl implements FieldTypeValidation {
 
+    private static final List<DateTimeFormatter> DATE_TIME_FORMATTERS = ImmutableList.of(
+            Tools.ISO_DATE_FORMAT_FORMATTER,
+            Tools.ES_DATE_FORMAT_FORMATTER,
+            Tools.ES_DATE_FORMAT_NO_MS_FORMATTER,
+            ISODateTimeFormat.dateTimeParser().withOffsetParsed());
+
+    private static final List<String> NUMERIC_OPERANDS = ImmutableList.of(">=", "<=", ">", "<").stream()
+            .sorted(Comparator.comparingInt(String::length).reversed())
+            .collect(Collectors.toList());
     private static final Map<String, Predicate<String>> VALIDATION_FUNCTIONS = new HashMap<>();
 
     private static final Predicate<String> ALWAYS_TRUE_PREDICATE = value -> true;
 
     static {
         VALIDATION_FUNCTIONS.put("string", ALWAYS_TRUE_PREDICATE);
-        VALIDATION_FUNCTIONS.put("long", wrapException(Long::parseLong));
-        VALIDATION_FUNCTIONS.put("int", wrapException(Integer::parseInt));
-        VALIDATION_FUNCTIONS.put("short", wrapException(Short::parseShort));
-        VALIDATION_FUNCTIONS.put("byte", wrapException(Byte::parseByte));
-        VALIDATION_FUNCTIONS.put("double", wrapException(Double::parseDouble));
-        VALIDATION_FUNCTIONS.put("float", wrapException(Float::parseFloat));
-        VALIDATION_FUNCTIONS.put("date", wrapException(DateTime::parse));
+        VALIDATION_FUNCTIONS.put("long", wrapException(removeNumericOperandsIfNeeded(Long::parseLong)));
+        VALIDATION_FUNCTIONS.put("int", wrapException(removeNumericOperandsIfNeeded(Integer::parseInt)));
+        VALIDATION_FUNCTIONS.put("short", wrapException(removeNumericOperandsIfNeeded(Short::parseShort)));
+        VALIDATION_FUNCTIONS.put("byte", wrapException(removeNumericOperandsIfNeeded(Byte::parseByte)));
+        VALIDATION_FUNCTIONS.put("double", wrapException(removeNumericOperandsIfNeeded(Double::parseDouble)));
+        VALIDATION_FUNCTIONS.put("float", wrapException(removeNumericOperandsIfNeeded(Float::parseFloat)));
+        VALIDATION_FUNCTIONS.put("date", FieldTypeValidationImpl::isDate);
         VALIDATION_FUNCTIONS.put("boolean", wrapException(Boolean::parseBoolean));
         VALIDATION_FUNCTIONS.put("binary", ALWAYS_TRUE_PREDICATE);
         VALIDATION_FUNCTIONS.put("geo-point", ALWAYS_TRUE_PREDICATE);
         VALIDATION_FUNCTIONS.put("ip", InetAddresses::isInetAddress);
+    }
+
+    private static Function<String, Object> removeNumericOperandsIfNeeded(Function<String, Object> numericParser) {
+        return (value) -> {
+            final Optional<String> operand = NUMERIC_OPERANDS.stream()
+                    .filter(value::startsWith)
+                    .findFirst();
+            if (operand.isPresent()) {
+                return numericParser.apply(value.substring(operand.get().length()));
+            } else {
+                return numericParser.apply(value);
+            }
+        };
+    }
+
+
+    private static boolean isDate(final String dateCandidate) {
+        for (DateTimeFormatter formatter : DATE_TIME_FORMATTERS) {
+            try {
+                formatter.parseDateTime(dateCandidate);
+                return true;
+            } catch (Exception ex) {
+                //do nothing, try next formatter in the loop
+            }
+        }
+        return false;
     }
 
     @SuppressWarnings("ReturnValueIgnored")

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/validation/FieldTypeValidationTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/validation/FieldTypeValidationTest.java
@@ -16,13 +16,15 @@
  */
 package org.graylog.plugins.views.search.validation;
 
- import org.apache.lucene.queryparser.classic.QueryParserConstants;
+import org.apache.lucene.queryparser.classic.QueryParserConstants;
 import org.apache.lucene.queryparser.classic.Token;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.testcontainers.shaded.com.google.common.collect.ImmutableList;
+
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
 class FieldTypeValidationTest {
 
@@ -34,10 +36,42 @@ class FieldTypeValidationTest {
     }
 
     @Test
-    void validateFieldValueType() {
-        assertThat(fieldTypeValidation.validateFieldValueType(term("123"), "long")).isNotPresent();
-        assertThat(fieldTypeValidation.validateFieldValueType(term("ABC"), "long")).isPresent();
+    void validateNumericFieldValueTypes() {
+        List<String> numericTypes = ImmutableList.of("long", "int", "short", "byte", "double", "float");
+        for (String numericType : numericTypes) {
+            assertThat(fieldTypeValidation.validateFieldValueType(term("123"), numericType)).isNotPresent();
+            assertThat(fieldTypeValidation.validateFieldValueType(term(">123"), numericType)).isNotPresent();
+            assertThat(fieldTypeValidation.validateFieldValueType(term(">=123"), numericType)).isNotPresent();
+            assertThat(fieldTypeValidation.validateFieldValueType(term("<42"), numericType)).isNotPresent();
+            assertThat(fieldTypeValidation.validateFieldValueType(term("<=42"), numericType)).isNotPresent();
+
+            assertThat(fieldTypeValidation.validateFieldValueType(term("ABC"), numericType)).isPresent();
+        }
+    }
+
+    @Test
+    void validateDateFieldValueType() {
+        assertThat(fieldTypeValidation.validateFieldValueType(term("2019-07-23 09:53:08.175"), "date")).isNotPresent();
+        assertThat(fieldTypeValidation.validateFieldValueType(term("2019-07-23 09:53:08"), "date")).isNotPresent();
+        assertThat(fieldTypeValidation.validateFieldValueType(term("2019-07-23"), "date")).isNotPresent();
         assertThat(fieldTypeValidation.validateFieldValueType(term("2020-07-29T12:00:00.000-05:00"), "date")).isNotPresent();
+
+        assertThat(fieldTypeValidation.validateFieldValueType(term("ABC"), "date")).isPresent();
+    }
+
+    @Test
+    void validateIPFieldValueType() {
+        assertThat(fieldTypeValidation.validateFieldValueType(term("123.34.45.56"), "ip")).isNotPresent();
+
+        assertThat(fieldTypeValidation.validateFieldValueType(term("ABC"), "ip")).isPresent();
+    }
+
+    @Test
+    void validateBooleanFieldValueType() {
+        assertThat(fieldTypeValidation.validateFieldValueType(term("true"), "boolean")).isNotPresent();
+        assertThat(fieldTypeValidation.validateFieldValueType(term("false"), "boolean")).isNotPresent();
+
+        assertThat(fieldTypeValidation.validateFieldValueType(term("hard to say"), "boolean")).isNotPresent();
     }
 
     private ParsedTerm term(String value) {


### PR DESCRIPTION
## Description
All queries from documentation are tested for successful validation.
Fixes #12780

Additionally, two small problems have been fixed: we used to have validation warnings while using proper numeric operands (i.e. ">=") and proper dates (as presented in the screenshot). It is not the case anymore. 

## Motivation and Context
We need to be sure that all the queries used in documentation actually pass the validation phase.

## How Has This Been Tested?
Unit and integration tests have been added.

## Screenshots (if appropriate):
![Screenshot 2022-06-28 at 09-58-04 Graylog - Unsaved Search](https://user-images.githubusercontent.com/100699120/176125755-73a0262a-7db9-4cc0-8662-36392d6034e1.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

