### PR TITLE
Feature/missing values in pivot via missing aggregation

### DIFF
--- a/full-backend-tests/src/test/java/org/graylog/plugins/views/aggregations/SearchWithAggregationsSupportingMissingBucketsIT.java
+++ b/full-backend-tests/src/test/java/org/graylog/plugins/views/aggregations/SearchWithAggregationsSupportingMissingBucketsIT.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog.plugins.views.aggregations;
 
 import io.restassured.response.ValidatableResponse;
@@ -64,7 +80,7 @@ public class SearchWithAggregationsSupportingMissingBucketsIT {
                 .body(pivotSearchTypePathInResponse + ".rows.find{ it.key[0] == 'Joe' }", notNullValue())
                 .body(pivotSearchTypePathInResponse + ".rows.find{ it.key[0] == 'Jane' }", notNullValue())
                 .body(pivotSearchTypePathInResponse + ".rows.find{ it.key[0] == 'Bob' }", notNullValue())
-                .body(pivotSearchTypePathInResponse + ".rows.find{ it.key[0] == " + MISSING_BUCKET_NAME + " }", notNullValue())
+                .body(pivotSearchTypePathInResponse + ".rows.find{ it.key[0] == '" + MISSING_BUCKET_NAME + "' }", notNullValue())
                 .body(pivotSearchTypePathInResponse + ".rows.find{ it.key == [] }", notNullValue());
 
         //Empty bucket verification (should precede the last/total one - index 3)
@@ -102,16 +118,16 @@ public class SearchWithAggregationsSupportingMissingBucketsIT {
                 .body(pivotSearchTypePathInResponse + ".rows.findAll{ it.key[0] == 'Joe' }", hasSize(3)) //Joe, Joe-Biden, Joe-Smith
                 .body(pivotSearchTypePathInResponse + ".rows.findAll{ it.key[0] == 'Bob' }", hasSize(2)) //Bob, Bob-empty
                 .body(pivotSearchTypePathInResponse + ".rows.findAll{ it.key[0] == 'Jane' }", hasSize(2)) //Jane, Jane-Smith
-                .body(pivotSearchTypePathInResponse + ".rows.findAll{ it.key[0] == " + MISSING_BUCKET_NAME + " }", hasSize(2)) //empty, empty-Cooper
+                .body(pivotSearchTypePathInResponse + ".rows.findAll{ it.key[0] == '" + MISSING_BUCKET_NAME + "' }", hasSize(2)) //empty, empty-Cooper
                 .body(pivotSearchTypePathInResponse + ".rows.find{ it.key == [] }", notNullValue()) //totals
                 .body(pivotSearchTypePathInResponse + ".total", equalTo(5));
 
         //Empty buckets verification
         //We have only one entry with missing first name {(...)"lastName": "Cooper","age": 60(...)}, so both empty buckets will have the same values
-        validatableResponse.body(pivotSearchTypePathInResponse + ".rows.find{ it.key[0] == " + MISSING_BUCKET_NAME + " && it.key[1] == 'Cooper'}.values[0].value", equalTo(1))
-                .body(pivotSearchTypePathInResponse + ".rows.find{ it.key[0] == " + MISSING_BUCKET_NAME + " && it.key[1] == 'Cooper'}.values[1].value", equalTo(60.0f))
-                .body(pivotSearchTypePathInResponse + ".rows.find{ it.key == [" + MISSING_BUCKET_NAME + "]}.values[0].value", equalTo(1))
-                .body(pivotSearchTypePathInResponse + ".rows.find{ it.key == [" + MISSING_BUCKET_NAME + "]}.values[1].value", equalTo(60.0f));
+        validatableResponse.body(pivotSearchTypePathInResponse + ".rows.find{ it.key[0] == '" + MISSING_BUCKET_NAME + "' && it.key[1] == 'Cooper'}.values[0].value", equalTo(1))
+                .body(pivotSearchTypePathInResponse + ".rows.find{ it.key[0] == '" + MISSING_BUCKET_NAME + "' && it.key[1] == 'Cooper'}.values[1].value", equalTo(60.0f))
+                .body(pivotSearchTypePathInResponse + ".rows.find{ it.key == ['" + MISSING_BUCKET_NAME + "']}.values[0].value", equalTo(1))
+                .body(pivotSearchTypePathInResponse + ".rows.find{ it.key == ['" + MISSING_BUCKET_NAME + "']}.values[1].value", equalTo(60.0f));
 
 
     }
@@ -139,7 +155,7 @@ public class SearchWithAggregationsSupportingMissingBucketsIT {
                 .body(pivotSearchTypePathInResponse + ".rows.find{ it.key == [] }", notNullValue());
 
         //Empty bucket is not there - in a fixture all the documents have "age" field
-        validatableResponse.body(pivotSearchTypePathInResponse + ".rows.find{ it.key[0] == " + MISSING_BUCKET_NAME + " }", nullValue());
+        validatableResponse.body(pivotSearchTypePathInResponse + ".rows.find{ it.key[0] == '" + MISSING_BUCKET_NAME + "' }", nullValue());
 
 
         //Top bucket verification

--- a/full-backend-tests/src/test/java/org/graylog/plugins/views/aggregations/SearchWithAggregationsSupportingMissingBucketsIT.java
+++ b/full-backend-tests/src/test/java/org/graylog/plugins/views/aggregations/SearchWithAggregationsSupportingMissingBucketsIT.java
@@ -1,0 +1,157 @@
+package org.graylog.plugins.views.aggregations;
+
+import io.restassured.response.ValidatableResponse;
+import io.restassured.specification.RequestSpecification;
+import org.graylog.testing.completebackend.GraylogBackend;
+import org.graylog.testing.containermatrix.MongodbServer;
+import org.graylog.testing.containermatrix.annotations.ContainerMatrixTest;
+import org.graylog.testing.containermatrix.annotations.ContainerMatrixTestsConfiguration;
+import org.junit.jupiter.api.BeforeAll;
+
+import java.io.InputStream;
+
+import static io.restassured.RestAssured.given;
+import static org.graylog.plugins.views.search.aggregations.MissingBucketConstants.MISSING_BUCKET_NAME;
+import static org.graylog.testing.containermatrix.SearchServer.ES6;
+import static org.graylog.testing.containermatrix.SearchServer.ES7;
+import static org.graylog.testing.containermatrix.SearchServer.OS1;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+@ContainerMatrixTestsConfiguration(mongoVersions = MongodbServer.MONGO5, searchVersions = {OS1, ES6, ES7})
+public class SearchWithAggregationsSupportingMissingBucketsIT {
+
+    @SuppressWarnings("unused")
+    //use this fixtureType:474877 in all fixtures to assure this test isolation from the others
+    private static final String FIXTURE_TYPE_FIELD_VALUE = "474877";
+    private static final String EXEC_PATH = "/views/search/sync";
+    private static final String QUERY_ID = "q1";
+    private static final String SEARCH_TYPE_ID = "st1";
+
+
+    private final RequestSpecification requestSpec;
+    private final GraylogBackend backend;
+
+    public SearchWithAggregationsSupportingMissingBucketsIT(final GraylogBackend backend, final RequestSpecification requestSpec) {
+        this.requestSpec = requestSpec;
+        this.backend = backend;
+    }
+
+    @BeforeAll
+    public void setUp() {
+        backend.importElasticsearchFixture("messages-for-missing-aggregation-check.json", SearchWithAggregationsSupportingMissingBucketsIT.class);
+    }
+
+    @ContainerMatrixTest
+    void testSingleFieldAggregationHasProperMissingBucket() {
+        final String pivotSearchTypePathInResponse = "results." + QUERY_ID + ".search_types." + SEARCH_TYPE_ID;
+        final ValidatableResponse validatableResponse = given()
+                .spec(requestSpec)
+                .when()
+                .body(fixture("org/graylog/plugins/views/aggregations/search_request_with_aggregation_on_single_field.json")) //aggregates on the 'firstName' field
+                .post(EXEC_PATH)
+                .then()
+                .log().ifStatusCodeMatches(not(200))
+                .statusCode(200);
+        //General verification
+        validatableResponse.body("execution.done", equalTo(true))
+                .body(pivotSearchTypePathInResponse + ".rows", hasSize(5))
+                .body(pivotSearchTypePathInResponse + ".total", equalTo(5))
+                .body(pivotSearchTypePathInResponse + ".rows.find{ it.key[0] == 'Joe' }", notNullValue())
+                .body(pivotSearchTypePathInResponse + ".rows.find{ it.key[0] == 'Jane' }", notNullValue())
+                .body(pivotSearchTypePathInResponse + ".rows.find{ it.key[0] == 'Bob' }", notNullValue())
+                .body(pivotSearchTypePathInResponse + ".rows.find{ it.key[0] == " + MISSING_BUCKET_NAME + " }", notNullValue())
+                .body(pivotSearchTypePathInResponse + ".rows.find{ it.key == [] }", notNullValue());
+
+        //Empty bucket verification (should precede the last/total one - index 3)
+        //The only message with "empty" first name in a fixture is {(...)"lastName": "Cooper","age": 60(...)}
+        validatableResponse.body(pivotSearchTypePathInResponse + ".rows[3].key", contains("(Empty Value)"));
+        validatableResponse.body(pivotSearchTypePathInResponse + ".rows[3].values[0].key", contains("count()"));
+        validatableResponse.body(pivotSearchTypePathInResponse + ".rows[3].values[0].value", equalTo(1));
+        validatableResponse.body(pivotSearchTypePathInResponse + ".rows[3].values[1].key", contains("avg(age)"));
+        validatableResponse.body(pivotSearchTypePathInResponse + ".rows[3].values[1].value", equalTo(60.0f));
+
+        //Top bucket verification
+        //There are 2 "Joes" in a fixture: {(...)"lastName": "Smith","age": 50(...)} and {(...)"lastName": "Biden","age": 80(...)}
+        validatableResponse.body(pivotSearchTypePathInResponse + ".rows[0].key", contains("Joe"));
+        validatableResponse.body(pivotSearchTypePathInResponse + ".rows[0].values[0].key", contains("count()"));
+        validatableResponse.body(pivotSearchTypePathInResponse + ".rows[0].values[0].value", equalTo(2));
+        validatableResponse.body(pivotSearchTypePathInResponse + ".rows[0].values[1].key", contains("avg(age)"));
+        validatableResponse.body(pivotSearchTypePathInResponse + ".rows[0].values[1].value", equalTo(65.0f));
+
+    }
+
+    @ContainerMatrixTest
+    void testTwoFieldAggregationHasProperMissingBucket() {
+        final String pivotSearchTypePathInResponse = "results." + QUERY_ID + ".search_types." + SEARCH_TYPE_ID;
+        final ValidatableResponse validatableResponse = given()
+                .spec(requestSpec)
+                .when()
+                .body(fixture("org/graylog/plugins/views/aggregations/search_request_with_aggregation_on_two_fields.json")) //aggregates on the 'firstName' and 'lastName' fields
+                .post(EXEC_PATH)
+                .then()
+                .log().ifStatusCodeMatches(not(200))
+                .statusCode(200);
+        //General verification
+        validatableResponse.body("execution.done", equalTo(true))
+                .body(pivotSearchTypePathInResponse + ".rows", hasSize(10))
+                .body(pivotSearchTypePathInResponse + ".rows.findAll{ it.key[0] == 'Joe' }", hasSize(3)) //Joe, Joe-Biden, Joe-Smith
+                .body(pivotSearchTypePathInResponse + ".rows.findAll{ it.key[0] == 'Bob' }", hasSize(2)) //Bob, Bob-empty
+                .body(pivotSearchTypePathInResponse + ".rows.findAll{ it.key[0] == 'Jane' }", hasSize(2)) //Jane, Jane-Smith
+                .body(pivotSearchTypePathInResponse + ".rows.findAll{ it.key[0] == " + MISSING_BUCKET_NAME + " }", hasSize(2)) //empty, empty-Cooper
+                .body(pivotSearchTypePathInResponse + ".rows.find{ it.key == [] }", notNullValue()) //totals
+                .body(pivotSearchTypePathInResponse + ".total", equalTo(5));
+
+        //Empty buckets verification
+        //We have only one entry with missing first name {(...)"lastName": "Cooper","age": 60(...)}, so both empty buckets will have the same values
+        validatableResponse.body(pivotSearchTypePathInResponse + ".rows.find{ it.key[0] == " + MISSING_BUCKET_NAME + " && it.key[1] == 'Cooper'}.values[0].value", equalTo(1))
+                .body(pivotSearchTypePathInResponse + ".rows.find{ it.key[0] == " + MISSING_BUCKET_NAME + " && it.key[1] == 'Cooper'}.values[1].value", equalTo(60.0f))
+                .body(pivotSearchTypePathInResponse + ".rows.find{ it.key == [" + MISSING_BUCKET_NAME + "]}.values[0].value", equalTo(1))
+                .body(pivotSearchTypePathInResponse + ".rows.find{ it.key == [" + MISSING_BUCKET_NAME + "]}.values[1].value", equalTo(60.0f));
+
+
+    }
+
+    @ContainerMatrixTest
+    void testMissingBucketIsNotPresentIfItHasZeroValues() {
+        final String pivotSearchTypePathInResponse = "results." + QUERY_ID + ".search_types." + SEARCH_TYPE_ID;
+        final ValidatableResponse validatableResponse = given()
+                .spec(requestSpec)
+                .when()
+                .body(fixture("org/graylog/plugins/views/aggregations/search_request_with_aggregation_that_has_no_missing_buckets.json")) //aggregates on the 'age' field
+                .post(EXEC_PATH)
+                .then()
+                .log().ifStatusCodeMatches(not(200))
+                .statusCode(200);
+
+        //General verification
+        validatableResponse.body("execution.done", equalTo(true))
+                .body(pivotSearchTypePathInResponse + ".rows", hasSize(5))
+                .body(pivotSearchTypePathInResponse + ".total", equalTo(5))
+                .body(pivotSearchTypePathInResponse + ".rows.find{ it.key[0] == '60' }", notNullValue())
+                .body(pivotSearchTypePathInResponse + ".rows.find{ it.key[0] == '40' }", notNullValue())
+                .body(pivotSearchTypePathInResponse + ".rows.find{ it.key[0] == '50' }", notNullValue())
+                .body(pivotSearchTypePathInResponse + ".rows.find{ it.key[0] == '80' }", notNullValue())
+                .body(pivotSearchTypePathInResponse + ".rows.find{ it.key == [] }", notNullValue());
+
+        //Empty bucket is not there - in a fixture all the documents have "age" field
+        validatableResponse.body(pivotSearchTypePathInResponse + ".rows.find{ it.key[0] == " + MISSING_BUCKET_NAME + " }", nullValue());
+
+
+        //Top bucket verification
+        //There are 2 guys of age 60
+        validatableResponse.body(pivotSearchTypePathInResponse + ".rows[0].key", contains("60"));
+        validatableResponse.body(pivotSearchTypePathInResponse + ".rows[0].values[0].key", contains("count()"));
+        validatableResponse.body(pivotSearchTypePathInResponse + ".rows[0].values[0].value", equalTo(2));
+
+    }
+
+    private InputStream fixture(final String filename) {
+        return getClass().getClassLoader().getResourceAsStream(filename);
+    }
+
+}

--- a/full-backend-tests/src/test/resources/org/graylog/plugins/views/aggregations/messages-for-missing-aggregation-check.json
+++ b/full-backend-tests/src/test/resources/org/graylog/plugins/views/aggregations/messages-for-missing-aggregation-check.json
@@ -1,0 +1,127 @@
+{
+  "documents": [
+    {
+      "document": [
+        {
+          "index": {
+            "indexName": "graylog_0",
+            "indexType": "message",
+            "indexId": "0"
+          }
+        },
+        {
+          "data": {
+            "source": "fbi.org",
+            "message": "Personal data added",
+            "timestamp": "2022-01-01 01:00:00.000",
+            "fixtureType": "474877",
+            "firstName": "Joe",
+            "lastName": "Smith",
+            "age": 50,
+            "streams": [
+              "000000000000000000000001"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "document": [
+        {
+          "index": {
+            "indexName": "graylog_0",
+            "indexType": "message",
+            "indexId": "1"
+          }
+        },
+        {
+          "data": {
+            "source": "fbi.org",
+            "message": "Personal data added",
+            "timestamp": "2022-01-01 01:00:00.000",
+            "fixtureType": "474877",
+            "firstName": "Jane",
+            "lastName": "Smith",
+            "age": 40,
+            "streams": [
+              "000000000000000000000001"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "document": [
+        {
+          "index": {
+            "indexName": "graylog_0",
+            "indexType": "message",
+            "indexId": "2"
+          }
+        },
+        {
+          "data": {
+            "source": "fbi.org",
+            "message": "Personal data added",
+            "timestamp": "2022-01-01 01:00:00.000",
+            "fixtureType": "474877",
+            "firstName": "Joe",
+            "lastName": "Biden",
+            "age": 80,
+            "streams": [
+              "000000000000000000000001"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "document": [
+        {
+          "index": {
+            "indexName": "graylog_0",
+            "indexType": "message",
+            "indexId": "3"
+          }
+        },
+        {
+          "data": {
+            "source": "fbi.org",
+            "message": "Personal data added",
+            "timestamp": "2022-01-01 01:00:00.000",
+            "fixtureType": "474877",
+            "lastName": "Cooper",
+            "age": 60,
+            "streams": [
+              "000000000000000000000001"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "document": [
+        {
+          "index": {
+            "indexName": "graylog_0",
+            "indexType": "message",
+            "indexId": "4"
+          }
+        },
+        {
+          "data": {
+            "source": "fbi.org",
+            "message": "Personal data added",
+            "timestamp": "2022-01-01 01:00:00.000",
+            "fixtureType": "474877",
+            "firstName": "Bob",
+            "age": 60,
+            "streams": [
+              "000000000000000000000001"
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/full-backend-tests/src/test/resources/org/graylog/plugins/views/aggregations/search_request_with_aggregation_on_single_field.json
+++ b/full-backend-tests/src/test/resources/org/graylog/plugins/views/aggregations/search_request_with_aggregation_on_single_field.json
@@ -1,0 +1,61 @@
+{
+  "id": "s1",
+  "queries": [
+    {
+      "id": "q1",
+      "timerange": {
+        "type": "relative",
+        "range": 0
+      },
+      "filter": null,
+      "filters": [],
+      "query": {
+        "type": "elasticsearch",
+        "query_string": ""
+      },
+      "search_types": [
+        {
+          "timerange": {
+            "type": "relative",
+            "range": 0
+          },
+          "query": {
+            "type": "elasticsearch",
+            "query_string": "fixtureType:474877"
+          },
+          "streams": [
+            "000000000000000000000001"
+          ],
+          "id": "st1",
+          "name": "chart",
+          "series": [
+            {
+              "type": "count",
+              "id": "count()",
+              "field": null
+            },
+            {
+              "type": "avg",
+              "id": "avg(age)",
+              "field": "age"
+            }
+          ],
+          "sort": [],
+          "rollup": true,
+          "type": "pivot",
+          "row_groups": [
+            {
+              "type": "values",
+              "field": "firstName",
+              "limit": 8
+            }
+          ],
+          "column_groups": [],
+          "filter": null,
+          "filters": []
+        }
+      ]
+    }
+  ],
+  "parameters": []
+}

--- a/full-backend-tests/src/test/resources/org/graylog/plugins/views/aggregations/search_request_with_aggregation_on_two_fields.json
+++ b/full-backend-tests/src/test/resources/org/graylog/plugins/views/aggregations/search_request_with_aggregation_on_two_fields.json
@@ -1,0 +1,66 @@
+{
+  "id": "s1",
+  "queries": [
+    {
+      "id": "q1",
+      "timerange": {
+        "type": "relative",
+        "range": 0
+      },
+      "filter": null,
+      "filters": [],
+      "query": {
+        "type": "elasticsearch",
+        "query_string": ""
+      },
+      "search_types": [
+        {
+          "timerange": {
+            "type": "relative",
+            "range": 0
+          },
+          "query": {
+            "type": "elasticsearch",
+            "query_string": "fixtureType:474877"
+          },
+          "streams": [
+            "000000000000000000000001"
+          ],
+          "id": "st1",
+          "name": "chart",
+          "series": [
+            {
+              "type": "count",
+              "id": "count()",
+              "field": null
+            },
+            {
+              "type": "avg",
+              "id": "avg(age)",
+              "field": "age"
+            }
+          ],
+          "sort": [],
+          "rollup": true,
+          "type": "pivot",
+          "row_groups": [
+            {
+              "type": "values",
+              "field": "firstName",
+              "limit": 8
+            },
+            {
+              "type": "values",
+              "field": "lastName",
+              "limit": 8
+            }
+          ],
+          "column_groups": [],
+          "filter": null,
+          "filters": []
+        }
+      ]
+    }
+  ],
+  "parameters": []
+}

--- a/full-backend-tests/src/test/resources/org/graylog/plugins/views/aggregations/search_request_with_aggregation_that_has_no_missing_buckets.json
+++ b/full-backend-tests/src/test/resources/org/graylog/plugins/views/aggregations/search_request_with_aggregation_that_has_no_missing_buckets.json
@@ -1,0 +1,56 @@
+{
+  "id": "s1",
+  "queries": [
+    {
+      "id": "q1",
+      "timerange": {
+        "type": "relative",
+        "range": 0
+      },
+      "filter": null,
+      "filters": [],
+      "query": {
+        "type": "elasticsearch",
+        "query_string": ""
+      },
+      "search_types": [
+        {
+          "timerange": {
+            "type": "relative",
+            "range": 0
+          },
+          "query": {
+            "type": "elasticsearch",
+            "query_string": "fixtureType:474877"
+          },
+          "streams": [
+            "000000000000000000000001"
+          ],
+          "id": "st1",
+          "name": "chart",
+          "series": [
+            {
+              "type": "count",
+              "id": "count()",
+              "field": null
+            }
+          ],
+          "sort": [],
+          "rollup": true,
+          "type": "pivot",
+          "row_groups": [
+            {
+              "type": "values",
+              "field": "age",
+              "limit": 8
+            }
+          ],
+          "column_groups": [],
+          "filter": null,
+          "filters": []
+        }
+      ]
+    }
+  ],
+  "parameters": []
+}

--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/views/searchtypes/pivot/ESPivot.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/views/searchtypes/pivot/ESPivot.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableList;
 import io.searchbox.core.SearchResult;
 import io.searchbox.core.search.aggregation.Aggregation;
 import io.searchbox.core.search.aggregation.MetricAggregation;
+import io.searchbox.core.search.aggregation.MissingAggregation;
 import one.util.streamex.EntryStream;
 import org.graylog.plugins.views.search.Query;
 import org.graylog.plugins.views.search.SearchJob;
@@ -32,8 +33,10 @@ import org.graylog.plugins.views.search.searchtypes.pivot.PivotSpec;
 import org.graylog.plugins.views.search.searchtypes.pivot.SeriesSpec;
 import org.graylog.shaded.elasticsearch6.org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.graylog.shaded.elasticsearch6.org.elasticsearch.search.aggregations.AggregationBuilders;
+import org.graylog.shaded.elasticsearch6.org.elasticsearch.search.aggregations.bucket.missing.MissingAggregationBuilder;
 import org.graylog.shaded.elasticsearch6.org.elasticsearch.search.aggregations.metrics.max.MaxAggregationBuilder;
 import org.graylog.shaded.elasticsearch6.org.elasticsearch.search.aggregations.metrics.min.MinAggregationBuilder;
+import org.graylog.shaded.elasticsearch6.org.elasticsearch.search.aggregations.support.ValuesSourceAggregationBuilder;
 import org.graylog.shaded.elasticsearch6.org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.graylog.storage.elasticsearch6.views.ESGeneratedQueryContext;
 import org.graylog.storage.elasticsearch6.views.searchtypes.ESSearchTypeHandler;
@@ -50,6 +53,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.Deque;
 import java.util.IdentityHashMap;
 import java.util.Iterator;
@@ -61,6 +65,10 @@ import java.util.stream.Stream;
 
 public class ESPivot implements ESSearchTypeHandler<Pivot> {
     private static final Logger LOG = LoggerFactory.getLogger(ESPivot.class);
+
+    static final String MISSING_AGGREGATION_NAME = "__missing__";
+    static final String MISSING_BUCKET_NAME = "(Empty Value)";
+
     private final Map<String, ESPivotBucketSpecHandler<? extends BucketSpec, ? extends Aggregation>> bucketHandlers;
     private final Map<String, ESPivotSeriesSpecHandler<? extends SeriesSpec, ? extends Aggregation>> seriesHandlers;
     private static final TimeRange ALL_MESSAGES_TIMERANGE = allMessagesTimeRange();
@@ -68,7 +76,7 @@ public class ESPivot implements ESSearchTypeHandler<Pivot> {
     private static TimeRange allMessagesTimeRange() {
         try {
             return RelativeRange.create(0);
-        } catch (InvalidRangeParametersException e){
+        } catch (InvalidRangeParametersException e) {
             LOG.error("Unable to instantiate all messages timerange: ", e);
         }
         return null;
@@ -96,9 +104,9 @@ public class ESPivot implements ESSearchTypeHandler<Pivot> {
                     .forEach(searchSourceBuilder::aggregation);
         }
 
-        final Optional<AggregationBuilder> rootBucketAggregation = doGenerateBucketAggregationsTree(query, pivot, queryContext);
-        if (rootBucketAggregation.isPresent()) {
-            searchSourceBuilder.aggregation(rootBucketAggregation.get());
+        final List<AggregationBuilder> rootBucketAggregations = doGenerateBucketAggregationsTree(query, pivot, queryContext);
+        if (!rootBucketAggregations.isEmpty()) {
+            rootBucketAggregations.forEach(searchSourceBuilder::aggregation);
         } else {
             LOG.debug("No aggregations generated for {}", pivot);
         }
@@ -109,9 +117,9 @@ public class ESPivot implements ESSearchTypeHandler<Pivot> {
         searchSourceBuilder.aggregation(endTimestamp);
     }
 
-    private Optional<AggregationBuilder> doGenerateBucketAggregationsTree(Query query,
-                                                                          Pivot pivot,
-                                                                          ESGeneratedQueryContext queryContext) {
+    private List<AggregationBuilder> doGenerateBucketAggregationsTree(Query query,
+                                                                      Pivot pivot,
+                                                                      ESGeneratedQueryContext queryContext) {
 
         //ordered from low-level to high-level aggregations
         Deque<AggregationBuilder> bucketAggregationChain = new LinkedList<>();
@@ -132,11 +140,30 @@ public class ESPivot implements ESSearchTypeHandler<Pivot> {
             generateSingleBucketAggregation.ifPresent(bucketAggregationChain::addFirst);
         }
 
-        return bucketAggregationChain.stream()
+        final Optional<AggregationBuilder> aggregationBuilder = bucketAggregationChain.stream()
                 .reduce((aggrLower, aggrHigher) -> {
                     aggrHigher.subAggregation(aggrLower);
+                    createMissingAggregation(aggrLower).map(aggrHigher::subAggregation);
                     return aggrHigher;
                 });
+
+        List<AggregationBuilder> result = new ArrayList<>();
+        if (aggregationBuilder.isPresent()) {
+            result.add(aggregationBuilder.get());
+            createMissingAggregation(aggregationBuilder.get()).ifPresent(result::add);
+        }
+        return result;
+    }
+
+    private Optional<MissingAggregationBuilder> createMissingAggregation(final AggregationBuilder aggregation) {
+        if (aggregation instanceof ValuesSourceAggregationBuilder) {
+            final ValuesSourceAggregationBuilder<?, ?> valueSourceAggr = (ValuesSourceAggregationBuilder<?, ?>) aggregation;
+            final MissingAggregationBuilder missingAggregationBuilder = new MissingAggregationBuilder(MISSING_AGGREGATION_NAME, valueSourceAggr.valueType())
+                    .field(valueSourceAggr.field());
+            aggregation.getSubAggregations().forEach(missingAggregationBuilder::subAggregation);
+            return Optional.of(missingAggregationBuilder);
+        }
+        return Optional.empty();
 
     }
 
@@ -283,6 +310,12 @@ public class ESPivot implements ESSearchTypeHandler<Pivot> {
                 processRows(resultBuilder, searchResult, queryContext, pivot, tail(remainingRows), rowKeys, bucket.aggregation());
                 rowKeys.removeLast();
             });
+            final MissingAggregation missingAggregation = aggregation.getMissingAggregation(MISSING_AGGREGATION_NAME);
+            if (missingAggregation != null && missingAggregation.getMissing() > 0) {
+                rowKeys.addLast(MISSING_BUCKET_NAME);
+                processRows(resultBuilder, searchResult, queryContext, pivot, tail(remainingRows), rowKeys, missingAggregation);
+                rowKeys.removeLast();
+            }
             // also add the series for this row key if the client wants rollups
             if (pivot.rollup()) {
                 final PivotResult.Row.Builder rowBuilder = PivotResult.Row.builder().key(ImmutableList.copyOf(rowKeys));

--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/views/searchtypes/pivot/series/ESCountHandler.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/views/searchtypes/pivot/series/ESCountHandler.java
@@ -20,17 +20,18 @@ import io.searchbox.core.SearchResult;
 import io.searchbox.core.search.aggregation.Aggregation;
 import io.searchbox.core.search.aggregation.Bucket;
 import io.searchbox.core.search.aggregation.MetricAggregation;
+import io.searchbox.core.search.aggregation.MissingAggregation;
 import io.searchbox.core.search.aggregation.RootAggregation;
 import io.searchbox.core.search.aggregation.ValueCountAggregation;
+import org.graylog.plugins.views.search.searchtypes.pivot.Pivot;
+import org.graylog.plugins.views.search.searchtypes.pivot.PivotSpec;
+import org.graylog.plugins.views.search.searchtypes.pivot.series.Count;
 import org.graylog.shaded.elasticsearch6.org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.graylog.shaded.elasticsearch6.org.elasticsearch.search.aggregations.AggregationBuilders;
 import org.graylog.shaded.elasticsearch6.org.elasticsearch.search.aggregations.metrics.valuecount.ValueCountAggregationBuilder;
 import org.graylog.storage.elasticsearch6.views.ESGeneratedQueryContext;
 import org.graylog.storage.elasticsearch6.views.searchtypes.pivot.ESPivot;
 import org.graylog.storage.elasticsearch6.views.searchtypes.pivot.ESPivotSeriesSpecHandler;
-import org.graylog.plugins.views.search.searchtypes.pivot.Pivot;
-import org.graylog.plugins.views.search.searchtypes.pivot.PivotSpec;
-import org.graylog.plugins.views.search.searchtypes.pivot.series.Count;
 import org.jooq.lambda.tuple.Tuple2;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -71,6 +72,8 @@ public class ESCountHandler extends ESPivotSeriesSpecHandler<Count, MetricAggreg
             value = searchResult.getTotal();
         } else if (metricAggregation instanceof ValueCountAggregation) {
             value = ((ValueCountAggregation) metricAggregation).getValueCount();
+        } else if (metricAggregation instanceof MissingAggregation) {
+            value = ((MissingAggregation) metricAggregation).getMissing();
         }
         if (value == null) {
             LOG.error("Unexpected aggregation type {}, returning 0 for the count. This is a bug.", metricAggregation);

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/ESPivot.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/ESPivot.java
@@ -366,6 +366,12 @@ public class ESPivot implements ESSearchTypeHandler<Pivot> {
                 processColumns(rowBuilder, searchResult, queryContext, pivot, tail(remainingColumns), columnKeys, bucket.aggregation());
                 columnKeys.removeLast();
             });
+            final Missing missingAggregation = aggregation.getAggregations().get(MissingBucketConstants.MISSING_AGGREGATION_NAME);
+            if (missingAggregation != null && missingAggregation.getDocCount() > 0) {
+                columnKeys.addLast(MissingBucketConstants.MISSING_BUCKET_NAME);
+                processColumns(rowBuilder, searchResult, queryContext, pivot, tail(remainingColumns), columnKeys, missingAggregation);
+                columnKeys.removeLast();
+            }
             // also add the series for the base column key if the client wants rollups, the complete column key is processed in the leaf branch
             // don't add the empty column key rollup, because that's not the correct bucket here, it's being done in the row-leaf code
             if (pivot.rollup() && !columnKeys.isEmpty()) {

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/ESPivot.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/ESPivot.java
@@ -33,10 +33,13 @@ import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.A
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.AggregationBuilders;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.Aggregations;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.HasAggregations;
+import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.bucket.missing.Missing;
+import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.bucket.missing.MissingAggregationBuilder;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.metrics.Max;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.metrics.MaxAggregationBuilder;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.metrics.Min;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.metrics.MinAggregationBuilder;
+import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.support.ValuesSourceAggregationBuilder;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.graylog.storage.elasticsearch7.views.ESGeneratedQueryContext;
 import org.graylog.storage.elasticsearch7.views.searchtypes.ESSearchTypeHandler;
@@ -53,6 +56,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.Deque;
 import java.util.IdentityHashMap;
 import java.util.Iterator;
@@ -64,6 +68,10 @@ import java.util.stream.Stream;
 
 public class ESPivot implements ESSearchTypeHandler<Pivot> {
     private static final Logger LOG = LoggerFactory.getLogger(ESPivot.class);
+
+    static final String MISSING_AGGREGATION_NAME = "__missing__";
+    static final String MISSING_BUCKET_NAME = "(Empty Value)";
+
     private final Map<String, ESPivotBucketSpecHandler<? extends BucketSpec, ? extends Aggregation>> bucketHandlers;
     private final Map<String, ESPivotSeriesSpecHandler<? extends SeriesSpec, ? extends Aggregation>> seriesHandlers;
     private static final TimeRange ALL_MESSAGES_TIMERANGE = allMessagesTimeRange();
@@ -71,7 +79,7 @@ public class ESPivot implements ESSearchTypeHandler<Pivot> {
     private static TimeRange allMessagesTimeRange() {
         try {
             return RelativeRange.create(0);
-        } catch (InvalidRangeParametersException e){
+        } catch (InvalidRangeParametersException e) {
             LOG.error("Unable to instantiate all messages timerange: ", e);
         }
         return null;
@@ -99,9 +107,9 @@ public class ESPivot implements ESSearchTypeHandler<Pivot> {
                     .forEach(searchSourceBuilder::aggregation);
         }
 
-        final Optional<AggregationBuilder> rootBucketAggregation = doGenerateBucketAggregationsTree(query, pivot, queryContext);
-        if (rootBucketAggregation.isPresent()) {
-            searchSourceBuilder.aggregation(rootBucketAggregation.get());
+        final List<AggregationBuilder> rootBucketAggregations = doGenerateBucketAggregationsTree(query, pivot, queryContext);
+        if (!rootBucketAggregations.isEmpty()) {
+            rootBucketAggregations.forEach(searchSourceBuilder::aggregation);
         } else {
             LOG.debug("No aggregations generated for {}", pivot);
         }
@@ -112,9 +120,9 @@ public class ESPivot implements ESSearchTypeHandler<Pivot> {
         searchSourceBuilder.aggregation(endTimestamp);
     }
 
-    private Optional<AggregationBuilder> doGenerateBucketAggregationsTree(Query query,
-                                                                          Pivot pivot,
-                                                                          ESGeneratedQueryContext queryContext) {
+    private List<AggregationBuilder> doGenerateBucketAggregationsTree(Query query,
+                                                                      Pivot pivot,
+                                                                      ESGeneratedQueryContext queryContext) {
 
         //ordered from low-level to high-level aggregations
         Deque<AggregationBuilder> bucketAggregationChain = new LinkedList<>();
@@ -135,12 +143,29 @@ public class ESPivot implements ESSearchTypeHandler<Pivot> {
             generateSingleBucketAggregation.ifPresent(bucketAggregationChain::addFirst);
         }
 
-        return bucketAggregationChain.stream()
+        final Optional<AggregationBuilder> aggregationBuilder = bucketAggregationChain.stream()
                 .reduce((aggrLower, aggrHigher) -> {
                     aggrHigher.subAggregation(aggrLower);
+                    createMissingAggregation(aggrLower).map(aggrHigher::subAggregation);
                     return aggrHigher;
                 });
 
+        List<AggregationBuilder> result = new ArrayList<>();
+        if (aggregationBuilder.isPresent()) {
+            result.add(aggregationBuilder.get());
+            createMissingAggregation(aggregationBuilder.get()).ifPresent(result::add);
+        }
+        return result;
+    }
+
+    private Optional<MissingAggregationBuilder> createMissingAggregation(final AggregationBuilder aggregation) {
+        if (aggregation instanceof ValuesSourceAggregationBuilder) {
+            final MissingAggregationBuilder missingAggregationBuilder = new MissingAggregationBuilder(MISSING_AGGREGATION_NAME)
+                    .field(((ValuesSourceAggregationBuilder<?>) aggregation).field());
+            aggregation.getSubAggregations().forEach(missingAggregationBuilder::subAggregation);
+            return Optional.of(missingAggregationBuilder);
+        }
+        return Optional.empty();
     }
 
     private Optional<AggregationBuilder> doGenerateSingleBucketAggregation(BucketSpec bucketSpec,
@@ -292,6 +317,12 @@ public class ESPivot implements ESSearchTypeHandler<Pivot> {
                 processRows(resultBuilder, searchResult, queryContext, pivot, tail(remainingRows), rowKeys, bucket.aggregation());
                 rowKeys.removeLast();
             });
+            final Missing missingAggregation = aggregation.getAggregations().get(MISSING_AGGREGATION_NAME);
+            if (missingAggregation != null && missingAggregation.getDocCount() > 0) {
+                rowKeys.addLast(MISSING_BUCKET_NAME);
+                processRows(resultBuilder, searchResult, queryContext, pivot, tail(remainingRows), rowKeys, missingAggregation);
+                rowKeys.removeLast();
+            }
             // also add the series for this row key if the client wants rollups
             if (pivot.rollup()) {
                 final PivotResult.Row.Builder rowBuilder = PivotResult.Row.builder().key(ImmutableList.copyOf(rowKeys));

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/aggregations/MissingBucketConstants.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/aggregations/MissingBucketConstants.java
@@ -1,0 +1,23 @@
+package org.graylog.plugins.views.search.aggregations;
+
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+public interface MissingBucketConstants {
+
+    String MISSING_AGGREGATION_NAME = "__missing__";
+    String MISSING_BUCKET_NAME = "(Empty Value)";
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/aggregations/MissingBucketConstants.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/aggregations/MissingBucketConstants.java
@@ -1,5 +1,3 @@
-package org.graylog.plugins.views.search.aggregations;
-
 /*
  * Copyright (C) 2020 Graylog, Inc.
  *
@@ -16,6 +14,9 @@ package org.graylog.plugins.views.search.aggregations;
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
+package org.graylog.plugins.views.search.aggregations;
+
+
 public interface MissingBucketConstants {
 
     String MISSING_AGGREGATION_NAME = "__missing__";

--- a/graylog2-web-interface/src/views/Constants.ts
+++ b/graylog2-web-interface/src/views/Constants.ts
@@ -29,6 +29,7 @@ export const FULL_MESSAGE_FIELD = 'full_message';
 export const TIMESTAMP_FIELD = 'timestamp';
 export const MESSAGE_FIELD = 'message';
 export const SOURCE_FIELD = 'source';
+export const MISSING_BUCKET_NAME = '(Empty Value)';
 
 export const DEFAULT_MESSAGE_FIELDS = [TIMESTAMP_FIELD, SOURCE_FIELD];
 

--- a/graylog2-web-interface/src/views/logic/valueactions/AddToQueryHandler.ts
+++ b/graylog2-web-interface/src/views/logic/valueactions/AddToQueryHandler.ts
@@ -33,7 +33,9 @@ const formatNewQuery = (oldQuery: string, field: string, value: string, type: Fi
   const predicateValue = type.type === 'date'
     ? formatTimestampForES(value)
     : escape(value);
-  const fieldPredicate = `${field}:${predicateValue}`;
+  const fieldPredicate = value === '(Empty Value)'
+    ? `NOT _exists_:${field}`
+    : `${field}:${predicateValue}`;
 
   return addToQuery(oldQuery, fieldPredicate);
 };

--- a/graylog2-web-interface/src/views/logic/valueactions/AddToQueryHandler.ts
+++ b/graylog2-web-interface/src/views/logic/valueactions/AddToQueryHandler.ts
@@ -16,10 +16,11 @@
  */
 import moment from 'moment-timezone';
 
+import { DATE_TIME_FORMATS } from 'util/DateTime';
+import { MISSING_BUCKET_NAME } from 'views/Constants';
 import type FieldType from 'views/logic/fieldtypes/FieldType';
 import { escape, addToQuery } from 'views/logic/queries/QueryHelper';
 import type { ActionHandler } from 'views/components/actions/ActionHandler';
-import { DATE_TIME_FORMATS } from 'util/DateTime';
 
 import QueryManipulationHandler from './QueryManipulationHandler';
 
@@ -33,7 +34,7 @@ const formatNewQuery = (oldQuery: string, field: string, value: string, type: Fi
   const predicateValue = type.type === 'date'
     ? formatTimestampForES(value)
     : escape(value);
-  const fieldPredicate = value === '(Empty Value)'
+  const fieldPredicate = value === MISSING_BUCKET_NAME
     ? `NOT _exists_:${field}`
     : `${field}:${predicateValue}`;
 

--- a/graylog2-web-interface/src/views/logic/valueactions/ExcludeFromQueryHandler.test.ts
+++ b/graylog2-web-interface/src/views/logic/valueactions/ExcludeFromQueryHandler.test.ts
@@ -23,6 +23,7 @@ import { GlobalOverrideActions, GlobalOverrideStore } from 'views/stores/GlobalO
 import { QueriesActions, QueriesStore } from 'views/stores/QueriesStore';
 import SearchActions from 'views/actions/SearchActions';
 import { ViewStore } from 'views/stores/ViewStore';
+import { MISSING_BUCKET_NAME } from 'views/Constants';
 
 import ExcludeFromQueryHandler from './ExcludeFromQueryHandler';
 
@@ -98,6 +99,16 @@ describe('ExcludeFromQueryHandler', () => {
     handler.handle({ queryId: 'queryId', field: 'do', value: 'panic', type: FieldType.Unknown, contexts: {} });
 
     expect(QueriesActions.query).toHaveBeenCalledWith('queryId', 'answer:42 AND NOT do:panic');
+  });
+
+  it('appends _exists_ fragment for proper field in case of missing bucket in input', () => {
+    asMock(QueriesStore.getInitialState).mockReturnValue(mockQueries('queryId', 'answer:42'));
+
+    const handler = new ExcludeFromQueryHandler();
+
+    handler.handle({ queryId: 'queryId', field: 'do', value: MISSING_BUCKET_NAME, type: FieldType.Unknown, contexts: {} });
+
+    expect(QueriesActions.query).toHaveBeenCalledWith('queryId', 'answer:42 AND _exists_:do');
   });
 
   it('escapes special characters in field value', () => {

--- a/graylog2-web-interface/src/views/logic/valueactions/ExcludeFromQueryHandler.ts
+++ b/graylog2-web-interface/src/views/logic/valueactions/ExcludeFromQueryHandler.ts
@@ -21,7 +21,9 @@ import QueryManipulationHandler from './QueryManipulationHandler';
 
 export default class ExcludeFromQueryHandler extends QueryManipulationHandler {
   formatNewQuery = (oldQuery: string, field: string, value: any) => {
-    const fieldPredicate = `NOT ${field}:${escape(value)}`;
+    const fieldPredicate = value === '(Empty Value)'
+      ? `_exists_:${field}`
+      : `NOT ${field}:${escape(value)}`;
 
     return addToQuery(oldQuery, fieldPredicate);
   };

--- a/graylog2-web-interface/src/views/logic/valueactions/ExcludeFromQueryHandler.ts
+++ b/graylog2-web-interface/src/views/logic/valueactions/ExcludeFromQueryHandler.ts
@@ -20,7 +20,7 @@ import type { ActionHandler } from 'views/components/actions/ActionHandler';
 import QueryManipulationHandler from './QueryManipulationHandler';
 
 export default class ExcludeFromQueryHandler extends QueryManipulationHandler {
-  formatNewQuery = (oldQuery: string, field: string, value: any) => {
+  static formatNewQuery = (oldQuery: string, field: string, value: any) => {
     const fieldPredicate = value === '(Empty Value)'
       ? `_exists_:${field}`
       : `NOT ${field}:${escape(value)}`;
@@ -30,7 +30,7 @@ export default class ExcludeFromQueryHandler extends QueryManipulationHandler {
 
   handle: ActionHandler<{}> = ({ queryId, field, value }) => {
     const oldQuery = this.currentQueryString(queryId);
-    const newQuery = this.formatNewQuery(oldQuery, field, value);
+    const newQuery = ExcludeFromQueryHandler.formatNewQuery(oldQuery, field, value);
 
     return this.updateQueryString(queryId, newQuery);
   };

--- a/graylog2-web-interface/src/views/logic/valueactions/ExcludeFromQueryHandler.ts
+++ b/graylog2-web-interface/src/views/logic/valueactions/ExcludeFromQueryHandler.ts
@@ -16,12 +16,13 @@
  */
 import { escape, addToQuery } from 'views/logic/queries/QueryHelper';
 import type { ActionHandler } from 'views/components/actions/ActionHandler';
+import { MISSING_BUCKET_NAME } from 'views/Constants';
 
 import QueryManipulationHandler from './QueryManipulationHandler';
 
 export default class ExcludeFromQueryHandler extends QueryManipulationHandler {
   static formatNewQuery = (oldQuery: string, field: string, value: any) => {
-    const fieldPredicate = value === '(Empty Value)'
+    const fieldPredicate = value === MISSING_BUCKET_NAME
       ? `_exists_:${field}`
       : `NOT ${field}:${escape(value)}`;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Missing values in pivot via missing aggregation have been implemented.
The screenshots show some main examples of the changes it is bringing to the UI.
"(Empty value)" string has been used to represent missing bucket, it can be of course changed if needed.

Some minor changes to the front-end have been implemented in order to support "Add to query" and "Exclude from results" functionality properly, but it is possible that more FE work will still be needed.

Is one of the tasks from this issue : #12611

## Motivation and Context
Currently, our users are not aware of how many documents miss values for certain field, cannot figure out metrics of those documents easily etc.

## How Has This Been Tested?
Integration tests have been added.
It has been tested manually, mainly on dashboards, with different aggregation types.

## Screenshots (if appropriate):
How "top values" are changed:
![Screenshot 2022-06-29 at 12-43-44 Graylog - Unsaved Search](https://user-images.githubusercontent.com/100699120/176419028-a3c4e544-48bc-4c47-808e-6fa9d1b8ed8d.png)

How pivot table and different charts are changed:
![Screenshot 2022-06-29 at 12-45-20 Graylog - War dashboard](https://user-images.githubusercontent.com/100699120/176419047-2c2c28d2-cad1-475b-8ea5-2d14139bd465.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

