### PR TITLE
Correct behavior when _cat/nodes API from the search engine returns n…

### DIFF
--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/ClusterAdapterES6.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/ClusterAdapterES6.java
@@ -92,8 +92,21 @@ public class ClusterAdapterES6 implements ClusterAdapter {
                 final String host = jsonElement.path("host").asText(null);
                 final String ip = jsonElement.path("ip").asText();
                 final JsonNode fileDescriptorMax = jsonElement.path("fileDescriptorMax");
-                final Long maxFileDescriptors = fileDescriptorMax.isLong() ? fileDescriptorMax.asLong() : null;
-                setBuilder.add(NodeFileDescriptorStats.create(name, ip, host, maxFileDescriptors));
+                if (!fileDescriptorMax.isLong()) {
+                    try {
+                        //try parsing the String, it may represent a Long value
+                        setBuilder.add(NodeFileDescriptorStats.create(name, ip, host, Long.parseLong(fileDescriptorMax.asText())));
+                    } catch (NumberFormatException e) {
+                        StringBuilder sb = new StringBuilder("{");
+                        sb.append("name = ").append(name);
+                        sb.append(", host = ").append(host);
+                        sb.append(", ip = ").append(ip);
+                        sb.append("}");
+                        LOG.info("_cat/nodes API has returned a node without disk statistics: " + sb);
+                    }
+                } else {
+                    setBuilder.add(NodeFileDescriptorStats.create(name, ip, host, fileDescriptorMax.asLong()));
+                }
             }
         }
 
@@ -106,17 +119,29 @@ public class ClusterAdapterES6 implements ClusterAdapter {
         final ImmutableSet.Builder<NodeDiskUsageStats> setBuilder = ImmutableSet.builder();
         for (JsonNode jsonElement : nodes) {
             if (jsonElement.isObject()) {
-                setBuilder.add(
-                        NodeDiskUsageStats.create(
-                                jsonElement.path("name").asText(),
-                                jsonElement.path("role").asText(),
-                                jsonElement.path("ip").asText(),
-                                jsonElement.path("host").asText(null),
-                                jsonElement.path("diskUsed").asText(),
-                                jsonElement.path("diskTotal").asText(),
-                                jsonElement.path("diskUsedPercent").asDouble(NodeDiskUsageStats.DEFAULT_DISK_USED_PERCENT)
-                        )
-                );
+                final JsonNode diskUsed = jsonElement.path("diskUsed");
+                final JsonNode diskTotal = jsonElement.path("diskTotal");
+                if (!diskTotal.isMissingNode() && !diskUsed.isMissingNode()) {
+                    setBuilder.add(
+                            NodeDiskUsageStats.create(
+                                    jsonElement.path("name").asText(),
+                                    jsonElement.path("role").asText(),
+                                    jsonElement.path("ip").asText(),
+                                    jsonElement.path("host").asText(null),
+                                    diskUsed.asText(),
+                                    diskTotal.asText(),
+                                    jsonElement.path("diskUsedPercent").asDouble(NodeDiskUsageStats.DEFAULT_DISK_USED_PERCENT)
+                            )
+                    );
+                } else {
+                    StringBuilder sb = new StringBuilder("{");
+                    sb.append("name = ").append(jsonElement.path("name").asText());
+                    sb.append(", host = ").append(jsonElement.path("host").asText(null));
+                    sb.append(", ip = ").append(jsonElement.path("ip").asText());
+                    sb.append(", role = ").append(jsonElement.path("role").asText());
+                    sb.append("}");
+                    LOG.info("_cat/nodes API has returned a node without disk statistics: " + sb);
+                }
             }
         }
         return setBuilder.build();

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/ClusterAdapterES7.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/ClusterAdapterES7.java
@@ -104,7 +104,14 @@ public class ClusterAdapterES7 implements ClusterAdapter {
     }
 
     private List<NodeResponse> nodes() {
-        return catApi.nodes();
+        final List<NodeResponse> allNodes = catApi.nodes();
+        final List<NodeResponse> nodesWithDiskStatistics = allNodes.stream().filter(NodeResponse::hasDiskStatistics).collect(Collectors.toList());
+        if (allNodes.size() != nodesWithDiskStatistics.size()) {
+            final List<NodeResponse> nodesWithMissingDiskStatistics = allNodes.stream().filter(nr -> !nr.hasDiskStatistics()).collect(Collectors.toList());
+            LOG.info("_cat/nodes API has returned " + nodesWithMissingDiskStatistics.size() + " nodes without disk statistics:");
+            nodesWithMissingDiskStatistics.forEach(node -> LOG.info(node.toString()));
+        }
+        return nodesWithDiskStatistics;
     }
 
     @Override

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/cat/NodeResponse.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/cat/NodeResponse.java
@@ -18,6 +18,7 @@ package org.graylog.storage.elasticsearch7.cat;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 
@@ -37,12 +38,16 @@ public abstract class NodeResponse {
 
     public abstract String ip();
 
+    @Nullable
     public abstract String diskUsed();
 
+    @Nullable
     public abstract String diskTotal();
 
+    @Nullable
     public abstract Double diskUsedPercent();
 
+    @Nullable
     public abstract Long fileDescriptorMax();
 
     @JsonCreator
@@ -51,10 +56,10 @@ public abstract class NodeResponse {
                                       @JsonProperty("role") String role,
                                       @JsonProperty("host") @Nullable String host,
                                       @JsonProperty("ip") String ip,
-                                      @JsonProperty("diskUsed") String diskUsed,
-                                      @JsonProperty("diskTotal") String diskTotal,
-                                      @JsonProperty("diskUsedPercent") Double diskUsedPercent,
-                                      @JsonProperty("fileDescriptorMax") Long fileDescriptorMax) {
+                                      @JsonProperty("diskUsed") @Nullable String diskUsed,
+                                      @JsonProperty("diskTotal") @Nullable String diskTotal,
+                                      @JsonProperty("diskUsedPercent") @Nullable Double diskUsedPercent,
+                                      @JsonProperty("fileDescriptorMax") @Nullable Long fileDescriptorMax) {
         return new AutoValue_NodeResponse(
                 id,
                 name,
@@ -66,5 +71,13 @@ public abstract class NodeResponse {
                 diskUsedPercent,
                 fileDescriptorMax
         );
+    }
+
+    @JsonIgnore
+    public boolean hasDiskStatistics() {
+        return diskUsed() != null &&
+                diskTotal() != null &&
+                diskUsedPercent() != null &&
+                fileDescriptorMax() != null;
     }
 }

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/cat/CatApiTest.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/cat/CatApiTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.storage.elasticsearch7.cat;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.graylog.storage.elasticsearch7.ElasticsearchClient;
+import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class CatApiTest {
+
+    private final static String SAMPLE_CAT_NODES_RESPONSE = "[" +
+            "{" +
+            "\"id\":\"nodeWithCorrectInfo\"," +
+            "\"name\":\"nodeWithCorrectInfo\"," +
+            "\"role\":\"dimr\"," +
+            "\"ip\":\"182.88.0.2\"," +
+            "\"fileDescriptorMax\":\"1048576\"," +
+            "\"diskUsed\":\"45gb\"," +
+            "\"diskTotal\":\"411.5gb\"," +
+            "\"diskUsedPercent\":\"10.95\"" +
+            "}," +
+            "{" +
+            "\"id\":\"nodeWithMissingDiskStatistics\"," +
+            "\"name\":\"nodeWithMissingDiskStatistics\"," +
+            "\"role\":\"dimr\"," +
+            "\"ip\":\"182.88.0.1\"" +
+            "}" +
+            "]";
+
+    @Test
+    void testNodesMethodParsesAndReturnsEvenNodesThatMissDiskUsageInfo() throws Exception {
+        final ObjectMapper objectMapper = new ObjectMapperProvider().get();
+        final ElasticsearchClient client = mock(ElasticsearchClient.class);
+        final CatApi toTest = new CatApi(objectMapper, client);
+
+        when(client.execute(any(), anyString()))
+                .thenReturn(objectMapper.readValue(SAMPLE_CAT_NODES_RESPONSE, new TypeReference<List<NodeResponse>>() {}));
+
+        final List<NodeResponse> nodes = toTest.nodes();
+
+        assertThat(nodes)
+                .hasSize(2)
+                .contains(NodeResponse.create("nodeWithCorrectInfo",
+                        "nodeWithCorrectInfo",
+                        "dimr",
+                        null,
+                        "182.88.0.2",
+                        "45gb",
+                        "411.5gb",
+                        10.95d,
+                        1048576L))
+                .contains(NodeResponse.create("nodeWithMissingDiskStatistics",
+                        "nodeWithMissingDiskStatistics",
+                        "dimr",
+                        null,
+                        "182.88.0.1",
+                        null,
+                        null,
+                        null,
+                        null));
+    }
+}


### PR DESCRIPTION
…odes without disk/file statistics present.

## Description
Backporting commit ab06fd3 into 4.3 branch in order to fix #12858.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

