### PR TITLE
Replace remaining usage of legacy `DateTime` class with new `DateTime` utils and `UserDateTimeContext`

### DIFF
--- a/graylog2-web-interface/src/components/common/DatePicker.tsx
+++ b/graylog2-web-interface/src/components/common/DatePicker.tsx
@@ -20,9 +20,8 @@ import type { DayModifiers } from 'react-day-picker';
 import DayPicker from 'react-day-picker';
 import styled, { css } from 'styled-components';
 
-import DateTime from 'logic/datetimes/DateTime';
-
 import 'react-day-picker/lib/style.css';
+import { toDateObject, adjustFormat } from 'util/DateTime';
 
 const StyledDayPicker = styled(DayPicker)(({ theme }) => css`
   width: 100%;
@@ -71,7 +70,7 @@ const DatePicker = ({ date, fromDate, onChange, showOutsideDays }: Props) => {
 
   if (date) {
     try {
-      selectedDate = DateTime.parseFromString(date);
+      selectedDate = toDateObject(date);
     } catch (e) {
       // don't do anything
     }
@@ -83,9 +82,9 @@ const DatePicker = ({ date, fromDate, onChange, showOutsideDays }: Props) => {
         return false;
       }
 
-      const dateTime = DateTime.ignoreTZ(moddedDate);
+      const dateTime = toDateObject(adjustFormat(moddedDate, 'complete'));
 
-      return (selectedDate.toString(DateTime.Formats.DATE) === dateTime.toString(DateTime.Formats.DATE));
+      return (adjustFormat(selectedDate, 'date') === adjustFormat(dateTime, 'date'));
     },
     disabled: {
       before: new Date(fromDate),

--- a/graylog2-web-interface/src/components/common/Timestamp.test.tsx
+++ b/graylog2-web-interface/src/components/common/Timestamp.test.tsx
@@ -29,7 +29,7 @@ describe('Timestamp', () => {
   it('should render date time', () => {
     render(<Timestamp dateTime="2020-01-01T10:00:00.000Z" />);
 
-    expect(screen.getByText('2020-01-01 10:00:00')).toBeInTheDocument();
+    expect(screen.getByText('2020-01-01 11:00:00')).toBeInTheDocument();
   });
 
   it('should render date time based on defined time zone', () => {
@@ -47,18 +47,18 @@ describe('Timestamp', () => {
   it('should display current time, when date time is not defined', () => {
     render(<Timestamp />);
 
-    expect(screen.getByText('2020-01-01 00:00:00')).toBeInTheDocument();
+    expect(screen.getByText('2020-01-01 01:00:00')).toBeInTheDocument();
   });
 
   it('should display current time, when date time is undefined', () => {
     render(<Timestamp dateTime={undefined} />);
 
-    expect(screen.getByText('2020-01-01 00:00:00')).toBeInTheDocument();
+    expect(screen.getByText('2020-01-01 01:00:00')).toBeInTheDocument();
   });
 
   it('should display current time, when date time is null', () => {
     render(<Timestamp dateTime={null} />);
 
-    expect(screen.getByText('2020-01-01 00:00:00')).toBeInTheDocument();
+    expect(screen.getByText('2020-01-01 01:00:00')).toBeInTheDocument();
   });
 });

--- a/graylog2-web-interface/src/components/common/Timestamp.test.tsx
+++ b/graylog2-web-interface/src/components/common/Timestamp.test.tsx
@@ -19,8 +19,6 @@ import { render, screen } from 'wrappedTestingLibrary';
 
 import Timestamp from './Timestamp';
 
-jest.mock('hooks/useUserDateTime');
-
 const mockedUnixTime = 1577836800000; // 2020-01-01 00:00:00.000
 
 jest.useFakeTimers()

--- a/graylog2-web-interface/src/components/content-packs/ContentPackInstallView.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackInstallView.jsx
@@ -19,7 +19,6 @@ import React from 'react';
 
 import { Timestamp } from 'components/common';
 import { Row, Col } from 'components/bootstrap';
-import DateTime from 'logic/datetimes/DateTime';
 
 import 'components/content-packs/ContentPackDetails.css';
 import ContentPackInstallEntityList from './ContentPackInstallEntityList';

--- a/graylog2-web-interface/src/components/events/events/Events.jsx
+++ b/graylog2-web-interface/src/components/events/events/Events.jsx
@@ -23,7 +23,6 @@ import { Link, LinkContainer } from 'components/common/router';
 import { OverlayTrigger, EmptyEntity, IfPermitted, PaginatedList, Timestamp, Icon } from 'components/common';
 import { Alert, Col, Label, Row, Table, Tooltip, Button } from 'components/bootstrap';
 import Routes from 'routing/Routes';
-import DateTime from 'logic/datetimes/DateTime';
 import EventDefinitionPriorityEnum from 'logic/alerts/EventDefinitionPriorityEnum';
 import { isPermitted } from 'util/PermissionsMixin';
 

--- a/graylog2-web-interface/src/components/nodes/SystemInformation.jsx
+++ b/graylog2-web-interface/src/components/nodes/SystemInformation.jsx
@@ -20,7 +20,6 @@ import moment from 'moment';
 import styled from 'styled-components';
 
 import { Timestamp } from 'components/common';
-import DateTime from 'logic/datetimes/DateTime';
 
 const _getInitialState = () => {
   return { time: moment() };

--- a/graylog2-web-interface/src/components/sidecars/common/StatusIndicator.jsx
+++ b/graylog2-web-interface/src/components/sidecars/common/StatusIndicator.jsx
@@ -25,70 +25,68 @@ import DateTime from 'logic/datetimes/DateTime';
 
 import style from './StatusIndicator.css';
 
-class StatusIndicator extends React.Component {
-  static propTypes = {
-    id: PropTypes.string,
-    lastSeen: PropTypes.string,
-    message: PropTypes.string,
-    status: PropTypes.number,
-  };
+const StatusIndicator = ({ message: messageProp, status, lastSeen, id }) => {
+  let message = messageProp;
+  const text = lodash.upperFirst(SidecarStatusEnum.toString(status));
+  const lastSeenDateTime = new DateTime(lastSeen);
 
-  static defaultProps = {
-    id: '',
-    lastSeen: undefined,
-    message: '',
-    status: -1,
-  };
+  let icon;
+  let className;
 
-  render() {
-    const text = lodash.upperFirst(SidecarStatusEnum.toString(this.props.status));
-    const lastSeenDateTime = new DateTime(this.props.lastSeen);
+  switch (status) {
+    case SidecarStatusEnum.RUNNING:
+      className = 'text-success';
+      icon = 'play';
+      break;
+    case SidecarStatusEnum.FAILING:
+      className = 'text-danger';
+      icon = 'exclamation-triangle';
+      break;
+    case SidecarStatusEnum.STOPPED:
+      className = 'text-danger';
+      icon = 'stop';
+      break;
+    default:
+      className = 'text-info';
+      icon = 'question-circle';
+      message += ` (${lastSeenDateTime.toRelativeString()})`;
+  }
 
-    let icon;
-    let className;
-    let { message } = this.props;
-
-    switch (this.props.status) {
-      case SidecarStatusEnum.RUNNING:
-        className = 'text-success';
-        icon = 'play';
-        break;
-      case SidecarStatusEnum.FAILING:
-        className = 'text-danger';
-        icon = 'exclamation-triangle';
-        break;
-      case SidecarStatusEnum.STOPPED:
-        className = 'text-danger';
-        icon = 'stop';
-        break;
-      default:
-        className = 'text-info';
-        icon = 'question-circle';
-        message += ` (${lastSeenDateTime.toRelativeString()})`;
-    }
-
-    if (this.props.message && this.props.id) {
-      const popover = (
-        <Popover id={`${this.props.id}-status-tooltip`}>
-          {message}
-        </Popover>
-      );
-
-      return (
-        <OverlayTrigger placement="top" overlay={popover} rootClose trigger="hover">
-          <span className={`${className} ${style.indicator}`}>
-            <Icon name={icon} fixedWidth /> {text}
-          </span>
-        </OverlayTrigger>
-      );
-    }
+  if (message && id) {
+    const popover = (
+      <Popover id={`${id}-status-tooltip`}>
+        {message}
+      </Popover>
+    );
 
     return (
-      <span className={`${className} ${style.indicator}`}>
-        <Icon name={icon} fixedWidth /> {text}
-      </span>
+      <OverlayTrigger placement="top" overlay={popover} rootClose trigger="hover">
+        <span className={`${className} ${style.indicator}`}>
+          <Icon name={icon} fixedWidth /> {text}
+        </span>
+      </OverlayTrigger>
     );
   }
-}
+
+  return (
+    <span className={`${className} ${style.indicator}`}>
+      <Icon name={icon} fixedWidth /> {text}
+    </span>
+  );
+};
+
+StatusIndicator.propTypes = {
+  id: PropTypes.string,
+  lastSeen: PropTypes.string,
+  message: PropTypes.string,
+  status: PropTypes.number,
+};
+
+StatusIndicator.defaultProps = {
+  id: '',
+  lastSeen: undefined,
+  message: '',
+  status: -1,
+};
 
 export default StatusIndicator;

--- a/graylog2-web-interface/src/components/sidecars/common/StatusIndicator.tsx
+++ b/graylog2-web-interface/src/components/sidecars/common/StatusIndicator.tsx
@@ -14,15 +14,15 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import React, { useContext } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import lodash from 'lodash';
 
 import { Popover } from 'components/bootstrap';
 import { OverlayTrigger, Icon } from 'components/common';
 import SidecarStatusEnum from 'logic/sidecar/SidecarStatusEnum';
-import UserDateTimeContext from 'contexts/UserDateTimeContext';
 import { relativeDifference } from 'util/DateTime';
+import useUserDateTime from 'hooks/useUserDateTime';
 
 import style from './StatusIndicator.css';
 
@@ -34,7 +34,7 @@ type Props = {
 }
 
 const StatusIndicator = ({ message: messageProp, status, lastSeen, id }: Props) => {
-  const { toUserTimezone } = useContext(UserDateTimeContext);
+  const { toUserTimezone } = useUserDateTime();
   let message = messageProp;
   const text = lodash.upperFirst(SidecarStatusEnum.toString(status));
   const lastSeenDateTime = toUserTimezone(lastSeen);

--- a/graylog2-web-interface/src/components/sidecars/common/StatusIndicator.tsx
+++ b/graylog2-web-interface/src/components/sidecars/common/StatusIndicator.tsx
@@ -25,7 +25,14 @@ import DateTime from 'logic/datetimes/DateTime';
 
 import style from './StatusIndicator.css';
 
-const StatusIndicator = ({ message: messageProp, status, lastSeen, id }) => {
+type Props = {
+  message: string,
+  status: number,
+  lastSeen: string,
+  id: string,
+}
+
+const StatusIndicator = ({ message: messageProp, status, lastSeen, id }: Props) => {
   let message = messageProp;
   const text = lodash.upperFirst(SidecarStatusEnum.toString(status));
   const lastSeenDateTime = new DateTime(lastSeen);

--- a/graylog2-web-interface/src/components/sidecars/common/StatusIndicator.tsx
+++ b/graylog2-web-interface/src/components/sidecars/common/StatusIndicator.tsx
@@ -14,14 +14,15 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import React from 'react';
+import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import lodash from 'lodash';
 
 import { Popover } from 'components/bootstrap';
 import { OverlayTrigger, Icon } from 'components/common';
 import SidecarStatusEnum from 'logic/sidecar/SidecarStatusEnum';
-import DateTime from 'logic/datetimes/DateTime';
+import UserDateTimeContext from 'contexts/UserDateTimeContext';
+import { relativeDifference } from 'util/DateTime';
 
 import style from './StatusIndicator.css';
 
@@ -33,9 +34,10 @@ type Props = {
 }
 
 const StatusIndicator = ({ message: messageProp, status, lastSeen, id }: Props) => {
+  const { toUserTimezone } = useContext(UserDateTimeContext);
   let message = messageProp;
   const text = lodash.upperFirst(SidecarStatusEnum.toString(status));
-  const lastSeenDateTime = new DateTime(lastSeen);
+  const lastSeenDateTime = toUserTimezone(lastSeen);
 
   let icon;
   let className;
@@ -56,7 +58,7 @@ const StatusIndicator = ({ message: messageProp, status, lastSeen, id }: Props) 
     default:
       className = 'text-info';
       icon = 'question-circle';
-      message += ` (${lastSeenDateTime.toRelativeString()})`;
+      message += ` (${relativeDifference(lastSeenDateTime)})`;
   }
 
   if (message && id) {

--- a/graylog2-web-interface/src/components/times/TimesList.jsx
+++ b/graylog2-web-interface/src/components/times/TimesList.jsx
@@ -21,7 +21,6 @@ import moment from 'moment';
 
 import { Col, Row } from 'components/bootstrap';
 import { Spinner, Timestamp, BrowserTime } from 'components/common';
-import DateTime from 'logic/datetimes/DateTime';
 import { CurrentUserStore } from 'stores/users/CurrentUserStore';
 import { SystemStore } from 'stores/system/SystemStore';
 

--- a/graylog2-web-interface/src/hooks/__mocks__/useUserDateTime.ts
+++ b/graylog2-web-interface/src/hooks/__mocks__/useUserDateTime.ts
@@ -17,13 +17,15 @@
 
 import type { DateTime } from 'util/DateTime';
 import { adjustFormat, toDateObject } from 'util/DateTime';
+import type { UserDateTimeContextType } from 'contexts/UserDateTimeContext';
 
-const userTimeZone = 'UTC';
-
-const useUserDateTimeMock = () => ({
+const userTimezone = 'UTC';
+const userDateTimeContextValue: UserDateTimeContextType = {
   formatTime: (dateTime: DateTime) => adjustFormat(dateTime),
-  toUserTime: (dateTime: DateTime) => toDateObject(dateTime, undefined, userTimeZone),
-  userTimeZone,
-});
+  toUserTimezone: (dateTime: DateTime) => toDateObject(dateTime, undefined, userTimezone),
+  userTimezone,
+};
+
+const useUserDateTimeMock = () => userDateTimeContextValue;
 
 export default useUserDateTimeMock;

--- a/graylog2-web-interface/src/hooks/__mocks__/useUserDateTime.ts
+++ b/graylog2-web-interface/src/hooks/__mocks__/useUserDateTime.ts
@@ -19,7 +19,7 @@ import type { DateTime } from 'util/DateTime';
 import { adjustFormat, toDateObject } from 'util/DateTime';
 import type { UserDateTimeContextType } from 'contexts/UserDateTimeContext';
 
-const userTimezone = 'UTC';
+const userTimezone = 'Europe/Berlin';
 const userDateTimeContextValue: UserDateTimeContextType = {
   formatTime: (dateTime: DateTime) => adjustFormat(dateTime),
   toUserTimezone: (dateTime: DateTime) => toDateObject(dateTime, undefined, userTimezone),

--- a/graylog2-web-interface/src/logic/datetimes/DateTime.ts
+++ b/graylog2-web-interface/src/logic/datetimes/DateTime.ts
@@ -19,6 +19,11 @@ import moment from 'moment-timezone';
 import AppConfig from 'util/AppConfig';
 import { CurrentUserStore } from 'stores/users/CurrentUserStore';
 
+// PLEASE NOTE: This is legacy code and should no longer be used. Instead, please use `utils/DateTime` and `contexts/UserDateTimeContext` and `components/common/Timestamp`.
+// - `utils/DateTime` if you just need to transform a date
+// - `contexts/UserDateTimeContext` whenever you need a date, based on the user timezone
+// - `components/common/Timestamp` whenever you want to display a date based on the user timezone
+
 class DateTime {
   private dateTime: moment.Moment | undefined;
 

--- a/graylog2-web-interface/src/pages/IndexSetCreationPage.tsx
+++ b/graylog2-web-interface/src/pages/IndexSetCreationPage.tsx
@@ -22,7 +22,6 @@ import { Row, Col, Button } from 'components/bootstrap';
 import { DocumentTitle, PageHeader, Spinner } from 'components/common';
 import { IndexSetConfigurationForm } from 'components/indices';
 import { DocumentationLink } from 'components/support';
-import DateTime from 'logic/datetimes/DateTime';
 import history from 'util/History';
 import DocsHelper from 'util/DocsHelper';
 import Routes from 'routing/Routes';
@@ -32,6 +31,7 @@ import type { IndexSet } from 'stores/indices/IndexSetsStore';
 import { IndicesConfigurationActions, IndicesConfigurationStore } from 'stores/indices/IndicesConfigurationStore';
 import { RetentionStrategyPropType, RotationStrategyPropType } from 'components/indices/Types';
 import type { RetentionStrategy, RotationStrategy, RetentionStrategyContext } from 'components/indices/Types';
+import { adjustFormat } from 'util/DateTime';
 
 type Props = {
   indexSet: Partial<IndexSet> | null | undefined,
@@ -49,7 +49,7 @@ const IndexSetCreationPage = ({ retentionStrategies, rotationStrategies, retenti
   const _saveConfiguration = (indexSetItem: IndexSet) => {
     const copy = indexSetItem;
 
-    copy.creation_date = DateTime.now().toISOString();
+    copy.creation_date = adjustFormat(new Date(), 'internal');
 
     IndexSetsActions.create(copy).then(() => {
       history.push(Routes.SYSTEM.INDICES.LIST);

--- a/graylog2-web-interface/src/pages/ProcessBufferDumpPage.jsx
+++ b/graylog2-web-interface/src/pages/ProcessBufferDumpPage.jsx
@@ -20,8 +20,7 @@ import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 
 import { Row, Col } from 'components/bootstrap';
-import { DocumentTitle, PageHeader, Spinner } from 'components/common';
-import DateTime from 'logic/datetimes/DateTime';
+import { DocumentTitle, PageHeader, Spinner, Timestamp } from 'components/common';
 import withParams from 'routing/withParams';
 import { ClusterOverviewStore } from 'stores/cluster/ClusterOverviewStore';
 import { CurrentUserStore } from 'stores/users/CurrentUserStore';
@@ -62,7 +61,7 @@ const ProcessBufferDumpPage = createReactClass({
       <span>
         Process-buffer dump of node {node.short_node_id} / {node.hostname}
         &nbsp;
-        <small>Taken at {DateTime.now().toString(DateTime.Formats.COMPLETE)}</small>
+        <small>Taken at <Timestamp dateTime={new Date()} /> </small>
       </span>
     );
 

--- a/graylog2-web-interface/src/pages/ThreadDumpPage.jsx
+++ b/graylog2-web-interface/src/pages/ThreadDumpPage.jsx
@@ -20,8 +20,7 @@ import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 
 import { Row, Col } from 'components/bootstrap';
-import { DocumentTitle, PageHeader, Spinner } from 'components/common';
-import DateTime from 'logic/datetimes/DateTime';
+import { DocumentTitle, PageHeader, Spinner, Timestamp } from 'components/common';
 import withParams from 'routing/withParams';
 import { ClusterOverviewStore } from 'stores/cluster/ClusterOverviewStore';
 import { CurrentUserStore } from 'stores/users/CurrentUserStore';
@@ -57,7 +56,7 @@ const ThreadDumpPage = createReactClass({
       <span>
         Thread dump of node {this.state.node.short_node_id} / {this.state.node.hostname}
         &nbsp;
-        <small>Taken at {DateTime.now().toString(DateTime.Formats.COMPLETE)}</small>
+        <small>Taken at <Timestamp dateTime={new Date()} /></small>
       </span>
     );
 

--- a/graylog2-web-interface/src/stores/tools/ToolsStore.ts
+++ b/graylog2-web-interface/src/stores/tools/ToolsStore.ts
@@ -20,7 +20,6 @@ import fetch from 'logic/rest/FetchProvider';
 import ApiRoutes from 'routing/ApiRoutes';
 import { qualifyUrl } from 'util/URLUtils';
 import UserNotification from 'util/UserNotification';
-import DateTime from 'logic/datetimes/DateTime';
 
 type NaturalDateResponse = {
   from: string,
@@ -29,9 +28,8 @@ type NaturalDateResponse = {
 };
 
 const ToolsStore = {
-  testNaturalDate(keyword: string): Promise<NaturalDateResponse> {
-    const timezone = DateTime.getUserTimezone();
-    const { url } = ApiRoutes.ToolsApiController.naturalDateTest(encodeURIComponent(keyword), encodeURIComponent(timezone));
+  testNaturalDate(keyword: string, userTimezone: string): Promise<NaturalDateResponse> {
+    const { url } = ApiRoutes.ToolsApiController.naturalDateTest(encodeURIComponent(keyword), encodeURIComponent(userTimezone));
     const promise = fetch('GET', qualifyUrl(url));
 
     promise.catch((errorThrown) => {

--- a/graylog2-web-interface/src/views/components/DashboardSearchBar.pluggableControls.test.tsx
+++ b/graylog2-web-interface/src/views/components/DashboardSearchBar.pluggableControls.test.tsx
@@ -151,6 +151,6 @@ describe('DashboardSearchBar pluggable controls', () => {
       customKey: 'Initial Value',
       queryString: '',
       timeRange: undefined,
-    }, 'UTC'));
+    }, 'Europe/Berlin'));
   });
 });

--- a/graylog2-web-interface/src/views/components/DashboardSearchBar.pluggableControls.test.tsx
+++ b/graylog2-web-interface/src/views/components/DashboardSearchBar.pluggableControls.test.tsx
@@ -33,7 +33,6 @@ import DashboardSearchBar from './DashboardSearchBar';
 const testTimeout = applyTimeoutMultiplier(30000);
 
 jest.mock('views/components/ViewActionsMenu', () => () => <span>View Actions</span>);
-jest.mock('hooks/useUserDateTime');
 jest.mock('views/logic/debounceWithPromise', () => (fn: any) => fn);
 
 jest.mock('views/stores/GlobalOverrideStore', () => ({

--- a/graylog2-web-interface/src/views/components/DashboardSearchBar.pluggableControls.test.tsx
+++ b/graylog2-web-interface/src/views/components/DashboardSearchBar.pluggableControls.test.tsx
@@ -152,6 +152,6 @@ describe('DashboardSearchBar pluggable controls', () => {
       customKey: 'Initial Value',
       queryString: '',
       timeRange: undefined,
-    }, 'Europe/Berlin'));
+    }, 'UTC'));
   });
 });

--- a/graylog2-web-interface/src/views/components/DashboardSearchBar.pluggableControls.test.tsx
+++ b/graylog2-web-interface/src/views/components/DashboardSearchBar.pluggableControls.test.tsx
@@ -152,6 +152,6 @@ describe('DashboardSearchBar pluggable controls', () => {
       customKey: 'Initial Value',
       queryString: '',
       timeRange: undefined,
-    }));
+    }, 'Europe/Berlin'));
   });
 });

--- a/graylog2-web-interface/src/views/components/DashboardSearchBar.test.tsx
+++ b/graylog2-web-interface/src/views/components/DashboardSearchBar.test.tsx
@@ -30,7 +30,6 @@ import DashboardSearchBar from './DashboardSearchBar';
 
 jest.mock('views/components/searchbar/queryinput/QueryInput', () => ({ value = '' }: { value: string }) => <span>{value}</span>);
 jest.mock('views/components/ViewActionsMenu', () => () => <span>View Actions</span>);
-jest.mock('hooks/useUserDateTime');
 
 jest.mock('views/stores/GlobalOverrideStore', () => ({
   GlobalOverrideStore: MockStore(),

--- a/graylog2-web-interface/src/views/components/DashboardSearchBar.tsx
+++ b/graylog2-web-interface/src/views/components/DashboardSearchBar.tsx
@@ -15,12 +15,11 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { useMemo, useCallback, useContext } from 'react';
+import { useMemo, useCallback } from 'react';
 import { Field } from 'formik';
 import moment from 'moment';
 import styled, { css } from 'styled-components';
 
-import UserDateTimeContext from 'contexts/UserDateTimeContext';
 import { useStore } from 'stores/connect';
 import RefreshControls from 'views/components/searchbar/RefreshControls';
 import { FlatContentRow, Spinner } from 'components/common';
@@ -49,6 +48,7 @@ import {
 import type { SearchBarControl } from 'views/types';
 import usePluginEntities from 'views/logic/usePluginEntities';
 import { SearchConfigStore } from 'views/stores/SearchConfigStore';
+import useUserDateTime from 'hooks/useUserDateTime';
 
 import TimeRangeInput from './searchbar/TimeRangeInput';
 import type { DashboardFormValues } from './DashboardSearchBarForm';
@@ -117,7 +117,7 @@ const useInitialFormValues = (timerange, queryString) => {
 };
 
 const DashboardSearchBar = () => {
-  const { userTimezone } = useContext(UserDateTimeContext);
+  const { userTimezone } = useUserDateTime();
   const { searchesClusterConfig: config } = useStore(SearchConfigStore);
   const { timerange, query: { query_string: queryString = '' } = {} } = useStore(GlobalOverrideStore) ?? {};
   const pluggableSearchBarControls = usePluginEntities('views.components.searchBar');

--- a/graylog2-web-interface/src/views/components/DashboardSearchBar.tsx
+++ b/graylog2-web-interface/src/views/components/DashboardSearchBar.tsx
@@ -15,11 +15,12 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { useMemo, useCallback } from 'react';
+import { useMemo, useCallback, useContext } from 'react';
 import { Field } from 'formik';
 import moment from 'moment';
 import styled, { css } from 'styled-components';
 
+import UserDateTimeContext from 'contexts/UserDateTimeContext';
 import { useStore } from 'stores/connect';
 import RefreshControls from 'views/components/searchbar/RefreshControls';
 import { FlatContentRow, Spinner } from 'components/common';
@@ -97,14 +98,14 @@ const SearchButtonAndQuery = styled.div`
 
 const debouncedValidateQuery = debounceWithPromise(validateQuery, 350);
 
-const _validateQueryString = (values: DashboardFormValues, pluggableSearchBarControls: Array<() => SearchBarControl>) => {
+const _validateQueryString = (values: DashboardFormValues, pluggableSearchBarControls: Array<() => SearchBarControl>, userTimezone: string) => {
   const request = {
     timeRange: isNoTimeRangeOverride(values?.timerange) ? undefined : values?.timerange,
     queryString: values?.queryString,
     ...pluggableValidationPayload(values, pluggableSearchBarControls),
   };
 
-  return debouncedValidateQuery(request);
+  return debouncedValidateQuery(request, userTimezone);
 };
 
 const useInitialFormValues = (timerange, queryString) => {
@@ -116,6 +117,7 @@ const useInitialFormValues = (timerange, queryString) => {
 };
 
 const DashboardSearchBar = () => {
+  const { userTimezone } = useContext(UserDateTimeContext);
   const { searchesClusterConfig: config } = useStore(SearchConfigStore);
   const { timerange, query: { query_string: queryString = '' } = {} } = useStore(GlobalOverrideStore) ?? {};
   const pluggableSearchBarControls = usePluginEntities('views.components.searchBar');
@@ -145,7 +147,7 @@ const DashboardSearchBar = () => {
               <DashboardSearchForm initialValues={initialValues}
                                    limitDuration={limitDuration}
                                    onSubmit={submitForm}
-                                   validateQueryString={(values) => _validateQueryString(values, pluggableSearchBarControls)}>
+                                   validateQueryString={(values) => _validateQueryString(values, pluggableSearchBarControls, userTimezone)}>
                 {({ dirty, errors, isSubmitting, isValid, isValidating, handleSubmit, values, setFieldValue, validateForm }) => {
                   const disableSearchSubmit = isSubmitting || isValidating || !isValid;
 

--- a/graylog2-web-interface/src/views/components/DashboardSearchBarForm.tsx
+++ b/graylog2-web-interface/src/views/components/DashboardSearchBarForm.tsx
@@ -27,7 +27,7 @@ import type { QueryValidationState } from 'views/components/searchbar/queryvalid
 import validate from 'views/components/searchbar/validate';
 import { isNoTimeRangeOverride } from 'views/typeGuards/timeRange';
 import usePluginEntities from 'views/logic/usePluginEntities';
-import UserDateTimeContext from 'contexts/UserDateTimeContext';
+import useUserDateTime from 'hooks/useUserDateTime';
 
 import { onInitializingTimerange, onSubmittingTimerange } from './TimerangeForForm';
 
@@ -47,7 +47,7 @@ type Props = {
 const _isFunction = (children: Props['children']): children is (props: FormikProps<DashboardFormValues>) => React.ReactElement => isFunction(children);
 
 const DashboardSearchForm = ({ initialValues, limitDuration, onSubmit, validateQueryString, children }: Props) => {
-  const { formatTime, userTimezone } = useContext(UserDateTimeContext);
+  const { formatTime, userTimezone } = useUserDateTime();
   const { setFieldWarning } = useContext(FormWarningsContext);
   const [enableReinitialize, setEnableReinitialize] = useState(true);
   const pluggableSearchBarControls = usePluginEntities('views.components.searchBar');

--- a/graylog2-web-interface/src/views/components/DashboardSearchBarForm.tsx
+++ b/graylog2-web-interface/src/views/components/DashboardSearchBarForm.tsx
@@ -59,7 +59,7 @@ const DashboardSearchForm = ({ initialValues, limitDuration, onSubmit, validateQ
       timerange: isNoTimeRangeOverride(timerange) ? undefined : onSubmittingTimerange(timerange, userTimezone),
       ...rest,
     }).then(() => setEnableReinitialize(true));
-  }, [onSubmit]);
+  }, [onSubmit, userTimezone]);
   const { timerange, ...rest } = initialValues;
   const initialTimeRange = timerange && !isNoTimeRangeOverride(timerange) ? onInitializingTimerange(timerange, formatTime) : {} as TimeRange;
   const _initialValues = {
@@ -67,8 +67,8 @@ const DashboardSearchForm = ({ initialValues, limitDuration, onSubmit, validateQ
     ...rest,
   };
 
-  const _validate = useCallback((values: DashboardFormValues) => validate(values, limitDuration, setFieldWarning, validateQueryString, pluggableSearchBarControls),
-    [limitDuration, setFieldWarning, validateQueryString, pluggableSearchBarControls]);
+  const _validate = useCallback((values: DashboardFormValues) => validate(values, limitDuration, setFieldWarning, validateQueryString, pluggableSearchBarControls, formatTime),
+    [limitDuration, setFieldWarning, validateQueryString, pluggableSearchBarControls, formatTime]);
 
   return (
     <Formik<DashboardFormValues> initialValues={_initialValues}

--- a/graylog2-web-interface/src/views/components/SearchBar.pluggableControls.test.tsx
+++ b/graylog2-web-interface/src/views/components/SearchBar.pluggableControls.test.tsx
@@ -186,6 +186,6 @@ describe('SearchBar pluggable controls', () => {
       queryString: '*',
       streams: [],
       timeRange: { from: 300, type: 'relative' },
-    }));
+    }, 'Europe/Berlin'));
   });
 });

--- a/graylog2-web-interface/src/views/components/SearchBar.tsx
+++ b/graylog2-web-interface/src/views/components/SearchBar.tsx
@@ -15,13 +15,14 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { useCallback } from 'react';
+import { useCallback, useContext } from 'react';
 import PropTypes from 'prop-types';
 import * as Immutable from 'immutable';
 import { Field } from 'formik';
 import styled from 'styled-components';
 import moment from 'moment';
 
+import UserDateTimeContext from 'contexts/UserDateTimeContext';
 import connect, { useStore } from 'stores/connect';
 import { Spinner, FlatContentRow } from 'components/common';
 import { Row, Col } from 'components/bootstrap';
@@ -129,7 +130,7 @@ const useInitialFormValues = ({ currentQuery, queryFilters }: { currentQuery: Qu
   return ({ timerange, streams, queryString, ...initialValuesFromPlugins });
 };
 
-const _validateQueryString = (values: SearchBarFormValues, pluggableSearchBarControls: Array<() => SearchBarControl>) => {
+const _validateQueryString = (values: SearchBarFormValues, pluggableSearchBarControls: Array<() => SearchBarControl>, userTimezone: string) => {
   const request = {
     timeRange: values?.timerange,
     streams: values?.streams,
@@ -137,7 +138,7 @@ const _validateQueryString = (values: SearchBarFormValues, pluggableSearchBarCon
     ...pluggableValidationPayload(values, pluggableSearchBarControls),
   };
 
-  return debouncedValidateQuery(request);
+  return debouncedValidateQuery(request, userTimezone);
 };
 
 const SearchBar = ({
@@ -147,6 +148,7 @@ const SearchBar = ({
   onSubmit = defaultProps.onSubmit,
 }: Props) => {
   const { searchesClusterConfig: config } = useStore(SearchConfigStore);
+  const { userTimezone } = useContext(UserDateTimeContext);
   const { parameters } = useParameters();
   const pluggableSearchBarControls = usePluginEntities('views.components.searchBar');
   const initialValues = useInitialFormValues({ queryFilters, currentQuery });
@@ -169,7 +171,7 @@ const SearchBar = ({
               <SearchBarForm initialValues={initialValues}
                              limitDuration={limitDuration}
                              onSubmit={_onSubmit}
-                             validateQueryString={(values) => _validateQueryString(values, pluggableSearchBarControls)}>
+                             validateQueryString={(values) => _validateQueryString(values, pluggableSearchBarControls, userTimezone)}>
                 {({ dirty, errors, isSubmitting, isValid, isValidating, handleSubmit, values, setFieldValue, validateForm }) => {
                   const disableSearchSubmit = isSubmitting || isValidating || !isValid;
 

--- a/graylog2-web-interface/src/views/components/SearchBar.tsx
+++ b/graylog2-web-interface/src/views/components/SearchBar.tsx
@@ -15,14 +15,13 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { useCallback, useContext } from 'react';
+import { useCallback } from 'react';
 import PropTypes from 'prop-types';
 import * as Immutable from 'immutable';
 import { Field } from 'formik';
 import styled from 'styled-components';
 import moment from 'moment';
 
-import UserDateTimeContext from 'contexts/UserDateTimeContext';
 import connect, { useStore } from 'stores/connect';
 import { Spinner, FlatContentRow } from 'components/common';
 import { Row, Col } from 'components/bootstrap';
@@ -57,6 +56,7 @@ import useParameters from 'views/hooks/useParameters';
 import ValidateOnParameterChange from 'views/components/searchbar/ValidateOnParameterChange';
 import type { SearchBarControl } from 'views/types';
 import { SearchConfigStore } from 'views/stores/SearchConfigStore';
+import useUserDateTime from 'hooks/useUserDateTime';
 
 import SearchBarForm from './searchbar/SearchBarForm';
 import {
@@ -148,7 +148,7 @@ const SearchBar = ({
   onSubmit = defaultProps.onSubmit,
 }: Props) => {
   const { searchesClusterConfig: config } = useStore(SearchConfigStore);
-  const { userTimezone } = useContext(UserDateTimeContext);
+  const { userTimezone } = useUserDateTime();
   const { parameters } = useParameters();
   const pluggableSearchBarControls = usePluginEntities('views.components.searchBar');
   const initialValues = useInitialFormValues({ queryFilters, currentQuery });

--- a/graylog2-web-interface/src/views/components/TimeRangeValidation.ts
+++ b/graylog2-web-interface/src/views/components/TimeRangeValidation.ts
@@ -43,7 +43,6 @@ const exceedsDuration = (timeRange: TimeRange, limitDuration, formatTime: (dateT
       const durationFrom = timeRange.from;
 
       const durationLimit = formatTime(toDateObject(new Date()).subtract(Number(limitDuration), 'seconds'), 'complete');
-      console.log(durationLimit, durationFrom);
 
       return moment(durationFrom).isBefore(durationLimit);
     }

--- a/graylog2-web-interface/src/views/components/TimeRangeValidation.ts
+++ b/graylog2-web-interface/src/views/components/TimeRangeValidation.ts
@@ -23,15 +23,16 @@ import type {
   RelativeTimeRangeWithEnd,
   AbsoluteTimeRange,
 } from 'views/logic/queries/Query';
-import DateTime from 'logic/datetimes/DateTime';
 import { isTypeAbsolute, isTypeRelativeWithEnd, isTypeKeyword } from 'views/typeGuards/timeRange';
+import type { DateTime } from 'util/DateTime';
+import { isValidDate, toDateObject } from 'util/DateTime';
 
 const invalidDateFormatError = 'Format must be: YYYY-MM-DD [HH:mm:ss[.SSS]].';
 const rangeLimitError = 'Range is outside limit duration.';
 const dateLimitError = 'Date is outside limit duration.';
 const timeRangeError = 'The "Until" date must come after the "From" date.';
 
-const exceedsDuration = (timeRange, limitDuration) => {
+const exceedsDuration = (timeRange: TimeRange, limitDuration, formatTime: (dateTime: DateTime, format: string) => string) => {
   if (limitDuration === 0) {
     return false;
   }
@@ -40,7 +41,9 @@ const exceedsDuration = (timeRange, limitDuration) => {
     case 'absolute':
     case 'keyword': { // eslint-disable-line no-fallthrough, padding-line-between-statements
       const durationFrom = timeRange.from;
-      const durationLimit = DateTime.now().subtract(Number(limitDuration), 'seconds').format(DateTime.Formats.TIMESTAMP);
+
+      const durationLimit = formatTime(toDateObject(new Date()).subtract(Number(limitDuration), 'seconds'), 'complete');
+      console.log(durationLimit, durationFrom);
 
       return moment(durationFrom).isBefore(durationLimit);
     }
@@ -50,17 +53,17 @@ const exceedsDuration = (timeRange, limitDuration) => {
   }
 };
 
-const validateAbsoluteTimeRange = (timeRange: AbsoluteTimeRange, limitDuration: number) => {
+const validateAbsoluteTimeRange = (timeRange: AbsoluteTimeRange, limitDuration: number, formatTime: (dateTime: DateTime, format: string) => string) => {
   let errors: {
     from?: string,
     to?: string,
   } = {};
 
-  if (!DateTime.isValidDateString(timeRange.from)) {
+  if (!isValidDate(timeRange.from)) {
     errors = { ...errors, from: invalidDateFormatError };
   }
 
-  if (!DateTime.isValidDateString(timeRange.to)) {
+  if (!isValidDate(timeRange.to)) {
     errors = { ...errors, to: invalidDateFormatError };
   }
 
@@ -68,7 +71,7 @@ const validateAbsoluteTimeRange = (timeRange: AbsoluteTimeRange, limitDuration: 
     errors = { ...errors, to: timeRangeError };
   }
 
-  if (exceedsDuration(timeRange, limitDuration)) {
+  if (exceedsDuration(timeRange, limitDuration, formatTime)) {
     errors = { ...errors, from: dateLimitError };
   }
 
@@ -103,21 +106,21 @@ const validateRelativeTimeRangeWithEnd = (timeRange: RelativeTimeRangeWithEnd, l
   return errors;
 };
 
-const validateKeywordTimeRange = (timeRange: KeywordTimeRange, limitDuration: number) => {
+const validateKeywordTimeRange = (timeRange: KeywordTimeRange, limitDuration: number, formatTime: (dateTime: DateTime, format: string) => string) => {
   let errors: { keyword?: string } = {};
 
-  if (exceedsDuration(timeRange, limitDuration)) {
+  if (exceedsDuration(timeRange, limitDuration, formatTime)) {
     errors = { keyword: rangeLimitError };
   }
 
   return errors;
 };
 
-const validateTimeRange = (timeRange: TimeRange | NoTimeRangeOverride, limitDuration: number) => {
+const validateTimeRange = (timeRange: TimeRange | NoTimeRangeOverride, limitDuration: number, formatTime: (dateTime: DateTime, format: string) => string) => {
   let errors = {};
 
   if (isTypeKeyword(timeRange)) {
-    errors = { ...errors, ...validateKeywordTimeRange(timeRange, limitDuration) };
+    errors = { ...errors, ...validateKeywordTimeRange(timeRange, limitDuration, formatTime) };
   }
 
   if (isTypeRelativeWithEnd(timeRange)) {
@@ -125,7 +128,7 @@ const validateTimeRange = (timeRange: TimeRange | NoTimeRangeOverride, limitDura
   }
 
   if (isTypeAbsolute(timeRange)) {
-    errors = { ...errors, ...validateAbsoluteTimeRange(timeRange, limitDuration) };
+    errors = { ...errors, ...validateAbsoluteTimeRange(timeRange, limitDuration, formatTime) };
   }
 
   return errors;

--- a/graylog2-web-interface/src/views/components/TimerangeForForm.ts
+++ b/graylog2-web-interface/src/views/components/TimerangeForForm.ts
@@ -61,7 +61,7 @@ export const onSubmittingTimerange = (timerange: TimeRange, userTz: string): Tim
   }
 };
 
-export const onInitializingTimerange = (timerange: TimeRange, formatTime: (dateTime: string, tz: DateTimeFormats) => string): SearchBarFormValues['timerange'] => {
+export const onInitializingTimerange = (timerange: TimeRange, formatTime: (dateTime: string, format: DateTimeFormats) => string): SearchBarFormValues['timerange'] => {
   const { type } = timerange;
 
   switch (timerange.type) {

--- a/graylog2-web-interface/src/views/components/TimerangeForForm.ts
+++ b/graylog2-web-interface/src/views/components/TimerangeForForm.ts
@@ -15,22 +15,21 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import { RELATIVE_ALL_TIME } from 'views/Constants';
-import DateTime from 'logic/datetimes/DateTime';
 import type { TimeRange } from 'views/logic/queries/Query';
 import type { SearchBarFormValues } from 'views/Constants';
 import { isTypeRelativeWithStartOnly, isTypeRelativeWithEnd } from 'views/typeGuards/timeRange';
+import type { DateTimeFormats } from 'util/DateTime';
+import { adjustFormat, toUTCFromTz } from 'util/DateTime';
 
-const formatDatetime = (datetime) => datetime.toString(DateTime.Formats.TIMESTAMP);
-
-export const onSubmittingTimerange = (timerange: TimeRange): TimeRange => {
+export const onSubmittingTimerange = (timerange: TimeRange, userTz: string): TimeRange => {
   const { type } = timerange;
 
   switch (timerange.type) {
     case 'absolute':
       return {
         type: timerange.type,
-        from: DateTime.parseFromString(timerange.from).toISOString(),
-        to: DateTime.parseFromString(timerange.to).toISOString(),
+        from: adjustFormat(toUTCFromTz(timerange.from, userTz), 'internal'),
+        to: adjustFormat(toUTCFromTz(timerange.to, userTz), 'internal'),
       };
     case 'relative':
       if (isTypeRelativeWithStartOnly(timerange)) {
@@ -62,15 +61,15 @@ export const onSubmittingTimerange = (timerange: TimeRange): TimeRange => {
   }
 };
 
-export const onInitializingTimerange = (timerange: TimeRange): SearchBarFormValues['timerange'] => {
+export const onInitializingTimerange = (timerange: TimeRange, formatTime: (dateTime: string, tz: DateTimeFormats) => string): SearchBarFormValues['timerange'] => {
   const { type } = timerange;
 
   switch (timerange.type) {
     case 'absolute':
       return {
         type: timerange.type,
-        from: formatDatetime(DateTime.parseFromString(timerange.from)),
-        to: formatDatetime(DateTime.parseFromString(timerange.to)),
+        from: formatTime(timerange.from, 'complete'),
+        to: formatTime(timerange.to, 'complete'),
       };
     case 'relative':
       if (isTypeRelativeWithStartOnly(timerange)) {

--- a/graylog2-web-interface/src/views/components/Value.test.tsx
+++ b/graylog2-web-interface/src/views/components/Value.test.tsx
@@ -46,10 +46,10 @@ describe('Value', () => {
                         render={({ value }) => `The date ${value}`}
                         type={new FieldType('date', [], [])} />);
 
-      openActionsMenu('The date 2018-10-02 14:45:40');
+      openActionsMenu('The date 2018-10-02 16:45:40.000');
       const title = await screen.findByTestId('value-actions-title');
 
-      expect(title).toHaveTextContent('foo = 2018-10-02 14:45:40');
+      expect(title).toHaveTextContent('foo = 2018-10-02 16:45:40.000');
     });
 
     it('renders numeric timestamps with a custom component', async () => {
@@ -118,12 +118,12 @@ describe('Value', () => {
   it.each`
      interactive | value                     | type                                                         | result
      ${true}     | ${42}                     | ${undefined}                                                 | ${'42'}
-     ${true}     | ${'2018-10-02T14:45:40Z'} | ${new FieldType('date', [], [])}    | ${'2018-10-02 14:45:40'}
+     ${true}     | ${'2018-10-02T14:45:40Z'} | ${new FieldType('date', [], [])}    | ${'2018-10-02 16:45:40.000'}
      ${true}     | ${false}                  | ${new FieldType('boolean', [], [])} | ${'false'}
      ${true}     | ${[23, 'foo']}            | ${FieldType.Unknown}                                         | ${'[23,"foo"]'}                
      ${true}     | ${{ foo: 23 }}            | ${FieldType.Unknown}                                         | ${'{"foo":23}'}
      ${false}    | ${42}                     | ${undefined}                                                 | ${'42'}
-     ${false}    | ${'2018-10-02T14:45:40Z'} | ${new FieldType('date', [], [])}    | ${'2018-10-02 14:45:40'}
+     ${false}    | ${'2018-10-02T14:45:40Z'} | ${new FieldType('date', [], [])}    | ${'2018-10-02 16:45:40.000'}
      ${false}    | ${false}                  | ${new FieldType('boolean', [], [])} | ${'false'}
      ${false}    | ${[23, 'foo']}            | ${FieldType.Unknown}                                         | ${'[23,"foo"]'}
      ${false}    | ${{ foo: 23 }}            | ${FieldType.Unknown}                                         | ${'{"foo":23}'}

--- a/graylog2-web-interface/src/views/components/Value.test.tsx
+++ b/graylog2-web-interface/src/views/components/Value.test.tsx
@@ -23,8 +23,6 @@ import FieldType from 'views/logic/fieldtypes/FieldType';
 import Value from './Value';
 import InteractiveContext from './contexts/InteractiveContext';
 
-jest.mock('hooks/useUserDateTime');
-
 describe('Value', () => {
   const openActionsMenu = (value) => {
     userEvent.click(screen.getByText(value));

--- a/graylog2-web-interface/src/views/components/WidgetQueryControls.pluggableControls.test.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetQueryControls.pluggableControls.test.tsx
@@ -217,6 +217,6 @@ describe('WidgetQueryControls pluggable controls', () => {
       queryString: '',
       streams: undefined,
       timeRange: { from: 300, type: 'relative' },
-    }, 'UTC'));
+    }, 'Europe/Berlin'));
   });
 });

--- a/graylog2-web-interface/src/views/components/WidgetQueryControls.pluggableControls.test.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetQueryControls.pluggableControls.test.tsx
@@ -218,6 +218,6 @@ describe('WidgetQueryControls pluggable controls', () => {
       queryString: '',
       streams: undefined,
       timeRange: { from: 300, type: 'relative' },
-    }));
+    }, 'Europe/Berlin'));
   });
 });

--- a/graylog2-web-interface/src/views/components/WidgetQueryControls.pluggableControls.test.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetQueryControls.pluggableControls.test.tsx
@@ -33,7 +33,6 @@ import FormikInput from '../../components/common/FormikInput';
 
 const testTimeout = applyTimeoutMultiplier(30000);
 
-jest.mock('hooks/useUserDateTime');
 jest.mock('views/components/searchbar/queryvalidation/QueryValidation', () => mockComponent('QueryValidation'));
 jest.mock('views/components/searchbar/queryinput/QueryInput', () => ({ value = '' }: { value: string }) => <span>{value}</span>);
 jest.mock('hooks/useFeature', () => (key: string) => key === 'search_filter');

--- a/graylog2-web-interface/src/views/components/WidgetQueryControls.pluggableControls.test.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetQueryControls.pluggableControls.test.tsx
@@ -218,6 +218,6 @@ describe('WidgetQueryControls pluggable controls', () => {
       queryString: '',
       streams: undefined,
       timeRange: { from: 300, type: 'relative' },
-    }, 'Europe/Berlin'));
+    }, 'UTC'));
   });
 });

--- a/graylog2-web-interface/src/views/components/WidgetQueryControls.test.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetQueryControls.test.tsx
@@ -28,7 +28,6 @@ import mockComponent from 'helpers/mocking/MockComponent';
 import WidgetQueryControls from './WidgetQueryControls';
 import WidgetContext from './contexts/WidgetContext';
 
-jest.mock('hooks/useUserDateTime');
 jest.mock('views/components/searchbar/queryvalidation/QueryValidation', () => mockComponent('QueryValidation'));
 jest.mock('views/components/searchbar/queryinput/QueryInput', () => ({ value = '' }: { value: string }) => <span>{value}</span>);
 

--- a/graylog2-web-interface/src/views/components/WidgetQueryControls.test.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetQueryControls.test.tsx
@@ -132,7 +132,7 @@ describe('WidgetQueryControls', () => {
   describe('displays if global override is set', () => {
     const resetTimeRangeButtonTitle = /reset global override/i;
     const resetQueryButtonTitle = /reset global filter/i;
-    const timeRangeOverrideInfo = '2019-10-10 12:26:31 - 2019-10-10 12:26:31';
+    const timeRangeOverrideInfo = '2019-10-10 14:26:31.146 - 2019-10-10 14:26:31.146';
     const queryOverrideInfo = globalOverrideWithQuery.query.query_string;
 
     it('shows preview of global override time range', async () => {

--- a/graylog2-web-interface/src/views/components/WidgetQueryControls.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetQueryControls.tsx
@@ -51,7 +51,7 @@ import {
 } from 'views/components/searchbar/pluggableSearchBarControlsHandler';
 import type { SearchBarControl } from 'views/types';
 import usePluginEntities from 'views/logic/usePluginEntities';
-import UserDateTimeContext from 'contexts/UserDateTimeContext';
+import useUserDateTime from 'hooks/useUserDateTime';
 
 import TimeRangeOverrideInfo from './searchbar/WidgetTimeRangeOverride';
 import TimeRangeInput from './searchbar/TimeRangeInput';
@@ -111,7 +111,7 @@ const _resetQueryOverride = () => GlobalOverrideActions.resetQuery().then(Search
 
 const useBindApplySearchControlsChanges = (formRef) => {
   const { bindApplySearchControlsChanges } = useContext(WidgetEditApplyAllChangesContext);
-  const { userTimezone } = useContext(UserDateTimeContext);
+  const { userTimezone } = useUserDateTime();
 
   useEffect(() => {
     bindApplySearchControlsChanges((newWidget: Widget) => {
@@ -157,7 +157,7 @@ const _validateQueryString = (values: SearchBarFormValues, globalOverride: Globa
 
 const WidgetQueryControls = ({ availableStreams, globalOverride }: Props) => {
   const widget = useContext(WidgetContext);
-  const { userTimezone } = useContext(UserDateTimeContext);
+  const { userTimezone } = useUserDateTime();
   const config = useStore(SearchConfigStore, ({ searchesClusterConfig }) => searchesClusterConfig);
   const isValidatingQuery = !!useIsFetching('validateSearchQuery');
   const pluggableSearchBarControls = usePluginEntities('views.components.searchBar');

--- a/graylog2-web-interface/src/views/components/WidgetQueryControls.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetQueryControls.tsx
@@ -51,6 +51,7 @@ import {
 } from 'views/components/searchbar/pluggableSearchBarControlsHandler';
 import type { SearchBarControl } from 'views/types';
 import usePluginEntities from 'views/logic/usePluginEntities';
+import UserDateTimeContext from 'contexts/UserDateTimeContext';
 
 import TimeRangeOverrideInfo from './searchbar/WidgetTimeRangeOverride';
 import TimeRangeInput from './searchbar/TimeRangeInput';
@@ -110,6 +111,7 @@ const _resetQueryOverride = () => GlobalOverrideActions.resetQuery().then(Search
 
 const useBindApplySearchControlsChanges = (formRef) => {
   const { bindApplySearchControlsChanges } = useContext(WidgetEditApplyAllChangesContext);
+  const { userTimezone } = useContext(UserDateTimeContext);
 
   useEffect(() => {
     bindApplySearchControlsChanges((newWidget: Widget) => {
@@ -117,7 +119,7 @@ const useBindApplySearchControlsChanges = (formRef) => {
         const { dirty, values, isValid } = formRef.current;
 
         if (dirty && isValid) {
-          const normalizedFormValues = normalizeSearchBarFormValues(values);
+          const normalizedFormValues = normalizeSearchBarFormValues(values, userTimezone);
 
           return updateWidgetSearchControls(newWidget, normalizedFormValues);
         }
@@ -125,7 +127,7 @@ const useBindApplySearchControlsChanges = (formRef) => {
 
       return undefined;
     });
-  }, [formRef, bindApplySearchControlsChanges]);
+  }, [formRef, bindApplySearchControlsChanges, userTimezone]);
 };
 
 const useInitialFormValues = (widget: Widget) => {
@@ -141,7 +143,7 @@ const useInitialFormValues = (widget: Widget) => {
 
 const debouncedValidateQuery = debounceWithPromise(validateQuery, 350);
 
-const _validateQueryString = (values: SearchBarFormValues, globalOverride: GlobalOverride, pluggableSearchBarControls: Array<() => SearchBarControl>) => {
+const _validateQueryString = (values: SearchBarFormValues, globalOverride: GlobalOverride, pluggableSearchBarControls: Array<() => SearchBarControl>, userTimezone: string) => {
   const request = {
     queryString: values?.queryString,
     timeRange: !isEmpty(globalOverride?.timerange) ? globalOverride.timerange : values?.timerange,
@@ -150,11 +152,12 @@ const _validateQueryString = (values: SearchBarFormValues, globalOverride: Globa
     ...pluggableValidationPayload(values, pluggableSearchBarControls),
   };
 
-  return debouncedValidateQuery(request);
+  return debouncedValidateQuery(request, userTimezone);
 };
 
 const WidgetQueryControls = ({ availableStreams, globalOverride }: Props) => {
   const widget = useContext(WidgetContext);
+  const { userTimezone } = useContext(UserDateTimeContext);
   const config = useStore(SearchConfigStore, ({ searchesClusterConfig }) => searchesClusterConfig);
   const isValidatingQuery = !!useIsFetching('validateSearchQuery');
   const pluggableSearchBarControls = usePluginEntities('views.components.searchBar');
@@ -163,7 +166,7 @@ const WidgetQueryControls = ({ availableStreams, globalOverride }: Props) => {
   const hasQueryOverride = globalOverride?.query !== undefined;
   const formRef = useRef(null);
   const { parameters } = useParameters();
-  const validate = (values) => _validateQueryString(values, globalOverride, pluggableSearchBarControls);
+  const validate = (values) => _validateQueryString(values, globalOverride, pluggableSearchBarControls, userTimezone);
   const initialValues = useInitialFormValues(widget);
   const _onSubmit = useCallback((values) => onSubmit(values, pluggableSearchBarControls, widget), [pluggableSearchBarControls, widget]);
 

--- a/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.metric.test.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.metric.test.tsx
@@ -59,8 +59,6 @@ jest.mock('views/stores/ViewMetadataStore', () => ({
   ViewMetadataStore: MockStore(['getInitialState', () => ({ activeQuery: 'queryId' })]),
 }));
 
-jest.mock('hooks/useUserDateTime');
-
 const selectEventConfig = { container: document.body };
 
 const plugin: PluginRegistration = { exports: { visualizationTypes: [dataTable] } };

--- a/graylog2-web-interface/src/views/components/datatable/DataTable.test.tsx
+++ b/graylog2-web-interface/src/views/components/datatable/DataTable.test.tsx
@@ -29,8 +29,6 @@ import DataTable from 'views/components/datatable/DataTable';
 
 import RenderCompletionCallback from '../widgets/RenderCompletionCallback';
 
-jest.mock('hooks/useUserDateTime');
-
 describe('DataTable', () => {
   const currentView = { activeQuery: 'deadbeef-23' };
 

--- a/graylog2-web-interface/src/views/components/datatable/DataTableEntry.test.tsx
+++ b/graylog2-web-interface/src/views/components/datatable/DataTableEntry.test.tsx
@@ -27,8 +27,6 @@ import DataTableEntry from './DataTableEntry';
 
 import EmptyValue from '../EmptyValue';
 
-jest.mock('hooks/useUserDateTime');
-
 const f = (source: string, field: string = source): { field: string, source: string } => ({ field, source });
 const createFields = (fields: Array<string>) => OrderedSet(fields.map((field) => f(field)));
 const fields = createFields(['nf_dst_address', 'count()', 'max(timestamp)', 'card(timestamp)']);

--- a/graylog2-web-interface/src/views/components/datatable/Headers.test.tsx
+++ b/graylog2-web-interface/src/views/components/datatable/Headers.test.tsx
@@ -27,7 +27,6 @@ import SeriesConfig from 'views/logic/aggregationbuilder/SeriesConfig';
 import Headers from './Headers';
 
 jest.mock('components/common/Timestamp', () => 'Timestamp');
-jest.mock('logic/datetimes/DateTime', () => 'DateTime');
 
 const seriesWithName = (fn, name) => Series.forFunction(fn)
   .toBuilder()

--- a/graylog2-web-interface/src/views/components/messagelist/CustomHighlighting.test.tsx
+++ b/graylog2-web-interface/src/views/components/messagelist/CustomHighlighting.test.tsx
@@ -25,8 +25,6 @@ import { StaticColor } from 'views/logic/views/formatting/highlighting/Highlight
 
 import CustomHighlighting from './CustomHighlighting';
 
-jest.mock('hooks/useUserDateTime');
-
 const renderDecorators = (decorators, field, value) => decorators.map((Decorator) => (
   <Decorator key={Decorator.name}
              type={FieldType.Unknown}

--- a/graylog2-web-interface/src/views/components/messagelist/MessagePreview.test.tsx
+++ b/graylog2-web-interface/src/views/components/messagelist/MessagePreview.test.tsx
@@ -25,7 +25,6 @@ import MessagesWidgetConfig from 'views/logic/widgets/MessagesWidgetConfig';
 import MessagePreview from './MessagePreview';
 
 jest.mock('views/logic/usePluginEntities', () => jest.fn());
-jest.mock('hooks/useUserDateTime');
 
 describe('MessagePreview', () => {
   afterEach(() => {

--- a/graylog2-web-interface/src/views/components/messagelist/MessageTableEntry.test.tsx
+++ b/graylog2-web-interface/src/views/components/messagelist/MessageTableEntry.test.tsx
@@ -31,8 +31,6 @@ jest.mock('stores/configurations/ConfigurationsStore', () => ({
   },
 }));
 
-jest.mock('hooks/useUserDateTime');
-
 describe('MessageTableEntry', () => {
   it('renders message for unknown selected fields', () => {
     const message = {

--- a/graylog2-web-interface/src/views/components/searchbar/SearchBarAutocompletions.test.ts
+++ b/graylog2-web-interface/src/views/components/searchbar/SearchBarAutocompletions.test.ts
@@ -60,7 +60,7 @@ const EMPTY_FIELDTYPES = { all: {}, query: {} };
 describe('SearchAutoCompletions', () => {
   describe('getCompletions', () => {
     it('should return completions based on provided Completers', async () => {
-      const searchBarAutoCompletions = new SearchBarAutoCompletions([new SimpleCompleter()], DEFAULT_TIMERANGE, [], EMPTY_FIELDTYPES);
+      const searchBarAutoCompletions = new SearchBarAutoCompletions([new SimpleCompleter()], DEFAULT_TIMERANGE, [], EMPTY_FIELDTYPES, 'Europe/Berlin');
 
       const callback = jest.fn();
 
@@ -77,7 +77,7 @@ describe('SearchAutoCompletions', () => {
     });
 
     it('should support Completers which provide the completions asynchronously', async () => {
-      const searchBarAutoCompletions = new SearchBarAutoCompletions([new SimpleCompleter(), new AsyncCompleter()], DEFAULT_TIMERANGE, [], EMPTY_FIELDTYPES);
+      const searchBarAutoCompletions = new SearchBarAutoCompletions([new SimpleCompleter(), new AsyncCompleter()], DEFAULT_TIMERANGE, [], EMPTY_FIELDTYPES, 'Europe/Berlin');
 
       const callback = jest.fn();
 
@@ -96,7 +96,7 @@ describe('SearchAutoCompletions', () => {
 
   describe('shouldShowCompletions', () => {
     it('should not show completions manually when no Completer provides `shouldShowCompletions`', async () => {
-      const searchBarAutoCompletions = new SearchBarAutoCompletions([new SimpleCompleter()], DEFAULT_TIMERANGE, [], EMPTY_FIELDTYPES);
+      const searchBarAutoCompletions = new SearchBarAutoCompletions([new SimpleCompleter()], DEFAULT_TIMERANGE, [], EMPTY_FIELDTYPES, 'Europe/Berlin');
 
       const result = searchBarAutoCompletions.shouldShowCompletions(1, [[{
         type: 'keyword',
@@ -117,7 +117,7 @@ describe('SearchAutoCompletions', () => {
         shouldShowCompletions = () => false;
       }
 
-      const searchBarAutoCompletions = new SearchBarAutoCompletions([new ExampleCompleter()], DEFAULT_TIMERANGE, [], EMPTY_FIELDTYPES);
+      const searchBarAutoCompletions = new SearchBarAutoCompletions([new ExampleCompleter()], DEFAULT_TIMERANGE, [], EMPTY_FIELDTYPES, 'Europe/Berlin');
       const result = searchBarAutoCompletions.shouldShowCompletions(1, [[{
         type: 'keyword',
         value: 'http_method:',
@@ -138,7 +138,7 @@ describe('SearchAutoCompletions', () => {
         shouldShowCompletions = mockShouldShowCompletions;
       }
 
-      const searchBarAutoCompletions = new SearchBarAutoCompletions([new ExampleCompleter()], DEFAULT_TIMERANGE, [], EMPTY_FIELDTYPES);
+      const searchBarAutoCompletions = new SearchBarAutoCompletions([new ExampleCompleter()], DEFAULT_TIMERANGE, [], EMPTY_FIELDTYPES, 'Europe/Berlin');
       const result = searchBarAutoCompletions.shouldShowCompletions(1, [[{
         type: 'keyword',
         value: 'http_method:',

--- a/graylog2-web-interface/src/views/components/searchbar/SearchBarAutocompletions.ts
+++ b/graylog2-web-interface/src/views/components/searchbar/SearchBarAutocompletions.ts
@@ -42,6 +42,7 @@ export type CompleterContext = Readonly<{
   timeRange?: TimeRange | NoTimeRangeOverride,
   streams?: Array<string>,
   fieldTypes?: FieldTypes,
+  userTimezone: string,
 }>;
 
 export interface Completer {
@@ -64,11 +65,14 @@ export default class SearchBarAutoCompletions implements AutoCompleter {
 
   private readonly fieldTypes: FieldTypes;
 
-  constructor(completers: Array<Completer>, timeRange: TimeRange | NoTimeRangeOverride | undefined, streams: Array<string>, fieldTypes: FieldTypes) {
+  private readonly userTimezone: string;
+
+  constructor(completers: Array<Completer>, timeRange: TimeRange | NoTimeRangeOverride | undefined, streams: Array<string>, fieldTypes: FieldTypes, userTimezone: string) {
     this.completers = completers;
     this.timeRange = timeRange;
     this.streams = streams;
     this.fieldTypes = fieldTypes;
+    this.userTimezone = userTimezone;
   }
 
   getCompletions = async (editor: Editor, _session: Session, pos: Position, prefix: string, callback: ResultsCallback) => {
@@ -82,7 +86,17 @@ export default class SearchBarAutoCompletions implements AutoCompleter {
       this.completers
         .map(async (completer) => {
           try {
-            return await completer.getCompletions({ currentToken, lastToken, prefix, tokens, currentTokenIdx, timeRange: this.timeRange, streams: this.streams, fieldTypes: this.fieldTypes });
+            return await completer.getCompletions({
+              currentToken,
+              lastToken,
+              prefix,
+              tokens,
+              currentTokenIdx,
+              timeRange: this.timeRange,
+              streams: this.streams,
+              fieldTypes: this.fieldTypes,
+              userTimezone: this.userTimezone,
+            });
           } catch (e) {
             onCompleterError(e);
           }

--- a/graylog2-web-interface/src/views/components/searchbar/SearchBarForm.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/SearchBarForm.tsx
@@ -57,7 +57,7 @@ const SearchBarForm = ({ initialValues, limitDuration, onSubmit, children, valid
     setEnableReinitialize(false);
 
     return onSubmit(normalizeSearchBarFormValues(values, userTimezone)).finally(() => setEnableReinitialize(true));
-  }, [onSubmit]);
+  }, [onSubmit, userTimezone]);
   const _initialValues = useMemo(() => {
     const { timerange, ...rest } = initialValues;
 
@@ -67,8 +67,8 @@ const SearchBarForm = ({ initialValues, limitDuration, onSubmit, children, valid
     });
   }, [formatTime, initialValues]);
 
-  const _validate = useCallback((values: SearchBarFormValues) => validate(values, limitDuration, setFieldWarning, validateQueryString, pluggableSearchBarControls),
-    [limitDuration, setFieldWarning, validateQueryString, pluggableSearchBarControls]);
+  const _validate = useCallback((values: SearchBarFormValues) => validate(values, limitDuration, setFieldWarning, validateQueryString, pluggableSearchBarControls, formatTime),
+    [limitDuration, setFieldWarning, validateQueryString, pluggableSearchBarControls, formatTime]);
 
   return (
     <Formik<SearchBarFormValues> initialValues={_initialValues}

--- a/graylog2-web-interface/src/views/components/searchbar/SearchBarForm.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/SearchBarForm.tsx
@@ -28,7 +28,7 @@ import FormWarningsContext from 'contexts/FormWarningsContext';
 import type { QueryValidationState } from 'views/components/searchbar/queryvalidation/types';
 import validate from 'views/components/searchbar/validate';
 import usePluginEntities from 'views/logic/usePluginEntities';
-import UserDateTimeContext from 'contexts/UserDateTimeContext';
+import useUserDateTime from 'hooks/useUserDateTime';
 
 type Props = {
   children: ((props: FormikProps<SearchBarFormValues>) => React.ReactNode) | React.ReactNode,
@@ -50,7 +50,7 @@ export const normalizeSearchBarFormValues = ({ timerange, ...rest }: SearchBarFo
 
 const SearchBarForm = ({ initialValues, limitDuration, onSubmit, children, validateOnMount, formRef, validateQueryString }: Props) => {
   const [enableReinitialize, setEnableReinitialize] = useState(true);
-  const { formatTime, userTimezone } = useContext(UserDateTimeContext);
+  const { formatTime, userTimezone } = useUserDateTime();
   const pluggableSearchBarControls = usePluginEntities('views.components.searchBar');
   const { setFieldWarning } = useContext(FormWarningsContext);
   const _onSubmit = useCallback((values: SearchBarFormValues) => {

--- a/graylog2-web-interface/src/views/components/searchbar/TimeRangeDisplay.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/TimeRangeDisplay.tsx
@@ -15,14 +15,14 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { useEffect, useRef, useState, useContext } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import styled, { css } from 'styled-components';
 
 import type { TimeRange, NoTimeRangeOverride } from 'views/logic/queries/Query';
 import { isTypeKeyword, isTypeRelativeWithStartOnly, isTypeRelativeWithEnd } from 'views/typeGuards/timeRange';
 import { readableRange } from 'views/logic/queries/TimeRangeToString';
 import ToolsStore from 'stores/tools/ToolsStore';
-import UserDateTimeContext from 'contexts/UserDateTimeContext';
+import useUserDateTime from 'hooks/useUserDateTime';
 
 type Props = {
   timerange: TimeRange | NoTimeRangeOverride | null | undefined,
@@ -88,7 +88,7 @@ const dateOutput = (timerange: TimeRange) => {
 };
 
 const TimeRangeDisplay = ({ timerange, toggleDropdownShow }: Props) => {
-  const { userTimezone } = useContext(UserDateTimeContext);
+  const { userTimezone } = useUserDateTime();
   const [{ from, until }, setTimeOutput] = useState(EMPTY_OUTPUT);
   const dateTested = useRef(false);
 

--- a/graylog2-web-interface/src/views/components/searchbar/TimeRangeDisplay.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/TimeRangeDisplay.tsx
@@ -15,13 +15,14 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState, useContext } from 'react';
 import styled, { css } from 'styled-components';
 
 import type { TimeRange, NoTimeRangeOverride } from 'views/logic/queries/Query';
 import { isTypeKeyword, isTypeRelativeWithStartOnly, isTypeRelativeWithEnd } from 'views/typeGuards/timeRange';
 import { readableRange } from 'views/logic/queries/TimeRangeToString';
 import ToolsStore from 'stores/tools/ToolsStore';
+import UserDateTimeContext from 'contexts/UserDateTimeContext';
 
 type Props = {
   timerange: TimeRange | NoTimeRangeOverride | null | undefined,
@@ -87,13 +88,14 @@ const dateOutput = (timerange: TimeRange) => {
 };
 
 const TimeRangeDisplay = ({ timerange, toggleDropdownShow }: Props) => {
+  const { userTimezone } = useContext(UserDateTimeContext);
   const [{ from, until }, setTimeOutput] = useState(EMPTY_OUTPUT);
   const dateTested = useRef(false);
 
   useEffect(() => {
     if (isTypeKeyword(timerange) && !timerange.from) {
       if (!dateTested.current) {
-        ToolsStore.testNaturalDate(timerange.keyword)
+        ToolsStore.testNaturalDate(timerange.keyword, userTimezone)
           .then((response) => {
             dateTested.current = true;
 
@@ -108,7 +110,7 @@ const TimeRangeDisplay = ({ timerange, toggleDropdownShow }: Props) => {
     } else if (timerange && 'type' in timerange) {
       setTimeOutput(dateOutput(timerange));
     }
-  }, [dateTested, timerange]);
+  }, [dateTested, timerange, userTimezone]);
 
   return (
     <TimeRangeWrapper aria-label="Search Time Range, Opens Time Range Selector On Click" role="button" onClick={toggleDropdownShow}>

--- a/graylog2-web-interface/src/views/components/searchbar/TimeRangeInput.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/TimeRangeInput.test.tsx
@@ -29,8 +29,6 @@ jest.mock('stores/configurations/ConfigurationsStore', () => ({
   },
 }));
 
-jest.mock('hooks/useUserDateTime');
-
 describe('TimeRangeInput', () => {
   const defaultTimeRange = { type: 'relative', range: 300 };
 

--- a/graylog2-web-interface/src/views/components/searchbar/completions/FieldNameCompletion.test.ts
+++ b/graylog2-web-interface/src/views/components/searchbar/completions/FieldNameCompletion.test.ts
@@ -26,6 +26,7 @@ const toIndex = (fields: Array<FieldTypeMapping>) => Object.fromEntries(fields.m
 const createFieldTypes = (fields: Array<FieldTypeMapping>) => ({ all: toIndex(fields), query: toIndex(fields) });
 
 const dummyFieldTypes = createFieldTypes(['source', 'message', 'timestamp'].map(_createField));
+const userTimezone = 'Europe/Berlin';
 
 describe('FieldNameCompletion', () => {
   it('returns empty list if inputs are empty', () => {
@@ -33,57 +34,118 @@ describe('FieldNameCompletion', () => {
 
     const completer = new FieldNameCompletion([]);
 
-    expect(completer.getCompletions({ currentToken: null, lastToken: null, prefix: '', tokens: [], currentTokenIdx: 0, fieldTypes })).toEqual([]);
+    expect(completer.getCompletions({
+      currentToken: null,
+      lastToken: null,
+      prefix: '',
+      tokens: [],
+      currentTokenIdx: 0,
+      fieldTypes,
+      userTimezone,
+    })).toEqual([]);
   });
 
   it('returns matching fields if prefix is present in one field name', () => {
     const completer = new FieldNameCompletion();
 
-    expect(completer.getCompletions({ currentToken: null, lastToken: null, prefix: 'mess', tokens: [], currentTokenIdx: 0, fieldTypes: dummyFieldTypes }).map((result) => result.name))
-      .toEqual(['message']);
+    expect(completer.getCompletions({
+      currentToken: null,
+      lastToken: null,
+      prefix: 'mess',
+      tokens: [],
+      currentTokenIdx: 0,
+      fieldTypes: dummyFieldTypes,
+      userTimezone,
+    }).map((result) => result.name)).toEqual(['message']);
   });
 
   it('returns matching fields if prefix is present in at least one field name', () => {
     const completer = new FieldNameCompletion([]);
 
-    expect(completer.getCompletions({ currentToken: null, lastToken: null, prefix: 'e', tokens: [], currentTokenIdx: 0, fieldTypes: dummyFieldTypes }).map((result) => result.name))
-      .toEqual(['source', 'message', 'timestamp']);
+    expect(completer.getCompletions({
+      currentToken: null,
+      lastToken: null,
+      prefix: 'e',
+      tokens: [],
+      currentTokenIdx: 0,
+      fieldTypes: dummyFieldTypes,
+      userTimezone,
+    }).map((result) => result.name)).toEqual(['source', 'message', 'timestamp']);
   });
 
   it('suffixes matching fields with colon', () => {
     const completer = new FieldNameCompletion([]);
 
-    expect(completer.getCompletions({ currentToken: null, lastToken: null, prefix: 'e', tokens: [], currentTokenIdx: 0, fieldTypes: dummyFieldTypes }).map((result) => result.value))
+    expect(completer.getCompletions({
+      currentToken: null,
+      lastToken: null,
+      prefix: 'e',
+      tokens: [],
+      currentTokenIdx: 0,
+      fieldTypes: dummyFieldTypes,
+      userTimezone,
+    }).map((result) => result.value))
       .toEqual(['source:', 'message:', 'timestamp:']);
   });
 
   it('returns _exist_-operator if matching prefix', () => {
     const completer = new FieldNameCompletion();
 
-    expect(completer.getCompletions({ currentToken: null, lastToken: null, prefix: '_e', tokens: [], currentTokenIdx: 0, fieldTypes: dummyFieldTypes }).map((result) => result.value))
-      .toEqual(['_exists_:']);
+    expect(completer.getCompletions({
+      currentToken: null,
+      lastToken: null,
+      prefix: '_e',
+      tokens: [],
+      currentTokenIdx: 0,
+      fieldTypes: dummyFieldTypes,
+      userTimezone,
+    }).map((result) => result.value)).toEqual(['_exists_:']);
   });
 
   it('returns matching fields after _exists_-operator', () => {
     const completer = new FieldNameCompletion();
 
-    expect(completer.getCompletions({ currentToken: null, lastToken: { type: 'keyword', value: '_exists_:' }, prefix: 'e', tokens: [], currentTokenIdx: 0, fieldTypes: dummyFieldTypes })
-      .map((result) => result.name))
-      .toEqual(['source', 'message', 'timestamp']);
+    expect(completer.getCompletions({
+      currentToken: null,
+      lastToken: {
+        type: 'keyword',
+        value: '_exists_:',
+      },
+      prefix: 'e',
+      tokens: [],
+      currentTokenIdx: 0,
+      fieldTypes: dummyFieldTypes,
+      userTimezone,
+    }).map((result) => result.name)).toEqual(['source', 'message', 'timestamp']);
   });
 
   it('returns exists operator together with matching fields', () => {
     const completer = new FieldNameCompletion();
 
-    expect(completer.getCompletions({ currentToken: null, lastToken: null, prefix: 'e', tokens: [], currentTokenIdx: 0, fieldTypes: dummyFieldTypes }).map((result) => result.name))
-      .toEqual(['_exists_', 'source', 'message', 'timestamp']);
+    expect(completer.getCompletions({
+      currentToken: null,
+      lastToken: null,
+      prefix: 'e',
+      tokens: [],
+      currentTokenIdx: 0,
+      fieldTypes: dummyFieldTypes,
+      userTimezone,
+    }).map((result) => result.name)).toEqual(['_exists_', 'source', 'message', 'timestamp']);
   });
 
   it('returns empty list when current token is a keyword and the the prefix is empty', () => {
     const completer = new FieldNameCompletion();
     const currentToken = { type: 'keyword', value: 'http_method:', index: 0, start: 0 };
 
-    expect(completer.getCompletions({ currentToken, lastToken: null, prefix: '', tokens: [], currentTokenIdx: 0, fieldTypes: dummyFieldTypes })).toEqual([]);
+    expect(completer.getCompletions({
+      currentToken,
+      lastToken: null,
+      prefix: '',
+      tokens: [],
+      currentTokenIdx: 0,
+      fieldTypes: dummyFieldTypes,
+      userTimezone,
+    })).toEqual([]);
   });
 
   describe('considers current query', () => {
@@ -102,7 +164,15 @@ describe('FieldNameCompletion', () => {
     it('scores fields of current query higher', () => {
       const completer = new FieldNameCompletion([]);
 
-      const completions = completer.getCompletions({ currentToken: null, lastToken: null, prefix: '', tokens: [], currentTokenIdx: 0, fieldTypes });
+      const completions = completer.getCompletions({
+        currentToken: null,
+        lastToken: null,
+        prefix: '',
+        tokens: [],
+        currentTokenIdx: 0,
+        fieldTypes,
+        userTimezone,
+      });
 
       const completion = (fieldName: string) => completionByName(fieldName, completions);
 

--- a/graylog2-web-interface/src/views/components/searchbar/completions/FieldValueCompletion.test.ts
+++ b/graylog2-web-interface/src/views/components/searchbar/completions/FieldValueCompletion.test.ts
@@ -70,9 +70,7 @@ describe('FieldValueCompletion', () => {
     { name: 'POST', value: 'POST', caption: 'POST', score: 300, meta: '300 hits' },
     { name: 'PUT', value: 'PUT', caption: 'PUT', score: 400, meta: '400 hits' },
   ];
-
   const createCurrentToken = (type: string, value: string, index: number, start: number) => ({ type, value, index, start });
-
   const createKeywordToken = (value: string) => createCurrentToken('keyword', value, 0, 0);
 
   beforeEach(() => {
@@ -90,6 +88,7 @@ describe('FieldValueCompletion', () => {
       timeRange: undefined,
       streams: undefined,
       fieldTypes,
+      userTimezone: 'Europe/Berlin',
     };
 
     it('returns empty list if inputs are empty', () => {

--- a/graylog2-web-interface/src/views/components/searchbar/completions/FieldValueCompletion.ts
+++ b/graylog2-web-interface/src/views/components/searchbar/completions/FieldValueCompletion.ts
@@ -150,6 +150,7 @@ class FieldValueCompletion implements Completer {
     timeRange,
     streams,
     fieldTypes,
+    userTimezone,
   }: CompleterContext) => {
     const { fieldName, input, isQuoted } = getFieldNameAndInput(currentToken, lastToken);
 
@@ -165,7 +166,7 @@ class FieldValueCompletion implements Completer {
       }
     }
 
-    const normalizedTimeRange = (!timeRange || isNoTimeRangeOverride(timeRange)) ? undefined : onSubmittingTimerange(timeRange);
+    const normalizedTimeRange = (!timeRange || isNoTimeRangeOverride(timeRange)) ? undefined : onSubmittingTimerange(timeRange, userTimezone);
 
     return SearchSuggestions.suggestFieldValue({
       field: fieldName,

--- a/graylog2-web-interface/src/views/components/searchbar/completions/OperatorCompletion.test.ts
+++ b/graylog2-web-interface/src/views/components/searchbar/completions/OperatorCompletion.test.ts
@@ -43,6 +43,7 @@ const term = (value: string, index?: number, start?: number) => ({ type: 'term',
 const whitespace = () => ({ type: 'text', value: ' ' });
 const and = () => ({ type: 'keyword.operator', value: 'AND' });
 const or = () => ({ type: 'keyword.operator', value: 'OR' });
+const userTimezone = 'Europe/Berlin';
 
 describe('OperatorCompletion', () => {
   let operatorCompletion: Completer;
@@ -53,7 +54,7 @@ describe('OperatorCompletion', () => {
 
   it('suggests NOT operator', () => {
     const token = term('N', 0, 0);
-    const results = operatorCompletion.getCompletions({ currentToken: token, lastToken: null, prefix: 'N', tokens: [token], currentTokenIdx: 0 });
+    const results = operatorCompletion.getCompletions({ currentToken: token, lastToken: null, prefix: 'N', tokens: [token], currentTokenIdx: 0, userTimezone });
 
     expect(results).toEqual([NOT]);
   });
@@ -61,7 +62,7 @@ describe('OperatorCompletion', () => {
   it('suggests NOT operator after empty term', () => {
     const token = term('N', 1, 1);
     const lastToken = whitespace();
-    const results = operatorCompletion.getCompletions({ currentToken: token, lastToken, prefix: 'N', tokens: [lastToken, token], currentTokenIdx: 1 });
+    const results = operatorCompletion.getCompletions({ currentToken: token, lastToken, prefix: 'N', tokens: [lastToken, token], currentTokenIdx: 1, userTimezone });
 
     expect(results).toEqual([NOT]);
   });
@@ -71,7 +72,7 @@ describe('OperatorCompletion', () => {
     const token = term(prefix, 2, 4);
     const lastToken = whitespace();
     const tokens = [term('foo'), lastToken, token];
-    const results = operatorCompletion.getCompletions({ currentToken: token, lastToken, prefix, tokens, currentTokenIdx: 2 });
+    const results = operatorCompletion.getCompletions({ currentToken: token, lastToken, prefix, tokens, currentTokenIdx: 2, userTimezone });
 
     expect(results).toEqual([AND]);
   });
@@ -81,7 +82,7 @@ describe('OperatorCompletion', () => {
     const token = term(prefix, 2, 4);
     const lastToken = whitespace();
     const tokens = [term('foo'), lastToken, token];
-    const results = operatorCompletion.getCompletions({ currentToken: token, lastToken, prefix, tokens, currentTokenIdx: 2 });
+    const results = operatorCompletion.getCompletions({ currentToken: token, lastToken, prefix, tokens, currentTokenIdx: 2, userTimezone });
 
     expect(results).toEqual([OR]);
   });
@@ -91,7 +92,7 @@ describe('OperatorCompletion', () => {
     const token = term(prefix, 2, 4);
     const lastToken = whitespace();
     const tokens = [term('foo'), lastToken, token];
-    const results = operatorCompletion.getCompletions({ currentToken: token, lastToken, prefix, tokens, currentTokenIdx: 2 });
+    const results = operatorCompletion.getCompletions({ currentToken: token, lastToken, prefix, tokens, currentTokenIdx: 2, userTimezone });
 
     expect(results).toEqual([OR, NOT]);
   });
@@ -101,7 +102,7 @@ describe('OperatorCompletion', () => {
     const token = term(prefix, 4, 8);
     const lastToken = whitespace();
     const tokens = [term('foo'), whitespace(), and(), whitespace(), token];
-    const results = operatorCompletion.getCompletions({ currentToken: token, lastToken, prefix, tokens, currentTokenIdx: 4 });
+    const results = operatorCompletion.getCompletions({ currentToken: token, lastToken, prefix, tokens, currentTokenIdx: 4, userTimezone });
 
     expect(results).toEqual([NOT]);
   });
@@ -111,7 +112,7 @@ describe('OperatorCompletion', () => {
     const token = term(prefix, 4, 8);
     const lastToken = whitespace();
     const tokens = [term('foo'), whitespace(), or(), whitespace(), token];
-    const results = operatorCompletion.getCompletions({ currentToken: token, lastToken, prefix, tokens, currentTokenIdx: 4 });
+    const results = operatorCompletion.getCompletions({ currentToken: token, lastToken, prefix, tokens, currentTokenIdx: 4, userTimezone });
 
     expect(results).toEqual([]);
   });
@@ -121,14 +122,14 @@ describe('OperatorCompletion', () => {
     const currentToken = term(prefix, 4, 8);
     const lastToken = whitespace();
     const tokens = [term('foo'), whitespace(), or(), whitespace(), currentToken, whitespace(), term('qux')];
-    const results = operatorCompletion.getCompletions({ currentToken, lastToken, prefix, tokens, currentTokenIdx: 4 });
+    const results = operatorCompletion.getCompletions({ currentToken, lastToken, prefix, tokens, currentTokenIdx: 4, userTimezone });
 
     expect(results).toEqual([]);
   });
 
   it('does not suggest anything if current token is a keyword without a prefix', () => {
     const token = { index: 0, start: 0, type: 'keyword', value: 'controller:' };
-    const results = operatorCompletion.getCompletions({ currentToken: token, lastToken: null, prefix: 'N', tokens: [token], currentTokenIdx: 0 });
+    const results = operatorCompletion.getCompletions({ currentToken: token, lastToken: null, prefix: 'N', tokens: [token], currentTokenIdx: 0, userTimezone });
 
     expect(results).toEqual([]);
   });

--- a/graylog2-web-interface/src/views/components/searchbar/date-time-picker/AbsoluteDateInput.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/date-time-picker/AbsoluteDateInput.test.tsx
@@ -18,7 +18,7 @@ import * as React from 'react';
 import { fireEvent, render, screen } from 'wrappedTestingLibrary';
 import moment from 'moment';
 
-import DateTime from 'logic/datetimes/DateTime';
+import { DATE_TIME_FORMATS } from 'util/DateTime';
 
 import AbsoluteDateInput from './AbsoluteDateInput';
 
@@ -44,7 +44,7 @@ describe('AbsoluteDateInput', () => {
   it('calls onChange upon changing the input', () => {
     const { getByPlaceholderText } = render(<AbsoluteDateInput {...defaultProps} />);
 
-    const input = getByPlaceholderText(DateTime.Formats.DATETIME);
+    const input = getByPlaceholderText(DATE_TIME_FORMATS.default);
 
     fireEvent.change(input, { target: { value: 'something' } });
 
@@ -52,7 +52,7 @@ describe('AbsoluteDateInput', () => {
   });
 
   it('pressing magic wand inserts current date', () => {
-    const output = moment().format(DateTime.Formats.TIMESTAMP);
+    const output = moment().format(DATE_TIME_FORMATS.complete);
     defaultProps.onChange.mockReturnValueOnce(output);
     const { getByTitle } = render(<AbsoluteDateInput {...defaultProps} />);
 

--- a/graylog2-web-interface/src/views/components/searchbar/date-time-picker/AbsoluteDateInput.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/date-time-picker/AbsoluteDateInput.tsx
@@ -17,10 +17,13 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
+import { useContext } from 'react';
 
 import DateTime from 'logic/datetimes/DateTime';
 import { Icon } from 'components/common';
 import { Button, Input } from 'components/bootstrap';
+import UserDateTimeContext from 'contexts/UserDateTimeContext';
+import { DATE_TIME_FORMATS } from 'util/DateTime';
 
 const Wrapper = styled.div`
   margin: 9px 6px;
@@ -32,7 +35,8 @@ const Wrapper = styled.div`
 `;
 
 const AbsoluteDateInput = ({ name, disabled, onChange, value, hasError }) => {
-  const _onSetTimeToNow = () => onChange(DateTime.now().format(DateTime.Formats.TIMESTAMP));
+  const { formatTime } = useContext(UserDateTimeContext);
+  const _onSetTimeToNow = () => onChange(formatTime(new Date(), 'complete'));
   const _onChange = (event) => onChange(event.target.value);
 
   return (
@@ -43,7 +47,7 @@ const AbsoluteDateInput = ({ name, disabled, onChange, value, hasError }) => {
              autoComplete="off"
              disabled={disabled}
              onChange={_onChange}
-             placeholder={DateTime.Formats.DATETIME}
+             placeholder={DATE_TIME_FORMATS.default}
              value={value}
              buttonAfter={(
                <Button disabled={disabled}

--- a/graylog2-web-interface/src/views/components/searchbar/date-time-picker/AbsoluteDateInput.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/date-time-picker/AbsoluteDateInput.tsx
@@ -17,12 +17,11 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { useContext } from 'react';
 
 import { Icon } from 'components/common';
 import { Button, Input } from 'components/bootstrap';
-import UserDateTimeContext from 'contexts/UserDateTimeContext';
 import { DATE_TIME_FORMATS } from 'util/DateTime';
+import useUserDateTime from 'hooks/useUserDateTime';
 
 const Wrapper = styled.div`
   margin: 9px 6px;
@@ -34,7 +33,7 @@ const Wrapper = styled.div`
 `;
 
 const AbsoluteDateInput = ({ name, disabled, onChange, value, hasError }) => {
-  const { formatTime } = useContext(UserDateTimeContext);
+  const { formatTime } = useUserDateTime();
   const _onSetTimeToNow = () => onChange(formatTime(new Date(), 'complete'));
   const _onChange = (event) => onChange(event.target.value);
 

--- a/graylog2-web-interface/src/views/components/searchbar/date-time-picker/AbsoluteDateInput.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/date-time-picker/AbsoluteDateInput.tsx
@@ -19,7 +19,6 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { useContext } from 'react';
 
-import DateTime from 'logic/datetimes/DateTime';
 import { Icon } from 'components/common';
 import { Button, Input } from 'components/bootstrap';
 import UserDateTimeContext from 'contexts/UserDateTimeContext';

--- a/graylog2-web-interface/src/views/components/searchbar/date-time-picker/AbsoluteDatePicker.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/date-time-picker/AbsoluteDatePicker.tsx
@@ -20,7 +20,7 @@ import { DateUtils } from 'react-day-picker';
 import moment from 'moment';
 
 import { DatePicker } from 'components/common';
-import DateTime from 'logic/datetimes/DateTime';
+import { DATE_TIME_FORMATS } from 'util/DateTime';
 
 type Props = {
   dateTime: string,
@@ -43,7 +43,7 @@ const AbsoluteDatePicker = ({ dateTime, onChange, startDate }: Props) => {
       years: newDate.years,
       months: newDate.months,
       date: newDate.date,
-    }).format(DateTime.Formats.DATETIME));
+    }).format(DATE_TIME_FORMATS.default));
   };
 
   return (

--- a/graylog2-web-interface/src/views/components/searchbar/date-time-picker/AbsoluteTimeInput.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/date-time-picker/AbsoluteTimeInput.tsx
@@ -15,7 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { useRef, useContext } from 'react';
+import { useRef } from 'react';
 import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
 import moment from 'moment';
@@ -25,7 +25,7 @@ import { Icon } from 'components/common';
 import { Button, FormGroup, InputGroup, FormControl } from 'components/bootstrap';
 import type { IconName } from 'components/common/Icon';
 import { DATE_TIME_FORMATS } from 'util/DateTime';
-import UserDateTimeContext from 'contexts/UserDateTimeContext';
+import useUserDateTime from 'hooks/useUserDateTime';
 
 const TIME_ICON_BOD = 'hourglass-start';
 const TIME_ICON_MID = 'hourglass-half';
@@ -198,7 +198,7 @@ const fieldUpdate = (value: string, toUserTimezone: (date: Date) => Moment) => {
 
 const AbsoluteTimeInput = ({ dateTime, range, onChange }) => {
   const hourIcon = useRef<IconName>(TIME_ICON_MID);
-  const { toUserTimezone } = useContext(UserDateTimeContext);
+  const { toUserTimezone } = useUserDateTime();
 
   const {
     initialDateTime,

--- a/graylog2-web-interface/src/views/components/searchbar/date-time-picker/AbsoluteTimeInput.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/date-time-picker/AbsoluteTimeInput.tsx
@@ -15,15 +15,17 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { useRef } from 'react';
+import { useRef, useContext } from 'react';
 import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
 import moment from 'moment';
+import type { Moment } from 'moment';
 
 import { Icon } from 'components/common';
 import { Button, FormGroup, InputGroup, FormControl } from 'components/bootstrap';
-import DateTime from 'logic/datetimes/DateTime';
 import type { IconName } from 'components/common/Icon';
+import { DATE_TIME_FORMATS } from 'util/DateTime';
+import UserDateTimeContext from 'contexts/UserDateTimeContext';
 
 const TIME_ICON_BOD = 'hourglass-start';
 const TIME_ICON_MID = 'hourglass-half';
@@ -131,7 +133,7 @@ const _onFocusSelect = (event) => {
 
 const zeroPad = (data, pad = 2) => String(data).padStart(pad, '0');
 
-const parseTimeValue = (value, type) => {
+const parseTimeValue = (value: string, type: string) => {
   const isNotNumeric = value.match(/[^0-9]/g);
 
   const timeValue = Number(isNotNumeric ? 0 : value);
@@ -147,7 +149,7 @@ const parseTimeValue = (value, type) => {
   return timeValue;
 };
 
-const fieldUpdate = (value) => {
+const fieldUpdate = (value: string, toUserTimezone: (date: Date) => Moment) => {
   const initialDateTime = moment(value).toObject();
 
   TIME_TYPES.forEach((type) => {
@@ -163,18 +165,18 @@ const fieldUpdate = (value) => {
       [timeType]: timeValue,
     });
 
-    return newTime.format(DateTime.Formats.DATETIME);
+    return newTime.format(DATE_TIME_FORMATS.default);
   };
 
   const handleClickTimeNow = () => {
-    const newTime = DateTime.now().toObject();
+    const newTime = toUserTimezone(new Date()).toObject();
 
     return moment({
       ...initialDateTime,
       hours: newTime.hours,
       minutes: newTime.minutes,
       seconds: newTime.seconds,
-    }).format(DateTime.Formats.DATETIME);
+    }).format(DATE_TIME_FORMATS.default);
   };
 
   const handleTimeToggle = (eod = false) => {
@@ -183,7 +185,7 @@ const fieldUpdate = (value) => {
       hours: eod ? 23 : 0,
       minutes: eod ? 59 : 0,
       seconds: eod ? 59 : 0,
-    }).format(DateTime.Formats.DATETIME);
+    }).format(DATE_TIME_FORMATS.default);
   };
 
   return {
@@ -196,13 +198,14 @@ const fieldUpdate = (value) => {
 
 const AbsoluteTimeInput = ({ dateTime, range, onChange }) => {
   const hourIcon = useRef<IconName>(TIME_ICON_MID);
+  const { toUserTimezone } = useContext(UserDateTimeContext);
 
   const {
     initialDateTime,
     handleChangeSetTime,
     handleClickTimeNow,
     handleTimeToggle,
-  } = fieldUpdate(dateTime);
+  } = fieldUpdate(dateTime, toUserTimezone);
 
   const _onChangeSetTime = (event) => {
     hourIcon.current = TIME_ICON_MID;

--- a/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TabAbsoluteTimeRange.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TabAbsoluteTimeRange.tsx
@@ -15,7 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { useState, useContext } from 'react';
+import { useState } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import moment from 'moment';
@@ -23,7 +23,7 @@ import { useFormikContext } from 'formik';
 
 import { Icon, Accordion, AccordionItem } from 'components/common';
 import type { AbsoluteTimeRange } from 'views/logic/queries/Query';
-import UserDateTimeContext from 'contexts/UserDateTimeContext';
+import useUserDateTime from 'hooks/useUserDateTime';
 
 import type { TimeRangeDropDownFormValues } from './TimeRangeDropdown';
 import AbsoluteTimestamp from './AbsoluteTimestamp';
@@ -77,7 +77,7 @@ const FlexWrap = styled.div`
 
 const TabAbsoluteTimeRange = ({ disabled, limitDuration }: Props) => {
   const { values: { nextTimeRange } } = useFormikContext<TimeRangeDropDownFormValues & { nextTimeRange: AbsoluteTimeRange }>();
-  const { toUserTimezone } = useContext(UserDateTimeContext);
+  const { toUserTimezone } = useUserDateTime();
   const [activeAccordion, setActiveAccordion] = useState<'Timestamp' | 'Calendar' | undefined>();
   const toStartDate = moment(nextTimeRange.from).toDate();
   const fromStartDate = limitDuration ? toUserTimezone(new Date()).seconds(-limitDuration).toDate() : undefined;

--- a/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TabAbsoluteTimeRange.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TabAbsoluteTimeRange.tsx
@@ -15,7 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { useState } from 'react';
+import { useState, useContext } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import moment from 'moment';
@@ -23,7 +23,7 @@ import { useFormikContext } from 'formik';
 
 import { Icon, Accordion, AccordionItem } from 'components/common';
 import type { AbsoluteTimeRange } from 'views/logic/queries/Query';
-import DateTime from 'logic/datetimes/DateTime';
+import UserDateTimeContext from 'contexts/UserDateTimeContext';
 
 import type { TimeRangeDropDownFormValues } from './TimeRangeDropdown';
 import AbsoluteTimestamp from './AbsoluteTimestamp';
@@ -77,11 +77,12 @@ const FlexWrap = styled.div`
 
 const TabAbsoluteTimeRange = ({ disabled, limitDuration }: Props) => {
   const { values: { nextTimeRange } } = useFormikContext<TimeRangeDropDownFormValues & { nextTimeRange: AbsoluteTimeRange }>();
-  const [activeAccordion, setActiveAccordion] = useState();
+  const { toUserTimezone } = useContext(UserDateTimeContext);
+  const [activeAccordion, setActiveAccordion] = useState<'Timestamp' | 'Calendar' | undefined>();
   const toStartDate = moment(nextTimeRange.from).toDate();
-  const fromStartDate = limitDuration ? DateTime.now().seconds(-limitDuration).toDate() : undefined;
+  const fromStartDate = limitDuration ? toUserTimezone(new Date()).seconds(-limitDuration).toDate() : undefined;
 
-  const handleSelect = (nextKey) => {
+  const handleSelect = (nextKey: 'Timestamp' | 'Calendar' | undefined) => {
     setActiveAccordion(nextKey ?? activeAccordion);
   };
 

--- a/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TabKeywordTimeRange.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TabKeywordTimeRange.test.tsx
@@ -73,6 +73,7 @@ describe('TabKeywordTimeRange', () => {
   const asyncRender = async (element) => {
     let wrapper;
 
+    // eslint-disable-next-line testing-library/no-unnecessary-act
     await act(async () => { wrapper = render(element); });
 
     if (!wrapper) {
@@ -102,7 +103,7 @@ describe('TabKeywordTimeRange', () => {
 
     await asyncRender(<TabKeywordTimeRange defaultValue="Last hour" />);
 
-    expect(ToolsStore.testNaturalDate).toHaveBeenCalledWith('Last hour');
+    expect(ToolsStore.testNaturalDate).toHaveBeenCalledWith('Last hour', 'Europe/Berlin');
   });
 
   it('sets validation state to error if initial value is empty', async () => {

--- a/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TabKeywordTimeRange.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TabKeywordTimeRange.test.tsx
@@ -38,12 +38,6 @@ const TabKeywordTimeRange = ({ defaultValue, ...props }: { defaultValue: string 
   </Formik>
 );
 
-jest.mock('logic/datetimes/DateTime', () => ({
-  fromUTCDateTime: (date) => date,
-  getUserTimezone: () => 'Europe/Berlin',
-  fromDateTimeAndTZ: (date) => date,
-}));
-
 describe('TabKeywordTimeRange', () => {
   beforeEach(() => {
     asMock(ToolsStore.testNaturalDate).mockImplementation(() => Promise.resolve({

--- a/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TabKeywordTimeRange.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TabKeywordTimeRange.tsx
@@ -92,7 +92,7 @@ const TabKeywordTimeRange = ({ defaultValue, disabled, setValidatingKeyword }: P
 
       return trim(keyword) === ''
         ? Promise.resolve('Keyword must not be empty!')
-        : ToolsStore.testNaturalDate(keyword)
+        : ToolsStore.testNaturalDate(keyword, userTimezone)
           .then((response) => {
             if (mounted.current) _setSuccessfullPreview(response);
           })
@@ -100,7 +100,7 @@ const TabKeywordTimeRange = ({ defaultValue, disabled, setValidatingKeyword }: P
     }
 
     return undefined;
-  }, [_setFailedPreview, _setSuccessfullPreview, setValidatingKeyword]);
+  }, [_setFailedPreview, _setSuccessfullPreview, setValidatingKeyword, userTimezone]);
 
   useEffect(() => {
     return () => {

--- a/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TabKeywordTimeRange.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TabKeywordTimeRange.tsx
@@ -15,7 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { useCallback, useEffect, useRef, useState, useContext } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
 import trim from 'lodash/trim';
@@ -26,8 +26,8 @@ import { Col, FormControl, FormGroup, Panel, Row } from 'components/bootstrap';
 import DocumentationLink from 'components/support/DocumentationLink';
 import DocsHelper from 'util/DocsHelper';
 import ToolsStore from 'stores/tools/ToolsStore';
-import UserDateTimeContext from 'contexts/UserDateTimeContext';
 import type { KeywordTimeRange } from 'views/logic/queries/Query';
+import useUserDateTime from 'hooks/useUserDateTime';
 
 import { EMPTY_RANGE } from '../TimeRangeDisplay';
 
@@ -44,7 +44,7 @@ const ErrorMessage = styled.span(({ theme }) => css`
   display: block;
 `);
 
-const _parseKeywordPreview = (data: Pick<KeywordTimeRange, 'from' | 'to' | 'timezone'>, formatTime: (dateTime: string, tz: string) => string) => {
+const _parseKeywordPreview = (data: Pick<KeywordTimeRange, 'from' | 'to' | 'timezone'>, formatTime: (dateTime: string, format: string) => string) => {
   const { timezone } = data;
 
   return {
@@ -61,7 +61,7 @@ type Props = {
 };
 
 const TabKeywordTimeRange = ({ defaultValue, disabled, setValidatingKeyword }: Props) => {
-  const { formatTime, userTimezone } = useContext(UserDateTimeContext);
+  const { formatTime, userTimezone } = useUserDateTime();
   const [nextRangeProps, , nextRangeHelpers] = useField('nextTimeRange');
   const mounted = useRef(true);
   const keywordRef = useRef<string>();

--- a/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TabKeywordTimeRange.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TabKeywordTimeRange.tsx
@@ -15,7 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState, useContext } from 'react';
 import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
 import trim from 'lodash/trim';
@@ -23,10 +23,11 @@ import isEqual from 'lodash/isEqual';
 import { Field, useField } from 'formik';
 
 import { Col, FormControl, FormGroup, Panel, Row } from 'components/bootstrap';
-import DateTime from 'logic/datetimes/DateTime';
 import DocumentationLink from 'components/support/DocumentationLink';
 import DocsHelper from 'util/DocsHelper';
 import ToolsStore from 'stores/tools/ToolsStore';
+import UserDateTimeContext from 'contexts/UserDateTimeContext';
+import type { KeywordTimeRange } from 'views/logic/queries/Query';
 
 import { EMPTY_RANGE } from '../TimeRangeDisplay';
 
@@ -43,12 +44,14 @@ const ErrorMessage = styled.span(({ theme }) => css`
   display: block;
 `);
 
-const _parseKeywordPreview = (data) => {
+const _parseKeywordPreview = (data: Pick<KeywordTimeRange, 'from' | 'to' | 'timezone'>, formatTime: (dateTime: string, tz: string) => string) => {
   const { timezone } = data;
-  const from = DateTime.fromDateTimeAndTZ(data.from, timezone).toString();
-  const to = DateTime.fromDateTimeAndTZ(data.to, timezone).toString();
 
-  return { from, to, timezone };
+  return {
+    from: formatTime(data.from, 'complete'),
+    to: formatTime(data.to, 'complete'),
+    timezone,
+  };
 };
 
 type Props = {
@@ -58,6 +61,7 @@ type Props = {
 };
 
 const TabKeywordTimeRange = ({ defaultValue, disabled, setValidatingKeyword }: Props) => {
+  const { formatTime, userTimezone } = useContext(UserDateTimeContext);
   const [nextRangeProps, , nextRangeHelpers] = useField('nextTimeRange');
   const mounted = useRef(true);
   const keywordRef = useRef<string>();
@@ -66,15 +70,15 @@ const TabKeywordTimeRange = ({ defaultValue, disabled, setValidatingKeyword }: P
   const _setSuccessfullPreview = useCallback((response: { from: string, to: string, timezone: string }) => {
     setValidatingKeyword(false);
 
-    return setKeywordPreview(_parseKeywordPreview(response));
+    return setKeywordPreview(_parseKeywordPreview(response, formatTime));
   },
-  [setValidatingKeyword]);
+  [setValidatingKeyword, formatTime]);
 
   const _setFailedPreview = useCallback(() => {
-    setKeywordPreview({ from: EMPTY_RANGE, to: EMPTY_RANGE, timezone: DateTime.getUserTimezone() });
+    setKeywordPreview({ from: EMPTY_RANGE, to: EMPTY_RANGE, timezone: userTimezone });
 
     return 'Unable to parse keyword.';
-  }, [setKeywordPreview]);
+  }, [userTimezone]);
 
   const _validateKeyword = useCallback((keyword: string) => {
     if (keyword === undefined) {
@@ -110,7 +114,7 @@ const TabKeywordTimeRange = ({ defaultValue, disabled, setValidatingKeyword }: P
 
   useEffect(() => {
     if (nextRangeProps?.value) {
-      const { type, keyword, ...restPreview } = nextRangeProps?.value;
+      const { type, keyword, ...restPreview } = nextRangeProps.value;
 
       if (!isEqual(restPreview, keywordPreview)) {
         nextRangeHelpers.setValue({

--- a/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TimeRangeDropdown.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TimeRangeDropdown.test.tsx
@@ -40,8 +40,6 @@ jest.mock('stores/tools/ToolsStore', () => ({
   testNaturalDate: jest.fn(),
 }));
 
-jest.mock('hooks/useUserDateTime');
-
 const defaultProps = {
   currentTimeRange: {
     type: 'relative',

--- a/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TimeRangeDropdown.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TimeRangeDropdown.tsx
@@ -23,7 +23,13 @@ import moment from 'moment';
 import { Button, Col, Tabs, Tab, Row, Popover } from 'components/bootstrap';
 import { Icon, KeyCapture } from 'components/common';
 import { availableTimeRangeTypes } from 'views/Constants';
-import type { AbsoluteTimeRange, KeywordTimeRange, NoTimeRangeOverride, TimeRange } from 'views/logic/queries/Query';
+import type {
+  AbsoluteTimeRange,
+  KeywordTimeRange,
+  NoTimeRangeOverride,
+  TimeRange,
+  RelativeTimeRange,
+} from 'views/logic/queries/Query';
 import type { SearchBarFormValues } from 'views/Constants';
 import { isTypeRelative } from 'views/typeGuards/timeRange';
 import { normalizeIfAllMessagesRange } from 'views/logic/queries/NormalizeTimeRange';
@@ -236,9 +242,9 @@ const TimeRangeDropdown = ({
                                            onSubmit={handleSubmit}
                                            validateOnMount>
         {(({ values: { nextTimeRange }, isValid, setFieldValue, submitForm }) => {
-          const handleActiveTab = (nextTab) => {
+          const handleActiveTab = (nextTab: AbsoluteTimeRange['type'] | RelativeTimeRange['type'] | KeywordTimeRange['type']) => {
             if ('type' in nextTimeRange) {
-              setFieldValue('nextTimeRange', migrateTimeRangeToNewType(nextTimeRange as TimeRange, nextTab));
+              setFieldValue('nextTimeRange', migrateTimeRangeToNewType(nextTimeRange as TimeRange, nextTab, formatTime));
             } else {
               setFieldValue('nextTimeRange', defaultRanges[nextTab]);
             }

--- a/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TimeRangeDropdown.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TimeRangeDropdown.tsx
@@ -165,10 +165,10 @@ const timeRangeTypeTabs = ({ activeTab, limitDuration, setValidatingKeyword, tab
     );
   });
 
-const dateTimeValidate = (nextTimeRange, limitDuration) => {
+const dateTimeValidate = (nextTimeRange, limitDuration, formatTime: (dateTime: DateTime, format: string) => string) => {
   let errors = {};
   const timeRange = normalizeIfClassifiedRelativeTimeRange(nextTimeRange);
-  const timeRangeErrors = validateTimeRange(timeRange, limitDuration);
+  const timeRangeErrors = validateTimeRange(timeRange, limitDuration, formatTime);
 
   if (Object.keys(timeRangeErrors).length !== 0) {
     errors = { ...errors, nextTimeRange: timeRangeErrors };
@@ -238,7 +238,7 @@ const TimeRangeDropdown = ({
                    arrowOffsetLeft={positionIsBottom ? 34 : -11}
                    title={title}>
       <Formik<TimeRangeDropDownFormValues> initialValues={{ nextTimeRange: onInitializingNextTimeRange(currentTimeRange) }}
-                                           validate={({ nextTimeRange }) => dateTimeValidate(nextTimeRange, limitDuration)}
+                                           validate={({ nextTimeRange }) => dateTimeValidate(nextTimeRange, limitDuration, formatTime)}
                                            onSubmit={handleSubmit}
                                            validateOnMount>
         {(({ values: { nextTimeRange }, isValid, setFieldValue, submitForm }) => {

--- a/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TimeRangeLivePreview.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TimeRangeLivePreview.tsx
@@ -24,8 +24,8 @@ import { readableRange } from 'views/logic/queries/TimeRangeToString';
 import { isTypeRelative, isTypeRelativeWithEnd, isTypeRelativeWithStartOnly } from 'views/typeGuards/timeRange';
 import type { TimeRange, NoTimeRangeOverride } from 'views/logic/queries/Query';
 import { Icon } from 'components/common';
-import DateTime from 'logic/datetimes/DateTime';
 import type { SearchBarFormValues } from 'views/Constants';
+import { DATE_TIME_FORMATS } from 'util/DateTime';
 
 import { EMPTY_OUTPUT, EMPTY_RANGE } from '../TimeRangeDisplay';
 
@@ -118,7 +118,7 @@ const TimeRangeLivePreview = ({ timerange }: Props) => {
     <PreviewWrapper data-testid="time-range-live-preview">
       <FromWrapper>
         <Title>From</Title>
-        <Date title={`Dates Formatted as [${DateTime.Formats.TIMESTAMP}]`}>{from}</Date>
+        <Date title={`Dates Formatted as [${DATE_TIME_FORMATS.complete}]`}>{from}</Date>
       </FromWrapper>
 
       <MiddleIcon>
@@ -127,7 +127,7 @@ const TimeRangeLivePreview = ({ timerange }: Props) => {
 
       <UntilWrapper>
         <Title>Until</Title>
-        <Date title={`Dates Formatted as [${DateTime.Formats.TIMESTAMP}]`}>{until}</Date>
+        <Date title={`Dates Formatted as [${DATE_TIME_FORMATS.complete}]`}>{until}</Date>
       </UntilWrapper>
     </PreviewWrapper>
   );

--- a/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TimerangeDropdown.relativeTimeRange.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TimerangeDropdown.relativeTimeRange.test.tsx
@@ -35,7 +35,6 @@ jest.mock('views/stores/SearchConfigStore', () => ({
   ),
 }));
 
-jest.mock('hooks/useUserDateTime');
 jest.mock('stores/tools/ToolsStore', () => ({}));
 
 const defaultProps = {

--- a/graylog2-web-interface/src/views/components/searchbar/queryinput/QueryInput.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/queryinput/QueryInput.tsx
@@ -28,6 +28,7 @@ import useFieldTypes from 'views/logic/fieldtypes/useFieldTypes';
 import { DEFAULT_TIMERANGE } from 'views/Constants';
 import { isNoTimeRangeOverride } from 'views/typeGuards/timeRange';
 import usePluginEntities from 'views/logic/usePluginEntities';
+import UserDateTimeContext from 'contexts/UserDateTimeContext';
 
 import type { AutoCompleter, Editor } from './ace-types';
 import type { BaseProps } from './BasicQueryInput';
@@ -134,7 +135,7 @@ const _updateEditorConfiguration = (node, completer, onExecute) => {
   }
 };
 
-const useCompleter = ({ streams, timeRange, completerFactory }: Pick<Props, 'streams' | 'timeRange' | 'completerFactory'>) => {
+const useCompleter = ({ streams, timeRange, completerFactory, userTimezone }: Pick<Props, 'streams' | 'timeRange' | 'completerFactory'> & { userTimezone: string }) => {
   const completers = usePluginEntities('views.completers') ?? [];
   const { data: queryFields } = useFieldTypes(streams, isNoTimeRangeOverride(timeRange) ? DEFAULT_TIMERANGE : timeRange);
   const { data: allFields } = useFieldTypes([], DEFAULT_TIMERANGE);
@@ -146,7 +147,7 @@ const useCompleter = ({ streams, timeRange, completerFactory }: Pick<Props, 'str
   }, [allFields, queryFields]);
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  return useMemo(() => completerFactory(completers, timeRange, streams, fieldTypes), [completerFactory, timeRange, streams, fieldTypes]);
+  return useMemo(() => completerFactory(completers, timeRange, streams, fieldTypes, userTimezone), [completerFactory, timeRange, streams, fieldTypes, userTimezone]);
 };
 
 type Props = BaseProps & {
@@ -155,6 +156,7 @@ type Props = BaseProps & {
     timeRange: TimeRange | NoTimeRangeOverride | undefined,
     streams: Array<string>,
     fieldTypes: FieldTypes,
+    userTimezone: string,
   ) => AutoCompleter,
   disableExecution?: boolean,
   isValidating?: boolean,
@@ -188,9 +190,10 @@ const QueryInput = ({
   wrapEnabled,
   name,
 }: Props) => {
+  const { userTimezone } = useContext(UserDateTimeContext);
   const isInitialTokenizerUpdate = useRef(true);
   const { enableSmartSearch } = useContext(UserPreferencesContext);
-  const completer = useCompleter({ streams, timeRange, completerFactory });
+  const completer = useCompleter({ streams, timeRange, completerFactory, userTimezone });
   const onLoadEditor = useCallback((editor: Editor) => _onLoadEditor(editor, isInitialTokenizerUpdate), []);
   const onExecute = useCallback((editor: Editor) => handleExecution({
     editor,

--- a/graylog2-web-interface/src/views/components/searchbar/queryinput/QueryInput.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/queryinput/QueryInput.tsx
@@ -28,7 +28,7 @@ import useFieldTypes from 'views/logic/fieldtypes/useFieldTypes';
 import { DEFAULT_TIMERANGE } from 'views/Constants';
 import { isNoTimeRangeOverride } from 'views/typeGuards/timeRange';
 import usePluginEntities from 'views/logic/usePluginEntities';
-import UserDateTimeContext from 'contexts/UserDateTimeContext';
+import useUserDateTime from 'hooks/useUserDateTime';
 
 import type { AutoCompleter, Editor } from './ace-types';
 import type { BaseProps } from './BasicQueryInput';
@@ -190,7 +190,7 @@ const QueryInput = ({
   wrapEnabled,
   name,
 }: Props) => {
-  const { userTimezone } = useContext(UserDateTimeContext);
+  const { userTimezone } = useUserDateTime();
   const isInitialTokenizerUpdate = useRef(true);
   const { enableSmartSearch } = useContext(UserPreferencesContext);
   const completer = useCompleter({ streams, timeRange, completerFactory, userTimezone });

--- a/graylog2-web-interface/src/views/components/searchbar/queryvalidation/QueryValidation.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/queryvalidation/QueryValidation.test.tsx
@@ -52,7 +52,6 @@ jest.mock('views/stores/SearchExecutionStateStore', () => ({
 
 jest.mock('views/logic/usePluginEntities');
 jest.mock('logic/rest/FetchProvider', () => jest.fn(() => Promise.resolve()));
-jest.mock('logic/datetimes/DateTime', () => ({}));
 
 type SUTProps = {
   // eslint-disable-next-line react/require-default-props

--- a/graylog2-web-interface/src/views/components/searchbar/queryvalidation/validateQuery.test.ts
+++ b/graylog2-web-interface/src/views/components/searchbar/queryvalidation/validateQuery.test.ts
@@ -68,7 +68,11 @@ describe('validateQuery', () => {
 
     const expectedPayload = {
       ...requestPayload,
-      timerange: { type: 'absolute', from: '2021-01-01T22:00:00.000Z', to: '2021-01-01T23:00:00.000Z' },
+      timerange: {
+        type: 'absolute',
+        from: '2021-01-01T15:00:00.000+00:00',
+        to: '2021-01-01T16:00:00.000+00:00',
+      },
     };
 
     expect(fetch).toHaveBeenCalledWith('POST', expect.any(String), expectedPayload);

--- a/graylog2-web-interface/src/views/components/searchbar/queryvalidation/validateQuery.test.ts
+++ b/graylog2-web-interface/src/views/components/searchbar/queryvalidation/validateQuery.test.ts
@@ -48,8 +48,10 @@ describe('validateQuery', () => {
     streams: ['stream-id'],
   };
 
+  const userTimezone = 'Europe/Berlin';
+
   it('calls validate API', async () => {
-    await validateQuery(validationInput);
+    await validateQuery(validationInput, userTimezone);
 
     await waitFor(() => expect(fetch).toHaveBeenCalledTimes(1));
 
@@ -60,7 +62,7 @@ describe('validateQuery', () => {
     await validateQuery({
       ...validationInput,
       timeRange: { type: 'absolute', from: '2021-01-01 16:00:00.000', to: '2021-01-01 17:00:00.000' },
-    });
+    }, userTimezone);
 
     await waitFor(() => expect(fetch).toHaveBeenCalledTimes(1));
 
@@ -78,7 +80,7 @@ describe('validateQuery', () => {
     const result = await validateQuery({
       ...validationInput,
       timeRange: { type: 'absolute', from: '2021-01-01 16:00:00.000', to: '2021-01-01 17:00:00.000' },
-    });
+    }, userTimezone);
 
     expect(UserNotification.error).toHaveBeenCalledWith('Validating search query failed with status: Error: Unexpected error');
     expect(result).toEqual({ status: 'OK' });

--- a/graylog2-web-interface/src/views/components/searchbar/queryvalidation/validateQuery.ts
+++ b/graylog2-web-interface/src/views/components/searchbar/queryvalidation/validateQuery.ts
@@ -33,20 +33,23 @@ const queryExists = (query: string | ElasticsearchQueryString) => {
   return typeof query === 'object' ? !!query.query_string : !!query;
 };
 
-export const validateQuery = ({
-  queryString,
-  timeRange,
-  streams,
-  filter,
-  ...rest
-}: ValidationQuery): Promise<QueryValidationState> => {
+export const validateQuery = (
+  {
+    queryString,
+    timeRange,
+    streams,
+    filter,
+    ...rest
+  }: ValidationQuery,
+  userTimezone: string,
+): Promise<QueryValidationState> => {
   if (!queryExists(queryString) && !queryExists(filter)) {
     return Promise.resolve({ status: 'OK', explanations: [] });
   }
 
   const payload = {
     query: queryString,
-    timerange: timeRange ? onSubmittingTimerange(timeRange) : undefined,
+    timerange: timeRange ? onSubmittingTimerange(timeRange, userTimezone) : undefined,
     streams,
     filter,
     ...rest,

--- a/graylog2-web-interface/src/views/components/searchbar/validate.ts
+++ b/graylog2-web-interface/src/views/components/searchbar/validate.ts
@@ -21,6 +21,7 @@ import validateTimeRange from 'views/components/TimeRangeValidation';
 import type { TimeRange, NoTimeRangeOverride } from 'views/logic/queries/Query';
 import type { SearchBarControl } from 'views/types';
 import { validatePluggableValues } from 'views/components/searchbar/pluggableSearchBarControlsHandler';
+import type { DateTime } from 'util/DateTime';
 
 type FormValues = {
   queryString: string,
@@ -33,11 +34,12 @@ const validate = async <T extends FormValues>(
   setFieldWarning: (fieldName: string, warning: unknown) => void,
   validateQueryString: (values: T) => Promise<QueryValidationState>,
   pluggableSearchBarControls: Array<() => SearchBarControl>,
+  formatTime: (dateTime: DateTime, format: string) => string,
 ) => {
   const { timerange: nextTimeRange } = values;
   let errors = {};
 
-  const timeRangeErrors = validateTimeRange(nextTimeRange, limitDuration);
+  const timeRangeErrors = validateTimeRange(nextTimeRange, limitDuration, formatTime);
 
   if (!isEmpty(timeRangeErrors)) {
     errors = { ...errors, timerange: timeRangeErrors };

--- a/graylog2-web-interface/src/views/components/sidebar/Sidebar.test.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/Sidebar.test.tsx
@@ -93,7 +93,7 @@ describe('<Sidebar />', () => {
 
     fireEvent.click(await screen.findByTitle(/open sidebar/i));
 
-    await screen.findAllByText((_content, node) => (node.textContent === 'Query executed in 64ms at 2018-08-28 14:39:26.'));
+    await screen.findAllByText((_content, node) => (node.textContent === 'Query executed in 64ms at 2018-08-28 16:39:26.'));
   });
 
   const emptyViewMetaData = {

--- a/graylog2-web-interface/src/views/components/sidebar/Sidebar.test.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/Sidebar.test.tsx
@@ -39,8 +39,6 @@ jest.mock('util/AppConfig', () => ({
   gl2ServerUrl: jest.fn(() => undefined),
 }));
 
-jest.mock('hooks/useUserDateTime');
-
 describe('<Sidebar />', () => {
   const viewMetaData = {
     activeQuery: '34efae1e-e78e-48ab-ab3f-e83c8611a683',

--- a/graylog2-web-interface/src/views/components/views/DashboardList.test.tsx
+++ b/graylog2-web-interface/src/views/components/views/DashboardList.test.tsx
@@ -23,7 +23,6 @@ import Search from 'views/logic/search/Search';
 import DashboardList from './DashboardList';
 
 jest.mock('routing/Routes', () => ({ pluginRoute: () => () => '/route' }));
-jest.mock('hooks/useUserDateTime');
 
 const createPaginatedDashboards = (count = 1) => {
   const dashboards: Array<View> = [];

--- a/graylog2-web-interface/src/views/components/views/DashboardListItem.test.tsx
+++ b/graylog2-web-interface/src/views/components/views/DashboardListItem.test.tsx
@@ -25,7 +25,6 @@ import CurrentUserContext from 'contexts/CurrentUserContext';
 import DashboardListItem from './DashboardListItem';
 
 jest.mock('routing/Routes', () => ({ pluginRoute: () => () => '/route' }));
-jest.mock('hooks/useUserDateTime');
 const mockedUnixTime = 1577836800000; // 2020-01-01 00:00:00.000
 
 jest.useFakeTimers()

--- a/graylog2-web-interface/src/views/components/views/DashboardListItem.test.tsx
+++ b/graylog2-web-interface/src/views/components/views/DashboardListItem.test.tsx
@@ -59,7 +59,7 @@ describe('Render DashboardListItem', () => {
     await screen.findByText('search-title-0');
     await screen.findByText('desc');
     await screen.findByText('sum');
-    await screen.findByText('2020-01-01 00:00:00');
+    await screen.findByText('2020-01-01 01:00:00');
   });
 
   it('should render text "Last saved" if current user the same as an owner', async () => {

--- a/graylog2-web-interface/src/views/components/visualizations/useChartData.ts
+++ b/graylog2-web-interface/src/views/components/visualizations/useChartData.ts
@@ -14,16 +14,16 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import { useContext, useMemo } from 'react';
+import { useMemo } from 'react';
 import type { Optional } from 'utility-types';
 
 import type { ChartDataConfig } from 'views/components/visualizations/ChartData';
 import { chartData } from 'views/components/visualizations/ChartData';
 import type { Rows } from 'views/logic/searchtypes/pivot/PivotHandler';
-import UserDateTimeContext from 'contexts/UserDateTimeContext';
+import useUserDateTime from 'hooks/useUserDateTime';
 
 const useChartData = (rows: Rows, config: Optional<ChartDataConfig, 'formatTime'>) => {
-  const { formatTime } = useContext(UserDateTimeContext);
+  const { formatTime } = useUserDateTime();
 
   return useMemo(() => chartData(rows, {
     formatTime,

--- a/graylog2-web-interface/src/views/components/visualizations/useEvents.ts
+++ b/graylog2-web-interface/src/views/components/visualizations/useEvents.ts
@@ -14,15 +14,15 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import { useCallback, useContext } from 'react';
+import { useCallback } from 'react';
 
 import type { Event } from 'views/logic/searchtypes/events/EventHandler';
 import EventHandler from 'views/logic/searchtypes/events/EventHandler';
-import UserDateTimeContext from 'contexts/UserDateTimeContext';
 import type AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
+import useUserDateTime from 'hooks/useUserDateTime';
 
 const useEvents = (config: AggregationWidgetConfig, events: Event[] | undefined) => {
-  const { formatTime } = useContext(UserDateTimeContext);
+  const { formatTime } = useUserDateTime();
   const formatTimestamp = useCallback((timestamp: string) => formatTime(timestamp, 'internal'), [formatTime]);
 
   return (config.eventAnnotation && events)

--- a/graylog2-web-interface/src/views/components/visualizations/worldmap/WorldMapVisualization.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/worldmap/WorldMapVisualization.tsx
@@ -24,7 +24,7 @@ import type { VisualizationComponentProps } from 'views/components/aggregationbu
 import { makeVisualization, retrieveChartData } from 'views/components/aggregationbuilder/AggregationBuilder';
 import type { Rows } from 'views/logic/searchtypes/pivot/PivotHandler';
 import type Pivot from 'views/logic/aggregationbuilder/Pivot';
-import UserDateTimeContext from 'contexts/UserDateTimeContext';
+import useUserDateTime from 'hooks/useUserDateTime';
 
 import MapVisualization from './MapVisualization';
 
@@ -74,7 +74,7 @@ const WorldMapVisualization = makeVisualization(({
   const hasMetric = !isEmpty(config.series);
   const markerRadiusSize = !hasMetric ? 1 : undefined;
   const seriesExtractor = hasMetric ? extractSeries() : _createSeriesWithoutMetric;
-  const { formatTime } = useContext(UserDateTimeContext);
+  const { formatTime } = useUserDateTime();
 
   const pipeline = flow([
     transformKeys(config.rowPivots, config.columnPivots, formatTime),

--- a/graylog2-web-interface/src/views/components/widgets/MessageTable.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageTable.test.tsx
@@ -38,8 +38,6 @@ jest.mock('stores/configurations/ConfigurationsStore', () => ({
   },
 }));
 
-jest.mock('hooks/useUserDateTime');
-
 const messages = [
   {
     highlight_ranges: {},

--- a/graylog2-web-interface/src/views/components/widgets/TimerangeInfo.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/TimerangeInfo.test.tsx
@@ -43,7 +43,7 @@ const mockSearchStoreState = (storeState: {} = {}): {} => ({
           'search-type-id': {
             type: 'pivot',
             effective_timerange: {
-              type: 'absolute', from: '2021-03-27T14:32:31.894Z', to: '2021-04-26T14:32:48.000Z',
+              type: 'absolute', from: '2021-04-26T12:32:48.000Z', to: '2021-04-26T14:32:48.000Z',
             },
           },
         },
@@ -74,7 +74,7 @@ describe('TimerangeInfo', () => {
     const relativeWidget = widget.toBuilder().timerange({ type: 'relative', range: 3000 }).build();
     render(<TimerangeInfo widget={relativeWidget} activeQuery="active-query-id" widgetId="widget-id" />);
 
-    expect(screen.getByTitle('2021-03-27 14:32:31 - 2021-04-26 14:32:48')).toBeInTheDocument();
+    expect(screen.getByTitle('2021-04-26T14:32:48.000+02:00 - 2021-04-26T16:32:48.000+02:00')).toBeInTheDocument();
   });
 
   it('should display a relative timerange', () => {
@@ -98,13 +98,13 @@ describe('TimerangeInfo', () => {
     expect(screen.getByText('All Time')).toBeInTheDocument();
   });
 
-  it('should display a absolute timerange', () => {
+  it('should display an absolute timerange', () => {
     const absoluteWidget = widget.toBuilder()
       .timerange({ type: 'absolute', from: '2021-03-27T14:32:31.894Z', to: '2021-04-26T14:32:48.000Z' })
       .build();
     render(<TimerangeInfo widget={absoluteWidget} />);
 
-    expect(screen.getByText('2021-03-27 14:32:31 - 2021-04-26 14:32:48')).toBeInTheDocument();
+    expect(screen.getByText('2021-03-27 15:32:31.894 - 2021-04-26 16:32:48.000')).toBeInTheDocument();
   });
 
   it('should display a keyword timerange', () => {

--- a/graylog2-web-interface/src/views/components/widgets/TimerangeInfo.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/TimerangeInfo.test.tsx
@@ -63,8 +63,6 @@ jest.mock('views/stores/SearchStore', () => ({
   ),
 }));
 
-jest.mock('hooks/useUserDateTime');
-
 describe('TimerangeInfo', () => {
   const widget = Widget.empty();
 

--- a/graylog2-web-interface/src/views/components/widgets/Widget.aggregations.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/Widget.aggregations.test.tsx
@@ -212,8 +212,8 @@ describe('Aggregation Widget', () => {
       const updatedWidget = dataTableWidget
         .toBuilder()
         .timerange({
-          from: '2019-12-31T23:55:00.000Z',
-          to: '2020-01-01T00:00:00.000Z',
+          from: '2019-12-31T23:55:00.000+00:00',
+          to: '2020-01-01T00:00:00.000+00:00',
           type: 'absolute',
         })
         .build();
@@ -228,13 +228,13 @@ describe('Aggregation Widget', () => {
       userEvent.click(absoluteTabButton);
 
       const timeRangeLivePreview = await screen.findByTestId('time-range-live-preview');
-      await within(timeRangeLivePreview).findByText('2019-12-31 18:00:00.000');
+      await within(timeRangeLivePreview).findByText('2020-01-01 00:55:00.000');
 
       const applyTimeRangeChangesButton = await screen.findByRole('button', { name: 'Apply' });
       userEvent.click(applyTimeRangeChangesButton);
 
       const timeRangeDisplay = await screen.findByLabelText('Search Time Range, Opens Time Range Selector On Click');
-      await within(timeRangeDisplay).findByText('2019-12-31 18:00:00.000');
+      await within(timeRangeDisplay).findByText('2020-01-01 00:55:00.000');
 
       // Submit all changes
       const saveButton = screen.getByText('Apply Changes');


### PR DESCRIPTION
_Please note, this PR needs to be merged together with https://github.com/Graylog2/graylog-plugin-enterprise/pull/3776_

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This is a follow-up PR for multiple PR's related to the refactoring of our date time handling. One goal it to replace the `DateTime` class. 
The class is directly calling the `CurrentUserStore`, which is not a good practice since it comes with some disadvantages. We used this class every time we worked with date times, but it is hard to understand that it will always transform the provided date, based on the user timezone. Instead we now implemented:
- `utils/DateTime` which provides functions to transform a date, independently of the timezone of the current user
- `contexts/UserDateTimeContext` which provides functions to convert a date, based on the user timezone.
- `components/common/Timestamp` and similar components to display a timestamp based on the user timezone. These components are already implementing the `UserDateTimeContext`.

With this PR we are replacing the remaining usage of the legacy `DateTime` class. There is only the `AlertMessages` component left in this repo, which will be removed completely soon.


Please note, I have not fixed all linter hints to reduce the complexity of this refactoring.

/jenkins-pr-deps https://github.com/Graylog2/graylog-plugin-enterprise/pull/3776