### PR TITLE
Auto select first suggestion in query input autocompletion.

### DIFF
--- a/graylog2-web-interface/src/views/components/searchbar/SearchBarAutocompletions.ts
+++ b/graylog2-web-interface/src/views/components/searchbar/SearchBarAutocompletions.ts
@@ -71,8 +71,6 @@ export default class SearchBarAutoCompletions implements AutoCompleter {
   }
 
   getCompletions = async (editor: Editor, _session: Session, pos: Position, prefix: string, callback: ResultsCallback) => {
-    // eslint-disable-next-line no-param-reassign
-    editor.completer.autoSelect = false;
     const tokens = editor.session.getTokens(pos.row);
     const currentToken = editor.session.getTokenAt(pos.row, pos.column);
     const currentTokenIdx = tokens.findIndex((t) => (t === currentToken));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

With this PR we are now selecting the first suggestion in the query input autocompletion. With this change we are reenabling the default `react-ace` behaviour. This reduces the amount of click it takes to select a suggestion.
