### PR TITLE
Fix `Show documents for value` field value action, for missing buckets.

### DIFF
--- a/graylog2-web-interface/src/views/logic/valueactions/ShowDocumentsHandler.test.ts
+++ b/graylog2-web-interface/src/views/logic/valueactions/ShowDocumentsHandler.test.ts
@@ -19,6 +19,7 @@ import FieldType from 'views/logic/fieldtypes/FieldType';
 import { TitlesActions } from 'views/stores/TitlesStore';
 import TitleTypes from 'views/stores/TitleTypes';
 import { WidgetActions } from 'views/stores/WidgetStore';
+import { MISSING_BUCKET_NAME } from 'views/Constants';
 
 import ShowDocumentsHandler from './ShowDocumentsHandler';
 
@@ -124,6 +125,16 @@ describe('ShowDocumentsHandler', () => {
 
         expect(newWidget.config.fields).toEqual(['timestamp', 'source', 'hello']);
       });
+  });
+
+  it('creates correct widget query for missing bucket field value', async () => {
+    await ShowDocumentsHandler({ queryId, field, value: 42, type: FieldType.Unknown, contexts: { widget, valuePath: [{ foo: MISSING_BUCKET_NAME }] } });
+
+    expect(WidgetActions.create).toHaveBeenCalled();
+
+    const newWidget = asMock(WidgetActions.create).mock.calls[0][0];
+
+    expect(newWidget.query).toEqual(createElasticsearchQueryString('NOT _exists_:foo'));
   });
 
   describe('on dashboard', () => {

--- a/graylog2-web-interface/src/views/logic/valueactions/ShowDocumentsHandler.ts
+++ b/graylog2-web-interface/src/views/logic/valueactions/ShowDocumentsHandler.ts
@@ -14,7 +14,7 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import { DEFAULT_MESSAGE_FIELDS } from 'views/Constants';
+import { DEFAULT_MESSAGE_FIELDS, MISSING_BUCKET_NAME } from 'views/Constants';
 import { WidgetActions } from 'views/stores/WidgetStore';
 import { escape, addToQuery } from 'views/logic/queries/QueryHelper';
 import TitleTypes from 'views/stores/TitleTypes';
@@ -52,7 +52,7 @@ const ShowDocumentsHandler: ValueActionHandler<Contexts> = ({ contexts: { valueP
   }), {});
   const widgetQuery = widget && widget.query ? widget.query.query_string : '';
   const valuePathQuery = Object.entries(mergedObject)
-    .map(([k, v]) => `${k}:${escape(String(v))}`)
+    .map(([k, v]) => (v === MISSING_BUCKET_NAME ? `NOT _exists_:${k}` : `${k}:${escape(String(v))}`))
     .reduce((prev: string, next: string) => addToQuery(prev, next), '');
   const query = addToQuery(widgetQuery, valuePathQuery);
   const valuePathFields = extractFieldsFromValuePath(valuePath);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

With https://github.com/Graylog2/graylog2-server/pull/12958 we are now considering documents which are missing the field being pivoted on, in aggregations. With this PR we are fixing the field value action "Show documents for value" for this information.

![image](https://user-images.githubusercontent.com/46300478/177272909-2ac9cac9-8f78-461a-97c3-d3610d2a8f62.png)

When a user click on this action we create a new widget with the following query: `NOT _exists_:fieldName`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

