### PR TITLE
Switch from 'openjdk' to 'eclipse-temurin' for Graylog Server test image

### DIFF
--- a/graylog2-server/src/test/resources/org/graylog/testing/graylognode/Dockerfile
+++ b/graylog2-server/src/test/resources/org/graylog/testing/graylognode/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jre-slim-buster
+FROM eclipse-temurin:8-jre-jammy
 
 ARG GRAYLOG_VERSION
 ARG BUILD_DATE
@@ -13,7 +13,6 @@ WORKDIR ${GRAYLOG_HOME}
 
 # hadolint ignore=DL3027,DL3008
 RUN \
-  echo "export JAVA_HOME=/usr/local/openjdk-8"     > /etc/profile.d/graylog.sh && \
   echo "export BUILD_DATE=${BUILD_DATE}"           >> /etc/profile.d/graylog.sh && \
   echo "export GRAYLOG_VERSION=${GRAYLOG_VERSION}" >> /etc/profile.d/graylog.sh && \
   echo "export GRAYLOG_SERVER_JAVA_OPTS='-Dlog4j2.formatMsgNoLookups=true -Djdk.tls.acknowledgeCloseNotify=true -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -XX:NewRatio=1 -XX:MaxMetaspaceSize=256m -server -XX:+ResizeTLAB -XX:+UseConcMarkSweepGC -XX:+CMSConcurrentMTEnabled -XX:+CMSClassUnloadingEnabled -XX:+UseParNewGC -XX:-OmitStackTraceInFastThrow " ${DEBUG_OPTS} "'" >> /etc/profile.d/graylog.sh && \
@@ -50,6 +49,10 @@ RUN \
     "${GRAYLOG_USER}" && \
   chown --recursive "${GRAYLOG_USER}":"${GRAYLOG_GROUP}" ${GRAYLOG_HOME} && \
   setcap 'cap_net_bind_service=+ep' "${JAVA_HOME}/bin/java" && \
+  # https://github.com/docker-library/openjdk/blob/da594d91b0364d5f1a32e0ce6b4d3fd8a9116844/8/jdk/slim-bullseye/Dockerfile#L105
+  # https://github.com/docker-library/openjdk/issues/331#issuecomment-498834472
+  find "$JAVA_HOME/lib" -name '*.so' -exec dirname '{}' ';' | sort -u > /etc/ld.so.conf.d/docker-openjdk.conf && \
+  ldconfig && \
   apt-get remove --assume-yes --purge \
     apt-utils > /dev/null && \
   rm -f /etc/apt/sources.list.d/* && \


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
The `openjdk` images are being retired/discontinued.  Since Eclipse Temurin (AdoptOpenJDK) was previously selected for other Graylog uses, it seems like a good pick for Graylog images.

Ubuntu Jammy, selected as the OS variant here (and by the Temurin project for non-specific tags), will have standard support until April 2027.

This also includes a fix for non-root SO loading that was being done in the 'openjdk' images, but isn't (currently) with Temurin.  Without it the following error will occur:
```
java: error while loading shared libraries: libjli.so: cannot open shared object file: No such file or directory
```

This is related to Graylog2/graylog-docker#213.

Closes #13114.

Refs:
* https://github.com/docker-library/openjdk/issues/505
* https://github.com/Graylog2/graylog2-server/issues/11467
* https://github.com/Graylog2/graylog2-server/blob/bf001c5a039380e0afadc9f570d070d2b70ee578/.github/workflows/build.yml#L18
* https://github.com/docker-library/openjdk/blob/da594d91b0364d5f1a32e0ce6b4d3fd8a9116844/8/jdk/slim-bullseye/Dockerfile#L105
* https://github.com/docker-library/openjdk/issues/331#issuecomment-498834472

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Keeps the test image current and using the same base image as the official Graylog images (pending other PR approval).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Checks passed.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

