### PR TITLE
Control registration of pluggable routes and navigation items depending on enabled feature flags.

### DIFF
--- a/graylog2-web-interface/src/@types/graylog-web-plugin/index.d.ts
+++ b/graylog2-web-interface/src/@types/graylog-web-plugin/index.d.ts
@@ -20,12 +20,22 @@ interface PluginRoute {
   path: string;
   component: React.ComponentType;
   parentComponent?: React.ComponentType | null;
-  permissions?: string;
+  permissions?: string | Array<string>;
+  requiredFeatureFlag?: string;
 }
 interface PluginNavigation {
   path: string;
   description: string;
+  children?: Array<PluginNavigationDropdownItem>
 }
+
+interface PluginNavigationDropdownItem {
+  description: string,
+  path: string,
+  permissions?: string | Array<string>,
+  requiredFeatureFlag?: string,
+}
+
 interface PluginNavigationItems {
   key: string;
   component: React.ComponentType<{ smallScreen?: boolean }>;

--- a/graylog2-web-interface/src/@types/graylog-web-plugin/index.d.ts
+++ b/graylog2-web-interface/src/@types/graylog-web-plugin/index.d.ts
@@ -26,6 +26,7 @@ interface PluginRoute {
 interface PluginNavigation {
   path: string;
   description: string;
+  requiredFeatureFlag?: string;
   children?: Array<PluginNavigationDropdownItem>
 }
 

--- a/graylog2-web-interface/src/components/navigation/Navigation.test.tsx
+++ b/graylog2-web-interface/src/components/navigation/Navigation.test.tsx
@@ -229,6 +229,7 @@ describe('Navigation', () => {
       links.forEach((title) => expect(wrapper.find(`NavItem[children="${title}"]`)).toExist());
     };
 
+    // eslint-disable-next-line jest/expect-expect
     it.each`
     permissions                    | count | links
     ${[]}                          | ${5}  | ${['Search', 'Streams', 'Alerts', 'Dashboards']}

--- a/graylog2-web-interface/src/components/navigation/Navigation.tsx
+++ b/graylog2-web-interface/src/components/navigation/Navigation.tsx
@@ -68,17 +68,21 @@ const formatSinglePluginRoute = ({ description, path, permissions, requiredFeatu
   }
 
   if (requiredFeatureFlag) {
-    link = <IfFeatureEnabled name={requiredFeatureFlag}>{link}</IfFeatureEnabled>;
+    link = <IfFeatureEnabled key={description} name={requiredFeatureFlag}>{link}</IfFeatureEnabled>;
   }
 
   return link;
 };
 
 const formatPluginRoute = (pluginRoute, permissions, pathname) => {
+  if (pluginRoute.requiredFeatureFlag && !AppConfig.isFeatureEnabled(pluginRoute.requiredFeatureFlag)) {
+    return null;
+  }
+
   if (pluginRoute.children) {
     const activeChild = pluginRoute.children.filter(({ path }) => (path && _isActive(pathname, path)));
     const title = activeChild.length > 0 ? `${pluginRoute.description} / ${activeChild[0].description}` : pluginRoute.description;
-    const isEmpty = !pluginRoute.children.some((child) => isPermitted(permissions, child.permissions));
+    const isEmpty = !pluginRoute.children.some((child) => isPermitted(permissions, child.permissions) && (child.requiredFeatureFlag ? AppConfig.isFeatureEnabled(child.requiredFeatureFlag) : true));
 
     if (isEmpty) {
       return null;

--- a/graylog2-web-interface/src/components/navigation/Navigation.tsx
+++ b/graylog2-web-interface/src/components/navigation/Navigation.tsx
@@ -18,6 +18,7 @@ import * as React from 'react';
 import { useContext } from 'react';
 import { useLocation } from 'react-router-dom';
 import { PluginStore } from 'graylog-web-plugin/plugin';
+import type { PluginNavigationDropdownItem } from 'graylog-web-plugin';
 
 import { defaultCompare as naturalSort } from 'logic/DefaultCompare';
 import { LinkContainer } from 'components/common/router';
@@ -29,6 +30,7 @@ import { isPermitted } from 'util/PermissionsMixin';
 import CurrentUserContext from 'contexts/CurrentUserContext';
 import GlobalThroughput from 'components/throughput/GlobalThroughput';
 import Routes, { ENTERPRISE_ROUTE_DESCRIPTION, SECURITY_ROUTE_DESCRIPTION } from 'routing/Routes';
+import IfFeatureEnabled from 'components/features/IfFeatureEnabled';
 
 import UserMenu from './UserMenu';
 import HelpMenu from './HelpMenu';
@@ -58,11 +60,15 @@ function pluginMenuItemExists(description: string): boolean {
   return !!pluginExports.find((value) => value.description?.toLowerCase() === description.toLowerCase());
 }
 
-const formatSinglePluginRoute = ({ description, path, permissions }, topLevel = false) => {
-  const link = <NavigationLink key={description} description={description} path={appPrefixed(path)} topLevel={topLevel} />;
+const formatSinglePluginRoute = ({ description, path, permissions, requiredFeatureFlag }: PluginNavigationDropdownItem, topLevel = false) => {
+  let link = <NavigationLink key={description} description={description} path={appPrefixed(path)} topLevel={topLevel} />;
 
   if (permissions) {
-    return <IfPermitted key={description} permissions={permissions}>{link}</IfPermitted>;
+    link = <IfPermitted key={description} permissions={permissions}>{link}</IfPermitted>;
+  }
+
+  if (requiredFeatureFlag) {
+    link = <IfFeatureEnabled name={requiredFeatureFlag}>{link}</IfFeatureEnabled>;
   }
 
   return link;

--- a/graylog2-web-interface/src/routing/AppRouter.tsx
+++ b/graylog2-web-interface/src/routing/AppRouter.tsx
@@ -113,7 +113,11 @@ import {
 import RouterErrorBoundary from 'components/errors/RouterErrorBoundary';
 import usePluginEntities from 'views/logic/usePluginEntities';
 
-const renderPluginRoute = ({ path, component: Component, parentComponent }: PluginRoute) => {
+const renderPluginRoute = ({ path, component: Component, parentComponent, requiredFeatureFlag }: PluginRoute) => {
+  if (requiredFeatureFlag && !AppConfig.isFeatureEnabled(requiredFeatureFlag)) {
+    return null;
+  }
+
   const ParentComponent = parentComponent ?? React.Fragment;
   const WrappedComponent = () => (
     <ParentComponent>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

With this feature it will be possible to only register a specific plugin route or menu item when a defined feature flag is enabled.

Example for routes:
```
routes: [
  { path: '/the-path', component: TheComponent, requiredFeatureFlag: 'required_feature_flag' },
]
```
Example for menu items:

```
{ path: '/the-path', description: 'The Menu Item', permissions: '*', requiredFeatureFlag: 'required_feature_flag' }
```

Example for menu item which is a dropdown:
```
navigation: [
  {
    description: 'The Menu Item',
    children: [
      { path: '/the-path', description: 'The Dropdown Item', permissions: '*', requiredFeatureFlag: 'required_feature_flag' },
    ]
  }
];
```

If you need to hide a default non-plugin route behind a feature flag, you can just wrap the route component:
```
<IfFeatureEnabled name="required_feature_flag">
  <Route path={'/the-path'} component={TheComponent} />
</IfFeatureEnabled/>
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

