### PR TITLE
Allow defining `id` for `QueryInput` textarea.

### DIFF
--- a/graylog2-web-interface/src/views/components/searchbar/queryinput/BasicQueryInput.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/queryinput/BasicQueryInput.tsx
@@ -94,7 +94,11 @@ const BasicQueryInput = forwardRef<StyledAceEditor, Props>((props, ref) => {
     if (editor) {
       editor.renderer.setScrollMargin(6, 5);
       editor.renderer.setPadding(12);
-      editor.textInput.getElement().setAttribute('id', inputId);
+
+      if (inputId) {
+        editor.textInput.getElement().setAttribute('id', inputId);
+      }
+
       onLoad?.(editor);
     }
   }, [inputId, onLoad]);
@@ -142,7 +146,6 @@ const BasicQueryInput = forwardRef<StyledAceEditor, Props>((props, ref) => {
                        enableBasicAutocompletion={enableAutocompletion}
                        enableLiveAutocompletion={enableAutocompletion}
                        onBlur={onBlur}
-                       name="just-a-test"
                        onChange={onChange}
                        onExecute={onExecute} />
     );
@@ -176,7 +179,7 @@ BasicQueryInput.defaultProps = {
   enableAutocompletion: false,
   error: undefined,
   height: undefined,
-  inputId: 'query-input-id',
+  inputId: undefined,
   maxLines: 4,
   onBlur: undefined,
   onChange: undefined,

--- a/graylog2-web-interface/src/views/components/searchbar/queryinput/BasicQueryInput.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/queryinput/BasicQueryInput.tsx
@@ -34,6 +34,7 @@ export type BaseProps = {
   value: string,
   warning?: QueryValidationState,
   wrapEnabled?: boolean,
+  inputId?: string,
 };
 
 type EnabledInputProps = BaseProps & {
@@ -85,6 +86,7 @@ const BasicQueryInput = forwardRef<StyledAceEditor, Props>((props, ref) => {
     warning,
     wrapEnabled,
     onLoad,
+    inputId,
   } = props;
   const theme = useTheme();
   const markers = useMemo(() => getMarkers(error, warning), [error, warning]);
@@ -92,6 +94,7 @@ const BasicQueryInput = forwardRef<StyledAceEditor, Props>((props, ref) => {
     if (editor) {
       editor.renderer.setScrollMargin(6, 5);
       editor.renderer.setPadding(12);
+      editor.textInput.getElement().setAttribute('id', inputId);
       onLoad?.(editor);
     }
   }, [onLoad]);
@@ -139,6 +142,7 @@ const BasicQueryInput = forwardRef<StyledAceEditor, Props>((props, ref) => {
                        enableBasicAutocompletion={enableAutocompletion}
                        enableLiveAutocompletion={enableAutocompletion}
                        onBlur={onBlur}
+                       name="just-a-test"
                        onChange={onChange}
                        onExecute={onExecute} />
     );
@@ -154,6 +158,7 @@ BasicQueryInput.propTypes = {
   enableAutocompletion: PropTypes.bool,
   error: PropTypes.any,
   height: PropTypes.number,
+  inputId: PropTypes.string,
   maxLines: PropTypes.number,
   onBlur: PropTypes.func,
   onChange: PropTypes.func,
@@ -171,6 +176,7 @@ BasicQueryInput.defaultProps = {
   enableAutocompletion: false,
   error: undefined,
   height: undefined,
+  inputId: 'query-input-id',
   maxLines: 4,
   onBlur: undefined,
   onChange: undefined,

--- a/graylog2-web-interface/src/views/components/searchbar/queryinput/BasicQueryInput.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/queryinput/BasicQueryInput.tsx
@@ -97,7 +97,7 @@ const BasicQueryInput = forwardRef<StyledAceEditor, Props>((props, ref) => {
       editor.textInput.getElement().setAttribute('id', inputId);
       onLoad?.(editor);
     }
-  }, [onLoad]);
+  }, [inputId, onLoad]);
   const editorProps = useMemo(() => ({ $blockScrolling: Infinity, selectionStyle: 'line' }), []);
   const setOptions = useMemo(() => ({ indentedSoftWrap: false }), []);
 

--- a/graylog2-web-interface/src/views/components/searchbar/queryinput/QueryInput.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/queryinput/QueryInput.tsx
@@ -173,6 +173,7 @@ const QueryInput = ({
   disableExecution,
   error,
   height,
+  inputId,
   isValidating,
   maxLines,
   onBlur,
@@ -213,6 +214,7 @@ const QueryInput = ({
                      disabled={false}
                      enableAutocompletion={enableSmartSearch}
                      error={error}
+                     inputId={inputId}
                      warning={warning}
                      maxLines={maxLines}
                      onBlur={onBlur}
@@ -231,6 +233,7 @@ QueryInput.propTypes = {
   completerFactory: PropTypes.func,
   disableExecution: PropTypes.bool,
   error: PropTypes.any,
+  inputId: PropTypes.string,
   height: PropTypes.number,
   isValidating: PropTypes.bool.isRequired,
   maxLines: PropTypes.number,
@@ -252,6 +255,7 @@ QueryInput.defaultProps = {
   disableExecution: false,
   error: undefined,
   height: undefined,
+  inputId: undefined,
   maxLines: undefined,
   onBlur: undefined,
   placeholder: '',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

With this PR it will be possible to define an `id` for the `textarea` of the `QueryInput`.
This way it will be possible to connect a label with input. For example like this:
```
<label htmlFor="query-input-id">A label</label>
<QueryInput inputId="query-input-id" />
```

Before this change clicking on the label had no effect, in the described case.
The `QueryInput` already has a `name` attribute, but it is being used for the id of the `textarea` container.
