### PR TITLE
Generic PageListResponse class introduced

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/models/tools/responses/PageListResponse.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/tools/responses/PageListResponse.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog2.rest.models.tools.responses;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;

--- a/graylog2-server/src/main/java/org/graylog2/rest/models/tools/responses/PageListResponse.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/tools/responses/PageListResponse.java
@@ -1,0 +1,57 @@
+package org.graylog2.rest.models.tools.responses;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+import org.graylog.autovalue.WithBeanGetter;
+import org.graylog2.database.PaginatedList;
+
+import javax.annotation.Nullable;
+import java.util.Collection;
+
+@JsonAutoDetect
+@AutoValue
+@WithBeanGetter
+public abstract class PageListResponse<T> {
+
+    @Nullable
+    @JsonProperty("query")
+    public abstract String query();
+
+    @JsonProperty("pagination")
+    public abstract PaginatedList.PaginationInfo paginationInfo();
+
+    @JsonProperty("total")
+    public abstract long total();
+
+    @Nullable
+    @JsonProperty("sort")
+    public abstract String sort();
+
+    @Nullable
+    @JsonProperty("order")
+    public abstract String order();
+
+    @JsonProperty("elements")
+    public abstract Collection<T> elements();
+
+    @JsonCreator
+    public static <T> PageListResponse<T> create(
+            @JsonProperty("query") @Nullable String query,
+            @JsonProperty("pagination") PaginatedList.PaginationInfo paginationInfo,
+            @JsonProperty("total") long total,
+            @JsonProperty("sort") @Nullable String sort,
+            @JsonProperty("order") @Nullable String order,
+            @JsonProperty("elements") Collection<T> elements) {
+        return new AutoValue_PageListResponse<>(query, paginationInfo, total, sort, order, elements);
+    }
+
+    public static <T> PageListResponse<T> create(
+            @Nullable String query,
+            final PaginatedList<T> paginatedList,
+            @Nullable String sort,
+            @Nullable String order) {
+        return new AutoValue_PageListResponse<>(query, paginatedList.pagination(), paginatedList.pagination().total(), sort, order, paginatedList);
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Generic PageListResponse class is introduced.

## Motivation and Context
Across our code base, we have a lot of very similar classes for a pagination response (i.e. StreamPageListResponse, ReportPageList, SearchFilterPageListResponse). They differ only by the name of the property containing elements on the page.

If we are fine with unifying the name of that property, we can get rid of those classes.
Even if we are not, it is a good idea to have a tool that would prevent us from introducing more classes like that in the future.
This small PR is a groundwork in that direction - it contains generic class for page list response.

## How Has This Been Tested?
No need to test it now.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

