### PR TITLE
Define `max-width: 100%;` for all `textarea` inputs.

### DIFF
--- a/graylog2-web-interface/src/theme/GlobalThemeStyles.js
+++ b/graylog2-web-interface/src/theme/GlobalThemeStyles.js
@@ -131,6 +131,10 @@ const GlobalThemeStyles = createGlobalStyle(({ theme }) => css`
       color: ${theme.colors.input.colorDisabled};
     }
   }
+  
+  textarea {
+    max-width: 100%;
+  }
 
   legend small {
     color: ${theme.colors.gray[60]};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

With this PR we are defining `max-width: 100%;` for all `textarea` inputs.
Currently it is possible to break the layout when changing the size of a `textarea`. This affects almost all `textarea`s.

![image](https://user-images.githubusercontent.com/46300478/177799106-5c145d6f-775d-4bce-b99f-80495d4593cf.png)

It is possible that the previous behaviour might be helpful for `textarea`s which are very small by default, but I am not aware of any case in the application.