### PR TITLE
Format index detail shard numbers

### DIFF
--- a/graylog2-web-interface/src/components/indices/IndexDetails.tsx
+++ b/graylog2-web-interface/src/components/indices/IndexDetails.tsx
@@ -15,7 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import PropTypes from 'prop-types';
-import React, { useEffect } from 'react';
+import React, { useCallback, useEffect, useMemo } from 'react';
 
 import HideOnCloud from 'util/conditional/HideOnCloud';
 import NumberUtils from 'util/NumberUtils';
@@ -44,35 +44,31 @@ const IndexDetails = ({ index, indexName, indexRange, indexSetId, isDeflector }:
     };
   }, [indexName]);
 
-  if (!index || !index.all_shards) {
-    return <Spinner />;
-  }
-
-  const _onRecalculateIndex = () => {
+  const _onRecalculateIndex = useCallback(() => {
     if (window.confirm(`Really recalculate the index ranges for index ${indexName}?`)) {
       IndexRangesActions.recalculateIndex(indexName).then(() => {
         IndicesActions.list(indexSetId);
       });
     }
-  };
+  }, [indexName, indexSetId]);
 
-  const _onCloseIndex = () => {
+  const _onCloseIndex = useCallback(() => {
     if (window.confirm(`Really close index ${indexName}?`)) {
       IndicesActions.close(indexName).then(() => {
         IndicesActions.list(indexSetId);
       });
     }
-  };
+  }, [indexName, indexSetId]);
 
-  const _onDeleteIndex = () => {
+  const _onDeleteIndex = useCallback(() => {
     if (window.confirm(`Really delete index ${indexName}?`)) {
       IndicesActions.delete(indexName).then(() => {
         IndicesActions.list(indexSetId);
       });
     }
-  };
+  }, [indexName, indexSetId]);
 
-  const _formatActionButtons = () => {
+  const actionButtons = useMemo(() => {
     if (isDeflector) {
       return (
         <span>
@@ -89,7 +85,11 @@ const IndexDetails = ({ index, indexName, indexRange, indexSetId, isDeflector }:
         <Button bsStyle="danger" bsSize="xs" onClick={_onDeleteIndex}>Delete index</Button>
       </span>
     );
-  };
+  }, [isDeflector, _onCloseIndex, _onDeleteIndex, _onRecalculateIndex]);
+
+  if (!index || !index.all_shards) {
+    return <Spinner />;
+  }
 
   return (
     <div className="index-info">
@@ -111,7 +111,7 @@ const IndexDetails = ({ index, indexName, indexRange, indexSetId, isDeflector }:
       </HideOnCloud>
       <hr style={{ marginBottom: '5', marginTop: '10' }} />
 
-      {_formatActionButtons()}
+      {actionButtons}
     </div>
   );
 };

--- a/graylog2-web-interface/src/components/indices/IndexDetails.tsx
+++ b/graylog2-web-interface/src/components/indices/IndexDetails.tsx
@@ -18,6 +18,7 @@ import PropTypes from 'prop-types';
 import React, { useEffect } from 'react';
 
 import HideOnCloud from 'util/conditional/HideOnCloud';
+import NumberUtils from 'util/NumberUtils';
 import { Col, Row, Button } from 'components/bootstrap';
 import { Spinner } from 'components/common';
 import { IndexRangeSummary, ShardMeter, ShardRoutingOverview } from 'components/indices';
@@ -95,9 +96,9 @@ const IndexDetails = ({ index, indexName, indexRange, indexSetId, isDeflector }:
       <IndexRangeSummary indexRange={indexRange} />{' '}
 
       <HideOnCloud>
-        {index.all_shards.segments} segments,{' '}
-        {index.all_shards.open_search_contexts} open search contexts,{' '}
-        {index.all_shards.documents.deleted} deleted messages
+        {NumberUtils.formatNumber(index.all_shards.segments)} segments,{' '}
+        {NumberUtils.formatNumber(index.all_shards.open_search_contexts)} open search contexts,{' '}
+        {NumberUtils.formatNumber(index.all_shards.documents.deleted)} deleted messages
         <Row style={{ marginBottom: '10' }}>
           <Col md={4} className="shard-meters">
             <ShardMeter title="Primary shard operations" shardMeter={index.primary_shards} />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR ensures index detail shard numbers (segments, open search contexts, and deleted messages) are formatted.

The linter items are unrelated to this, but I took a stab at fixing the `react/no-unstable-nested-components` error.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When purging some documents I noticed that, unlike other numbers in the index overview, the "deleted messages" number wasn't formatted, making it a bit difficult to read.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually replaced the values with some numbers and checked that they were properly formatted.

## Screenshots (if appropriate):
**Before:**
![image](https://user-images.githubusercontent.com/288958/178111626-e3e3eb8c-4323-4b3e-9437-b8aef65897b4.png)

**After:**
![image](https://user-images.githubusercontent.com/288958/178111509-bc97dce5-90aa-4f0c-85de-b5c734fdd5af.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

