### PR TITLE
Add new property to bootstrapmodalform

### DIFF
--- a/graylog2-web-interface/src/components/bootstrap/BootstrapModalForm.jsx
+++ b/graylog2-web-interface/src/components/bootstrap/BootstrapModalForm.jsx
@@ -47,6 +47,7 @@ class BootstrapModalForm extends React.Component {
     cancelButtonText: PropTypes.string,
     /* Text to use in the submit button. "Submit" is the default */
     submitButtonText: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+    submitButtonVisible: PropTypes.bool,
     submitButtonDisabled: PropTypes.bool,
     show: PropTypes.bool,
   };
@@ -57,6 +58,7 @@ class BootstrapModalForm extends React.Component {
     cancelButtonText: 'Cancel',
     submitButtonText: 'Submit',
     submitButtonDisabled: false,
+    submitButtonVisible: true,
     onModalOpen: () => {},
     onModalClose: () => {},
     onSubmitForm: undefined,
@@ -107,6 +109,7 @@ class BootstrapModalForm extends React.Component {
       cancelButtonText,
       show,
       submitButtonText,
+      submitButtonVisible,
       onModalOpen,
       title,
       children,
@@ -137,7 +140,7 @@ class BootstrapModalForm extends React.Component {
           </Modal.Body>
           <Modal.Footer>
             <Button type="button" onClick={this.onModalCancel}>{cancelButtonText}</Button>
-            <Button type="submit" disabled={submitButtonDisabled} bsStyle="primary">{submitButtonText}</Button>
+            {submitButtonVisible && <Button type="submit" disabled={submitButtonDisabled} bsStyle="primary">{submitButtonText}</Button> }
           </Modal.Footer>
         </form>
       </BootstrapModalWrapper>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added a property 'submitButtonVisible'  to the BootstrapModalForm to support disabling submit button only when required.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Used this BootstrapModalForm in DBConnector Input configuration, where submit button is not required.
Adding a property 'submitButtonVisible' property as boolean, which can be used to disable the submit button where needed.
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

