### PR TITLE
Message Table Context Providers

### DIFF
--- a/graylog2-web-interface/src/views/components/messagelist/MessageTableEntry.tsx
+++ b/graylog2-web-interface/src/views/components/messagelist/MessageTableEntry.tsx
@@ -43,11 +43,11 @@ import HighlightMessageContext from '../contexts/HighlightMessageContext';
 export const TableBody = styled.tbody<{ expanded?: boolean, highlighted?: boolean }>(({ expanded, highlighted, theme }) => `
   && {
     border-top: 0;
-  
+
     ${expanded ? `
       border-left: 7px solid ${theme.colors.variant.light.info};
     ` : ''}
-    
+
     ${highlighted ? `
       border-left: 7px solid ${theme.colors.variant.light.success};
     ` : ''}
@@ -56,7 +56,7 @@ export const TableBody = styled.tbody<{ expanded?: boolean, highlighted?: boolea
 
 const FieldsRow = styled.tr(({ theme }) => `
   cursor: pointer;
-  
+
   td {
     min-width: 50px;
     word-break: break-word;
@@ -76,7 +76,7 @@ const MessageDetailRow = styled.tr`
   .row {
     margin-right: 0;
   }
-  
+
   div[class*="col-"] {
     padding-right: 0;
   }

--- a/graylog2-web-interface/src/views/components/messagelist/MessageTableProviders.test.tsx
+++ b/graylog2-web-interface/src/views/components/messagelist/MessageTableProviders.test.tsx
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import { render, screen } from 'wrappedTestingLibrary';
+
+import asMock from 'helpers/mocking/AsMock';
+import suppressConsole from 'helpers/suppressConsole';
+import usePluginEntities from 'views/logic/usePluginEntities';
+
+import MessageTableProviders from './MessageTableProviders';
+
+jest.mock('views/logic/usePluginEntities');
+
+const renderProvider = (children, index, throwError = false) => {
+  if (throwError) {
+    throw Error('The error');
+  }
+
+  return (
+    <>
+      {throwError}
+      <div>The provider {index}</div>
+      <div>{children}</div>
+    </>
+  );
+};
+
+describe('MessageTableProviders', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render children, when there is no message detail provider', () => {
+    asMock(usePluginEntities).mockReturnValue(undefined);
+
+    render(
+      <MessageTableProviders>
+        <div>The children</div>
+      </MessageTableProviders>,
+    );
+
+    expect(screen.getByText('The children')).toBeInTheDocument();
+  });
+
+  it('should render one pluggable message table provider', () => {
+    asMock(usePluginEntities).mockReturnValue([({ children }) => renderProvider(children, 1)]);
+
+    render(
+      <MessageTableProviders>
+        <div>The children</div>
+      </MessageTableProviders>,
+    );
+
+    expect(screen.getByText(/The provider 1/)).toBeInTheDocument();
+    expect(screen.getByText('The children')).toBeInTheDocument();
+  });
+
+  it('should render multiple pluggable message table providers', () => {
+    asMock(usePluginEntities).mockReturnValue([
+      ({ children }) => renderProvider(children, 1),
+      ({ children }) => renderProvider(children, 2),
+    ]);
+
+    render(
+      <MessageTableProviders>
+        <div>The children</div>
+      </MessageTableProviders>,
+    );
+
+    expect(screen.getByText('The provider 1')).toBeInTheDocument();
+    expect(screen.getByText('The provider 2')).toBeInTheDocument();
+    expect(screen.getByText('The children')).toBeInTheDocument();
+  });
+
+  it('should render children and other providers, when one provider throws an error', async () => {
+    asMock(usePluginEntities).mockReturnValue([
+      ({ children }) => renderProvider(children, 1),
+      ({ children }) => renderProvider(children, 2, true),
+      ({ children }) => renderProvider(children, 3),
+    ]);
+
+    await suppressConsole(() => {
+      render(
+        <MessageTableProviders>
+          <div>The children</div>
+        </MessageTableProviders>,
+      );
+    });
+
+    expect(screen.getByText('The provider 1')).toBeInTheDocument();
+    expect(screen.queryByText('The provider 2')).not.toBeInTheDocument();
+    expect(screen.getByText('The provider 3')).toBeInTheDocument();
+    expect(screen.getByText('The children')).toBeInTheDocument();
+  });
+});

--- a/graylog2-web-interface/src/views/components/messagelist/MessageTableProviders.tsx
+++ b/graylog2-web-interface/src/views/components/messagelist/MessageTableProviders.tsx
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
+
+import usePluginEntities from 'views/logic/usePluginEntities';
+
+type Props = {
+  children: React.ReactElement,
+};
+
+const MessageTableProviders = ({ children }: Props) => {
+  const contextProviders = usePluginEntities('views.components.widgets.messageTable.contextProviders');
+
+  if (!contextProviders || contextProviders?.length === 0) {
+    return children;
+  }
+
+  return contextProviders.reduce((nestedChildren, MessageTableContextProvider) => (
+    <ErrorBoundary FallbackComponent={() => nestedChildren}>
+      <MessageTableContextProvider>
+        {nestedChildren}
+      </MessageTableContextProvider>
+    </ErrorBoundary>
+  ), children);
+};
+
+export default MessageTableProviders;

--- a/graylog2-web-interface/src/views/components/widgets/MessageTable.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageTable.tsx
@@ -32,6 +32,7 @@ import type { BackendMessage, Message } from 'views/components/messagelist/Types
 import FieldSortIcon from 'views/components/widgets/FieldSortIcon';
 import Field from 'views/components/Field';
 import { SOURCE_FIELD } from 'views/Constants';
+import MessageTableProviders from 'views/components/messagelist/MessageTableProviders';
 
 import InteractiveContext from '../contexts/InteractiveContext';
 
@@ -142,49 +143,51 @@ const MessageTable = ({ fields, activeQueryId, messages, config, onSortChange, s
   const toggleDetail = useCallback((id: string) => _toggleMessageDetail(id, expandedMessages, setExpandedMessages), [expandedMessages]);
 
   return (
-    <TableWrapper className="table-responsive" id="sticky-augmentations-container" ref={scrollContainerRef}>
-      <Table className="table table-condensed">
-        <TableHead>
-          <tr>
-            {selectedFields.toSeq().map((selectedFieldName) => {
-              return (
-                <th key={selectedFieldName}
-                    style={_columnStyle(selectedFieldName)}>
-                  <Field type={_fieldTypeFor(selectedFieldName, fields)}
-                         name={selectedFieldName}
-                         queryId={activeQueryId}>
-                    {selectedFieldName}
-                  </Field>
-                  <InteractiveContext.Consumer>
-                    {(interactive) => (interactive && (
+    <MessageTableProviders>
+      <TableWrapper className="table-responsive" id="sticky-augmentations-container" ref={scrollContainerRef}>
+        <Table className="table table-condensed">
+          <TableHead>
+            <tr>
+              {selectedFields.toSeq().map((selectedFieldName) => {
+                return (
+                  <th key={selectedFieldName}
+                      style={_columnStyle(selectedFieldName)}>
+                    <Field type={_fieldTypeFor(selectedFieldName, fields)}
+                           name={selectedFieldName}
+                           queryId={activeQueryId}>
+                      {selectedFieldName}
+                    </Field>
+                    <InteractiveContext.Consumer>
+                      {(interactive) => (interactive && (
                       <FieldSortIcon fieldName={selectedFieldName}
                                      onSortChange={onSortChange}
                                      setLoadingState={setLoadingState}
                                      config={config} />
-                    ))}
-                  </InteractiveContext.Consumer>
-                </th>
-              );
-            })}
-          </tr>
-        </TableHead>
-        {formattedMessages.map((message) => {
-          const messageKey = `${message.index}-${message.id}`;
+                      ))}
+                    </InteractiveContext.Consumer>
+                  </th>
+                );
+              })}
+            </tr>
+          </TableHead>
+          {formattedMessages.map((message) => {
+            const messageKey = `${message.index}-${message.id}`;
 
-          return (
-            <MessageTableEntry fields={fields}
-                               key={messageKey}
-                               message={message}
-                               config={config}
-                               showMessageRow={config?.showMessageRow}
-                               selectedFields={selectedFields}
-                               expanded={expandedMessages.contains(messageKey)}
-                               toggleDetail={toggleDetail}
-                               expandAllRenderAsync={false} />
-          );
-        })}
-      </Table>
-    </TableWrapper>
+            return (
+              <MessageTableEntry fields={fields}
+                                 key={messageKey}
+                                 message={message}
+                                 config={config}
+                                 showMessageRow={config?.showMessageRow}
+                                 selectedFields={selectedFields}
+                                 expanded={expandedMessages.contains(messageKey)}
+                                 toggleDetail={toggleDetail}
+                                 expandAllRenderAsync={false} />
+            );
+          })}
+        </Table>
+      </TableWrapper>
+    </MessageTableProviders>
   );
 };
 

--- a/graylog2-web-interface/src/views/types.ts
+++ b/graylog2-web-interface/src/views/types.ts
@@ -275,6 +275,7 @@ declare module 'graylog-web-plugin/plugin' {
     'views.components.widgets.messageTable.previewOptions'?: Array<MessagePreviewOption>;
     'views.components.widgets.messageTable.messageRowOverride'?: Array<React.ComponentType<MessageRowOverrideProps>>;
     'views.components.widgets.messageDetails.contextProviders'?: Array<React.ComponentType<MessageDetailContextProviderProps>>;
+    'views.components.widgets.messageTable.contextProviders'?: Array<React.ComponentType>;
     'views.components.searchBar'?: Array<() => SearchBarControl | null>;
     'views.elements.header'?: Array<React.ComponentType>;
     'views.elements.queryBar'?: Array<React.ComponentType>;


### PR DESCRIPTION

## Description

Adds to the plugin system to allow for additional MessageTable contexts.

- Additional context to the MessageTable.
- Tests for the new MessageTableProviders component.

## Motivation and Context
Need the ability to provide additional context to the MessageTable

## How Has This Been Tested?
Tested locally and unit tests have been run.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

