### PR TITLE
TokenCollectingQueryParser.getBooleanQuery() is prone to create NPEs

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/validation/TokenCollectingQueryParser.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/validation/TokenCollectingQueryParser.java
@@ -111,7 +111,8 @@ public class TokenCollectingQueryParser extends QueryParser {
     @Override
     protected Query getBooleanQuery(List<BooleanClause> clauses) throws ParseException {
         final Query delegate = super.getBooleanQuery(clauses);
-        return new FixedBooleanQuery((BooleanQuery) delegate);
+        // if the superclass returns null, we also return null to mimic the same behaviour
+        return delegate != null ? new FixedBooleanQuery((BooleanQuery) delegate) : null;
     }
 
     /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
fixes #13037

see the error description in the issue 

Our own Parser returned a result in `getBooleanQuery()` even if the superclass returns `null` in the same case. This PR fixes this behaviour.

**Note: backport to 4.3?**

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

