### PR TITLE
Fix NPE in email notification

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/events/notifications/types/EmailSender.java
+++ b/graylog2-server/src/main/java/org/graylog/events/notifications/types/EmailSender.java
@@ -117,6 +117,10 @@ public class EmailSender {
             email.setFrom(config.sender());
         }
 
+        if (email.getFromAddress() == null) {
+            throw new TransportConfigurationException("No from address specified for email transport.");
+        }
+
         email.setSubject(buildSubject(config, model));
         email.addTo(emailAddress);
 

--- a/graylog2-server/src/main/java/org/graylog2/shared/email/EmailFactory.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/email/EmailFactory.java
@@ -31,6 +31,8 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.util.function.Supplier;
 
+import static com.google.common.base.Strings.isNullOrEmpty;
+
 /**
  * Utility class to create preconfigured {@link Email} instances by applying the settings from
  * {@link EmailConfiguration}.
@@ -113,7 +115,9 @@ public class EmailFactory {
         email.setSSLOnConnect(configuration.isUseSsl());
         email.setStartTLSEnabled(configuration.isUseTls());
 
-        email.setFrom(configuration.getFromEmail());
+        if (!isNullOrEmpty(configuration.getFromEmail())) {
+            email.setFrom(configuration.getFromEmail());
+        }
 
         return email;
     }


### PR DESCRIPTION
Pre 4.3, a NPE was also thrown when there was no sender in both the notifiation settings and the config. This is also now taken care of and a more verbose TransportConfigurationException is thrown. 

The possible NPE was introduced with https://github.com/Graylog2/graylog2-server/pull/12034 where the behavior was changed from first checking for a notification setting from address to first setting the config from address and overwriting it with the notification setting. 