### PR TITLE
PageListResponse can hide confidential data

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/models/tools/responses/PageListResponse.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/tools/responses/PageListResponse.java
@@ -25,9 +25,6 @@ import org.graylog2.database.PaginatedList;
 
 import javax.annotation.Nullable;
 import java.util.Collection;
-import java.util.function.Predicate;
-import java.util.function.UnaryOperator;
-import java.util.stream.Collectors;
 
 @JsonAutoDetect
 @AutoValue
@@ -74,25 +71,4 @@ public abstract class PageListResponse<T> {
         return new AutoValue_PageListResponse<>(query, paginatedList.pagination(), paginatedList.pagination().total(), sort, order, paginatedList);
     }
 
-    public PageListResponse<T> withHiddenConfidentialInfo(final Predicate<T> hasConfidentialInfoChecker, final UnaryOperator<T> confidentialInfoHider) {
-        if (elements().isEmpty()) {
-            return this;
-        }
-        return PageListResponse.create(
-                query(),
-                paginationInfo(),
-                total(),
-                sort(),
-                order(),
-                elements()
-                        .stream()
-                        .map(element -> {
-                            if (hasConfidentialInfoChecker.test(element)) {
-                                return confidentialInfoHider.apply(element);
-                            } else {
-                                return element;
-                            }
-                        })
-                        .collect(Collectors.toList()));
-    }
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/models/tools/responses/PageListResponse.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/tools/responses/PageListResponse.java
@@ -25,6 +25,9 @@ import org.graylog2.database.PaginatedList;
 
 import javax.annotation.Nullable;
 import java.util.Collection;
+import java.util.function.Predicate;
+import java.util.function.UnaryOperator;
+import java.util.stream.Collectors;
 
 @JsonAutoDetect
 @AutoValue
@@ -69,5 +72,27 @@ public abstract class PageListResponse<T> {
             @Nullable String sort,
             @Nullable String order) {
         return new AutoValue_PageListResponse<>(query, paginatedList.pagination(), paginatedList.pagination().total(), sort, order, paginatedList);
+    }
+
+    public PageListResponse<T> withHiddenConfidentialInfo(final Predicate<T> hasConfidentialInfoChecker, final UnaryOperator<T> confidentialInfoHider) {
+        if (elements().isEmpty()) {
+            return this;
+        }
+        return PageListResponse.create(
+                query(),
+                paginationInfo(),
+                total(),
+                sort(),
+                order(),
+                elements()
+                        .stream()
+                        .map(element -> {
+                            if (hasConfidentialInfoChecker.test(element)) {
+                                return confidentialInfoHider.apply(element);
+                            } else {
+                                return element;
+                            }
+                        })
+                        .collect(Collectors.toList()));
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/rest/models/tools/responses/PageListResponseTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/rest/models/tools/responses/PageListResponseTest.java
@@ -20,8 +20,6 @@ import com.google.common.collect.ImmutableList;
 import org.graylog2.database.PaginatedList;
 import org.junit.jupiter.api.Test;
 
-import java.util.Collections;
-
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -42,44 +40,6 @@ class PageListResponseTest {
         assertThat(pageListResponse.sort()).isEqualTo("whatever");
         assertThat(pageListResponse.order()).isEqualTo("asc");
         assertTrue(pageListResponse.elements().containsAll(ImmutableList.of("1", "2")));
-    }
-
-    @Test
-    void hidesConfidentialInfo() {
-        PageListResponse<String> pageListResponse = PageListResponse.create("gimme me data!",
-                new PaginatedList<>(
-                        ImmutableList.of("secret:Financial fraud", "secret:Scandal", "whatever", "smth nice", "smth cool"),
-                        500, 1, 5),
-                "whatever", "asc");
-
-        final PageListResponse<String> pageListResponseWithHiddenData = pageListResponse.withHiddenConfidentialInfo(
-                s -> s.startsWith("secret"),
-                s -> "you shall not pass!");
-
-        assertThat(pageListResponseWithHiddenData.total()).isEqualTo(500);
-        assertThat(pageListResponseWithHiddenData.paginationInfo().page()).isEqualTo(1);
-        assertThat(pageListResponseWithHiddenData.paginationInfo().total()).isEqualTo(500);
-        assertThat(pageListResponseWithHiddenData.paginationInfo().perPage()).isEqualTo(5);
-        assertThat(pageListResponseWithHiddenData.sort()).isEqualTo("whatever");
-        assertThat(pageListResponseWithHiddenData.order()).isEqualTo("asc");
-        assertThat(pageListResponseWithHiddenData.query()).isEqualTo("gimme me data!");
-
-        assertThat(pageListResponseWithHiddenData.elements())
-                .isEqualTo(ImmutableList.of("you shall not pass!", "you shall not pass!", "whatever", "smth nice", "smth cool"));
-    }
-
-    @Test
-    void hidingConfidentialInfoReturnsOriginalResponseIfItContainsNoElements() {
-        PageListResponse<String> pageListResponse = PageListResponse.create("gimme me data!",
-                new PaginatedList<>(
-                        Collections.emptyList(),
-                        500, 1, 5),
-                "whatever", "asc");
-
-        final PageListResponse<String> pageListResponseWithHiddenData = pageListResponse.withHiddenConfidentialInfo(
-                s -> s.startsWith("secret"),
-                s -> "you shall not pass!");
-        assertThat(pageListResponseWithHiddenData).isSameAs(pageListResponse);
     }
 
 }

--- a/graylog2-server/src/test/java/org/graylog2/rest/models/tools/responses/PageListResponseTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/rest/models/tools/responses/PageListResponseTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.rest.models.tools.responses;
+
+import com.google.common.collect.ImmutableList;
+import org.graylog2.database.PaginatedList;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PageListResponseTest {
+
+    @Test
+    void createsProperResponse() {
+        PageListResponse<String> pageListResponse = PageListResponse.create("gimme me data!",
+                new PaginatedList<>(
+                        ImmutableList.of("1", "2"),
+                        500, 1, 5),
+                "whatever", "asc");
+
+        assertThat(pageListResponse.total()).isEqualTo(500);
+        assertThat(pageListResponse.paginationInfo().page()).isEqualTo(1);
+        assertThat(pageListResponse.paginationInfo().total()).isEqualTo(500);
+        assertThat(pageListResponse.paginationInfo().perPage()).isEqualTo(5);
+        assertThat(pageListResponse.sort()).isEqualTo("whatever");
+        assertThat(pageListResponse.order()).isEqualTo("asc");
+        assertTrue(pageListResponse.elements().containsAll(ImmutableList.of("1", "2")));
+    }
+
+    @Test
+    void hidesConfidentialInfo() {
+        PageListResponse<String> pageListResponse = PageListResponse.create("gimme me data!",
+                new PaginatedList<>(
+                        ImmutableList.of("secret:Financial fraud", "secret:Scandal", "whatever", "smth nice", "smth cool"),
+                        500, 1, 5),
+                "whatever", "asc");
+
+        final PageListResponse<String> pageListResponseWithHiddenData = pageListResponse.withHiddenConfidentialInfo(
+                s -> s.startsWith("secret"),
+                s -> "you shall not pass!");
+
+        assertThat(pageListResponseWithHiddenData.total()).isEqualTo(500);
+        assertThat(pageListResponseWithHiddenData.paginationInfo().page()).isEqualTo(1);
+        assertThat(pageListResponseWithHiddenData.paginationInfo().total()).isEqualTo(500);
+        assertThat(pageListResponseWithHiddenData.paginationInfo().perPage()).isEqualTo(5);
+        assertThat(pageListResponseWithHiddenData.sort()).isEqualTo("whatever");
+        assertThat(pageListResponseWithHiddenData.order()).isEqualTo("asc");
+        assertThat(pageListResponseWithHiddenData.query()).isEqualTo("gimme me data!");
+
+        assertThat(pageListResponseWithHiddenData.elements())
+                .isEqualTo(ImmutableList.of("you shall not pass!", "you shall not pass!", "whatever", "smth nice", "smth cool"));
+    }
+
+    @Test
+    void hidingConfidentialInfoReturnsOriginalResponseIfItContainsNoElements() {
+        PageListResponse<String> pageListResponse = PageListResponse.create("gimme me data!",
+                new PaginatedList<>(
+                        Collections.emptyList(),
+                        500, 1, 5),
+                "whatever", "asc");
+
+        final PageListResponse<String> pageListResponseWithHiddenData = pageListResponse.withHiddenConfidentialInfo(
+                s -> s.startsWith("secret"),
+                s -> "you shall not pass!");
+        assertThat(pageListResponseWithHiddenData).isSameAs(pageListResponse);
+    }
+
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
PageListResponse class has a new method that can hide confidential data.

## Motivation and Context
I need it for Search Filters Usage list, where some pieces of information need to be hidden if a user misses proper permissions.

## How Has This Been Tested?
With unit test.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

