### PR TITLE
fix: NPE when sender not set in graylog.conf (#13055)

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/events/notifications/types/EmailSender.java
+++ b/graylog2-server/src/main/java/org/graylog/events/notifications/types/EmailSender.java
@@ -117,6 +117,10 @@ public class EmailSender {
             email.setFrom(config.sender());
         }
 
+        if (email.getFromAddress() == null) {
+            throw new TransportConfigurationException("No from address specified for email transport.");
+        }
+
         email.setSubject(buildSubject(config, model));
         email.addTo(emailAddress);
 

--- a/graylog2-server/src/main/java/org/graylog2/shared/email/EmailFactory.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/email/EmailFactory.java
@@ -31,6 +31,8 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.util.function.Supplier;
 
+import static com.google.common.base.Strings.isNullOrEmpty;
+
 /**
  * Utility class to create preconfigured {@link Email} instances by applying the settings from
  * {@link EmailConfiguration}.
@@ -113,7 +115,9 @@ public class EmailFactory {
         email.setSSLOnConnect(configuration.isUseSsl());
         email.setStartTLSEnabled(configuration.isUseTls());
 
-        email.setFrom(configuration.getFromEmail());
+        if (!isNullOrEmpty(configuration.getFromEmail())) {
+            email.setFrom(configuration.getFromEmail());
+        }
 
         return email;
     }


### PR DESCRIPTION
closes #12900

(cherry picked from commit 299e07bcffe9d5dcde43a5491cfcc496b4bee405)

