### PR TITLE
Adjust server startup to log all throwables to the log file

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/bootstrap/CmdLineTool.java
+++ b/graylog2-server/src/main/java/org/graylog2/bootstrap/CmdLineTool.java
@@ -254,8 +254,17 @@ public abstract class CmdLineTool implements CliCommand {
 
     @Override
     public void run() {
+        // Setup logger first to ensure we can log any caught Throwable to the configured log file
         final Level logLevel = setupLogger();
+        try {
+            doRun(logLevel);
+        } catch (Throwable e) {
+            LOG.error("Startup error:", e);
+            throw e;
+        }
+    }
 
+    public void doRun(Level logLevel) {
         if (isDumpDefaultConfig()) {
             dumpDefaultConfigAndExit();
         }


### PR DESCRIPTION
Previously all Errors (Exceptions are handled) haven't been logged to
the log file but only STDERR. Not logging these errors can make
debugging harder if STDERR output and the log files are configured to
be in different places. (e.g., operating system packages with systemd)