### PR TITLE
Handle slashes in unquoted/escaped field values for completions.

### DIFF
--- a/graylog2-web-interface/src/views/components/searchbar/SearchBarAutocompletions.ts
+++ b/graylog2-web-interface/src/views/components/searchbar/SearchBarAutocompletions.ts
@@ -47,6 +47,7 @@ export type CompleterContext = Readonly<{
 export interface Completer {
   getCompletions(context: CompleterContext): Array<CompletionResult> | Promise<Array<CompletionResult>>;
   shouldShowCompletions?: (currentLine: number, lines: Array<Array<Line>>) => boolean;
+  identifierRegexps?: RegExp[];
 }
 
 const onCompleterError = (error: Error) => {
@@ -108,5 +109,5 @@ export default class SearchBarAutoCompletions implements AutoCompleter {
     });
   };
 
-  get identifierRegexps() { return [/[a-zA-Z_0-9$\\/\-\u00A2-\u2000\u2070-\uFFFF]/]; }
+  get identifierRegexps() { return this.completers.reduce((prev, completer) => [...prev, ...(completer.identifierRegexps ?? [])], []); }
 }

--- a/graylog2-web-interface/src/views/components/searchbar/SearchBarAutocompletions.ts
+++ b/graylog2-web-interface/src/views/components/searchbar/SearchBarAutocompletions.ts
@@ -109,5 +109,5 @@ export default class SearchBarAutoCompletions implements AutoCompleter {
     });
   };
 
-  get identifierRegexps() { return this.completers.reduce((prev, completer) => [...prev, ...(completer.identifierRegexps ?? [])], []); }
+  get identifierRegexps() { return this.completers.map((completer) => completer.identifierRegexps ?? []).flat(); }
 }

--- a/graylog2-web-interface/src/views/components/searchbar/SearchBarAutocompletions.ts
+++ b/graylog2-web-interface/src/views/components/searchbar/SearchBarAutocompletions.ts
@@ -107,4 +107,6 @@ export default class SearchBarAutoCompletions implements AutoCompleter {
       return false;
     });
   };
+
+  get identifierRegexps() { return [/[a-zA-Z_0-9$\\/\-\u00A2-\u2000\u2070-\uFFFF]/]; }
 }

--- a/graylog2-web-interface/src/views/components/searchbar/completions/FieldValueCompletion.test.ts
+++ b/graylog2-web-interface/src/views/components/searchbar/completions/FieldValueCompletion.test.ts
@@ -295,7 +295,7 @@ describe('FieldValueCompletion', () => {
         {
           name: 'C:\\Windows\\System32\\lsass.exe',
           value: 'C\\:\\\\Windows\\\\System32\\\\lsass.exe',
-          caption: 'C:\\Windows\\System32\\lsass.exe',
+          caption: 'C\\:\\\\Windows\\\\System32\\\\lsass.exe',
           score: 300,
           meta: '300 hits',
         },

--- a/graylog2-web-interface/src/views/components/searchbar/completions/FieldValueCompletion.ts
+++ b/graylog2-web-interface/src/views/components/searchbar/completions/FieldValueCompletion.ts
@@ -48,8 +48,8 @@ const formatValue = (value: string, type: string) => {
   }
 };
 
-const completionCaption = (fieldValue: string, input: string | number) => {
-  if (fieldValue.startsWith(String(input))) {
+const completionCaption = (fieldValue: string, input: string | number, isQuoted: boolean) => {
+  if ((isQuoted ? fieldValue : escape(fieldValue)).startsWith(String(input))) {
     return fieldValue;
   }
 
@@ -86,7 +86,7 @@ const formatSuggestion = (value: string, occurrence: number, input: string | num
   name: value,
   value: isQuoted ? value : escape(value),
   score: occurrence,
-  caption: completionCaption(value, input),
+  caption: completionCaption(value, input, isQuoted),
   meta: `${occurrence} hits`,
 });
 
@@ -145,7 +145,7 @@ class FieldValueCompletion implements Completer {
   private filterExistingSuggestions(input: string | number, isQuoted: boolean) {
     if (this.previousSuggestions) {
       return this.previousSuggestions.suggestions
-        .filter((suggestion) => suggestion.value.startsWith(String(input)))
+        .filter(({ value }) => (isQuoted ? value : escape(value)).startsWith(String(input)))
         .map(({ value, occurrence }) => formatSuggestion(value, occurrence, input, isQuoted));
     }
 

--- a/graylog2-web-interface/src/views/components/searchbar/completions/FieldValueCompletion.ts
+++ b/graylog2-web-interface/src/views/components/searchbar/completions/FieldValueCompletion.ts
@@ -218,6 +218,8 @@ class FieldValueCompletion implements Completer {
 
     return (currentTokenIsFieldName || currentTokenIsFieldValue) && !nextTokenIsTerm;
   };
+
+  public identifierRegexps = [/[a-zA-Z_0-9$\\/\-\u00A2-\u2000\u2070-\uFFFF]/];
 }
 
 export default FieldValueCompletion;

--- a/graylog2-web-interface/src/views/components/searchbar/completions/FieldValueCompletion.ts
+++ b/graylog2-web-interface/src/views/components/searchbar/completions/FieldValueCompletion.ts
@@ -50,7 +50,7 @@ const formatValue = (value: string, type: string) => {
 
 const completionCaption = (fieldValue: string, input: string | number, isQuoted: boolean) => {
   if ((isQuoted ? fieldValue : escape(fieldValue)).startsWith(String(input))) {
-    return fieldValue;
+    return isQuoted ? fieldValue : escape(fieldValue);
   }
 
   return `${fieldValue} ⭢ ${input}`;

--- a/graylog2-web-interface/src/views/components/searchbar/queryinput/ace.ts
+++ b/graylog2-web-interface/src/views/components/searchbar/queryinput/ace.ts
@@ -18,7 +18,7 @@ import AceEditor from 'react-ace';
 
 import './ace-queryinput';
 import 'ace-builds/src-noconflict/ext-language_tools';
-import 'ace-builds/src-noconflict/mode-lucene';
+import './custom-lucene-mode';
 import 'ace-builds/webpack-resolver';
 
 export default AceEditor;

--- a/graylog2-web-interface/src/views/components/searchbar/queryinput/custom-lucene-mode.js
+++ b/graylog2-web-interface/src/views/components/searchbar/queryinput/custom-lucene-mode.js
@@ -19,6 +19,7 @@ ace.define('ace/mode/lucene_highlight_rules', ['require', 'exports', 'module', '
   const oop = require('../lib/oop');
   const { TextHighlightRules } = require('./text_highlight_rules');
 
+  // eslint-disable-next-line func-names
   const LuceneHighlightRules = function () {
     this.$rules = {
       start: [
@@ -97,6 +98,7 @@ ace.define('ace/mode/lucene_highlight_rules', ['require', 'exports', 'module', '
           regex: /\(\?[:=!]|\)|\{\d+\b,?\d*\}|[+*]\?|[()$^+*?.]/,
         }, {
           token: 'constant.language.escape',
+          // eslint-disable-next-line no-useless-escape
           regex: '<\d+-\d+>|[~&@]',
         }, {
           token: 'constant.language.delimiter',
@@ -147,6 +149,7 @@ ace.define('ace/mode/lucene', ['require', 'exports', 'module', 'ace/lib/oop', 'a
   const TextMode = require('./text').Mode;
   const { LuceneHighlightRules } = require('./lucene_highlight_rules');
 
+  // eslint-disable-next-line func-names
   const Mode = function () {
     this.HighlightRules = LuceneHighlightRules;
     this.$behaviour = this.$defaultBehaviour;
@@ -154,6 +157,7 @@ ace.define('ace/mode/lucene', ['require', 'exports', 'module', 'ace/lib/oop', 'a
 
   oop.inherits(Mode, TextMode);
 
+  // eslint-disable-next-line func-names
   (function () {
     this.$id = 'ace/mode/lucene';
   }).call(Mode.prototype);
@@ -162,6 +166,7 @@ ace.define('ace/mode/lucene', ['require', 'exports', 'module', 'ace/lib/oop', 'a
   exports.Mode = Mode;
 });
 
+// eslint-disable-next-line func-names
 (function () {
   // eslint-disable-next-line no-undef
   ace.require(['ace/mode/lucene'], (m) => {

--- a/graylog2-web-interface/src/views/components/searchbar/queryinput/custom-lucene-mode.js
+++ b/graylog2-web-interface/src/views/components/searchbar/queryinput/custom-lucene-mode.js
@@ -1,0 +1,156 @@
+// eslint-disable-next-line no-undef
+ace.define('ace/mode/lucene_highlight_rules', ['require', 'exports', 'module', 'ace/lib/oop', 'ace/mode/text_highlight_rules'], (require, exports) => {
+  const oop = require('../lib/oop');
+  const { TextHighlightRules } = require('./text_highlight_rules');
+
+  const LuceneHighlightRules = function () {
+    this.$rules = {
+      start: [
+        {
+          token: 'constant.language.escape',
+          regex: /\\[-+&|!(){}[\]^"~*?:\\]/,
+        }, {
+          token: 'constant.character.negation',
+          regex: '\\-',
+        }, {
+          token: 'constant.character.interro',
+          regex: '\\?',
+        }, {
+          token: 'constant.character.required',
+          regex: '\\+',
+        }, {
+          token: 'constant.character.asterisk',
+          regex: '\\*',
+        }, {
+          token: 'constant.character.proximity',
+          regex: '~(?:0\\.[0-9]+|[0-9]+)?',
+        }, {
+          token: 'keyword.operator',
+          regex: '(AND|OR|NOT|TO)\\b',
+        }, {
+          token: 'paren.lparen',
+          regex: '[\\(\\{\\[]',
+        }, {
+          token: 'paren.rparen',
+          regex: '[\\)\\}\\]]',
+        }, {
+          token: 'keyword.operator',
+          regex: /[><=^]/,
+        }, {
+          token: 'constant.numeric',
+          regex: /\d[\d.-]*/,
+        }, {
+          token: 'string',
+          regex: /"(?:\\"|[^"])*"/,
+        }, {
+          token: 'keyword',
+          regex: /(?:\\.|[^\s\-+&|!(){}[\]^"~*?:\\])+:/,
+          next: 'maybeRegex',
+        }, {
+          token: 'term',
+          regex: /[\w(\\/)]+/,
+        }, {
+          token: 'text',
+          regex: /\s+/,
+        },
+      ],
+      maybeRegex: [{
+        token: 'text',
+        regex: /\s+/,
+      }, {
+        token: 'string.regexp.start',
+        regex: '/',
+        next: 'regex',
+      }, {
+        regex: '',
+        next: 'start',
+      }],
+      regex: [
+        {
+          token: 'regexp.keyword.operator',
+          regex: '\\\\(?:u[\\da-fA-F]{4}|x[\\da-fA-F]{2}|.)',
+        }, {
+          token: 'string.regexp.end',
+          regex: '/[sxngimy]*',
+          next: 'no_regex',
+        }, {
+          token: 'invalid',
+          regex: /\{\d+\b,?\d*\}[+*]|[+*$^?][+*]|[$^][?]|\?{3,}/,
+        }, {
+          token: 'constant.language.escape',
+          regex: /\(\?[:=!]|\)|\{\d+\b,?\d*\}|[+*]\?|[()$^+*?.]/,
+        }, {
+          token: 'constant.language.escape',
+          regex: '<\d+-\d+>|[~&@]',
+        }, {
+          token: 'constant.language.delimiter',
+          regex: /\|/,
+        }, {
+          token: 'constant.language.escape',
+          regex: /\[\^?/,
+          next: 'regex_character_class',
+        }, {
+          token: 'empty',
+          regex: '$',
+          next: 'no_regex',
+        }, {
+          defaultToken: 'string.regexp',
+        },
+      ],
+      regex_character_class: [
+        {
+          token: 'regexp.charclass.keyword.operator',
+          regex: '\\\\(?:u[\\da-fA-F]{4}|x[\\da-fA-F]{2}|.)',
+        }, {
+          token: 'constant.language.escape',
+          regex: ']',
+          next: 'regex',
+        }, {
+          token: 'constant.language.escape',
+          regex: '-',
+        }, {
+          token: 'empty',
+          regex: '$',
+          next: 'no_regex',
+        }, {
+          defaultToken: 'string.regexp.charachterclass',
+        },
+      ],
+    };
+  };
+
+  oop.inherits(LuceneHighlightRules, TextHighlightRules);
+
+  // eslint-disable-next-line no-param-reassign
+  exports.LuceneHighlightRules = LuceneHighlightRules;
+});
+
+// eslint-disable-next-line no-undef
+ace.define('ace/mode/lucene', ['require', 'exports', 'module', 'ace/lib/oop', 'ace/mode/text', 'ace/mode/lucene_highlight_rules'], (require, exports) => {
+  const oop = require('../lib/oop');
+  const TextMode = require('./text').Mode;
+  const { LuceneHighlightRules } = require('./lucene_highlight_rules');
+
+  const Mode = function () {
+    this.HighlightRules = LuceneHighlightRules;
+    this.$behaviour = this.$defaultBehaviour;
+  };
+
+  oop.inherits(Mode, TextMode);
+
+  (function () {
+    this.$id = 'ace/mode/lucene';
+  }).call(Mode.prototype);
+
+  // eslint-disable-next-line no-param-reassign
+  exports.Mode = Mode;
+});
+
+(function () {
+  // eslint-disable-next-line no-undef
+  ace.require(['ace/mode/lucene'], (m) => {
+    if (typeof module === 'object' && typeof exports === 'object' && module) {
+      module.exports = m;
+    }
+  });
+}());

--- a/graylog2-web-interface/src/views/components/searchbar/queryinput/custom-lucene-mode.js
+++ b/graylog2-web-interface/src/views/components/searchbar/queryinput/custom-lucene-mode.js
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 // eslint-disable-next-line no-undef
 ace.define('ace/mode/lucene_highlight_rules', ['require', 'exports', 'module', 'ace/lib/oop', 'ace/mode/text_highlight_rules'], (require, exports) => {
   const oop = require('../lib/oop');


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

**Note:** This requires #13087 to merged before.

Prior to this PR, getting suggestions for a field value containing a slash did not work. This is related due to the tokenization logic of the lucene mode in the ace editor, which is treating it as a token separator, as it could potentially be part of a regex.

This PR is now doing the following to fix this:

  - copy the existing lucene mode to allow customization
  - including `\` and `/` in `term` tokens
  - extend identifier regex which is used in ace to determine the boundary of the current input which is replaced by the selected completion with `\` and `/`
  - escape completion captions if in unquoted context so matching completions are not filtered out

The drawback of this approach is that we now have to maintain the lucene mode ourselves, but due to the fact that it was not updated in the last years, the additional maintenance overhead will hopefully be small/close to zero.

Fixes #13082.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.