### PR TITLE
Added additional validation of email configuration

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/events/rest/EventNotificationsResource.java
+++ b/graylog2-server/src/main/java/org/graylog/events/rest/EventNotificationsResource.java
@@ -29,10 +29,12 @@ import org.graylog.events.audit.EventsAuditEventTypes;
 import org.graylog.events.notifications.DBNotificationService;
 import org.graylog.events.notifications.NotificationDto;
 import org.graylog.events.notifications.NotificationResourceHandler;
+import org.graylog.events.notifications.types.EmailEventNotificationConfig;
 import org.graylog.security.UserContext;
 import org.graylog2.alarmcallbacks.EmailAlarmCallback;
 import org.graylog2.audit.jersey.AuditEvent;
 import org.graylog2.audit.jersey.NoAuditEvent;
+import org.graylog2.configuration.EmailConfiguration;
 import org.graylog2.database.PaginatedList;
 import org.graylog2.plugin.alarms.callbacks.AlarmCallback;
 import org.graylog2.plugin.configuration.ConfigurationRequest;
@@ -65,6 +67,7 @@ import javax.ws.rs.core.Response;
 import java.util.Map;
 import java.util.Set;
 
+import static com.google.common.base.Strings.isNullOrEmpty;
 import static org.graylog2.shared.security.RestPermissions.USERS_LIST;
 
 @Api(value = "Events/Notifications", description = "Manage event notifications")
@@ -83,15 +86,19 @@ public class EventNotificationsResource extends RestResource implements PluginRe
     private final Set<AlarmCallback> availableLegacyAlarmCallbacks;
     private final SearchQueryParser searchQueryParser;
     private final NotificationResourceHandler resourceHandler;
+    private final EmailConfiguration emailConfiguration;
 
     @Inject
     public EventNotificationsResource(DBNotificationService dbNotificationService,
                                       Set<AlarmCallback> availableLegacyAlarmCallbacks,
-                                      NotificationResourceHandler resourceHandler) {
+                                      NotificationResourceHandler resourceHandler,
+                                      EmailConfiguration emailConfiguration) {
         this.dbNotificationService = dbNotificationService;
         this.availableLegacyAlarmCallbacks = availableLegacyAlarmCallbacks;
         this.resourceHandler = resourceHandler;
         this.searchQueryParser = new SearchQueryParser(NotificationDto.FIELD_TITLE, SEARCH_FIELD_MAPPING);
+        this.emailConfiguration = emailConfiguration;
+
     }
 
     @GET
@@ -121,6 +128,7 @@ public class EventNotificationsResource extends RestResource implements PluginRe
     @RequiresPermissions(RestPermissions.EVENT_NOTIFICATIONS_CREATE)
     public Response create(@ApiParam(name = "JSON Body") NotificationDto dto, @Context UserContext userContext) {
         final ValidationResult validationResult = dto.validate();
+        validateEmailConfiguration(dto, validationResult);
         if (validationResult.failed()) {
             return Response.status(Response.Status.BAD_REQUEST).entity(validationResult).build();
         }
@@ -142,11 +150,25 @@ public class EventNotificationsResource extends RestResource implements PluginRe
         }
 
         final ValidationResult validationResult = dto.validate();
+        validateEmailConfiguration(dto, validationResult);
         if (validationResult.failed()) {
             return Response.status(Response.Status.BAD_REQUEST).entity(validationResult).build();
         }
 
         return Response.ok().entity(resourceHandler.update(dto)).build();
+    }
+
+    private ValidationResult validateEmailConfiguration(NotificationDto dto, ValidationResult validationResult) {
+        if (dto.config() instanceof EmailEventNotificationConfig) {
+            EmailEventNotificationConfig emailEventNotificationConfig = (EmailEventNotificationConfig) dto.config();
+            if (!emailConfiguration.isEnabled()) {
+                validationResult.addError("config", "Email transport is not configured in graylog.conf");
+            }
+            if (isNullOrEmpty(emailConfiguration.getFromEmail()) && isNullOrEmpty(emailEventNotificationConfig.sender())) {
+                validationResult.addError("sender", "No default sender specified in graylog.conf. You must specify one here.");
+            }
+        }
+        return validationResult;
     }
 
     @DELETE

--- a/graylog2-server/src/main/java/org/graylog/events/rest/EventNotificationsResource.java
+++ b/graylog2-server/src/main/java/org/graylog/events/rest/EventNotificationsResource.java
@@ -168,19 +168,22 @@ public class EventNotificationsResource extends RestResource implements PluginRe
             }
             if (isNullOrEmpty(emailConfiguration.getFromEmail()) && isNullOrEmpty(emailEventNotificationConfig.sender())) {
                 validationResult.addError("sender", "No default sender specified in graylog.conf. You must specify one here.");
-            } else if (!isNullOrEmpty(emailEventNotificationConfig.sender())) {
-                try {
-                    InternetAddress email = new InternetAddress(emailEventNotificationConfig.sender());
-                    email.validate();
-                } catch (AddressException e) {
-                    validationResult.addError("sender", "Invalid email address.");
-                }
             } else {
-                try {
-                    InternetAddress email = new InternetAddress(emailConfiguration.getFromEmail());
-                    email.validate();
-                } catch (AddressException e) {
-                    validationResult.addError("sender", "Invalid sender email address specified in graylog.conf. Please correct or set a custom sender for this notification.");
+                if (!isNullOrEmpty(emailEventNotificationConfig.sender())) {
+                    try {
+                        InternetAddress email = new InternetAddress(emailEventNotificationConfig.sender());
+                        email.validate();
+                    } catch (AddressException e) {
+                        validationResult.addError("sender", "Invalid email address.");
+                    }
+                }
+                if (!isNullOrEmpty(emailConfiguration.getFromEmail())) {
+                    try {
+                        InternetAddress email = new InternetAddress(emailConfiguration.getFromEmail());
+                        email.validate();
+                    } catch (AddressException e) {
+                        validationResult.addError("sender", "Invalid default sender email address specified in graylog.conf.");
+                    }
                 }
             }
         }

--- a/graylog2-server/src/main/java/org/graylog/events/rest/EventNotificationsResource.java
+++ b/graylog2-server/src/main/java/org/graylog/events/rest/EventNotificationsResource.java
@@ -48,6 +48,8 @@ import org.graylog2.shared.rest.resources.RestResource;
 import org.graylog2.shared.security.RestPermissions;
 
 import javax.inject.Inject;
+import javax.mail.internet.AddressException;
+import javax.mail.internet.InternetAddress;
 import javax.validation.constraints.NotBlank;
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.Consumes;
@@ -166,6 +168,20 @@ public class EventNotificationsResource extends RestResource implements PluginRe
             }
             if (isNullOrEmpty(emailConfiguration.getFromEmail()) && isNullOrEmpty(emailEventNotificationConfig.sender())) {
                 validationResult.addError("sender", "No default sender specified in graylog.conf. You must specify one here.");
+            } else if (!isNullOrEmpty(emailEventNotificationConfig.sender())) {
+                try {
+                    InternetAddress email = new InternetAddress(emailEventNotificationConfig.sender());
+                    email.validate();
+                } catch (AddressException e) {
+                    validationResult.addError("sender", "Invalid email address.");
+                }
+            } else {
+                try {
+                    InternetAddress email = new InternetAddress(emailConfiguration.getFromEmail());
+                    email.validate();
+                } catch (AddressException e) {
+                    validationResult.addError("sender", "Invalid sender email address specified in graylog.conf. Please correct or set a custom sender for this notification.");
+                }
             }
         }
     }

--- a/graylog2-server/src/main/java/org/graylog/events/rest/EventNotificationsResource.java
+++ b/graylog2-server/src/main/java/org/graylog/events/rest/EventNotificationsResource.java
@@ -158,7 +158,7 @@ public class EventNotificationsResource extends RestResource implements PluginRe
         return Response.ok().entity(resourceHandler.update(dto)).build();
     }
 
-    private ValidationResult validateEmailConfiguration(NotificationDto dto, ValidationResult validationResult) {
+    private void validateEmailConfiguration(NotificationDto dto, ValidationResult validationResult) {
         if (dto.config() instanceof EmailEventNotificationConfig) {
             EmailEventNotificationConfig emailEventNotificationConfig = (EmailEventNotificationConfig) dto.config();
             if (!emailConfiguration.isEnabled()) {
@@ -168,7 +168,6 @@ public class EventNotificationsResource extends RestResource implements PluginRe
                 validationResult.addError("sender", "No default sender specified in graylog.conf. You must specify one here.");
             }
         }
-        return validationResult;
     }
 
     @DELETE

--- a/graylog2-web-interface/src/components/event-notifications/event-notification-form/EventNotificationFormContainer.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-form/EventNotificationFormContainer.jsx
@@ -112,6 +112,7 @@ class EventNotificationFormContainer extends React.Component {
 
           if (errorResponse.status === 400 && body && body.failed) {
             this.setState({ validation: body });
+            this.scrollToFirstError();
           }
         },
       );
@@ -131,6 +132,7 @@ class EventNotificationFormContainer extends React.Component {
 
           if (errorResponse.status === 400 && body && body.failed) {
             this.setState({ validation: body });
+            this.scrollToFirstError();
           }
         },
       );
@@ -138,6 +140,12 @@ class EventNotificationFormContainer extends React.Component {
 
     onSubmit(promise);
   };
+
+  scrollToFirstError() {
+    if (document.getElementsByClassName('has-error')[0] !== undefined) {
+      document.getElementsByClassName('has-error')[0].scrollIntoView(true);
+    }
+  }
 
   handleTest = () => {
     const { notification } = this.state;
@@ -195,6 +203,9 @@ class EventNotificationFormContainer extends React.Component {
       </>
     );
   }
+
 }
+
+
 
 export default EventNotificationFormContainer;

--- a/graylog2-web-interface/src/components/event-notifications/event-notification-form/EventNotificationFormContainer.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-form/EventNotificationFormContainer.jsx
@@ -60,6 +60,12 @@ class EventNotificationFormContainer extends React.Component {
     onSubmit: () => {},
   };
 
+  static scrollToFirstError() {
+    if (document.getElementsByClassName('has-error')[0] !== undefined) {
+      document.getElementsByClassName('has-error')[0].scrollIntoView(true);
+    }
+  }
+
   constructor(props) {
     super(props);
 
@@ -86,6 +92,7 @@ class EventNotificationFormContainer extends React.Component {
     this.setState({ notification: nextNotification, isDirty: true, testResult: initialTestResult });
   };
 
+  // eslint-disable-next-line class-methods-use-this
   handleCancel = () => {
     history.push(Routes.ALERTS.NOTIFICATIONS.LIST);
   };
@@ -112,7 +119,7 @@ class EventNotificationFormContainer extends React.Component {
 
           if (errorResponse.status === 400 && body && body.failed) {
             this.setState({ validation: body });
-            this.scrollToFirstError();
+            EventNotificationFormContainer.scrollToFirstError();
           }
         },
       );
@@ -132,7 +139,7 @@ class EventNotificationFormContainer extends React.Component {
 
           if (errorResponse.status === 400 && body && body.failed) {
             this.setState({ validation: body });
-            this.scrollToFirstError();
+            EventNotificationFormContainer.scrollToFirstError();
           }
         },
       );
@@ -140,12 +147,6 @@ class EventNotificationFormContainer extends React.Component {
 
     onSubmit(promise);
   };
-
-  scrollToFirstError() {
-    if (document.getElementsByClassName('has-error')[0] !== undefined) {
-      document.getElementsByClassName('has-error')[0].scrollIntoView(true);
-    }
-  }
 
   handleTest = () => {
     const { notification } = this.state;
@@ -203,9 +204,6 @@ class EventNotificationFormContainer extends React.Component {
       </>
     );
   }
-
 }
-
-
 
 export default EventNotificationFormContainer;


### PR DESCRIPTION
Adds validation of email configuration in graylog.conf to EventNotificationResource.

## Description
Checks that email transport is enabled and that there is a sender set either in graylog.conf or the notification itself.

closes #13085

## Motivation and Context
If sender isn't set in configuration and notification, a NPE is produced when trying to send the notification.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

