### PR TITLE
Use legacy Geo IP fields if GIM schema enforcement is disabled

### DIFF
--- a/graylog2-server/src/test/java/org/graylog/plugins/map/geoip/GeoIpResolverEngineTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/map/geoip/GeoIpResolverEngineTest.java
@@ -156,10 +156,8 @@ public class GeoIpResolverEngineTest {
     @Test
     public void testPublicIpSchemaEnforceOff() {
 
-        // With schema enforcement off, we expect 'source_ip' to be the prefix for ALL Geo data fields.
-        String[] expectedFields = {"source_ip_geo_name", "source_ip_geo_region", "source_ip_geo_city", "source_ip_geo_timezone",
-                "source_ip_geo_country", "source_ip_geo_country_iso", "source_ip_as_organization", "source_ip_geo_coordinates",
-                "source_ip_as_number"};
+        // With schema enforcement off, legacy fields will be added to the message.
+        String[] expectedFields = {"source_ip_geolocation", "source_ip_country_code", "source_ip_city_name"};
 
         testSourceIpGeoDataFieldsWithSchemaEnforcementFlag(false, expectedFields);
     }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Reverts to using pre-4.3 Geo IP processor logic if the GIM schema enforcement is disabled

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
4.3 introduced a breaking change to fields added by the Geo Location Processor. Fields had the GIM Geo-location subfield suffixes added even with the Graylog Schema enforcement disabled. Closes #12909 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Confirm that added IP fields have the original field name post-fixed with  `_country_code`, `_geolocation`, and `_city_name`  when Geo IP processor has GIM enforcement disabled and that the GIM fields are added if it is enabled.

## Screenshots (if appropriate):
`Enforce Graylog schema` disabled:
![image](https://user-images.githubusercontent.com/91903901/180025845-780af66e-3d51-4419-a48a-bfe5cd575ff7.png)
`Enforce Graylog schema` enabled:
![image](https://user-images.githubusercontent.com/91903901/180025734-be313b9a-9107-428d-811f-8a987ef18f30.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

