### PR TITLE
Implement new GRN type `search_filter` in frontend.

### DIFF
--- a/graylog2-web-interface/src/logic/permissions/GRN.ts
+++ b/graylog2-web-interface/src/logic/permissions/GRN.ts
@@ -51,6 +51,8 @@ export const getShowRouteFromGRN = (grn: string) => {
       return Routes.getPluginRoute('SEARCH_VIEWID')(id);
     case 'stream':
       return Routes.stream_search(id);
+    case 'search_filter':
+      return Routes.getPluginRoute('MY-FILTERS_DETAILS_FILTERID')(id)
     default:
       return assertUnreachable(grn, type);
   }

--- a/graylog2-web-interface/src/logic/permissions/GRN.ts
+++ b/graylog2-web-interface/src/logic/permissions/GRN.ts
@@ -52,7 +52,7 @@ export const getShowRouteFromGRN = (grn: string) => {
     case 'stream':
       return Routes.stream_search(id);
     case 'search_filter':
-      return Routes.getPluginRoute('MY-FILTERS_DETAILS_FILTERID')(id)
+      return Routes.getPluginRoute('MY-FILTERS_DETAILS_FILTERID')(id);
     default:
       return assertUnreachable(grn, type);
   }

--- a/graylog2-web-interface/src/logic/permissions/types.ts
+++ b/graylog2-web-interface/src/logic/permissions/types.ts
@@ -27,6 +27,7 @@ export type GRNType =
   | 'event_definition'
   | 'notification'
   | 'search'
+  | 'search_filter'
   | 'stream'
   | 'global';
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

When a user shares a search filter with other users they will appear on their "Shared Entities" overview on the user details page. With this PR we generate the correct route for the search filter details page.