### PR TITLE
Auto focus first suggestion in query input autocompletion. (backport of #12991 for 4.2)

### DIFF
--- a/graylog2-web-interface/src/views/components/searchbar/SearchBarAutocompletions.ts
+++ b/graylog2-web-interface/src/views/components/searchbar/SearchBarAutocompletions.ts
@@ -30,8 +30,6 @@ export default class SearchBarAutoCompletions implements AutoCompleter {
   }
 
   getCompletions = (editor: Editor, session: Session, pos: Position, prefix: string, callback: ResultsCallback) => {
-    // eslint-disable-next-line no-param-reassign
-    editor.completer.autoSelect = false;
     const tokens = editor.session.getTokens(pos.row);
     const currentToken = editor.session.getTokenAt(pos.row, pos.column);
     const currentTokenIdx = tokens.findIndex((t) => (t === currentToken));


### PR DESCRIPTION
_Please note, this is a backport of #12991 for 4.2_

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

With this PR we are now focusing the first suggestion in the query input autocompletion. With this change we are reenabling the default `react-ace` behaviour. This reduces the amount of click it takes to select a suggestion.

Related to: #6909