### PR TITLE
Create helper function to get a "show entity" route based on an entity type and id.

### DIFF
--- a/graylog2-web-interface/src/logic/permissions/GRN.ts
+++ b/graylog2-web-interface/src/logic/permissions/GRN.ts
@@ -14,9 +14,8 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-// eslint-disable-next-line import/prefer-default-export
-import Routes from 'routing/Routes';
 import type { GRN, GRNType } from 'logic/permissions/types';
+import getShowRouteForEntity from 'routing/getShowRouteForEntity';
 
 const _convertEmptyString = (value: string) => (value === '' ? undefined : value);
 
@@ -29,29 +28,8 @@ export const getValuesFromGRN = (grn: GRN) => {
   return { resourceNameType, cluster, tenent, scope, type: type as GRNType, id };
 };
 
-const assertUnreachable = (grn: string, type: 'global'): never => {
-  throw new Error(`Can't find route for grn ${grn} of type: ${type ?? '(undefined)'}`);
-};
-
 export const getShowRouteFromGRN = (grn: string) => {
   const { id, type } = getValuesFromGRN(grn);
 
-  switch (type) {
-    case 'user':
-      return Routes.SYSTEM.USERS.show(id);
-    case 'team':
-      return Routes.getPluginRoute('SYSTEM_TEAMS_TEAMID')(id);
-    case 'dashboard':
-      return Routes.dashboard_show(id);
-    case 'event_definition':
-      return Routes.ALERTS.DEFINITIONS.show(id);
-    case 'notification':
-      return Routes.ALERTS.NOTIFICATIONS.show(id);
-    case 'search':
-      return Routes.getPluginRoute('SEARCH_VIEWID')(id);
-    case 'stream':
-      return Routes.stream_search(id);
-    default:
-      return assertUnreachable(grn, type);
-  }
+  return getShowRouteForEntity(id, type);
 };

--- a/graylog2-web-interface/src/routing/getShowRouteForEntity.test.ts
+++ b/graylog2-web-interface/src/routing/getShowRouteForEntity.test.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+
+import getShowRouteForEntity from 'routing/getShowRouteForEntity';
+import Routes from 'routing/Routes';
+
+describe('getShowRouteFromGRN should return correct route', () => {
+  const createsCorrectShowEntityURL = ({ id, type, entityShowURL }) => {
+    expect(getShowRouteForEntity(id, type)).toBe(entityShowURL);
+  };
+
+  // eslint-disable-next-line jest/expect-expect
+  it.each`
+      id              | type               | entityShowURL
+      ${'user-id'}    | ${'user'}          | ${Routes.SYSTEM.USERS.show('user-id')}
+      ${'stream-id'}  | ${'stream'}        | ${Routes.stream_search('stream-id')}
+    `('for $type with id $id', createsCorrectShowEntityURL);
+});

--- a/graylog2-web-interface/src/routing/getShowRouteForEntity.ts
+++ b/graylog2-web-interface/src/routing/getShowRouteForEntity.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import Routes from 'routing/Routes';
+
+const assertUnreachable = (type: string): never => {
+  throw new Error(`Can't find route for type: ${type ?? '(undefined)'}`);
+};
+
+const getShowRouteForEntity = (id: string, type: string) => {
+  switch (type?.toLowerCase()) {
+    case 'user':
+      return Routes.SYSTEM.USERS.show(id);
+    case 'team':
+      return Routes.getPluginRoute('SYSTEM_TEAMS_TEAMID')(id);
+    case 'dashboard':
+      return Routes.dashboard_show(id);
+    case 'event_definition':
+      return Routes.ALERTS.DEFINITIONS.show(id);
+    case 'notification':
+      return Routes.ALERTS.NOTIFICATIONS.show(id);
+    case 'search':
+      return Routes.getPluginRoute('SEARCH_VIEWID')(id);
+    case 'stream':
+      return Routes.stream_search(id);
+    default:
+      return assertUnreachable(type);
+  }
+};
+
+export default getShowRouteForEntity;


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

With this PR we are simple extracting existing logic into a helper function.
The function provides the "show entity" based on the entity type and id. With this PR the logic can be reused outside of the GRN context.