### PR TITLE
Block create/update of view if forbidden search filters are used

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/ViewsResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/ViewsResource.java
@@ -28,6 +28,8 @@ import org.graylog.plugins.views.search.Search;
 import org.graylog.plugins.views.search.SearchDomain;
 import org.graylog.plugins.views.search.SearchType;
 import org.graylog.plugins.views.search.permissions.SearchUser;
+import org.graylog.plugins.views.search.searchfilters.db.SearchFilterVisibilityCheckStatus;
+import org.graylog.plugins.views.search.searchfilters.db.SearchFilterVisibilityChecker;
 import org.graylog.plugins.views.search.views.ViewDTO;
 import org.graylog.plugins.views.search.views.ViewResolver;
 import org.graylog.plugins.views.search.views.ViewResolverDecoder;
@@ -46,8 +48,7 @@ import org.graylog2.search.SearchQuery;
 import org.graylog2.search.SearchQueryField;
 import org.graylog2.search.SearchQueryParser;
 import org.graylog2.shared.rest.resources.RestResource;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.graylog2.shared.security.RestPermissions;
 
 import javax.inject.Inject;
 import javax.validation.Valid;
@@ -80,7 +81,6 @@ import static java.util.Locale.ENGLISH;
 @Produces(MediaType.APPLICATION_JSON)
 @RequiresAuthentication
 public class ViewsResource extends RestResource implements PluginRestResource {
-    private static final Logger LOG = LoggerFactory.getLogger(ViewsResource.class);
     private static final ImmutableMap<String, SearchQueryField> SEARCH_FIELD_MAPPING = ImmutableMap.<String, SearchQueryField>builder()
             .put("id", SearchQueryField.create(ViewDTO.FIELD_ID))
             .put("title", SearchQueryField.create(ViewDTO.FIELD_TITLE))
@@ -92,16 +92,19 @@ public class ViewsResource extends RestResource implements PluginRestResource {
     private final ClusterEventBus clusterEventBus;
     private final SearchDomain searchDomain;
     private final Map<String, ViewResolver> viewResolvers;
+    private final SearchFilterVisibilityChecker searchFilterVisibilityChecker;
 
     @Inject
     public ViewsResource(ViewService dbService,
                          ClusterEventBus clusterEventBus, SearchDomain searchDomain,
-                         Map<String, ViewResolver> viewResolvers) {
+                         Map<String, ViewResolver> viewResolvers,
+                         SearchFilterVisibilityChecker searchFilterVisibilityChecker) {
         this.dbService = dbService;
         this.clusterEventBus = clusterEventBus;
         this.searchDomain = searchDomain;
         this.viewResolvers = viewResolvers;
         this.searchQueryParser = new SearchQueryParser(ViewDTO.FIELD_TITLE, SEARCH_FIELD_MAPPING);
+        this.searchFilterVisibilityChecker = searchFilterVisibilityChecker;
     }
 
     @GET
@@ -236,9 +239,15 @@ public class ViewsResource extends RestResource implements PluginRestResource {
         final Set<String> widgetPositions = dto.state().values().stream()
                 .flatMap(v -> v.widgetPositions().keySet().stream()).collect(Collectors.toSet());
 
-        if(!widgetPositions.containsAll(widgetIds)) {
+        if (!widgetPositions.containsAll(widgetIds)) {
             final Sets.SetView<String> diff = Sets.difference(widgetPositions, widgetIds);
             throw new BadRequestException("Widget positions don't correspond to widgets, missing widget possitions: " + diff);
+        }
+
+        final SearchFilterVisibilityCheckStatus searchFilterVisibilityCheckStatus = searchFilterVisibilityChecker.checkSearchFilterVisibility(
+                filterID -> isPermitted(RestPermissions.SEARCH_FILTERS_READ, filterID), search);
+        if (!searchFilterVisibilityCheckStatus.allSearchFiltersVisible()) {
+            throw new BadRequestException(searchFilterVisibilityCheckStatus.toMessage());
         }
     }
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchfilters/db/SearchFilterVisibilityCheckStatus.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchfilters/db/SearchFilterVisibilityCheckStatus.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.views.search.searchfilters.db;
+
+import java.util.Collections;
+import java.util.List;
+
+public class SearchFilterVisibilityCheckStatus {
+
+    private final List<String> hiddenSearchFiltersIDs;
+
+    public SearchFilterVisibilityCheckStatus() {
+        this.hiddenSearchFiltersIDs = Collections.emptyList();
+    }
+
+    public SearchFilterVisibilityCheckStatus(final List<String> hiddenSearchFiltersIDs) {
+        this.hiddenSearchFiltersIDs = hiddenSearchFiltersIDs;
+    }
+
+    public List<String> getHiddenSearchFiltersIDs() {
+        return hiddenSearchFiltersIDs;
+    }
+
+    public boolean allSearchFiltersVisible() {
+        return hiddenSearchFiltersIDs.isEmpty();
+    }
+
+    public String toMessage() {
+        if (!allSearchFiltersVisible()) {
+            return "Search cannot be saved, as it contains Search Filters which you are not privileged to view : " + hiddenSearchFiltersIDs.toString();
+        } else {
+            return "Search can be created with provided list of Search Filters";
+        }
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchfilters/db/SearchFilterVisibilityChecker.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchfilters/db/SearchFilterVisibilityChecker.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.views.search.searchfilters.db;
+
+import org.graylog.plugins.views.search.Query;
+import org.graylog.plugins.views.search.Search;
+import org.graylog.plugins.views.search.searchfilters.model.ReferencedSearchFilter;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+public class SearchFilterVisibilityChecker {
+
+    public SearchFilterVisibilityCheckStatus checkSearchFilterVisibility(final Predicate<String> readPermissionPredicate, final Search search) {
+        final List<String> hiddenSearchFiltersIDs = search.queries()
+                .stream()
+                .filter(Objects::nonNull)
+                .map(Query::filters)
+                .filter(Objects::nonNull)
+                .flatMap(Collection::stream)
+                .filter(usedSearchFilter -> usedSearchFilter instanceof ReferencedSearchFilter)
+                .map(usedSearchFilter -> (ReferencedSearchFilter) usedSearchFilter)
+                .map(ReferencedSearchFilter::id)
+                .filter(id -> !readPermissionPredicate.test(id))
+                .collect(Collectors.toList());
+
+        return new SearchFilterVisibilityCheckStatus(hiddenSearchFiltersIDs);
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/ViewsResourceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/ViewsResourceTest.java
@@ -22,6 +22,8 @@ import org.apache.shiro.subject.Subject;
 import org.graylog.plugins.views.search.Search;
 import org.graylog.plugins.views.search.SearchDomain;
 import org.graylog.plugins.views.search.permissions.SearchUser;
+import org.graylog.plugins.views.search.searchfilters.db.SearchFilterVisibilityCheckStatus;
+import org.graylog.plugins.views.search.searchfilters.db.SearchFilterVisibilityChecker;
 import org.graylog.plugins.views.search.views.ViewDTO;
 import org.graylog.plugins.views.search.views.ViewResolver;
 import org.graylog.plugins.views.search.views.ViewService;
@@ -33,17 +35,18 @@ import org.graylog2.security.PasswordAlgorithmFactory;
 import org.graylog2.shared.security.Permissions;
 import org.graylog2.shared.users.UserService;
 import org.graylog2.users.UserImpl;
+import org.junit.Assert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
 import javax.annotation.Nullable;
+import javax.ws.rs.BadRequestException;
 import javax.ws.rs.ForbiddenException;
 import javax.ws.rs.NotFoundException;
 import java.util.Collections;
@@ -61,6 +64,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -95,6 +99,9 @@ public class ViewsResourceTest {
     @Mock
     private SearchDomain searchDomain;
 
+    @Mock
+    private SearchFilterVisibilityChecker searchFilterVisibilityChecker;
+
     private ViewsResource viewsResource;
 
     @BeforeEach
@@ -104,6 +111,7 @@ public class ViewsResourceTest {
         final Search search = mock(Search.class, RETURNS_DEEP_STUBS);
         when(search.queries()).thenReturn(ImmutableSet.of());
         when(searchDomain.getForUser(eq("6141d457d3a6b9d73c8ac55a"), eq(searchUser))).thenReturn(Optional.of(search));
+        when(searchFilterVisibilityChecker.checkSearchFilterVisibility(any(), any())).thenReturn(new SearchFilterVisibilityCheckStatus());
     }
 
     class ViewsTestResource extends ViewsResource {
@@ -112,7 +120,7 @@ public class ViewsResourceTest {
         }
 
         ViewsTestResource(ViewService viewService, ClusterEventBus clusterEventBus, UserService userService, SearchDomain searchDomain, Map<String, ViewResolver> viewResolvers) {
-            super(viewService, clusterEventBus, searchDomain, viewResolvers);
+            super(viewService, clusterEventBus, searchDomain, viewResolvers, searchFilterVisibilityChecker);
             this.userService = userService;
         }
 
@@ -130,25 +138,79 @@ public class ViewsResourceTest {
 
     @Test
     public void creatingViewAddsCurrentUserAsOwner() throws Exception {
-        final ViewDTO.Builder builder = mock(ViewDTO.Builder.class);
-
-        when(view.toBuilder()).thenReturn(builder);
-        when(view.type()).thenReturn(ViewDTO.Type.DASHBOARD);
-        when(view.searchId()).thenReturn("6141d457d3a6b9d73c8ac55a");
-        when(builder.owner(any())).thenReturn(builder);
-        when(builder.build()).thenReturn(view);
-
-        final UserImpl testUser = new UserImpl(mock(PasswordAlgorithmFactory.class), new Permissions(ImmutableSet.of()), ImmutableMap.of("username", "testuser"));
-
-        final UserContext userContext = mock(UserContext.class);
-        when(userContext.getUser()).thenReturn(testUser);
-        when(searchUser.username()).thenReturn("testuser");
-
+        final ViewDTO.Builder builder = mockView(ViewDTO.Type.DASHBOARD);
+        final UserContext userContext = mockUser();
         this.viewsResource.create(view, userContext, searchUser);
 
         final ArgumentCaptor<String> ownerCaptor = ArgumentCaptor.forClass(String.class);
         verify(builder, times(1)).owner(ownerCaptor.capture());
         assertThat(ownerCaptor.getValue()).isEqualTo("testuser");
+    }
+
+    @Test
+    public void throwsExceptionWhenCreatingSearchWithFilterThatUserIsNotAllowedToSee() throws Exception {
+        mockView(ViewDTO.Type.SEARCH);
+        final UserContext userContext = mockUser();
+        doReturn(new SearchFilterVisibilityCheckStatus(Collections.singletonList("<<You cannot see this filter>>")))
+                .when(searchFilterVisibilityChecker)
+                .checkSearchFilterVisibility(any(), any());
+
+        Assert.assertThrows(BadRequestException.class, () -> this.viewsResource.create(view, userContext, searchUser));
+    }
+
+    @Test
+    public void throwsExceptionWhenCreatingDashboardWithFilterThatUserIsNotAllowedToSee() throws Exception {
+        mockView(ViewDTO.Type.DASHBOARD);
+        final UserContext userContext = mockUser();
+        doReturn(new SearchFilterVisibilityCheckStatus(Collections.singletonList("<<You cannot see this filter>>")))
+                .when(searchFilterVisibilityChecker)
+                .checkSearchFilterVisibility(any(), any());
+
+        Assert.assertThrows(BadRequestException.class, () -> this.viewsResource.create(view, userContext, searchUser));
+    }
+
+    @Test
+    public void throwsExceptionWhenUpdatingSearchWithFilterThatUserIsNotAllowedToSee() throws Exception {
+        final ViewDTO.Builder builder = mockView(ViewDTO.Type.SEARCH);
+        mockUser();
+        doReturn(new SearchFilterVisibilityCheckStatus(Collections.singletonList("<<You cannot see this filter>>")))
+                .when(searchFilterVisibilityChecker)
+                .checkSearchFilterVisibility(any(), any());
+
+        Assert.assertThrows(BadRequestException.class, () -> this.viewsResource.update(view.id(), builder.build(), searchUser));
+    }
+
+    @Test
+    public void throwsExceptionWhenUpdatingDashboardWithFilterThatUserIsNotAllowedToSee() throws Exception {
+        final ViewDTO.Builder builder = mockView(ViewDTO.Type.DASHBOARD);
+        mockUser();
+        doReturn(new SearchFilterVisibilityCheckStatus(Collections.singletonList("<<You cannot see this filter>>")))
+                .when(searchFilterVisibilityChecker)
+                .checkSearchFilterVisibility(any(), any());
+
+        Assert.assertThrows(BadRequestException.class, () -> this.viewsResource.update(view.id(), builder.build(), searchUser));
+    }
+
+    private UserContext mockUser() {
+        final UserImpl testUser = new UserImpl(mock(PasswordAlgorithmFactory.class), new Permissions(ImmutableSet.of()), ImmutableMap.of("username", "testuser"));
+
+        final UserContext userContext = mock(UserContext.class);
+        when(userContext.getUser()).thenReturn(testUser);
+        when(searchUser.username()).thenReturn("testuser");
+        when(searchUser.canUpdateView(any())).thenReturn(true);
+        return userContext;
+    }
+
+    private ViewDTO.Builder mockView(final ViewDTO.Type type) {
+        final ViewDTO.Builder builder = mock(ViewDTO.Builder.class);
+
+        when(view.toBuilder()).thenReturn(builder);
+        when(view.type()).thenReturn(type);
+        when(view.searchId()).thenReturn("6141d457d3a6b9d73c8ac55a");
+        when(builder.owner(any())).thenReturn(builder);
+        when(builder.id(any())).thenReturn(builder);
+        when(builder.build()).thenReturn(view);
+        return builder;
     }
 
     @Test

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/searchfilters/db/SearchFilterVisibilityCheckerTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/searchfilters/db/SearchFilterVisibilityCheckerTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.views.search.searchfilters.db;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import org.graylog.plugins.views.search.Query;
+import org.graylog.plugins.views.search.Search;
+import org.graylog.plugins.views.search.searchfilters.model.InlineQueryStringSearchFilter;
+import org.graylog.plugins.views.search.searchfilters.model.ReferencedSearchFilter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+import java.util.function.Predicate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class SearchFilterVisibilityCheckerTest {
+
+    @Mock
+    private Search search;
+
+    private SearchFilterVisibilityChecker toTest;
+    private final Predicate<String> alwaysFalsePredicate = filterId -> false;
+
+    @BeforeEach
+    void setUp() {
+        toTest = new SearchFilterVisibilityChecker();
+    }
+
+    @Test
+    void testSuccessfulCheckOnSearchWithoutQueries() {
+        doReturn(ImmutableSet.of()).when(search).queries();
+        final SearchFilterVisibilityCheckStatus result = toTest.checkSearchFilterVisibility(alwaysFalsePredicate, search);
+        assertTrue(result.allSearchFiltersVisible());
+    }
+
+    @Test
+    void testSuccessfulCheckOnSearchWithQueriesWithoutFilters() {
+        Query query1 = mock(Query.class);
+        Query query2 = mock(Query.class);
+        doReturn(ImmutableSet.of(query1, query2)).when(search).queries();
+        final SearchFilterVisibilityCheckStatus result = toTest.checkSearchFilterVisibility(alwaysFalsePredicate, search);
+        assertTrue(result.allSearchFiltersVisible());
+    }
+
+    @Test
+    void testSuccessfulCheckOnSearchWithQueriesWithOnlyVisibleFilters() {
+        Query query1 = mock(Query.class);
+        Query query2 = mock(Query.class);
+        doReturn(ImmutableList.of(mock(ReferencedSearchFilter.class), mock(ReferencedSearchFilter.class))).when(query1).filters();
+        doReturn(ImmutableList.of(mock(ReferencedSearchFilter.class))).when(query2).filters();
+        doReturn(ImmutableSet.of(query1, query2)).when(search).queries();
+        final Predicate<String> alwaysTruePredicate = filterId -> true;
+        final SearchFilterVisibilityCheckStatus result = toTest.checkSearchFilterVisibility(alwaysTruePredicate, search);
+        assertTrue(result.allSearchFiltersVisible());
+    }
+
+    @Test
+    void testSingleInvisibleFilterMakesCheckFail() {
+        Query query1 = mock(Query.class);
+        Query query2 = mock(Query.class);
+        ReferencedSearchFilter hiddenSearchFilter = mock(ReferencedSearchFilter.class);
+        doReturn("hidden").when(hiddenSearchFilter).id();
+        doReturn(ImmutableList.of(mock(ReferencedSearchFilter.class), mock(ReferencedSearchFilter.class), hiddenSearchFilter)).when(query1).filters();
+        doReturn(ImmutableList.of(mock(ReferencedSearchFilter.class))).when(query2).filters();
+        doReturn(ImmutableSet.of(query1, query2)).when(search).queries();
+        final Predicate<String> readPermissionPredicate = filterId -> !"hidden".equals(filterId);
+        final SearchFilterVisibilityCheckStatus result = toTest.checkSearchFilterVisibility(readPermissionPredicate, search);
+
+        assertFalse(result.allSearchFiltersVisible());
+        assertEquals(Collections.singletonList("hidden"), result.getHiddenSearchFiltersIDs());
+    }
+
+    @Test
+    void testWorksOnlyWithReferencedSearchFilters() {
+        Query query1 = mock(Query.class);
+        Query query2 = mock(Query.class);
+        doReturn(ImmutableList.of(mock(InlineQueryStringSearchFilter.class), mock(InlineQueryStringSearchFilter.class))).when(query1).filters();
+        doReturn(ImmutableList.of(mock(ReferencedSearchFilter.class))).when(query2).filters();
+        doReturn(ImmutableSet.of(query1, query2)).when(search).queries();
+        final Predicate<String> predicateMock = mock(Predicate.class);
+        toTest.checkSearchFilterVisibility(predicateMock, search);
+
+        verify(predicateMock, times(1)).test(any());//there is only 1 ReferencedSearchFilter
+
+    }
+
+}


### PR DESCRIPTION
## Description
Block create/update of a view if forbidden/hidden search filters are used.

## Motivation and Context
When it comes to our UI, front-end will implement proper blocking.

The problem is that someone can still try to invoke creation/update of a view directly through our REST API.
This person can manipulate Search JSON so that it contains a Search Filter current user has no permissions for.
In this scenario creation/update should fail.

## How Has This Been Tested?
Manually and with unit tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

