### PR TITLE
Fix field value suggestions when quoting is used. (`4.3`)

### DIFF
--- a/graylog2-web-interface/src/views/components/searchbar/completions/FieldValueCompletion.test.ts
+++ b/graylog2-web-interface/src/views/components/searchbar/completions/FieldValueCompletion.test.ts
@@ -74,18 +74,22 @@ describe('FieldValueCompletion', () => {
   });
 
   describe('getCompletions', () => {
+    const requestDefaults = {
+      currentToken: null,
+      lastToken: null,
+      prefix: '',
+      tokens: [],
+      currentTokenIdx: -1,
+      timeRange: undefined,
+      streams: undefined,
+      fieldTypes,
+    };
+
     it('returns empty list if inputs are empty', () => {
       const completer = new FieldValueCompletion();
 
       expect(completer.getCompletions({
-        currentToken: null,
-        lastToken: null,
-        prefix: '',
-        tokens: [],
-        currentTokenIdx: -1,
-        timeRange: undefined,
-        streams: undefined,
-        fieldTypes,
+        ...requestDefaults,
       })).toEqual([]);
     });
 
@@ -94,14 +98,10 @@ describe('FieldValueCompletion', () => {
       const completer = new FieldValueCompletion();
 
       const suggestions = await completer.getCompletions({
+        ...requestDefaults,
         currentToken,
-        lastToken: null,
-        prefix: '',
         tokens: [currentToken],
         currentTokenIdx: 0,
-        timeRange: undefined,
-        streams: undefined,
-        fieldTypes,
       });
 
       expect(suggestions).toEqual(expectedSuggestions);
@@ -116,14 +116,52 @@ describe('FieldValueCompletion', () => {
       const completer = new FieldValueCompletion();
 
       const suggestions = await completer.getCompletions({
+        ...requestDefaults,
         currentToken,
         lastToken,
         prefix: 'P',
         tokens: [lastToken, currentToken],
         currentTokenIdx: 1,
-        timeRange: undefined,
-        streams: undefined,
-        fieldTypes,
+      });
+
+      expect(suggestions).toEqual(expectedSuggestions);
+    });
+
+    it('returns suggestions, field value is a quoted string', async () => {
+      const currentToken = createCurrentToken('string', '"P"', 1, 12);
+      const lastToken = {
+        type: 'keyword',
+        value: 'http_method:',
+      };
+      const completer = new FieldValueCompletion();
+
+      const suggestions = await completer.getCompletions({
+        ...requestDefaults,
+        currentToken,
+        lastToken,
+        prefix: 'P',
+        tokens: [lastToken, currentToken],
+        currentTokenIdx: 1,
+      });
+
+      expect(suggestions).toEqual(expectedSuggestions);
+    });
+
+    it('returns suggestions, field value is an empty quoted string', async () => {
+      const currentToken = createCurrentToken('string', '""', 1, 12);
+      const lastToken = {
+        type: 'keyword',
+        value: 'http_method:',
+      };
+      const completer = new FieldValueCompletion();
+
+      const suggestions = await completer.getCompletions({
+        ...requestDefaults,
+        currentToken,
+        lastToken,
+        prefix: '',
+        tokens: [lastToken, currentToken],
+        currentTokenIdx: 1,
       });
 
       expect(suggestions).toEqual(expectedSuggestions);
@@ -135,13 +173,10 @@ describe('FieldValueCompletion', () => {
       const completer = new FieldValueCompletion();
 
       const suggestions = await completer.getCompletions({
+        ...requestDefaults,
         currentToken,
-        lastToken: null,
-        prefix: '',
         tokens: [currentToken],
         currentTokenIdx: 0,
-        timeRange: undefined,
-        streams: undefined,
         fieldTypes: {
           all: { http_method: httpMethodField },
           query: {},
@@ -156,14 +191,10 @@ describe('FieldValueCompletion', () => {
       const completer = new FieldValueCompletion();
 
       const suggestions = await completer.getCompletions({
+        ...requestDefaults,
         currentToken,
-        lastToken: null,
-        prefix: '',
         tokens: [currentToken],
         currentTokenIdx: 0,
-        timeRange: undefined,
-        streams: undefined,
-        fieldTypes,
       });
 
       expect(suggestions).toEqual([]);
@@ -174,13 +205,10 @@ describe('FieldValueCompletion', () => {
       const completer = new FieldValueCompletion();
 
       const suggestions = await completer.getCompletions({
+        ...requestDefaults,
         currentToken,
-        lastToken: null,
-        prefix: '',
         tokens: [currentToken],
         currentTokenIdx: 0,
-        timeRange: undefined,
-        streams: undefined,
         fieldTypes: { all: {}, query: {} },
       });
 
@@ -193,13 +221,10 @@ describe('FieldValueCompletion', () => {
       const completer = new FieldValueCompletion();
 
       const suggestions = await completer.getCompletions({
+        ...requestDefaults,
         currentToken,
-        lastToken: null,
-        prefix: '',
         tokens: [currentToken],
         currentTokenIdx: 0,
-        timeRange: undefined,
-        streams: undefined,
         fieldTypes: { all: { message: messageField }, query: { message: messageField } },
       });
 
@@ -225,14 +250,12 @@ describe('FieldValueCompletion', () => {
       const completer = new FieldValueCompletion();
 
       const suggestions = await completer.getCompletions({
+        ...requestDefaults,
         currentToken,
         lastToken,
         prefix: 'PSOT',
         tokens: [lastToken, currentToken],
         currentTokenIdx: 1,
-        timeRange: undefined,
-        streams: undefined,
-        fieldTypes,
       });
 
       const expectedCorrections = [
@@ -261,14 +284,11 @@ describe('FieldValueCompletion', () => {
       const completer = new FieldValueCompletion();
 
       const suggestions = await completer.getCompletions({
+        ...requestDefaults,
         currentToken,
         lastToken,
-        prefix: '',
         tokens: [lastToken, currentToken],
         currentTokenIdx: 1,
-        timeRange: undefined,
-        streams: undefined,
-        fieldTypes,
       });
 
       expect(suggestions).toEqual([
@@ -310,14 +330,12 @@ describe('FieldValueCompletion', () => {
         const completer = new FieldValueCompletion();
 
         const firstSuggestions = await completer.getCompletions({
+          ...requestDefaults,
           currentToken,
           lastToken,
           prefix: 'a',
           tokens: [lastToken, currentToken],
           currentTokenIdx: 1,
-          timeRange: undefined,
-          streams: undefined,
-          fieldTypes,
         });
 
         expect(firstSuggestions).toEqual(expectedFirstSuggestions);
@@ -334,14 +352,12 @@ describe('FieldValueCompletion', () => {
         asMock(fetch).mockResolvedValue(secondResponse);
 
         const secondSuggestions = await completer.getCompletions({
+          ...requestDefaults,
           currentToken,
           lastToken,
           prefix: 'ac',
           tokens: [lastToken, currentToken],
           currentTokenIdx: 1,
-          timeRange: undefined,
-          streams: undefined,
-          fieldTypes,
         });
 
         expect(secondSuggestions).toEqual([
@@ -356,27 +372,23 @@ describe('FieldValueCompletion', () => {
         const completer = new FieldValueCompletion();
 
         const firstSuggestions = await completer.getCompletions({
+          ...requestDefaults,
           currentToken,
           lastToken,
           prefix: 'a',
           tokens: [lastToken, currentToken],
           currentTokenIdx: 1,
-          timeRange: undefined,
-          streams: undefined,
-          fieldTypes,
         });
 
         expect(firstSuggestions).toEqual(expectedFirstSuggestions);
 
         const secondSuggestions = await completer.getCompletions({
+          ...requestDefaults,
           currentToken,
           lastToken,
           prefix: 'ac',
           tokens: [lastToken, currentToken],
           currentTokenIdx: 1,
-          timeRange: undefined,
-          streams: undefined,
-          fieldTypes,
         });
 
         expect(secondSuggestions).toEqual(expectedFirstSuggestions);
@@ -402,6 +414,13 @@ describe('FieldValueCompletion', () => {
     it('returns true if current token is a keyword and ends with ":"', async () => {
       const completer = new FieldValueCompletion();
       const result = completer.shouldShowCompletions(1, [[{ type: 'keyword', value: 'http_method:', index: 0, start: 0 }, null]]);
+
+      expect(result).toEqual(true);
+    });
+
+    it('returns true if current token is a string and consits only of ""', async () => {
+      const completer = new FieldValueCompletion();
+      const result = completer.shouldShowCompletions(1, [[{ type: 'keyword', value: 'http_method:' }, { type: 'string', value: '""', index: 1, start: 12 }, null]]);
 
       expect(result).toEqual(true);
     });

--- a/graylog2-web-interface/src/views/components/searchbar/completions/FieldValueCompletion.ts
+++ b/graylog2-web-interface/src/views/components/searchbar/completions/FieldValueCompletion.ts
@@ -38,12 +38,14 @@ type SuggestionsResponse = {
 
 const suggestionsUrl = qualifyUrl('/search/suggest');
 
-const formatValue = (value: string, type: string) => {
-  if (type === 'constant.numeric') {
-    return Number(value);
-  }
+const unquote = (s: string) => s.replace(/^"(.*(?="$))"$/, '$1');
 
-  return value;
+const formatValue = (value: string, type: string) => {
+  switch (type) {
+    case 'constant.numeric': return Number(value);
+    case 'string': return unquote(value);
+    default: return value;
+  }
 };
 
 const completionCaption = (fieldValue: string, input: string | number) => {
@@ -54,18 +56,22 @@ const completionCaption = (fieldValue: string, input: string | number) => {
   return `${fieldValue} ⭢ ${input}`;
 };
 
+const isValueToken = (token: Line) => ['term', 'string'].includes(token?.type);
+
 const getFieldNameAndInput = (currentToken: Token | undefined | null, lastToken: Token | undefined | null) => {
   if (currentToken?.type === 'keyword' && currentToken?.value.endsWith(':')) {
     return {
       fieldName: currentToken.value.slice(0, -1),
       input: '',
+      isQuoted: false,
     };
   }
 
-  if (currentToken?.type === 'term' && lastToken?.type === 'keyword') {
+  if (isValueToken(currentToken) && lastToken?.type === 'keyword') {
     return {
       fieldName: lastToken.value.slice(0, -1),
       input: formatValue(currentToken.value, currentToken.type),
+      isQuoted: currentToken?.type === 'string',
     };
   }
 
@@ -76,10 +82,18 @@ const isEnumerableField = (field: FieldTypeMapping | undefined) => {
   return field?.type.isEnumerable() ?? false;
 };
 
+const formatSuggestion = (value: string, occurrence: number, input: string | number, isQuoted: boolean): CompletionResult => ({
+  name: value,
+  value: isQuoted ? value : escape(value),
+  score: occurrence,
+  caption: completionCaption(value, input),
+  meta: `${occurrence} hits`,
+});
+
 class FieldValueCompletion implements Completer {
   private previousSuggestions: undefined | {
     furtherSuggestionsCount: number,
-    completions: Array<CompletionResult>,
+    suggestions: SuggestionsResponse['suggestions'],
     fieldName: string,
     input: string | number,
     timeRange: TimeRange | NoTimeRangeOverride | undefined,
@@ -128,9 +142,11 @@ class FieldValueCompletion implements Completer {
       && !furtherSuggestionsCount;
   }
 
-  private filterExistingSuggestions(input: string | number) {
+  private filterExistingSuggestions(input: string | number, isQuoted: boolean) {
     if (this.previousSuggestions) {
-      return this.previousSuggestions.completions.filter((completion) => completion.name.startsWith(String(input)));
+      return this.previousSuggestions.suggestions
+        .filter((suggestion) => suggestion.value.startsWith(String(input)))
+        .map(({ value, occurrence }) => formatSuggestion(value, occurrence, input, isQuoted));
     }
 
     return [];
@@ -143,16 +159,16 @@ class FieldValueCompletion implements Completer {
     streams,
     fieldTypes,
   }: CompleterContext) => {
-    const { fieldName, input } = getFieldNameAndInput(currentToken, lastToken);
+    const { fieldName, input, isQuoted } = getFieldNameAndInput(currentToken, lastToken);
 
     if (!this.shouldFetchCompletions(fieldName, fieldTypes)) {
       return [];
     }
 
     if (this.alreadyFetchedAllSuggestions(input, fieldName, streams, timeRange)) {
-      const existingSuggestions = this.filterExistingSuggestions(input);
+      const existingSuggestions = this.filterExistingSuggestions(input, isQuoted);
 
-      if (existingSuggestions.length) {
+      if (existingSuggestions.length > 0) {
         return existingSuggestions;
       }
     }
@@ -170,24 +186,16 @@ class FieldValueCompletion implements Completer {
         return [];
       }
 
-      const completions = suggestions.map(({ value, occurrence }) => ({
-        name: value,
-        value: escape(value),
-        score: occurrence,
-        caption: completionCaption(value, input),
-        meta: `${occurrence} hits`,
-      }));
-
       this.previousSuggestions = {
         furtherSuggestionsCount,
         streams,
         timeRange,
         fieldName,
         input,
-        completions,
+        suggestions,
       };
 
-      return completions;
+      return suggestions.map(({ value, occurrence }) => formatSuggestion(value, occurrence, input, isQuoted));
     });
   };
 
@@ -205,7 +213,7 @@ class FieldValueCompletion implements Completer {
     const nextToken = currentLineTokens[currentTokenIndex + 1];
 
     const currentTokenIsFieldName = currentToken?.type === 'keyword' && currentToken?.value.endsWith(':');
-    const currentTokenIsFieldValue = currentToken?.type === 'term' && previousToken?.type === 'keyword';
+    const currentTokenIsFieldValue = isValueToken(currentToken) && previousToken?.type === 'keyword';
     const nextTokenIsTerm = nextToken?.type === 'term';
 
     return (currentTokenIsFieldName || currentTokenIsFieldValue) && !nextTokenIsTerm;

--- a/graylog2-web-interface/src/views/components/searchbar/queryinput/ace-types.ts
+++ b/graylog2-web-interface/src/views/components/searchbar/queryinput/ace-types.ts
@@ -70,6 +70,7 @@ export type CompletionResult = {
   value: string,
   score: number,
   meta: any,
+  caption?: string,
 };
 
 export type ResultsCallback = (obj: null, results: Array<CompletionResult>) => void;


### PR DESCRIPTION
**Note:** This is a backport of #13087 to `4.3`.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is fixing an issue with the field value completions not working when the user is starting a field value with quoting, e.g. when the user types `field:""`, no completions appear.

This PR is fixing this and also retains quoting information, so when the user uses quoting, the value returned is not escaped, if the user is not using quoting, escaping is used.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.