### PR TITLE
Fix AddJobTypeToJobTrigger migration with Mongo 3.6

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/migrations/V20220623125450_AddJobTypeToJobTrigger.java
+++ b/graylog2-server/src/main/java/org/graylog2/migrations/V20220623125450_AddJobTypeToJobTrigger.java
@@ -22,14 +22,13 @@ import com.google.auto.value.AutoValue;
 import com.google.common.base.Stopwatch;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Streams;
-import com.mongodb.client.AggregateIterable;
+import com.mongodb.client.FindIterable;
 import com.mongodb.client.MongoCollection;
-import com.mongodb.client.model.Aggregates;
 import com.mongodb.client.model.Filters;
-import com.mongodb.client.model.Projections;
 import com.mongodb.client.model.UpdateOneModel;
 import com.mongodb.client.model.Updates;
 import org.bson.Document;
+import org.bson.types.ObjectId;
 import org.graylog.scheduler.DBJobDefinitionService;
 import org.graylog.scheduler.DBJobTriggerService;
 import org.graylog.scheduler.JobTriggerDto;
@@ -40,8 +39,8 @@ import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import java.time.ZonedDateTime;
-import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
@@ -71,22 +70,20 @@ public class V20220623125450_AddJobTypeToJobTrigger extends Migration {
         final Stopwatch started = Stopwatch.createStarted();
 
         final MongoCollection<Document> jobTriggers = mongoConnection.getMongoDatabase().getCollection(DBJobTriggerService.COLLECTION_NAME);
+        final MongoCollection<Document> jobDefinitions = mongoConnection.getMongoDatabase().getCollection(DBJobDefinitionService.COLLECTION_NAME);
+
 
         // Duplicate the type field from the JobDefinition config to their JobTriggers
-        // Yes, this is what it takes to perform a join in MongoDB  ¯\_(ツ)_/¯
-        final AggregateIterable<Document> query = jobTriggers.aggregate(
-                ImmutableList.of(
-                        Aggregates.match(Filters.exists(JobTriggerDto.FIELD_JOB_DEFINITION_TYPE, false)),
-                        Aggregates.project(Projections.computed("job_definition_id", new Document("$toObjectId", "$job_definition_id"))),
-                        Aggregates.lookup(DBJobDefinitionService.COLLECTION_NAME, "job_definition_id", "_id", "job_definition"),
-                        Aggregates.project(Projections.computed("job_definition", new Document("$arrayElemAt", Arrays.asList("$job_definition", 0)))),
-                        Aggregates.project(Projections.computed("job_type", "$job_definition.config.type"))
-                )
-        );
+
+        // We cannot use aggregations because Mongo 3.6 does not support $toString or $toObjectId
+        final Map<ObjectId, String> typeMap = Streams.stream(jobDefinitions.find())
+                .collect(Collectors.toMap(d -> d.getObjectId("_id"), d -> d.getEmbedded(ImmutableList.of("config", "type"), String.class)));
+
+        final FindIterable<Document> query = jobTriggers.find(Filters.exists(JobTriggerDto.FIELD_JOB_DEFINITION_TYPE, false));
 
         List<UpdateOneModel<Document>> typeUpdate = Streams.stream(query).map(d -> new UpdateOneModel<Document>(
                 Filters.eq("_id", d.getObjectId("_id")),
-                Updates.set(JobTriggerDto.FIELD_JOB_DEFINITION_TYPE, d.getString("job_type")))).collect(Collectors.toList());
+                Updates.set(JobTriggerDto.FIELD_JOB_DEFINITION_TYPE, typeMap.get(d.getObjectId("_id"))))).collect(Collectors.toList());
 
         long modifiedCount = 0;
         if (!typeUpdate.isEmpty()) {

--- a/graylog2-server/src/test/resources/org/graylog2/migrations/V20220623125450_AddJobTypeToJobTriggerTest.json
+++ b/graylog2-server/src/test/resources/org/graylog2/migrations/V20220623125450_AddJobTypeToJobTriggerTest.json
@@ -2,7 +2,7 @@
   "scheduler_job_definitions": [
     {
       "_id": {
-        "$oid": "54e3deadbeefdeadbeef0000"
+        "$oid": "54e3deadbeefdeadbeef1000"
       },
       "title": "Test 1",
       "description": "A test event definition",
@@ -12,7 +12,7 @@
     },
     {
       "_id": {
-        "$oid": "54e3deadbeefdeadbeef0001"
+        "$oid": "54e3deadbeefdeadbeef1001"
       },
       "title": "Test 2",
       "description": "A second test event definition",
@@ -22,7 +22,7 @@
     },
     {
       "_id": {
-        "$oid": "54e3deadbeefdeadbeef0002"
+        "$oid": "54e3deadbeefdeadbeef1002"
       },
       "title": "Test 3",
       "description": "A event notification definition",
@@ -36,7 +36,7 @@
       "_id": {
         "$oid": "54e3deadbeefdeadbeef0000"
       },
-      "job_definition_id": "54e3deadbeefdeadbeef0000",
+      "job_definition_id": "54e3deadbeefdeadbeef1000",
       "start_time": {
         "$date": "2019-01-01T00:00:00.000Z"
       },
@@ -74,7 +74,7 @@
       "_id": {
         "$oid": "54e3deadbeefdeadbeef0001"
       },
-      "job_definition_id": "54e3deadbeefdeadbeef0001",
+      "job_definition_id": "54e3deadbeefdeadbeef1001",
       "start_time": {
         "$date": "2019-01-01T00:00:00.000Z"
       },
@@ -112,7 +112,7 @@
       "_id": {
         "$oid": "54e3deadbeefdeadbeef0002"
       },
-      "job_definition_id": "54e3deadbeefdeadbeef0002",
+      "job_definition_id": "54e3deadbeefdeadbeef1002",
       "start_time": {
         "$date": "2019-01-01T00:00:00.000Z"
       },


### PR DESCRIPTION
Mongo 3.6 does neither support $toString, nor $toObjectId
Thus we cannot use an aggregation to lookup the jobdefinition type.
We need to convert ObjectIds to Strings or vice versa to do the looukup.

Instead we are just fetching a map of all jobdefinition types.

Performance should still be okay, because we only expect lots of
JobTriggers, not JobDefinitions.
