### PR TITLE
Add default param to set_field function

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/messages/SetField.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/messages/SetField.java
@@ -58,11 +58,14 @@ public class SetField extends AbstractFunction<Void> {
         try {
             value = valueParam.required(args, context);
         } catch (Exception e) {
-            // swallow the exception;
+            // swallow the exception if there is an available default value;
+            if (!args.isPresent("default")) {
+                throw e;
+            }
         }
         finally {
             if (value == null) {
-                value = defaultParam.required(args, context);
+                value = defaultParam.optional(args, context).orElse(null);
             }
         }
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/messages/SetField.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/messages/SetField.java
@@ -40,6 +40,7 @@ public class SetField extends AbstractFunction<Void> {
     private final ParameterDescriptor<String, String> prefixParam;
     private final ParameterDescriptor<String, String> suffixParam;
     private final ParameterDescriptor<Message, Message> messageParam;
+    private final ParameterDescriptor<Object, Object> defaultParam;
 
     public SetField() {
         fieldParam = string("field").description("The new field name").build();
@@ -47,12 +48,23 @@ public class SetField extends AbstractFunction<Void> {
         prefixParam = string("prefix").optional().description("The prefix for the field name").build();
         suffixParam = string("suffix").optional().description("The suffix for the field name").build();
         messageParam = type("message", Message.class).optional().description("The message to use, defaults to '$message'").build();
+        defaultParam = object("default").optional().description("Used when value not available").build();
     }
 
     @Override
     public Void evaluate(FunctionArgs args, EvaluationContext context) {
         String field = fieldParam.required(args, context);
-        final Object value = valueParam.required(args, context);
+        Object value = null;
+        try {
+            value = valueParam.required(args, context);
+        } catch (Exception e) {
+            // swallow the exception;
+        }
+        finally {
+            if (value == null) {
+                value = defaultParam.required(args, context);
+            }
+        }
 
         if (!Strings.isNullOrEmpty(field)) {
             final Message message = messageParam.optional(args, context).orElse(context.currentMessage());
@@ -76,11 +88,12 @@ public class SetField extends AbstractFunction<Void> {
                 .name(NAME)
                 .returnType(Void.class)
                 .params(of(fieldParam,
-                           valueParam,
-                           prefixParam,
-                           suffixParam,
-                           messageParam))
-                .description("Sets a new field in a message")
-                .build();
+                        valueParam,
+                        prefixParam,
+                        suffixParam,
+                        messageParam,
+                        defaultParam))
+                        .description("Sets a new field in a message")
+                        .build();
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Extends parameter list of `set_field` by an optional default parameter. The default can be specified as a positional parameter (5th parameter value) or named as `default`. 
The default is assigned if 
- the primary value is null
- evaluation of the primary value throws an exception. In this case (provided the default is valid), the exception is suppressed. This is desired so we can specify a default when an array value is not present, resulting in _index out of bounds_ exception.

## Description
<!--- Describe your changes in detail -->
The default parameter value is assigned whenever the value parameter is null; or when an exception is encountered in evaluating the value parameter. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
See linked issue for details

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

Resolves #5911 