### PR TITLE
add flag ignore_migration_failures

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/Configuration.java
+++ b/graylog2-server/src/main/java/org/graylog2/Configuration.java
@@ -202,6 +202,9 @@ public class Configuration extends BaseConfiguration {
     @Parameter(value = "run_migrations")
     private boolean runMigrations = true;
 
+    @Parameter(value = "ignore_migration_failures")
+    private boolean ignoreMigrationFailures = false;
+
     @Parameter(value = "skip_preflight_checks")
     private boolean skipPreflightChecks = false;
 
@@ -297,6 +300,10 @@ public class Configuration extends BaseConfiguration {
 
     public boolean runMigrations() {
         return runMigrations;
+    }
+
+    public boolean ignoreMigrationFailures() {
+        return ignoreMigrationFailures;
     }
 
     public boolean getSkipPreflightChecks() {

--- a/graylog2-server/src/main/java/org/graylog2/bootstrap/ServerBootstrap.java
+++ b/graylog2-server/src/main/java/org/graylog2/bootstrap/ServerBootstrap.java
@@ -308,7 +308,7 @@ public abstract class ServerBootstrap extends CmdLineTool {
                 m.upgrade();
             } catch (Exception e) {
                 if (configuration.ignoreMigrationFailures()) {
-                    LOG.warn("  Ignoring migration failure: {}", e.getMessage());
+                    LOG.warn("Ignoring failure of migration <{}>: {}", m.getClass().getCanonicalName(), e.getMessage());
                 } else {
                     throw e;
                 }

--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -754,3 +754,7 @@ proxied_requests_thread_pool_size = 32
 # Default: false
 #skip_preflight_checks = false
 
+# Ignore any exceptions encountered when running migrations
+# Use with caution - skipping failing migrations may result in an inconsistent DB state.
+# Default: false
+#ignore_migration_failures = false


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Introduces a new configuration flag `ignore_migration_failures`. This provides an alternative to skipping all migrations via `run_migrations = false` when specific migrations are blocked.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

Resolves Graylog2/graylog2-server#13053
