### PR TITLE
Updated GeoIpDbFileChangeMonitorService Refresh scheduling

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/map/geoip/GeoIpDbFileChangeMonitorService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/map/geoip/GeoIpDbFileChangeMonitorService.java
@@ -151,7 +151,7 @@ public final class GeoIpDbFileChangeMonitorService extends AbstractIdleService {
                 this.cityDbFileInfo = getDbFileInfo(config.cityDbPath());
                 this.asnDbFileInfo = getDbFileInfo(config.asnDbPath());
             } else {
-                LOG.info("GeoIP Processor is disabled.  Will not schedule GeoIP database file change monitor");
+                LOG.debug("GeoIP Processor is disabled.  Will not schedule GeoIP database file change monitor");
                 cancelScheduledRefreshTask();
 
                 // Set interval to ZERO to allow rescheduling when enabled again, even if interval is not changed.
@@ -167,7 +167,7 @@ public final class GeoIpDbFileChangeMonitorService extends AbstractIdleService {
         if (refreshTask != null) {
             boolean canceled = refreshTask.cancel(true);
             if (canceled) {
-                LOG.info("The GeoIP database file change monitor was running.  It has been cancelled");
+                LOG.debug("The GeoIP database file change monitor was running.  It has been cancelled");
                 refreshTask = null;
             } else {
                 LOG.warn("The GeoIP database file change monitor was running and failed to stop it");

--- a/graylog2-server/src/main/java/org/graylog/plugins/map/geoip/GeoIpDbFileChangeMonitorService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/map/geoip/GeoIpDbFileChangeMonitorService.java
@@ -146,12 +146,32 @@ public final class GeoIpDbFileChangeMonitorService extends AbstractIdleService {
             config = getCurrentConfig();
             geoIpResolverConfigValidator.validate(config);
 
-            reScheduleRefreshIfNeeded();
-            this.cityDbFileInfo = getDbFileInfo(config.cityDbPath());
-            this.asnDbFileInfo = getDbFileInfo(config.asnDbPath());
+            if (config.enabled()) {
+                reScheduleRefreshIfNeeded();
+                this.cityDbFileInfo = getDbFileInfo(config.cityDbPath());
+                this.asnDbFileInfo = getDbFileInfo(config.asnDbPath());
+            } else {
+                LOG.info("GeoIP Processor is disabled.  Will not schedule GeoIP database file change monitor");
+                cancelScheduledRefreshTask();
+
+                // Set interval to ZERO to allow rescheduling when enabled again, even if interval is not changed.
+                dbRefreshInterval = Duration.ZERO;
+            }
 
         } catch (ConfigValidationException | IllegalArgumentException | IllegalStateException e) {
             LOG.error("Error validating GeoIP Database files. {}", e.getMessage(), e);
+        }
+    }
+
+    private void cancelScheduledRefreshTask() {
+        if (refreshTask != null) {
+            boolean canceled = refreshTask.cancel(true);
+            if (canceled) {
+                LOG.info("The GeoIP database file change monitor was running.  It has been cancelled");
+                refreshTask = null;
+            } else {
+                LOG.warn("The GeoIP database file change monitor was running and failed to stop it");
+            }
         }
     }
 


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Updated GeoIpDbFileChangeMonitorService to cancel running refresh task and NOT reschedule if processor is disabled.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Disabling refresh scheduling when the processor is disabled keeps refresh attempts, in particular when the configuration does not yet have database files.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
End-to-end testing.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

