### PR TITLE
Allow obtaining all triggers for one job definition ID

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/events/processor/EventDefinitionHandler.java
+++ b/graylog2-server/src/main/java/org/graylog/events/processor/EventDefinitionHandler.java
@@ -334,7 +334,7 @@ public class EventDefinitionHandler {
     }
 
     private Optional<JobTriggerDto> getJobTrigger(JobDefinitionDto jobDefinition) {
-        final List<JobTriggerDto> jobTriggers = jobTriggerService.getForJob(jobDefinition.id());
+        final List<JobTriggerDto> jobTriggers = jobTriggerService.getOneForJob(jobDefinition.id());
 
         if (jobTriggers.isEmpty()) {
             return Optional.empty();

--- a/graylog2-server/src/main/java/org/graylog/events/processor/EventDefinitionHandler.java
+++ b/graylog2-server/src/main/java/org/graylog/events/processor/EventDefinitionHandler.java
@@ -334,17 +334,11 @@ public class EventDefinitionHandler {
     }
 
     private Optional<JobTriggerDto> getJobTrigger(JobDefinitionDto jobDefinition) {
-        final List<JobTriggerDto> jobTriggers = jobTriggerService.getOneForJob(jobDefinition.id());
-
-        if (jobTriggers.isEmpty()) {
-            return Optional.empty();
-        }
-
-        // DBJobTriggerService#getForJob currently returns only one trigger. (raises an exception otherwise)
+        // DBJobTriggerService#getOneForJob currently returns only one trigger. (raises an exception otherwise)
         // Once we allow multiple triggers per job definition, this code will fail. We need some kind of label
         // to figure out which trigger was created automatically. (e.g. event processor)
         // TODO: Fix this code for multiple triggers per job definition
-        return Optional.ofNullable(jobTriggers.get(0));
+        return jobTriggerService.getOneForJob(jobDefinition.id());
     }
 
     private void updateJobTrigger(EventDefinitionDto eventDefinition,

--- a/graylog2-server/src/main/java/org/graylog/scheduler/DBJobTriggerService.java
+++ b/graylog2-server/src/main/java/org/graylog/scheduler/DBJobTriggerService.java
@@ -131,14 +131,14 @@ public class DBJobTriggerService {
     }
 
     /**
-     * Returns all job triggers for the given job definition ID.
+     * Returns one trigger for the given job definition ID.
      *
      * TODO: Don't throw exception when there is more than one trigger for a job definition. (see source code)
      *
      * @param jobDefinitionId the job definition ID
-     * @return list of found job triggers
+     * @return One found job trigger
      */
-    public List<JobTriggerDto> getOneForJob(String jobDefinitionId) {
+    public Optional<JobTriggerDto> getOneForJob(String jobDefinitionId) {
         final List<JobTriggerDto> triggers = getAllForJob(jobDefinitionId);
         // We are currently expecting only one trigger per job definition. This will most probably change in the
         // future once we extend our scheduler usage.
@@ -148,8 +148,7 @@ public class DBJobTriggerService {
         if (triggers.size() > 1) {
             throw new IllegalStateException("More than one trigger for job definition <" + jobDefinitionId + ">");
         }
-        return triggers;
-
+        return triggers.stream().findFirst();
     }
 
     public List<JobTriggerDto> getAllForJob(String jobDefinitionId) {

--- a/graylog2-server/src/main/java/org/graylog/scheduler/DBJobTriggerService.java
+++ b/graylog2-server/src/main/java/org/graylog/scheduler/DBJobTriggerService.java
@@ -138,7 +138,7 @@ public class DBJobTriggerService {
      * @param jobDefinitionId the job definition ID
      * @return list of found job triggers
      */
-    public List<JobTriggerDto> getForJob(String jobDefinitionId) {
+    public List<JobTriggerDto> getOneForJob(String jobDefinitionId) {
         final List<JobTriggerDto> triggers = getAllForJob(jobDefinitionId);
         // We are currently expecting only one trigger per job definition. This will most probably change in the
         // future once we extend our scheduler usage.

--- a/graylog2-server/src/test/java/org/graylog/events/processor/EventDefinitionHandlerTest.java
+++ b/graylog2-server/src/test/java/org/graylog/events/processor/EventDefinitionHandlerTest.java
@@ -316,7 +316,7 @@ public class EventDefinitionHandlerTest {
         assertThat(newJobDefinition.description()).isEqualTo(newDescription);
         assertThat(((EventProcessorExecutionJob.Config) newJobDefinition.config()).processingHopSize()).isEqualTo(550000);
 
-        assertThat(jobTriggerService.getForJob(newJobDefinition.id()).get(0)).satisfies(trigger -> {
+        assertThat(jobTriggerService.getOneForJob(newJobDefinition.id()).get(0)).satisfies(trigger -> {
             final IntervalJobSchedule schedule = (IntervalJobSchedule) trigger.schedule();
             assertThat(schedule.interval()).isEqualTo(550000);
         });

--- a/graylog2-server/src/test/java/org/graylog/events/processor/EventDefinitionHandlerTest.java
+++ b/graylog2-server/src/test/java/org/graylog/events/processor/EventDefinitionHandlerTest.java
@@ -316,7 +316,9 @@ public class EventDefinitionHandlerTest {
         assertThat(newJobDefinition.description()).isEqualTo(newDescription);
         assertThat(((EventProcessorExecutionJob.Config) newJobDefinition.config()).processingHopSize()).isEqualTo(550000);
 
-        assertThat(jobTriggerService.getOneForJob(newJobDefinition.id()).get(0)).satisfies(trigger -> {
+        assertThat(jobTriggerService.getOneForJob(newJobDefinition.id()))
+                .isPresent()
+                .hasValueSatisfying(trigger -> {
             final IntervalJobSchedule schedule = (IntervalJobSchedule) trigger.schedule();
             assertThat(schedule.interval()).isEqualTo(550000);
         });

--- a/graylog2-server/src/test/java/org/graylog/scheduler/DBJobTriggerServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/scheduler/DBJobTriggerServiceTest.java
@@ -194,11 +194,11 @@ public class DBJobTriggerServiceTest {
                 .hasMessageContaining("jobDefinitionId");
 
 
-        assertThat(dbJobTriggerService.getOneForJob("54e3deadbeefdeadbeefaff4")).hasSize(1).satisfies(triggers ->
-                assertThat(triggers.get(0)).satisfies(trigger -> {
+        assertThat(dbJobTriggerService.getOneForJob("54e3deadbeefdeadbeefaff4")).isPresent()
+                .hasValueSatisfying(trigger -> {
                     assertThat(trigger.id()).isEqualTo("54e3deadbeefdeadbeef0002");
                     assertThat(trigger.jobDefinitionId()).isEqualTo("54e3deadbeefdeadbeefaff4");
-                }));
+                });
 
         assertThat(dbJobTriggerService.getOneForJob("doesntexist")).isEmpty();
 

--- a/graylog2-server/src/test/java/org/graylog/scheduler/DBJobTriggerServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/scheduler/DBJobTriggerServiceTest.java
@@ -185,28 +185,45 @@ public class DBJobTriggerServiceTest {
     @Test
     @MongoDBFixtures("job-triggers.json")
     public void getForJob() {
-        assertThatCode(() -> dbJobTriggerService.getForJob(null))
+        assertThatCode(() -> dbJobTriggerService.getOneForJob(null))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("jobDefinitionId");
 
-        assertThatCode(() -> dbJobTriggerService.getForJob(""))
+        assertThatCode(() -> dbJobTriggerService.getOneForJob(""))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("jobDefinitionId");
 
 
-        assertThat(dbJobTriggerService.getForJob("54e3deadbeefdeadbeefaff4")).hasSize(1).satisfies(triggers ->
+        assertThat(dbJobTriggerService.getOneForJob("54e3deadbeefdeadbeefaff4")).hasSize(1).satisfies(triggers ->
                 assertThat(triggers.get(0)).satisfies(trigger -> {
                     assertThat(trigger.id()).isEqualTo("54e3deadbeefdeadbeef0002");
                     assertThat(trigger.jobDefinitionId()).isEqualTo("54e3deadbeefdeadbeefaff4");
                 }));
 
-        assertThat(dbJobTriggerService.getForJob("doesntexist")).isEmpty();
+        assertThat(dbJobTriggerService.getOneForJob("doesntexist")).isEmpty();
 
         // We expect a ISE when there is more than one trigger for a single job definition
-        assertThatCode(() -> dbJobTriggerService.getForJob("54e3deadbeefdeadbeefaff3"))
+        assertThatCode(() -> dbJobTriggerService.getOneForJob("54e3deadbeefdeadbeefaff3"))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("54e3deadbeefdeadbeefaff3");
     }
+
+    @Test
+    @MongoDBFixtures("job-triggers.json")
+    public void getAllForJob() {
+
+        // We expect a ISE when there is more than one trigger for a single job definition
+        assertThatCode(() -> dbJobTriggerService.getOneForJob("54e3deadbeefdeadbeefaff3"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("54e3deadbeefdeadbeefaff3");
+
+        // But we can also obtain all by calling following method:
+        assertThat(dbJobTriggerService.getAllForJob("54e3deadbeefdeadbeefaff3"))
+                .hasSize(2)
+                .allSatisfy(trigger -> assertThat(trigger.jobDefinitionId()).isEqualTo("54e3deadbeefdeadbeefaff3"));
+    }
+
+
 
     @Test
     @MongoDBFixtures("job-triggers.json")


### PR DESCRIPTION
So far our DBJobTriggerService allowed to get only one trigger for one job definition ID. This PR adds a call to obtain all triggers for the job ID.

## Description
Adding new method called `getAllForJob`, returning a list of available triggers. Additionally renaming `getForJob` to `getOneForJob`, returning an `Optional`, either empty or with a value. This method still throws an `IllegalStateException` if there are more triggers, in the same way the original call did.

## Motivation and Context
The reporting migration to our generic scheduler needs more triggers for one job. One report is represented by one job, each delivery configuration is represented by its own trigger.

## How Has This Been Tested?
Added unit tests, adapted existing


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

