### PR TITLE
Add styles for different sizes of nav component

### DIFF
--- a/graylog2-web-interface/src/components/bootstrap/Nav.jsx
+++ b/graylog2-web-interface/src/components/bootstrap/Nav.jsx
@@ -63,6 +63,28 @@ const Nav = styled(BootstrapNav)(({ theme }) => css`
         }
       }
     }
+    
+    &.nav-sm {
+      > li > a {
+        padding: 8px 12px;
+        font-size: 12px;
+      }
+    };
+
+    &.nav-xs {
+      > li > a {
+        padding: 2px 6px;
+        font-size: 12px;
+      }
+    };
+
+    &.nav-lg {
+      > li > a {
+        padding: 14px 18px;
+        font-size: 18px;
+        line-height: 1.3;
+      }
+    };
 
     &${navTabsStyles} /* This is a known non-issue that stylelint won't ignore but will hopefully be patched soon https://github.com/stylelint/stylelint/issues/4574 */
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR add styles for .nav-sm, .nav-xs and .nav-lg classes of Nav component. Now we can add props bsSize: sm | xs | lg | small | large to Nav component and we will have different sizes for navigation items

## Motivation and Context
According to react-bootstrap documentation https://react-bootstrap-v3.netlify.app/components/navs/  we can add bsStyle one of: "lg", "large", "sm", "small" to change the size of the Navs. That doesn't work and also looks like a mistake in documentation because as bsStyle we use `pills`or  `tabs` to change the style for them.  
Adding bsSize props to `Nav` (like we usually do for other components) component adds an appropriate class to the component. But there are no written styles for these classes. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

