### PR TITLE
Updates the external actions plugin use to be hook based

### DIFF
--- a/graylog2-web-interface/src/views/components/actions/Action.test.tsx
+++ b/graylog2-web-interface/src/views/components/actions/Action.test.tsx
@@ -17,6 +17,7 @@
 import * as React from 'react';
 import { render, screen } from 'wrappedTestingLibrary';
 import userEvent from '@testing-library/user-event';
+import { noop } from 'lodash';
 
 import { createSimpleExternalValueAction } from 'fixtures/externalValueActions';
 import type { ActionContexts } from 'views/types';
@@ -29,6 +30,10 @@ import Action from './Action';
 jest.mock('views/logic/usePluginEntities', () => jest.fn(() => []));
 
 describe('Action', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
   const exampleHandlerArgs = {
     queryId: 'query-id',
     field: 'field1',
@@ -39,6 +44,8 @@ describe('Action', () => {
 
   type Props = Partial<React.ComponentProps<typeof Action>>;
 
+  const OpenActionsMenu = () => (<div>Open Actions Menu</div>);
+
   const SimpleAction = ({
     children = 'The dropdown header',
     handlerArgs = exampleHandlerArgs,
@@ -46,7 +53,7 @@ describe('Action', () => {
     type = 'field',
   }: Props) => {
     return (
-      <Action element={() => <div>Open Actions Menu</div>}
+      <Action element={OpenActionsMenu}
               handlerArgs={handlerArgs}
               menuContainer={menuContainer}
               type={type}>
@@ -92,12 +99,28 @@ describe('Action', () => {
     expect(mockActionHandler).toHaveBeenCalledTimes(1);
   });
 
+  it('does not fail when plugin is not present for external actions', async () => {
+    asMock(usePluginEntities).mockImplementation((entityKey) => ({ wrongKey: noop }[entityKey]));
+
+    render(<SimpleAction>The dropdown header</SimpleAction>);
+    await openDropdown('The dropdown header');
+
+    expect(screen.getByText('The dropdown header')).toBeInTheDocument();
+  });
+
   it('should work with external value actions', async () => {
     const linkTarget = ({ field }) => `the-link-to-${field}`;
     const simpleExternalAction = createSimpleExternalValueAction({ title: 'External value action', linkTarget });
     const externalValueActions = [simpleExternalAction];
 
-    asMock(usePluginEntities).mockImplementation((entityKey) => ({ externalValueActions }[entityKey]));
+    asMock(usePluginEntities).mockImplementation((entityKey) => ({
+      useExternalActions: [() => ({
+        externalValueActions,
+        isLoading: false,
+        isError: false,
+        error: null,
+      })],
+    }[entityKey]));
 
     render(
       <SimpleAction type="value" />,

--- a/graylog2-web-interface/src/views/components/actions/ActionDropdown.tsx
+++ b/graylog2-web-interface/src/views/components/actions/ActionDropdown.tsx
@@ -17,6 +17,7 @@
 import * as React from 'react';
 import styled from 'styled-components';
 
+import Spinner from 'components/common/Spinner';
 import usePluginEntities from 'views/logic/usePluginEntities';
 import { MenuItem } from 'components/bootstrap';
 import ActionMenuItem from 'views/components/actions/ActionMenuItem';
@@ -35,7 +36,7 @@ const StyledListItem = styled.li`
   list-style: none;
 `;
 
-const filterVisibleActions = (actions: Array<ActionDefinition> | undefined = [], handlerArgs: Props['handlerArgs']) => {
+const filterVisibleActions = (handlerArgs: Props['handlerArgs'], actions: Array<ActionDefinition> | undefined = []) => {
   return actions.filter((action: ActionDefinition) => {
     const { isHidden = () => false } = action;
 
@@ -48,24 +49,32 @@ const useInternalActions = (type: Props['type'], handlerArgs: Props['handlerArgs
   const fieldActions = usePluginEntities('fieldActions');
 
   if (type === 'value') {
-    return filterVisibleActions(valueActions, handlerArgs);
+    return filterVisibleActions(handlerArgs, valueActions);
   }
 
   if (type === 'field') {
-    return filterVisibleActions(fieldActions, handlerArgs);
+    return filterVisibleActions(handlerArgs, fieldActions);
   }
 
   return [];
 };
 
 const useExternalActions = (type: Props['type'], handlerArgs: Props['handlerArgs']) => {
-  const valueActions = usePluginEntities('externalValueActions');
+  const usePluginExternalActions = usePluginEntities('useExternalActions');
 
-  if (type !== 'value') {
-    return [];
+  if (usePluginExternalActions && typeof usePluginExternalActions[0] === 'function') {
+    const { isLoading, isError, externalValueActions } = usePluginExternalActions[0]();
+
+    if (type !== 'value') {
+      return { isLoading, isError, externalValueActions: [] };
+    }
+
+    const externalActions = filterVisibleActions(handlerArgs, externalValueActions);
+
+    return { isLoading, isError, externalActions };
   }
 
-  return filterVisibleActions(valueActions, handlerArgs);
+  return { isLoading: false, isError: false, externalValueActions: [] };
 };
 
 type Props = {
@@ -86,7 +95,7 @@ const ActionDropdown = ({
   onMenuToggle,
 }: Props) => {
   const internalActions = useInternalActions(type, handlerArgs);
-  const externalActions = useExternalActions(type, handlerArgs);
+  const { isLoading, externalActions } = useExternalActions(type, handlerArgs);
 
   return (
     <>
@@ -107,8 +116,8 @@ const ActionDropdown = ({
                         type={type}
                         onMenuToggle={onMenuToggle} />
       ))}
-
-      {(externalActions && externalActions.length !== 0) && (
+      {isLoading && (<><MenuItem divider /><MenuItem disabled><Spinner text="Loading" /></MenuItem></>)}
+      {(!isLoading && externalActions && externalActions.length !== 0) && (
         <>
           <MenuItem divider />
           {externalActions.map((action) => (

--- a/graylog2-web-interface/src/views/types.ts
+++ b/graylog2-web-interface/src/views/types.ts
@@ -212,6 +212,13 @@ export type MessagePreviewOption = {
   sort: number,
 }
 
+type ExternalActionsHookData = {
+      error: Error | null;
+      externalValueActions: Array<ActionDefinition> | null;
+      isLoading: boolean;
+      isError: boolean
+}
+
 type MessageAugmentation = {
   id: string,
   component: React.ComponentType<{ message: Message }>,
@@ -265,7 +272,7 @@ declare module 'graylog-web-plugin/plugin' {
   export interface PluginExports {
     creators?: Array<Creator>;
     enterpriseWidgets?: Array<WidgetExport>;
-    externalValueActions?: Array<ActionDefinition>;
+    useExternalActions?: Array<() => ExternalActionsHookData>,
     fieldActions?: Array<ActionDefinition>;
     messageAugmentations?: Array<MessageAugmentation>;
     searchTypes?: Array<SearchType<any, any>>;


### PR DESCRIPTION
The external actions plugin now returns a hook to give it more functionality.

## Description
- Update types to include the new typing for the external actions hook
  plugin.
- Update ActionDropdown component to utilize the new plugin correctly
  and fail gracefully if the plugin isn't present.
- Update tests to work with the new hook and test the component works
  fine if the plugin is not present.

## Motivation and Context
There was a requirement for more robust functionality when using the external actions plugin.

## How Has This Been Tested?
- Unit tests have been written, and it has been tested locally.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

