### PR TITLE
Support $message expression in pipeline rules

### DIFF
--- a/graylog2-server/src/main/antlr4/org/graylog/plugins/pipelineprocessor/parser/RuleLang.g4
+++ b/graylog2-server/src/main/antlr4/org/graylog/plugins/pipelineprocessor/parser/RuleLang.g4
@@ -82,6 +82,7 @@ expression
     |   '[' (expression (',' expression)*)* ']'                         # ArrayLiteralExpr
     |   '{' (propAssignment (',' propAssignment)*)* '}'                 # MapLiteralExpr
     |   MessageRef '.' field=expression                                 # MessageRef
+    |   MessageRef                                                      # MessageRef
     |   fieldSet=expression '.' field=expression                        # Nested
     |   array=expression '[' index=expression ']'                       # IndexedAccess
     |   sign=('+'|'-') expr=expression                                  # SignedExpression

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/ast/expressions/MessageRefExpression.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/ast/expressions/MessageRefExpression.java
@@ -18,6 +18,7 @@ package org.graylog.plugins.pipelineprocessor.ast.expressions;
 
 import org.antlr.v4.runtime.Token;
 import org.graylog.plugins.pipelineprocessor.EvaluationContext;
+import org.graylog2.plugin.Message;
 
 import java.util.Collections;
 
@@ -36,6 +37,9 @@ public class MessageRefExpression extends BaseExpression {
 
     @Override
     public Object evaluateUnsafe(EvaluationContext context) {
+        if (fieldExpr == null) {
+            return context.currentMessage();
+        }
         final Object fieldName = fieldExpr.evaluateUnsafe(context);
         if (fieldName == null) {
             return null;
@@ -45,15 +49,24 @@ public class MessageRefExpression extends BaseExpression {
 
     @Override
     public Class getType() {
+        if (fieldExpr == null) {
+            return Message.class;
+        }
         return Object.class;
     }
 
     @Override
     public String toString() {
+        if (fieldExpr == null) {
+            return "$message";
+        }
         return "$message." + fieldExpr.toString();
     }
 
     public Expression getFieldExpr() {
+        if (fieldExpr == null) {
+            return this;
+        }
         return fieldExpr;
     }
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/debug/Debug.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/debug/Debug.java
@@ -21,8 +21,7 @@ import org.graylog.plugins.pipelineprocessor.ast.functions.AbstractFunction;
 import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionArgs;
 import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionDescriptor;
 import org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor;
-
-import java.util.Optional;
+import org.graylog2.plugin.Message;
 
 import static com.google.common.collect.ImmutableList.of;
 
@@ -33,21 +32,18 @@ public class Debug extends AbstractFunction<Void> {
     public static final String NAME = "debug";
 
     public Debug() {
-        valueParam = ParameterDescriptor.object("value")
-                .description("The value to print in the graylog-server log.")
-                .optional().build();
+        valueParam = ParameterDescriptor.object("value").description("The value to print in the graylog-server log.").build();
     }
 
     @Override
     public Void evaluate(FunctionArgs args, EvaluationContext context) {
-        final Optional<Object> value = valueParam.optional(args, context);
+        final Object value = valueParam.required(args, context);
 
-        if (value.isPresent()) {
-            log.info("PIPELINE DEBUG: {}", value.get());
+        if (value instanceof Message) {
+            log.info("PIPELINE DEBUG Message: <{}>", ((Message) value).toDumpString());
         } else {
-            log.info("PIPELINE DEBUG Message: <{}>", context.currentMessage().toDumpString());
+            log.info("PIPELINE DEBUG: {}", value);
         }
-
         return null;
     }
 
@@ -58,7 +54,7 @@ public class Debug extends AbstractFunction<Void> {
                 .returnType(Void.class)
                 .params(of(valueParam))
                 .description("Print the passed value as string in the graylog-server log." +
-                        " If no parameter is supplied it will print the current $message." +
+                        " You can also pass $message to print the current Message object." +
                         " Note that this will only appear in the log of the graylog-server node" +
                         " that is processing the message you are trying to debug.")
                 .build();

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/debug/Debug.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/debug/Debug.java
@@ -16,23 +16,34 @@
  */
 package org.graylog.plugins.pipelineprocessor.functions.debug;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.graylog.plugins.pipelineprocessor.EvaluationContext;
 import org.graylog.plugins.pipelineprocessor.ast.functions.AbstractFunction;
 import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionArgs;
 import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionDescriptor;
 import org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor;
 import org.graylog2.plugin.Message;
+import org.slf4j.Logger;
 
 import static com.google.common.collect.ImmutableList.of;
 
 public class Debug extends AbstractFunction<Void> {
 
     private final ParameterDescriptor<Object, Object> valueParam;
+    private final Logger logger;
 
     public static final String NAME = "debug";
 
     public Debug() {
         valueParam = ParameterDescriptor.object("value").description("The value to print in the graylog-server log.").build();
+        logger = log;
+    }
+
+    // Only used in unit tests
+    @VisibleForTesting
+    public Debug(Logger logger) {
+        valueParam = ParameterDescriptor.object("value").description("The value to print in the graylog-server log.").build();
+        this.logger = logger;
     }
 
     @Override
@@ -40,9 +51,9 @@ public class Debug extends AbstractFunction<Void> {
         final Object value = valueParam.required(args, context);
 
         if (value instanceof Message) {
-            log.info("PIPELINE DEBUG Message: <{}>", ((Message) value).toDumpString());
+            logger.info("PIPELINE DEBUG Message: <{}>", ((Message) value).toDumpString());
         } else {
-            log.info("PIPELINE DEBUG: {}", value);
+            logger.info("PIPELINE DEBUG: {}", value);
         }
         return null;
     }

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/parser/PipelineRuleParser.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/parser/PipelineRuleParser.java
@@ -83,6 +83,7 @@ import org.graylog.plugins.pipelineprocessor.parser.errors.SyntaxError;
 import org.graylog.plugins.pipelineprocessor.parser.errors.UndeclaredFunction;
 import org.graylog.plugins.pipelineprocessor.parser.errors.UndeclaredVariable;
 import org.graylog.plugins.pipelineprocessor.parser.errors.WrongNumberOfArgs;
+import org.graylog2.plugin.Message;
 import org.joda.time.DateTime;
 import org.joda.time.Duration;
 import org.joda.time.Period;
@@ -814,8 +815,9 @@ public class PipelineRuleParser {
         @Override
         public void exitMessageRef(RuleLangParser.MessageRefContext ctx) {
             final MessageRefExpression expr = (MessageRefExpression) parseContext.expressions().get(ctx);
-            if (!expr.getFieldExpr().getType().equals(String.class)) {
-                parseContext.addError(new IncompatibleType(ctx, String.class, expr.getFieldExpr().getType()));
+            final Class type = expr.getFieldExpr().getType();
+            if (!type.equals(String.class) && !type.equals(Message.class)) {
+                parseContext.addError(new IncompatibleType(ctx, String.class, type));
             }
         }
 

--- a/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
@@ -152,6 +152,8 @@ import org.joda.time.Duration;
 import org.joda.time.Period;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 import org.slf4j.Logger;
@@ -876,10 +878,12 @@ public class FunctionsSnippetsTest extends BaseParserTest {
 
         evaluateRule(rule, in);
 
-        verify(loggerMock).info("PIPELINE DEBUG: {}", "moo");
-        verify(loggerMock).info("PIPELINE DEBUG: {}", "somevalue");
-        verify(loggerMock, times(2)).info("PIPELINE DEBUG Message: <{}>", in.toDumpString());
-        verify(loggerMock).info("PIPELINE DEBUG: {}", (Object) null);
+        InOrder inOrder = Mockito.inOrder(loggerMock);
+        inOrder.verify(loggerMock).info("PIPELINE DEBUG: {}", "moo");
+        inOrder.verify(loggerMock).info("PIPELINE DEBUG: {}", "somevalue");
+        inOrder.verify(loggerMock, times(2)).info("PIPELINE DEBUG Message: <{}>", in.toDumpString());
+        inOrder.verify(loggerMock).info("PIPELINE DEBUG: {}", (Object) null);
+        inOrder.verify(loggerMock).info("PIPELINE DEBUG: {}", "message converted with to_string: " + in.toString());
     }
 
     @Test

--- a/graylog2-server/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/debug.txt
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/debug.txt
@@ -5,10 +5,11 @@ then
     debug($message.somefield);
     debug($message);
 
-    debug($message.nullfield);
 
     let messagevar = $message;
     debug(messagevar);
+
+    debug($message.nullfield);
 
     debug("message converted with to_string: " + to_string($message));
 end

--- a/graylog2-server/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/debug.txt
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/debug.txt
@@ -1,0 +1,14 @@
+rule "debug"
+when true
+then
+    debug("moo");
+    debug($message.somefield);
+    debug($message);
+
+    debug($message.nullfield);
+
+    let messagevar = $message;
+    debug(messagevar);
+
+    debug("message converted with to_string: " + to_string($message));
+end

--- a/graylog2-server/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/fieldRenaming.txt
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/fieldRenaming.txt
@@ -4,5 +4,7 @@ then
 
     rename_field("no_such_field", "field_1");
     rename_field("field_a", "field_2");
-    rename_field("field_b", "field_b");
+
+    // use implicit $message object. Just to test if that works as well
+    rename_field("field_b", "field_b", $message);
 end


### PR DESCRIPTION
This extends the pipeline rule syntax to allow
passing the entire `$message` object as parameters.

A useful example of this would be
 `debug($message);`

Other rule examples that are now possible:
 `has_field("source", $message);`
 `let foo = $message;`