### PR TITLE
Set `X-Frame-Options` header, disallow embedding by default. (`4.3`)

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -7,6 +7,20 @@ Please make sure to create a MongoDB database backup before starting the upgrade
 
 ## Breaking Changes
 
+## Disallowing embedding the frontend by default
+
+To prevent [click-jacking](https://developer.mozilla.org/en-US/docs/Web/Security/Types_of_attacks#click-jacking), we are now preventing the frontend to be embedded in `<frame>`/`<iframe>`/etc. elements by sending the `X-Frame-Options`-header with all HTTP responses. The header value depends on the new configuration setting `http_allow_embedding`. The different combinations are:
+
+| `http_allow_embedding` | `X-Frame-Options`-header value |
+|------------------------|--------------------------------|
+| not set                | `DENY`                         |
+| `false`                | `DENY`                         |
+| `true`                 | `SAMEORIGIN`                   |
+
+If you want to be able to embed the Graylog frontend in another HTML page, you most probably want to set `http_allow_embedding` to `true`. Only do this if you are aware of the implications!
+
+For further information about the meanings of the different header values and how they are interpreted by browsers, please read [this](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options).
+
 ### Notable API Endpoint Changes ##
 
 | Endpoint                        | Description                 |

--- a/graylog2-server/src/main/java/org/graylog2/configuration/HttpConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/HttpConfiguration.java
@@ -83,6 +83,9 @@ public class HttpConfiguration {
     @Parameter(value = "http_external_uri")
     private URI httpExternalUri;
 
+    @Parameter(value = "http_allow_embedding")
+    private boolean httpAllowEmbedding = false;
+
     public HostAndPort getHttpBindAddress() {
         return httpBindAddress
                 .requireBracketsForIPv6()

--- a/graylog2-server/src/main/java/org/graylog2/shared/initializers/JerseyService.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/initializers/JerseyService.java
@@ -48,6 +48,7 @@ import org.graylog2.plugin.rest.PluginRestResource;
 import org.graylog2.rest.MoreMediaTypes;
 import org.graylog2.rest.filter.WebAppNotFoundResponseFilter;
 import org.graylog2.shared.rest.CORSFilter;
+import org.graylog2.shared.rest.EmbeddingControlFilter;
 import org.graylog2.shared.rest.NodeIdResponseFilter;
 import org.graylog2.shared.rest.NotAuthorizedResponseFilter;
 import org.graylog2.shared.rest.PrintModelProcessor;
@@ -122,7 +123,8 @@ public class JerseyService extends AbstractIdleService {
 
     @Inject
     public JerseyService(final HttpConfiguration configuration,
-                         Configuration graylogConfiguration, Set<Class<? extends DynamicFeature>> dynamicFeatures,
+                         Configuration graylogConfiguration,
+                         Set<Class<? extends DynamicFeature>> dynamicFeatures,
                          Set<Class<? extends ContainerResponseFilter>> containerResponseFilters,
                          Set<Class<? extends ExceptionMapper>> exceptionMappers,
                          @Named("additionalJerseyComponents") final Set<Class> additionalComponents,
@@ -260,7 +262,8 @@ public class JerseyService extends AbstractIdleService {
                         RequestIdFilter.class,
                         XHRFilter.class,
                         NotAuthorizedResponseFilter.class,
-                        WebAppNotFoundResponseFilter.class)
+                        WebAppNotFoundResponseFilter.class,
+                        EmbeddingControlFilter.class)
                 // Replacing this with a lambda leads to missing subtypes - https://github.com/Graylog2/graylog2-server/pull/10617#discussion_r630236360
                 .register(new ContextResolver<ObjectMapper>() {
                     @Override

--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/EmbeddingControlFilter.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/EmbeddingControlFilter.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.shared.rest;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+import java.io.IOException;
+
+public class EmbeddingControlFilter implements ContainerResponseFilter {
+    private static final String X_FRAME_OPTIONS = "X-Frame-Options";
+    private final boolean httpAllowEmbedding;
+
+    enum EmbeddingOptions {
+        DENY,
+        SAMEORIGIN;
+    }
+
+    @Inject
+    public EmbeddingControlFilter(@Named("http_allow_embedding") boolean httpAllowEmbedding) {
+        this.httpAllowEmbedding = httpAllowEmbedding;
+    }
+
+    @Override
+    public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) throws IOException {
+        responseContext.getHeaders().add(X_FRAME_OPTIONS, (httpAllowEmbedding ? EmbeddingOptions.SAMEORIGIN : EmbeddingOptions.DENY).toString());
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/shared/rest/EmbeddingControlFilterTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/shared/rest/EmbeddingControlFilterTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.shared.rest;
+
+import org.glassfish.jersey.internal.MapPropertiesDelegate;
+import org.glassfish.jersey.server.ContainerRequest;
+import org.glassfish.jersey.server.ContainerResponse;
+import org.junit.jupiter.api.Test;
+
+import javax.ws.rs.HttpMethod;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.core.Response;
+import java.io.IOException;
+import java.net.URI;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class EmbeddingControlFilterTest {
+    private static final ContainerRequest requestContext = new ContainerRequest(URI.create("http://localhost"), URI.create("/"), HttpMethod.GET, null, new MapPropertiesDelegate(), null);
+
+    @Test
+    void disallowsEmbeddingIfConfigurationSettingIsFalse() throws IOException {
+        final EmbeddingControlFilter filter = new EmbeddingControlFilter(false);
+
+        final ContainerResponseContext responseContext = new ContainerResponse(requestContext, Response.ok().build());
+        filter.filter(requestContext, responseContext);
+
+        assertThat(responseContext.getHeaders())
+                .containsEntry("X-Frame-Options", Collections.singletonList("DENY"));
+    }
+
+    @Test
+    void allowsEmbeddingForSameOriginIfConfigurationSettingIsTrue() throws IOException {
+        final EmbeddingControlFilter filter = new EmbeddingControlFilter(true);
+
+        final ContainerResponseContext responseContext = new ContainerResponse(requestContext, Response.ok().build());
+        filter.filter(requestContext, responseContext);
+
+        assertThat(responseContext.getHeaders())
+                .containsEntry("X-Frame-Options", Collections.singletonList("SAMEORIGIN"));
+    }
+}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

**Note:** This is a backport of #13160 to `4.3`.

This PR is adding a configuration option `http_allow_embedding`, which is configuring if embedding the web frontend (or any other API request) is allowed or not. It defaults to `false`, disallowing embedding to prevent clickjacking. It can be set to `true`, which would allow embedding "as long as the site including it in a frame is the same as the one serving the page."[*]

This is a short-term solution to prevent clickjacking. It should be replaced at some point with a complete content security policy, particularly because the `X-Frame-Options` header is deprecated by the corresponding CSP directive.

Fixes Graylog2/graylog-plugin-enterprise#3884

[*]: <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options#directives> "MDN Docs for `X-Frame-Options`"

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.