### PR TITLE
Use @Api tags to control visibility API docs in cloud

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/api/GenerateApiDefinition.java
+++ b/graylog2-server/src/main/java/org/graylog/api/GenerateApiDefinition.java
@@ -87,7 +87,7 @@ public class GenerateApiDefinition {
 
         final ObjectMapper objectMapper = new ObjectMapperProvider().get();
 
-        final Generator generator = new Generator(resourceClasses, Collections.emptyMap(), "/plugins", objectMapper);
+        final Generator generator = new Generator(resourceClasses, Collections.emptyMap(), "/plugins", objectMapper, false);
 
         final Map<String, Object> overview = generator.generateOverview();
         writeJsonToFile(targetName + "/api.json", overview);

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/FailuresResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/FailuresResource.java
@@ -47,8 +47,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import static org.graylog2.shared.rest.documentation.generator.Generator.CLOUD_VISIBLE;
+
 @RequiresAuthentication
-@Api(value = "Indexer/Failures", description = "Indexer failures")
+@Api(value = "Indexer/Failures", description = "Indexer failures", tags={CLOUD_VISIBLE})
 @Path("/system/indexer/failures")
 public class FailuresResource extends RestResource {
     private static final Logger LOG = LoggerFactory.getLogger(FailuresResource.class);

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndexSetsResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndexSetsResource.java
@@ -75,9 +75,10 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static java.util.Objects.requireNonNull;
+import static org.graylog2.shared.rest.documentation.generator.Generator.CLOUD_VISIBLE;
 
 @RequiresAuthentication
-@Api(value = "System/IndexSets", description = "Index sets")
+@Api(value = "System/IndexSets", description = "Index sets", tags={CLOUD_VISIBLE})
 @Path("/system/indices/index_sets")
 @Produces(MediaType.APPLICATION_JSON)
 public class IndexSetsResource extends RestResource {

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndexTemplatesResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndexTemplatesResource.java
@@ -44,8 +44,10 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static org.graylog2.shared.rest.documentation.generator.Generator.CLOUD_VISIBLE;
+
 @RequiresAuthentication
-@Api(value = "Indexer/Indices/Templates", description = "Index Template Management")
+@Api(value = "Indexer/Indices/Templates", description = "Index Template Management", tags={CLOUD_VISIBLE})
 @Path("/system/indexer/indices/templates")
 @Produces(MediaType.APPLICATION_JSON)
 public class IndexTemplatesResource extends RestResource {

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndexerClusterResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndexerClusterResource.java
@@ -34,8 +34,10 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
+import static org.graylog2.shared.rest.documentation.generator.Generator.CLOUD_VISIBLE;
+
 @RequiresAuthentication
-@Api(value = "Indexer/Cluster", description = "Indexer cluster information")
+@Api(value = "Indexer/Cluster", description = "Indexer cluster information", tags={CLOUD_VISIBLE})
 @Path("/system/indexer/cluster")
 public class IndexerClusterResource extends RestResource {
 

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndexerOverviewResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndexerOverviewResource.java
@@ -54,8 +54,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static org.graylog2.shared.rest.documentation.generator.Generator.CLOUD_VISIBLE;
+
 @RequiresAuthentication
-@Api(value = "Indexer/Overview", description = "Indexing overview")
+@Api(value = "Indexer/Overview", description = "Indexing overview", tags={CLOUD_VISIBLE})
 @Path("/system/indexer/overview")
 public class IndexerOverviewResource extends RestResource {
     private final DeflectorResource deflectorResource;

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndicesResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndicesResource.java
@@ -64,8 +64,10 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static org.graylog2.shared.rest.documentation.generator.Generator.CLOUD_VISIBLE;
+
 @RequiresAuthentication
-@Api(value = "Indexer/Indices", description = "Index information")
+@Api(value = "Indexer/Indices", description = "Index information", tags={CLOUD_VISIBLE})
 @Path("/system/indexer/indices")
 public class IndicesResource extends RestResource {
     private static final Logger LOG = LoggerFactory.getLogger(IndicesResource.class);

--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/documentation/generator/Generator.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/documentation/generator/Generator.java
@@ -88,6 +88,7 @@ public class Generator {
     private static final Logger LOG = LoggerFactory.getLogger(Generator.class);
 
     public static final String EMULATED_SWAGGER_VERSION = "1.2";
+    public static final String CLOUD_VISIBLE = "cloud";
 
     private static final Map<String, Object> overviewResult = Maps.newHashMap();
 
@@ -95,16 +96,18 @@ public class Generator {
     private final Map<Class<?>, String> pluginMapping;
     private final String pluginPathPrefix;
     private final ObjectMapper mapper;
-
-    public Generator(Set<Class<?>> resourceClasses, Map<Class<?>, String> pluginMapping, String pluginPathPrefix, ObjectMapper mapper) {
+    private final boolean isCloud;
+    public Generator(Set<Class<?>> resourceClasses, Map<Class<?>, String> pluginMapping,
+                     String pluginPathPrefix, ObjectMapper mapper, boolean isCloud) {
         this.resourceClasses = resourceClasses;
         this.pluginMapping = pluginMapping;
         this.pluginPathPrefix = pluginPathPrefix;
         this.mapper = mapper;
+        this.isCloud = isCloud;
     }
 
-    public Generator(Set<Class<?>> resourceClasses, ObjectMapper mapper) {
-        this(resourceClasses, ImmutableMap.of(), "", mapper);
+    public Generator(Set<Class<?>> resourceClasses, ObjectMapper mapper, boolean isCloud) {
+        this(resourceClasses, ImmutableMap.of(), "", mapper, isCloud);
     }
 
     private String prefixedPath(Class<?> resourceClass, @Nullable String resourceAnnotationPath) {
@@ -140,6 +143,11 @@ public class Generator {
             }
 
             final String prefixedPath = prefixedPath(clazz, path.value());
+            if (isCloud && Arrays.stream(info.tags()).noneMatch(CLOUD_VISIBLE::equalsIgnoreCase)) {
+                LOG.info("Hiding in cloud: {}", prefixedPath);
+                continue;
+            }
+
             final Map<String, Object> apiDescription = Maps.newHashMap();
             apiDescription.put("name", prefixedPath.startsWith(pluginPathPrefix) ? "Plugins/" + info.value() : info.value());
             apiDescription.put("path", prefixedPath);
@@ -676,7 +684,7 @@ public class Generator {
         return route;
     }
 
-    private final static Set<String> PRIMITIVES = ImmutableSet.of(
+    private static final Set<String> PRIMITIVES = ImmutableSet.of(
             "boolean",
             "Boolean",
             "Double",

--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/documentation/DocumentationBrowserResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/documentation/DocumentationBrowserResource.java
@@ -45,7 +45,6 @@ import java.util.Map;
 import static java.util.Objects.requireNonNull;
 
 @Path("/api-browser")
-@HideOnCloud
 public class DocumentationBrowserResource extends RestResource {
     private final MimetypesFileTypeMap mimeTypes;
     private final HttpConfiguration httpConfiguration;

--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/documentation/DocumentationBrowserResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/documentation/DocumentationBrowserResource.java
@@ -19,6 +19,7 @@ package org.graylog2.shared.rest.resources.documentation;
 import com.floreysoft.jmte.Engine;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Resources;
+import org.graylog2.Configuration;
 import org.graylog2.configuration.HttpConfiguration;
 import org.graylog2.rest.RestTools;
 import org.graylog2.shared.rest.HideOnCloud;
@@ -52,11 +53,15 @@ public class DocumentationBrowserResource extends RestResource {
     private final ClassLoader classLoader = ClassLoader.getSystemClassLoader();
     private final Engine templateEngine;
 
+    private final Configuration configuration;
+
     @Inject
-    public DocumentationBrowserResource(MimetypesFileTypeMap mimeTypes, HttpConfiguration httpConfiguration, Engine templateEngine) {
+    public DocumentationBrowserResource(
+            MimetypesFileTypeMap mimeTypes, HttpConfiguration httpConfiguration, Engine templateEngine, Configuration configuration) {
         this.mimeTypes = requireNonNull(mimeTypes, "mimeTypes");
         this.httpConfiguration = requireNonNull(httpConfiguration, "httpConfiguration");
         this.templateEngine = requireNonNull(templateEngine, "templateEngine");
+        this.configuration = configuration;
     }
 
     @GET
@@ -96,7 +101,7 @@ public class DocumentationBrowserResource extends RestResource {
                 "globalModePath", "global/index.html",
                 "globalUriMarker", "/global",
                 "showWarning", "true",
-                "isCloud", "true");
+                "isCloud", configuration.isCloud());
         return templateEngine.transform(template, model);
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/documentation/DocumentationBrowserResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/documentation/DocumentationBrowserResource.java
@@ -95,7 +95,8 @@ public class DocumentationBrowserResource extends RestResource {
                 "baseUri", relativePath.resolve(HttpConfiguration.PATH_API).toString(),
                 "globalModePath", "global/index.html",
                 "globalUriMarker", "/global",
-                "showWarning", "true");
+                "showWarning", "true",
+                "isCloud", "true");
         return templateEngine.transform(template, model);
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/documentation/DocumentationBrowserResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/documentation/DocumentationBrowserResource.java
@@ -22,7 +22,6 @@ import com.google.common.io.Resources;
 import org.graylog2.Configuration;
 import org.graylog2.configuration.HttpConfiguration;
 import org.graylog2.rest.RestTools;
-import org.graylog2.shared.rest.HideOnCloud;
 import org.graylog2.shared.rest.resources.RestResource;
 
 import javax.activation.MimetypesFileTypeMap;
@@ -101,7 +100,7 @@ public class DocumentationBrowserResource extends RestResource {
                 "globalModePath", "global/index.html",
                 "globalUriMarker", "/global",
                 "showWarning", "true",
-                "isCloud", configuration.isCloud());
+                "isCloud", configuration.isCloud() ? "true" : "");
         return templateEngine.transform(template, model);
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/documentation/DocumentationResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/documentation/DocumentationResource.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableSet;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
+import org.graylog2.Configuration;
 import org.graylog2.configuration.HttpConfiguration;
 import org.graylog2.plugin.rest.PluginRestResource;
 import org.graylog2.rest.RestTools;
@@ -58,7 +59,8 @@ public class DocumentationResource extends RestResource {
     @Inject
     public DocumentationResource(HttpConfiguration httpConfiguration,
                                  ObjectMapper objectMapper,
-                                 DocumentationRestResourceClasses documentationRestResourceClasses) {
+                                 DocumentationRestResourceClasses documentationRestResourceClasses,
+                                 Configuration configuration) {
 
         this.httpConfiguration = requireNonNull(httpConfiguration, "httpConfiguration");
 
@@ -76,7 +78,7 @@ public class DocumentationResource extends RestResource {
             }
         }
 
-        this.generator = new Generator(resourceClasses.build(), pluginRestControllerMapping, PLUGIN_PREFIX, objectMapper);
+        this.generator = new Generator(resourceClasses.build(), pluginRestControllerMapping, PLUGIN_PREFIX, objectMapper, configuration.isCloud());
     }
 
     @GET

--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/documentation/DocumentationResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/documentation/DocumentationResource.java
@@ -27,7 +27,6 @@ import org.graylog2.configuration.HttpConfiguration;
 import org.graylog2.plugin.rest.PluginRestResource;
 import org.graylog2.rest.RestTools;
 import org.graylog2.shared.plugins.DocumentationRestResourceClasses;
-import org.graylog2.shared.rest.HideOnCloud;
 import org.graylog2.shared.rest.documentation.generator.Generator;
 import org.graylog2.shared.rest.resources.RestResource;
 

--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/documentation/DocumentationResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/documentation/DocumentationResource.java
@@ -50,7 +50,6 @@ import static org.graylog2.shared.initializers.JerseyService.PLUGIN_PREFIX;
 
 @Api(value = "Documentation", description = "Documentation of this API in JSON format.")
 @Path("/api-docs")
-@HideOnCloud
 public class DocumentationResource extends RestResource {
 
     private final Generator generator;

--- a/graylog2-server/src/main/resources/swagger/index.html.template
+++ b/graylog2-server/src/main/resources/swagger/index.html.template
@@ -39,7 +39,10 @@
         }
         $('pre code').each(function(i, e) {hljs.highlightBlock(e)});
 
-        if ("${showWarning}") {
+        if ("${isCloud}") {
+          $('#api_selector').css('visibility', 'hidden');
+          $('.warning-box').css('visibility', 'hidden');
+        } else if ("${showWarning}") {
           $('.warning-box').css('visibility', '');
         }
       },

--- a/graylog2-server/src/test/java/org/graylog2/rest/documentation/generator/GeneratorTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/rest/documentation/generator/GeneratorTest.java
@@ -49,7 +49,7 @@ public class GeneratorTest {
 
     @Test
     public void testGenerateOverview() throws Exception {
-        Generator generator = new Generator(Collections.singleton(HelloWorldResource.class), objectMapper);
+        Generator generator = new Generator(Collections.singleton(HelloWorldResource.class), objectMapper, false);
         Map<String, Object> result = generator.generateOverview();
 
         assertEquals(ServerVersion.VERSION.toString(), result.get("apiVersion"));
@@ -61,7 +61,7 @@ public class GeneratorTest {
 
     @Test
     public void testGenerateForRoute() throws Exception {
-        Generator generator = new Generator(Collections.singleton(HelloWorldResource.class), objectMapper);
+        Generator generator = new Generator(Collections.singleton(HelloWorldResource.class), objectMapper, false);
         Map<String, Object> result = generator.generateForRoute("/system", "http://localhost:12900/");
     }
 

--- a/graylog2-web-interface/src/components/navigation/HelpMenu.jsx
+++ b/graylog2-web-interface/src/components/navigation/HelpMenu.jsx
@@ -20,6 +20,7 @@ import React from 'react';
 import { LinkContainer } from 'components/common/router';
 import { MenuItem, NavDropdown } from 'components/bootstrap';
 import { ExternalLink, Icon } from 'components/common';
+import AppConfig from 'util/AppConfig';
 import DocsHelper from 'util/DocsHelper';
 import Routes from 'routing/Routes';
 
@@ -37,6 +38,12 @@ const HelpMenu = ({ active }) => (
     <MenuItem href={DocsHelper.versionedDocsHomePage()} target="_blank">
       <ExternalLink>Documentation</ExternalLink>
     </MenuItem>
+
+    {AppConfig.isCloud() && (
+    <MenuItem href={Routes.global_api_browser()} target="_blank">
+      <ExternalLink>Cluster Global API browser</ExternalLink>
+    </MenuItem>
+    )}
   </NavDropdown>
 );
 

--- a/graylog2-web-interface/src/routing/Routes.ts
+++ b/graylog2-web-interface/src/routing/Routes.ts
@@ -57,7 +57,7 @@ const Routes = {
   SOURCES: '/sources',
   DASHBOARDS: '/dashboards',
   GETTING_STARTED: '/gettingstarted',
-  GLOBAL_API_BROWSER_URL: '/api-browser/global/index.html',
+  GLOBAL_API_BROWSER_URL: '/api/api-browser/global/index.html',
   SYSTEM: {
     CONFIGURATIONS: '/system/configurations',
     CONTENTPACKS: {

--- a/graylog2-web-interface/src/routing/Routes.ts
+++ b/graylog2-web-interface/src/routing/Routes.ts
@@ -57,6 +57,7 @@ const Routes = {
   SOURCES: '/sources',
   DASHBOARDS: '/dashboards',
   GETTING_STARTED: '/gettingstarted',
+  GLOBAL_API_BROWSER_URL: '/api-browser/global/index.html',
   SYSTEM: {
     CONFIGURATIONS: '/system/configurations',
     CONTENTPACKS: {
@@ -241,6 +242,7 @@ const Routes = {
   edit_input_extractor: (nodeId: string, inputId: string, extractorId: string) => `/system/inputs/${nodeId}/${inputId}/extractors/${extractorId}/edit`,
   getting_started: (fromMenu) => `${Routes.GETTING_STARTED}?menu=${fromMenu}`,
   filtered_metrics: (nodeId: string, filter: string) => `${Routes.SYSTEM.METRICS(nodeId)}?filter=${filter}`,
+  global_api_browser: () => Routes.GLOBAL_API_BROWSER_URL,
 } as const;
 
 const prefixUrlWithoutHostname = (url: string, prefix: string) => {


### PR DESCRIPTION
Resolves Graylog2/graylog-plugin-cloud#1035

Enable API-Browser in Cloud context, while providing the ability to hide APIs that are not relevant or should not be exposed in Cloud. Visible APIs must be explicitly marked for Cloud by setting a specific `tags` value, e.g.:
`@Api(value = "MyCloudAPI", description = "Does something useful in Cloud", tags = {CLOUD_VISIBLE})`

By default, APIs are hidden in Cloud.

Currently the API Browser is accessible from the help menu.

# Screenshots

![Screenshot 2022-08-16 at 11 43 44](https://user-images.githubusercontent.com/92227/184853476-190a8e74-30de-4ef9-bda3-a39440b9c257.png)