### PR TITLE
Fix #12971 Event Definition broken find button

### DIFF
--- a/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitionsContainer.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitionsContainer.jsx
@@ -82,12 +82,12 @@ class EventDefinitionsContainer extends React.Component {
   handlePageChange = (nextPage, nextPageSize) => {
     const { eventDefinitions } = this.props;
 
-    this.fetchData({ page: nextPage, pageSize: nextPageSize, query: eventDefinitions.query });
+    EventDefinitionsContainer.fetchData({ page: nextPage, pageSize: nextPageSize, query: eventDefinitions.query });
   };
 
   handleQueryChange = (nextQuery, callback = () => {}) => {
     const { eventDefinitions } = this.props;
-    const promise = this.fetchData({ query: nextQuery, pageSize: eventDefinitions.pagination.pageSize });
+    const promise = EventDefinitionsContainer.fetchData({ query: nextQuery, pageSize: eventDefinitions.pagination.pageSize });
 
     promise.finally(callback);
   };


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Event Definition find button is now working fine, before it was broken because fetchData static method was accessed with this. instead of className.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/Graylog2/graylog2-server/issues/12971

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

