### PR TITLE
Return correct time range when creating aggregation events during catch-up processing

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/events/processor/aggregation/AggregationEventProcessor.java
+++ b/graylog2-server/src/main/java/org/graylog/events/processor/aggregation/AggregationEventProcessor.java
@@ -335,7 +335,8 @@ public class AggregationEventProcessor implements EventProcessor {
             final Message message = new Message(eventMessage, "", result.effectiveTimerange().to());
             message.addFields(fields);
 
-            LOG.debug("Creating event {}/{} - {} {} ({})", eventDefinition.title(), eventDefinition.id(), keyResult.key(), seriesString(keyResult), fields);
+            LOG.info("Creating event {}/{} - {} {} ({}) from={} to={}", eventDefinition.title(), eventDefinition.id(), keyResult.key(), seriesString(keyResult), fields,
+                    event.getTimerangeStart(), event.getTimerangeEnd());
             eventsWithContext.add(EventWithContext.create(event, message));
         }
 

--- a/graylog2-server/src/main/java/org/graylog/events/processor/aggregation/AggregationEventProcessor.java
+++ b/graylog2-server/src/main/java/org/graylog/events/processor/aggregation/AggregationEventProcessor.java
@@ -335,7 +335,7 @@ public class AggregationEventProcessor implements EventProcessor {
             final Message message = new Message(eventMessage, "", result.effectiveTimerange().to());
             message.addFields(fields);
 
-            LOG.info("Creating event {}/{} - {} {} ({}) from={} to={}", eventDefinition.title(), eventDefinition.id(), keyResult.key(), seriesString(keyResult), fields,
+            LOG.debug("Creating event {}/{} - {} {} ({}) from={} to={}", eventDefinition.title(), eventDefinition.id(), keyResult.key(), seriesString(keyResult), fields,
                     event.getTimerangeStart(), event.getTimerangeEnd());
             eventsWithContext.add(EventWithContext.create(event, message));
         }

--- a/graylog2-server/src/main/java/org/graylog/events/processor/aggregation/AggregationEventProcessor.java
+++ b/graylog2-server/src/main/java/org/graylog/events/processor/aggregation/AggregationEventProcessor.java
@@ -282,8 +282,8 @@ public class AggregationEventProcessor implements EventProcessor {
             // These can be different, e.g. during catch up processing.
             final DateTime eventTime = keyResult.timestamp().orElse(result.effectiveTimerange().to());
             final Event event = eventFactory.createEvent(eventDefinition, eventTime, eventMessage);
-            event.setTimerangeStart(keyResult.from().orElse(parameters.timerange().getFrom()));
             // The keyResult timestamp is set to the end of the range
+            event.setTimerangeStart(keyResult.timestamp().map(t -> t.minus(config.searchWithinMs())).orElse(parameters.timerange().getFrom()));
             event.setTimerangeEnd(keyResult.timestamp().orElse(parameters.timerange().getTo()));
 
             sourceStreams.forEach(event::addSourceStream);

--- a/graylog2-server/src/main/java/org/graylog/events/processor/aggregation/AggregationEventProcessor.java
+++ b/graylog2-server/src/main/java/org/graylog/events/processor/aggregation/AggregationEventProcessor.java
@@ -283,7 +283,7 @@ public class AggregationEventProcessor implements EventProcessor {
             final DateTime eventTime = keyResult.timestamp().orElse(result.effectiveTimerange().to());
             final Event event = eventFactory.createEvent(eventDefinition, eventTime, eventMessage);
             event.setTimerangeStart(keyResult.from().orElse(parameters.timerange().getFrom()));
-            // The keyResult timestamp is set to end of the range
+            // The keyResult timestamp is set to the end of the range
             event.setTimerangeEnd(keyResult.timestamp().orElse(parameters.timerange().getTo()));
 
             sourceStreams.forEach(event::addSourceStream);

--- a/graylog2-server/src/main/java/org/graylog/events/processor/aggregation/AggregationEventProcessor.java
+++ b/graylog2-server/src/main/java/org/graylog/events/processor/aggregation/AggregationEventProcessor.java
@@ -283,7 +283,8 @@ public class AggregationEventProcessor implements EventProcessor {
             final DateTime eventTime = keyResult.timestamp().orElse(result.effectiveTimerange().to());
             final Event event = eventFactory.createEvent(eventDefinition, eventTime, eventMessage);
             event.setTimerangeStart(keyResult.from().orElse(parameters.timerange().getFrom()));
-            event.setTimerangeEnd(parameters.timerange().getTo());
+            // The keyResult timestamp is set to end of the range
+            event.setTimerangeEnd(keyResult.timestamp().orElse(parameters.timerange().getTo()));
 
             sourceStreams.forEach(event::addSourceStream);
 

--- a/graylog2-server/src/main/java/org/graylog/events/processor/aggregation/AggregationKeyResult.java
+++ b/graylog2-server/src/main/java/org/graylog/events/processor/aggregation/AggregationKeyResult.java
@@ -31,12 +31,10 @@ import java.util.Optional;
 public abstract class AggregationKeyResult {
     public abstract ImmutableList<String> key();
 
+    // timestamp() is set to the end of the date range.
     public abstract Optional<DateTime> timestamp();
 
     public abstract ImmutableList<AggregationSeriesValue> seriesValues();
-
-    // timestamp() is set to the end of the date range. that's why we don't need to()
-    public abstract Optional<DateTime> from();
 
     public static Builder builder() {
         return Builder.create();
@@ -56,8 +54,6 @@ public abstract class AggregationKeyResult {
         public abstract Builder key(List<String> key);
 
         public abstract Builder seriesValues(List<AggregationSeriesValue> seriesValues);
-
-        public abstract Builder from(@Nullable DateTime from);
 
         public abstract AggregationKeyResult build();
     }

--- a/graylog2-server/src/main/java/org/graylog/events/processor/aggregation/AggregationKeyResult.java
+++ b/graylog2-server/src/main/java/org/graylog/events/processor/aggregation/AggregationKeyResult.java
@@ -35,6 +35,8 @@ public abstract class AggregationKeyResult {
 
     public abstract ImmutableList<AggregationSeriesValue> seriesValues();
 
+    public abstract Optional<DateTime> from();
+
     public static Builder builder() {
         return Builder.create();
     }
@@ -42,7 +44,7 @@ public abstract class AggregationKeyResult {
     public abstract Builder toBuilder();
 
     @AutoValue.Builder
-    public static abstract class Builder {
+    public abstract static class Builder {
         @JsonCreator
         public static Builder create() {
             return new AutoValue_AggregationKeyResult.Builder();
@@ -53,6 +55,8 @@ public abstract class AggregationKeyResult {
         public abstract Builder key(List<String> key);
 
         public abstract Builder seriesValues(List<AggregationSeriesValue> seriesValues);
+
+        public abstract Builder from(@Nullable DateTime from);
 
         public abstract AggregationKeyResult build();
     }

--- a/graylog2-server/src/main/java/org/graylog/events/processor/aggregation/AggregationKeyResult.java
+++ b/graylog2-server/src/main/java/org/graylog/events/processor/aggregation/AggregationKeyResult.java
@@ -35,6 +35,7 @@ public abstract class AggregationKeyResult {
 
     public abstract ImmutableList<AggregationSeriesValue> seriesValues();
 
+    // timestamp() is set to the end of the date range. that's why we don't need to()
     public abstract Optional<DateTime> from();
 
     public static Builder builder() {

--- a/graylog2-server/src/main/java/org/graylog/events/processor/aggregation/PivotAggregationSearch.java
+++ b/graylog2-server/src/main/java/org/graylog/events/processor/aggregation/PivotAggregationSearch.java
@@ -324,7 +324,6 @@ public class PivotAggregationSearch implements AggregationSearch {
                     .key(groupKey)
                     .timestamp(resultTimestamp)
                     .seriesValues(values.build())
-                    .from(resultTimestamp.minus(config.searchWithinMs()))
                     .build());
         }
 

--- a/graylog2-server/src/main/java/org/graylog/events/processor/aggregation/PivotAggregationSearch.java
+++ b/graylog2-server/src/main/java/org/graylog/events/processor/aggregation/PivotAggregationSearch.java
@@ -319,10 +319,12 @@ public class PivotAggregationSearch implements AggregationSearch {
                 }
             }
 
+            DateTime resultTimestamp = DateTime.parse(timeKey).withZone(DateTimeZone.UTC);
             results.add(AggregationKeyResult.builder()
                     .key(groupKey)
-                    .timestamp(DateTime.parse(timeKey).withZone(DateTimeZone.UTC))
+                    .timestamp(resultTimestamp)
                     .seriesValues(values.build())
+                    .from(resultTimestamp.minus(config.searchWithinMs()))
                     .build());
         }
 

--- a/graylog2-server/src/test/java/org/graylog/events/processor/aggregation/AggregationEventProcessorTest.java
+++ b/graylog2-server/src/test/java/org/graylog/events/processor/aggregation/AggregationEventProcessorTest.java
@@ -93,7 +93,7 @@ public class AggregationEventProcessorTest {
         // We expect to get the end of the aggregation timerange as event time
         final TestEvent event1 = new TestEvent(timerange.to());
         final TestEvent event2 = new TestEvent(timerange.to());
-        when(eventFactory.createEvent(any(EventDefinition.class), eq(now), anyString()))
+        when(eventFactory.createEvent(any(EventDefinition.class), any(DateTime.class), anyString()))
                 .thenReturn(event1)  // first invocation return value
                 .thenReturn(event2); // second invocation return value
 
@@ -112,7 +112,7 @@ public class AggregationEventProcessorTest {
                 .keyResults(ImmutableList.of(
                         AggregationKeyResult.builder()
                                 .key(ImmutableList.of("one", "two"))
-                                .timestamp(now)
+                                .timestamp(timerange.to())
                                 .seriesValues(ImmutableList.of(
                                         AggregationSeriesValue.builder()
                                                 .key(ImmutableList.of("a"))
@@ -184,7 +184,7 @@ public class AggregationEventProcessorTest {
         // We expect to get the end of the aggregation timerange as event time
         final TestEvent event1 = new TestEvent(timerange.to());
         final TestEvent event2 = new TestEvent(timerange.to());
-        when(eventFactory.createEvent(any(EventDefinition.class), eq(now), anyString()))
+        when(eventFactory.createEvent(any(EventDefinition.class), any(DateTime.class), anyString()))
                 .thenReturn(event1)  // first invocation return value
                 .thenReturn(event2); // second invocation return value
 
@@ -211,7 +211,7 @@ public class AggregationEventProcessorTest {
                 .keyResults(ImmutableList.of(
                         AggregationKeyResult.builder()
                                 .key(ImmutableList.of("one", "two"))
-                                .timestamp(now)
+                                .timestamp(timerange.to())
                                 .seriesValues(ImmutableList.of(
                                         AggregationSeriesValue.builder()
                                                 .key(ImmutableList.of("a"))
@@ -392,7 +392,7 @@ public class AggregationEventProcessorTest {
         // We expect to get the end of the aggregation timerange as event time
         final TestEvent event1 = new TestEvent(timerange.to());
         final TestEvent event2 = new TestEvent(timerange.to());
-        when(eventFactory.createEvent(any(EventDefinition.class), eq(now), anyString()))
+        when(eventFactory.createEvent(any(EventDefinition.class), any(DateTime.class), anyString()))
                 .thenReturn(event1)  // first invocation return value
                 .thenReturn(event2); // second invocation return value
 
@@ -402,7 +402,7 @@ public class AggregationEventProcessorTest {
                 .build();
 
         final AggregationEventProcessor eventProcessor = new AggregationEventProcessor(eventDefinitionDto, searchFactory, eventProcessorDependencyCheck, stateService, moreSearch, streamService, messages);
-        final AggregationResult result = buildAggregationResult(timerange, now, ImmutableList.of("one", "two"));
+        final AggregationResult result = buildAggregationResult(timerange, timerange.to(), ImmutableList.of("one", "two"));
         final ImmutableList<EventWithContext> eventsWithContext = eventProcessor.eventsFromAggregationResult(eventFactory, parameters, result);
 
         assertThat(eventsWithContext).hasSize(1);
@@ -436,7 +436,7 @@ public class AggregationEventProcessorTest {
         // We expect to get the end of the aggregation timerange as event time
         final TestEvent event1 = new TestEvent(timerange.to());
         final TestEvent event2 = new TestEvent(timerange.to());
-        when(eventFactory.createEvent(any(EventDefinition.class), eq(now), anyString()))
+        when(eventFactory.createEvent(any(EventDefinition.class), any(DateTime.class), anyString()))
                 .thenReturn(event1)  // first invocation return value
                 .thenReturn(event2); // second invocation return value
 
@@ -455,7 +455,7 @@ public class AggregationEventProcessorTest {
                 .build();
 
         final AggregationEventProcessor eventProcessor = new AggregationEventProcessor(eventDefinitionDto, searchFactory, eventProcessorDependencyCheck, stateService, moreSearch, streamService, messages);
-        final AggregationResult result = buildAggregationResult(timerange, now, ImmutableList.of("one", "two"));
+        final AggregationResult result = buildAggregationResult(timerange, timerange.to(), ImmutableList.of("one", "two"));
         final ImmutableList<EventWithContext> eventsWithContext = eventProcessor.eventsFromAggregationResult(eventFactory, parameters, result);
 
         assertThat(eventsWithContext).hasSize(1);

--- a/graylog2-server/src/test/java/org/graylog/events/processor/aggregation/AggregationEventProcessorTest.java
+++ b/graylog2-server/src/test/java/org/graylog/events/processor/aggregation/AggregationEventProcessorTest.java
@@ -65,6 +65,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class AggregationEventProcessorTest {
+    public static final int SEARCH_WINDOW_MS = 30000;
     @Rule
     public final MockitoRule mockitoRule = MockitoJUnit.rule();
 
@@ -88,7 +89,7 @@ public class AggregationEventProcessorTest {
     @Test
     public void testEventsFromAggregationResult() {
         final DateTime now = DateTime.now(DateTimeZone.UTC);
-        final AbsoluteRange timerange = AbsoluteRange.create(now.minusHours(1), now.plusHours(1));
+        final AbsoluteRange timerange = AbsoluteRange.create(now.minusHours(1), now.minusHours(1).plusMillis(SEARCH_WINDOW_MS));
 
         // We expect to get the end of the aggregation timerange as event time
         final TestEvent event1 = new TestEvent(timerange.to());
@@ -179,7 +180,7 @@ public class AggregationEventProcessorTest {
     @Test
     public void testEventsFromAggregationResultWithConditions() {
         final DateTime now = DateTime.now(DateTimeZone.UTC);
-        final AbsoluteRange timerange = AbsoluteRange.create(now.minusHours(1), now.plusHours(1));
+        final AbsoluteRange timerange = AbsoluteRange.create(now.minusHours(1), now.minusHours(1).plusMillis(SEARCH_WINDOW_MS));
 
         // We expect to get the end of the aggregation timerange as event time
         final TestEvent event1 = new TestEvent(timerange.to());
@@ -293,7 +294,7 @@ public class AggregationEventProcessorTest {
         when(eventProcessorDependencyCheck.hasMessagesIndexedUpTo(any(DateTime.class))).thenReturn(true);
 
         final DateTime now = DateTime.now(DateTimeZone.UTC);
-        final AbsoluteRange timerange = AbsoluteRange.create(now.minusHours(1), now.plusHours(1));
+        final AbsoluteRange timerange = AbsoluteRange.create(now.minusHours(1), now.minusHours(1).plusMillis(SEARCH_WINDOW_MS));
 
         final AggregationEventProcessorConfig config = AggregationEventProcessorConfig.builder()
                 .query("aQueryString")
@@ -301,8 +302,8 @@ public class AggregationEventProcessorTest {
                 .groupBy(ImmutableList.of())
                 .series(ImmutableList.of())
                 .conditions(null)
-                .searchWithinMs(30000)
-                .executeEveryMs(30000)
+                .searchWithinMs(SEARCH_WINDOW_MS)
+                .executeEveryMs(SEARCH_WINDOW_MS)
                 .build();
         final EventDefinitionDto eventDefinitionDto = buildEventDefinitionDto(ImmutableSet.of(), ImmutableList.of(), null);
         final AggregationEventProcessorParameters parameters = AggregationEventProcessorParameters.builder()
@@ -387,7 +388,7 @@ public class AggregationEventProcessorTest {
     @Test
     public void testEventsFromAggregationResultWithEmptyResultUsesEventDefinitionStreamAsSourceStreams() {
         final DateTime now = DateTime.now(DateTimeZone.UTC);
-        final AbsoluteRange timerange = AbsoluteRange.create(now.minusHours(1), now.plusHours(1));
+        final AbsoluteRange timerange = AbsoluteRange.create(now.minusHours(1), now.minusHours(1).plusMillis(SEARCH_WINDOW_MS));
 
         // We expect to get the end of the aggregation timerange as event time
         final TestEvent event1 = new TestEvent(timerange.to());
@@ -431,7 +432,7 @@ public class AggregationEventProcessorTest {
     @Test
     public void testEventsFromAggregationResultWithEmptyResultAndNoConfiguredStreamsUsesAllStreamsAsSourceStreams() {
         final DateTime now = DateTime.now(DateTimeZone.UTC);
-        final AbsoluteRange timerange = AbsoluteRange.create(now.minusHours(1), now.plusHours(1));
+        final AbsoluteRange timerange = AbsoluteRange.create(now.minusHours(1), now.minusHours(1).plusMillis(SEARCH_WINDOW_MS));
 
         // We expect to get the end of the aggregation timerange as event time
         final TestEvent event1 = new TestEvent(timerange.to());
@@ -592,8 +593,8 @@ public class AggregationEventProcessorTest {
                         .groupBy(ImmutableList.of("group_field_one", "group_field_two"))
                         .series(testSeries)
                         .conditions(testConditions)
-                        .searchWithinMs(30000)
-                        .executeEveryMs(30000)
+                        .searchWithinMs(SEARCH_WINDOW_MS)
+                        .executeEveryMs(SEARCH_WINDOW_MS)
                         .build())
                 .keySpec(ImmutableList.of())
                 .build();

--- a/graylog2-server/src/test/java/org/graylog/events/processor/aggregation/PivotAggregationSearchTest.java
+++ b/graylog2-server/src/test/java/org/graylog/events/processor/aggregation/PivotAggregationSearchTest.java
@@ -120,7 +120,6 @@ public class PivotAggregationSearchTest {
 
         assertThat(results.get(0)).isEqualTo(AggregationKeyResult.builder()
                 .timestamp(timerange.getTo())
-                .from(timerange.getTo().minus(WINDOW_LENGTH))
                 .key(ImmutableList.of("a", "b"))
                 .seriesValues(ImmutableList.of(
                         AggregationSeriesValue.builder()
@@ -139,7 +138,6 @@ public class PivotAggregationSearchTest {
         assertThat(results.get(1)).isEqualTo(AggregationKeyResult.builder()
                 .timestamp(timerange.getTo())
                 .key(ImmutableList.of("a", "c"))
-                .from(timerange.getTo().minus(WINDOW_LENGTH))
                 .seriesValues(ImmutableList.of(
                         AggregationSeriesValue.builder()
                                 .key(ImmutableList.of("a", "c"))
@@ -208,7 +206,6 @@ public class PivotAggregationSearchTest {
         assertThat(results.get(0)).isEqualTo(AggregationKeyResult.builder()
                 .key(ImmutableList.of())
                 .timestamp(timerange.getTo())
-                .from(timerange.getTo().minus(WINDOW_LENGTH))
                 .seriesValues(ImmutableList.of(
                         AggregationSeriesValue.builder()
                                 .key(ImmutableList.of())
@@ -281,7 +278,6 @@ public class PivotAggregationSearchTest {
         assertThat(results.get(0)).isEqualTo(AggregationKeyResult.builder()
                 .key(ImmutableList.of())
                 .timestamp(timerange.getTo())
-                .from(timerange.getTo().minus(WINDOW_LENGTH))
                 .seriesValues(ImmutableList.of(
                         AggregationSeriesValue.builder()
                                 .key(ImmutableList.of())

--- a/graylog2-server/src/test/java/org/graylog/events/processor/aggregation/PivotAggregationSearchTest.java
+++ b/graylog2-server/src/test/java/org/graylog/events/processor/aggregation/PivotAggregationSearchTest.java
@@ -59,6 +59,7 @@ public class PivotAggregationSearchTest {
 
     @Test
     public void testExtractValuesWithGroupBy() throws Exception {
+        final long WINDOW_LENGTH = 30000;
         final AbsoluteRange timerange = AbsoluteRange.create(DateTime.now(DateTimeZone.UTC).minusSeconds(3600), DateTime.now(DateTimeZone.UTC));
         final AggregationSeries seriesCount = AggregationSeries.create("abc123", AggregationFunction.COUNT, "source");
         final AggregationSeries seriesCard = AggregationSeries.create("abc123", AggregationFunction.CARD, "source");
@@ -68,8 +69,8 @@ public class PivotAggregationSearchTest {
                 .groupBy(Collections.emptyList())
                 .series(ImmutableList.of(seriesCount, seriesCard))
                 .conditions(null)
-                .searchWithinMs(30000)
-                .executeEveryMs(30000)
+                .searchWithinMs(WINDOW_LENGTH)
+                .executeEveryMs(WINDOW_LENGTH)
                 .build();
         final AggregationEventProcessorParameters parameters = AggregationEventProcessorParameters.builder()
                 .streams(Collections.emptySet())
@@ -119,6 +120,7 @@ public class PivotAggregationSearchTest {
 
         assertThat(results.get(0)).isEqualTo(AggregationKeyResult.builder()
                 .timestamp(timerange.getTo())
+                .from(timerange.getTo().minus(WINDOW_LENGTH))
                 .key(ImmutableList.of("a", "b"))
                 .seriesValues(ImmutableList.of(
                         AggregationSeriesValue.builder()
@@ -137,6 +139,7 @@ public class PivotAggregationSearchTest {
         assertThat(results.get(1)).isEqualTo(AggregationKeyResult.builder()
                 .timestamp(timerange.getTo())
                 .key(ImmutableList.of("a", "c"))
+                .from(timerange.getTo().minus(WINDOW_LENGTH))
                 .seriesValues(ImmutableList.of(
                         AggregationSeriesValue.builder()
                                 .key(ImmutableList.of("a", "c"))
@@ -154,6 +157,7 @@ public class PivotAggregationSearchTest {
 
     @Test
     public void testExtractValuesWithoutGroupBy() throws Exception {
+        final long WINDOW_LENGTH = 30000;
         final AbsoluteRange timerange = AbsoluteRange.create(DateTime.now(DateTimeZone.UTC).minusSeconds(3600), DateTime.now(DateTimeZone.UTC));
         final AggregationSeries seriesCount = AggregationSeries.create("abc123", AggregationFunction.COUNT, "source");
         final AggregationSeries seriesCountNoField = AggregationSeries.create("abc123", AggregationFunction.COUNT, "");
@@ -204,6 +208,7 @@ public class PivotAggregationSearchTest {
         assertThat(results.get(0)).isEqualTo(AggregationKeyResult.builder()
                 .key(ImmutableList.of())
                 .timestamp(timerange.getTo())
+                .from(timerange.getTo().minus(WINDOW_LENGTH))
                 .seriesValues(ImmutableList.of(
                         AggregationSeriesValue.builder()
                                 .key(ImmutableList.of())
@@ -226,6 +231,7 @@ public class PivotAggregationSearchTest {
 
     @Test
     public void testExtractValuesWithNullValues() throws Exception {
+        final long WINDOW_LENGTH = 30000;
         final AbsoluteRange timerange = AbsoluteRange.create(DateTime.now(DateTimeZone.UTC).minusSeconds(3600), DateTime.now(DateTimeZone.UTC));
         final AggregationSeries seriesCount = AggregationSeries.create("abc123", AggregationFunction.COUNT, "source");
         final AggregationSeries seriesAvg = AggregationSeries.create("abc123", AggregationFunction.AVG, "some_field");
@@ -235,8 +241,8 @@ public class PivotAggregationSearchTest {
                 .groupBy(Collections.emptyList())
                 .series(ImmutableList.of(seriesCount, seriesAvg))
                 .conditions(null)
-                .searchWithinMs(30000)
-                .executeEveryMs(30000)
+                .searchWithinMs(WINDOW_LENGTH)
+                .executeEveryMs(WINDOW_LENGTH)
                 .build();
         final AggregationEventProcessorParameters parameters = AggregationEventProcessorParameters.builder()
                 .streams(Collections.emptySet())
@@ -275,6 +281,7 @@ public class PivotAggregationSearchTest {
         assertThat(results.get(0)).isEqualTo(AggregationKeyResult.builder()
                 .key(ImmutableList.of())
                 .timestamp(timerange.getTo())
+                .from(timerange.getTo().minus(WINDOW_LENGTH))
                 .seriesValues(ImmutableList.of(
                         AggregationSeriesValue.builder()
                                 .key(ImmutableList.of())


### PR DESCRIPTION
Resolves #13061 

During catch-up processing, aggregation events were being generated with the time range of the extended catch-up window, instead of the time range of the actual result bucket. 

We now add a `from` field to each `AggregationKeyResult` and use that to determine the event time range.