### PR TITLE
Make `title` prop of `HoverForHelp` component optional.

### DIFF
--- a/graylog2-web-interface/src/components/common/HoverForHelp.tsx
+++ b/graylog2-web-interface/src/components/common/HoverForHelp.tsx
@@ -64,7 +64,7 @@ type Props = {
   placement?: 'top' | 'right' | 'bottom' | 'left',
   iconSize?: SizeProp
   pullRight?: boolean,
-  title: string,
+  title?: string,
   testId?: string,
   type?: 'info' | 'error',
 };
@@ -84,7 +84,7 @@ HoverForHelp.propTypes = {
   id: PropTypes.string,
   placement: PropTypes.oneOf(['top', 'right', 'bottom', 'left']),
   pullRight: PropTypes.bool,
-  title: PropTypes.string.isRequired,
+  title: PropTypes.string,
   testId: PropTypes.string,
 };
 
@@ -94,6 +94,7 @@ HoverForHelp.defaultProps = {
   pullRight: true,
   placement: 'bottom',
   testId: undefined,
+  title: undefined,
   type: 'info',
   iconSize: undefined,
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Make `title` prop of `HoverForHelp` component optional. The title is not required to display the popover, the component is based on.

It can be helpful to display the help text without a title, when the explanation is comparable short.