### PR TITLE
Explicitly trigger binders once to avoid injection errors.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/SearchJob.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/SearchJob.java
@@ -99,7 +99,9 @@ public class SearchJob implements ParameterProvider {
 
     @JsonProperty("execution")
     public ExecutionInfo execution() {
-        return new ExecutionInfo(resultFuture.isDone(), resultFuture.isCancelled(), !errors.isEmpty());
+        final boolean isDone = resultFuture != null && resultFuture.isDone();
+        final boolean isCancelled = resultFuture != null && resultFuture.isCancelled();
+        return new ExecutionInfo(isDone, isCancelled, !errors.isEmpty());
     }
 
     public CompletableFuture<QueryResult> getQueryResultFuture(String queryId) {

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/engine/EngineBindings.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/engine/EngineBindings.java
@@ -31,6 +31,8 @@ public class EngineBindings extends ViewsModule {
         bind(SearchValidation.class).to(PluggableSearchValidation.class);
 
         registerSearchNormalizer(DecorateQueryStringsNormalizer.class);
+        // Triggering set binder explicitly, so no injection errors are being caused if no implementation is bound.
+        searchPostValidationNormalizerBinder();
         registerSearchValidator(TimeRangeValidator.class);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/lookup/LookupModule.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/LookupModule.java
@@ -17,6 +17,8 @@
 package org.graylog2.lookup;
 
 import com.google.inject.Scopes;
+import com.google.inject.multibindings.MapBinder;
+import com.google.inject.multibindings.MapBinderBinding;
 import org.graylog2.Configuration;
 import org.graylog2.lookup.adapters.CSVFileDataAdapter;
 import org.graylog2.lookup.adapters.DSVHTTPDataAdapter;
@@ -26,6 +28,8 @@ import org.graylog2.lookup.caches.CaffeineLookupCache;
 import org.graylog2.lookup.caches.NullCache;
 import org.graylog2.lookup.db.DBLookupTableConfigService;
 import org.graylog2.plugin.inject.Graylog2Module;
+import org.graylog2.plugin.lookup.LookupDataAdapter;
+import org.graylog2.system.SystemEntity;
 import org.graylog2.system.urlwhitelist.UrlWhitelistNotificationService;
 import org.graylog2.system.urlwhitelist.UrlWhitelistService;
 
@@ -43,6 +47,8 @@ public class LookupModule extends Graylog2Module {
         binder().bind(AllowedAuxiliaryPathChecker.class).in(Scopes.SINGLETON);
 
         bind(LookupTableConfigService.class).to(DBLookupTableConfigService.class).asEagerSingleton();
+        // Triggering map binder once, so it does not break injection when no instance is bound.
+        MapBinder.newMapBinder(binder(), String.class, LookupDataAdapter.Factory2.class, SystemEntity.class);
         serviceBinder().addBinding().to(LookupTableService.class).asEagerSingleton();
 
         installLookupCache(NullCache.NAME,


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Prior to this PR, setting up the injector could fail if running without plugins, due to:

  - No post-validation search normalizer being bound
  - No lookup table service factory annotated with `@SystemEntity` being bound

Guice works in different ways when the type of a multi-binder is supposed to be injected and no implementations are present:

  - When the map/set-binder has never been instantiated, guice throws an injection error
  - When the map/set-binder has been instantiated, but no implementation was bound, no error is raised and an empty collection is injected

So in order to fix the startup failure, this PR is calling just the binder of those two entities once, so instead of throwing an error, empty collections are injected.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.