### PR TITLE
Backport: Properly register notification config entity subtypes

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -43,6 +43,16 @@ The following API endpoints have been removed in 4.3.
 | ------------------------------------------- | --------------------------- |
 | `PUT /example/placeholder`                  | TODO placeholder comment    |
 
+## Java Code API Deprecations
+
+The following Java Code API deprecations have been made in 4.3.
+
+- The `org.graylog2.plugin.PluginModule.addNotificationType(name, notificationClass, handlerClass, factoryClass)`
+  method has been deprecated in favor of a new/preferred version, which also properly registers the notification 
+  config content pack entity, so that instances the corresponding content pack entity can can be installed successfully:
+`org.graylog2.plugin.PluginModule.addNotificationType(name, notificationClass, handlerClass, factoryClass, contentPackEntityName, contentPackEntityClass)`. 
+  See <PR link> for more info.
+
 ## Removed Migrations
 
 - Removed two migrations that convert pre-1.2 user permissions and index ranges to newer formats.

--- a/graylog2-server/src/main/java/org/graylog/events/EventsModule.java
+++ b/graylog2-server/src/main/java/org/graylog/events/EventsModule.java
@@ -93,12 +93,6 @@ public class EventsModule extends PluginModule {
 
         registerJacksonSubtype(AggregationEventProcessorConfigEntity.class,
             AggregationEventProcessorConfigEntity.TYPE_NAME);
-        registerJacksonSubtype(HttpEventNotificationConfigEntity.class,
-            HttpEventNotificationConfigEntity.TYPE_NAME);
-        registerJacksonSubtype(EmailEventNotificationConfigEntity.class,
-            EmailEventNotificationConfigEntity.TYPE_NAME);
-        registerJacksonSubtype(LegacyAlarmCallbackEventNotificationConfigEntity.class,
-            LegacyAlarmCallbackEventNotificationConfigEntity.TYPE_NAME);
 
         addEventProcessor(AggregationEventProcessorConfig.TYPE_NAME,
                 AggregationEventProcessor.class,
@@ -134,15 +128,21 @@ public class EventsModule extends PluginModule {
         addNotificationType(EmailEventNotificationConfig.TYPE_NAME,
                 EmailEventNotificationConfig.class,
                 EmailEventNotification.class,
-                EmailEventNotification.Factory.class);
+                EmailEventNotification.Factory.class,
+                EmailEventNotificationConfigEntity.TYPE_NAME,
+                EmailEventNotificationConfigEntity.class);
         addNotificationType(HTTPEventNotificationConfig.TYPE_NAME,
                 HTTPEventNotificationConfig.class,
                 HTTPEventNotification.class,
-                HTTPEventNotification.Factory.class);
+                HTTPEventNotification.Factory.class,
+                HttpEventNotificationConfigEntity.TYPE_NAME,
+                HttpEventNotificationConfigEntity.class);
         addNotificationType(LegacyAlarmCallbackEventNotificationConfig.TYPE_NAME,
                 LegacyAlarmCallbackEventNotificationConfig.class,
                 LegacyAlarmCallbackEventNotification.class,
-                LegacyAlarmCallbackEventNotification.Factory.class);
+                LegacyAlarmCallbackEventNotification.Factory.class,
+                LegacyAlarmCallbackEventNotificationConfigEntity.TYPE_NAME,
+                LegacyAlarmCallbackEventNotificationConfigEntity.class);
 
         addJobSchedulerSchedule(IntervalJobSchedule.TYPE_NAME, IntervalJobSchedule.class);
         addJobSchedulerSchedule(OnceJobSchedule.TYPE_NAME, OnceJobSchedule.class);

--- a/graylog2-server/src/main/java/org/graylog2/plugin/PluginModule.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/PluginModule.java
@@ -22,6 +22,7 @@ import com.google.inject.TypeLiteral;
 import com.google.inject.assistedinject.FactoryModuleBuilder;
 import com.google.inject.multibindings.MapBinder;
 import com.google.inject.multibindings.Multibinder;
+import org.graylog.events.contentpack.entities.EventNotificationConfigEntity;
 import org.graylog.events.fields.providers.FieldValueProvider;
 import org.graylog.events.notifications.EventNotification;
 import org.graylog.events.notifications.EventNotificationConfig;
@@ -301,6 +302,12 @@ public abstract class PluginModule extends Graylog2Module {
         return MapBinder.newMapBinder(binder(), String.class, EventNotification.Factory.class);
     }
 
+    /**
+     * Deprecated. Please use the below version of the method that also accepts the contentPackEntityName and
+     * contentPackEntityClass arguments, so that content pack entities are properly registered.
+     * TODO: Consider removing in Graylog 5.0.
+     */
+    @Deprecated
     protected void addNotificationType(String name,
                                        Class<? extends EventNotificationConfig> notificationClass,
                                        Class<? extends EventNotification> handlerClass,
@@ -308,6 +315,16 @@ public abstract class PluginModule extends Graylog2Module {
         install(new FactoryModuleBuilder().implement(EventNotification.class, handlerClass).build(factoryClass));
         eventNotificationBinder().addBinding(name).to(factoryClass);
         registerJacksonSubtype(notificationClass, name);
+    }
+
+    protected void addNotificationType(String name,
+                                       Class<? extends EventNotificationConfig> notificationClass,
+                                       Class<? extends EventNotification> handlerClass,
+                                       Class<? extends EventNotification.Factory> factoryClass,
+                                       String contentPackEntityName,
+                                       Class<? extends EventNotificationConfigEntity> contentPackEntityClass) {
+        addNotificationType(name, notificationClass, handlerClass, factoryClass);
+        registerJacksonSubtype(contentPackEntityClass, contentPackEntityName);
     }
 
     protected void addGRNType(GRNType type, Class<? extends GRNDescriptorProvider> descriptorProvider) {


### PR DESCRIPTION
Backport https://github.com/Graylog2/graylog2-server/pull/13171 to the `4.3` branch.