### PR TITLE
Avoid calling `undefined` when checking if error is ignored.

### DIFF
--- a/graylog2-web-interface/packages/jest-preset-graylog/src/setup-files/console-warnings-fail-tests.js
+++ b/graylog2-web-interface/packages/jest-preset-graylog/src/setup-files/console-warnings-fail-tests.js
@@ -28,7 +28,7 @@ const ignoredWarnings = [
   DEPRECATION_NOTICE,
 ];
 
-const ignoreWarning = (args) => (!args[0] || ignoredWarnings.filter((warning) => args[0].includes(warning)).length > 0);
+const ignoreWarning = (args) => (!args[0] || ignoredWarnings.filter((warning) => args[0]?.includes?.(warning)).length > 0);
 
 console.warn = jest.fn((...args) => {
   console.origWarn(...args);


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR fixes an error that can happen in tests, when a `console.error/warn` call is performed. This should cause a test failure, but we are ignoring some of the logged errors. In the code checking if the error should be ignored, we are unconditionally calling `includes` on the passed arguments. In some scenarios this can cause calling `undefined` as a function, when the argument is not an array.

This change is now using optional chaining to prevent this and fixes proper error logging in affected tests.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.