### PR TITLE
Display error message when the pipeline rule title already exists

### DIFF
--- a/graylog2-web-interface/src/components/rules/RuleContext.tsx
+++ b/graylog2-web-interface/src/components/rules/RuleContext.tsx
@@ -24,7 +24,7 @@ let VALIDATE_TIMEOUT;
 
 export const PipelineRulesContext = createContext(undefined);
 
-const savePipelineRule = (nextRule: RuleType, callback: (rule: RuleType) => void = () => {}) => {
+const savePipelineRule = (nextRule: RuleType, callback: (rule: RuleType) => void = () => {}, onError: (error: object) => void = () => {}) => {
   let promise;
 
   if (nextRule?.id) {
@@ -33,7 +33,7 @@ const savePipelineRule = (nextRule: RuleType, callback: (rule: RuleType) => void
     promise = RulesActions.save(nextRule);
   }
 
-  promise.then((response) => callback(response));
+  promise.then(callback).catch(onError);
 };
 
 type Props = {
@@ -87,8 +87,8 @@ export const PipelineRulesProvider = ({ children, usedInPipelines, rule }: Props
       RulesActions.parse(savedRule, () => callback(savedRule));
     };
 
-    const handleSavePipelineRule = (callback: (rule: RuleType) => void = () => {}) => {
-      validateBeforeSave((nextRule) => savePipelineRule(nextRule, callback));
+    const handleSavePipelineRule = (callback: (rule: RuleType) => void = () => {}, onError: (error: object) => void = () => {}) => {
+      validateBeforeSave((nextRule) => savePipelineRule(nextRule, callback, onError));
     };
 
     const onChangeSource = (source: string) => {

--- a/graylog2-web-interface/src/components/rules/RuleForm.jsx
+++ b/graylog2-web-interface/src/components/rules/RuleForm.jsx
@@ -37,21 +37,31 @@ const RuleForm = ({ create }) => {
   } = useContext(PipelineRulesContext);
 
   const [isDirty, setIsDirty] = useState(false);
+  const [errorMessage, setErrorMessage] = useState('');
+
+  const handleError = (error) => {
+    if (error.responseMessage.includes('duplicate key error')) {
+      const duplicatedTitle = error.responseMessage.match(/title: "(.*)"/i)[1];
+      setErrorMessage(`Rule title "${duplicatedTitle}" already exists!`);
+    }
+  };
 
   const handleSubmit = (event) => {
     event.preventDefault();
 
     handleSavePipelineRule(() => {
+      setErrorMessage('');
       setIsDirty(false);
       history.goBack();
-    });
+    }, handleError);
   };
 
   const handleApply = () => {
     handleSavePipelineRule((rule) => {
+      setErrorMessage('');
       setIsDirty(false);
       history.replace(Routes.SYSTEM.PIPELINES.RULE(rule.id));
-    });
+    }, handleError);
   };
 
   const handleDescriptionChange = (event) => {
@@ -60,6 +70,7 @@ const RuleForm = ({ create }) => {
   };
 
   const handleSourceChange = (newSource) => {
+    setErrorMessage('');
     setIsDirty(true);
     onChangeSource(newSource);
   };
@@ -91,7 +102,7 @@ const RuleForm = ({ create }) => {
 
         <PipelinesUsingRule create={create} />
 
-        <Input id="rule-source-editor" label="Rule source" help="Rule source, see quick reference for more information.">
+        <Input id="rule-source-editor" label="Rule source" help="Rule source, see quick reference for more information." error={errorMessage}>
           <SourceCodeEditor id={`source${create ? '-create' : '-edit'}`}
                             mode="pipeline"
                             onLoad={onAceLoaded}


### PR DESCRIPTION
## Description
As described in this issue https://github.com/Graylog2/graylog2-server/issues/11812 the description was not being saved when creating a pipeline rule but the real reason was testing with the same existing title. So in this PR the error is displayed in a readable way that the user will know why he couldn't create a new pipeline rule.

![Screenshot 2022-08-10 at 14 06 34](https://user-images.githubusercontent.com/106236152/183922958-20edc6f9-6ca4-4711-8a16-649d826e6a29.png)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/Graylog2/graylog2-server/issues/11812

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![Screenshot 2022-08-10 at 16 17 20](https://user-images.githubusercontent.com/106236152/183924531-58b05f3f-c7a3-4657-80cb-29a9e26b4b18.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

