### PR TITLE
Using updated view when calling `onSave` in view properties modal.

### DIFF
--- a/graylog2-web-interface/src/views/components/views/ViewPropertiesModal.test.tsx
+++ b/graylog2-web-interface/src/views/components/views/ViewPropertiesModal.test.tsx
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 import * as React from 'react';
 import { render, screen, waitFor } from 'wrappedTestingLibrary';
 import userEvent from '@testing-library/user-event';

--- a/graylog2-web-interface/src/views/components/views/ViewPropertiesModal.test.tsx
+++ b/graylog2-web-interface/src/views/components/views/ViewPropertiesModal.test.tsx
@@ -1,0 +1,30 @@
+import * as React from 'react';
+import { render, screen, waitFor } from 'wrappedTestingLibrary';
+import userEvent from '@testing-library/user-event';
+
+import View from 'views/logic/views/View';
+
+import ViewPropertiesModal from './ViewPropertiesModal';
+
+describe('ViewPropertiesModal', () => {
+  it('should use updated view when saving', async () => {
+    const onSave = jest.fn();
+    const view = View.builder()
+      .type(View.Type.Dashboard)
+      .title('')
+      .build();
+    render(<ViewPropertiesModal onClose={jest.fn()} onSave={onSave} title="Saving new dashboard" view={view} show />);
+
+    await screen.findByText('Saving new dashboard');
+    const titleInput = await screen.findByRole('textbox', { name: /title/i, hidden: true });
+
+    await userEvent.type(titleInput, 'My title');
+    userEvent.click(await screen.findByRole('button', { name: 'Save', hidden: true }));
+
+    await waitFor(() => {
+      expect(onSave).toHaveBeenCalledWith(expect.objectContaining({
+        title: 'My title',
+      }));
+    });
+  });
+});

--- a/graylog2-web-interface/src/views/components/views/ViewPropertiesModal.tsx
+++ b/graylog2-web-interface/src/views/components/views/ViewPropertiesModal.tsx
@@ -62,7 +62,7 @@ const ViewPropertiesModal = ({ onClose, onSave, show, view, title: modalTitle }:
   };
 
   const _onSave = () => {
-    onSave(view);
+    onSave(updatedView);
     onClose();
   };
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Prior to this PR, the `_onSave` function in the `ViewPropertiesModal` component used the view instance that was originally passed to the component when saving it instead of the updated one. This lead to updates to properties (title/description/etc.) not being propagated and new views failing backend validation due to not having a title, even if one was entered.

This PR is changing `_onSave` to use the `updatedView` instance.

Fixes #13223.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.