### PR TITLE
Link to input in message details

### DIFF
--- a/graylog2-web-interface/src/components/common/EntityList.md
+++ b/graylog2-web-interface/src/components/common/EntityList.md
@@ -29,8 +29,18 @@ const entities = [
 const items = entities.map(entity => {
   // You can encapsulate `EntityListItem` into its own component,
   // so it's easy to see what data you transform and feed into it.
+  //
+  // You can optionally pass an `id` property to `EntityListItem`
+  // to set its ID, which can then be used for linking directly to
+  // that item.  By default `EntityList` prop `scrollToHashId`
+  // is `true`, so it will attempt to scroll to the value of
+  // `window.location.hash`. For example, you could link to
+  // "/some/path#entity-2", a page with an `EntityList` containing
+  // an `EntityListItem` with an ID "entity-2", to go directly
+  // to that item.
   return (
     <EntityListItem key={`entity-${entity.id}`}
+                    id={`entity-${entity.id}`}
                     title={entity.title}
                     titleSuffix={entity.nickname}
                     description={entity.description}

--- a/graylog2-web-interface/src/components/common/EntityList.tsx
+++ b/graylog2-web-interface/src/components/common/EntityList.tsx
@@ -15,7 +15,8 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import PropTypes from 'prop-types';
-import React from 'react';
+import * as React from 'react';
+import { useEffect, useRef } from 'react';
 import styled from 'styled-components';
 
 import { Alert } from 'components/bootstrap';
@@ -31,6 +32,7 @@ type Props = {
   bsNoItemsStyle?: 'info' | 'success' | 'warning',
   noItemsText?: string | React.ReactNode,
   items: Array<React.ReactNode>,
+  scrollToHashId: boolean,
 }
 
 /**
@@ -38,7 +40,16 @@ type Props = {
  * action buttons, etc. You need to use this component alongside `EntityListItem` in order to get a similar
  * look and feel among different entities.
  */
-const EntityList = ({ bsNoItemsStyle, items, noItemsText }: Props) => {
+const EntityList = ({ bsNoItemsStyle, items, noItemsText, scrollToHashId }: Props) => {
+  const scrollNeeded = useRef(scrollToHashId && !!window.location.hash);
+
+  useEffect(() => {
+    if (items.length && scrollNeeded.current) {
+      scrollNeeded.current = false;
+      document.getElementById(window.location.hash.slice(1))?.scrollIntoView();
+    }
+  }, [items]);
+
   if (items.length === 0) {
     return (
       <Alert bsStyle={bsNoItemsStyle}>
@@ -58,6 +69,7 @@ const EntityList = ({ bsNoItemsStyle, items, noItemsText }: Props) => {
 EntityList.defaultProps = {
   bsNoItemsStyle: 'info',
   noItemsText: 'No items available',
+  scrollToHashId: true,
 };
 
 EntityList.propTypes = {
@@ -70,6 +82,8 @@ EntityList.propTypes = {
   ]),
   /** Array of `EntityListItem` that will be shown.  */
   items: PropTypes.array.isRequired,
+  /** Whether to scroll to an element ID specified in window.location.hash */
+  scrollToHashId: PropTypes.bool,
 };
 
 export default EntityList;

--- a/graylog2-web-interface/src/components/common/EntityListItem.tsx
+++ b/graylog2-web-interface/src/components/common/EntityListItem.tsx
@@ -53,13 +53,14 @@ type Props = {
   description?: React.ReactNode,
   actions?: React.ReactNode | Array<React.ReactNode>,
   contentRow?: React.ReactNode,
+  id?: string,
 }
 
 /**
  * Component that let you render an entity item using a similar look and feel as other entities in Graylog.
  * This component is meant to use alongside `EntityList`. Look there for an example of how to use this component.
  */
-const EntityListItem = ({ actions, contentRow, description, title, titleSuffix }: Props) => {
+const EntityListItem = ({ actions, contentRow, description, title, titleSuffix, id }: Props) => {
   const wrappedTitleSuffix = titleSuffix ? <small>{titleSuffix}</small> : null;
   const actionsContainer = (
     <div className="item-actions text-right">
@@ -68,7 +69,7 @@ const EntityListItem = ({ actions, contentRow, description, title, titleSuffix }
   );
 
   return (
-    <StyledListItem>
+    <StyledListItem id={id}>
       <Row className="row-sm">
         <Col md={12}>
           <div className="pull-right hidden-xs">
@@ -111,6 +112,8 @@ EntityListItem.propTypes = {
    * to show configuration options.
    */
   contentRow: PropTypes.node,
+  /** Optional `id` attribute of the entity list item (useful for direct linking). */
+  id: PropTypes.string,
 };
 
 EntityListItem.defaultProps = {
@@ -118,6 +121,7 @@ EntityListItem.defaultProps = {
   contentRow: undefined,
   description: undefined,
   titleSuffix: undefined,
+  id: undefined,
 };
 
 export default EntityListItem;

--- a/graylog2-web-interface/src/components/inputs/InputListItem.jsx
+++ b/graylog2-web-interface/src/components/inputs/InputListItem.jsx
@@ -184,11 +184,12 @@ const InputListItem = createReactClass({
     );
 
     return (
-      <EntityListItem key={`entry-list-${this.props.input.id}`}
-                      title={this.props.input.title}
+      <EntityListItem key={`entry-list-${input.id}`}
+                      id={`input-${input.id}`}
+                      title={input.title}
                       titleSuffix={titleSuffix}
                       description={subtitle}
-                      createdFromContentPack={!!this.props.input.content_pack}
+                      createdFromContentPack={!!input.content_pack}
                       actions={actions}
                       contentRow={additionalContent} />
     );

--- a/graylog2-web-interface/src/views/components/messagelist/FormatReceivedBy.tsx
+++ b/graylog2-web-interface/src/views/components/messagelist/FormatReceivedBy.tsx
@@ -19,6 +19,7 @@ import type * as Immutable from 'immutable';
 
 import { Spinner } from 'components/common';
 import NodeName from 'views/components/messagelist/NodeName';
+import Routes from 'routing/Routes';
 import type { Input } from 'components/messageloaders/Types';
 import usePluginEntities from 'views/logic/usePluginEntities';
 
@@ -27,7 +28,11 @@ type Inputs = Immutable.Map<string, Input>;
 const _inputName = (inputs: Inputs, inputId: string) => {
   const input = inputs.get(inputId);
 
-  return input ? <span style={{ wordBreak: 'break-word' }}>{input.title}</span> : 'deleted input';
+  return input ? (
+    <span style={{ wordBreak: 'break-word' }}>
+      <a href={`${Routes.SYSTEM.INPUTS}#input-${input.id}`}>{input.title}</a>
+    </span>
+  ) : 'deleted input';
 };
 
 const FormatReceivedBy = ({ isLocalNode, inputs, sourceInputId, sourceNodeId }: {isLocalNode: boolean, inputs: Inputs, sourceNodeId: string, sourceInputId: string }) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR makes the Input name in the `Received by` section of message details a link to the Input on the Inputs page (if the Input still exists).

## Description
<!--- Describe your changes in detail -->
This PR introduces aupport for linking and jumping (once) directly to an `EntityListItem` within an `EntityList`,  and then uses that to link to an input from the `Received by` section of message details.

The ReviewBot items are unrelated to the changes in this PR, so I've skipped addressing them (for now).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently the details section links to the receiving node, but not the corresponding input.  Being able to directly jump from a message to the related input on the Inputs page eliminates several manual steps.

Closes #2829. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Verified I can click the message details input name/link and get to the corresponding input on the Inputs page.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/288958/184270335-64accd72-8c8b-44a8-aa7e-7ec812dda49c.png)
![image](https://user-images.githubusercontent.com/288958/184270150-3e7d4775-5f4a-48ab-9bfd-03f27d2b88d0.png)

![image](https://user-images.githubusercontent.com/288958/184270270-191c5408-c077-4b15-a73d-c4d70a4be1d5.png)
![image](https://user-images.githubusercontent.com/288958/184270188-5e7ad911-ca73-40ad-b108-4dcc22f7bd5c.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

