### PR TITLE
feat: Hide Hostname on Cloud

### DIFF
--- a/graylog2-web-interface/src/components/common/LinkToNode.jsx
+++ b/graylog2-web-interface/src/components/common/LinkToNode.jsx
@@ -15,18 +15,18 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import PropTypes from 'prop-types';
-import React from 'react';
-import createReactClass from 'create-react-class';
-import Reflux from 'reflux';
+import * as React from 'react';
 
 import { Link } from 'components/common/router';
 import Routes from 'routing/Routes';
 import AppConfig from 'util/AppConfig';
+import HideOnCloud from 'util/conditional/HideOnCloud';
 import { NodesStore } from 'stores/nodes/NodesStore';
 
 import Icon from './Icon';
 import Spinner from './Spinner';
 
+import connect from '../../stores/connect';
 /**
  * Component that creates a link to a Graylog node. The information in the link includes:
  *  - Marker indicating whether the Graylog node is leader or not
@@ -35,22 +35,22 @@ import Spinner from './Spinner';
  *
  * All this information will be obtained from the `NodesStore`.
  */
-const LinkToNode = createReactClass({
-  displayName: 'LinkToNode',
 
-  propTypes: {
+class LinkToNode extends React.Component {
+  static propTypes = {
     /** Node ID that will be used to generate the link. */
     nodeId: PropTypes.string.isRequired,
-  },
-
-  mixins: [Reflux.connect(NodesStore)],
+    nodeStore: PropTypes.object.isRequired,
+  };
 
   render() {
-    if (!this.state.nodes) {
+    const { nodes } = this.props.nodeStore;
+
+    if (!nodes) {
       return <Spinner />;
     }
 
-    const node = this.state.nodes[this.props.nodeId];
+    const node = nodes[this.props.nodeId];
 
     if (node) {
       const iconName = node.is_leader ? 'star' : 'code-branch';
@@ -61,7 +61,7 @@ const LinkToNode = createReactClass({
         <>
           <Icon name={iconName} className={iconClass} title={iconTitle} />
           {' '}
-          {node.short_node_id} / {node.hostname}
+          {node.short_node_id}<HideOnCloud> / {node.hostname}</HideOnCloud>
         </>
       );
 
@@ -75,7 +75,10 @@ const LinkToNode = createReactClass({
     }
 
     return <i>Unknown Node</i>;
-  },
-});
+  }
+}
 
-export default LinkToNode;
+export default connect(
+  LinkToNode,
+  { nodeStore: NodesStore },
+);

--- a/graylog2-web-interface/src/components/common/LinkToNode.jsx
+++ b/graylog2-web-interface/src/components/common/LinkToNode.jsx
@@ -22,11 +22,11 @@ import Routes from 'routing/Routes';
 import AppConfig from 'util/AppConfig';
 import HideOnCloud from 'util/conditional/HideOnCloud';
 import { NodesStore } from 'stores/nodes/NodesStore';
+import connect from 'stores/connect';
 
 import Icon from './Icon';
 import Spinner from './Spinner';
 
-import connect from '../../stores/connect';
 /**
  * Component that creates a link to a Graylog node. The information in the link includes:
  *  - Marker indicating whether the Graylog node is leader or not
@@ -40,11 +40,11 @@ class LinkToNode extends React.PureComponent {
   static propTypes = {
     /** Node ID that will be used to generate the link. */
     nodeId: PropTypes.string.isRequired,
-    nodeStore: PropTypes.object.isRequired,
+    nodes: PropTypes.object.isRequired,
   };
 
   render() {
-    const { nodes } = this.props.nodeStore;
+    const { nodes } = this.props;
 
     if (!nodes) {
       return <Spinner />;
@@ -81,4 +81,5 @@ class LinkToNode extends React.PureComponent {
 export default connect(
   LinkToNode,
   { nodeStore: NodesStore },
+  ({ nodeStore, ...rest }) => ({ ...rest, nodes: nodeStore.nodes }),
 );

--- a/graylog2-web-interface/src/components/common/LinkToNode.jsx
+++ b/graylog2-web-interface/src/components/common/LinkToNode.jsx
@@ -36,7 +36,7 @@ import connect from '../../stores/connect';
  * All this information will be obtained from the `NodesStore`.
  */
 
-class LinkToNode extends React.Component {
+class LinkToNode extends React.PureComponent {
   static propTypes = {
     /** Node ID that will be used to generate the link. */
     nodeId: PropTypes.string.isRequired,

--- a/graylog2-web-interface/src/components/common/LinkToNode.jsx
+++ b/graylog2-web-interface/src/components/common/LinkToNode.jsx
@@ -40,7 +40,7 @@ class LinkToNode extends React.PureComponent {
   static propTypes = {
     /** Node ID that will be used to generate the link. */
     nodeId: PropTypes.string.isRequired,
-    nodes: PropTypes.object.isRequired,
+    nodes: PropTypes.object,
   };
 
   render() {
@@ -77,6 +77,10 @@ class LinkToNode extends React.PureComponent {
     return <i>Unknown Node</i>;
   }
 }
+
+LinkToNode.defaultProps = {
+  nodes: undefined,
+};
 
 export default connect(
   LinkToNode,


### PR DESCRIPTION
Hides the host name in the system messages log on the System Overview Page. 

No other occurences where this could be visible were found in cloud instances.

## Description
removes the host name in LinkToNode on cloud installations.

## Motivation and Context
closes Graylog2/graylog-plugin-cloud#1040

## How Has This Been Tested?
Host name not shown in cloud installations, still shown in on prem installations (also for inputs etc)

## Screenshots (if appropriate):
<img width="434" alt="image" src="https://user-images.githubusercontent.com/33032967/184324490-b1145c66-10f8-43eb-8744-d8b29784f907.png">

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


