### PR TITLE
Create new package for custom ESLint rules.

### DIFF
--- a/graylog2-web-interface/packages/eslint-config-graylog/index.js
+++ b/graylog2-web-interface/packages/eslint-config-graylog/index.js
@@ -71,11 +71,13 @@ module.exports = {
     'plugin:import/warnings',
     'plugin:import/react',
     'plugin:jest-formatting/strict',
+    'plugin:graylog/recommended',
   ],
   plugins: [
     'import',
     'react-hooks',
     'jest-formatting',
+    'graylog',
   ],
   rules: {
     'arrow-body-style': 'off',

--- a/graylog2-web-interface/packages/eslint-config-graylog/package.json
+++ b/graylog2-web-interface/packages/eslint-config-graylog/package.json
@@ -20,6 +20,7 @@
     "eslint-config-airbnb": "19.0.4",
     "eslint-import-resolver-webpack": "0.13.2",
     "eslint-plugin-compat": "4.0.2",
+    "eslint-plugin-graylog": "file:../eslint-plugin-graylog",
     "eslint-plugin-import": "2.25.3",
     "eslint-plugin-jest": "26.8.2",
     "eslint-plugin-jest-dom": "4.0.2",

--- a/graylog2-web-interface/packages/eslint-plugin-graylog/lib/index.js
+++ b/graylog2-web-interface/packages/eslint-plugin-graylog/lib/index.js
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+/* eslint-disable global-require */
+module.exports = {
+  rules: {
+    'user-date-time-injection': require('./rules/user-date-time-injection'),
+  },
+  configs: {
+    recommended: {
+      rules: {
+        'graylog/user-date-time-injection': 'warn',
+      },
+    },
+  },
+};

--- a/graylog2-web-interface/packages/eslint-plugin-graylog/lib/index.js
+++ b/graylog2-web-interface/packages/eslint-plugin-graylog/lib/index.js
@@ -17,12 +17,12 @@
 /* eslint-disable global-require */
 module.exports = {
   rules: {
-    'user-date-time-injection': require('./rules/user-date-time-injection'),
+    'prefer-hook': require('./rules/prefer-hook'),
   },
   configs: {
     recommended: {
       rules: {
-        'graylog/user-date-time-injection': 'warn',
+        'graylog/prefer-hook': 'warn',
       },
     },
   },

--- a/graylog2-web-interface/packages/eslint-plugin-graylog/lib/rules/prefer-hook.js
+++ b/graylog2-web-interface/packages/eslint-plugin-graylog/lib/rules/prefer-hook.js
@@ -21,6 +21,10 @@ const hooks = [
     name: 'useUserDateTime',
     relatedContext: 'UserDateTimeContext',
   },
+  {
+    name: 'useCurrentUser',
+    relatedContext: 'CurrentUserContext',
+  },
 ];
 
 module.exports = (context) => ({

--- a/graylog2-web-interface/packages/eslint-plugin-graylog/lib/rules/prefer-hook.js
+++ b/graylog2-web-interface/packages/eslint-plugin-graylog/lib/rules/prefer-hook.js
@@ -15,16 +15,28 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 /* eslint-disable global-require */
+
+const hooks = [
+  {
+    name: 'useUserDateTime',
+    relatedContext: 'UserDateTimeContext',
+  },
+];
+
 module.exports = (context) => ({
   CallExpression: (node) => {
     const { callee } = node;
 
-    if (callee.name === 'useContext'
-      && callee?.parent?.arguments?.[0].name === 'UserDateTimeContext'
-      && !context.getFilename().endsWith('useUserDateTime.ts')
-    ) {
-      context.report(node, 'Implement useUserDateTime hook instead of consuming UserDateTimeContext.');
-    }
+    hooks.forEach(({ name: hookName, relatedContext }) => {
+      if (relatedContext) {
+        if (callee.name === 'useContext'
+          && callee?.parent?.arguments?.[0].name === relatedContext
+          && !context.getFilename().includes(hookName)
+        ) {
+          context.report(node, `Implement ${hookName} hook instead of consuming ${relatedContext}.`);
+        }
+      }
+    });
   },
 });
 

--- a/graylog2-web-interface/packages/eslint-plugin-graylog/lib/rules/user-date-time-injection.js
+++ b/graylog2-web-interface/packages/eslint-plugin-graylog/lib/rules/user-date-time-injection.js
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+/* eslint-disable global-require */
+module.exports = (context) => ({
+  CallExpression: (node) => {
+    const { callee } = node;
+
+    if (callee.name === 'useContext'
+      && callee?.parent?.arguments?.[0].name === 'UserDateTimeContext'
+      && !context.getFilename().endsWith('useUserDateTime.ts')
+    ) {
+      context.report(node, 'Implement useUserDateTime hook instead of consuming UserDateTimeContext.');
+    }
+  },
+});
+
+module.schema = [];

--- a/graylog2-web-interface/packages/eslint-plugin-graylog/package.json
+++ b/graylog2-web-interface/packages/eslint-plugin-graylog/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "eslint-plugin-graylog",
+  "version": "1.0.0",
+  "description": "Collection of custom ESLint rules.",
+  "main": "./lib/index.js",
+  "exports": "./lib/index.js",
+  "author": "Graylog, Inc. <hello@graylog.com>",
+  "license": "SSPL-1.0"
+}

--- a/graylog2-web-interface/yarn.lock
+++ b/graylog2-web-interface/yarn.lock
@@ -5985,6 +5985,7 @@ eslint-config-airbnb@19.0.4:
     eslint-config-airbnb "19.0.4"
     eslint-import-resolver-webpack "0.13.2"
     eslint-plugin-compat "4.0.2"
+    eslint-plugin-graylog "file:../../../../Library/Caches/Yarn/v6/npm-eslint-config-graylog-1.3.0-76bca5d0-222c-47c6-b20d-95d2d8548ed5-1660566162465/node_modules/eslint-plugin-graylog"
     eslint-plugin-import "2.25.3"
     eslint-plugin-jest "26.8.2"
     eslint-plugin-jest-dom "4.0.2"
@@ -6041,6 +6042,9 @@ eslint-plugin-compat@4.0.2:
     find-up "^5.0.0"
     lodash.memoize "4.1.2"
     semver "7.3.5"
+
+"eslint-plugin-graylog@file:packages/eslint-plugin-graylog":
+  version "1.0.0"
 
 eslint-plugin-import@2.25.3:
   version "2.25.3"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

With this PR we are adding a new package, which allows us to create custom ESLint rules.
It contains a first rule that suggests implementing the `useUserDateTime` context instead of consuming the `CurrentUserContext`.

Implementing a specific hook instead of consuming the context is a pattern we want to apply more in the future.
Since it is very easy to forget this pattern and consume the context directly, it is great to have an ESLint rule to avoid these mistakes.

I also considered implementing an auto fix suggestion, but the problem is, that running `eslint --fix` would then result in a problem, since we are not automatically adding the necessary import.

Please note I have not yet added tests for the new rule. 

To test this change you need to remove and reinstall the `node_modules`.