### PR TITLE
Fix 13198 Sort Content Pack version list numerically

### DIFF
--- a/graylog2-web-interface/src/components/common/DataTable/DataTable.jsx
+++ b/graylog2-web-interface/src/components/common/DataTable/DataTable.jsx
@@ -28,6 +28,7 @@ const StyledTable = styled.table`
   ${tableCss}
 `;
 
+// eslint-disable-next-line react/prop-types
 const NoData = ({ noDataText }) => {
   if (typeof noDataText === 'string') {
     return (
@@ -111,10 +112,11 @@ class DataTable extends React.Component {
     noDataText: 'No data available.',
     rowClassName: '',
     useResponsiveTable: true,
+    // eslint-disable-next-line react/no-unstable-nested-components
     headerCellFormatter: (header) => { return (<th>{header}</th>); },
     sortByKey: undefined,
     sortBy: undefined,
-    isNumericSort: false
+    isNumericSort: false,
   };
 
   constructor(props) {

--- a/graylog2-web-interface/src/components/common/DataTable/DataTable.jsx
+++ b/graylog2-web-interface/src/components/common/DataTable/DataTable.jsx
@@ -97,7 +97,7 @@ class DataTable extends React.Component {
      */
     useResponsiveTable: PropTypes.bool,
     /** boolean value to set sort numeric  */
-    isNumericSort: PropTypes.bool,
+    useNumericSort: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -116,7 +116,7 @@ class DataTable extends React.Component {
     headerCellFormatter: (header) => { return (<th>{header}</th>); },
     sortByKey: undefined,
     sortBy: undefined,
-    isNumericSort: false,
+    useNumericSort: false,
   };
 
   constructor(props) {
@@ -144,16 +144,16 @@ class DataTable extends React.Component {
 
   getFormattedDataRows = () => {
     let i = 0;
-    const { sortByKey, sortBy, dataRowFormatter, isNumericSort } = this.props;
+    const { sortByKey, sortBy, dataRowFormatter, useNumericSort } = this.props;
     let sortedDataRows = this._getEffectiveRows();
 
     if (sortByKey) {
       sortedDataRows = sortedDataRows.sort((a, b) => {
-        return a[sortByKey].localeCompare(b[sortByKey], undefined, { numeric: isNumericSort });
+        return a[sortByKey].localeCompare(b[sortByKey], undefined, { numeric: useNumericSort });
       });
     } else if (sortBy) {
       sortedDataRows = sortedDataRows.sort((a, b) => {
-        return sortBy(a).localeCompare(sortBy(b), undefined, { numeric: isNumericSort });
+        return sortBy(a).localeCompare(sortBy(b), undefined, { numeric: useNumericSort });
       });
     }
 

--- a/graylog2-web-interface/src/components/common/DataTable/DataTable.jsx
+++ b/graylog2-web-interface/src/components/common/DataTable/DataTable.jsx
@@ -95,6 +95,8 @@ class DataTable extends React.Component {
      * The main reason to disable this is if the table is clipping a dropdown menu or another component in a table edge.
      */
     useResponsiveTable: PropTypes.bool,
+    /** boolean value to set sort numeric  */
+    isNumericSort: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -112,6 +114,7 @@ class DataTable extends React.Component {
     headerCellFormatter: (header) => { return (<th>{header}</th>); },
     sortByKey: undefined,
     sortBy: undefined,
+    isNumericSort: false
   };
 
   constructor(props) {
@@ -139,16 +142,16 @@ class DataTable extends React.Component {
 
   getFormattedDataRows = () => {
     let i = 0;
-    const { sortByKey, sortBy, dataRowFormatter } = this.props;
+    const { sortByKey, sortBy, dataRowFormatter, isNumericSort } = this.props;
     let sortedDataRows = this._getEffectiveRows();
 
     if (sortByKey) {
       sortedDataRows = sortedDataRows.sort((a, b) => {
-        return a[sortByKey].localeCompare(b[sortByKey]);
+        return a[sortByKey].localeCompare(b[sortByKey], undefined, { numeric: isNumericSort });
       });
     } else if (sortBy) {
       sortedDataRows = sortedDataRows.sort((a, b) => {
-        return sortBy(a).localeCompare(sortBy(b));
+        return sortBy(a).localeCompare(sortBy(b), undefined, { numeric: isNumericSort });
       });
     }
 

--- a/graylog2-web-interface/src/components/content-packs/ContentPackInstallations.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackInstallations.jsx
@@ -87,6 +87,7 @@ class ContentPackInstallations extends React.Component {
     );
   };
 
+  // eslint-disable-next-line class-methods-use-this
   headerFormater = (header) => {
     if (header === 'Action') {
       return (<th className="text-right">{header}</th>);
@@ -108,7 +109,8 @@ class ContentPackInstallations extends React.Component {
       <DataTable id="content-packs-versions"
                  headers={headers}
                  headerCellFormatter={this.headerFormater}
-                 sortByKey="comment"
+                 useNumericSort
+                 sortBy={(c) => c.content_pack_revision.toString()}
                  dataRowFormatter={this.rowFormatter}
                  rows={installations}
                  filterKeys={[]} />

--- a/graylog2-web-interface/src/components/content-packs/ContentPackVersions.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackVersions.jsx
@@ -160,6 +160,7 @@ class ContentPackVersions extends React.Component {
       <DataTable id="content-packs-versions"
                  headers={headers}
                  headerCellFormatter={this.headerFormatter}
+                 isNumericSort={true}
                  sortBy={(c) => c.rev.toString()}
                  dataRowFormatter={this.rowFormatter}
                  rows={contentPacks}

--- a/graylog2-web-interface/src/components/content-packs/ContentPackVersions.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackVersions.jsx
@@ -61,6 +61,7 @@ class ContentPackVersions extends React.Component {
     onChange(event.target.value);
   }
 
+  // eslint-disable-next-line class-methods-use-this
   headerFormatter = (header) => {
     if (header === 'Action') {
       return (<th className="text-right">{header}</th>);
@@ -160,7 +161,7 @@ class ContentPackVersions extends React.Component {
       <DataTable id="content-packs-versions"
                  headers={headers}
                  headerCellFormatter={this.headerFormatter}
-                 isNumericSort={true}
+                 isNumericSort
                  sortBy={(c) => c.rev.toString()}
                  dataRowFormatter={this.rowFormatter}
                  rows={contentPacks}

--- a/graylog2-web-interface/src/components/content-packs/ContentPackVersions.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackVersions.jsx
@@ -161,7 +161,7 @@ class ContentPackVersions extends React.Component {
       <DataTable id="content-packs-versions"
                  headers={headers}
                  headerCellFormatter={this.headerFormatter}
-                 isNumericSort
+                 useNumericSort
                  sortBy={(c) => c.rev.toString()}
                  dataRowFormatter={this.rowFormatter}
                  rows={contentPacks}


### PR DESCRIPTION
## Description
As described in the issue https://github.com/Graylog2/graylog2-server/issues/13198 the content pack version list was sorted lexicographically now it is sorted numerically

![Screenshot 2022-08-16 at 15 44 27](https://user-images.githubusercontent.com/106236152/184894937-b1c74cdf-9214-43e9-b5c1-8d8001f36063.png)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/Graylog2/graylog2-server/issues/13198

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![Screenshot 2022-08-16 at 15 39 15](https://user-images.githubusercontent.com/106236152/184893791-ca085c58-bd7f-4cd1-8b8b-0d9e244ea268.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

