### PR TITLE
Create `useCurrentUser` hook to receive current user.

### DIFF
--- a/graylog2-web-interface/src/components/cluster/GraylogClusterOverview.tsx
+++ b/graylog2-web-interface/src/components/cluster/GraylogClusterOverview.tsx
@@ -17,7 +17,7 @@
 /* eslint-disable react/no-find-dom-node */
 
 import * as React from 'react';
-import { useState, useEffect, useRef, useContext } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { reduce } from 'lodash';
 import styled, { css } from 'styled-components';
@@ -29,11 +29,11 @@ import NumberUtils from 'util/NumberUtils';
 import { useStore } from 'stores/connect';
 import { Col, Row } from 'components/bootstrap';
 import { Spinner } from 'components/common';
-import CurrentUserContext from 'contexts/CurrentUserContext';
 import { ClusterTrafficActions, ClusterTrafficStore } from 'stores/cluster/ClusterTrafficStore';
 import { NodesStore } from 'stores/nodes/NodesStore';
 import { formatTrafficData } from 'util/TrafficUtils';
 import { isPermitted } from 'util/PermissionsMixin';
+import useCurrentUser from 'hooks/useCurrentUser';
 
 import TrafficGraph from './TrafficGraph';
 
@@ -74,7 +74,7 @@ const GraylogClusterTrafficGraph = () => {
   const eventThrottler = useRef(new EventHandlersThrottler());
   const containerRef = useRef(null);
   const licensePlugin = PluginStore.exports('license');
-  const currentUser = useContext(CurrentUserContext);
+  const currentUser = useCurrentUser();
 
   useEffect(() => {
     ClusterTrafficActions.getTraffic();

--- a/graylog2-web-interface/src/components/common/HasOwnership.test.tsx
+++ b/graylog2-web-interface/src/components/common/HasOwnership.test.tsx
@@ -16,44 +16,18 @@
  */
 import * as React from 'react';
 import * as Immutable from 'immutable';
-import { render } from 'wrappedTestingLibrary';
+import { render, screen } from 'wrappedTestingLibrary';
 
-import { alice as currentUser } from 'fixtures/users';
-import type User from 'logic/users/User';
-import CurrentUserContext from 'contexts/CurrentUserContext';
+import { alice as currentUser, adminUser } from 'fixtures/users';
 import { createGRN } from 'logic/permissions/GRN';
+import { asMock } from 'helpers/mocking';
+import useCurrentUser from 'hooks/useCurrentUser';
 
 import HasOwnership from './HasOwnership';
 
-type Props = {
-  currentUser: User,
-  id: string,
-  type: string,
-  hideChildren?: boolean,
-};
+jest.mock('hooks/useCurrentUser');
 
 describe('HasOwnership', () => {
-  // eslint-disable-next-line react/prop-types
-  const DisabledComponent = ({ disabled }: { disabled: boolean}) => {
-    return disabled
-      ? <span>disabled</span>
-      : <span>enabled</span>;
-  };
-
-  const SimpleHasOwnership = ({ currentUser: user = currentUser, ...props }: Props) => (
-    <CurrentUserContext.Provider value={user}>
-      <HasOwnership {...props}>
-        {({ disabled }) => (
-          <DisabledComponent disabled={disabled} />
-        )}
-      </HasOwnership>
-    </CurrentUserContext.Provider>
-  );
-
-  SimpleHasOwnership.defaultProps = {
-    hideChildren: false,
-  };
-
   const type = 'stream';
   const id = '000000000001';
   const grn = createGRN(type, id);
@@ -64,16 +38,46 @@ describe('HasOwnership', () => {
   const otherGrn = createGRN(otherType, otherId);
   const otherGrnPermission = `entity:own:${otherGrn}`;
 
+  // eslint-disable-next-line react/prop-types
+  const DisabledComponent = ({ disabled }: { disabled: boolean}) => {
+    return disabled
+      ? <span>disabled</span>
+      : <span>enabled</span>;
+  };
+
+  type Props = {
+    id: string,
+    type: string,
+    hideChildren?: boolean,
+  };
+
+  const SimpleHasOwnership = (props: Props) => (
+    <HasOwnership {...props}>
+      {({ disabled }) => (
+        <DisabledComponent disabled={disabled} />
+      )}
+    </HasOwnership>
+  );
+
+  SimpleHasOwnership.defaultProps = {
+    hideChildren: false,
+  };
+
+  beforeEach(() => {
+    asMock(useCurrentUser).mockReturnValue(adminUser);
+  });
+
   it('should render children enabled if user has ownership', () => {
-    const user = currentUser.toBuilder()
+    const user = adminUser.toBuilder()
       .grnPermissions(Immutable.List([grnPermission]))
       .permissions(Immutable.List())
       .build();
-    const { getByText: queryByText } = render(
-      <SimpleHasOwnership currentUser={user} id={id} type={type} />,
-    );
 
-    expect(queryByText('enabled')).toBeTruthy();
+    asMock(useCurrentUser).mockReturnValue(user);
+
+    render(<SimpleHasOwnership id={id} type={type} />);
+
+    expect(screen.getByText('enabled')).toBeTruthy();
   });
 
   it('should render children disabled if user has empty ownership and is not admin', () => {
@@ -81,11 +85,10 @@ describe('HasOwnership', () => {
       .grnPermissions(Immutable.List(Immutable.List()))
       .permissions(Immutable.List())
       .build();
-    const { queryByText } = render(
-      <SimpleHasOwnership currentUser={user} id={id} type={type} />,
-    );
+    asMock(useCurrentUser).mockReturnValue(user);
+    render(<SimpleHasOwnership id={id} type={type} />);
 
-    expect(queryByText('disabled')).toBeTruthy();
+    expect(screen.getByText('disabled')).toBeTruthy();
   });
 
   it('should render children disabled if user has wrong ownership and is not admin', () => {
@@ -93,11 +96,11 @@ describe('HasOwnership', () => {
       .grnPermissions(Immutable.List([otherGrnPermission]))
       .permissions(Immutable.List())
       .build();
-    const { queryByText } = render(
-      <SimpleHasOwnership currentUser={user} id={id} type={type} />,
-    );
 
-    expect(queryByText('disabled')).toBeTruthy();
+    asMock(useCurrentUser).mockReturnValue(user);
+    render(<SimpleHasOwnership id={id} type={type} />);
+
+    expect(screen.getByText('disabled')).toBeTruthy();
   });
 
   it('should render children disabled if user has wrong ownership and is reader', () => {
@@ -105,11 +108,10 @@ describe('HasOwnership', () => {
       .grnPermissions(Immutable.List([otherGrnPermission]))
       .permissions(Immutable.List([`streams:read:${id}`]))
       .build();
-    const { queryByText } = render(
-      <SimpleHasOwnership currentUser={user} id={id} type={type} />,
-    );
+    asMock(useCurrentUser).mockReturnValue(user);
+    render(<SimpleHasOwnership id={id} type={type} />);
 
-    expect(queryByText('disabled')).toBeTruthy();
+    expect(screen.getByText('disabled')).toBeTruthy();
   });
 
   it('should render children disabled if user has no ownership and is reader', () => {
@@ -117,11 +119,10 @@ describe('HasOwnership', () => {
       .grnPermissions(Immutable.List([]))
       .permissions(Immutable.List([`streams:read:${id}`]))
       .build();
-    const { queryByText } = render(
-      <SimpleHasOwnership currentUser={user} id={id} type={type} />,
-    );
+    asMock(useCurrentUser).mockReturnValue(user);
+    render(<SimpleHasOwnership id={id} type={type} />);
 
-    expect(queryByText('disabled')).toBeTruthy();
+    expect(screen.getByText('disabled')).toBeTruthy();
   });
 
   it('should render children enabled if user has empty ownership and is admin', () => {
@@ -129,11 +130,10 @@ describe('HasOwnership', () => {
       .grnPermissions(Immutable.List([]))
       .permissions(Immutable.List(['*']))
       .build();
-    const { queryByText } = render(
-      <SimpleHasOwnership currentUser={user} id={id} type={type} />,
-    );
+    asMock(useCurrentUser).mockReturnValue(user);
+    render(<SimpleHasOwnership id={id} type={type} />);
 
-    expect(queryByText('enabled')).toBeTruthy();
+    expect(screen.getByText('enabled')).toBeTruthy();
   });
 
   it('should render children enabled if user has wrong ownership and is admin', () => {
@@ -141,11 +141,10 @@ describe('HasOwnership', () => {
       .grnPermissions(Immutable.List([otherGrnPermission]))
       .permissions(Immutable.List(['*']))
       .build();
-    const { queryByText } = render(
-      <SimpleHasOwnership currentUser={user} id={id} type={type} />,
-    );
+    asMock(useCurrentUser).mockReturnValue(user);
+    render(<SimpleHasOwnership id={id} type={type} />);
 
-    expect(queryByText('enabled')).toBeTruthy();
+    expect(screen.getByText('enabled')).toBeTruthy();
   });
 
   it('should hide children when configured', () => {
@@ -153,11 +152,10 @@ describe('HasOwnership', () => {
       .grnPermissions(Immutable.List([otherGrnPermission]))
       .permissions(Immutable.List([]))
       .build();
-    const { queryByText } = render(
-      <SimpleHasOwnership currentUser={user} id={id} type={type} hideChildren />,
-    );
+    asMock(useCurrentUser).mockReturnValue(user);
+    render(<SimpleHasOwnership id={id} type={type} hideChildren />);
 
-    expect(queryByText('disabled')).toBeFalsy();
-    expect(queryByText('enabled')).toBeFalsy();
+    expect(screen.queryByText('disabled')).not.toBeInTheDocument();
+    expect(screen.queryByText('enabled')).not.toBeInTheDocument();
   });
 });

--- a/graylog2-web-interface/src/components/common/HasOwnership.tsx
+++ b/graylog2-web-interface/src/components/common/HasOwnership.tsx
@@ -15,11 +15,10 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { useContext } from 'react';
 import PropTypes from 'prop-types';
 
-import CurrentUserContext from 'contexts/CurrentUserContext';
 import { createGRN } from 'logic/permissions/GRN';
+import useCurrentUser from 'hooks/useCurrentUser';
 
 type ChildFun = ({ disabled: boolean }) => React.ReactElement;
 
@@ -31,7 +30,7 @@ type Props = {
 };
 
 const HasOwnership = ({ children, id, type, hideChildren }: Props) => {
-  const currentUser = useContext(CurrentUserContext);
+  const currentUser = useCurrentUser();
   const entity = createGRN(type, id);
   const ownership = `entity:own:${entity}`;
   const adminPermission = '*';

--- a/graylog2-web-interface/src/components/common/IfPermitted.tsx
+++ b/graylog2-web-interface/src/components/common/IfPermitted.tsx
@@ -15,10 +15,9 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { useContext } from 'react';
 import PropTypes from 'prop-types';
 
-import CurrentUserContext from 'contexts/CurrentUserContext';
+import useCurrentUser from 'hooks/useCurrentUser';
 import { isPermitted, isAnyPermitted } from 'util/PermissionsMixin';
 
 /**
@@ -41,7 +40,7 @@ const _checkPermissions = (permissions, anyPermissions, currentUser) => {
 };
 
 const IfPermitted = ({ children, permissions, anyPermissions, ...rest }: Props) => {
-  const currentUser = useContext(CurrentUserContext);
+  const currentUser = useCurrentUser();
 
   if ((!permissions || permissions.length === 0) || (currentUser && _checkPermissions(permissions, anyPermissions, currentUser))) {
     return (

--- a/graylog2-web-interface/src/components/common/URLWhiteListFormModal.test.tsx
+++ b/graylog2-web-interface/src/components/common/URLWhiteListFormModal.test.tsx
@@ -17,15 +17,18 @@
 
 import React from 'react';
 import { screen, render } from 'wrappedTestingLibrary';
+import Immutable from 'immutable';
 
-import { adminUser, alice } from 'fixtures/users';
+import { adminUser } from 'fixtures/users';
 import MockAction from 'helpers/mocking/MockAction';
 import MockStore from 'helpers/mocking/StoreMock';
 import { asMock } from 'helpers/mocking';
-import CurrentUserContext from 'contexts/CurrentUserContext';
 import { ConfigurationsStore } from 'stores/configurations/ConfigurationsStore';
+import useCurrentUser from 'hooks/useCurrentUser';
 
 import URLWhiteListFormModal from './URLWhiteListFormModal';
+
+jest.mock('hooks/useCurrentUser');
 
 jest.mock('stores/configurations/ConfigurationsStore', () => ({
   ConfigurationsStore: MockStore(['getInitialState', jest.fn(() => ({
@@ -42,13 +45,15 @@ jest.mock('stores/configurations/ConfigurationsStore', () => ({
 }));
 
 describe('<URLWhiteListFormModal>', () => {
-  const renderSUT = (user = adminUser) => {
+  const renderSUT = () => {
     return render(
-      <CurrentUserContext.Provider value={user}>
-        <URLWhiteListFormModal newUrlEntry="http://graylog.com" urlType="literal" />
-      </CurrentUserContext.Provider>,
+      <URLWhiteListFormModal newUrlEntry="http://graylog.com" urlType="literal" />,
     );
   };
+
+  beforeEach(() => {
+    asMock(useCurrentUser).mockReturnValue(adminUser);
+  });
 
   it('renders elements to add URL to allow list', async () => {
     renderSUT();
@@ -67,7 +72,8 @@ describe('<URLWhiteListFormModal>', () => {
   });
 
   it('does not render if user has no permissions to add to allow list', () => {
-    renderSUT(alice);
+    asMock(useCurrentUser).mockReturnValue(adminUser.toBuilder().permissions(Immutable.List([])).build());
+    renderSUT();
 
     expect(screen.queryByRole('button', { name: /add to url whitelist/i })).not.toBeInTheDocument();
   });

--- a/graylog2-web-interface/src/components/common/URLWhiteListFormModal.tsx
+++ b/graylog2-web-interface/src/components/common/URLWhiteListFormModal.tsx
@@ -14,9 +14,10 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import React, { useCallback, useContext, useEffect, useState, useRef } from 'react';
+import React, { useCallback, useEffect, useState, useRef } from 'react';
 import PropTypes from 'prop-types';
 
+import useCurrentUser from 'hooks/useCurrentUser';
 import { useStore } from 'stores/connect';
 import { Button } from 'components/bootstrap';
 import BootstrapModalForm from 'components/bootstrap/BootstrapModalForm';
@@ -26,7 +27,6 @@ import { ConfigurationsActions, ConfigurationsStore } from 'stores/configuration
 // Explicit import to fix eslint import/no-cycle
 import IfPermitted from 'components/common/IfPermitted';
 import { isPermitted } from 'util/PermissionsMixin';
-import CurrentUserContext from 'contexts/CurrentUserContext';
 import generateId from 'logic/generateId';
 
 const URL_WHITELIST_CONFIG = 'org.graylog2.system.urlwhitelist.UrlWhitelist';
@@ -47,7 +47,7 @@ const URLWhiteListFormModal = ({ newUrlEntry, urlType, onUpdate }: Props) => {
   const { configuration } = useStore<ConfigurationsStoreState>(ConfigurationsStore);
   const urlWhiteListConfig = configuration[URL_WHITELIST_CONFIG];
 
-  const currentUser = useContext(CurrentUserContext);
+  const currentUser = useCurrentUser();
 
   useEffect(() => {
     if (isPermitted(currentUser.permissions, ['urlwhitelist:read'])) {

--- a/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitionEntry.test.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitionEntry.test.tsx
@@ -19,10 +19,10 @@ import * as Immutable from 'immutable';
 import { render, screen, fireEvent, waitFor } from 'wrappedTestingLibrary';
 
 import { asMock } from 'helpers/mocking';
-import { alice } from 'fixtures/users';
+import { adminUser } from 'fixtures/users';
 import { simpleEventDefinition } from 'fixtures/eventDefinition';
-import CurrentUserContext from 'contexts/CurrentUserContext';
 import useGetPermissionsByScope from 'hooks/useScopePermissions';
+import useCurrentUser from 'hooks/useCurrentUser';
 
 import EventDefinitionEntry from './EventDefinitionEntry';
 
@@ -40,38 +40,40 @@ type getPermissionsByScopeReturnType = {
   data: entityScope;
 };
 
+const currentUser = adminUser.toBuilder().permissions(Immutable.List([])).build();
+
 const exampleEntityScopeMutable: getPermissionsByScopeReturnType = { isLoading: false, data: { is_mutable: true } };
 const exampleEntityScopeImmutable: getPermissionsByScopeReturnType = { isLoading: false, data: { is_mutable: false } };
 
 jest.mock('components/permissions/EntityShareModal', () => () => <div>EntityShareModal content</div>);
 jest.mock('hooks/useScopePermissions', () => jest.fn());
+jest.mock('hooks/useCurrentUser');
 
 describe('EventDefinitionEntry', () => {
-  const renderSUT = (grnPermissions = [], permissions = [], scope = 'DEFAULT') => {
-    const currentUser = alice.toBuilder()
-      .grnPermissions(Immutable.List(grnPermissions))
-      .permissions(Immutable.List(permissions))
-      .build();
-
+  const renderSUT = (scope = 'DEFAULT') => {
     exampleEventDefinition._scope = scope;
 
     return (
-      <CurrentUserContext.Provider value={currentUser}>
-        <EventDefinitionEntry onDelete={() => { }}
-                              onCopy={() => { }}
-                              onDisable={() => { }}
-                              onEnable={() => { }}
-                              context={{ scheduler: {} }}
-                              eventDefinition={exampleEventDefinition} />
-      </CurrentUserContext.Provider>
+      <EventDefinitionEntry onDelete={() => { }}
+                            onCopy={() => { }}
+                            onDisable={() => { }}
+                            onEnable={() => { }}
+                            context={{ scheduler: {} }}
+                            eventDefinition={exampleEventDefinition} />
     );
   };
 
-  it('allows sharing for owners', async () => {
-    asMock(useGetPermissionsByScope).mockReturnValue(exampleEntityScopeMutable);
+  beforeEach(() => {
+    asMock(useCurrentUser).mockReturnValue(adminUser);
+  });
 
-    const grnPermissions = ['entity:own:grn::::event_definition:event-definition-id'];
-    render(renderSUT(grnPermissions));
+  it('allows sharing for owners', async () => {
+    const user = currentUser.toBuilder()
+      .grnPermissions(Immutable.List(['entity:own:grn::::event_definition:event-definition-id']))
+      .build();
+    asMock(useCurrentUser).mockReturnValue(user);
+    asMock(useGetPermissionsByScope).mockReturnValue(exampleEntityScopeMutable);
+    render(renderSUT());
 
     const button = screen.getAllByRole('button', { name: /Share/ })[0];
     fireEvent.click(button);
@@ -81,8 +83,8 @@ describe('EventDefinitionEntry', () => {
 
   it('allows sharing for admins', async () => {
     asMock(useGetPermissionsByScope).mockReturnValue(exampleEntityScopeMutable);
-
-    render(renderSUT([], ['*']));
+    asMock(useCurrentUser).mockReturnValue(adminUser);
+    render(renderSUT());
 
     const button = screen.getAllByRole('button', { name: /Share/ })[0];
     fireEvent.click(button);
@@ -91,10 +93,13 @@ describe('EventDefinitionEntry', () => {
   });
 
   it('does not allow sharing for viewer', () => {
+    const user = currentUser.toBuilder()
+      .grnPermissions(Immutable.List(['entity:view:grn::::event_definition:event-definition-id']))
+      .build();
+    asMock(useCurrentUser).mockReturnValue(user);
     asMock(useGetPermissionsByScope).mockReturnValue(exampleEntityScopeMutable);
 
-    const grnPermissions = ['entity:view:grn::::event_definition:event-definition-id'];
-    render(renderSUT(grnPermissions));
+    render(renderSUT());
 
     expect(screen.getAllByRole('button', { name: /Share/ })[1]).toHaveAttribute('disabled');
   });
@@ -102,7 +107,7 @@ describe('EventDefinitionEntry', () => {
   it('shows "edit" button', async () => {
     asMock(useGetPermissionsByScope).mockReturnValue(exampleEntityScopeMutable);
 
-    render(renderSUT([], ['*'], 'DEFAULT'));
+    render(renderSUT('DEFAULT'));
 
     await waitFor(() => {
       expect(screen.getAllByTestId('edit-button')[0]).toBeVisible();
@@ -112,7 +117,7 @@ describe('EventDefinitionEntry', () => {
   it('hides "edit" button for immutable definitions', async () => {
     asMock(useGetPermissionsByScope).mockReturnValue(exampleEntityScopeImmutable);
 
-    render(renderSUT([], ['*'], 'ILLUMINATE'));
+    render(renderSUT('ILLUMINATE'));
 
     await waitFor(() => {
       expect(screen.queryByTestId('edit-button')).toBeNull();
@@ -122,7 +127,7 @@ describe('EventDefinitionEntry', () => {
   it('shows "delete" button', async () => {
     asMock(useGetPermissionsByScope).mockReturnValue(exampleEntityScopeMutable);
 
-    render(renderSUT([], ['*'], 'DEFAULT'));
+    render(renderSUT('DEFAULT'));
 
     await waitFor(() => {
       expect(screen.getAllByTestId('delete-button')[0]).toBeVisible();
@@ -132,7 +137,7 @@ describe('EventDefinitionEntry', () => {
   it('hides "delete" button for immutable definitions', async () => {
     asMock(useGetPermissionsByScope).mockReturnValue(exampleEntityScopeImmutable);
 
-    render(renderSUT([], ['*'], 'ILLUMINATE'));
+    render(renderSUT('ILLUMINATE'));
 
     await waitFor(() => {
       expect(screen.queryByTestId('delete-button')).toBeNull();

--- a/graylog2-web-interface/src/components/indexers/IndexerClusterHealth.tsx
+++ b/graylog2-web-interface/src/components/indexers/IndexerClusterHealth.tsx
@@ -14,7 +14,7 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import React, { useContext } from 'react';
+import React from 'react';
 import { useQueries } from 'react-query';
 
 import { isPermitted } from 'util/PermissionsMixin';
@@ -27,7 +27,7 @@ import type FetchError from 'logic/errors/FetchError';
 import ApiRoutes from 'routing/ApiRoutes';
 import fetch from 'logic/rest/FetchProvider';
 import * as URLUtils from 'util/URLUtils';
-import CurrentUserContext from 'contexts/CurrentUserContext';
+import useCurrentUser from 'hooks/useCurrentUser';
 
 import IndexerClusterHealthError from './IndexerClusterHealthError';
 
@@ -70,7 +70,7 @@ const useLoadHealthAndName = (enabled: boolean) => {
 };
 
 const IndexerClusterHealth = ({ minimal }: Props) => {
-  const currentUser = useContext(CurrentUserContext);
+  const currentUser = useCurrentUser();
   const userHasRequiredPermissions = isPermitted(currentUser.permissions, 'indexercluster:read');
   const { health, name, loading, error, isSuccess } = useLoadHealthAndName(userHasRequiredPermissions);
 

--- a/graylog2-web-interface/src/components/navigation/Navigation.tsx
+++ b/graylog2-web-interface/src/components/navigation/Navigation.tsx
@@ -15,7 +15,6 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { useContext } from 'react';
 import { useLocation } from 'react-router-dom';
 import { PluginStore } from 'graylog-web-plugin/plugin';
 import type { PluginNavigationDropdownItem, PluginNavigation } from 'graylog-web-plugin';
@@ -27,7 +26,7 @@ import { appPrefixed } from 'util/URLUtils';
 import AppConfig from 'util/AppConfig';
 import { Navbar, Nav, NavItem, NavDropdown } from 'components/bootstrap';
 import { isPermitted } from 'util/PermissionsMixin';
-import CurrentUserContext from 'contexts/CurrentUserContext';
+import useCurrentUser from 'hooks/useCurrentUser';
 import GlobalThroughput from 'components/throughput/GlobalThroughput';
 import Routes, { ENTERPRISE_ROUTE_DESCRIPTION, SECURITY_ROUTE_DESCRIPTION } from 'routing/Routes';
 
@@ -100,7 +99,7 @@ type Props = {
 };
 
 const Navigation = React.memo(({ pathname }: Props) => {
-  const currentUser = useContext(CurrentUserContext);
+  const currentUser = useCurrentUser();
   const { permissions, fullName, readOnly, id: userId } = currentUser || {};
 
   const pluginExports = PluginStore.exports('navigation');

--- a/graylog2-web-interface/src/components/navigation/SystemMenu.test.tsx
+++ b/graylog2-web-interface/src/components/navigation/SystemMenu.test.tsx
@@ -17,9 +17,12 @@
 import * as React from 'react';
 import * as Immutable from 'immutable';
 import { mount } from 'wrappedEnzyme';
+import { useLocation } from 'react-router-dom';
+import type { Location } from 'history';
 
-import { alice } from 'fixtures/users';
-import CurrentUserContext from 'contexts/CurrentUserContext';
+import { asMock } from 'helpers/mocking';
+import useCurrentUser from 'hooks/useCurrentUser';
+import { adminUser } from 'fixtures/users';
 
 import AppConfig from '../../util/AppConfig';
 
@@ -34,7 +37,12 @@ jest.mock('util/AppConfig', () => ({
   isCloud: jest.fn(() => false),
 }));
 
-jest.mock('routing/withLocation', () => (x) => x);
+jest.mock('hooks/useCurrentUser');
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useLocation: jest.fn(),
+}));
 
 describe('SystemMenu', () => {
   let exports;
@@ -46,24 +54,9 @@ describe('SystemMenu', () => {
 
     jest.doMock('graylog-web-plugin/plugin', () => ({ PluginStore }));
     AppConfig.gl2AppPathPrefix = jest.fn(() => '');
+    asMock(useLocation).mockReturnValue({ pathname: '/' } as Location<{ pathname: string }>);
+    asMock(useCurrentUser).mockReturnValue(adminUser.toBuilder().permissions(Immutable.List([])).build());
   });
-
-  const SimpleSystemMenu = ({ permissions, component: Component, location }: { permissions?: Array<string>, component: any, location?: { pathname: string }}) => {
-    const currentUser = alice.toBuilder()
-      .permissions(Immutable.List(permissions ?? []))
-      .build();
-
-    return (
-      <CurrentUserContext.Provider value={currentUser}>
-        <Component location={location} />
-      </CurrentUserContext.Provider>
-    );
-  };
-
-  SimpleSystemMenu.defaultProps = {
-    permissions: [],
-    location: { pathname: '/' },
-  };
 
   describe('uses correct permissions:', () => {
     let SystemMenu;
@@ -74,7 +67,11 @@ describe('SystemMenu', () => {
     });
 
     const verifyPermissions = ({ permissions, count, links }) => {
-      const wrapper = mount(<SimpleSystemMenu component={SystemMenu} permissions={permissions} />);
+      asMock(useCurrentUser).mockReturnValue(adminUser.toBuilder()
+        .permissions(Immutable.List(permissions))
+        .build());
+
+      const wrapper = mount(<SystemMenu />);
       const navigationLinks = wrapper.find('NavigationLink');
 
       expect(navigationLinks).toHaveLength(count);
@@ -119,7 +116,7 @@ describe('SystemMenu', () => {
     });
 
     it('includes plugin item in system navigation', () => {
-      const wrapper = mount(<SimpleSystemMenu component={SystemMenu} />);
+      const wrapper = mount(<SystemMenu />);
       containsLink(wrapper, 'Audit Log');
 
       expect(findLink(wrapper, 'Audit Log')).toHaveProp('path', '/system/auditlog');
@@ -127,21 +124,29 @@ describe('SystemMenu', () => {
     });
 
     it('includes plugin item in system navigation if required permissions are present', () => {
-      const wrapper = mount(<SimpleSystemMenu component={SystemMenu} permissions={['inputs:create']} />);
+      asMock(useCurrentUser).mockReturnValue(adminUser.toBuilder()
+        .permissions(Immutable.List(['inputs:create']))
+        .build());
+
+      const wrapper = mount(<SystemMenu />);
 
       containsLink(wrapper, 'Audit Log');
       containsLink(wrapper, 'Licenses');
     });
 
     it('does not include plugin item in system navigation if required permissions are not present', () => {
-      const wrapper = mount(<SimpleSystemMenu component={SystemMenu} permissions={[]} />);
+      asMock(useCurrentUser).mockReturnValue(adminUser.toBuilder()
+        .permissions(Immutable.List([]))
+        .build());
+
+      const wrapper = mount(<SystemMenu />);
 
       expect(findLink(wrapper, 'Licenses')).not.toExist();
     });
 
     it('prefixes plugin path with current application path prefix', () => {
       AppConfig.gl2AppPathPrefix = jest.fn(() => '/my/fancy/prefix');
-      const wrapper = mount(<SimpleSystemMenu component={SystemMenu} />);
+      const wrapper = mount(<SystemMenu />);
 
       expect(findLink(wrapper, 'Audit Log')).toHaveProp('path', '/my/fancy/prefix/system/auditlog');
     });
@@ -165,19 +170,21 @@ describe('SystemMenu', () => {
     });
 
     it('uses a default title if location is not matched', () => {
-      const wrapper = mount(<SimpleSystemMenu component={SystemMenu} />);
+      const wrapper = mount(<SystemMenu />);
 
       expect(wrapper.find('NavDropdown').at(1)).toHaveProp('title', 'System');
     });
 
     it('uses a custom title if location is matched', () => {
-      const wrapper = mount(<SimpleSystemMenu component={SystemMenu} location={{ pathname: '/system/overview' }} />);
+      asMock(useLocation).mockReturnValue({ pathname: '/system/overview' } as Location<{ pathname: string }>);
+      const wrapper = mount(<SystemMenu />);
 
       expect(wrapper.find('NavDropdown').at(1)).toHaveProp('title', 'System / Overview');
     });
 
     it('uses a custom title for a plugin route if location is matched', () => {
-      const wrapper = mount(<SimpleSystemMenu component={SystemMenu} location={{ pathname: '/system/licenses' }} />);
+      asMock(useLocation).mockReturnValue({ pathname: '/system/licenses' } as Location<{ pathname: string }>);
+      const wrapper = mount(<SystemMenu />);
 
       expect(wrapper.find('NavDropdown').at(1)).toHaveProp('title', 'System / Licenses');
     });

--- a/graylog2-web-interface/src/components/permissions/SharedEntitiesOverview/SharedEntitiesOverviewItem/OwnersCell.tsx
+++ b/graylog2-web-interface/src/components/permissions/SharedEntitiesOverview/SharedEntitiesOverviewItem/OwnersCell.tsx
@@ -16,14 +16,13 @@
  */
 
 import * as React from 'react';
-import { useContext } from 'react';
 import type { List } from 'immutable';
 
 import { isPermitted } from 'util/PermissionsMixin';
 import type Grantee from 'logic/permissions/Grantee';
 import { Link } from 'components/common/router';
 import { defaultCompare } from 'logic/DefaultCompare';
-import CurrentUserContext from 'contexts/CurrentUserContext';
+import useCurrentUser from 'hooks/useCurrentUser';
 import type { GranteesList } from 'logic/permissions/EntityShareState';
 import { getShowRouteFromGRN } from 'logic/permissions/GRN';
 
@@ -55,7 +54,7 @@ const _getOwnerTitle = ({ type, id, title }: Grantee, userPermissions: List<stri
 };
 
 const OwnersCell = ({ owners }: Props) => {
-  const currentUser = useContext(CurrentUserContext);
+  const currentUser = useCurrentUser();
   const sortedOwners = owners.sort((o1, o2) => defaultCompare(o1.type, o2.type) || defaultCompare(o1.title, o2.title));
 
   return (

--- a/graylog2-web-interface/src/components/roles/RolesOverview/ActionsCell.tsx
+++ b/graylog2-web-interface/src/components/roles/RolesOverview/ActionsCell.tsx
@@ -72,14 +72,14 @@ const ActionsCell = ({ roleId, roleName, readOnly }: Props) => {
           </LinkContainer>
         </IfPermitted>
         {!readOnly && (
-        <IfPermitted permissions={[`roles:delete:${roleName}`]}>
-          <>
-            &nbsp;
-            <Button id={`delete-role-${roleId}`} bsStyle="danger" bsSize="xs" title={`Delete role ${roleName}`} onClick={() => _deleteRole(roleId, roleName, setDeleting)} type="button">
-              {deleting ? <Spinner text="Deleting" delay={0} /> : 'Delete'}
-            </Button>
-          </>
-        </IfPermitted>
+          <IfPermitted permissions={[`roles:delete:${roleName}`]}>
+            <>
+              &nbsp;
+              <Button id={`delete-role-${roleId}`} bsStyle="danger" bsSize="xs" title={`Delete role ${roleName}`} onClick={() => _deleteRole(roleId, roleName, setDeleting)} type="button">
+                {deleting ? <Spinner text="Deleting" delay={0} /> : 'Delete'}
+              </Button>
+            </>
+          </IfPermitted>
         )}
       </ActionsWrapper>
     </td>

--- a/graylog2-web-interface/src/components/users/UserDetails/UserDetails.test.tsx
+++ b/graylog2-web-interface/src/components/users/UserDetails/UserDetails.test.tsx
@@ -20,8 +20,6 @@ import { render, screen, waitFor } from 'wrappedTestingLibrary';
 
 import { paginatedShares } from 'fixtures/sharedEntities';
 import { reader as assignedRole } from 'fixtures/roles';
-import { alice } from 'fixtures/users';
-import CurrentUserContext from 'contexts/CurrentUserContext';
 import User from 'logic/users/User';
 
 import UserDetails from './UserDetails';
@@ -55,20 +53,13 @@ const user = User
   .timezone('Europe/Berlin')
   .build();
 
-describe('<UserDetails />', () => {
-  const currentUser = alice.toBuilder().permissions(Immutable.List(['*'])).build();
-  const SutComponent = (props) => (
-    <CurrentUserContext.Provider value={currentUser}>
-      <UserDetails {...props} />
-    </CurrentUserContext.Provider>
-  );
-
+describe('UserDetails', () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
 
   it('user profile should display profile information', async () => {
-    render(<SutComponent user={user} />);
+    render(<UserDetails user={user} />);
 
     await screen.findByText(user.username);
 
@@ -84,7 +75,7 @@ describe('<UserDetails />', () => {
 
   describe('user settings', () => {
     it('should display timezone', async () => {
-      render(<SutComponent user={user} />);
+      render(<UserDetails user={user} />);
 
       await waitFor(() => {
         if (!user.timezone) throw Error('timezone must be defined for provided user');
@@ -95,26 +86,26 @@ describe('<UserDetails />', () => {
 
     describe('should display session timeout in a readable format', () => {
       it('for seconds', async () => {
-        const test = user.toBuilder().sessionTimeoutMs(10000).build();
-        render(<SutComponent user={test} />);
+        const exampleUser = user.toBuilder().sessionTimeoutMs(10000).build();
+        render(<UserDetails user={exampleUser} />);
 
         await screen.findByText('10 Seconds');
       });
 
       it('for minutes', async () => {
-        render(<SutComponent user={user.toBuilder().sessionTimeoutMs(600000).build()} />);
+        render(<UserDetails user={user.toBuilder().sessionTimeoutMs(600000).build()} />);
 
         await screen.findByText('10 Minutes');
       });
 
       it('for hours', async () => {
-        render(<SutComponent user={user.toBuilder().sessionTimeoutMs(36000000).build()} />);
+        render(<UserDetails user={user.toBuilder().sessionTimeoutMs(36000000).build()} />);
 
         await screen.findByText('10 Hours');
       });
 
       it('for days', async () => {
-        render(<SutComponent user={user.toBuilder().sessionTimeoutMs(864000000).build()} />);
+        render(<UserDetails user={user.toBuilder().sessionTimeoutMs(864000000).build()} />);
 
         await screen.findByText('10 Days');
       });
@@ -123,7 +114,7 @@ describe('<UserDetails />', () => {
 
   describe('roles section', () => {
     it('should display assigned roles', async () => {
-      render(<SutComponent user={user} />);
+      render(<UserDetails user={user} />);
 
       await screen.findByText(assignedRole.name);
     });
@@ -131,7 +122,7 @@ describe('<UserDetails />', () => {
 
   describe('teams section', () => {
     it('should display info if license is not present', async () => {
-      render(<SutComponent user={user} />);
+      render(<UserDetails user={user} />);
 
       await screen.findByText(/Enterprise Feature/);
     });

--- a/graylog2-web-interface/src/components/users/UserEdit/PasswordSection.tsx
+++ b/graylog2-web-interface/src/components/users/UserEdit/PasswordSection.tsx
@@ -15,13 +15,12 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { useContext } from 'react';
 import { Formik, Form } from 'formik';
 import { PluginStore } from 'graylog-web-plugin/plugin';
 
 import AppConfig from 'util/AppConfig';
 import UsersDomain from 'domainActions/users/UsersDomain';
-import CurrentUserContext from 'contexts/CurrentUserContext';
+import useCurrentUser from 'hooks/useCurrentUser';
 import { Button, Row, Col } from 'components/bootstrap';
 import { FormikFormGroup } from 'components/common';
 import type User from 'logic/users/User';
@@ -61,7 +60,7 @@ const _onSubmit = (formData, userId) => {
 };
 
 const PasswordSection = ({ user: { id } }: Props) => {
-  const currentUser = useContext(CurrentUserContext);
+  const currentUser = useCurrentUser();
   let requiresOldPassword = true;
 
   if (isPermitted(currentUser?.permissions, 'users:passwordchange:*')) {

--- a/graylog2-web-interface/src/components/users/UserEdit/SettingsSection.test.tsx
+++ b/graylog2-web-interface/src/components/users/UserEdit/SettingsSection.test.tsx
@@ -19,10 +19,9 @@ import { render, fireEvent, waitFor, screen } from 'wrappedTestingLibrary';
 import selectEvent from 'react-select-event';
 import { List } from 'immutable';
 
-import { alice, adminUser } from 'fixtures/users';
+import { alice } from 'fixtures/users';
 import SharedEntity from 'logic/permissions/SharedEntity';
 import Grantee from 'logic/permissions/Grantee';
-import CurrentUserContext from 'contexts/CurrentUserContext';
 
 import SettingsSection from './SettingsSection';
 
@@ -68,11 +67,7 @@ describe('<SettingsSection />', () => {
   it('should allow session timeout name and timezone change', async () => {
     const onSubmitStub = jest.fn();
 
-    render(
-      <CurrentUserContext.Provider value={adminUser}>
-        <SettingsSection user={exampleUser} onSubmit={(data) => onSubmitStub(data)} />
-      </CurrentUserContext.Provider>,
-    );
+    render(<SettingsSection user={exampleUser} onSubmit={(data) => onSubmitStub(data)} />);
 
     const timeoutAmountInput = screen.getByPlaceholderText('Timeout amount');
     const timezoneSelect = screen.getByLabelText('Time Zone');

--- a/graylog2-web-interface/src/components/users/UserEdit/UserEdit.test.tsx
+++ b/graylog2-web-interface/src/components/users/UserEdit/UserEdit.test.tsx
@@ -18,7 +18,6 @@ import React from 'react';
 import { screen, render, act } from 'wrappedTestingLibrary';
 
 import { adminUser, bob } from 'fixtures/users';
-import CurrentUserContext from 'contexts/CurrentUserContext';
 
 import UserEdit from './UserEdit';
 
@@ -34,18 +33,13 @@ describe('<UserEdit />', () => {
     jest.clearAllMocks();
   });
 
-  const currentUser = adminUser.toBuilder()
+  const user = adminUser.toBuilder()
     .readOnly(false)
     .external(false)
     .build();
-  const SimpleUserEdit = (props) => (
-    <CurrentUserContext.Provider value={currentUser}>
-      <UserEdit {...props} />
-    </CurrentUserContext.Provider>
-  );
 
   it('should display loading indicator, if no user is provided', async () => {
-    render(<SimpleUserEdit user={undefined} />);
+    render(<UserEdit user={undefined} />);
 
     act(() => {
       jest.advanceTimersByTime(200);
@@ -55,18 +49,18 @@ describe('<UserEdit />', () => {
   });
 
   it('should not allow editing a readOnly user', () => {
-    const readOnlyUser = currentUser.toBuilder()
+    const readOnlyUser = user.toBuilder()
       .readOnly(true)
       .fullName('Full name')
       .build();
-    render(<SimpleUserEdit user={readOnlyUser} />);
+    render(<UserEdit user={readOnlyUser} />);
 
     expect(screen.getByText(`The selected user ${readOnlyUser.fullName} can't be edited.`)).toBeInTheDocument();
     expect(screen.queryByText('Profile')).not.toBeInTheDocument();
   });
 
   it('should display profile, settings and password section', () => {
-    render(<SimpleUserEdit user={currentUser} />);
+    render(<UserEdit user={user} />);
 
     expect(screen.getByText('ProfileSection')).toBeInTheDocument();
     expect(screen.getByText('SettingsSection')).toBeInTheDocument();
@@ -76,7 +70,7 @@ describe('<UserEdit />', () => {
 
   describe('external user', () => {
     it('should not render profile section for external user', () => {
-      render(<SimpleUserEdit user={bob} />);
+      render(<UserEdit user={bob} />);
 
       expect(bob.external).toBeTruthy();
       expect(screen.queryByLabelText('Full Name')).not.toBeInTheDocument();

--- a/graylog2-web-interface/src/components/users/UserEdit/UserEdit.tsx
+++ b/graylog2-web-interface/src/components/users/UserEdit/UserEdit.tsx
@@ -15,10 +15,9 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { useContext } from 'react';
 
 import UsersDomain from 'domainActions/users/UsersDomain';
-import CurrentUserContext from 'contexts/CurrentUserContext';
+import useCurrentUser from 'hooks/useCurrentUser';
 import { Spinner, IfPermitted } from 'components/common';
 import { Alert } from 'components/bootstrap';
 import SectionComponent from 'components/common/Section/SectionComponent';
@@ -49,7 +48,7 @@ const _updateUser = (data, currentUser, userId, fullName) => {
 };
 
 const UserEdit = ({ user }: Props) => {
-  const currentUser = useContext(CurrentUserContext);
+  const currentUser = useCurrentUser();
 
   if (!user) {
     return <Spinner />;

--- a/graylog2-web-interface/src/components/users/UsersOverview/UserOverviewItem/ActionsCell.tsx
+++ b/graylog2-web-interface/src/components/users/UsersOverview/UserOverviewItem/ActionsCell.tsx
@@ -15,10 +15,9 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { useContext } from 'react';
 import styled from 'styled-components';
 
-import CurrentUserContext from 'contexts/CurrentUserContext';
+import useCurrentUser from 'hooks/useCurrentUser';
 import { LinkContainer } from 'components/common/router';
 import type UserOverview from 'logic/users/UserOverview';
 import UsersDomain from 'domainActions/users/UsersDomain';
@@ -67,7 +66,7 @@ const ReadOnlyActions = ({ user }: { user: UserOverview }) => {
 };
 
 const EditActions = ({ user, user: { username, id, fullName, accountStatus, external, readOnly } }: { user: UserOverview }) => {
-  const currentUser = useContext(CurrentUserContext);
+  const currentUser = useCurrentUser();
 
   const _toggleStatus = () => {
     if (accountStatus === 'enabled') {

--- a/graylog2-web-interface/src/components/users/UsersOverview/UsersOverview.test.tsx
+++ b/graylog2-web-interface/src/components/users/UsersOverview/UsersOverview.test.tsx
@@ -18,11 +18,9 @@ import * as React from 'react';
 import * as Immutable from 'immutable';
 import { render, waitFor, fireEvent, screen } from 'wrappedTestingLibrary';
 
-import { adminUser as currentUser } from 'fixtures/users';
 import { paginatedUsers, alice, bob, admin as adminOverview } from 'fixtures/userOverviews';
 import asMock from 'helpers/mocking/AsMock';
 import mockAction from 'helpers/mocking/MockAction';
-import CurrentUserContext from 'contexts/CurrentUserContext';
 import { UsersActions } from 'stores/users/UsersStore';
 
 import UsersOverview from './UsersOverview';
@@ -106,12 +104,6 @@ describe('UsersOverview', () => {
     const readOnlyUsersList = Immutable.List([readOnlyUser]);
     let oldConfirm;
 
-    const UsersOverviewAsAdmin = () => (
-      <CurrentUserContext.Provider value={currentUser}>
-        <UsersOverview />
-      </CurrentUserContext.Provider>
-    );
-
     beforeEach(() => {
       oldConfirm = window.confirm;
       window.confirm = jest.fn(() => true);
@@ -124,7 +116,7 @@ describe('UsersOverview', () => {
     it('be able to delete a modifiable user', async () => {
       const loadUsersPaginatedPromise = Promise.resolve({ ...paginatedUsers, list: modifiableUsersList });
       asMock(UsersActions.loadUsersPaginated).mockReturnValueOnce(loadUsersPaginatedPromise);
-      render(<UsersOverviewAsAdmin />);
+      render(<UsersOverview />);
 
       const deleteButton = await screen.findByTitle(`Delete user ${modifiableUser.fullName}`);
       fireEvent.click(deleteButton);
@@ -137,14 +129,14 @@ describe('UsersOverview', () => {
 
     it('not be able to delete a "read only" user', async () => {
       asMock(UsersActions.loadUsersPaginated).mockReturnValueOnce(Promise.resolve({ ...paginatedUsers, list: readOnlyUsersList }));
-      render(<UsersOverviewAsAdmin />);
+      render(<UsersOverview />);
 
       await waitFor(() => expect(screen.queryByTitle(`Delete user ${readOnlyUser.fullName}`)).not.toBeInTheDocument());
     });
 
     it('see edit and edit tokens link for a modifiable user', async () => {
       asMock(UsersActions.loadUsersPaginated).mockReturnValueOnce(Promise.resolve({ ...paginatedUsers, list: modifiableUsersList }));
-      render(<UsersOverviewAsAdmin />);
+      render(<UsersOverview />);
 
       await screen.findByTitle(`Edit user ${modifiableUser.fullName}`);
 
@@ -153,14 +145,14 @@ describe('UsersOverview', () => {
 
     it('not see edit link for a "read only" user', async () => {
       asMock(UsersActions.loadUsersPaginated).mockReturnValueOnce(Promise.resolve({ ...paginatedUsers, list: readOnlyUsersList }));
-      render(<UsersOverviewAsAdmin />);
+      render(<UsersOverview />);
 
       await waitFor(() => expect(screen.queryByTitle(`Edit user ${readOnlyUser.fullName}`)).not.toBeInTheDocument());
     });
 
     it('see edit tokens link for a "read only" user', async () => {
       asMock(UsersActions.loadUsersPaginated).mockReturnValueOnce(Promise.resolve({ ...paginatedUsers, list: readOnlyUsersList }));
-      render(<UsersOverviewAsAdmin />);
+      render(<UsersOverview />);
 
       await screen.findByTitle(`Edit tokens of user ${readOnlyUser.fullName}`);
     });

--- a/graylog2-web-interface/src/components/users/UsersOverview/UsersOverview.tsx
+++ b/graylog2-web-interface/src/components/users/UsersOverview/UsersOverview.tsx
@@ -15,13 +15,13 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { useEffect, useContext, useState } from 'react';
+import { useEffect, useState } from 'react';
 import styled, { css } from 'styled-components';
 
 import type { PaginatedUsers } from 'stores/users/UsersStore';
 import UsersDomain from 'domainActions/users/UsersDomain';
 import { UsersActions } from 'stores/users/UsersStore';
-import CurrentUserContext from 'contexts/CurrentUserContext';
+import useCurrentUser from 'hooks/useCurrentUser';
 import { DataTable, Spinner, PaginatedList, EmptyResult } from 'components/common';
 import { Col, Row } from 'components/bootstrap';
 import type UserOverview from 'logic/users/UserOverview';
@@ -85,7 +85,7 @@ const _updateListOnUserDelete = (perPage, query, setPagination) => UsersActions.
 const _updateListOnUserSetStatus = (pagination, setLoading, setPaginatedUsers) => UsersActions.setStatus.completed.listen(() => _loadUsers(pagination, setLoading, setPaginatedUsers));
 
 const UsersOverview = () => {
-  const currentUser = useContext(CurrentUserContext);
+  const currentUser = useCurrentUser();
   const [paginatedUsers, setPaginatedUsers] = useState<PaginatedUsers | undefined>();
   const [loading, setLoading] = useState(false);
   const [pagination, setPagination] = useState(DEFAULT_PAGINATION);

--- a/graylog2-web-interface/src/contexts/CurrentUserPreferencesProvider.tsx
+++ b/graylog2-web-interface/src/contexts/CurrentUserPreferencesProvider.tsx
@@ -15,14 +15,14 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { useContext } from 'react';
 import PropTypes from 'prop-types';
 
+import useCurrentUser from 'hooks/useCurrentUser';
+
 import UserPreferencesContext from './UserPreferencesContext';
-import CurrentUserContext from './CurrentUserContext';
 
 const CurrentUserPreferencesProvider = ({ children }: { children: React.ReactElement }) => {
-  const currentUser = useContext(CurrentUserContext);
+  const currentUser = useCurrentUser();
   const preferences = currentUser?.preferences;
 
   return preferences

--- a/graylog2-web-interface/src/contexts/CurrentUserProvider.test.tsx
+++ b/graylog2-web-interface/src/contexts/CurrentUserProvider.test.tsx
@@ -37,6 +37,7 @@ describe('CurrentUserProvider', () => {
           {consume}
         </CurrentUserContext.Consumer>
       </CurrentUserProvider>,
+      { wrapper: undefined },
     );
 
     return consume;

--- a/graylog2-web-interface/src/contexts/CurrentUserProvider.tsx
+++ b/graylog2-web-interface/src/contexts/CurrentUserProvider.tsx
@@ -24,7 +24,7 @@ import { CurrentUserStore } from 'stores/users/CurrentUserStore';
 
 import CurrentUserContext from './CurrentUserContext';
 
-const CurrentUserProvider = ({ children }: { children: JSX.Element }) => {
+const CurrentUserProvider = ({ children }) => {
   const currentUserJSON = useStore(CurrentUserStore, (state) => get(state, 'currentUser'));
   const currentUser = currentUserJSON ? User.fromJSON(currentUserJSON) : undefined;
 
@@ -37,29 +37,8 @@ const CurrentUserProvider = ({ children }: { children: JSX.Element }) => {
     : children;
 };
 
-const UserProvider = ({ children, user: userOverride }: { children: JSX.Element, user?: User}) => {
-  if (userOverride) {
-    return (
-      <CurrentUserContext.Provider value={userOverride}>
-        {children}
-      </CurrentUserContext.Provider>
-    );
-  }
-
-  return (
-    <CurrentUserProvider>
-      {children}
-    </CurrentUserProvider>
-  );
-};
-
-UserProvider.propTypes = {
+CurrentUserProvider.propTypes = {
   children: PropTypes.node.isRequired,
-  user: PropTypes.object,
 };
 
-UserProvider.defaultProps = {
-  user: PropTypes.object,
-};
-
-export default UserProvider;
+export default CurrentUserProvider;

--- a/graylog2-web-interface/src/contexts/CurrentUserProvider.tsx
+++ b/graylog2-web-interface/src/contexts/CurrentUserProvider.tsx
@@ -24,7 +24,7 @@ import { CurrentUserStore } from 'stores/users/CurrentUserStore';
 
 import CurrentUserContext from './CurrentUserContext';
 
-const CurrentUserProvider = ({ children }) => {
+const CurrentUserProvider = ({ children }: { children: JSX.Element }) => {
   const currentUserJSON = useStore(CurrentUserStore, (state) => get(state, 'currentUser'));
   const currentUser = currentUserJSON ? User.fromJSON(currentUserJSON) : undefined;
 
@@ -37,8 +37,29 @@ const CurrentUserProvider = ({ children }) => {
     : children;
 };
 
-CurrentUserProvider.propTypes = {
-  children: PropTypes.node.isRequired,
+const UserProvider = ({ children, user: userOverride }: { children: JSX.Element, user?: User}) => {
+  if (userOverride) {
+    return (
+      <CurrentUserContext.Provider value={userOverride}>
+        {children}
+      </CurrentUserContext.Provider>
+    );
+  }
+
+  return (
+    <CurrentUserProvider>
+      {children}
+    </CurrentUserProvider>
+  );
 };
 
-export default CurrentUserProvider;
+UserProvider.propTypes = {
+  children: PropTypes.node.isRequired,
+  user: PropTypes.object,
+};
+
+UserProvider.defaultProps = {
+  user: PropTypes.object,
+};
+
+export default UserProvider;

--- a/graylog2-web-interface/src/contexts/UserDateTimeProvider.tsx
+++ b/graylog2-web-interface/src/contexts/UserDateTimeProvider.tsx
@@ -15,11 +15,11 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { useCallback, useMemo, useContext } from 'react';
+import { useCallback, useMemo } from 'react';
 
 import UserDateTimeContext from 'contexts/UserDateTimeContext';
 import AppConfig from 'util/AppConfig';
-import CurrentUserContext from 'contexts/CurrentUserContext';
+import useCurrentUser from 'hooks/useCurrentUser';
 import type { DateTime, DateTimeFormats } from 'util/DateTime';
 import { DATE_TIME_FORMATS, getBrowserTimezone, toDateObject } from 'util/DateTime';
 
@@ -63,7 +63,7 @@ const StaticTimezoneProvider = ({ children, tz }: Required<Props>) => {
 };
 
 const CurrentUserDateTimeProvider = ({ children }: Omit<Props, 'tz'>) => {
-  const currentUser = useContext(CurrentUserContext);
+  const currentUser = useCurrentUser();
   const userTimezone = useMemo(() => getUserTimezone(currentUser?.timezone), [currentUser?.timezone]);
 
   return (

--- a/graylog2-web-interface/src/hooks/__mocks__/useCurrentUser.ts
+++ b/graylog2-web-interface/src/hooks/__mocks__/useCurrentUser.ts
@@ -14,18 +14,8 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
+import { adminUser } from 'fixtures/users';
 
-import type { DateTime } from 'util/DateTime';
-import { adjustFormat, toDateObject } from 'util/DateTime';
-import type { UserDateTimeContextType } from 'contexts/UserDateTimeContext';
+const useCurrentUser = jest.fn(() => adminUser);
 
-const userTimezone = 'Europe/Berlin';
-const userDateTimeContextValue: UserDateTimeContextType = {
-  formatTime: (dateTime: DateTime) => adjustFormat(dateTime),
-  toUserTimezone: (dateTime: DateTime) => toDateObject(dateTime, undefined, userTimezone),
-  userTimezone,
-};
-
-const useUserDateTimeMock = jest.fn(() => userDateTimeContextValue);
-
-export default useUserDateTimeMock;
+export default useCurrentUser;

--- a/graylog2-web-interface/src/hooks/useCurrentUser.test.tsx
+++ b/graylog2-web-interface/src/hooks/useCurrentUser.test.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react';
+import { renderHook } from '@testing-library/react-hooks';
+
+import { adminUser } from 'fixtures/users';
+import CurrentUserContext from 'contexts/CurrentUserContext';
+import useCurrentUser from 'hooks/useCurrentUser';
+
+describe('useCurrentUser', () => {
+  it('should return value of CurrentUserContext', () => {
+    const Wrapper = ({ children }: {children: React.ReactNode}) => (
+      <CurrentUserContext.Provider value={adminUser}>
+        {children}
+      </CurrentUserContext.Provider>
+    );
+
+    const { result } = renderHook(() => useCurrentUser(), { wrapper: Wrapper });
+
+    expect(result.current).toBe(adminUser);
+  });
+
+  it('should throw error when being used outside of CurrentUserContext.Provider', () => {
+    const result = renderHook(() => useCurrentUser());
+
+    expect(result.result.error).toEqual(new Error('useCurrentUser hook needs to be used inside CurrentUserContext.Provider'));
+  });
+});

--- a/graylog2-web-interface/src/hooks/useCurrentUser.test.tsx
+++ b/graylog2-web-interface/src/hooks/useCurrentUser.test.tsx
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 import * as React from 'react';
 import { renderHook } from '@testing-library/react-hooks';
 

--- a/graylog2-web-interface/src/hooks/useCurrentUser.ts
+++ b/graylog2-web-interface/src/hooks/useCurrentUser.ts
@@ -14,7 +14,6 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-
 import { useContext } from 'react';
 
 import CurrentUserContext from 'contexts/CurrentUserContext';

--- a/graylog2-web-interface/src/hooks/useCurrentUser.ts
+++ b/graylog2-web-interface/src/hooks/useCurrentUser.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+
+import { useContext } from 'react';
+
+import CurrentUserContext from 'contexts/CurrentUserContext';
+
+const useCurrentUser = () => {
+  const currentUser = useContext(CurrentUserContext);
+
+  if (!currentUser) {
+    throw new Error('useCurrentUser hook needs to be used inside CurrentUserContext.Provider');
+  }
+
+  return currentUser;
+};
+
+export default useCurrentUser;

--- a/graylog2-web-interface/src/pages/ShowEventNotificationPage.jsx
+++ b/graylog2-web-interface/src/pages/ShowEventNotificationPage.jsx
@@ -15,11 +15,11 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { useContext, useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 
 import ErrorsActions from 'actions/errors/ErrorsActions';
-import CurrentUserContext from 'contexts/CurrentUserContext';
+import useCurrentUser from 'hooks/useCurrentUser';
 import { LinkContainer } from 'components/common/router';
 import { ButtonToolbar, Button } from 'components/bootstrap';
 import { createFromFetchError } from 'logic/errors/ReportedErrors';
@@ -37,7 +37,7 @@ import { EventNotificationsActions } from 'stores/event-notifications/EventNotif
 import {} from 'components/event-notifications/event-notification-types';
 
 const ShowEventDefinitionPage = ({ params: { notificationId } }) => {
-  const currentUser = useContext(CurrentUserContext) || {};
+  const currentUser = useCurrentUser();
   const [notification, setNotification] = useState();
 
   useEffect(() => {

--- a/graylog2-web-interface/src/pages/SidecarsPage.jsx
+++ b/graylog2-web-interface/src/pages/SidecarsPage.jsx
@@ -15,20 +15,20 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { useEffect, useState, useContext } from 'react';
+import { useEffect, useState } from 'react';
 
 import { LinkContainer, Link } from 'components/common/router';
 import { ButtonToolbar, Col, Row, Button } from 'components/bootstrap';
 import { DocumentTitle, PageHeader, Spinner } from 'components/common';
 import { isPermitted } from 'util/PermissionsMixin';
-import CurrentUserContext from 'contexts/CurrentUserContext';
+import useCurrentUser from 'hooks/useCurrentUser';
 import UsersDomain from 'domainActions/users/UsersDomain';
 import SidecarListContainer from 'components/sidecars/sidecars/SidecarListContainer';
 import Routes from 'routing/Routes';
 
 const SidecarsPage = () => {
   const [sidecarUser, setSidecarUser] = useState();
-  const currentUser = useContext(CurrentUserContext);
+  const currentUser = useCurrentUser();
   const canCreateSidecarUserTokens = isPermitted(currentUser?.permissions, ['users:tokenlist:graylog-sidecar']);
 
   useEffect(() => {

--- a/graylog2-web-interface/src/pages/UserTokensEditPage.tsx
+++ b/graylog2-web-interface/src/pages/UserTokensEditPage.tsx
@@ -15,12 +15,11 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { useEffect, useState, useContext, useCallback } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 
 import type User from 'logic/users/User';
 import withParams from 'routing/withParams';
 import { Row, Col } from 'components/bootstrap';
-import CurrentUserContext from 'contexts/CurrentUserContext';
 import { isPermitted } from 'util/PermissionsMixin';
 import DocsHelper from 'util/DocsHelper';
 import UsersDomain from 'domainActions/users/UsersDomain';
@@ -30,6 +29,7 @@ import TokenList from 'components/users/TokenList';
 import UserOverviewLinks from 'components/users/navigation/UserOverviewLinks';
 import UserActionLinks from 'components/users/navigation/UserActionLinks';
 import DocumentationLink from 'components/support/DocumentationLink';
+import useCurrentUser from 'hooks/useCurrentUser';
 
 type Props = {
   params: {
@@ -82,7 +82,7 @@ const _createToken = (tokenName, userId, loadTokens, setCreatingToken) => {
 };
 
 const UserEditPage = ({ params }: Props) => {
-  const currentUser = useContext(CurrentUserContext);
+  const currentUser = useCurrentUser();
   const [loadedUser, setLoadedUser] = useState<User | undefined>();
   const [tokens, setTokens] = useState([]);
   const [deletingTokenId, setDeletingTokenId] = useState();

--- a/graylog2-web-interface/src/pages/ViewEventDefinitionPage.tsx
+++ b/graylog2-web-interface/src/pages/ViewEventDefinitionPage.tsx
@@ -15,7 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { useState, useEffect, useContext } from 'react';
+import { useState, useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 
 import { useStore } from 'stores/connect';
@@ -24,8 +24,8 @@ import { ButtonToolbar, Col, Row, Button } from 'components/bootstrap';
 import Routes from 'routing/Routes';
 import DocsHelper from 'util/DocsHelper';
 import { DocumentTitle, IfPermitted, PageHeader, Spinner } from 'components/common';
-import CurrentUserContext from 'contexts/CurrentUserContext';
 import DocumentationLink from 'components/support/DocumentationLink';
+import useCurrentUser from 'hooks/useCurrentUser';
 import { isPermitted } from 'util/PermissionsMixin';
 import history from 'util/History';
 import EventDefinitionSummary from 'components/event-definitions/event-definition-form/EventDefinitionSummary';
@@ -34,7 +34,7 @@ import { EventNotificationsActions, EventNotificationsStore } from 'stores/event
 
 const ViewEventDefinitionPage = () => {
   const params = useParams<{definitionId?: string}>();
-  const currentUser = useContext(CurrentUserContext);
+  const currentUser = useCurrentUser();
   const [eventDefinition, setEventDefinition] = useState<{ title: string } | undefined>();
   const { all: notifications } = useStore(EventNotificationsStore);
 

--- a/graylog2-web-interface/src/routing/AppRouter.test.tsx
+++ b/graylog2-web-interface/src/routing/AppRouter.test.tsx
@@ -20,8 +20,6 @@ import { render, screen } from 'wrappedTestingLibrary';
 import mockComponent from 'helpers/mocking/MockComponent';
 import { StoreMock as MockStore } from 'helpers/mocking';
 import asMock from 'helpers/mocking/AsMock';
-import { adminUser as currentUser } from 'fixtures/users';
-import CurrentUserContext from 'contexts/CurrentUserContext';
 import usePluginEntities from 'views/logic/usePluginEntities';
 import history from 'util/History';
 import AppConfig from 'util/AppConfig';
@@ -38,7 +36,6 @@ jest.mock('components/errors/RouterErrorBoundary', () => mockComponent('RouterEr
 
 jest.mock('pages/StartPage', () => () => <>This is the start page</>);
 jest.mock('views/logic/usePluginEntities');
-jest.mock('stores/users/CurrentUserStore', () => ({ CurrentUserStore: MockStore() }));
 
 jest.mock('util/AppConfig', () => ({
   gl2AppPathPrefix: jest.fn(() => ''),
@@ -54,20 +51,14 @@ describe('AppRouter', () => {
     AppConfig.isFeatureEnabled = jest.fn(() => false);
   });
 
-  const AppRouterWithContext = () => (
-    <CurrentUserContext.Provider value={currentUser}>
-      <AppRouter />
-    </CurrentUserContext.Provider>
-  );
-
   it('routes to Getting Started Page for `/` or empty location', async () => {
-    const { findByText } = render(<AppRouterWithContext />);
+    const { findByText } = render(<AppRouter />);
 
     await findByText('This is the start page');
   });
 
   it('renders a not found page for unknown URLs', async () => {
-    const { findByText } = render(<AppRouterWithContext />);
+    const { findByText } = render(<AppRouter />);
 
     history.push('/this-url-is-not-registered-and-should-never-be');
 
@@ -77,7 +68,7 @@ describe('AppRouter', () => {
   describe('plugin routes', () => {
     it('renders simple plugin routes', async () => {
       asMock(usePluginEntities).mockReturnValue([{ component: () => <span>Hey there!</span>, path: '/a-plugin-route' }]);
-      const { findByText } = render(<AppRouterWithContext />);
+      const { findByText } = render(<AppRouter />);
 
       history.push('/a-plugin-route');
 
@@ -87,7 +78,7 @@ describe('AppRouter', () => {
     it('renders null-parent component plugin routes without application chrome', async () => {
       asMock(usePluginEntities).mockReturnValue([{ parentComponent: null, component: () => <span>Hey there!</span>, path: '/' }]);
 
-      const { findByText, queryByTitle } = render(<AppRouterWithContext />);
+      const { findByText, queryByTitle } = render(<AppRouter />);
 
       history.push('/');
 
@@ -98,7 +89,7 @@ describe('AppRouter', () => {
 
     it('does not render plugin route when required feature flag is not enabled', async () => {
       asMock(usePluginEntities).mockReturnValue([{ component: () => <span>Hey there!</span>, path: '/a-plugin-route', requiredFeatureFlag: 'a_feature_flag' }]);
-      render(<AppRouterWithContext />);
+      render(<AppRouter />);
 
       history.push('/a-plugin-route');
 
@@ -110,7 +101,7 @@ describe('AppRouter', () => {
     it('render plugin route when required feature flag is enabled', async () => {
       asMock(AppConfig.isFeatureEnabled).mockReturnValue(true);
       asMock(usePluginEntities).mockReturnValue([{ component: () => <span>Hey there!</span>, path: '/a-plugin-route', requiredFeatureFlag: 'a_feature_flag' }]);
-      const { findByText } = render(<AppRouterWithContext />);
+      const { findByText } = render(<AppRouter />);
 
       history.push('/a-plugin-route');
 

--- a/graylog2-web-interface/src/views/components/Search.tsx
+++ b/graylog2-web-interface/src/views/components/Search.tsx
@@ -52,7 +52,7 @@ import WidgetFocusProvider from 'views/components/contexts/WidgetFocusProvider';
 import WidgetFocusContext from 'views/components/contexts/WidgetFocusContext';
 import type SearchExecutionState from 'views/logic/search/SearchExecutionState';
 import type { RefluxActions } from 'stores/StoreTypes';
-import CurrentUserContext from 'contexts/CurrentUserContext';
+import useCurrentUser from 'hooks/useCurrentUser';
 import SynchronizeUrl from 'views/components/SynchronizeUrl';
 
 const GridContainer = styled.div<{ interactive: boolean }>(({ interactive }) => {
@@ -108,7 +108,7 @@ const _refreshSearch = (executionState: SearchExecutionState) => {
 const ViewAdditionalContextProvider = ({ children }: { children: React.ReactNode }) => {
   const { view } = useStore(ViewStore);
   const { searchesClusterConfig } = useStore(SearchConfigStore) ?? {};
-  const currentUser = useContext(CurrentUserContext);
+  const currentUser = useCurrentUser();
   const contextValue = useMemo(() => ({
     view,
     analysisDisabledFields: searchesClusterConfig?.analysis_disabled_fields,

--- a/graylog2-web-interface/src/views/components/ViewActionsMenu.tsx
+++ b/graylog2-web-interface/src/views/components/ViewActionsMenu.tsx
@@ -14,7 +14,7 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import React, { useState, useContext, useCallback } from 'react';
+import React, { useState, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 
@@ -34,7 +34,7 @@ import * as ViewPermissions from 'views/Permissions';
 import useSearchPageLayout from 'hooks/useSearchPageLayout';
 import View from 'views/logic/views/View';
 import type User from 'logic/users/User';
-import CurrentUserContext from 'contexts/CurrentUserContext';
+import useCurrentUser from 'hooks/useCurrentUser';
 import EntityShareModal from 'components/permissions/EntityShareModal';
 import ViewTypeLabel from 'views/components/ViewTypeLabel';
 import {
@@ -52,7 +52,7 @@ const _isAllowedToEdit = (view: View, currentUser: User | undefined | null) => i
 const _hasUndeclaredParameters = (searchMetadata: SearchMetadata) => searchMetadata.undeclared.size > 0;
 
 const ViewActionsMenu = ({ view, isNewView, metadata }) => {
-  const currentUser = useContext(CurrentUserContext);
+  const currentUser = useCurrentUser();
   const {
     viewActions: {
       save: {

--- a/graylog2-web-interface/src/views/components/contexts/SearchPagePreferencesState.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/SearchPagePreferencesState.tsx
@@ -22,7 +22,7 @@ import View from 'views/logic/views/View';
 import ViewTypeContext from 'views/components/contexts/ViewTypeContext';
 import type { UserPreferences } from 'contexts/UserPreferencesContext';
 import UserPreferencesContext from 'contexts/UserPreferencesContext';
-import CurrentUserContext from 'contexts/CurrentUserContext';
+import useCurrentUser from 'hooks/useCurrentUser';
 import Store from 'logic/local-storage/Store';
 import { PreferencesActions } from 'stores/users/PreferencesStore';
 import type User from 'logic/users/User';
@@ -75,7 +75,7 @@ const _updateUserSidebarPinningPref = (currentUser: User, userPreferences: UserP
 };
 
 const SearchPagePreferencesState = ({ children }: Props) => {
-  const currentUser = useContext(CurrentUserContext);
+  const currentUser = useCurrentUser();
   const userPreferences = useContext(UserPreferencesContext);
   const viewType = useContext(ViewTypeContext);
   const [state, setState] = useState({

--- a/graylog2-web-interface/src/views/components/searchbar/RangePresetDropdown.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/RangePresetDropdown.test.tsx
@@ -15,13 +15,10 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import * as Immutable from 'immutable';
 import { fireEvent, render, screen } from 'wrappedTestingLibrary';
 
 import MockStore from 'helpers/mocking/StoreMock';
-import { alice } from 'fixtures/users';
 import mockSearchClusterConfig from 'fixtures/searchClusterConfig';
-import CurrentUserContext from 'contexts/CurrentUserContext';
 
 import RangePresetDropdown from './RangePresetDropdown';
 
@@ -40,19 +37,9 @@ jest.mock('views/stores/SearchConfigStore', () => ({
 }));
 
 describe('RangePresetDropdown', () => {
-  type SUTProps = Partial<React.ComponentProps<typeof RangePresetDropdown>>;
-
-  const currentUser = alice.toBuilder().permissions(Immutable.List(['*'])).build();
-
-  const SUTRangePresetDropdown = (props: SUTProps) => (
-    <CurrentUserContext.Provider value={currentUser}>
-      <RangePresetDropdown {...props} />
-    </CurrentUserContext.Provider>
-  );
-
   it('should not call onChange prop when selecting "Configure Ranges" option.', async () => {
     const onSelectOption = jest.fn();
-    render(<SUTRangePresetDropdown onChange={onSelectOption} />);
+    render(<RangePresetDropdown onChange={onSelectOption} />);
 
     const timeRangeButton = screen.getByLabelText('Open time range preset select');
     fireEvent.click(timeRangeButton);

--- a/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchControls.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchControls.tsx
@@ -32,7 +32,7 @@ import NewViewLoaderContext from 'views/logic/NewViewLoaderContext';
 import ExportModal from 'views/components/export/ExportModal';
 import ViewTypeLabel from 'views/components/ViewTypeLabel';
 import EntityShareModal from 'components/permissions/EntityShareModal';
-import CurrentUserContext from 'contexts/CurrentUserContext';
+import useCurrentUser from 'hooks/useCurrentUser';
 import * as ViewsPermissions from 'views/Permissions';
 import type User from 'logic/users/User';
 import ViewPropertiesModal from 'views/components/views/ViewPropertiesModal';
@@ -55,7 +55,7 @@ const SavedSearchControls = () => {
   const theme = useTheme();
   const { view, dirty } = useStore(ViewStore);
   const viewLoaderFunc = useContext(ViewLoaderContext);
-  const currentUser = useContext(CurrentUserContext);
+  const currentUser = useCurrentUser();
   const loadNewView = useContext(NewViewLoaderContext);
   const isAllowedToEdit = (view && view.id) && _isAllowedToEdit(view, currentUser);
   const formTarget = useRef();

--- a/graylog2-web-interface/src/views/components/sidebar/Sidebar.test.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/Sidebar.test.tsx
@@ -17,21 +17,12 @@
 import * as React from 'react';
 import { fireEvent, render, screen } from 'wrappedTestingLibrary';
 
-import { StoreMock as MockStore } from 'helpers/mocking';
 import ViewTypeContext from 'views/components/contexts/ViewTypeContext';
 import View from 'views/logic/views/View';
 import QueryResult from 'views/logic/QueryResult';
 import type { ViewMetaData } from 'views/stores/ViewMetadataStore';
 
 import Sidebar from './Sidebar';
-
-const mockCurrentUser = { timezone: 'UTC' };
-
-jest.mock('stores/users/CurrentUserStore', () => ({
-  CurrentUserStore: MockStore(['get', () => mockCurrentUser], ['getInitialState', () => ({ mockCurrentUser })]),
-}));
-
-jest.mock('stores/sessions/SessionStore', () => ({ SessionStore: MockStore('isLoggedIn') }));
 
 jest.mock('util/AppConfig', () => ({
   gl2AppPathPrefix: jest.fn(() => ''),

--- a/graylog2-web-interface/src/views/components/views/DashboardListItem.test.tsx
+++ b/graylog2-web-interface/src/views/components/views/DashboardListItem.test.tsx
@@ -17,21 +17,28 @@
 import React from 'react';
 import { render, screen } from 'wrappedTestingLibrary';
 
-import { alice } from 'fixtures/users';
+import { alice, adminUser } from 'fixtures/users';
 import View from 'views/logic/views/View';
 import Search from 'views/logic/search/Search';
-import CurrentUserContext from 'contexts/CurrentUserContext';
+import { asMock } from 'helpers/mocking';
+import useCurrentUser from 'hooks/useCurrentUser';
 
 import DashboardListItem from './DashboardListItem';
 
-jest.mock('routing/Routes', () => ({ pluginRoute: () => () => '/route' }));
 const mockedUnixTime = 1577836800000; // 2020-01-01 00:00:00.000
 
 jest.useFakeTimers()
   // @ts-expect-error
   .setSystemTime(mockedUnixTime);
 
+jest.mock('hooks/useCurrentUser');
+jest.mock('routing/Routes', () => ({ pluginRoute: () => () => '/route' }));
+
 describe('Render DashboardListItem', () => {
+  beforeEach(() => {
+    asMock(useCurrentUser).mockReturnValue(adminUser);
+  });
+
   const dashboard = View.builder()
     .type('DASHBOARD')
     .id('search-id-0')
@@ -63,36 +70,36 @@ describe('Render DashboardListItem', () => {
   });
 
   it('should render text "Last saved" if current user the same as an owner', async () => {
+    asMock(useCurrentUser).mockReturnValue(alice);
+
     render(
-      <CurrentUserContext.Provider value={alice}>
-        <DashboardListItem id={dashboard.id}
-                           createdAt={dashboard.createdAt}
-                           requires={dashboard.requires}
-                           owner={alice.username}
-                           description={dashboard.description}
-                           title={dashboard.title}
-                           summary={dashboard.summary}>
-          <div />
-        </DashboardListItem>
-      </CurrentUserContext.Provider>,
+      <DashboardListItem id={dashboard.id}
+                         createdAt={dashboard.createdAt}
+                         requires={dashboard.requires}
+                         owner={alice.username}
+                         description={dashboard.description}
+                         title={dashboard.title}
+                         summary={dashboard.summary}>
+        <div />
+      </DashboardListItem>,
     );
 
     await screen.findByText('Last saved');
   });
 
   it('should render text "Shared by user" if current user not the same as an owner', async () => {
+    asMock(useCurrentUser).mockReturnValue(alice);
+
     render(
-      <CurrentUserContext.Provider value={alice}>
-        <DashboardListItem id={dashboard.id}
-                           createdAt={dashboard.createdAt}
-                           requires={dashboard.requires}
-                           owner="bob"
-                           description={dashboard.description}
-                           title={dashboard.title}
-                           summary={dashboard.summary}>
-          <div />
-        </DashboardListItem>
-      </CurrentUserContext.Provider>,
+      <DashboardListItem id={dashboard.id}
+                         createdAt={dashboard.createdAt}
+                         requires={dashboard.requires}
+                         owner="bob"
+                         description={dashboard.description}
+                         title={dashboard.title}
+                         summary={dashboard.summary}>
+        <div />
+      </DashboardListItem>,
     );
 
     await screen.findByText('Shared by bob, last saved');

--- a/graylog2-web-interface/src/views/components/views/DashboardListItem.tsx
+++ b/graylog2-web-interface/src/views/components/views/DashboardListItem.tsx
@@ -14,13 +14,13 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import React, { useContext } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 
 import { Link } from 'components/common/router';
 import Routes from 'routing/Routes';
 import { EntityListItem } from 'components/common';
-import CurrentUserContext from 'contexts/CurrentUserContext';
+import useCurrentUser from 'hooks/useCurrentUser';
 import Timestamp from 'components/common/Timestamp';
 import withPluginEntities from 'views/logic/withPluginEntities';
 
@@ -29,7 +29,7 @@ const formatTitle = (title, id, disabled = false) => (disabled
   : <Link to={Routes.pluginRoute('DASHBOARDS_VIEWID')(id)}>{title}</Link>);
 
 const OwnerTag = ({ owner }) => {
-  const currentUser = useContext(CurrentUserContext);
+  const currentUser = useCurrentUser();
 
   if (!owner || owner === currentUser?.username) {
     return <span>Last saved</span>;

--- a/graylog2-web-interface/src/views/pages/DashboardsPage.test.tsx
+++ b/graylog2-web-interface/src/views/pages/DashboardsPage.test.tsx
@@ -26,9 +26,6 @@ import Routes from 'routing/Routes';
 import useDashboards from 'views/logic/dashboards/useDashboards';
 import { simpleView } from 'views/test/ViewFixtures';
 import UserDateTimeContext from 'contexts/UserDateTimeContext';
-import CurrentUserContext from 'contexts/CurrentUserContext';
-import { adminUser } from 'fixtures/users';
-import type User from 'logic/users/User';
 import { ViewManagementActions } from 'views/stores/ViewManagementStore';
 
 import DashboardsPage from './DashboardsPage';
@@ -45,21 +42,15 @@ jest.mock('views/stores/ViewManagementStore', () => ({
   },
 }));
 
-const WrappedDashboardsPage = ({ currentUser }: { currentUser?: User }) => (
-  <CurrentUserContext.Provider value={currentUser}>
-    <UserDateTimeContext.Provider value={{
-      formatTime: (dateTime) => dateTime.toString(),
-      toUserTimezone: (time) => moment(time),
-      userTimezone: 'Europe/Paris',
-    }}>
-      <DashboardsPage />
-    </UserDateTimeContext.Provider>
-  </CurrentUserContext.Provider>
+const SUT = () => (
+  <UserDateTimeContext.Provider value={{
+    formatTime: (dateTime) => dateTime.toString(),
+    toUserTimezone: (time) => moment(time),
+    userTimezone: 'Europe/Paris',
+  }}>
+    <DashboardsPage />
+  </UserDateTimeContext.Provider>
 );
-
-WrappedDashboardsPage.defaultProps = {
-  currentUser: adminUser,
-};
 
 const noDashboards: DashboardsStoreState = {
   list: [],
@@ -108,14 +99,14 @@ describe('DashboardsPage', () => {
   it('shows placeholder text if dashboards are empty', async () => {
     mockDashboards(noDashboards);
 
-    render(<WrappedDashboardsPage />);
+    render(<SUT />);
 
     await screen.findByText(/Create a new dashboard here/);
   });
 
   it('shows list of dashboards', async () => {
     mockDashboards(simpleDashboardList);
-    render(<WrappedDashboardsPage />);
+    render(<SUT />);
 
     await screen.findByRole('link', { name: 'Foo' });
   });
@@ -123,7 +114,7 @@ describe('DashboardsPage', () => {
   it('does not delete dashboard when user clicks cancel', async () => {
     asMock(window.confirm).mockReturnValue(false);
 
-    render(<WrappedDashboardsPage />);
+    render(<SUT />);
 
     await clickDashboardAction('foo', 'Delete');
 
@@ -135,7 +126,7 @@ describe('DashboardsPage', () => {
   it('deletes dashboard when user confirms deletion', async () => {
     asMock(window.confirm).mockReturnValue(true);
 
-    render(<WrappedDashboardsPage />);
+    render(<SUT />);
 
     await clickDashboardAction('foo', 'Delete');
 
@@ -165,7 +156,7 @@ describe('DashboardsPage', () => {
     });
 
     it('triggers hook when deleting dashboard', async () => {
-      render(<WrappedDashboardsPage />);
+      render(<SUT />);
 
       await clickDashboardAction('foo', 'Delete');
 
@@ -177,7 +168,7 @@ describe('DashboardsPage', () => {
     it('does not delete dashboard when hook returns false', async () => {
       asMock(deletingDashboard).mockResolvedValue(false);
 
-      render(<WrappedDashboardsPage />);
+      render(<SUT />);
 
       await clickDashboardAction('foo', 'Delete');
 
@@ -190,7 +181,7 @@ describe('DashboardsPage', () => {
       asMock(deletingDashboard).mockReturnValue(null);
       asMock(window.confirm).mockReturnValue(true);
 
-      render(<WrappedDashboardsPage />);
+      render(<SUT />);
 
       await clickDashboardAction('foo', 'Delete');
 
@@ -206,7 +197,7 @@ describe('DashboardsPage', () => {
       asMock(deletingDashboard).mockImplementation(() => { throw error; });
       asMock(window.confirm).mockReturnValue(true);
 
-      render(<WrappedDashboardsPage />);
+      render(<SUT />);
 
       /* eslint-disable no-console */
       const oldConsoleTrace = console.trace;

--- a/graylog2-web-interface/test/DefaultProviders.tsx
+++ b/graylog2-web-interface/test/DefaultProviders.tsx
@@ -22,6 +22,8 @@ import { colors, utils, breakpoints, fonts, spacings } from 'theme';
 import { THEME_MODE_LIGHT } from 'theme/constants';
 import buttonStyles from 'components/bootstrap/styles/buttonStyles';
 import aceEditorStyles from 'components/bootstrap/styles/aceEditorStyles';
+import CurrentUserProvider from 'contexts/CurrentUserProvider';
+import { adminUser } from 'fixtures/users';
 
 const themeColors = colors[THEME_MODE_LIGHT];
 const formattedUtils = {
@@ -48,11 +50,13 @@ type Props = {
   children: React.ReactNode,
 }
 const DefaultProviders = ({ children }: Props) => (
-  <ThemeProvider theme={theme}>
-    <UserDateTimeProvider tz="Europe/Berlin">
-      {children}
-    </UserDateTimeProvider>
-  </ThemeProvider>
+  <CurrentUserProvider user={adminUser}>
+    <ThemeProvider theme={theme}>
+      <UserDateTimeProvider tz="Europe/Berlin">
+        {children}
+      </UserDateTimeProvider>
+    </ThemeProvider>
+  </CurrentUserProvider>
 );
 
 export default DefaultProviders;

--- a/graylog2-web-interface/test/DefaultProviders.tsx
+++ b/graylog2-web-interface/test/DefaultProviders.tsx
@@ -17,12 +17,12 @@
 import * as React from 'react';
 import { ThemeProvider } from 'styled-components';
 
+import CurrentUserContext from 'contexts/CurrentUserContext';
 import UserDateTimeProvider from 'contexts/UserDateTimeProvider';
 import { colors, utils, breakpoints, fonts, spacings } from 'theme';
 import { THEME_MODE_LIGHT } from 'theme/constants';
 import buttonStyles from 'components/bootstrap/styles/buttonStyles';
 import aceEditorStyles from 'components/bootstrap/styles/aceEditorStyles';
-import CurrentUserProvider from 'contexts/CurrentUserProvider';
 import { adminUser } from 'fixtures/users';
 
 const themeColors = colors[THEME_MODE_LIGHT];
@@ -50,13 +50,13 @@ type Props = {
   children: React.ReactNode,
 }
 const DefaultProviders = ({ children }: Props) => (
-  <CurrentUserProvider user={adminUser}>
+  <CurrentUserContext.Provider value={adminUser}>
     <ThemeProvider theme={theme}>
       <UserDateTimeProvider tz="Europe/Berlin">
         {children}
       </UserDateTimeProvider>
     </ThemeProvider>
-  </CurrentUserProvider>
+  </CurrentUserContext.Provider>
 );
 
 export default DefaultProviders;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

With this PR we are creating a new `useCurrentUser` hook to receive the current user in frontend components.
Before this change we were consuming the `CurrentUserContext` for this purpose.

This is not the first time we are replacing the consumption of a context with implementing a specialised hook. This pattern has a few benefit:
- The main advantage: If we ever change the way we provide the current user, for example if we replace the `CurrentUserContext.Provider` with `react-query`, we only need to change one file instead of every file were we access the current user.
- if we forget to wrap a component with the necessary context provider, the hook throws a more meaningful error message.
- it is simpler to mock and change the return value of an hook in tests

This PR also affects the general mocking of the current user in tests.
Similar to the [UserDateTimeProvider](https://github.com/Graylog2/graylog2-server/blob/master/graylog2-web-interface/test/DefaultProviders.tsx#L52) we are now always providing a current user when rendering something in tests.

This simplifies many tests, since we often just had to mock the current user, because some child component is consuming the context, while mocking the user is not important for the tested logic.

Here is what changes, in case you need to test for example different user permissions in a test.
Instead of wrapping every component in every test caste with `CurrentUserContext.Provider`, you need to

1. mock the hook `jest.mock('hooks/useCurrentUser');`
2. reset the return value before every test 
```
beforeEach(() => {
  asMock(useCurrentUser).mockReturnValue(adminUser);
})
```
3. change the return value for a specific test case.
```
asMock(useCurrentUser).mockReturnValue(
  adminUser.toBuilder().permissions(Immutable.List(['example-permission'])).build()
);
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

/jenkins-pr-deps https://github.com/Graylog2/graylog-plugin-enterprise/pull/3948