### PR TITLE
Backport for 4.3: fix ConfirmDialog close behaviour via X button (or pressing ESC or clicking on the background)

### DIFF
--- a/graylog2-web-interface/src/components/common/ConfirmDialog.tsx
+++ b/graylog2-web-interface/src/components/common/ConfirmDialog.tsx
@@ -35,7 +35,7 @@ const ConfirmDialog = ({
   btnConfirmText,
 }) => {
   return (
-    <Modal show={show}>
+    <Modal show={show} onHide={onCancel}>
       <Modal.Header closeButton>
         <Modal.Title>{title}</Modal.Title>
       </Modal.Header>

--- a/graylog2-web-interface/src/components/common/index.tsx
+++ b/graylog2-web-interface/src/components/common/index.tsx
@@ -26,6 +26,7 @@ export { default as Center } from './Center';
 export { default as ClipboardButton } from './ClipboardButton';
 export { default as ColorPicker } from './ColorPicker';
 export { default as ColorPickerPopover } from './ColorPickerPopover';
+export { default as ConfirmDialog } from './ConfirmDialog';
 export { default as ConfirmLeaveDialog } from './ConfirmLeaveDialog';
 export { default as ContentHeadRow } from './ContentHeadRow';
 export { default as ControlledTableList } from './ControlledTableList';


### PR DESCRIPTION
Backport for 4.3 with the fix in https://github.com/Graylog2/graylog2-server/pull/12480

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)