### PR TITLE
Unify styling for dropdown menu items with icons.

### DIFF
--- a/graylog2-web-interface/src/components/bootstrap/MenuItem.tsx
+++ b/graylog2-web-interface/src/components/bootstrap/MenuItem.tsx
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+// eslint-disable-next-line no-restricted-imports
+import { MenuItem as BootstrapMenuItem } from 'react-bootstrap';
+import styled from 'styled-components';
+
+import Icon from 'components/common/Icon';
+
+const Container = styled.div`
+  display: flex;
+`;
+
+const IconWrapper = styled.div`
+  display: inline-flex;
+  min-width: 20px;
+  margin-right: 5px;
+  justify-content: center;
+  align-items: center;
+`;
+
+type Props = React.ComponentProps<typeof BootstrapMenuItem> & {
+  icon?: React.ComponentProps<typeof Icon>['name'],
+}
+
+const MenuItem = ({ className, children, icon, ...props } : Props) => {
+  return (
+    <BootstrapMenuItem bsClass={className} {...props}>
+      {children && (
+        <Container>
+          {icon && <IconWrapper><Icon name={icon} /></IconWrapper>}
+          {children}
+        </Container>
+      )}
+    </BootstrapMenuItem>
+  );
+};
+
+MenuItem.propTypes = {
+  className: PropTypes.string,
+  icon: PropTypes.string,
+};
+
+MenuItem.defaultProps = {
+  className: undefined,
+  icon: undefined,
+};
+
+/** @component */
+export default MenuItem;

--- a/graylog2-web-interface/src/components/bootstrap/MenuItem.tsx
+++ b/graylog2-web-interface/src/components/bootstrap/MenuItem.tsx
@@ -22,10 +22,6 @@ import styled from 'styled-components';
 
 import Icon from 'components/common/Icon';
 
-const Container = styled.div`
-  display: flex;
-`;
-
 const IconWrapper = styled.div`
   display: inline-flex;
   min-width: 20px;
@@ -38,28 +34,26 @@ type Props = React.ComponentProps<typeof BootstrapMenuItem> & {
   icon?: React.ComponentProps<typeof Icon>['name'],
 }
 
-const MenuItem = ({ className, children, icon, ...props } : Props) => {
-  return (
-    <BootstrapMenuItem bsClass={className} {...props}>
-      {children && (
-        <Container>
-          {icon && <IconWrapper><Icon name={icon} /></IconWrapper>}
-          {children}
-        </Container>
-      )}
-    </BootstrapMenuItem>
-  );
-};
+const CustomMenuItem = ({ className, children, icon, ...props } : Props) => (
+  <BootstrapMenuItem bsClass={className} {...props}>
+    {children && (
+      <>
+        {icon && <IconWrapper><Icon name={icon} /></IconWrapper>}
+        {children}
+      </>
+    )}
+  </BootstrapMenuItem>
+);
 
-MenuItem.propTypes = {
+CustomMenuItem.propTypes = {
   className: PropTypes.string,
   icon: PropTypes.string,
 };
 
-MenuItem.defaultProps = {
+CustomMenuItem.defaultProps = {
   className: undefined,
   icon: undefined,
 };
 
 /** @component */
-export default MenuItem;
+export default CustomMenuItem;

--- a/graylog2-web-interface/src/components/bootstrap/imports.js
+++ b/graylog2-web-interface/src/components/bootstrap/imports.js
@@ -27,7 +27,6 @@ export {
   Dropdown,
   Form,
   Grid,
-  MenuItem,
   NavItem,
   Pager,
   PanelGroup,

--- a/graylog2-web-interface/src/components/bootstrap/index.js
+++ b/graylog2-web-interface/src/components/bootstrap/index.js
@@ -32,6 +32,7 @@ export { default as Jumbotron } from './Jumbotron';
 export { default as Label } from './Label';
 export { default as ListGroup } from './ListGroup';
 export { default as ListGroupItem } from './ListGroupItem';
+export { default as MenuItem } from './MenuItem';
 export { default as Modal } from './Modal';
 export { default as Nav } from './Nav';
 export { default as NavDropdown } from './NavDropdown';

--- a/graylog2-web-interface/src/components/bootstrap/styles/menuItem.js
+++ b/graylog2-web-interface/src/components/bootstrap/styles/menuItem.js
@@ -22,6 +22,7 @@ const menuItemStyles = css(({ theme }) => css`
     box-shadow: 0 3px 3px ${theme.colors.global.navigationBoxShadow};
     
     > li > a {
+      display: flex;
       color: ${theme.colors.global.textDefault};
 
       :hover,

--- a/graylog2-web-interface/src/components/common/TimeUnitInput.test.jsx
+++ b/graylog2-web-interface/src/components/common/TimeUnitInput.test.jsx
@@ -32,7 +32,7 @@ describe('<TimeUnitInput />', () => {
 
     expect(checkbox.prop('checked')).toBe(false);
     expect(wrapper.find('input[type="number"]').prop('value')).toBe(1);
-    expect(wrapper.find('li.active a').prop('children')).toBe('seconds');
+    expect(wrapper.find('li.active a')).toHaveText('seconds');
 
     checkbox.simulate('click');
   });
@@ -65,7 +65,7 @@ describe('<TimeUnitInput />', () => {
 
     expect(checkbox.prop('checked')).toBe(true);
     expect(wrapper.find('input[type="number"]').prop('value')).toBe(1);
-    expect(wrapper.find('li.active a').prop('children')).toBe('days');
+    expect(wrapper.find('li.active a')).toHaveText('days');
 
     wrapper.find('input[type="number"]').simulate('change', { target: { value: 42, type: 'number' } });
   });

--- a/graylog2-web-interface/src/components/content-packs/ContentPackVersions.test.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackVersions.test.jsx
@@ -64,7 +64,8 @@ describe('<ContentPackVersions />', () => {
     });
     const wrapper = mount(<ContentPackVersions onDeletePack={deleteFn} contentPackRevisions={contentPackRevision} />);
 
-    wrapper.find('a[children="Delete"]').at(0).simulate('click');
+    const menuItem = wrapper.findWhere((node) => node.type() === 'a' && node.text() === 'Delete').at(0);
+    menuItem.simulate('click');
 
     expect(deleteFn.mock.calls.length).toBe(1);
   });

--- a/graylog2-web-interface/src/components/content-packs/ContentPacksList.test.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPacksList.test.jsx
@@ -77,7 +77,8 @@ describe('<ContentPacksList />', () => {
     });
     const wrapper = mount(<ContentPacksList contentPacks={contentPacks} onDeletePack={deleteFn} />);
 
-    wrapper.find('a[children="Delete All Versions"]').at(0).simulate('click');
+    const menuItem = wrapper.findWhere((node) => node.type() === 'a' && node.text() === 'Delete All Versions').at(0);
+    menuItem.simulate('click');
 
     expect(deleteFn.mock.calls.length).toBe(1);
   });

--- a/graylog2-web-interface/src/views/components/DashboardActionsMenu.tsx
+++ b/graylog2-web-interface/src/views/components/DashboardActionsMenu.tsx
@@ -75,8 +75,8 @@ const DashboardActionsMenu = ({ view, isNewView, metadata }) => {
   const debugOverlay = AppConfig.gl2DevMode() && (
     <>
       <MenuItem divider />
-      <MenuItem onSelect={() => setDebugOpen(true)}>
-        <Icon name="code" /> Debug
+      <MenuItem onSelect={() => setDebugOpen(true)} icon="code">
+        Debug
       </MenuItem>
     </>
   );
@@ -117,15 +117,15 @@ const DashboardActionsMenu = ({ view, isNewView, metadata }) => {
                    disabledInfo={isNewView && 'Only saved dashboards can be shared.'} />
       )}
       {showDropDownButton && (
-      <DropdownButton title={<Icon name="ellipsis-h" />} id="query-tab-actions-dropdown" pullRight noCaret>
-        <MenuItem onSelect={() => setEditDashboardOpen(true)} disabled={isNewView || !allowedToEdit}>
-          <Icon name="edit" /> Edit metadata
-        </MenuItem>
-        <MenuItem onSelect={() => setExportOpen(true)}><Icon name="cloud-download-alt" /> Export</MenuItem>
-        {debugOverlay}
-        <MenuItem divider />
-        <BigDisplayModeConfiguration view={view} disabled={isNewView} />
-      </DropdownButton>
+        <DropdownButton title={<Icon name="ellipsis-h" />} id="query-tab-actions-dropdown" pullRight noCaret>
+          <MenuItem onSelect={() => setEditDashboardOpen(true)} disabled={isNewView || !allowedToEdit} icon="edit">
+            Edit metadata
+          </MenuItem>
+          <MenuItem onSelect={() => setExportOpen(true)} icon="cloud-download-alt">Export</MenuItem>
+          {debugOverlay}
+          <MenuItem divider />
+          <BigDisplayModeConfiguration view={view} disabled={isNewView} />
+        </DropdownButton>
       )}
       {debugOpen && <DebugOverlay show onClose={() => setDebugOpen(false)} />}
       {saveNewDashboardOpen && (

--- a/graylog2-web-interface/src/views/components/common/ActionDropdown.test.tsx
+++ b/graylog2-web-interface/src/views/components/common/ActionDropdown.test.tsx
@@ -16,12 +16,17 @@
  */
 import * as React from 'react';
 import { mount } from 'wrappedEnzyme';
+import type { ReactWrapper } from 'enzyme';
 
 import { MenuItem } from 'components/bootstrap';
 
 import ActionDropdown from './ActionDropdown';
 
 describe('ActionDropdown', () => {
+  const findLink = (wrapper: ReactWrapper, text: string) => wrapper.findWhere((node) => {
+    return node.type() === 'a' && node.text() === text;
+  });
+
   it('opens menu when trigger element is clicked', () => {
     const wrapper = mount((
       <ActionDropdown element={<div className="my-trigger-element">Trigger!</div>}>
@@ -67,7 +72,7 @@ describe('ActionDropdown', () => {
 
     trigger.simulate('click');
 
-    const menuItem = wrapper.find('a[children="Foo"]');
+    const menuItem = findLink(wrapper, 'Foo');
 
     menuItem.simulate('click');
 
@@ -88,7 +93,7 @@ describe('ActionDropdown', () => {
 
     trigger.simulate('click');
 
-    const menuItem = wrapper.find('a[children="Foo"]');
+    const menuItem = findLink(wrapper, 'Foo');
 
     menuItem.simulate('click');
 
@@ -110,7 +115,7 @@ describe('ActionDropdown', () => {
 
     trigger.simulate('click');
 
-    const menuItem = wrapper.find('a[children="Foo"]');
+    const menuItem = findLink(wrapper, 'Foo');
 
     menuItem.simulate('click');
 

--- a/graylog2-web-interface/src/views/components/dashboard/BigDisplayModeConfiguration.tsx
+++ b/graylog2-web-interface/src/views/components/dashboard/BigDisplayModeConfiguration.tsx
@@ -21,7 +21,6 @@ import history from 'util/History';
 import BootstrapModalForm from 'components/bootstrap/BootstrapModalForm';
 import { Checkbox, ControlLabel, FormGroup, HelpBlock, MenuItem } from 'components/bootstrap';
 import Input from 'components/bootstrap/Input';
-import { Icon } from 'components/common';
 import Routes from 'routing/Routes';
 import type View from 'views/logic/views/View';
 import queryTitle from 'views/logic/queries/QueryTitle';
@@ -157,8 +156,8 @@ const BigDisplayModeConfiguration = ({ disabled, show, view }: Props) => {
                             show
                             view={view} />
       )}
-      <MenuItem disabled={disabled} onSelect={() => setShowConfigurationModal(true)}>
-        <Icon name="desktop" /> Full Screen
+      <MenuItem disabled={disabled} onSelect={() => setShowConfigurationModal(true)} icon="desktop">
+        Full Screen
       </MenuItem>
     </>
   );

--- a/graylog2-web-interface/src/views/components/dashboard/__snapshots__/BigDisplayModeConfiguration.test.tsx.snap
+++ b/graylog2-web-interface/src/views/components/dashboard/__snapshots__/BigDisplayModeConfiguration.test.tsx.snap
@@ -1,6 +1,23 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`BigDisplayModeConfiguration generates markup that matches snapshot 1`] = `
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  min-width: 20px;
+  margin-right: 5px;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
 <div>
   <li
     class=""
@@ -11,7 +28,10 @@ exports[`BigDisplayModeConfiguration generates markup that matches snapshot 1`] 
       role="menuitem"
       tabindex="-1"
     >
-       Full Screen
+      <div
+        class="c0"
+      />
+      Full Screen
     </a>
   </li>
 </div>

--- a/graylog2-web-interface/src/views/components/searchbar/saved-search/SearchActionsMenu.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/saved-search/SearchActionsMenu.tsx
@@ -173,16 +173,20 @@ const SearchActionsMenu = () => {
                    onClick={toggleShareSearch}
                    bsStyle="default"
                    disabledInfo={!view.id && 'Only saved searches can be shared.'} />
-      <DropdownButton title={<Icon name="ellipsis-h" />} aria-label="Open search actions dropdown" id="search-actions-dropdown" pullRight noCaret>
-        <MenuItem onSelect={toggleMetadataEdit} disabled={!isAllowedToEdit}>
-          <Icon name="edit" /> Edit metadata
+      <DropdownButton title={<Icon name="ellipsis-h" />}
+                      aria-label="Open search actions dropdown"
+                      id="search-actions-dropdown"
+                      pullRight
+                      noCaret>
+        <MenuItem onSelect={toggleMetadataEdit} disabled={!isAllowedToEdit} icon="edit">
+          Edit metadata
         </MenuItem>
         <IfPermitted permissions="dashboards:create">
-          <MenuItem onSelect={_loadAsDashboard}><Icon name="tachometer-alt" /> Export to dashboard</MenuItem>
+          <MenuItem onSelect={_loadAsDashboard} icon="tachometer-alt">Export to dashboard</MenuItem>
         </IfPermitted>
-        <MenuItem onSelect={toggleExport}><Icon name="cloud-download-alt" /> Export</MenuItem>
-        <MenuItem disabled={disableReset} onSelect={() => loadNewView()}>
-          <Icon name="eraser" /> Reset search
+        <MenuItem onSelect={toggleExport} icon="cloud-download-alt">Export</MenuItem>
+        <MenuItem disabled={disableReset} onSelect={() => loadNewView()} icon="eraser">
+          Reset search
         </MenuItem>
         <MenuItem divider />
       </DropdownButton>

--- a/graylog2-web-interface/src/views/components/widgets/WidgetActionDropdown.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/WidgetActionDropdown.test.tsx
@@ -49,8 +49,7 @@ describe('WidgetActionDropdown', () => {
 
     trigger.simulate('click');
 
-    const menuItem = wrapper.find('a[children="Foo"]');
-
+    const menuItem = wrapper.findWhere((node) => node.type() === 'a' && node.text() === 'Foo');
     menuItem.simulate('click');
 
     expect(onSelect).toHaveBeenCalled();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

There are a few cases where we display an icon for a dropdown menu item.

Saved search action dropdown (before)
<img width="205" alt="image" src="https://user-images.githubusercontent.com/46300478/186102904-ca180734-f3bd-42b0-afa1-1e5423d1399e.png">

Dashboard action dropdown (before)
<img width="169" alt="image" src="https://user-images.githubusercontent.com/46300478/186102562-c745a10b-673f-4e2e-994a-75550221bd15.png">

With this PR we make it simpler to define an icon for the `MenuItem` component and we improve the positioning of icons and text.

Search action dropdown (after)
<img width="205" alt="image" src="https://user-images.githubusercontent.com/46300478/186102965-333cf784-5139-4643-b0c2-f1a1c1935732.png">


Dashboard action dropdown (after)
<img width="169" alt="image" src="https://user-images.githubusercontent.com/46300478/186102345-948f57dd-18af-400e-a500-c6458f0cae8f.png">


/jenkins-pr-deps https://github.com/Graylog2/graylog-plugin-enterprise/pull/3966
