### PR TITLE
Reintroduce required create methods for ES instances

### DIFF
--- a/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/testing/ElasticsearchInstanceES6.java
+++ b/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/testing/ElasticsearchInstanceES6.java
@@ -36,6 +36,7 @@ import java.net.URI;
 public class ElasticsearchInstanceES6 extends TestableSearchServerInstance {
     private static final Logger LOG = LoggerFactory.getLogger(SearchServerInstance.class);
     private static final String DEFAULT_IMAGE_OSS = "docker.elastic.co/elasticsearch/elasticsearch-oss";
+    public static final String DEFAULT_HEAP_SIZE = "2g";
 
     private final Client client;
     private final JestClient jestClient;
@@ -68,11 +69,16 @@ public class ElasticsearchInstanceES6 extends TestableSearchServerInstance {
     }
 
     public static TestableSearchServerInstance create() {
-        return create(SearchServer.ES6.getSearchVersion(), Network.newNetwork(), "2g");
+        return create(SearchServer.ES6.getSearchVersion(), Network.newNetwork(), DEFAULT_HEAP_SIZE);
     }
 
     public static TestableSearchServerInstance create(String heapSize) {
         return create(SearchServer.ES6.getSearchVersion(), Network.newNetwork(), heapSize);
+    }
+
+    // Caution, do not change this signature. It's required by our container matrix tests. See SearchServerInstanceFactoryByVersion
+    public static TestableSearchServerInstance create(SearchVersion version, Network network) {
+        return create(version, network, DEFAULT_HEAP_SIZE);
     }
 
     private static TestableSearchServerInstance create(SearchVersion version, Network network, String heapSize) {

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/testing/ElasticsearchInstanceES7.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/testing/ElasticsearchInstanceES7.java
@@ -40,6 +40,7 @@ public class ElasticsearchInstanceES7 extends TestableSearchServerInstance {
     private static final Logger LOG = LoggerFactory.getLogger(ElasticsearchInstanceES7.class);
     protected static final String ES_VERSION = "7.10.2";
     private static final String DEFAULT_IMAGE_OSS = "docker.elastic.co/elasticsearch/elasticsearch-oss";
+    public static final String DEFAULT_HEAP_SIZE = "2g";
 
     private final RestHighLevelClient restHighLevelClient;
     private final ElasticsearchClient elasticsearchClient;
@@ -54,7 +55,7 @@ public class ElasticsearchInstanceES7 extends TestableSearchServerInstance {
         this.fixtureImporter = new FixtureImporterES7(this.elasticsearchClient);
     }
     protected ElasticsearchInstanceES7(String image, SearchVersion version, Network network) {
-        this(image, version, network, "2g");
+        this(image, version, network, DEFAULT_HEAP_SIZE);
     }
 
     @Override
@@ -83,11 +84,16 @@ public class ElasticsearchInstanceES7 extends TestableSearchServerInstance {
     }
 
     public static ElasticsearchInstanceES7 create() {
-        return create(SearchVersion.elasticsearch(ES_VERSION), Network.newNetwork(), "2g");
+        return create(SearchVersion.elasticsearch(ES_VERSION), Network.newNetwork(), DEFAULT_HEAP_SIZE);
     }
 
     public static ElasticsearchInstanceES7 create(String heapSize) {
         return create(SearchVersion.elasticsearch(ES_VERSION), Network.newNetwork(), heapSize);
+    }
+
+    // Caution, do not change this signature. It's required by our container matrix tests. See SearchServerInstanceFactoryByVersion
+    public static ElasticsearchInstanceES7 create(SearchVersion searchVersion, Network network) {
+        return create(searchVersion, network, DEFAULT_HEAP_SIZE);
     }
 
     private static ElasticsearchInstanceES7 create(SearchVersion searchVersion, Network network, String heapSize) {


### PR DESCRIPTION
Reintroduce `create(SearchVersion searchVersion, Network network)` methods in ES instances, that are needed by our container matrix tests integration.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

