### PR TITLE
Do not toggle message details in message table widget, when selecting text. (backport of #13263 for 4.3)

### DIFF
--- a/graylog2-web-interface/src/views/components/messagelist/MessageTableEntry.tsx
+++ b/graylog2-web-interface/src/views/components/messagelist/MessageTableEntry.tsx
@@ -118,7 +118,11 @@ const MessageTableEntry = ({
   const inputs = Immutable.Map<string, Input>(inputsList.map((input) => [input.id, input]));
 
   const _toggleDetail = () => {
-    toggleDetail(`${message.index}-${message.id}`);
+    const isSelectingText = !!window.getSelection()?.toString();
+
+    if (!isSelectingText) {
+      toggleDetail(`${message.index}-${message.id}`);
+    }
   };
 
   const _renderStrong = (children, strong = false) => {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

As described in https://github.com/Graylog2/graylog2-server/issues/13259 we currently toggle the message row details when selecting text in the message table. 

Example (before)

![message-table-text-select-before](https://user-images.githubusercontent.com/46300478/185583475-4554f22c-6821-47ee-b420-e603cd4678c6.gif)

With this PR we are improving the behaviour, only a simple click will toggle the message row details.

Example (after)

![message-table-text-select-after](https://user-images.githubusercontent.com/46300478/185583519-82348c10-6b5c-48d4-b11c-bfed93d60b4f.gif)

One thing which may is not optimal, if you select a text and you click on the selected text it requires a second click to actually toggle the message details.

Related to https://github.com/Graylog2/graylog2-server/issues/13259

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)