### PR TITLE
Reduce logging level for per-message log statements

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/buffers/processors/OutputBufferProcessor.java
+++ b/graylog2-server/src/main/java/org/graylog2/buffers/processors/OutputBufferProcessor.java
@@ -127,7 +127,7 @@ public class OutputBufferProcessor implements WorkHandler<MessageEvent> {
             LOG.debug("Skipping null message.");
             return;
         }
-        LOG.debug("Processing message <{}> from OutputBuffer.", msg.getId());
+        LOG.trace("Processing message <{}> from OutputBuffer.", msg.getId());
 
         final Set<MessageOutput> messageOutputs = outputRouter.getStreamOutputsForMessage(msg);
         msg.recordCounter(serverStatus, "matched-outputs", messageOutputs.size());

--- a/graylog2-server/src/main/java/org/graylog2/messageprocessors/MessageFilterChainProcessor.java
+++ b/graylog2-server/src/main/java/org/graylog2/messageprocessors/MessageFilterChainProcessor.java
@@ -99,7 +99,7 @@ public class MessageFilterChainProcessor implements MessageProcessor {
                 final Timer.Context timerContext = timer.time();
 
                 try {
-                    LOG.debug("Applying filter [{}] on message <{}>.", filter.getName(), msg.getId());
+                    LOG.trace("Applying filter [{}] on message <{}>.", filter.getName(), msg.getId());
 
                     if (filter.filter(msg)) {
                         LOG.debug("Filter [{}] marked message <{}> to be discarded. Dropping message.",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Reduce the logging level for several per-message log entries to `trace`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
While investigating a customer issue and reviewing their server debug-level logs, I saw a large number of these log statements. I believe the usual pattern is to set per-log message logging statements to `trace`, so that it is possible to retrieve common debug level logs without being overwhelmed by too many log entries if the Graylog server is processing a large number of messages.

```
DEBUG [MessageFilterChainProcessor] Applying filter [Extractor] on message <message-id>
DEBUG [OutputBufferProcessor] Processing message <message-id> from OutputBuffer
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
No testing needed, just a log-level change.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

