### PR TITLE
Improve performance of ContainerMatrixTestEngine

### DIFF
--- a/graylog2-server/src/test/java/org/graylog/testing/containermatrix/ContainerMatrixTestEngine.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/containermatrix/ContainerMatrixTestEngine.java
@@ -64,7 +64,10 @@ public class ContainerMatrixTestEngine extends ContainerMatrixHierarchicalTestEn
 
     static {
         // Collect all annotated classes once to avoid the class scanning overhead on each #discover() call
-        final ClassGraph classGraph = new ClassGraph().enableAnnotationInfo().acceptPackages("org.graylog", "org.graylog2");
+        final ClassGraph classGraph = new ClassGraph()
+                .ignoreClassVisibility() // JUnit5 test classes might be package-private
+                .enableAnnotationInfo()
+                .acceptPackages("org.graylog", "org.graylog2");
         try (final ScanResult scanResult = classGraph.scan()) {
             annotatedClasses = scanResult.getClassesWithAnnotation(ContainerMatrixTestsConfiguration.class.getCanonicalName()).stream()
                     .map(ClassInfo::loadClass)


### PR DESCRIPTION
The "#discover()" method was running reflection on every call to find all
classes that are annotated with the "ContainerMatrixTestsConfiguration"
annotation. Since the "#discover()" method is called quite often during
test setup, we saw a long "pause" before the test execution started when
running "mvn test".

We now run the reflection in a "static" block and re-use the result for
each "#discover()" invocation.

The change improves running "mvn -Dskip.web.build clean test" in the
graylog2-server repository as follows:

Before: 05:10 min
After:  02:23 min