### PR TITLE
Fixed timerange deserialization

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/MessageListEntity.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/MessageListEntity.java
@@ -128,7 +128,7 @@ public abstract class MessageListEntity implements SearchTypeEntity {
         public abstract Builder filters(List<UsedSearchFilter> filters);
 
         @JsonProperty
-        @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "type", visible = true)
+        @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "type", visible = false)
         @JsonSubTypes({
                 @JsonSubTypes.Type(name = AbsoluteRange.ABSOLUTE, value = AbsoluteRange.class),
                 @JsonSubTypes.Type(name = RelativeRange.RELATIVE, value = RelativeRange.class),


### PR DESCRIPTION
Fix deserialization of TimeRange instances

## Description
```
Caused by: com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException: Unrecognized field "type" (class org.graylog2.plugin.indexer.searches.timeranges.AutoValue_RelativeRange$Builder), not marked as ignorable (3 known properties: "from", "to", "range"])
 at [Source: de.undercouch.bson4jackson.io.LittleEndianInputStream@3f73538b; pos: 485] (through reference chain: org.graylog.plugins.views.search.AutoValue_Search$Builder["queries"]->org.graylog.plugins.views.search.AutoValue_Query$Builder["search_types"]->java.util.HashSet[0]->org.graylog.plugins.enterprise.search.searchtypes.AutoValue_LogsList$Builder["timerange"]->org.graylog2.plugin.indexer.searches.timeranges.AutoValue_RelativeRange$Builder["type"])
```

## Motivation and Context
Recently we have changed the deserialization in https://github.com/Graylog2/graylog2-server/pull/13327 and removed the type property, as it's not needed. But it needs to be consistently configured everywhere where we specify JsonTypeInfo annotation for TimeRange.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

