### PR TITLE
Introduce shared `Markdown` component.

### DIFF
--- a/graylog2-web-interface/src/components/common/Markdown.test.tsx
+++ b/graylog2-web-interface/src/components/common/Markdown.test.tsx
@@ -1,0 +1,42 @@
+import * as React from 'react';
+import { render } from 'wrappedTestingLibrary';
+
+import Markdown from './Markdown';
+
+describe('Markdown', () => {
+  it('renders `undefined`', () => {
+    const { container } = render(<Markdown text={undefined} />);
+
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <div />
+      </div>
+    `);
+  });
+
+  it('renders empty string', () => {
+    const { container } = render(<Markdown text="" />);
+
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <div />
+      </div>
+    `);
+  });
+
+  it('renders simple markdown', () => {
+    const { container } = render(<Markdown text="# Title" />);
+
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <div>
+          <h1>
+            Title
+          </h1>
+          
+      
+        </div>
+      </div>
+    `);
+  });
+});

--- a/graylog2-web-interface/src/components/common/Markdown.test.tsx
+++ b/graylog2-web-interface/src/components/common/Markdown.test.tsx
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 import * as React from 'react';
 import { render } from 'wrappedTestingLibrary';
 

--- a/graylog2-web-interface/src/components/common/Markdown.tsx
+++ b/graylog2-web-interface/src/components/common/Markdown.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react';
+import { useMemo } from 'react';
+import { marked } from 'marked';
+import DOMPurify from 'dompurify';
+
+type Props = {
+  text: string,
+}
+
+const Markdown = ({ text }: Props) => {
+  const markdown = useMemo(() => DOMPurify.sanitize(marked(text ?? '')), [text]);
+
+  // eslint-disable-next-line react/no-danger
+  return <div dangerouslySetInnerHTML={{ __html: markdown }} />;
+};
+
+export default Markdown;

--- a/graylog2-web-interface/src/components/common/Markdown.tsx
+++ b/graylog2-web-interface/src/components/common/Markdown.tsx
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 import * as React from 'react';
 import { useMemo } from 'react';
 import { marked } from 'marked';

--- a/graylog2-web-interface/src/components/common/index.tsx
+++ b/graylog2-web-interface/src/components/common/index.tsx
@@ -68,6 +68,7 @@ export { default as LinkToNode } from './LinkToNode';
 export { default as ListingWithCount } from './ListingWithCount';
 export { default as LoadingIndicator } from './LoadingIndicator';
 export { default as LocaleSelect } from './LocaleSelect';
+export { default as Markdown } from './Markdown';
 export { default as MessageDetailsDefinitionList } from './MessageDetailsDefinitionList';
 export { default as MultiSelect } from './MultiSelect';
 export { default as OverlayElement } from './OverlayElement';

--- a/graylog2-web-interface/src/components/content-packs/ContentPackDetails.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackDetails.jsx
@@ -15,9 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import PropTypes from 'prop-types';
-import React from 'react';
-import { marked } from 'marked';
-import DOMPurify from 'dompurify';
+import * as React from 'react';
 
 import { Col, Row, Well } from 'components/bootstrap';
 import ContentPackStatus from 'components/content-packs/ContentPackStatus';
@@ -26,10 +24,10 @@ import ContentPackEntitiesList from 'components/content-packs/ContentPackEntitie
 import ContentPackParameterList from 'components/content-packs/ContentPackParameterList';
 import 'components/content-packs/ContentPackDetails.css';
 import { hasAcceptedProtocol } from 'util/URLUtils';
+import Markdown from 'components/common/Markdown';
 
 const ContentPackDetails = (props) => {
   const { contentPack, offset, verbose, constraints, showConstraints } = props;
-  const markdownDescription = DOMPurify.sanitize(marked(contentPack.description || ''));
   let contentPackAnchor = contentPack.url;
 
   try {
@@ -64,8 +62,7 @@ const ContentPackDetails = (props) => {
             <h2>Description</h2>
             <br />
             <Well>
-              {/* eslint-disable-next-line react/no-danger */}
-              <div dangerouslySetInnerHTML={{ __html: markdownDescription }} />
+              <Markdown text={contentPack.description} />
             </Well>
           </div>
           )}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This change is introducing a shared `Markdown` component, which solely renders markdown passed in the `text` prop to HTML and returns it. The reason for this is that we use this pattern repeatedly in an identical way, using `dompurify` as an XSS filter, which can be easily forgotten.  Also, we have to include `marked` & `dompurify` in each plugin that wants to do this.


<!--- Provide a general summary of your changes in the Title above -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.