### PR TITLE
Removing unnecessary usage of SearchJob throughout the API

### DIFF
--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/ESGeneratedQueryContext.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/ESGeneratedQueryContext.java
@@ -21,8 +21,6 @@ import com.google.common.collect.Maps;
 import com.google.inject.assistedinject.Assisted;
 import com.google.inject.assistedinject.AssistedInject;
 import org.graylog.plugins.views.search.Filter;
-import org.graylog.plugins.views.search.Query;
-import org.graylog.plugins.views.search.SearchJob;
 import org.graylog.plugins.views.search.SearchType;
 import org.graylog.plugins.views.search.elasticsearch.FieldTypesLookup;
 import org.graylog.plugins.views.search.engine.GeneratedQueryContext;
@@ -48,8 +46,6 @@ public class ESGeneratedQueryContext implements GeneratedQueryContext {
     private final UniqueNamer uniqueNamer = new UniqueNamer("agg-");
     private final Set<SearchError> errors;
     private final SearchSourceBuilder ssb;
-    private final SearchJob job;
-    private final Query query;
 
     private final FieldTypesLookup fieldTypes;
 
@@ -57,14 +53,10 @@ public class ESGeneratedQueryContext implements GeneratedQueryContext {
     public ESGeneratedQueryContext(
             @Assisted ElasticsearchBackend elasticsearchBackend,
             @Assisted SearchSourceBuilder ssb,
-            @Assisted SearchJob job,
-            @Assisted Query query,
             @Assisted Collection<SearchError> validationErrors,
             FieldTypesLookup fieldTypes) {
         this.elasticsearchBackend = elasticsearchBackend;
         this.ssb = ssb;
-        this.job = job;
-        this.query = query;
         this.fieldTypes = fieldTypes;
         this.errors = new HashSet<>(validationErrors);
     }
@@ -73,8 +65,6 @@ public class ESGeneratedQueryContext implements GeneratedQueryContext {
         ESGeneratedQueryContext create(
                 ElasticsearchBackend elasticsearchBackend,
                 SearchSourceBuilder ssb,
-                SearchJob job,
-                Query query,
                 Collection<SearchError> validationErrors
         );
     }
@@ -110,7 +100,7 @@ public class ESGeneratedQueryContext implements GeneratedQueryContext {
     }
 
     private Optional<QueryBuilder> generateFilterClause(Filter filter) {
-        return elasticsearchBackend.generateFilterClause(filter, job, query);
+        return elasticsearchBackend.generateFilterClause(filter);
     }
 
     public String seriesName(SeriesSpec seriesSpec, Pivot pivot) {

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/ESEventList.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/ESEventList.java
@@ -34,7 +34,7 @@ import java.util.stream.StreamSupport;
 
 public class ESEventList implements ESSearchTypeHandler<EventList> {
     @Override
-    public void doGenerateQueryPart(SearchJob job, Query query, EventList eventList,
+    public void doGenerateQueryPart(Query query, EventList eventList,
                                     ESGeneratedQueryContext queryContext) {
         queryContext.searchSourceBuilder(eventList)
                 .size(10000);

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/ESMessageList.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/ESMessageList.java
@@ -85,13 +85,13 @@ public class ESMessageList implements ESSearchTypeHandler<MessageList> {
     }
 
     @Override
-    public void doGenerateQueryPart(SearchJob job, Query query, MessageList messageList, ESGeneratedQueryContext queryContext) {
+    public void doGenerateQueryPart(Query query, MessageList messageList, ESGeneratedQueryContext queryContext) {
 
         final SearchSourceBuilder searchSourceBuilder = queryContext.searchSourceBuilder(messageList)
                 .size(messageList.limit())
                 .from(messageList.offset());
 
-        applyHighlightingIfActivated(searchSourceBuilder, job, query);
+        applyHighlightingIfActivated(searchSourceBuilder, query);
 
         final Set<String> effectiveStreamIds = query.effectiveStreams(messageList);
 
@@ -110,17 +110,21 @@ public class ESMessageList implements ESSearchTypeHandler<MessageList> {
 
     private SortOrder toSortOrder(Sort.Order sortOrder) {
         switch (sortOrder) {
-            case ASC: return SortOrder.ASC;
-            case DESC: return SortOrder.DESC;
-            default: throw new IllegalStateException("Invalid sort order: " + sortOrder);
+            case ASC:
+                return SortOrder.ASC;
+            case DESC:
+                return SortOrder.DESC;
+            default:
+                throw new IllegalStateException("Invalid sort order: " + sortOrder);
         }
     }
-    private void applyHighlightingIfActivated(SearchSourceBuilder searchSourceBuilder, SearchJob job, Query query) {
+
+    private void applyHighlightingIfActivated(SearchSourceBuilder searchSourceBuilder, Query query) {
         if (!allowHighlighting) {
             return;
         }
 
-        final QueryStringQueryBuilder highlightQuery = decoratedHighlightQuery(job, query);
+        final QueryStringQueryBuilder highlightQuery = decoratedHighlightQuery(query);
 
         searchSourceBuilder.highlighter(new HighlightBuilder().requireFieldMatch(false)
                 .highlightQuery(highlightQuery)
@@ -129,7 +133,7 @@ public class ESMessageList implements ESSearchTypeHandler<MessageList> {
                 .numOfFragments(0));
     }
 
-    private QueryStringQueryBuilder decoratedHighlightQuery(SearchJob job, Query query) {
+    private QueryStringQueryBuilder decoratedHighlightQuery(Query query) {
         final String queryString = query.query().queryString();
 
         return QueryBuilders.queryStringQuery(queryString);

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/ESPivot.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/ESPivot.java
@@ -91,7 +91,7 @@ public class ESPivot implements ESSearchTypeHandler<Pivot> {
     }
 
     @Override
-    public void doGenerateQueryPart(SearchJob job, Query query, Pivot pivot, ESGeneratedQueryContext queryContext) {
+    public void doGenerateQueryPart(Query query, Pivot pivot, ESGeneratedQueryContext queryContext) {
         LOG.debug("Generating aggregation for {}", pivot);
         final SearchSourceBuilder searchSourceBuilder = queryContext.searchSourceBuilder(pivot);
 

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackendErrorHandlingTest.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackendErrorHandlingTest.java
@@ -79,7 +79,7 @@ public class ElasticsearchBackendErrorHandlingTest {
                 ),
                 client,
                 indexLookup,
-                (elasticsearchBackend, ssb, job, query, errors) -> new ESGeneratedQueryContext(elasticsearchBackend, ssb, job, query, errors, fieldTypesLookup),
+                (elasticsearchBackend, ssb, errors) -> new ESGeneratedQueryContext(elasticsearchBackend, ssb, errors, fieldTypesLookup),
                 usedSearchFilters -> Collections.emptySet(),
                 false);
         when(indexLookup.indexNamesForStreamsInTimeRange(any(), any())).thenReturn(Collections.emptySet());
@@ -108,8 +108,6 @@ public class ElasticsearchBackendErrorHandlingTest {
         this.queryContext = new ESGeneratedQueryContext(
                 this.backend,
                 new SearchSourceBuilder(),
-                searchJob,
-                query,
                 Collections.emptySet(),
                 mock(FieldTypesLookup.class)
         );

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackendGeneratedRequestTestBase.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackendGeneratedRequestTestBase.java
@@ -94,7 +94,7 @@ public class ElasticsearchBackendGeneratedRequestTestBase {
         this.elasticsearchBackend = new ElasticsearchBackend(elasticSearchTypeHandlers,
                 client,
                 indexLookup,
-                (elasticsearchBackend, ssb, job, query, errors) -> new ESGeneratedQueryContext(elasticsearchBackend, ssb, job, query, errors, fieldTypesLookup),
+                (elasticsearchBackend, ssb, errors) -> new ESGeneratedQueryContext(elasticsearchBackend, ssb, errors, fieldTypesLookup),
                 usedSearchFilters -> usedSearchFilters.stream()
                         .filter(sf -> sf instanceof InlineQueryStringSearchFilter)
                         .map(inlineSf -> ((InlineQueryStringSearchFilter) inlineSf).queryString())

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackendMultiSearchTest.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackendMultiSearchTest.java
@@ -57,7 +57,7 @@ public class ElasticsearchBackendMultiSearchTest extends ElasticsearchBackendGen
 
     @Before
     public void setUpFixtures() {
-        final Set<SearchType> searchTypes = new HashSet<SearchType>() {{
+        final Set<SearchType> searchTypes = new HashSet<>() {{
             add(
                     Pivot.builder()
                             .id("pivot1")
@@ -85,7 +85,7 @@ public class ElasticsearchBackendMultiSearchTest extends ElasticsearchBackendGen
 
     @Test
     public void everySearchTypeGeneratesASearchSourceBuilder() {
-        final ESGeneratedQueryContext queryContext = this.elasticsearchBackend.generate(searchJob, query, Collections.emptySet());
+        final ESGeneratedQueryContext queryContext = this.elasticsearchBackend.generate(query, Collections.emptySet());
 
         assertThat(queryContext.searchTypeQueries())
                 .hasSize(2)
@@ -99,7 +99,7 @@ public class ElasticsearchBackendMultiSearchTest extends ElasticsearchBackendGen
                 .collect(Collectors.toList());
         when(client.msearch(any(), any())).thenReturn(items);
 
-        final ESGeneratedQueryContext queryContext = this.elasticsearchBackend.generate(searchJob, query, Collections.emptySet());
+        final ESGeneratedQueryContext queryContext = this.elasticsearchBackend.generate(query, Collections.emptySet());
         final List<SearchRequest> generatedRequest = run(searchJob, query, queryContext, Collections.emptySet());
 
         assertThat(generatedRequest).hasSize(2);
@@ -112,7 +112,7 @@ public class ElasticsearchBackendMultiSearchTest extends ElasticsearchBackendGen
                 .collect(Collectors.toList());
         when(client.msearch(any(), any())).thenReturn(items);
 
-        final ESGeneratedQueryContext queryContext = this.elasticsearchBackend.generate(searchJob, query, Collections.emptySet());
+        final ESGeneratedQueryContext queryContext = this.elasticsearchBackend.generate(query, Collections.emptySet());
         final QueryResult queryResult = this.elasticsearchBackend.doRun(searchJob, query, queryContext);
 
         assertThat(queryResult.searchTypes()).containsOnlyKeys("pivot1", "pivot2");
@@ -134,7 +134,7 @@ public class ElasticsearchBackendMultiSearchTest extends ElasticsearchBackendGen
 
     @Test
     public void oneFailingSearchTypeReturnsPartialResults() throws Exception {
-        final ESGeneratedQueryContext queryContext = this.elasticsearchBackend.generate(searchJob, query, Collections.emptySet());
+        final ESGeneratedQueryContext queryContext = this.elasticsearchBackend.generate(query, Collections.emptySet());
 
         final MultiSearchResponse response = TestMultisearchResponse.fromFixture("partiallySuccessfulMultiSearchResponse.json");
         final List<MultiSearchResponse.Item> items = Arrays.stream(response.getResponses())

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackendSearchTypeOverridesTest.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackendSearchTypeOverridesTest.java
@@ -66,7 +66,7 @@ public class ElasticsearchBackendSearchTypeOverridesTest extends ElasticsearchBa
 
     @Before
     public void setUpFixtures() throws InvalidRangeParametersException {
-        final Set<SearchType> searchTypes = new HashSet<SearchType>() {{
+        final Set<SearchType> searchTypes = new HashSet<>() {{
             add(
                     Pivot.builder()
                             .id("pivot1")
@@ -99,7 +99,7 @@ public class ElasticsearchBackendSearchTypeOverridesTest extends ElasticsearchBa
 
     @Test
     public void overridesInSearchTypeAreIncorporatedIntoGeneratedQueries() throws IOException {
-        final ESGeneratedQueryContext queryContext = this.elasticsearchBackend.generate(searchJob, query, Collections.emptySet());
+        final ESGeneratedQueryContext queryContext = this.elasticsearchBackend.generate(query, Collections.emptySet());
         final MultiSearchResponse response = TestMultisearchResponse.fromFixture("successfulMultiSearchResponse.json");
         final List<MultiSearchResponse.Item> items = Arrays.stream(response.getResponses())
                 .collect(Collectors.toList());
@@ -130,19 +130,19 @@ public class ElasticsearchBackendSearchTypeOverridesTest extends ElasticsearchBa
     }
 
     private List<String> queryStrings(DocumentContext pivot) {
-        return pivot.read("$..query_string.query", new TypeRef<List<String>>() {});
+        return pivot.read("$..query_string.query", new TypeRef<>() {});
     }
 
     private List<List<String>> streams(DocumentContext pivot) {
-        return pivot.read("$..terms.streams", new TypeRef<List<List<String>>>() {});
+        return pivot.read("$..terms.streams", new TypeRef<>() {});
     }
 
     private List<String> timerangeFrom(DocumentContext pivot) {
-        return pivot.read("$..timestamp.from", new TypeRef<List<String>>() {});
+        return pivot.read("$..timestamp.from", new TypeRef<>() {});
     }
 
     private List<String> timerangeTo(DocumentContext pivot) {
-        return pivot.read("$..timestamp.to", new TypeRef<List<String>>() {});
+        return pivot.read("$..timestamp.to", new TypeRef<>() {});
     }
 
     @Test
@@ -154,7 +154,7 @@ public class ElasticsearchBackendSearchTypeOverridesTest extends ElasticsearchBa
         when(indexLookup.indexNamesForStreamsInTimeRange(ImmutableSet.of("stream1"), tr))
                 .thenReturn(ImmutableSet.of("searchTypeIndex"));
 
-        final ESGeneratedQueryContext queryContext = this.elasticsearchBackend.generate(searchJob, query, Collections.emptySet());
+        final ESGeneratedQueryContext queryContext = this.elasticsearchBackend.generate(query, Collections.emptySet());
         final MultiSearchResponse response = TestMultisearchResponse.fromFixture("successfulMultiSearchResponse.json");
         final List<MultiSearchResponse.Item> items = Arrays.stream(response.getResponses())
                 .collect(Collectors.toList());

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackendSearchTypesWithStreamsOverridesTest.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackendSearchTypesWithStreamsOverridesTest.java
@@ -131,7 +131,7 @@ public class ElasticsearchBackendSearchTypesWithStreamsOverridesTest extends Ela
 
     private List<SearchRequest> run(Query query) throws IOException {
         final SearchJob job = searchJobForQuery(query);
-        final ESGeneratedQueryContext context = this.elasticsearchBackend.generate(job, query, Collections.emptySet());
+        final ESGeneratedQueryContext context = this.elasticsearchBackend.generate(query, Collections.emptySet());
 
         this.elasticsearchBackend.doRun(job, query, context);
 

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackendTest.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackendTest.java
@@ -68,7 +68,7 @@ public class ElasticsearchBackendTest {
         backend = new ElasticsearchBackend(handlers,
                 null,
                 mock(IndexLookup.class),
-                (elasticsearchBackend, ssb, job, query, errors) -> new ESGeneratedQueryContext(elasticsearchBackend, ssb, job, query, errors, fieldTypesLookup),
+                (elasticsearchBackend, ssb, errors) -> new ESGeneratedQueryContext(elasticsearchBackend, ssb, errors, fieldTypesLookup),
                 usedSearchFiltersToQueryStringsMapper,
                 false);
     }
@@ -80,10 +80,7 @@ public class ElasticsearchBackendTest {
                 .query(ElasticsearchQueryString.of(""))
                 .timerange(RelativeRange.create(300))
                 .build();
-        final Search search = Search.builder().queries(ImmutableSet.of(query)).build();
-        final SearchJob job = new SearchJob("deadbeef", search, "admin");
-
-        backend.generate(job, query, Collections.emptySet());
+        backend.generate(query, Collections.emptySet());
     }
 
     @Test
@@ -120,10 +117,8 @@ public class ElasticsearchBackendTest {
                 .filters(usedSearchFilters)
                 .timerange(RelativeRange.create(300))
                 .build();
-        final Search search = Search.builder().queries(ImmutableSet.of(query)).build();
-        final SearchJob job = new SearchJob("deadbeef", search, "admin");
 
-        final ESGeneratedQueryContext queryContext = backend.generate(job, query, Collections.emptySet());
+        final ESGeneratedQueryContext queryContext = backend.generate(query, Collections.emptySet());
         final QueryBuilder esQuery = queryContext.searchSourceBuilder(new SearchType.Fallback()).query();
         assertThat(esQuery)
                 .isNotNull()

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/searchtypes/ESMessageListTest.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/searchtypes/ESMessageListTest.java
@@ -21,7 +21,6 @@ import com.jayway.jsonpath.JsonPath;
 import com.revinate.assertj.json.JsonPathAssert;
 import org.graylog.plugins.views.search.LegacyDecoratorProcessor;
 import org.graylog.plugins.views.search.Query;
-import org.graylog.plugins.views.search.SearchJob;
 import org.graylog.plugins.views.search.SearchType;
 import org.graylog.plugins.views.search.elasticsearch.ElasticsearchQueryString;
 import org.graylog.plugins.views.search.searchtypes.MessageList;
@@ -166,7 +165,7 @@ public class ESMessageListTest {
                 new LegacyDecoratorProcessor.Fake(),
                 allowHighlighting);
 
-        sut.doGenerateQueryPart(mock(SearchJob.class), someQuery(), messageList, context);
+        sut.doGenerateQueryPart(someQuery(), messageList, context);
 
         return context;
     }

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivots/ESPivotTest.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivots/ESPivotTest.java
@@ -159,7 +159,7 @@ public class ESPivotTest {
         final Values values = Values.builder().field("action").limit(10).build();
         when(pivot.columnGroups()).thenReturn(Collections.singletonList(values));
 
-        this.esPivot.doGenerateQueryPart(job, query, pivot, queryContext);
+        this.esPivot.doGenerateQueryPart(query, pivot, queryContext);
 
         verify(bucketHandler, times(1)).createAggregation(eq("agg-1"), eq(pivot), eq(values), eq(queryContext), eq(query));
     }
@@ -187,7 +187,7 @@ public class ESPivotTest {
         final Time time = Time.builder().field("timestamp").interval(AutoInterval.create()).build();
         when(pivot.columnGroups()).thenReturn(ImmutableList.of(values, time));
 
-        this.esPivot.doGenerateQueryPart(job, query, pivot, queryContext);
+        this.esPivot.doGenerateQueryPart(query, pivot, queryContext);
 
         verify(valuesBucketHandler, times(1)).createAggregation(eq("values-agg"), eq(pivot), eq(values), eq(queryContext), eq(query));
         verify(timeBucketHandler, times(1)).createAggregation(eq("time-agg"), eq(pivot), eq(time), eq(queryContext), eq(query));
@@ -217,7 +217,7 @@ public class ESPivotTest {
         final Values values = Values.builder().field("action").limit(10).build();
         when(pivot.rowGroups()).thenReturn(ImmutableList.of(time, values));
 
-        this.esPivot.doGenerateQueryPart(job, query, pivot, queryContext);
+        this.esPivot.doGenerateQueryPart(query, pivot, queryContext);
 
         verify(valuesBucketHandler, times(1)).createAggregation(eq("values-agg"), eq(pivot), eq(values), eq(queryContext), eq(query));
         verify(timeBucketHandler, times(1)).createAggregation(eq("time-agg"), eq(pivot), eq(time), eq(queryContext), eq(query));
@@ -248,7 +248,7 @@ public class ESPivotTest {
         when(pivot.rowGroups()).thenReturn(Collections.singletonList(time));
         when(pivot.columnGroups()).thenReturn(Collections.singletonList(values));
 
-        this.esPivot.doGenerateQueryPart(job, query, pivot, queryContext);
+        this.esPivot.doGenerateQueryPart(query, pivot, queryContext);
 
         verify(valuesBucketHandler, times(1)).createAggregation(eq("values-agg"), eq(pivot), eq(values), eq(queryContext), eq(query));
         verify(timeBucketHandler, times(1)).createAggregation(eq("time-agg"), eq(pivot), eq(time), eq(queryContext), eq(query));
@@ -294,7 +294,7 @@ public class ESPivotTest {
         when(pivot.rollup()).thenReturn(false);
         when(queryContext.seriesName(any(), any())).thenCallRealMethod();
 
-        this.esPivot.doGenerateQueryPart(job, query, pivot, queryContext);
+        this.esPivot.doGenerateQueryPart(query, pivot, queryContext);
 
         verify(timeBucketHandler).createAggregation(eq("rowPivot1"), eq(pivot), eq(rowPivot1), eq(queryContext), eq(query));
         verify(valuesBucketHandler).createAggregation(eq("rowPivot2"), eq(pivot), eq(rowPivot2), eq(queryContext), eq(query));

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/engine/QueryBackend.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/engine/QueryBackend.java
@@ -45,11 +45,10 @@ public interface QueryBackend<T extends GeneratedQueryContext> {
     /**
      * Generate a backend-specific query out of the logical query structure.
      *
-     * @param job                currently executing job
-     * @param query              the graylog query structure
+     * @param query the graylog query structure
      * @return a backend specific generated query
      */
-    T generate(SearchJob job, Query query, Set<SearchError> validationErrors);
+    T generate(Query query, Set<SearchError> validationErrors);
 
     default boolean isAllMessages(TimeRange timeRange) {
         return timeRange instanceof RelativeRange && ((RelativeRange)timeRange).isAllMessages();

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/engine/QueryEngine.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/engine/QueryEngine.java
@@ -117,7 +117,7 @@ public class QueryEngine {
         // with all the results done, we can execute the current query and eventually complete our own result
         // if any of this throws an exception, the handle in #execute will convert it to an error and return a "failed" result instead
         // if the backend already returns a "failed result" then nothing special happens here
-        final GeneratedQueryContext generatedQueryContext = backend.generate(searchJob, query, validationErrors);
+        final GeneratedQueryContext generatedQueryContext = backend.generate(query, validationErrors);
         LOG.trace("[{}] Generated query {}, running it on backend {}", query.id(), generatedQueryContext, backend);
         final QueryResult result = backend.run(searchJob, query, generatedQueryContext);
         LOG.debug("[{}] Query returned {}", query.id(), result);

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/engine/SearchTypeHandler.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/engine/SearchTypeHandler.java
@@ -31,12 +31,12 @@ import org.graylog.plugins.views.search.errors.SearchTypeError;
 @SuppressWarnings("unchecked")
 public interface SearchTypeHandler<S extends SearchType, Q, R> {
 
-    default void generateQueryPart(SearchJob job, Query query, SearchType searchType, Q queryContext) {
+    default void generateQueryPart(Query query, SearchType searchType, Q queryContext) {
         // We need to typecast manually here, because '? extends SearchType' and 'SearchType' are never compatible
         // and thus the compiler won't accept the types at their call sites
         // This allows us to get proper types in the implementing classes instead of having to cast there.
         try {
-            doGenerateQueryPart(job, query, (S) searchType, queryContext);
+            doGenerateQueryPart(query, (S) searchType, queryContext);
         } catch (SearchException e) {
             // these already have a specific error, so we don't need to handle them specially
             throw e;
@@ -45,7 +45,7 @@ public interface SearchTypeHandler<S extends SearchType, Q, R> {
         }
     }
 
-    void doGenerateQueryPart(SearchJob job, Query query, S searchType, Q queryContext);
+    void doGenerateQueryPart(Query query, S searchType, Q queryContext);
 
     default SearchType.Result extractResult(SearchJob job, Query query, SearchType searchType, R queryResult, Q queryContext) {
         // see above for the reason for typecasting


### PR DESCRIPTION
## Description
Removing unnecessary usage of SearchJob throughout the API.

## Motivation and Context
When developing upgrades for query-aware field list, I'd like to execute single Query, without referencing Search.
This need made me realize that in many places in our code SearchJob is passed without any need, so I have cleaned it a little bit.
It turned out that we might have passed SearchJob around just because of its usage in ElasticsearchBackend#generateFilterClause() and this method ... was just pretending it needs this parameter, only passing it to recursive invocations, without any actual work on this param.

Even if it does not turn useful for my current task, this simplification probably deserves to be merged on its own.

## How Has This Been Tested?
By re-runing the tests.

/jenkins-pr-deps Graylog2/graylog-plugin-enterprise#4030

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

