### PR TITLE
Query-based awareness instead of stream-based awareness. Concept.

### DIFF
--- a/full-backend-tests/src/test/java/org/graylog/plugins/views/FieldTypesResourceIT.java
+++ b/full-backend-tests/src/test/java/org/graylog/plugins/views/FieldTypesResourceIT.java
@@ -90,6 +90,8 @@ public class FieldTypesResourceIT {
                 .accept(ContentType.JSON)
                 .body(OBJECT_MAPPER.writeValueAsString(request))
                 .queryParam("size", 100)
+                .queryParam("useSampler", false)
+                .queryParam("sampleSize", 100)
                 .post("/views/fields/byQuery");
 
         final ValidatableResponse validatableResponse = response.then()
@@ -116,6 +118,8 @@ public class FieldTypesResourceIT {
                 .accept(ContentType.JSON)
                 .body(OBJECT_MAPPER.writeValueAsString(request))
                 .queryParam("size", 100)
+                .queryParam("useSampler", false)
+                .queryParam("sampleSize", 100)
                 .post("/views/fields/byQuery");
 
         final ValidatableResponse validatableResponse = response.then()
@@ -145,6 +149,8 @@ public class FieldTypesResourceIT {
                 .accept(ContentType.JSON)
                 .body(OBJECT_MAPPER.writeValueAsString(request))
                 .queryParam("size", 100)
+                .queryParam("useSampler", false)
+                .queryParam("sampleSize", 100)
                 .post("/views/fields/byQuery");
 
         final ValidatableResponse validatableResponse = response.then()

--- a/full-backend-tests/src/test/java/org/graylog/plugins/views/FieldTypesResourceIT.java
+++ b/full-backend-tests/src/test/java/org/graylog/plugins/views/FieldTypesResourceIT.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.views;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableSet;
+import io.restassured.http.ContentType;
+import io.restassured.response.Response;
+import io.restassured.response.ValidatableResponse;
+import io.restassured.specification.RequestSpecification;
+import org.graylog.plugins.views.search.elasticsearch.ElasticsearchQueryString;
+import org.graylog.plugins.views.search.rest.FieldTypesForQueryRequest;
+import org.graylog.plugins.views.search.rest.FieldTypesForStreamsRequest;
+import org.graylog.plugins.views.search.rest.QueryDTO;
+import org.graylog.plugins.views.search.searchfilters.model.InlineQueryStringSearchFilter;
+import org.graylog.testing.completebackend.GraylogBackend;
+import org.graylog.testing.containermatrix.annotations.ContainerMatrixTest;
+import org.graylog.testing.containermatrix.annotations.ContainerMatrixTestsConfiguration;
+import org.graylog.testing.utils.SearchUtils;
+import org.graylog2.plugin.indexer.searches.timeranges.RelativeRange;
+import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
+import org.junit.jupiter.api.BeforeAll;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+
+@ContainerMatrixTestsConfiguration
+public class FieldTypesResourceIT {
+
+    private final RequestSpecification requestSpec;
+    private final GraylogBackend backend;
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapperProvider().get();
+
+    public FieldTypesResourceIT(RequestSpecification requestSpec, GraylogBackend backend) {
+        this.requestSpec = requestSpec;
+        this.backend = backend;
+    }
+
+    @BeforeAll
+    public void setUp() {
+        backend.importElasticsearchFixture("field_type_test_messages.json", FieldTypesResourceIT.class);
+
+        SearchUtils.waitForFieldTypeDefinition(requestSpec, "medieval_field");
+        SearchUtils.waitForFieldTypeDefinition(requestSpec, "telegram_field");
+        SearchUtils.waitForFieldTypeDefinition(requestSpec, "modern_field");
+    }
+
+    @ContainerMatrixTest
+    void http400OnEmptyBody() {
+        given()
+                .spec(requestSpec)
+                .when()
+                .post("/views/fields/byQuery")
+                .then()
+                .statusCode(400);
+    }
+
+    @ContainerMatrixTest
+    void returnsFieldsForAllMessages() throws Exception {
+        final FieldTypesForQueryRequest request = FieldTypesForQueryRequest.Builder.builder()
+                .query(createQueryDTOBuilder().build())
+                .parameters(ImmutableSet.of())
+                .fallback(FieldTypesForStreamsRequest.Builder.builder().build())
+                .build();
+        final Response response = given()
+                .spec(requestSpec)
+                .when()
+                .accept(ContentType.JSON)
+                .body(OBJECT_MAPPER.writeValueAsString(request))
+                .queryParam("size", 100)
+                .post("/views/fields/byQuery");
+
+        final ValidatableResponse validatableResponse = response.then()
+                .log().ifStatusCodeMatches(not(200))
+                .statusCode(200);
+
+        containsFields(validatableResponse, Set.of("message", "source", "timestamp", "streams", "medieval_field", "telegram_field", "modern_field"));
+        doesNotContainFields(validatableResponse, Set.of("carramba"));
+
+    }
+
+    @ContainerMatrixTest
+    void returnsProperFieldsForMessagesFilteredByQueryString() throws Exception {
+        final FieldTypesForQueryRequest request = FieldTypesForQueryRequest.Builder.builder()
+                .query(createQueryDTOBuilder()
+                        .query(ElasticsearchQueryString.of("message:message"))
+                        .build())
+                .parameters(ImmutableSet.of())
+                .fallback(FieldTypesForStreamsRequest.Builder.builder().build())
+                .build();
+        final Response response = given()
+                .spec(requestSpec)
+                .when()
+                .accept(ContentType.JSON)
+                .body(OBJECT_MAPPER.writeValueAsString(request))
+                .queryParam("size", 100)
+                .post("/views/fields/byQuery");
+
+        final ValidatableResponse validatableResponse = response.then()
+                .log().ifStatusCodeMatches(not(200))
+                .statusCode(200);
+
+        containsFields(validatableResponse, Set.of("message", "source", "timestamp", "streams", "telegram_field", "modern_field"));
+        doesNotContainFields(validatableResponse, Set.of("medieval_field"));
+
+    }
+
+    @ContainerMatrixTest
+    void ignoresSearchFiltersWithoutALicense() throws Exception {
+        final FieldTypesForQueryRequest request = FieldTypesForQueryRequest.Builder.builder()
+                .query(createQueryDTOBuilder()
+                        .query(ElasticsearchQueryString.of("_exists_:telegram_field")) //will be used
+                        .filters(List.of(
+                                InlineQueryStringSearchFilter.builder().queryString("_exists_:medieval_field").build() //will be ignored
+                        ))
+                        .build())
+                .parameters(ImmutableSet.of())
+                .fallback(FieldTypesForStreamsRequest.Builder.builder().build())
+                .build();
+        final Response response = given()
+                .spec(requestSpec)
+                .when()
+                .accept(ContentType.JSON)
+                .body(OBJECT_MAPPER.writeValueAsString(request))
+                .queryParam("size", 100)
+                .post("/views/fields/byQuery");
+
+        final ValidatableResponse validatableResponse = response.then()
+                .log().ifStatusCodeMatches(not(200))
+                .statusCode(200);
+
+        containsFields(validatableResponse, Set.of("message", "source", "timestamp", "streams", "telegram_field"));
+        doesNotContainFields(validatableResponse, Set.of("modern_field", "medieval_field"));
+
+    }
+
+    private void containsFields(final ValidatableResponse validatableResponse, final Collection<String> fieldNames) {
+        fieldNames.forEach(
+                fieldName -> validatableResponse.body("find { it.name == '" + fieldName + "' }", notNullValue())
+        );
+    }
+
+    private void doesNotContainFields(final ValidatableResponse validatableResponse, final Collection<String> fieldNames) {
+        fieldNames.forEach(
+                fieldName -> validatableResponse.body("find { it.name == '" + fieldName + "' }", nullValue())
+        );
+    }
+
+    private QueryDTO.Builder createQueryDTOBuilder() {
+        return QueryDTO.builder()
+                .searchTypes(Set.of())
+                .filters(List.of())
+                .id("query id")
+                .timerange(RelativeRange.allTime())
+                .query(ElasticsearchQueryString.of("*"));
+    }
+
+}

--- a/full-backend-tests/src/test/resources/org/graylog/plugins/views/field_type_test_messages.json
+++ b/full-backend-tests/src/test/resources/org/graylog/plugins/views/field_type_test_messages.json
@@ -1,0 +1,81 @@
+{
+  "documents": [
+    {
+      "document": [
+        {
+          "index": {
+            "indexName": "graylog_0",
+            "indexType": "message",
+            "indexId": "0"
+          }
+        },
+        {
+          "data": {
+            "source": "pigeon",
+            "message": "Medieval letter",
+            "medieval_field": "Liege",
+            "timestamp": "2022-01-01 01:00:00.000",
+            "streams": [
+              "000000000000000000000001"
+            ],
+            "gl2_message_fields" : ["source","message","medieval_field","timestamp","streams"]
+          }
+        }
+      ]
+    },
+    {
+      "document": [
+        {
+          "index": {
+            "indexName": "graylog_0",
+            "indexType": "message",
+            "indexId": "1"
+          }
+        },
+        {
+          "data": {
+            "source": "telegram",
+            "message": "Telegram message",
+            "telegram_field": "Lord",
+            "timestamp": "2022-01-01 01:00:00.000",
+            "streams": [
+              "000000000000000000000001"
+            ],
+            "gl2_message_fields" : ["source","message","telegram_field","timestamp","streams"]
+          }
+        }
+      ]
+    },
+    {
+      "document": [
+        {
+          "index": {
+            "indexName": "graylog_0",
+            "indexType": "message",
+            "indexId": "2"
+          }
+        },
+        {
+          "index": {
+            "indexName": "gl-events_0",
+            "indexType": "message",
+            "indexId": "3"
+          }
+        },
+        {
+          "data": {
+            "source": "e-mail",
+            "message": "Modern message",
+            "modern_field": "CEO",
+            "timestamp": "2022-01-01 01:00:00.000",
+            "streams": [
+              "000000000000000000000001",
+              "000000000000000000000002"
+            ],
+            "gl2_message_fields" : ["source","message","modern_field","timestamp","streams"]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/BoolQueryTools.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/BoolQueryTools.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog.storage.elasticsearch7;
 
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.index.query.BoolQueryBuilder;

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/BoolQueryTools.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/BoolQueryTools.java
@@ -1,0 +1,25 @@
+package org.graylog.storage.elasticsearch7;
+
+import org.graylog.shaded.elasticsearch7.org.elasticsearch.index.query.BoolQueryBuilder;
+import org.graylog.shaded.elasticsearch7.org.elasticsearch.index.query.QueryBuilders;
+import org.graylog2.plugin.Message;
+import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
+
+import java.util.Collection;
+import java.util.Objects;
+
+public class BoolQueryTools {
+
+    public static void addTimeRange(BoolQueryBuilder boolQueryBuilder, final TimeRange timeRange, final String identifier) {
+        boolQueryBuilder.must(
+                Objects.requireNonNull(
+                        TimeRangeQueryFactory.create(timeRange),
+                        "Timerange for " + identifier + " cannot be found."
+                )
+        );
+    }
+
+    public static void addStreams(BoolQueryBuilder boolQueryBuilder, final Collection<String> streamIds) {
+        boolQueryBuilder.must(QueryBuilders.termsQuery(Message.FIELD_STREAMS, streamIds));
+    }
+}

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/BoolQueryTools.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/BoolQueryTools.java
@@ -26,16 +26,33 @@ import java.util.Objects;
 
 public class BoolQueryTools {
 
-    public static void addTimeRange(BoolQueryBuilder boolQueryBuilder, final TimeRange timeRange, final String identifier) {
-        boolQueryBuilder.must(
-                Objects.requireNonNull(
-                        TimeRangeQueryFactory.create(timeRange),
-                        "Timerange for " + identifier + " cannot be found."
-                )
-        );
+    public enum Mode {
+        FILTER, MUST
     }
 
-    public static void addStreams(BoolQueryBuilder boolQueryBuilder, final Collection<String> streamIds) {
-        boolQueryBuilder.must(QueryBuilders.termsQuery(Message.FIELD_STREAMS, streamIds));
+    public static void addTimeRange(BoolQueryBuilder boolQueryBuilder, final TimeRange timeRange, final String identifier, final Mode mode) {
+        if (mode == Mode.MUST) {
+            boolQueryBuilder.must(
+                    Objects.requireNonNull(
+                            TimeRangeQueryFactory.create(timeRange),
+                            "Timerange for " + identifier + " cannot be found."
+                    )
+            );
+        } else {
+            boolQueryBuilder.filter(
+                    Objects.requireNonNull(
+                            TimeRangeQueryFactory.create(timeRange),
+                            "Timerange for " + identifier + " cannot be found."
+                    )
+            );
+        }
+    }
+
+    public static void addStreams(BoolQueryBuilder boolQueryBuilder, final Collection<String> streamIds, final Mode mode) {
+        if (mode == Mode.MUST) {
+            boolQueryBuilder.must(QueryBuilders.termsQuery(Message.FIELD_STREAMS, streamIds));
+        } else {
+            boolQueryBuilder.filter(QueryBuilders.termsQuery(Message.FIELD_STREAMS, streamIds));
+        }
     }
 }

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/ESGeneratedQueryContext.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/ESGeneratedQueryContext.java
@@ -91,6 +91,10 @@ public class ESGeneratedQueryContext implements GeneratedQueryContext {
                 .toString();
     }
 
+    public SearchSourceBuilder getSsb() {
+        return ssb;
+    }
+
     public Map<Object, Object> contextMap() {
         return contextMap;
     }

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/ESGeneratedQueryContext.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/ESGeneratedQueryContext.java
@@ -91,10 +91,6 @@ public class ESGeneratedQueryContext implements GeneratedQueryContext {
                 .toString();
     }
 
-    public SearchSourceBuilder getSsb() {
-        return ssb;
-    }
-
     public Map<Object, Object> contextMap() {
         return contextMap;
     }

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackend.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackend.java
@@ -198,7 +198,7 @@ public class ElasticsearchBackend implements QueryBackend<ESGeneratedQueryContex
     }
 
     @Override
-    public Set<String> getFieldsPresentInSearchResultDocuments(final Query normalizedQuery, final int size) {
+    public Set<String> getFieldsPresentInQueryResultDocuments(final Query normalizedQuery, final int size) {
         final Set<String> affectedIndices = indexLookup.indexNamesForStreamsInTimeRange(normalizedQuery.usedStreamIds(), normalizedQuery.timerange());
         final SearchSourceBuilder searchSourceBuilder = createSearchSourceBuilder(normalizedQuery);
         final QueryBuilder query = searchSourceBuilder.query();

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackend.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackend.java
@@ -22,7 +22,6 @@ import org.graylog.plugins.views.search.Filter;
 import org.graylog.plugins.views.search.GlobalOverride;
 import org.graylog.plugins.views.search.Query;
 import org.graylog.plugins.views.search.QueryResult;
-import org.graylog.plugins.views.search.Search;
 import org.graylog.plugins.views.search.SearchJob;
 import org.graylog.plugins.views.search.SearchType;
 import org.graylog.plugins.views.search.elasticsearch.IndexLookup;
@@ -207,21 +206,20 @@ public class ElasticsearchBackend implements QueryBackend<ESGeneratedQueryContex
     }
 
     @Override
-    public Set<String> getFieldsPresentInSearchResultDocuments(final Search normalizedSearch) {
-        final Query mainQuery = normalizedSearch.queries().stream().findFirst().orElseThrow(() -> new IllegalArgumentException("No queries in search : " + normalizedSearch.id()));
-        final ESGeneratedQueryContext generatedQueryContext = generate(mainQuery, Set.of());
-        final Set<String> affectedIndices = indexLookup.indexNamesForStreamsInTimeRange(mainQuery.usedStreamIds(), mainQuery.timerange());
+    public Set<String> getFieldsPresentInSearchResultDocuments(final Query normalizedQuery) {
+        final ESGeneratedQueryContext generatedQueryContext = generate(normalizedQuery, Set.of());
+        final Set<String> affectedIndices = indexLookup.indexNamesForStreamsInTimeRange(normalizedQuery.usedStreamIds(), normalizedQuery.timerange());
         final SearchSourceBuilder searchSourceBuilder = generatedQueryContext.getSsb().shallowCopy();
         final QueryBuilder query = searchSourceBuilder.query();
 
         if (query instanceof BoolQueryBuilder boolQueryBuilder) {
-            boolQueryBuilder.must(QueryBuilders.termsQuery(Message.FIELD_STREAMS, mainQuery.usedStreamIds()))
+            boolQueryBuilder.must(QueryBuilders.termsQuery(Message.FIELD_STREAMS, normalizedQuery.usedStreamIds()))
                     .must(
                             Objects.requireNonNull(
                                     TimeRangeQueryFactory.create(
-                                            mainQuery.timerange()
+                                            normalizedQuery.timerange()
                                     ),
-                                    "Timerange for query " + mainQuery.id() + " cannot be found in query or search type."
+                                    "Timerange for query " + normalizedQuery.id() + " cannot be found in query or search type."
                             )
                     );
 

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackend.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackend.java
@@ -106,31 +106,10 @@ public class ElasticsearchBackend implements QueryBackend<ESGeneratedQueryContex
 
     @Override
     public ESGeneratedQueryContext generate(Query query, Set<SearchError> validationErrors) {
-        final BackendQuery backendQuery = query.query();
-
-        final Set<SearchType> searchTypes = query.searchTypes();
-
-        final QueryBuilder normalizedRootQuery = translateQueryString(backendQuery.queryString());
-
-        final BoolQueryBuilder boolQuery = QueryBuilders.boolQuery()
-                .filter(normalizedRootQuery);
-
-        usedSearchFiltersToQueryStringsMapper.map(query.filters())
-                .stream()
-                .map(this::translateQueryString)
-                .forEach(boolQuery::filter);
-
-        // add the optional root query filters
-        generateFilterClause(query.filter()).map(boolQuery::filter);
-
-        final SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder()
-                .query(boolQuery)
-                .from(0)
-                .size(0)
-                .trackTotalHits(true);
+        final SearchSourceBuilder searchSourceBuilder = createSearchSourceBuilder(query);
 
         final ESGeneratedQueryContext queryContext = queryContextFactory.create(this, searchSourceBuilder, validationErrors);
-        searchTypes.stream()
+        query.searchTypes().stream()
                 .filter(searchType -> !isSearchTypeWithError(queryContext, searchType.id()))
                 .forEach(searchType -> {
                     final String type = searchType.type();
@@ -175,6 +154,27 @@ public class ElasticsearchBackend implements QueryBackend<ESGeneratedQueryContex
         return queryContext;
     }
 
+    private SearchSourceBuilder createSearchSourceBuilder(final Query query) {
+        final BackendQuery backendQuery = query.query();
+        final QueryBuilder normalizedRootQuery = translateQueryString(backendQuery.queryString());
+        final BoolQueryBuilder boolQuery = QueryBuilders.boolQuery()
+                .filter(normalizedRootQuery);
+
+        usedSearchFiltersToQueryStringsMapper.map(query.filters())
+                .stream()
+                .map(this::translateQueryString)
+                .forEach(boolQuery::filter);
+
+        // add the optional root query filters
+        generateFilterClause(query.filter()).map(boolQuery::filter);
+
+        return new SearchSourceBuilder()
+                .query(boolQuery)
+                .from(0)
+                .size(0)
+                .trackTotalHits(true);
+    }
+
     // TODO make pluggable
     public Optional<QueryBuilder> generateFilterClause(Filter filter) {
         if (filter == null) {
@@ -207,9 +207,8 @@ public class ElasticsearchBackend implements QueryBackend<ESGeneratedQueryContex
 
     @Override
     public Set<String> getFieldsPresentInSearchResultDocuments(final Query normalizedQuery) {
-        final ESGeneratedQueryContext generatedQueryContext = generate(normalizedQuery, Set.of());
         final Set<String> affectedIndices = indexLookup.indexNamesForStreamsInTimeRange(normalizedQuery.usedStreamIds(), normalizedQuery.timerange());
-        final SearchSourceBuilder searchSourceBuilder = generatedQueryContext.getSsb().shallowCopy();
+        final SearchSourceBuilder searchSourceBuilder = createSearchSourceBuilder(normalizedQuery);
         final QueryBuilder query = searchSourceBuilder.query();
 
         if (query instanceof BoolQueryBuilder boolQueryBuilder) {

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackend.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackend.java
@@ -128,8 +128,8 @@ public class ElasticsearchBackend implements QueryBackend<ESGeneratedQueryContex
 
                     final BoolQueryBuilder searchTypeOverrides = QueryBuilders.boolQuery()
                             .must(searchTypeSourceBuilder.query());
-                    BoolQueryTools.addTimeRange(searchTypeOverrides, query.effectiveTimeRange(searchType), "search type " + searchType.id());
-                    BoolQueryTools.addStreams(searchTypeOverrides, effectiveStreamIds);
+                    BoolQueryTools.addTimeRange(searchTypeOverrides, query.effectiveTimeRange(searchType), "search type " + searchType.id(), BoolQueryTools.Mode.MUST);
+                    BoolQueryTools.addStreams(searchTypeOverrides, effectiveStreamIds, BoolQueryTools.Mode.MUST);
 
                     searchType.query().ifPresent(searchTypeQuery -> {
                         final QueryBuilder normalizedSearchTypeQuery = translateQueryString(searchTypeQuery.queryString());
@@ -207,8 +207,8 @@ public class ElasticsearchBackend implements QueryBackend<ESGeneratedQueryContex
         final QueryBuilder query = searchSourceBuilder.query();
 
         if (query instanceof BoolQueryBuilder boolQueryBuilder) {
-            BoolQueryTools.addTimeRange(boolQueryBuilder, normalizedQuery.timerange(), "query " + normalizedQuery.id());
-            BoolQueryTools.addStreams(boolQueryBuilder, normalizedQuery.usedStreamIds());
+            BoolQueryTools.addTimeRange(boolQueryBuilder, normalizedQuery.timerange(), "query " + normalizedQuery.id(), BoolQueryTools.Mode.FILTER);
+            BoolQueryTools.addStreams(boolQueryBuilder, normalizedQuery.usedStreamIds(), BoolQueryTools.Mode.FILTER);
         }
 
         final String aggregationName = ALL_MESSAGE_FIELDS_DOCUMENT_FIELD + "_aggr";

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackend.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackend.java
@@ -22,6 +22,7 @@ import org.graylog.plugins.views.search.Filter;
 import org.graylog.plugins.views.search.GlobalOverride;
 import org.graylog.plugins.views.search.Query;
 import org.graylog.plugins.views.search.QueryResult;
+import org.graylog.plugins.views.search.Search;
 import org.graylog.plugins.views.search.SearchJob;
 import org.graylog.plugins.views.search.SearchType;
 import org.graylog.plugins.views.search.elasticsearch.IndexLookup;
@@ -43,6 +44,9 @@ import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.support.Indice
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.index.query.BoolQueryBuilder;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.index.query.QueryBuilder;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.index.query.QueryBuilders;
+import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.Aggregation;
+import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.bucket.MultiBucketsAggregation;
+import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.graylog.storage.elasticsearch7.ElasticsearchClient;
 import org.graylog.storage.elasticsearch7.TimeRangeQueryFactory;
@@ -66,6 +70,8 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import static org.graylog2.indexer.fieldtypes.DiscoveredFieldTypeService.ALL_MESSAGE_FIELDS_DOCUMENT_FIELD;
 
 public class ElasticsearchBackend implements QueryBackend<ESGeneratedQueryContext> {
     private static final Logger LOG = LoggerFactory.getLogger(ElasticsearchBackend.class);
@@ -162,7 +168,7 @@ public class ElasticsearchBackend implements QueryBackend<ESGeneratedQueryContex
                             .map(this::translateQueryString)
                             .forEach(searchTypeOverrides::must);
 
-            searchTypeSourceBuilder.query(searchTypeOverrides);
+                    searchTypeSourceBuilder.query(searchTypeOverrides);
 
                     searchTypeHandler.get().generateQueryPart(query, searchType, queryContext);
                 });
@@ -198,6 +204,49 @@ public class ElasticsearchBackend implements QueryBackend<ESGeneratedQueryContex
                 return Optional.of(QueryBuilders.queryStringQuery(((QueryStringFilter) filter).query()));
         }
         return Optional.empty();
+    }
+
+    @Override
+    public Set<String> getFieldsPresentInSearchResultDocuments(final Search normalizedSearch) {
+        final Query mainQuery = normalizedSearch.queries().stream().findFirst().orElseThrow(() -> new IllegalArgumentException("No queries in search : " + normalizedSearch.id()));
+        final ESGeneratedQueryContext generatedQueryContext = generate(mainQuery, Set.of());
+        final Set<String> affectedIndices = indexLookup.indexNamesForStreamsInTimeRange(mainQuery.usedStreamIds(), mainQuery.timerange());
+        final SearchSourceBuilder searchSourceBuilder = generatedQueryContext.getSsb().shallowCopy();
+        final QueryBuilder query = searchSourceBuilder.query();
+
+        if (query instanceof BoolQueryBuilder boolQueryBuilder) {
+            boolQueryBuilder.must(QueryBuilders.termsQuery(Message.FIELD_STREAMS, mainQuery.usedStreamIds()))
+                    .must(
+                            Objects.requireNonNull(
+                                    TimeRangeQueryFactory.create(
+                                            mainQuery.timerange()
+                                    ),
+                                    "Timerange for query " + mainQuery.id() + " cannot be found in query or search type."
+                            )
+                    );
+
+        }
+        final String aggregationName = ALL_MESSAGE_FIELDS_DOCUMENT_FIELD + "_aggr";
+        searchSourceBuilder.aggregation(new TermsAggregationBuilder(aggregationName)
+                .field(ALL_MESSAGE_FIELDS_DOCUMENT_FIELD)
+                .size(1000));
+        final SearchResponse res = client.search(new SearchRequest()
+                .source(searchSourceBuilder)
+                .indices(affectedIndices.toArray(new String[0]))
+                .indicesOptions(IndicesOptions.fromOptions(false, false, true, false)), "Unable to retrieve fields used in search result documents");
+
+        final Aggregation aggregationResult = res.getAggregations().get(aggregationName);
+        if (aggregationResult instanceof MultiBucketsAggregation) {
+            final List<? extends MultiBucketsAggregation.Bucket> buckets = ((MultiBucketsAggregation) aggregationResult).getBuckets();
+            if (buckets != null) {
+                return buckets.stream()
+                        .filter(Objects::nonNull)
+                        .map(MultiBucketsAggregation.Bucket::getKeyAsString)
+                        .collect(Collectors.toSet());
+            }
+        }
+
+        return Set.of();
     }
 
     @Override

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/BoolQueryTools.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/BoolQueryTools.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog.storage.opensearch2;
 
 import org.graylog.shaded.opensearch2.org.opensearch.index.query.BoolQueryBuilder;

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/BoolQueryTools.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/BoolQueryTools.java
@@ -1,0 +1,25 @@
+package org.graylog.storage.opensearch2;
+
+import org.graylog.shaded.opensearch2.org.opensearch.index.query.BoolQueryBuilder;
+import org.graylog.shaded.opensearch2.org.opensearch.index.query.QueryBuilders;
+import org.graylog2.plugin.Message;
+import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
+
+import java.util.Collection;
+import java.util.Objects;
+
+public class BoolQueryTools {
+
+    public static void addTimeRange(BoolQueryBuilder boolQueryBuilder, final TimeRange timeRange, final String identifier) {
+        boolQueryBuilder.must(
+                Objects.requireNonNull(
+                        TimeRangeQueryFactory.create(timeRange),
+                        "Timerange for " + identifier + " cannot be found."
+                )
+        );
+    }
+
+    public static void addStreams(BoolQueryBuilder boolQueryBuilder, final Collection<String> streamIds) {
+        boolQueryBuilder.must(QueryBuilders.termsQuery(Message.FIELD_STREAMS, streamIds));
+    }
+}

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/BoolQueryTools.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/BoolQueryTools.java
@@ -24,18 +24,36 @@ import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
 import java.util.Collection;
 import java.util.Objects;
 
+
 public class BoolQueryTools {
 
-    public static void addTimeRange(BoolQueryBuilder boolQueryBuilder, final TimeRange timeRange, final String identifier) {
-        boolQueryBuilder.must(
-                Objects.requireNonNull(
-                        TimeRangeQueryFactory.create(timeRange),
-                        "Timerange for " + identifier + " cannot be found."
-                )
-        );
+    public enum Mode {
+        FILTER, MUST
     }
 
-    public static void addStreams(BoolQueryBuilder boolQueryBuilder, final Collection<String> streamIds) {
-        boolQueryBuilder.must(QueryBuilders.termsQuery(Message.FIELD_STREAMS, streamIds));
+    public static void addTimeRange(BoolQueryBuilder boolQueryBuilder, final TimeRange timeRange, final String identifier, final Mode mode) {
+        if (mode == Mode.MUST) {
+            boolQueryBuilder.must(
+                    Objects.requireNonNull(
+                            TimeRangeQueryFactory.create(timeRange),
+                            "Timerange for " + identifier + " cannot be found."
+                    )
+            );
+        } else {
+            boolQueryBuilder.filter(
+                    Objects.requireNonNull(
+                            TimeRangeQueryFactory.create(timeRange),
+                            "Timerange for " + identifier + " cannot be found."
+                    )
+            );
+        }
+    }
+
+    public static void addStreams(BoolQueryBuilder boolQueryBuilder, final Collection<String> streamIds, final Mode mode) {
+        if (mode == Mode.MUST) {
+            boolQueryBuilder.must(QueryBuilders.termsQuery(Message.FIELD_STREAMS, streamIds));
+        } else {
+            boolQueryBuilder.filter(QueryBuilders.termsQuery(Message.FIELD_STREAMS, streamIds));
+        }
     }
 }

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/OSGeneratedQueryContext.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/OSGeneratedQueryContext.java
@@ -90,6 +90,10 @@ public class OSGeneratedQueryContext implements GeneratedQueryContext {
                 .toString();
     }
 
+    public SearchSourceBuilder getSsb() {
+        return ssb;
+    }
+
     public Map<Object, Object> contextMap() {
         return contextMap;
     }

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/OSGeneratedQueryContext.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/OSGeneratedQueryContext.java
@@ -90,10 +90,6 @@ public class OSGeneratedQueryContext implements GeneratedQueryContext {
                 .toString();
     }
 
-    public SearchSourceBuilder getSsb() {
-        return ssb;
-    }
-
     public Map<Object, Object> contextMap() {
         return contextMap;
     }

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/OpenSearchBackend.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/OpenSearchBackend.java
@@ -27,6 +27,7 @@ import org.graylog.plugins.views.search.SearchType;
 import org.graylog.plugins.views.search.elasticsearch.IndexLookup;
 import org.graylog.plugins.views.search.engine.BackendQuery;
 import org.graylog.plugins.views.search.engine.QueryBackend;
+import org.graylog.plugins.views.search.engine.fieldlist.QueryAwareFieldListRetrievalParams;
 import org.graylog.plugins.views.search.errors.SearchError;
 import org.graylog.plugins.views.search.errors.SearchTypeError;
 import org.graylog.plugins.views.search.errors.SearchTypeErrorParser;
@@ -44,7 +45,9 @@ import org.graylog.shaded.opensearch2.org.opensearch.index.query.BoolQueryBuilde
 import org.graylog.shaded.opensearch2.org.opensearch.index.query.QueryBuilder;
 import org.graylog.shaded.opensearch2.org.opensearch.index.query.QueryBuilders;
 import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.Aggregation;
+import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.HasAggregations;
 import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.bucket.MultiBucketsAggregation;
+import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.bucket.sampler.SamplerAggregationBuilder;
 import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
 import org.graylog.shaded.opensearch2.org.opensearch.search.builder.SearchSourceBuilder;
 import org.graylog.storage.opensearch2.BoolQueryTools;
@@ -198,7 +201,7 @@ public class OpenSearchBackend implements QueryBackend<OSGeneratedQueryContext> 
     }
 
     @Override
-    public Set<String> getFieldsPresentInQueryResultDocuments(final Query normalizedQuery, final int size) {
+    public Set<String> getFieldsPresentInQueryResultDocuments(final Query normalizedQuery, final QueryAwareFieldListRetrievalParams params) {
         final Set<String> affectedIndices = indexLookup.indexNamesForStreamsInTimeRange(normalizedQuery.usedStreamIds(), normalizedQuery.timerange());
         final SearchSourceBuilder searchSourceBuilder = createSearchSourceBuilder(normalizedQuery);
         final QueryBuilder query = searchSourceBuilder.query();
@@ -208,22 +211,46 @@ public class OpenSearchBackend implements QueryBackend<OSGeneratedQueryContext> 
             BoolQueryTools.addStreams(boolQueryBuilder, normalizedQuery.usedStreamIds());
         }
         final String aggregationName = ALL_MESSAGE_FIELDS_DOCUMENT_FIELD + "_aggr";
-        searchSourceBuilder.aggregation(new TermsAggregationBuilder(aggregationName)
+        final TermsAggregationBuilder termsAggregationBuilder = new TermsAggregationBuilder(aggregationName)
                 .field(ALL_MESSAGE_FIELDS_DOCUMENT_FIELD)
-                .size(size));
+                .size(params.size());
+        if (params.useSampler()) {
+            searchSourceBuilder.aggregation(new SamplerAggregationBuilder("sampler")
+                    .subAggregation(termsAggregationBuilder)
+                    .shardSize(params.sampleSize()));
+        } else {
+            searchSourceBuilder.aggregation(termsAggregationBuilder);
+        }
         final SearchResponse res = client.search(new SearchRequest()
                 .source(searchSourceBuilder)
                 .indices(affectedIndices.toArray(new String[0]))
                 .indicesOptions(IndicesOptions.fromOptions(false, false, true, false)), "Unable to retrieve fields used in search result documents");
 
-        final Aggregation aggregationResult = res.getAggregations().get(aggregationName);
-        if (aggregationResult instanceof MultiBucketsAggregation) {
-            final List<? extends MultiBucketsAggregation.Bucket> buckets = ((MultiBucketsAggregation) aggregationResult).getBuckets();
-            if (buckets != null) {
-                return buckets.stream()
-                        .filter(Objects::nonNull)
-                        .map(MultiBucketsAggregation.Bucket::getKeyAsString)
-                        .collect(Collectors.toSet());
+        if (params.useSampler()) {
+            final Aggregation samplerAggregationResult = res.getAggregations().get("sampler");
+            if (samplerAggregationResult instanceof HasAggregations samplerAggregation) {
+                final Aggregation aggregationResult = samplerAggregation.getAggregations().get(aggregationName);
+                if (aggregationResult instanceof MultiBucketsAggregation multiBucketsAggregation) {
+                    final List<? extends MultiBucketsAggregation.Bucket> buckets = multiBucketsAggregation.getBuckets();
+                    if (buckets != null) {
+                        return buckets.stream()
+                                .filter(Objects::nonNull)
+                                .map(MultiBucketsAggregation.Bucket::getKeyAsString)
+                                .collect(Collectors.toSet());
+                    }
+                }
+            }
+
+        } else {
+            final Aggregation aggregationResult = res.getAggregations().get(aggregationName);
+            if (aggregationResult instanceof MultiBucketsAggregation multiBucketsAggregation) {
+                final List<? extends MultiBucketsAggregation.Bucket> buckets = multiBucketsAggregation.getBuckets();
+                if (buckets != null) {
+                    return buckets.stream()
+                            .filter(Objects::nonNull)
+                            .map(MultiBucketsAggregation.Bucket::getKeyAsString)
+                            .collect(Collectors.toSet());
+                }
             }
         }
 

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/OpenSearchBackend.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/OpenSearchBackend.java
@@ -203,7 +203,7 @@ public class OpenSearchBackend implements QueryBackend<OSGeneratedQueryContext> 
     @Override
     public Set<String> getFieldsPresentInQueryResultDocuments(final Query normalizedQuery, final QueryAwareFieldListRetrievalParams params) {
         final Set<String> affectedIndices = indexLookup.indexNamesForStreamsInTimeRange(normalizedQuery.usedStreamIds(), normalizedQuery.timerange());
-        final SearchSourceBuilder searchSourceBuilder = createSearchSourceBuilder(normalizedQuery);
+        final SearchSourceBuilder searchSourceBuilder = createSearchSourceBuilder(normalizedQuery).trackTotalHits(false);
         final QueryBuilder query = searchSourceBuilder.query();
 
         if (query instanceof BoolQueryBuilder boolQueryBuilder) {

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/OpenSearchBackend.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/OpenSearchBackend.java
@@ -198,7 +198,7 @@ public class OpenSearchBackend implements QueryBackend<OSGeneratedQueryContext> 
     }
 
     @Override
-    public Set<String> getFieldsPresentInSearchResultDocuments(final Query normalizedQuery, final int size) {
+    public Set<String> getFieldsPresentInQueryResultDocuments(final Query normalizedQuery, final int size) {
         final Set<String> affectedIndices = indexLookup.indexNamesForStreamsInTimeRange(normalizedQuery.usedStreamIds(), normalizedQuery.timerange());
         final SearchSourceBuilder searchSourceBuilder = createSearchSourceBuilder(normalizedQuery);
         final QueryBuilder query = searchSourceBuilder.query();

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/OpenSearchBackend.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/OpenSearchBackend.java
@@ -128,8 +128,8 @@ public class OpenSearchBackend implements QueryBackend<OSGeneratedQueryContext> 
 
                     final BoolQueryBuilder searchTypeOverrides = QueryBuilders.boolQuery()
                             .must(searchTypeSourceBuilder.query());
-                    BoolQueryTools.addTimeRange(searchTypeOverrides, query.effectiveTimeRange(searchType), "search type " + searchType.id());
-                    BoolQueryTools.addStreams(searchTypeOverrides, effectiveStreamIds);
+                    BoolQueryTools.addTimeRange(searchTypeOverrides, query.effectiveTimeRange(searchType), "search type " + searchType.id(), BoolQueryTools.Mode.MUST);
+                    BoolQueryTools.addStreams(searchTypeOverrides, effectiveStreamIds, BoolQueryTools.Mode.MUST);
 
                     searchType.query().ifPresent(searchTypeQuery -> {
                         final QueryBuilder normalizedSearchTypeQuery = translateQueryString(searchTypeQuery.queryString());
@@ -207,8 +207,8 @@ public class OpenSearchBackend implements QueryBackend<OSGeneratedQueryContext> 
         final QueryBuilder query = searchSourceBuilder.query();
 
         if (query instanceof BoolQueryBuilder boolQueryBuilder) {
-            BoolQueryTools.addTimeRange(boolQueryBuilder, normalizedQuery.timerange(), "query " + normalizedQuery.id());
-            BoolQueryTools.addStreams(boolQueryBuilder, normalizedQuery.usedStreamIds());
+            BoolQueryTools.addTimeRange(boolQueryBuilder, normalizedQuery.timerange(), "query " + normalizedQuery.id(), BoolQueryTools.Mode.FILTER);
+            BoolQueryTools.addStreams(boolQueryBuilder, normalizedQuery.usedStreamIds(), BoolQueryTools.Mode.FILTER);
         }
         final String aggregationName = ALL_MESSAGE_FIELDS_DOCUMENT_FIELD + "_aggr";
         final TermsAggregationBuilder termsAggregationBuilder = new TermsAggregationBuilder(aggregationName)

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/ViewsBindings.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/ViewsBindings.java
@@ -116,6 +116,8 @@ import org.graylog.plugins.views.search.views.widgets.aggregation.sort.SeriesSor
 import org.graylog.plugins.views.search.views.widgets.messagelist.MessageListConfigDTO;
 import org.graylog2.contentpacks.facades.DashboardEntityCreator;
 import org.graylog2.contentpacks.facades.DashboardFacade;
+import org.graylog2.indexer.fieldtypes.DiscoveredFieldTypeService;
+import org.graylog2.indexer.fieldtypes.DiscoveredFieldTypeServiceImpl;
 import org.graylog2.indexer.fieldtypes.MappedFieldTypesService;
 import org.graylog2.indexer.fieldtypes.MappedFieldTypesServiceImpl;
 import org.graylog2.plugin.PluginConfigBean;
@@ -187,6 +189,7 @@ public class ViewsBindings extends ViewsModule {
 
         bind(SearchJobService.class).to(InMemorySearchJobService.class).in(Scopes.SINGLETON);
         bind(MappedFieldTypesService.class).to(MappedFieldTypesServiceImpl.class).in(Scopes.SINGLETON);
+        bind(DiscoveredFieldTypeService.class).to(DiscoveredFieldTypeServiceImpl.class).in(Scopes.SINGLETON);
         bind(FieldTypeValidation.class).to(FieldTypeValidationImpl.class).in(Scopes.SINGLETON);
 
         // The order of injections is significant!

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/engine/QueryBackend.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/engine/QueryBackend.java
@@ -111,7 +111,7 @@ public interface QueryBackend<T extends GeneratedQueryContext> {
      */
     QueryResult doRun(SearchJob job, Query query, T queryContext);
 
-    Set<String> getFieldsPresentInSearchResultDocuments(final Query normalizedQuery, final int size);
+    Set<String> getFieldsPresentInQueryResultDocuments(final Query normalizedQuery, final int size);
 
     default boolean isSearchTypeWithError(T queryContext, String searchTypeId) {
         return queryContext.errors().stream()

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/engine/QueryBackend.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/engine/QueryBackend.java
@@ -111,7 +111,7 @@ public interface QueryBackend<T extends GeneratedQueryContext> {
      */
     QueryResult doRun(SearchJob job, Query query, T queryContext);
 
-    Set<String> getFieldsPresentInSearchResultDocuments(final Query normalizedQuery);
+    Set<String> getFieldsPresentInSearchResultDocuments(final Query normalizedQuery, final int size);
 
     default boolean isSearchTypeWithError(T queryContext, String searchTypeId) {
         return queryContext.errors().stream()

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/engine/QueryBackend.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/engine/QueryBackend.java
@@ -20,7 +20,6 @@ import com.google.common.base.Stopwatch;
 import org.graylog.plugins.views.search.GlobalOverride;
 import org.graylog.plugins.views.search.Query;
 import org.graylog.plugins.views.search.QueryResult;
-import org.graylog.plugins.views.search.Search;
 import org.graylog.plugins.views.search.SearchJob;
 import org.graylog.plugins.views.search.errors.QueryError;
 import org.graylog.plugins.views.search.errors.SearchError;
@@ -112,7 +111,7 @@ public interface QueryBackend<T extends GeneratedQueryContext> {
      */
     QueryResult doRun(SearchJob job, Query query, T queryContext);
 
-    Set<String> getFieldsPresentInSearchResultDocuments(final Search normalizedSearch);
+    Set<String> getFieldsPresentInSearchResultDocuments(final Query normalizedQuery);
 
     default boolean isSearchTypeWithError(T queryContext, String searchTypeId) {
         return queryContext.errors().stream()

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/engine/QueryBackend.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/engine/QueryBackend.java
@@ -20,6 +20,7 @@ import com.google.common.base.Stopwatch;
 import org.graylog.plugins.views.search.GlobalOverride;
 import org.graylog.plugins.views.search.Query;
 import org.graylog.plugins.views.search.QueryResult;
+import org.graylog.plugins.views.search.Search;
 import org.graylog.plugins.views.search.SearchJob;
 import org.graylog.plugins.views.search.errors.QueryError;
 import org.graylog.plugins.views.search.errors.SearchError;
@@ -103,13 +104,15 @@ public interface QueryBackend<T extends GeneratedQueryContext> {
      * <p>
      * This method is typically being run in an executor and can safely block.
      *
-     * @param job                currently executing job
-     * @param query              the individual query to run from the current job
-     * @param queryContext       the generated query by {@link #generate(SearchJob, Query, Set) <SearchError>)}
+     * @param job          currently executing job
+     * @param query        the individual query to run from the current job
+     * @param queryContext the generated query by {@link #generate(Query, Set) <SearchError>)}
      * @return the result for the query
      * @throws RuntimeException if the query could not be executed for some reason
      */
     QueryResult doRun(SearchJob job, Query query, T queryContext);
+
+    Set<String> getFieldsPresentInSearchResultDocuments(final Search normalizedSearch);
 
     default boolean isSearchTypeWithError(T queryContext, String searchTypeId) {
         return queryContext.errors().stream()

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/engine/QueryBackend.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/engine/QueryBackend.java
@@ -21,6 +21,7 @@ import org.graylog.plugins.views.search.GlobalOverride;
 import org.graylog.plugins.views.search.Query;
 import org.graylog.plugins.views.search.QueryResult;
 import org.graylog.plugins.views.search.SearchJob;
+import org.graylog.plugins.views.search.engine.fieldlist.QueryAwareFieldListRetrievalParams;
 import org.graylog.plugins.views.search.errors.QueryError;
 import org.graylog.plugins.views.search.errors.SearchError;
 import org.graylog.plugins.views.search.errors.SearchTypeError;
@@ -111,7 +112,7 @@ public interface QueryBackend<T extends GeneratedQueryContext> {
      */
     QueryResult doRun(SearchJob job, Query query, T queryContext);
 
-    Set<String> getFieldsPresentInQueryResultDocuments(final Query normalizedQuery, final int size);
+    Set<String> getFieldsPresentInQueryResultDocuments(final Query normalizedQuery, final QueryAwareFieldListRetrievalParams params);
 
     default boolean isSearchTypeWithError(T queryContext, String searchTypeId) {
         return queryContext.errors().stream()

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/engine/QueryEngine.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/engine/QueryEngine.java
@@ -70,8 +70,8 @@ public class QueryEngine {
                 .orElse(parsedMetadata);
     }
 
-    public Set<String> getFieldsPresentInSearchResultDocuments(final Query normalizedQuery) {
-        return backend.getFieldsPresentInSearchResultDocuments(normalizedQuery);
+    public Set<String> getFieldsPresentInSearchResultDocuments(final Query normalizedQuery, final int size) {
+        return backend.getFieldsPresentInSearchResultDocuments(normalizedQuery, size);
     }
 
     public SearchJob execute(SearchJob searchJob, Set<SearchError> validationErrors) {

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/engine/QueryEngine.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/engine/QueryEngine.java
@@ -70,8 +70,8 @@ public class QueryEngine {
                 .orElse(parsedMetadata);
     }
 
-    public Set<String> getFieldsPresentInSearchResultDocuments(final Search normalizedSearch) {
-        return backend.getFieldsPresentInSearchResultDocuments(normalizedSearch);
+    public Set<String> getFieldsPresentInSearchResultDocuments(final Query normalizedQuery) {
+        return backend.getFieldsPresentInSearchResultDocuments(normalizedQuery);
     }
 
     public SearchJob execute(SearchJob searchJob, Set<SearchError> validationErrors) {

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/engine/QueryEngine.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/engine/QueryEngine.java
@@ -70,8 +70,8 @@ public class QueryEngine {
                 .orElse(parsedMetadata);
     }
 
-    public Set<String> getFieldsPresentInSearchResultDocuments(final Query normalizedQuery, final int size) {
-        return backend.getFieldsPresentInSearchResultDocuments(normalizedQuery, size);
+    public Set<String> getFieldsPresentInQueryResultDocuments(final Query normalizedQuery, final int size) {
+        return backend.getFieldsPresentInQueryResultDocuments(normalizedQuery, size);
     }
 
     public SearchJob execute(SearchJob searchJob, Set<SearchError> validationErrors) {

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/engine/QueryEngine.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/engine/QueryEngine.java
@@ -23,6 +23,7 @@ import org.graylog.plugins.views.search.QueryMetadataDecorator;
 import org.graylog.plugins.views.search.QueryResult;
 import org.graylog.plugins.views.search.Search;
 import org.graylog.plugins.views.search.SearchJob;
+import org.graylog.plugins.views.search.engine.fieldlist.QueryAwareFieldListRetrievalParams;
 import org.graylog.plugins.views.search.errors.QueryError;
 import org.graylog.plugins.views.search.errors.SearchError;
 import org.graylog.plugins.views.search.errors.SearchException;
@@ -70,8 +71,9 @@ public class QueryEngine {
                 .orElse(parsedMetadata);
     }
 
-    public Set<String> getFieldsPresentInQueryResultDocuments(final Query normalizedQuery, final int size) {
-        return backend.getFieldsPresentInQueryResultDocuments(normalizedQuery, size);
+    public Set<String> getFieldsPresentInQueryResultDocuments(final Query normalizedQuery,
+                                                              final QueryAwareFieldListRetrievalParams params) {
+        return backend.getFieldsPresentInQueryResultDocuments(normalizedQuery, params);
     }
 
     public SearchJob execute(SearchJob searchJob, Set<SearchError> validationErrors) {

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/engine/QueryEngine.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/engine/QueryEngine.java
@@ -70,6 +70,10 @@ public class QueryEngine {
                 .orElse(parsedMetadata);
     }
 
+    public Set<String> getFieldsPresentInSearchResultDocuments(final Search normalizedSearch) {
+        return backend.getFieldsPresentInSearchResultDocuments(normalizedSearch);
+    }
+
     public SearchJob execute(SearchJob searchJob, Set<SearchError> validationErrors) {
         final Set<Query> validQueries = searchJob.getSearch().queries()
                 .stream()

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/engine/SearchExecutor.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/engine/SearchExecutor.java
@@ -68,7 +68,7 @@ public class SearchExecutor {
     }
 
     @Deprecated
-    public Set<String> getFieldsPresentInSearchResultDocuments(final Search search, SearchUser searchUser) {
+    public Set<String> getFieldsPresentInSearchResultDocuments(final Search search, SearchUser searchUser, final int size) {
         final ExecutionState executionState = ExecutionState.empty();
         final Search preValidationSearch = searchNormalization.preValidation(search, searchUser, executionState);
         final Set<SearchError> validationErrors = searchValidation.validate(preValidationSearch, searchUser);
@@ -77,12 +77,13 @@ public class SearchExecutor {
         }
         final Search normalizedSearch = searchNormalization.postValidation(preValidationSearch, searchUser, executionState);
         final Query mainQuery = normalizedSearch.queries().stream().findFirst().orElseThrow(() -> new IllegalArgumentException("No queries in search : " + normalizedSearch.id()));
-        return queryEngine.getFieldsPresentInSearchResultDocuments(mainQuery);
+        return queryEngine.getFieldsPresentInSearchResultDocuments(mainQuery, size);
     }
 
     public Set<String> getFieldsPresentInSearchResultDocuments(final Query query,
                                                                final ParameterProvider parameterProvider,
-                                                               final SearchUser searchUser) {
+                                                               final SearchUser searchUser,
+                                                               final int size) {
         final ExecutionState executionState = ExecutionState.empty();
         final Query preValidationQuery = searchNormalization.preValidation(query, parameterProvider, searchUser, executionState);
         final Set<SearchError> validationErrors = searchValidation.validate(preValidationQuery, searchUser);
@@ -90,7 +91,7 @@ public class SearchExecutor {
             return Set.of();
         }
         final Query normalizedQuery = searchNormalization.postValidation(preValidationQuery, parameterProvider);
-        return queryEngine.getFieldsPresentInSearchResultDocuments(normalizedQuery);
+        return queryEngine.getFieldsPresentInSearchResultDocuments(normalizedQuery, size);
     }
 
     public SearchJob execute(Search search, SearchUser searchUser, ExecutionState executionState) {

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/engine/SearchExecutor.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/engine/SearchExecutor.java
@@ -77,13 +77,13 @@ public class SearchExecutor {
         }
         final Search normalizedSearch = searchNormalization.postValidation(preValidationSearch, searchUser, executionState);
         final Query mainQuery = normalizedSearch.queries().stream().findFirst().orElseThrow(() -> new IllegalArgumentException("No queries in search : " + normalizedSearch.id()));
-        return queryEngine.getFieldsPresentInSearchResultDocuments(mainQuery, size);
+        return queryEngine.getFieldsPresentInQueryResultDocuments(mainQuery, size);
     }
 
-    public Set<String> getFieldsPresentInSearchResultDocuments(final Query query,
-                                                               final ParameterProvider parameterProvider,
-                                                               final SearchUser searchUser,
-                                                               final int size) {
+    public Set<String> getFieldsPresentInQueryResultDocuments(final Query query,
+                                                              final ParameterProvider parameterProvider,
+                                                              final SearchUser searchUser,
+                                                              final int size) {
         final ExecutionState executionState = ExecutionState.empty();
         final Query preValidationQuery = searchNormalization.preValidation(query, parameterProvider, searchUser, executionState);
         final Set<SearchError> validationErrors = searchValidation.validate(preValidationQuery, searchUser);
@@ -91,7 +91,7 @@ public class SearchExecutor {
             return Set.of();
         }
         final Query normalizedQuery = searchNormalization.postValidation(preValidationQuery, parameterProvider);
-        return queryEngine.getFieldsPresentInSearchResultDocuments(normalizedQuery, size);
+        return queryEngine.getFieldsPresentInQueryResultDocuments(normalizedQuery, size);
     }
 
     public SearchJob execute(Search search, SearchUser searchUser, ExecutionState executionState) {

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/engine/fieldlist/QueryAwareFieldListRetrievalParams.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/engine/fieldlist/QueryAwareFieldListRetrievalParams.java
@@ -1,0 +1,14 @@
+package org.graylog.plugins.views.search.engine.fieldlist;
+
+import org.graylog.plugins.views.search.permissions.SearchUser;
+
+public record QueryAwareFieldListRetrievalParams(SearchUser searchUser,
+                                                 int size,
+                                                 boolean useSampler,
+                                                 int sampleSize) {
+
+
+    public QueryAwareFieldListRetrievalParams(final SearchUser searchUser) {
+        this(searchUser, 1000, false, 100);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/engine/fieldlist/QueryAwareFieldListRetrievalParams.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/engine/fieldlist/QueryAwareFieldListRetrievalParams.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog.plugins.views.search.engine.fieldlist;
 
 import org.graylog.plugins.views.search.permissions.SearchUser;

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/FieldTypesForQueryRequest.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/FieldTypesForQueryRequest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.views.search.rest;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableSet;
+import org.graylog.plugins.views.search.Parameter;
+
+@AutoValue
+@JsonAutoDetect
+@JsonDeserialize(builder = FieldTypesForQueryRequest.Builder.class)
+public abstract class FieldTypesForQueryRequest {
+
+    private static final String FIELD_QUERY = "query";
+    private static final String FIELD_PARAMS = "parameters";
+    private static final String FIELD_FALLBACK = "fallback";
+
+    @JsonProperty(FIELD_QUERY)
+    public abstract QueryDTO query();
+
+    @JsonProperty(FIELD_PARAMS)
+    public abstract ImmutableSet<Parameter> parameters();
+
+    @JsonProperty(FIELD_FALLBACK)
+    public abstract FieldTypesForStreamsRequest fallback();
+
+    @AutoValue.Builder
+    public abstract static class Builder {
+
+        @JsonProperty(FIELD_QUERY)
+        public abstract FieldTypesForQueryRequest.Builder query(final QueryDTO queryDTO);
+
+        @JsonProperty(FIELD_PARAMS)
+        public abstract FieldTypesForQueryRequest.Builder parameters(final ImmutableSet<Parameter> parameters);
+
+        @JsonProperty(FIELD_FALLBACK)
+        public abstract FieldTypesForQueryRequest.Builder fallback(final FieldTypesForStreamsRequest fallback);
+
+        public abstract FieldTypesForQueryRequest build();
+
+        @JsonCreator
+        public static FieldTypesForQueryRequest.Builder builder() {
+            return new AutoValue_FieldTypesForQueryRequest.Builder();
+        }
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/FieldTypesForQueryRequest.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/FieldTypesForQueryRequest.java
@@ -21,8 +21,9 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
-import com.google.common.collect.ImmutableSet;
 import org.graylog.plugins.views.search.Parameter;
+
+import java.util.Set;
 
 @AutoValue
 @JsonAutoDetect
@@ -37,7 +38,7 @@ public abstract class FieldTypesForQueryRequest {
     public abstract QueryDTO query();
 
     @JsonProperty(FIELD_PARAMS)
-    public abstract ImmutableSet<Parameter> parameters();
+    public abstract Set<Parameter> parameters();
 
     @JsonProperty(FIELD_FALLBACK)
     public abstract FieldTypesForStreamsRequest fallback();
@@ -49,7 +50,7 @@ public abstract class FieldTypesForQueryRequest {
         public abstract FieldTypesForQueryRequest.Builder query(final QueryDTO queryDTO);
 
         @JsonProperty(FIELD_PARAMS)
-        public abstract FieldTypesForQueryRequest.Builder parameters(final ImmutableSet<Parameter> parameters);
+        public abstract FieldTypesForQueryRequest.Builder parameters(final Set<Parameter> parameters);
 
         @JsonProperty(FIELD_FALLBACK)
         public abstract FieldTypesForQueryRequest.Builder fallback(final FieldTypesForStreamsRequest fallback);

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/FieldTypesResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/FieldTypesResource.java
@@ -104,4 +104,27 @@ public class FieldTypesResource extends RestResource implements PluginRestResour
             return byStreams(fallbackRequest, searchUser);
         }
     }
+
+    @POST
+    @Path("/byQuery")
+    @ApiOperation(value = "Retrieve the field list for a given query")
+    @NoAuditEvent("This is not changing any data")
+    public Set<MappedFieldTypeDTO> byQuery(@ApiParam(name = "JSON body", required = true)
+                                           @Valid @NotNull final FieldTypesForQueryRequest request,
+                                           @Context SearchUser searchUser) {
+        try {
+
+            final Set<MappedFieldTypeDTO> mappedFieldTypeDTOS = discoveredFieldTypeService.fieldTypesByQuery(
+                    request.query().toQuery(),
+                    name -> request.parameters().stream().filter(p -> p.name().equals(name)).findFirst(),
+                    searchUser);
+            if (mappedFieldTypeDTOS != null && !mappedFieldTypeDTOS.isEmpty()) {
+                return mappedFieldTypeDTOS;
+            }
+
+            return byStreams(request.fallback(), searchUser);
+        } catch (Exception ex) {
+            return byStreams(request.fallback(), searchUser);
+        }
+    }
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/DiscoveredFieldTypeService.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/DiscoveredFieldTypeService.java
@@ -16,6 +16,8 @@
  */
 package org.graylog2.indexer.fieldtypes;
 
+import org.graylog.plugins.views.search.ParameterProvider;
+import org.graylog.plugins.views.search.Query;
 import org.graylog.plugins.views.search.Search;
 import org.graylog.plugins.views.search.permissions.SearchUser;
 import org.graylog.plugins.views.search.rest.MappedFieldTypeDTO;
@@ -27,4 +29,6 @@ public interface DiscoveredFieldTypeService {
     String ALL_MESSAGE_FIELDS_DOCUMENT_FIELD = "gl2_message_fields";
 
     Set<MappedFieldTypeDTO> fieldTypesBySearch(Search search, SearchUser searchUser);
+
+    Set<MappedFieldTypeDTO> fieldTypesByQuery(Query query, ParameterProvider parameterProvider, SearchUser searchUser);
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/DiscoveredFieldTypeService.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/DiscoveredFieldTypeService.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.indexer.fieldtypes;
+
+import org.graylog.plugins.views.search.Search;
+import org.graylog.plugins.views.search.permissions.SearchUser;
+import org.graylog.plugins.views.search.rest.MappedFieldTypeDTO;
+
+import java.util.Set;
+
+public interface DiscoveredFieldTypeService {
+
+    String ALL_MESSAGE_FIELDS_DOCUMENT_FIELD = "gl2_message_fields";
+
+    Set<MappedFieldTypeDTO> fieldTypesBySearch(Search search, SearchUser searchUser);
+}

--- a/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/DiscoveredFieldTypeService.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/DiscoveredFieldTypeService.java
@@ -19,7 +19,7 @@ package org.graylog2.indexer.fieldtypes;
 import org.graylog.plugins.views.search.ParameterProvider;
 import org.graylog.plugins.views.search.Query;
 import org.graylog.plugins.views.search.Search;
-import org.graylog.plugins.views.search.permissions.SearchUser;
+import org.graylog.plugins.views.search.engine.fieldlist.QueryAwareFieldListRetrievalParams;
 import org.graylog.plugins.views.search.rest.MappedFieldTypeDTO;
 
 import java.util.Set;
@@ -28,7 +28,10 @@ public interface DiscoveredFieldTypeService {
 
     String ALL_MESSAGE_FIELDS_DOCUMENT_FIELD = "gl2_message_fields";
 
-    Set<MappedFieldTypeDTO> fieldTypesBySearch(Search search, SearchUser searchUser, int size);
+    Set<MappedFieldTypeDTO> fieldTypesBySearch(Search search,
+                                               QueryAwareFieldListRetrievalParams params);
 
-    Set<MappedFieldTypeDTO> fieldTypesByQuery(Query query, ParameterProvider parameterProvider, SearchUser searchUser, int size);
+    Set<MappedFieldTypeDTO> fieldTypesByQuery(Query query,
+                                              ParameterProvider parameterProvider,
+                                              QueryAwareFieldListRetrievalParams params);
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/DiscoveredFieldTypeService.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/DiscoveredFieldTypeService.java
@@ -28,7 +28,7 @@ public interface DiscoveredFieldTypeService {
 
     String ALL_MESSAGE_FIELDS_DOCUMENT_FIELD = "gl2_message_fields";
 
-    Set<MappedFieldTypeDTO> fieldTypesBySearch(Search search, SearchUser searchUser);
+    Set<MappedFieldTypeDTO> fieldTypesBySearch(Search search, SearchUser searchUser, int size);
 
-    Set<MappedFieldTypeDTO> fieldTypesByQuery(Query query, ParameterProvider parameterProvider, SearchUser searchUser);
+    Set<MappedFieldTypeDTO> fieldTypesByQuery(Query query, ParameterProvider parameterProvider, SearchUser searchUser, int size);
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/DiscoveredFieldTypeServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/DiscoveredFieldTypeServiceImpl.java
@@ -44,16 +44,19 @@ public class DiscoveredFieldTypeServiceImpl implements DiscoveredFieldTypeServic
     }
 
     @Override
-    public Set<MappedFieldTypeDTO> fieldTypesBySearch(final Search search, final SearchUser searchUser) {
-        final Set<String> discoveredFields = searchExecutor.getFieldsPresentInSearchResultDocuments(search, searchUser);
+    public Set<MappedFieldTypeDTO> fieldTypesBySearch(final Search search,
+                                                      final SearchUser searchUser,
+                                                      final int size) {
+        final Set<String> discoveredFields = searchExecutor.getFieldsPresentInSearchResultDocuments(search, searchUser, size);
         return fieldNamesToFieldTypeDTOs(discoveredFields);
     }
 
     @Override
     public Set<MappedFieldTypeDTO> fieldTypesByQuery(final Query query,
                                                      final ParameterProvider parameterProvider,
-                                                     final SearchUser searchUser) {
-        final Set<String> discoveredFields = searchExecutor.getFieldsPresentInSearchResultDocuments(query, parameterProvider, searchUser);
+                                                     final SearchUser searchUser,
+                                                     final int size) {
+        final Set<String> discoveredFields = searchExecutor.getFieldsPresentInSearchResultDocuments(query, parameterProvider, searchUser, size);
         return fieldNamesToFieldTypeDTOs(discoveredFields);
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/DiscoveredFieldTypeServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/DiscoveredFieldTypeServiceImpl.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.indexer.fieldtypes;
+
+import org.graylog.plugins.views.search.Search;
+import org.graylog.plugins.views.search.engine.SearchExecutor;
+import org.graylog.plugins.views.search.permissions.SearchUser;
+import org.graylog.plugins.views.search.rest.MappedFieldTypeDTO;
+
+import javax.inject.Inject;
+import java.util.Collection;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class DiscoveredFieldTypeServiceImpl implements DiscoveredFieldTypeService {
+
+    private final SearchExecutor searchExecutor;
+    private final IndexFieldTypesService indexFieldTypesService;
+    private final FieldTypesMerger fieldTypesMerger;
+
+    @Inject
+    public DiscoveredFieldTypeServiceImpl(final SearchExecutor searchExecutor,
+                                          final IndexFieldTypesService indexFieldTypesService,
+                                          final FieldTypesMerger fieldTypesMerger) {
+        this.searchExecutor = searchExecutor;
+        this.indexFieldTypesService = indexFieldTypesService;
+        this.fieldTypesMerger = fieldTypesMerger;
+    }
+
+    @Override
+    public Set<MappedFieldTypeDTO> fieldTypesBySearch(final Search search, final SearchUser searchUser) {
+        final Set<String> discoveredFields = searchExecutor.getFieldsPresentInSearchResultDocuments(search, searchUser);
+        if (discoveredFields != null && !discoveredFields.isEmpty()) {
+            final Collection<IndexFieldTypesDTO> forFieldNames = indexFieldTypesService.findForFieldNames(discoveredFields);
+            final Collection<IndexFieldTypesDTO> withOnlyDiscoveredFieldsRetained = forFieldNames.stream()
+                    .map(i -> IndexFieldTypesDTO.create(
+                            i.indexSetId(),
+                            i.indexName(),
+                            i.fields().stream()
+                                    .filter(f -> discoveredFields.contains(f.fieldName()))
+                                    .collect(Collectors.toSet()))
+                    )
+                    .collect(Collectors.toSet());
+            return fieldTypesMerger.mergeCompoundFieldTypes(withOnlyDiscoveredFieldsRetained.stream()
+                    .flatMap(fieldTypes -> fieldTypes.fields().stream())
+                    .map(fieldTypesMerger::mapPhysicalFieldType));
+        }
+        return Set.of();
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/DiscoveredFieldTypeServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/DiscoveredFieldTypeServiceImpl.java
@@ -20,7 +20,7 @@ import org.graylog.plugins.views.search.ParameterProvider;
 import org.graylog.plugins.views.search.Query;
 import org.graylog.plugins.views.search.Search;
 import org.graylog.plugins.views.search.engine.SearchExecutor;
-import org.graylog.plugins.views.search.permissions.SearchUser;
+import org.graylog.plugins.views.search.engine.fieldlist.QueryAwareFieldListRetrievalParams;
 import org.graylog.plugins.views.search.rest.MappedFieldTypeDTO;
 
 import javax.inject.Inject;
@@ -45,18 +45,16 @@ public class DiscoveredFieldTypeServiceImpl implements DiscoveredFieldTypeServic
 
     @Override
     public Set<MappedFieldTypeDTO> fieldTypesBySearch(final Search search,
-                                                      final SearchUser searchUser,
-                                                      final int size) {
-        final Set<String> discoveredFields = searchExecutor.getFieldsPresentInSearchResultDocuments(search, searchUser, size);
+                                                      final QueryAwareFieldListRetrievalParams params) {
+        final Set<String> discoveredFields = searchExecutor.getFieldsPresentInSearchResultDocuments(search, params);
         return fieldNamesToFieldTypeDTOs(discoveredFields);
     }
 
     @Override
     public Set<MappedFieldTypeDTO> fieldTypesByQuery(final Query query,
                                                      final ParameterProvider parameterProvider,
-                                                     final SearchUser searchUser,
-                                                     final int size) {
-        final Set<String> discoveredFields = searchExecutor.getFieldsPresentInQueryResultDocuments(query, parameterProvider, searchUser, size);
+                                                     final QueryAwareFieldListRetrievalParams params) {
+        final Set<String> discoveredFields = searchExecutor.getFieldsPresentInQueryResultDocuments(query, parameterProvider, params);
         return fieldNamesToFieldTypeDTOs(discoveredFields);
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/DiscoveredFieldTypeServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/DiscoveredFieldTypeServiceImpl.java
@@ -56,7 +56,7 @@ public class DiscoveredFieldTypeServiceImpl implements DiscoveredFieldTypeServic
                                                      final ParameterProvider parameterProvider,
                                                      final SearchUser searchUser,
                                                      final int size) {
-        final Set<String> discoveredFields = searchExecutor.getFieldsPresentInSearchResultDocuments(query, parameterProvider, searchUser, size);
+        final Set<String> discoveredFields = searchExecutor.getFieldsPresentInQueryResultDocuments(query, parameterProvider, searchUser, size);
         return fieldNamesToFieldTypeDTOs(discoveredFields);
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/DiscoveredFieldTypeServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/DiscoveredFieldTypeServiceImpl.java
@@ -16,6 +16,8 @@
  */
 package org.graylog2.indexer.fieldtypes;
 
+import org.graylog.plugins.views.search.ParameterProvider;
+import org.graylog.plugins.views.search.Query;
 import org.graylog.plugins.views.search.Search;
 import org.graylog.plugins.views.search.engine.SearchExecutor;
 import org.graylog.plugins.views.search.permissions.SearchUser;
@@ -44,6 +46,18 @@ public class DiscoveredFieldTypeServiceImpl implements DiscoveredFieldTypeServic
     @Override
     public Set<MappedFieldTypeDTO> fieldTypesBySearch(final Search search, final SearchUser searchUser) {
         final Set<String> discoveredFields = searchExecutor.getFieldsPresentInSearchResultDocuments(search, searchUser);
+        return fieldNamesToFieldTypeDTOs(discoveredFields);
+    }
+
+    @Override
+    public Set<MappedFieldTypeDTO> fieldTypesByQuery(final Query query,
+                                                     final ParameterProvider parameterProvider,
+                                                     final SearchUser searchUser) {
+        final Set<String> discoveredFields = searchExecutor.getFieldsPresentInSearchResultDocuments(query, parameterProvider, searchUser);
+        return fieldNamesToFieldTypeDTOs(discoveredFields);
+    }
+
+    private Set<MappedFieldTypeDTO> fieldNamesToFieldTypeDTOs(Set<String> discoveredFields) {
         if (discoveredFields != null && !discoveredFields.isEmpty()) {
             final Collection<IndexFieldTypesDTO> forFieldNames = indexFieldTypesService.findForFieldNames(discoveredFields);
             final Collection<IndexFieldTypesDTO> withOnlyDiscoveredFieldsRetained = forFieldNames.stream()
@@ -61,4 +75,5 @@ public class DiscoveredFieldTypeServiceImpl implements DiscoveredFieldTypeServic
         }
         return Set.of();
     }
+
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/FieldTypesMerger.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/FieldTypesMerger.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.indexer.fieldtypes;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import org.graylog.plugins.views.search.rest.MappedFieldTypeDTO;
+
+import javax.inject.Inject;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static com.google.common.collect.ImmutableSet.of;
+import static org.graylog2.indexer.fieldtypes.FieldTypes.Type.createType;
+
+public class FieldTypesMerger {
+
+    private static final FieldTypes.Type UNKNOWN_TYPE = createType("unknown", of());
+    private static final String PROP_COMPOUND_TYPE = "compound";
+
+    private final FieldTypeMapper fieldTypeMapper;
+
+    @Inject
+    public FieldTypesMerger(final FieldTypeMapper fieldTypeMapper) {
+        this.fieldTypeMapper = fieldTypeMapper;
+    }
+
+    public MappedFieldTypeDTO mapPhysicalFieldType(FieldTypeDTO fieldType) {
+        final FieldTypes.Type mappedFieldType = fieldTypeMapper.mapType(fieldType).orElse(UNKNOWN_TYPE);
+        return MappedFieldTypeDTO.create(fieldType.fieldName(), mappedFieldType);
+    }
+
+    public Set<MappedFieldTypeDTO> mergeCompoundFieldTypes(java.util.stream.Stream<MappedFieldTypeDTO> stream) {
+        return stream.collect(Collectors.groupingBy(MappedFieldTypeDTO::name, Collectors.toSet()))
+                .entrySet()
+                .stream()
+                .map(entry -> {
+                    final Set<MappedFieldTypeDTO> fieldTypes = entry.getValue();
+                    final String fieldName = entry.getKey();
+                    if (fieldTypes.size() == 1) {
+                        return fieldTypes.iterator().next();
+                    }
+
+                    final Set<String> distinctTypes = fieldTypes.stream()
+                            .map(mappedFieldTypeDTO -> mappedFieldTypeDTO.type().type())
+                            .sorted()
+                            .collect(Collectors.toCollection(LinkedHashSet::new));
+                    final String resultingFieldType = distinctTypes.size() > 1
+                            ? distinctTypes.stream().collect(Collectors.joining(",", "compound(", ")"))
+                            : distinctTypes.stream().findFirst().orElse("unknown");
+                    final Set<String> commonProperties = fieldTypes.stream()
+                            .map(mappedFieldTypeDTO -> mappedFieldTypeDTO.type().properties())
+                            .reduce((s1, s2) -> Sets.intersection(s1, s2).immutableCopy())
+                            .orElse(ImmutableSet.of());
+
+                    final Set<String> properties = distinctTypes.size() > 1
+                            ? Sets.union(commonProperties, Collections.singleton(PROP_COMPOUND_TYPE))
+                            : commonProperties;
+                    return MappedFieldTypeDTO.create(fieldName, createType(resultingFieldType, properties));
+
+                })
+                .collect(Collectors.toSet());
+
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/MappedFieldTypesServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/MappedFieldTypesServiceImpl.java
@@ -17,7 +17,6 @@
 package org.graylog2.indexer.fieldtypes;
 
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Sets;
 import org.graylog.plugins.views.search.elasticsearch.IndexLookup;
 import org.graylog.plugins.views.search.rest.MappedFieldTypeDTO;
 import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
@@ -25,34 +24,28 @@ import org.graylog2.streams.StreamService;
 
 import javax.inject.Inject;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.LinkedHashSet;
 import java.util.Set;
-import java.util.stream.Collectors;
-
-import static com.google.common.collect.ImmutableSet.of;
-import static org.graylog2.indexer.fieldtypes.FieldTypes.Type.createType;
 
 public class MappedFieldTypesServiceImpl implements MappedFieldTypesService {
     private final StreamService streamService;
     private final IndexFieldTypesService indexFieldTypesService;
-    private final FieldTypeMapper fieldTypeMapper;
-    private final IndexLookup indexLookup;
 
-    private static final FieldTypes.Type UNKNOWN_TYPE = createType("unknown", of());
-    private static final String PROP_COMPOUND_TYPE = "compound";
+    private final IndexLookup indexLookup;
+    private final FieldTypesMerger fieldTypesMerger;
+
 
     @Inject
     public MappedFieldTypesServiceImpl(StreamService streamService,
                                        IndexFieldTypesService indexFieldTypesService,
-                                       FieldTypeMapper fieldTypeMapper,
+                                       FieldTypesMerger fieldTypesMerger,
                                        IndexLookup indexLookup) {
         this.streamService = streamService;
         this.indexFieldTypesService = indexFieldTypesService;
-        this.fieldTypeMapper = fieldTypeMapper;
+        this.fieldTypesMerger = fieldTypesMerger;
         this.indexLookup = indexLookup;
     }
 
+    @Override
     public Set<MappedFieldTypeDTO> fieldTypesByStreamIds(Collection<String> streamIds, TimeRange timeRange) {
         final Set<String> indexSets = streamService.indexSetIdsByIds(streamIds);
 
@@ -62,45 +55,9 @@ public class MappedFieldTypesServiceImpl implements MappedFieldTypesService {
                 .stream()
                 .filter(fieldTypes -> indexNames.contains(fieldTypes.indexName()))
                 .flatMap(fieldTypes -> fieldTypes.fields().stream())
-                .map(this::mapPhysicalFieldType);
-        return mergeCompoundFieldTypes(types);
+                .map(fieldTypesMerger::mapPhysicalFieldType);
+        return fieldTypesMerger.mergeCompoundFieldTypes(types);
     }
 
-    private MappedFieldTypeDTO mapPhysicalFieldType(FieldTypeDTO fieldType) {
-        final FieldTypes.Type mappedFieldType = fieldTypeMapper.mapType(fieldType).orElse(UNKNOWN_TYPE);
-        return MappedFieldTypeDTO.create(fieldType.fieldName(), mappedFieldType);
-    }
 
-    private Set<MappedFieldTypeDTO> mergeCompoundFieldTypes(java.util.stream.Stream<MappedFieldTypeDTO> stream) {
-        return stream.collect(Collectors.groupingBy(MappedFieldTypeDTO::name, Collectors.toSet()))
-                .entrySet()
-                .stream()
-                .map(entry -> {
-                    final Set<MappedFieldTypeDTO> fieldTypes = entry.getValue();
-                    final String fieldName = entry.getKey();
-                    if (fieldTypes.size() == 1) {
-                        return fieldTypes.iterator().next();
-                    }
-
-                    final Set<String> distinctTypes = fieldTypes.stream()
-                            .map(mappedFieldTypeDTO -> mappedFieldTypeDTO.type().type())
-                            .sorted()
-                            .collect(Collectors.toCollection(LinkedHashSet::new));
-                    final String resultingFieldType = distinctTypes.size() > 1
-                            ? distinctTypes.stream().collect(Collectors.joining(",", "compound(", ")"))
-                            : distinctTypes.stream().findFirst().orElse("unknown");
-                    final Set<String> commonProperties = fieldTypes.stream()
-                            .map(mappedFieldTypeDTO -> mappedFieldTypeDTO.type().properties())
-                            .reduce((s1, s2) -> Sets.intersection(s1, s2).immutableCopy())
-                            .orElse(ImmutableSet.of());
-
-                    final Set<String> properties = distinctTypes.size() > 1
-                            ? Sets.union(commonProperties, Collections.singleton(PROP_COMPOUND_TYPE))
-                            : commonProperties;
-                    return MappedFieldTypeDTO.create(fieldName, createType(resultingFieldType, properties));
-
-                })
-                .collect(Collectors.toSet());
-
-    }
 }

--- a/graylog2-server/src/main/java/org/graylog2/plugin/Message.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/Message.java
@@ -35,6 +35,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.graylog.failure.FailureCause;
 import org.graylog.failure.ProcessingFailureCause;
 import org.graylog2.indexer.IndexSet;
+import org.graylog2.indexer.fieldtypes.DiscoveredFieldTypeService;
 import org.graylog2.indexer.messages.Indexable;
 import org.graylog2.plugin.streams.Stream;
 import org.graylog2.plugin.utilities.date.DateTimeConverter;
@@ -392,7 +393,7 @@ public class Message implements Messages, Indexable {
 
     @Override
     public Map<String, Object> toElasticSearchObject(ObjectMapper objectMapper, @Nonnull final Meter invalidTimestampMeter) {
-        final Map<String, Object> obj = Maps.newHashMapWithExpectedSize(REQUIRED_FIELDS.size() + fields.size());
+        final Map<String, Object> obj = Maps.newHashMapWithExpectedSize(REQUIRED_FIELDS.size() + fields.size() + 1);
 
         for (Map.Entry<String, Object> entry : fields.entrySet()) {
             final String key = entry.getKey();
@@ -448,6 +449,7 @@ public class Message implements Messages, Indexable {
                             .collect(Collectors.joining(", ")));
         }
 
+        obj.put(DiscoveredFieldTypeService.ALL_MESSAGE_FIELDS_DOCUMENT_FIELD, obj.keySet());
         return obj;
     }
 

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/engine/SearchExecutorTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/engine/SearchExecutorTest.java
@@ -147,7 +147,8 @@ public class SearchExecutorTest {
         doReturn(preValidationQuery).when(searchNormalization).preValidation(eq(query), eq(parameterProvider), eq(searchUser), any());
         doReturn(normalizedQuery).when(searchNormalization).postValidation(eq(preValidationQuery), eq(parameterProvider));
         doReturn(Set.of()).when(searchValidation).validate(eq(preValidationQuery), any());
-        doReturn(Set.of("field1", "field2")).when(queryEngine).getFieldsPresentInQueryResultDocuments(normalizedQuery, new QueryAwareFieldListRetrievalParams(searchUser, 1000, false, 100));
+        final QueryAwareFieldListRetrievalParams params = new QueryAwareFieldListRetrievalParams(searchUser, 1000, false, 100);
+        doReturn(Set.of("field1", "field2")).when(queryEngine).getFieldsPresentInQueryResultDocuments(normalizedQuery, params);
 
         this.searchExecutor = new SearchExecutor(searchDomain,
                 new InMemorySearchJobService(),
@@ -156,7 +157,7 @@ public class SearchExecutorTest {
                 searchNormalization);
 
 
-        final Set<String> result = searchExecutor.getFieldsPresentInQueryResultDocuments(query, parameterProvider, new QueryAwareFieldListRetrievalParams(searchUser, 1000, false, -1));
+        final Set<String> result = searchExecutor.getFieldsPresentInQueryResultDocuments(query, parameterProvider, params);
 
         assertThat(result).containsOnly("field1", "field2");
     }

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/engine/SearchExecutorTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/engine/SearchExecutorTest.java
@@ -30,6 +30,7 @@ import org.graylog.plugins.views.search.db.InMemorySearchJobService;
 import org.graylog.plugins.views.search.db.SearchJobService;
 import org.graylog.plugins.views.search.elasticsearch.ElasticsearchQueryString;
 import org.graylog.plugins.views.search.elasticsearch.QueryStringDecorators;
+import org.graylog.plugins.views.search.engine.fieldlist.QueryAwareFieldListRetrievalParams;
 import org.graylog.plugins.views.search.engine.normalization.DecorateQueryStringsNormalizer;
 import org.graylog.plugins.views.search.engine.normalization.PluggableSearchNormalization;
 import org.graylog.plugins.views.search.engine.normalization.SearchNormalization;
@@ -128,7 +129,7 @@ public class SearchExecutorTest {
                 searchNormalization);
 
 
-        final Set<String> result = searchExecutor.getFieldsPresentInQueryResultDocuments(query, parameterProvider, searchUser, 1000);
+        final Set<String> result = searchExecutor.getFieldsPresentInQueryResultDocuments(query, parameterProvider, new QueryAwareFieldListRetrievalParams(searchUser, 1000, false, -1));
 
         verifyNoInteractions(queryEngine);
         assertThat(result).isEmpty();
@@ -146,7 +147,7 @@ public class SearchExecutorTest {
         doReturn(preValidationQuery).when(searchNormalization).preValidation(eq(query), eq(parameterProvider), eq(searchUser), any());
         doReturn(normalizedQuery).when(searchNormalization).postValidation(eq(preValidationQuery), eq(parameterProvider));
         doReturn(Set.of()).when(searchValidation).validate(eq(preValidationQuery), any());
-        doReturn(Set.of("field1", "field2")).when(queryEngine).getFieldsPresentInQueryResultDocuments(normalizedQuery, 1000);
+        doReturn(Set.of("field1", "field2")).when(queryEngine).getFieldsPresentInQueryResultDocuments(normalizedQuery, new QueryAwareFieldListRetrievalParams(searchUser, 1000, false, 100));
 
         this.searchExecutor = new SearchExecutor(searchDomain,
                 new InMemorySearchJobService(),
@@ -155,7 +156,7 @@ public class SearchExecutorTest {
                 searchNormalization);
 
 
-        final Set<String> result = searchExecutor.getFieldsPresentInQueryResultDocuments(query, parameterProvider, searchUser, 1000);
+        final Set<String> result = searchExecutor.getFieldsPresentInQueryResultDocuments(query, parameterProvider, new QueryAwareFieldListRetrievalParams(searchUser, 1000, false, -1));
 
         assertThat(result).containsOnly("field1", "field2");
     }

--- a/graylog2-server/src/test/java/org/graylog2/indexer/fieldtypes/MappedFieldTypesServiceImplTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/fieldtypes/MappedFieldTypesServiceImplTest.java
@@ -66,7 +66,7 @@ public class MappedFieldTypesServiceImplTest {
 
     @Before
     public void setUp() throws Exception {
-        this.mappedFieldTypesService = new MappedFieldTypesServiceImpl(streamService, indexFieldTypesService, new FieldTypeMapper(), indexLookup);
+        this.mappedFieldTypesService = new MappedFieldTypesServiceImpl(streamService, indexFieldTypesService, new FieldTypesMerger(new FieldTypeMapper()), indexLookup);
         when(streamService.indexSetIdsByIds(Collections.singleton("stream1"))).thenReturn(Collections.singleton("indexSetId"));
     }
 

--- a/graylog2-web-interface/src/logic/message/MessageFieldsFilter.js
+++ b/graylog2-web-interface/src/logic/message/MessageFieldsFilter.js
@@ -27,6 +27,7 @@ const MessageFieldsFilter = {
 
     // Our reserved fields.
     'gl2_accounted_message_size',
+    'gl2_message_fields',
     'gl2_message_id',
     'gl2_source_node',
     'gl2_source_input',

--- a/graylog2-web-interface/src/views/components/contexts/DefaultFieldTypesProvider.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/DefaultFieldTypesProvider.tsx
@@ -19,10 +19,12 @@ import { useMemo } from 'react';
 import * as Immutable from 'immutable';
 import PropTypes from 'prop-types';
 
-import useFieldTypes from 'views/logic/fieldtypes/useFieldTypes';
+import useFieldTypes, { useFieldTypesForSearch } from 'views/logic/fieldtypes/useFieldTypes';
 import { filtersToStreamSet } from 'views/logic/queries/Query';
 import type { RelativeTimeRange } from 'views/logic/queries/Query';
 import useCurrentQuery from 'views/logic/queries/useCurrentQuery';
+import { useStore } from 'stores/connect';
+import { SearchStore } from 'views/stores/SearchStore';
 
 import FieldTypesContext from './FieldTypesContext';
 
@@ -30,9 +32,10 @@ const defaultId = '';
 const defaultTimeRange: RelativeTimeRange = { type: 'relative', from: 300 };
 
 const DefaultFieldTypesProvider = ({ children }: { children: React.ReactElement }) => {
+  const searchId = useStore(SearchStore, (state) => state?.search?.id);
   const currentQuery = useCurrentQuery();
   const currentStreams = useMemo(() => filtersToStreamSet(currentQuery?.filter).toArray(), [currentQuery?.filter]);
-  const { data: currentFieldTypes } = useFieldTypes(currentStreams, currentQuery?.timerange || defaultTimeRange);
+  const { data: currentFieldTypes } = useFieldTypesForSearch(searchId, currentStreams, currentQuery?.timerange || defaultTimeRange);
   const { data: allFieldTypes } = useFieldTypes([], currentQuery?.timerange || defaultTimeRange);
   const queryFields = useMemo(() => Immutable.Map({ [currentQuery?.id || defaultId]: Immutable.List(currentFieldTypes) }), [currentFieldTypes, currentQuery?.id]);
   const all = useMemo(() => Immutable.List(allFieldTypes ?? []), [allFieldTypes]);


### PR DESCRIPTION
Query-based awareness instead of stream-based awareness. Concept.

## Disclaimer
It is still work in progress.
Development speed was the priority, as we want to try different approaches.
There are no tests and code may look ugly here and there.

## Description
Query-based awareness instead of stream-based awareness.
The concept has two main parts:
1. While indexing, we will store all field names for all documents in a new field, called "**gl2_message_fields**".
    For the messages indexed before the change, you can create and fill that field by invoking the following query on your index:
`POST <index_name>/_update_by_query
{
  "query": {
    "match_all": {}
  },
  "script": {
    "source": "ctx._source.gl2_message_fields=ctx._source.keySet()",
    "lang": "painless"
  }
}`
2. Field types will be identified by search/query, using aggregations on "**gl2_message_fields**".

## Motivation and Context
Instead of returning stream-based aware field lists, we can go even further and return search/query-based aware field list.

## How Has This Been Tested?
Just a few manual tests with REST API.

## Performance implications
1. Indexing additional field with this line of code :
`obj.put(DiscoveredFieldTypeService.ALL_MESSAGE_FIELDS_DOCUMENT_FIELD, obj.keySet());`
didn't show any visible performance degradation.
When indexing with and without this option, using Random HTTP input, it took 12-18 ms to index a bulk of messages on my machine. More precise tests could be possibly performed, but I do not see the need for them at this point.

2. Obtaining field types with additional aggregation is slightly slower than before (15 ms vs 12 ms before the change, on average), but with lower data transfer (you don't have to transfer all the fields in the response).
Testes with banal JMeter Test Plan against index set with ~2M messages spread across 4 indices, 500k messages each.
Messages populated with Random HTTP input.

![perf_results](https://user-images.githubusercontent.com/100699120/190150637-4be63776-0af3-4a15-ab8a-3af55f88a954.png)


## Screenshots (if appropriate):
![Screenshot 2022-09-13 at 11-51-39 Graylog REST API browser](https://user-images.githubusercontent.com/100699120/189871092-2901ff35-6689-4864-b088-87cdee0a10bf.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

