### PR TITLE
Calculate write index alias once, during MongoIndexSet creation.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/MongoIndexSet.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/MongoIndexSet.java
@@ -65,12 +65,12 @@ public class MongoIndexSet implements IndexSet {
     // TODO: Hardcoded archive suffix. See: https://github.com/Graylog2/graylog2-server/issues/2058
     // TODO 3.0: Remove this in 3.0, only used for pre 2.2 backwards compatibility.
     public static final String RESTORED_ARCHIVE_SUFFIX = "_restored_archive";
-
     public interface Factory {
         MongoIndexSet create(IndexSetConfig config);
     }
 
     private final IndexSetConfig config;
+    private final String writeIndexAlias;
     private final Indices indices;
     private final Pattern indexPattern;
     private final Pattern deflectorIndexPattern;
@@ -93,6 +93,7 @@ public class MongoIndexSet implements IndexSet {
                          final ActivityWriter activityWriter
     ) {
         this.config = requireNonNull(config);
+        this.writeIndexAlias = config.indexPrefix() + SEPARATOR + DEFLECTOR_SUFFIX;
         this.indices = requireNonNull(indices);
         this.nodeId = requireNonNull(nodeId);
         this.indexRangeService = requireNonNull(indexRangeService);
@@ -131,7 +132,7 @@ public class MongoIndexSet implements IndexSet {
 
     @Override
     public String getWriteIndexAlias() {
-        return config.indexPrefix() + SEPARATOR + DEFLECTOR_SUFFIX;
+        return writeIndexAlias;
     }
 
     @Override
@@ -374,8 +375,12 @@ public class MongoIndexSet implements IndexSet {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
         MongoIndexSet that = (MongoIndexSet) o;
         return Objects.equals(config, that.config);
     }


### PR DESCRIPTION
## Description
Calculate write index alias once, during MongoIndexSet creation.

## Motivation and Context
It seems that > 5% of bulk request creation time has been spend on concatenating the same strings over and over again.
The screenshot shows that the whole section disappears from the execution after this change.

## Screenshots (if appropriate):
![Screenshot 2022-09-13 at 15-03-25 Zrzut ekranu z 2022-09-13 15-02-40 png (obraz PNG 3840×1200 pikseli) — Skala (49%)](https://user-images.githubusercontent.com/100699120/189909358-efca9cf1-d18a-4772-a11b-659d17ed5231.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

