### PR TITLE
Add exception for ESLint rule `no-unused-vars`.

### DIFF
--- a/graylog2-web-interface/packages/eslint-config-graylog/index.js
+++ b/graylog2-web-interface/packages/eslint-config-graylog/index.js
@@ -14,6 +14,8 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
+const noUnusedVarsOptions = { argsIgnorePattern: '^_' };
+
 module.exports = {
   parser: '@babel/eslint-parser',
   env: {
@@ -30,7 +32,7 @@ module.exports = {
         'no-use-before-define': 'off',
         '@typescript-eslint/no-use-before-define': ['error'],
         'no-unused-vars': 'off',
-        '@typescript-eslint/no-unused-vars': ['error'],
+        '@typescript-eslint/no-unused-vars': ['error', noUnusedVarsOptions],
         'no-redeclare': 'off',
         '@typescript-eslint/no-redeclare': ['error'],
         'no-shadow': 'off',
@@ -96,6 +98,7 @@ module.exports = {
     'max-len': 'off',
     'new-cap': 'off',
     'no-else-return': 'warn',
+    'no-unused-vars': ['error', noUnusedVarsOptions],
     'no-nested-ternary': 'warn',
     'no-restricted-imports': ['error', {
       paths: [{


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Sometime we want to exclude, for example an attribute from the component props, before passing them to a child component.
`const Component = ({ exampleProp, ...props }) =>`
Currently this results an ESLint warning, because `exampleProp` is not being used.

With this PR it will be possible to avoid this warning by changing the variable name:
`const Component = ({ exampleProp: _exampleProp, ...props }) =>`
