### PR TITLE
Open hyperlink decorator links in a new window (4.3 backport)

### DIFF
--- a/graylog2-web-interface/src/views/components/DecoratorValue.tsx
+++ b/graylog2-web-interface/src/views/components/DecoratorValue.tsx
@@ -43,7 +43,7 @@ const DecoratorValue = ({ field, value, truncate, render, type }: Props) => {
   if (value && value.href && value.type) {
     const formattedValue = _formatValue(field, value.href, truncate, render, type);
 
-    return <a href={value.href}>{formattedValue}</a>;
+    return <a href={value.href} target="_blank" rel="noreferrer">{formattedValue}</a>;
   }
 
   return _formatValue(field, value, truncate, render, type);


### PR DESCRIPTION
Backport https://github.com/Graylog2/graylog2-server/pull/13351 to the `4.3` branch.