### PR TITLE
Fix DiskJournalPreflightCheck (4.3 backport)

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/bootstrap/preflight/DiskJournalPreflightCheck.java
+++ b/graylog2-server/src/main/java/org/graylog2/bootstrap/preflight/DiskJournalPreflightCheck.java
@@ -72,10 +72,11 @@ public class DiskJournalPreflightCheck implements PreflightCheck {
             if (availableOnFS > 0) {
                 final long usedByJournal = FileUtils.sizeOfDirectory(journalDirectory.toFile());
                 if (availableOnFS + usedByJournal < journalMaxSize.toBytes()) {
-                    throw new PreflightCheckException(StringUtils.f(
-                            "Journal directory <%s> has not enough free space (%d MB) to contain 'message_journal_max_size = %d MB' ",
+                       throw new PreflightCheckException(StringUtils.f(
+                            "Journal directory <%s> has not enough free space (%d MB) available. You need to provide additional %d MB to contain 'message_journal_max_size = %d MB' ",
                             journalDirectory.toAbsolutePath(),
-                            Size.bytes(availableOnFS + usedByJournal).toMegabytes(),
+                            Size.bytes(availableOnFS).toMegabytes(),
+                            Size.bytes(journalMaxSize.toBytes() - usedByJournal - availableOnFS).toMegabytes(),
                             journalMaxSize.toMegabytes()
                     ));
                 }
@@ -100,7 +101,7 @@ public class DiskJournalPreflightCheck implements PreflightCheck {
             try {
                 Files.createDirectories(journalDirectory);
             } catch (IOException e) {
-                throw new PreflightCheckException(StringUtils.f("Cannot create journal directory at <%s>", journalDirectory.toAbsolutePath()));
+                throw new PreflightCheckException(StringUtils.f("Cannot create journal directory at <%s>", journalDirectory.toAbsolutePath()), e);
             }
         }
         if (!Files.isWritable(journalDirectory)) {


### PR DESCRIPTION
Include the already used size of the journal directory into the size calcalation.

Fixes #13454

(cherry picked from commit e323126580607873dd3541516721ddd108f13443)
