### PR TITLE
Adding FreeBSD icon for sidecars.

### DIFF
--- a/graylog2-web-interface/src/components/common/CustomFontAwesomeIcon.tsx
+++ b/graylog2-web-interface/src/components/common/CustomFontAwesomeIcon.tsx
@@ -19,9 +19,9 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { library } from '@fortawesome/fontawesome-svg-core';
 import { fas } from '@fortawesome/free-solid-svg-icons';
 import { far } from '@fortawesome/free-regular-svg-icons';
-import { faApple, faGithub, faGithubAlt, faLinux, faWindows } from '@fortawesome/free-brands-svg-icons';
+import { faApple, faFreebsd, faGithub, faGithubAlt, faLinux, faWindows } from '@fortawesome/free-brands-svg-icons';
 
-library.add(fas, far, faApple, faGithub, faGithubAlt, faLinux, faWindows);
+library.add(fas, far, faApple, faGithub, faGithubAlt, faLinux, faWindows, faFreebsd);
 
 const CustomFontAwesomeIcon = (props: React.ComponentProps<typeof FontAwesomeIcon>) => <FontAwesomeIcon {...props} />;
 

--- a/graylog2-web-interface/src/components/sidecars/common/OperatingSystemIcon.tsx
+++ b/graylog2-web-interface/src/components/sidecars/common/OperatingSystemIcon.tsx
@@ -14,7 +14,7 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import React from 'react';
+import * as React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
@@ -25,24 +25,47 @@ const SidecarIcon = styled(Icon)`
   margin-left: 2px;
 `;
 
-const OperatingSystemIcon = ({ operatingSystem }) => {
-  let iconName = 'question-circle';
-  let iconType = 'solid';
+type Props = {
+  operatingSystem: string,
+};
 
-  if (operatingSystem) {
-    const os = operatingSystem.trim().toLowerCase();
-
-    if (os.indexOf('darwin') !== -1 || os.indexOf('mac os') !== -1) {
-      iconName = 'apple';
-      iconType = 'brand';
-    } else if (os.indexOf('linux') !== -1) {
-      iconName = 'linux';
-      iconType = 'brand';
-    } else if (os.indexOf('win') !== -1) {
-      iconName = 'windows';
-      iconType = 'brand';
-    }
+const matchIcon = (os: string) => {
+  if (os.includes('darwin') || os.includes('mac os')) {
+    return {
+      iconName: 'apple',
+      iconType: 'brand',
+    } as const;
   }
+
+  if (os.includes('linux')) {
+    return {
+      iconName: 'linux',
+      iconType: 'brand',
+    } as const;
+  }
+
+  if (os.includes('win')) {
+    return {
+      iconName: 'windows',
+      iconType: 'brand',
+    } as const;
+  }
+
+  if (os.includes('freebsd')) {
+    return {
+      iconName: 'freebsd',
+      iconType: 'brand',
+    } as const;
+  }
+
+  return {
+    iconName: 'question-circle',
+    iconType: 'solid',
+  } as const;
+};
+
+const OperatingSystemIcon = ({ operatingSystem }: Props) => {
+  const { iconName, iconType } = matchIcon(operatingSystem.trim().toLowerCase());
 
   return (
     <SidecarIcon name={iconName} type={iconType} fixedWidth />


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The Log Collectors management section of the sidecar management UI comes with a FreeBSD-config, but is lacking the corresponding icon. This PR is fixing that.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

Before:

![image](https://user-images.githubusercontent.com/41929/191011212-d33577c5-c390-4a1a-9a2d-deecfe7f11c2.png)

After:

![image](https://user-images.githubusercontent.com/41929/191011126-39a2387f-2293-4d89-bf91-5c164db759d4.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.