### PR TITLE
Exists term is now properly validated, no matter what type of field i…

### DIFF
--- a/full-backend-tests/src/test/java/org/graylog/plugins/views/QueryValidationResourceIT.java
+++ b/full-backend-tests/src/test/java/org/graylog/plugins/views/QueryValidationResourceIT.java
@@ -147,6 +147,12 @@ public class QueryValidationResourceIT {
     }
 
     @ContainerMatrixTest
+    void testSuccessfullyValidatesExistsTerms() {
+        verifyQueryIsValidatedSuccessfully("_exists_:timestamp");
+        verifyQueryIsValidatedSuccessfully("_exists_:level");
+    }
+
+    @ContainerMatrixTest
     void testQuotedDefaultField() {
         // if the validation correctly recognizes the quoted text, it should not warn about lowercase or
         verifyQueryIsValidatedSuccessfully("\\\"A or B\\\"");

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/validation/ParsedQuery.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/validation/ParsedQuery.java
@@ -20,7 +20,6 @@ import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
 
 import javax.validation.constraints.NotNull;
-import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/validation/validators/FieldValueTypeValidator.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/validation/validators/FieldValueTypeValidator.java
@@ -93,6 +93,7 @@ public class FieldValueTypeValidator implements QueryValidator {
         final Map<String, MappedFieldTypeDTO> fields = availableFields.stream().collect(Collectors.toMap(MappedFieldTypeDTO::name, Function.identity()));
 
         return parsedQuery.terms().stream()
+                .filter(term -> !term.isExistsField())
                 .map(term -> {
                     final MappedFieldTypeDTO fieldType = fields.get(term.getRealFieldName());
                     final Optional<String> typeName = Optional.ofNullable(fieldType)


### PR DESCRIPTION
…s used

<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes #13455

## Motivation and Context
**_exists_** terms **should not** go through field type validation. The value of this special type of term does not contain data, but the name of the field. It is enough that **_exists_** terms go through unknown field validation.


## How Has This Been Tested?
Manually and by additional integration test.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

