### PR TITLE
Fix cache invalidation for collector actions

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/requests/BulkActionRequest.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/requests/BulkActionRequest.java
@@ -33,8 +33,8 @@ public abstract class BulkActionRequest {
     public abstract List<String> collectorIds();
 
     @JsonCreator
-    public static BulkActionRequest create(@JsonProperty("sidecar_id") String collectorId,
+    public static BulkActionRequest create(@JsonProperty("sidecar_id") String sidecarId,
                                            @JsonProperty("collector_ids") List<String> collectorIds) {
-        return new AutoValue_BulkActionRequest(collectorId, collectorIds);
+        return new AutoValue_BulkActionRequest(sidecarId, collectorIds);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/resources/AdministrationResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/resources/AdministrationResource.java
@@ -44,7 +44,6 @@ import org.graylog.plugins.sidecar.rest.responses.SidecarListResponse;
 import org.graylog.plugins.sidecar.services.ActionService;
 import org.graylog.plugins.sidecar.services.CollectorService;
 import org.graylog.plugins.sidecar.services.ConfigurationService;
-import org.graylog.plugins.sidecar.services.EtagService;
 import org.graylog.plugins.sidecar.services.SidecarService;
 import org.graylog.plugins.sidecar.system.SidecarConfiguration;
 import org.graylog2.audit.jersey.AuditEvent;
@@ -91,7 +90,6 @@ public class AdministrationResource extends RestResource implements PluginRestRe
     private final AdministrationFiltersFactory administrationFiltersFactory;
     private final ActiveSidecarFilter activeSidecarFilter;
     private final SidecarStatusMapper sidecarStatusMapper;
-    private final EtagService etagService;
 
     @Inject
     public AdministrationResource(SidecarService sidecarService,
@@ -100,8 +98,7 @@ public class AdministrationResource extends RestResource implements PluginRestRe
                                   ActionService actionService,
                                   AdministrationFiltersFactory administrationFiltersFactory,
                                   ClusterConfigService clusterConfigService,
-                                  SidecarStatusMapper sidecarStatusMapper,
-                                  EtagService etagService) {
+                                  SidecarStatusMapper sidecarStatusMapper) {
         final SidecarConfiguration sidecarConfiguration = clusterConfigService.getOrDefault(SidecarConfiguration.class, SidecarConfiguration.defaultConfiguration());
         this.sidecarService = sidecarService;
         this.configurationService = configurationService;
@@ -109,7 +106,6 @@ public class AdministrationResource extends RestResource implements PluginRestRe
         this.actionService = actionService;
         this.administrationFiltersFactory = administrationFiltersFactory;
         this.sidecarStatusMapper = sidecarStatusMapper;
-        this.etagService = etagService;
         this.activeSidecarFilter = new ActiveSidecarFilter(sidecarConfiguration.sidecarInactiveThreshold());
         this.searchQueryParser = new SearchQueryParser(Sidecar.FIELD_NODE_NAME, SidecarResource.SEARCH_FIELD_MAPPING);
     }
@@ -170,7 +166,6 @@ public class AdministrationResource extends RestResource implements PluginRestRe
                     .collect(Collectors.toList());
             final CollectorActions collectorActions = actionService.fromRequest(bulkActionRequest.sidecarId(), actions);
             actionService.saveAction(collectorActions);
-            etagService.invalidateRegistration(bulkActionRequest.sidecarId());
         }
 
         return Response.accepted().build();

--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/resources/SidecarResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/resources/SidecarResource.java
@@ -223,7 +223,7 @@ public class SidecarResource extends RestResource implements PluginRestResource 
         // If the sidecar has the recent registration, return with HTTP 304
         if (ifNoneMatch != null) {
             EntityTag etag = new EntityTag(ifNoneMatch.replaceAll("\"", ""));
-            if (etagService.registrationIsCached(sidecar.id(), etag.toString())) {
+            if (etagService.registrationIsCached(sidecar.nodeId(), etag.toString())) {
                 sidecarService.save(sidecar);
                 return Response.notModified().tag(etag).build();
             }
@@ -247,7 +247,7 @@ public class SidecarResource extends RestResource implements PluginRestResource 
                 sidecar.assignments());
         // add new etag to cache
         EntityTag registrationEtag = etagService.buildEntityTagForResponse(sidecarRegistrationResponse);
-        etagService.addSidecarRegistration(sidecar.id(), registrationEtag.toString());
+        etagService.addSidecarRegistration(sidecar.nodeId(), registrationEtag.toString());
 
         return Response.accepted(sidecarRegistrationResponse).tag(registrationEtag).build();
     }
@@ -273,7 +273,7 @@ public class SidecarResource extends RestResource implements PluginRestResource 
             try {
                 Sidecar sidecar = sidecarService.applyManualAssignments(nodeId, nodeRelations);
                 sidecarService.save(sidecar);
-                etagService.invalidateRegistration(sidecar.id());
+                etagService.invalidateRegistration(sidecar.nodeId());
             } catch (org.graylog2.database.NotFoundException e) {
                 throw new NotFoundException(e.getMessage());
             }

--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/services/EtagService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/services/EtagService.java
@@ -132,8 +132,8 @@ public class EtagService extends AbstractIdleService {
         configurationCache.put(etag, Boolean.TRUE);
     }
 
-    public void addSidecarRegistration(String sidecarId, String etag) {
-        registrationCache.put(sidecarId, etag);
+    public void addSidecarRegistration(String sidecarNodeId, String etag) {
+        registrationCache.put(sidecarNodeId, etag);
     }
 
 
@@ -152,9 +152,9 @@ public class EtagService extends AbstractIdleService {
         clusterEventBus.post(EtagCacheInvalidation.create(CacheContext.REGISTRATION, ""));
     }
 
-    public void invalidateRegistration(String sidecarId) {
-        registrationCache.invalidate(sidecarId);
-        clusterEventBus.post(EtagCacheInvalidation.create(CacheContext.REGISTRATION, sidecarId));
+    public void invalidateRegistration(String sidecarNodeId) {
+        registrationCache.invalidate(sidecarNodeId);
+        clusterEventBus.post(EtagCacheInvalidation.create(CacheContext.REGISTRATION, sidecarNodeId));
     }
 
     public EntityTag buildEntityTagForResponse(Object o) throws JsonProcessingException {

--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/services/EtagService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/services/EtagService.java
@@ -120,8 +120,8 @@ public class EtagService extends AbstractIdleService {
         return configurationCache.getIfPresent(etag) != null;
     }
 
-    public boolean registrationIsCached(String sidecarId, String etag) {
-        return etag.equals(registrationCache.getIfPresent(sidecarId));
+    public boolean registrationIsCached(String sidecarNodeId, String etag) {
+        return etag.equals(registrationCache.getIfPresent(sidecarNodeId));
     }
 
     public void registerCollector(String etag) {


### PR DESCRIPTION
The registration cache was using the sidecar "_id", while the ActionService was invalidating the sidecar "node_id".

Change the entire cache to using the "node_id"
