### PR TITLE
Fix server --dump-default-config command

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/bootstrap/CmdLineTool.java
+++ b/graylog2-server/src/main/java/org/graylog2/bootstrap/CmdLineTool.java
@@ -265,12 +265,13 @@ public abstract class CmdLineTool implements CliCommand {
     }
 
     public void doRun(Level logLevel) {
-        if (isDumpDefaultConfig()) {
-            dumpDefaultConfigAndExit();
-        }
         // This is holding all our metrics.
         MetricRegistry metricRegistry = MetricRegistryFactory.create();
         featureFlags = getFeatureFlags(metricRegistry);
+
+        if (isDumpDefaultConfig()) {
+            dumpDefaultConfigAndExit();
+        }
 
         installConfigRepositories();
         installCommandConfig();


### PR DESCRIPTION
The `setupCoreConfigInjector()` method reqires the feature flags to be set up already.
