### PR TITLE
Disable `react-query` retries for tests.

### DIFF
--- a/graylog2-web-interface/src/contexts/DefaultQueryClientProvider.tsx
+++ b/graylog2-web-interface/src/contexts/DefaultQueryClientProvider.tsx
@@ -35,7 +35,7 @@ const defaultOptions = {
 
 const DefaultQueryClientProvider = ({ children, options: optionsProp }: Props) => {
   const options = optionsProp ? merge({}, defaultOptions, optionsProp) : defaultOptions;
-  const queryClient = useMemo(() => new QueryClient(options), []);
+  const queryClient = useMemo(() => new QueryClient(options), [options]);
 
   return (
     <QueryClientProvider client={queryClient}>

--- a/graylog2-web-interface/src/contexts/DefaultQueryClientProvider.tsx
+++ b/graylog2-web-interface/src/contexts/DefaultQueryClientProvider.tsx
@@ -16,13 +16,16 @@
  */
 import * as React from 'react';
 import { useMemo } from 'react';
+import type { QueryClientConfig } from '@tanstack/react-query';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { merge } from 'lodash';
 
 type Props = {
   children: React.ReactNode,
+  options?: QueryClientConfig
 };
 
-const options = {
+const defaultOptions = {
   defaultOptions: {
     queries: {
       refetchOnWindowFocus: false,
@@ -30,7 +33,8 @@ const options = {
   },
 };
 
-const DefaultQueryClientProvider = ({ children }: Props) => {
+const DefaultQueryClientProvider = ({ children, options: optionsProp }: Props) => {
+  const options = optionsProp ? merge({}, defaultOptions, optionsProp) : defaultOptions;
   const queryClient = useMemo(() => new QueryClient(options), []);
 
   return (
@@ -38,6 +42,10 @@ const DefaultQueryClientProvider = ({ children }: Props) => {
       {children}
     </QueryClientProvider>
   );
+};
+
+DefaultQueryClientProvider.defaultProps = {
+  options: undefined,
 };
 
 export default DefaultQueryClientProvider;

--- a/graylog2-web-interface/src/views/components/Search.dashboard.test.tsx
+++ b/graylog2-web-interface/src/views/components/Search.dashboard.test.tsx
@@ -47,6 +47,7 @@ jest.mock('views/stores/ViewMetadataStore', () => ({
   ),
 }));
 
+jest.mock('views/logic/fieldtypes/useFieldTypes');
 jest.mock('hooks/useElementDimensions', () => () => ({ width: 1024, height: 768 }));
 
 const mockedQueryIds = Immutable.OrderedSet(['query-id-1', 'query-id-2']);

--- a/graylog2-web-interface/src/views/components/searchbar/queryinput/QueryInput.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/queryinput/QueryInput.test.tsx
@@ -23,6 +23,8 @@ import { validationError } from 'fixtures/queryValidationState';
 
 import QueryInput from './QueryInput';
 
+jest.mock('views/logic/fieldtypes/useFieldTypes');
+
 jest.mock('views/actions/QueryValidationActions', () => ({
   displayValidationErrors: jest.fn(),
 }));

--- a/graylog2-web-interface/src/views/components/widgets/Widget.aggregations.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/Widget.aggregations.test.tsx
@@ -52,6 +52,7 @@ const mockedUnixTime = 1577836800000; // 2020-01-01 00:00:00.000
 
 jest.mock('./WidgetHeader', () => 'widget-header');
 jest.mock('./WidgetColorContext', () => ({ children }) => children);
+jest.mock('views/logic/fieldtypes/useFieldTypes');
 
 const MockWidgetStoreState = Immutable.Map();
 

--- a/graylog2-web-interface/test/WrappingContainer.tsx
+++ b/graylog2-web-interface/test/WrappingContainer.tsx
@@ -27,8 +27,16 @@ type Props = {
   children: React.ReactNode,
 }
 
+const queryClientOptions = {
+  defaultOptions: {
+    queries: {
+      retry: false,
+    },
+  },
+};
+
 const WrappingContainer = ({ children }: Props) => (
-  <DefaultQueryClientProvider>
+  <DefaultQueryClientProvider options={queryClientOptions}>
     <Router history={history}>
       <DefaultProviders>
         {children}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

With this PR we are fixing a few flaky tests. They all have in common, that `react-query` was dealing with an unrelated error while the tests were running.

By default `react-query` is retrying a request three times before it errors. Because of this behaviour the tests were only failing when the retries finished before the test succeeded.   When a test succeeded before all retries finished, the retries got "canceled".

By disabling the retires for tests, they fail reliable. For example with the following error:
`response.map is not a function` 
This error occurs because we mock our `FetchProvider` in tests with the following default return value `{}`. This is problematic, when the expected return value is for example an array.
 
 /jenkins-pr-deps https://github.com/Graylog2/graylog-plugin-enterprise/pull/4084