### PR TITLE
Fix server --dump-default-config command (#13507)

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/bootstrap/CmdLineTool.java
+++ b/graylog2-server/src/main/java/org/graylog2/bootstrap/CmdLineTool.java
@@ -254,12 +254,13 @@ public abstract class CmdLineTool implements CliCommand {
     public void run() {
         final Level logLevel = setupLogger();
 
-        if (isDumpDefaultConfig()) {
-            dumpDefaultConfigAndExit();
-        }
         // This is holding all our metrics.
         MetricRegistry metricRegistry = MetricRegistryFactory.create();
         featureFlags = getFeatureFlags(metricRegistry);
+
+        if (isDumpDefaultConfig()) {
+            dumpDefaultConfigAndExit();
+        }
 
         installConfigRepositories();
         installCommandConfig();


### PR DESCRIPTION
Backport of #13507 to fix `--dump-default-config` option for server command.