### PR TITLE
fixing the directions, `Set.difference` is used (backport to 4.3 of #13500)

### DIFF
--- a/full-backend-tests/src/test/java/org/graylog/plugins/views/ViewsResourceIT.java
+++ b/full-backend-tests/src/test/java/org/graylog/plugins/views/ViewsResourceIT.java
@@ -93,6 +93,6 @@ public class ViewsResourceIT {
                 .then()
                 .statusCode(400)
                 .assertThat()
-                .body("message", equalTo("Search types do not correspond to view/search types, missing searches: [967d2217-fd99-48a6-b829-5acdab906807]"));
+                .body("message", equalTo("Search types do not correspond to view/search types, missing searches [967d2217-fd99-48a6-b829-5acdab906808]; search types: [967d2217-fd99-48a6-b829-5acdab906807]; state types: [967d2217-fd99-48a6-b829-5acdab906808]"));
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/ViewsResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/ViewsResource.java
@@ -202,6 +202,10 @@ public class ViewsResource extends RestResource implements PluginRestResource {
         final Search search = searchDomain.getForUser(dto.searchId(), searchUser)
                 .orElseThrow(() -> new BadRequestException("Search " + dto.searchId() + " not available"));
 
+        validateSearchProperties(dto, search);
+    }
+
+    protected void validateSearchProperties(ViewDTO dto, Search search) {
         final Set<String> searchQueries = search.queries().stream()
                 .map(Query::id)
                 .collect(Collectors.toSet());
@@ -209,8 +213,11 @@ public class ViewsResource extends RestResource implements PluginRestResource {
         final Set<String> stateQueries = dto.state().keySet();
 
         if(!searchQueries.containsAll(stateQueries)) {
-            final Sets.SetView<String> diff = Sets.difference(searchQueries, stateQueries);
-            throw new BadRequestException("Search queries do not correspond to view/state queries, missing query IDs: " + diff);
+            final Sets.SetView<String> diff = Sets.difference(stateQueries, searchQueries);
+            final String message = String.format(Locale.ROOT,
+                    "Search queries do not correspond to view/state queries, missing query IDs: %s; search queries: %s; state queries: %s",
+                    diff, searchQueries, stateQueries);
+            throw new BadRequestException(message);
         }
 
         final Set<String> searchTypes = search.queries().stream()
@@ -225,8 +232,11 @@ public class ViewsResource extends RestResource implements PluginRestResource {
                 .collect(Collectors.toSet());
 
         if(!searchTypes.containsAll(stateTypes)) {
-            final Sets.SetView<String> diff = Sets.difference(searchTypes, stateTypes);
-            throw new BadRequestException("Search types do not correspond to view/search types, missing searches: " + diff);
+            final Sets.SetView<String> diff = Sets.difference(stateTypes, searchTypes);
+            final String message = String.format(Locale.ROOT,
+                    "Search types do not correspond to view/search types, missing searches %s; search types: %s; state types: %s",
+                    diff, searchTypes, stateTypes);
+            throw new BadRequestException(message);
         }
 
         final Set<String> widgetIds = dto.state().values().stream()
@@ -238,8 +248,11 @@ public class ViewsResource extends RestResource implements PluginRestResource {
                 .flatMap(v -> v.widgetPositions().keySet().stream()).collect(Collectors.toSet());
 
         if(!widgetPositions.containsAll(widgetIds)) {
-            final Sets.SetView<String> diff = Sets.difference(widgetPositions, widgetIds);
-            throw new BadRequestException("Widget positions don't correspond to widgets, missing widget possitions: " + diff);
+            final Sets.SetView<String> diff = Sets.difference(widgetIds, widgetPositions);
+            final String message = String.format(Locale.ROOT,
+                    "Widget positions don't correspond to widgets, missing widget positions %s; widget IDs: %s; widget positions: %s",
+                    diff, widgetIds, widgetPositions);
+            throw new BadRequestException(message);
         }
     }
 

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/ViewsResourceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/ViewsResourceTest.java
@@ -226,7 +226,7 @@ public class ViewsResourceTest {
     }
 
     @Test(expected = Test.None.class)
-    void testVerifyIntegrity() {
+    public void testVerifyIntegrity() {
         final ViewDTO view = ViewDTO.builder()
                 .searchId("123")
                 .title("my-search")

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/ViewsResourceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/ViewsResourceTest.java
@@ -65,8 +65,7 @@ import java.util.function.Predicate;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
@@ -226,7 +225,7 @@ public class ViewsResourceTest {
                 () -> testResource.get(resolverName + ":invalid-view-id", searchUser));
     }
 
-    @Test
+    @Test(expected = Test.None.class)
     void testVerifyIntegrity() {
         final ViewDTO view = ViewDTO.builder()
                 .searchId("123")
@@ -239,7 +238,7 @@ public class ViewsResourceTest {
                 .build();
 
         // empty search, nothing to validate, should succeed
-        assertDoesNotThrow(() -> viewsResource.validateSearchProperties(view, search));
+        viewsResource.validateSearchProperties(view, search);
 
         final Search searchWithQuery = search.toBuilder().queries(ImmutableSet.of(Query.builder().id("Q-111").build())).build();
         final ViewDTO viewWithQuery = view.toBuilder().state(Collections.singletonMap("Q-123", ViewStateDTO.builder()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The views resource checks for missing elements but the parameters of Sets.difference was used wrong way around.

Note: backported from #13500 to 4.3 to help solving a customer issue.

<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

