### PR TITLE
Unify placement and styling of form buttons.

### DIFF
--- a/graylog2-web-interface/src/components/bootstrap/ButtonToolbar.tsx
+++ b/graylog2-web-interface/src/components/bootstrap/ButtonToolbar.tsx
@@ -14,20 +14,10 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-
 // eslint-disable-next-line no-restricted-imports
-export {
-  /* 👇 no custom theme colors needed 👇 */
-  ButtonGroup,
-  Checkbox, // NOTE: do we want custom or keep OS styles
-  Clearfix,
-  Col,
-  Collapse,
-  Dropdown,
-  Form,
-  Grid,
-  Pager,
-  PanelGroup,
-  Radio, // NOTE: do we want custom or keep OS styles
-  /* 👆 no custom theme colors needed 👆 */
-} from 'react-bootstrap';
+import { ButtonToolbar as BootstrapButtonToolbar } from 'react-bootstrap';
+
+const ButtonToolbar = BootstrapButtonToolbar;
+
+/** @component */
+export default ButtonToolbar;

--- a/graylog2-web-interface/src/components/bootstrap/index.js
+++ b/graylog2-web-interface/src/components/bootstrap/index.js
@@ -20,6 +20,7 @@ export { default as BootstrapModalConfirm } from './BootstrapModalConfirm';
 export { default as BootstrapModalForm } from './BootstrapModalForm';
 export { default as BootstrapModalWrapper } from './BootstrapModalWrapper';
 export { default as Button } from './Button';
+export { default as ButtonToolbar } from './ButtonToolbar';
 export { default as ControlLabel } from './ControlLabel';
 export { default as DropdownButton } from './DropdownButton';
 export { default as FormControl } from './FormControl';

--- a/graylog2-web-interface/src/components/common/FormSubmit.tsx
+++ b/graylog2-web-interface/src/components/common/FormSubmit.tsx
@@ -65,7 +65,7 @@ const FormSubmit = (props: Props) => {
     <ButtonToolbar className={className}>
       <Button bsStyle="success"
               bsSize={bsSize}
-              disabled={disabledSubmit}
+              disabled={disabledSubmit || isSubmitting}
               form={formId}
               title={submitButtonText}
               type={submitButtonType}
@@ -77,7 +77,7 @@ const FormSubmit = (props: Props) => {
         <Button type="button"
                 bsSize={bsSize}
                 onClick={props.onCancel}
-                disabled={props.disableCancel}>
+                disabled={props.disableCancel || isSubmitting}>
           Cancel
         </Button>
       )}

--- a/graylog2-web-interface/src/components/common/FormSubmit.tsx
+++ b/graylog2-web-interface/src/components/common/FormSubmit.tsx
@@ -15,19 +15,12 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import styled from 'styled-components';
 
-import Button from 'components/bootstrap/Button';
 import ButtonToolbar from 'components/bootstrap/ButtonToolbar';
+import Button from 'components/bootstrap/Button';
 import type { IconName } from 'components/common/Icon';
 import Icon from 'components/common/Icon';
 import Spinner from 'components/common/Spinner';
-
-const StyledButtonToolbar = styled(ButtonToolbar)`
-  display: flex;
-  justify-content: flex-end;
-  align-items: end;
-`;
 
 type WithCancelProps = {
   displayCancel: true,
@@ -46,7 +39,6 @@ type Props = {
   disabledSubmit?: boolean,
   formId?: string,
   isSubmitting?: boolean,
-  leftCol?: React.ReactNode,
   onSubmit?: () => void,
   submitButtonText: string,
   submitIcon?: IconName,
@@ -62,7 +54,6 @@ const FormSubmit = (props: Props) => {
     disabledSubmit,
     formId,
     isSubmitting,
-    leftCol,
     onSubmit,
     submitButtonText,
     submitButtonType,
@@ -71,16 +62,7 @@ const FormSubmit = (props: Props) => {
   } = props;
 
   return (
-    <StyledButtonToolbar className={className}>
-      {leftCol}
-      {displayCancel === true && (
-        <Button type="button"
-                bsSize={bsSize}
-                onClick={props.onCancel}
-                disabled={props.disableCancel}>
-          Cancel
-        </Button>
-      )}
+    <ButtonToolbar className={className}>
       <Button bsStyle="success"
               bsSize={bsSize}
               disabled={disabledSubmit}
@@ -91,7 +73,15 @@ const FormSubmit = (props: Props) => {
         {(submitIcon && !isSubmitting) && <><Icon name={submitIcon} /> </>}
         {isSubmitting ? <Spinner text={submitLoadingText} delay={0} /> : submitButtonText}
       </Button>
-    </StyledButtonToolbar>
+      {displayCancel === true && (
+        <Button type="button"
+                bsSize={bsSize}
+                onClick={props.onCancel}
+                disabled={props.disableCancel}>
+          Cancel
+        </Button>
+      )}
+    </ButtonToolbar>
   );
 };
 
@@ -102,7 +92,6 @@ FormSubmit.defaultProps = {
   displayCancel: true,
   formId: undefined,
   isSubmitting: false,
-  leftCol: undefined,
   onSubmit: undefined,
   submitButtonType: 'submit',
   submitIcon: undefined,

--- a/graylog2-web-interface/src/components/common/FormSubmit.tsx
+++ b/graylog2-web-interface/src/components/common/FormSubmit.tsx
@@ -26,6 +26,7 @@ import Spinner from 'components/common/Spinner';
 const StyledButtonToolbar = styled(ButtonToolbar)`
   display: flex;
   justify-content: flex-end;
+  align-items: end;
 `;
 
 type WithCancelProps = {

--- a/graylog2-web-interface/src/components/common/FormSubmit.tsx
+++ b/graylog2-web-interface/src/components/common/FormSubmit.tsx
@@ -15,11 +15,18 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
+import styled from 'styled-components';
 
-import { Button, ButtonToolbar } from 'components/bootstrap';
+import Button from 'components/bootstrap/Button';
+import ButtonToolbar from 'components/bootstrap/ButtonToolbar';
 import type { IconName } from 'components/common/Icon';
 import Icon from 'components/common/Icon';
 import Spinner from 'components/common/Spinner';
+
+const StyledButtonToolbar = styled(ButtonToolbar)`
+  display: flex;
+  justify-content: flex-end;
+`;
 
 type WithCancelProps = {
   displayCancel: true,
@@ -32,6 +39,7 @@ type WithoutCancelProps = {
 }
 
 type Props = {
+  bsSize?: 'large' | 'small' | 'xsmall',
   className?: string,
   displayCancel?: boolean,
   disabledSubmit?: boolean,
@@ -46,6 +54,7 @@ type Props = {
 
 const FormSubmit = (props: Props) => {
   const {
+    bsSize,
     className,
     displayCancel,
     disabledSubmit,
@@ -59,10 +68,17 @@ const FormSubmit = (props: Props) => {
   } = props;
 
   return (
-    <ButtonToolbar className={`${className} pull-right`}>
+    <StyledButtonToolbar className={className}>
       {leftCol}
-      {displayCancel === true && <Button type="button" onClick={props.onCancel} disabled={props.disableCancel}>Cancel</Button>}
+      {displayCancel === true && (
+        <Button type="button"
+                bsSize={bsSize}
+                onClick={props.onCancel}
+                disabled={props.disableCancel}>Cancel
+        </Button>
+      )}
       <Button bsStyle="success"
+              bsSize={bsSize}
               disabled={disabledSubmit}
               title={submitButtonText}
               type={submitButtonType}
@@ -70,11 +86,12 @@ const FormSubmit = (props: Props) => {
         {(submitIcon && !isSubmitting) && <><Icon name={submitIcon} /> </>}
         {isSubmitting ? <Spinner text={submitLoadingText} delay={0} /> : submitButtonText}
       </Button>
-    </ButtonToolbar>
+    </StyledButtonToolbar>
   );
 };
 
 FormSubmit.defaultProps = {
+  bsSize: undefined,
   className: undefined,
   disabledSubmit: false,
   displayCancel: true,

--- a/graylog2-web-interface/src/components/common/FormSubmit.tsx
+++ b/graylog2-web-interface/src/components/common/FormSubmit.tsx
@@ -21,51 +21,63 @@ import type { IconName } from 'components/common/Icon';
 import Icon from 'components/common/Icon';
 import Spinner from 'components/common/Spinner';
 
+type WithCancelProps = {
+  displayCancel: true,
+  disableCancel?: boolean,
+  onCancel: () => void,
+}
+
+type WithoutCancelProps = {
+  displayCancel: false
+}
+
 type Props = {
   className?: string,
-  disableCancel?: boolean,
+  displayCancel?: boolean,
   disabledSubmit?: boolean,
   isSubmitting?: boolean,
   leftCol?: React.ReactNode,
-  onCancel: () => void,
   onSubmit?: () => void,
   submitButtonText: string,
   submitIcon?: IconName,
   submitButtonType?: 'submit' | 'button',
   submitLoadingText?: string,
-}
+} & (WithCancelProps | WithoutCancelProps)
 
-const FormSubmit = ({
-  className,
-  disableCancel,
-  disabledSubmit,
-  isSubmitting,
-  leftCol,
-  onCancel,
-  onSubmit,
-  submitButtonText,
-  submitButtonType,
-  submitIcon,
-  submitLoadingText,
-}: Props) => (
-  <ButtonToolbar className={`${className} pull-right`}>
-    {leftCol}
-    <Button type="button" onClick={onCancel} disabled={disableCancel}>Cancel</Button>
-    <Button bsStyle="success"
-            disabled={disabledSubmit}
-            title={submitButtonText}
-            type={submitButtonType}
-            onClick={onSubmit}>
-      {(submitIcon && !isSubmitting) && <><Icon name={submitIcon} /> </>}
-      {isSubmitting ? <Spinner text={submitLoadingText} delay={0} /> : submitButtonText}
-    </Button>
-  </ButtonToolbar>
-);
+const FormSubmit = (props: Props) => {
+  const {
+    className,
+    displayCancel,
+    disabledSubmit,
+    isSubmitting,
+    leftCol,
+    onSubmit,
+    submitButtonText,
+    submitButtonType,
+    submitIcon,
+    submitLoadingText,
+  } = props;
+
+  return (
+    <ButtonToolbar className={`${className} pull-right`}>
+      {leftCol}
+      {displayCancel === true && <Button type="button" onClick={props.onCancel} disabled={props.disableCancel}>Cancel</Button>}
+      <Button bsStyle="success"
+              disabled={disabledSubmit}
+              title={submitButtonText}
+              type={submitButtonType}
+              onClick={onSubmit}>
+        {(submitIcon && !isSubmitting) && <><Icon name={submitIcon} /> </>}
+        {isSubmitting ? <Spinner text={submitLoadingText} delay={0} /> : submitButtonText}
+      </Button>
+    </ButtonToolbar>
+  );
+};
 
 FormSubmit.defaultProps = {
   className: undefined,
-  disableCancel: false,
   disabledSubmit: false,
+  displayCancel: true,
   isSubmitting: false,
   leftCol: undefined,
   onSubmit: undefined,

--- a/graylog2-web-interface/src/components/common/FormSubmit.tsx
+++ b/graylog2-web-interface/src/components/common/FormSubmit.tsx
@@ -44,6 +44,7 @@ type Props = {
   className?: string,
   displayCancel?: boolean,
   disabledSubmit?: boolean,
+  formId?: string,
   isSubmitting?: boolean,
   leftCol?: React.ReactNode,
   onSubmit?: () => void,
@@ -59,6 +60,7 @@ const FormSubmit = (props: Props) => {
     className,
     displayCancel,
     disabledSubmit,
+    formId,
     isSubmitting,
     leftCol,
     onSubmit,
@@ -75,12 +77,14 @@ const FormSubmit = (props: Props) => {
         <Button type="button"
                 bsSize={bsSize}
                 onClick={props.onCancel}
-                disabled={props.disableCancel}>Cancel
+                disabled={props.disableCancel}>
+          Cancel
         </Button>
       )}
       <Button bsStyle="success"
               bsSize={bsSize}
               disabled={disabledSubmit}
+              form={formId}
               title={submitButtonText}
               type={submitButtonType}
               onClick={onSubmit}>
@@ -96,6 +100,7 @@ FormSubmit.defaultProps = {
   className: undefined,
   disabledSubmit: false,
   displayCancel: true,
+  formId: undefined,
   isSubmitting: false,
   leftCol: undefined,
   onSubmit: undefined,

--- a/graylog2-web-interface/src/components/common/ModalSubmit.tsx
+++ b/graylog2-web-interface/src/components/common/ModalSubmit.tsx
@@ -77,7 +77,7 @@ const ModalSubmit = (props: Props) => {
         <Button type="button"
                 bsSize={bsSize}
                 onClick={props.onCancel}
-                disabled={props.disableCancel}>
+                disabled={props.disableCancel || isSubmitting}>
           Cancel
         </Button>
       )}

--- a/graylog2-web-interface/src/components/common/ModalSubmit.tsx
+++ b/graylog2-web-interface/src/components/common/ModalSubmit.tsx
@@ -15,34 +15,21 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
+import PropTypes from 'prop-types';
 
 import FormSubmit from 'components/common/FormSubmit';
 
 type Props = React.ComponentProps<typeof FormSubmit>
 
 /* eslint-disable react/prop-types */
-const ModalSubmit = ({
-  className,
-  disabledSubmit,
-  disableCancel,
-  isSubmitting,
-  leftCol,
-  onCancel,
-  onSubmit,
-  submitLoadingText,
-  submitIcon,
-  submitButtonText,
-}: Props) => (
-  <FormSubmit disableCancel={disableCancel}
-              disabledSubmit={disabledSubmit}
-              isSubmitting={isSubmitting}
-              leftCol={leftCol}
-              onCancel={onCancel}
-              onSubmit={onSubmit}
-              submitButtonText={submitButtonText}
-              submitIcon={submitIcon}
-              submitLoadingText={submitLoadingText}
-              className={className} />
-);
+const ModalSubmit = (props: Props) => <FormSubmit {...props} />;
+
+ModalSubmit.defaultProps = {
+  displayCancel: true,
+};
+
+ModalSubmit.propTypes = {
+  displayCancel: PropTypes.bool,
+};
 
 export default ModalSubmit;

--- a/graylog2-web-interface/src/components/common/ModalSubmit.tsx
+++ b/graylog2-web-interface/src/components/common/ModalSubmit.tsx
@@ -15,21 +15,98 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import styled from 'styled-components';
 
-import FormSubmit from 'components/common/FormSubmit';
+import Button from 'components/bootstrap/Button';
+import ButtonToolbar from 'components/bootstrap/ButtonToolbar';
+import type { IconName } from 'components/common/Icon';
+import Icon from 'components/common/Icon';
+import Spinner from 'components/common/Spinner';
 
-type Props = React.ComponentProps<typeof FormSubmit>
+const StyledButtonToolbar = styled(ButtonToolbar)`
+  display: flex;
+  justify-content: flex-end;
+  align-items: end;
+`;
 
-/* eslint-disable react/prop-types */
-const ModalSubmit = (props: Props) => <FormSubmit {...props} />;
-
-ModalSubmit.defaultProps = {
+type WithCancelProps = {
   displayCancel: true,
+  disableCancel?: boolean,
+  onCancel: () => void,
+}
+
+type WithoutCancelProps = {
+  displayCancel: false
+}
+
+type Props = {
+  bsSize?: 'large' | 'small' | 'xsmall',
+  className?: string,
+  displayCancel?: boolean,
+  disabledSubmit?: boolean,
+  formId?: string,
+  isSubmitting?: boolean,
+  leftCol?: React.ReactNode,
+  onSubmit?: () => void,
+  submitButtonText: string,
+  submitIcon?: IconName,
+  submitButtonType?: 'submit' | 'button',
+  submitLoadingText?: string,
+} & (WithCancelProps | WithoutCancelProps)
+
+const ModalSubmit = (props: Props) => {
+  const {
+    bsSize,
+    className,
+    displayCancel,
+    disabledSubmit,
+    formId,
+    isSubmitting,
+    leftCol,
+    onSubmit,
+    submitButtonText,
+    submitButtonType,
+    submitIcon,
+    submitLoadingText,
+  } = props;
+
+  return (
+    <StyledButtonToolbar className={className}>
+      {leftCol}
+      {displayCancel && (
+        <Button type="button"
+                bsSize={bsSize}
+                onClick={props.onCancel}
+                disabled={props.disableCancel}>
+          Cancel
+        </Button>
+      )}
+      <Button bsStyle="success"
+              bsSize={bsSize}
+              disabled={disabledSubmit}
+              form={formId}
+              title={submitButtonText}
+              type={submitButtonType}
+              onClick={onSubmit}>
+        {(submitIcon && !isSubmitting) && <><Icon name={submitIcon} /> </>}
+        {isSubmitting ? <Spinner text={submitLoadingText} delay={0} /> : submitButtonText}
+      </Button>
+    </StyledButtonToolbar>
+  );
 };
 
-ModalSubmit.propTypes = {
-  displayCancel: PropTypes.bool,
+ModalSubmit.defaultProps = {
+  bsSize: undefined,
+  className: undefined,
+  disabledSubmit: false,
+  displayCancel: true,
+  formId: undefined,
+  isSubmitting: false,
+  leftCol: undefined,
+  onSubmit: undefined,
+  submitButtonType: 'submit',
+  submitIcon: undefined,
+  submitLoadingText: undefined,
 };
 
 export default ModalSubmit;

--- a/graylog2-web-interface/src/components/common/URLWhiteListFormModal.test.tsx
+++ b/graylog2-web-interface/src/components/common/URLWhiteListFormModal.test.tsx
@@ -68,7 +68,7 @@ describe('<URLWhiteListFormModal>', () => {
     expect(await screen.findByText('Whitelist URLs')).toBeInTheDocument();
     expect(screen.getByDisplayValue('http://graylog.com')).toBeInTheDocument();
     expect(screen.getByText(/exact match/i)).toBeInTheDocument();
-    expect(screen.getByText(/save/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /update configuration/i, hidden: true })).toBeInTheDocument();
     expect(screen.getByText(/cancel/i)).toBeInTheDocument();
   });
 

--- a/graylog2-web-interface/src/components/common/URLWhiteListFormModal.tsx
+++ b/graylog2-web-interface/src/components/common/URLWhiteListFormModal.tsx
@@ -127,7 +127,7 @@ const URLWhiteListFormModal = ({ newUrlEntry, urlType, onUpdate }: Props) => {
                             onSubmitForm={saveConfig}
                             onModalClose={resetConfig}
                             submitButtonDisabled={!isValid}
-                            submitButtonText="Save">
+                            submitButtonText="Update configuration">
           <h3>Whitelist URLs</h3>
           <UrlWhiteListForm key={newUrlEntryId}
                             urls={entries}

--- a/graylog2-web-interface/src/components/configurationforms/ConfigurationForm.jsx
+++ b/graylog2-web-interface/src/components/configurationforms/ConfigurationForm.jsx
@@ -133,6 +133,7 @@ class ConfigurationForm extends React.Component {
     }
   };
 
+  // eslint-disable-next-line react/no-unused-class-component-methods
   open = () => {
     if (this.modal && this.modal.open) {
       this.modal.open();

--- a/graylog2-web-interface/src/components/configurationforms/ConfigurationForm.jsx
+++ b/graylog2-web-interface/src/components/configurationforms/ConfigurationForm.jsx
@@ -34,6 +34,7 @@ class ConfigurationForm extends React.Component {
     // eslint-disable-next-line react/no-unused-prop-types
     values: PropTypes.object,
     wrapperComponent: PropTypes.elementType,
+    submitButtonText: PropTypes.string.isRequired,
   };
 
   static defaultProps = {
@@ -176,7 +177,15 @@ class ConfigurationForm extends React.Component {
   };
 
   render() {
-    const { typeName, title, helpBlock, wrapperComponent: WrapperComponent = BootstrapModalForm, includeTitleField, children } = this.props;
+    const {
+      typeName,
+      title,
+      helpBlock,
+      wrapperComponent: WrapperComponent = BootstrapModalForm,
+      includeTitleField,
+      children,
+      submitButtonText,
+    } = this.props;
 
     let shouldAutoFocus = true;
     let titleElement;
@@ -215,7 +224,7 @@ class ConfigurationForm extends React.Component {
                         title={title}
                         onCancel={this._closeModal}
                         onSubmitForm={this._save}
-                        submitButtonText="Save">
+                        submitButtonText={submitButtonText}>
         <fieldset>
           <input type="hidden" name="type" value={typeName} />
           {children}

--- a/graylog2-web-interface/src/components/configurations/DecoratorsConfig.tsx
+++ b/graylog2-web-interface/src/components/configurations/DecoratorsConfig.tsx
@@ -77,7 +77,7 @@ const DecoratorsConfig = () => {
       <StreamSelect streams={streamOptions} onChange={setCurrentStream} value={currentStream} />
       <DecoratorList decorators={readOnlyDecoratorItems} disableDragging />
       <IfPermitted permissions="decorators:edit">
-        <Button bsStyle="info" bsSize="xs" onClick={openModal}>Update</Button>
+        <Button bsStyle="info" bsSize="xs" onClick={openModal}>Edit configuration</Button>
       </IfPermitted>
       <DecoratorsConfigUpdate ref={configModal}
                               streams={streams}

--- a/graylog2-web-interface/src/components/configurations/EventsConfig.jsx
+++ b/graylog2-web-interface/src/components/configurations/EventsConfig.jsx
@@ -216,7 +216,7 @@ const EventsConfig = createReactClass({
                              enabled={eventsCatchupWindow.duration > 0}
                              units={TIME_UNITS} />
               <HelpBlock>If Event processor execution is behind schedule, queries on older data will be run with this window size to speed up processing.
-                (If the &quot;search within the last&quot; setting of an event definiton is greater, this setting will be ignored)
+                (If the &quot;search within the last&quot; setting of an event definition is greater, this setting will be ignored)
               </HelpBlock>
             </FormGroup>
           </fieldset>

--- a/graylog2-web-interface/src/components/configurations/EventsConfig.jsx
+++ b/graylog2-web-interface/src/components/configurations/EventsConfig.jsx
@@ -166,14 +166,14 @@ const EventsConfig = createReactClass({
         </dl>
 
         <IfPermitted permissions="clusterconfigentry:edit">
-          <Button bsStyle="info" bsSize="xs" onClick={this._openModal}>Update</Button>
+          <Button bsStyle="info" bsSize="xs" onClick={this._openModal}>Edit configuration</Button>
         </IfPermitted>
 
         <BootstrapModalForm ref={(modal) => { this.modal = modal; }}
                             title="Update Events System Configuration"
                             onSubmitForm={this._saveConfig}
                             onModalClose={this._resetConfig}
-                            submitButtonText="Save">
+                            submitButtonText="Update configuration">
           <fieldset>
             <FormGroup controlId="search-timeout-field">
               <TimeUnitInput label="Search Timeout"

--- a/graylog2-web-interface/src/components/configurations/EventsConfig.jsx
+++ b/graylog2-web-interface/src/components/configurations/EventsConfig.jsx
@@ -16,13 +16,14 @@
  */
 import PropTypes from 'prop-types';
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import createReactClass from 'create-react-class';
 import lodash from 'lodash';
 import moment from 'moment';
 
 import { Button, FormGroup, HelpBlock, BootstrapModalForm } from 'components/bootstrap';
 import { IfPermitted, TimeUnitInput } from 'components/common';
-import FormUtils from 'util/FormsUtils';
+import { getValueFromInput } from 'util/FormsUtils';
 import Input from 'components/bootstrap/Input';
 import { extractDurationAndUnit } from 'components/common/TimeUnitInput';
 
@@ -30,8 +31,10 @@ const TIME_UNITS = ['HOURS', 'MINUTES', 'SECONDS'];
 const DEFAULT_CATCH_UP_WINDOW = 3600000;
 
 const EventsConfig = createReactClass({
+  // eslint-disable-next-line react/no-unused-class-component-methods
   displayName: 'EventsConfig',
 
+  // eslint-disable-next-line react/no-unused-class-component-methods
   propTypes: {
     config: PropTypes.shape({
       events_search_timeout: PropTypes.number,
@@ -120,7 +123,7 @@ const EventsConfig = createReactClass({
   },
 
   _onBacklogUpdate(event) {
-    const value = FormUtils.getValueFromInput(event.target);
+    const value = getValueFromInput(event.target);
 
     this._propagateChanges('events_notification_default_backlog', value);
   },

--- a/graylog2-web-interface/src/components/configurations/MessageProcessorsConfig.jsx
+++ b/graylog2-web-interface/src/components/configurations/MessageProcessorsConfig.jsx
@@ -191,14 +191,14 @@ const MessageProcessorsConfig = createReactClass({
         </Table>
 
         <IfPermitted permissions="clusterconfigentry:edit">
-          <Button bsStyle="info" bsSize="xs" onClick={this._openModal}>Update</Button>
+          <Button bsStyle="info" bsSize="xs" onClick={this._openModal}>Edit configuration</Button>
         </IfPermitted>
 
         <BootstrapModalForm ref={(configModal) => { this.configModal = configModal; }}
                             title="Update Message Processors Configuration"
                             onSubmitForm={this._saveConfig}
                             onModalClose={this._resetConfig}
-                            submitButtonText="Save">
+                            submitButtonText="Update configuration">
           <h3>Order</h3>
           <p>Use drag and drop to change the execution order of the message processors.</p>
           <SortableList items={this._sortableItems()} onMoveItem={this._updateSorting} displayOverlayInPortal />

--- a/graylog2-web-interface/src/components/configurations/MessageProcessorsConfig.jsx
+++ b/graylog2-web-interface/src/components/configurations/MessageProcessorsConfig.jsx
@@ -26,8 +26,10 @@ import BootstrapModalForm from 'components/bootstrap/BootstrapModalForm';
 import ObjectUtils from 'util/ObjectUtils';
 
 const MessageProcessorsConfig = createReactClass({
+  // eslint-disable-next-line react/no-unused-class-component-methods
   displayName: 'MessageProcessorsConfig',
 
+  // eslint-disable-next-line react/no-unused-class-component-methods
   propTypes: {
     config: PropTypes.object,
     updateConfig: PropTypes.func.isRequired,
@@ -111,18 +113,6 @@ const MessageProcessorsConfig = createReactClass({
     const { config } = this.state;
 
     return config.disabled_processors.length >= config.processor_order.length;
-  },
-
-  _noActiveProcessorWarning() {
-    if (this._hasNoActiveProcessor()) {
-      return (
-        <Alert bsStyle="danger">
-          <strong>ERROR:</strong> No active message processor!
-        </Alert>
-      );
-    }
-
-    return null;
   },
 
   _summary() {
@@ -216,7 +206,11 @@ const MessageProcessorsConfig = createReactClass({
               {this._statusForm()}
             </tbody>
           </Table>
-          {this._noActiveProcessorWarning()}
+          {this._hasNoActiveProcessor() && (
+            <Alert bsStyle="danger">
+              <strong>ERROR:</strong> No active message processor!
+            </Alert>
+          )}
         </BootstrapModalForm>
       </div>
     );

--- a/graylog2-web-interface/src/components/configurations/PermissionsConfig.tsx
+++ b/graylog2-web-interface/src/components/configurations/PermissionsConfig.tsx
@@ -24,7 +24,7 @@ import type { PermissionsConfigType } from 'src/stores/configurations/Configurat
 import { Button, Col, Modal, Row } from 'components/bootstrap';
 import FormikInput from 'components/common/FormikInput';
 import Spinner from 'components/common/Spinner';
-import { InputDescription } from 'components/common';
+import { InputDescription, ModalSubmit } from 'components/common';
 
 type Props = {
   config: PermissionsConfigType,
@@ -80,7 +80,8 @@ const PermissionsConfig = ({ config, updateConfig }: Props) => {
                     bsStyle="info"
                     onClick={() => {
                       setShowModal(true);
-                    }}>Configure
+                    }}>
+              Edit configuration
             </Button>
           </p>
 
@@ -121,8 +122,10 @@ const PermissionsConfig = ({ config, updateConfig }: Props) => {
                     </Modal.Body>
 
                     <Modal.Footer>
-                      <Button type="button" bsStyle="link" onClick={_resetConfig}>Close</Button>
-                      <Button type="submit" bsStyle="success" disabled={isSubmitting}>{isSubmitting ? 'Saving' : 'Save'}</Button>
+                      <ModalSubmit onCancel={_resetConfig}
+                                   isSubmitting={isSubmitting}
+                                   submitLoadingText="Update configuration"
+                                   submitButtonText="Update configuration" />
                     </Modal.Footer>
                   </Form>
                 );

--- a/graylog2-web-interface/src/components/configurations/SearchesConfig.jsx
+++ b/graylog2-web-interface/src/components/configurations/SearchesConfig.jsx
@@ -251,14 +251,14 @@ class SearchesConfig extends React.Component {
 
         </Row>
         <IfPermitted permissions="clusterconfigentry:edit">
-          <Button bsStyle="info" bsSize="xs" onClick={this._openModal}>Update</Button>
+          <Button bsStyle="info" bsSize="xs" onClick={this._openModal}>Edit configuration</Button>
         </IfPermitted>
 
         <BootstrapModalForm ref={this.searchesConfigModal}
                             title="Update Search Configuration"
                             onSubmitForm={this._saveConfig}
                             onModalClose={this._resetConfig}
-                            submitButtonText="Save">
+                            submitButtonText="Update configuration">
           <fieldset>
             <label htmlFor="query-limit-checkbox">Relative Timerange Options</label>
             <Input id="query-limit-checkbox"

--- a/graylog2-web-interface/src/components/configurations/SidecarConfig.jsx
+++ b/graylog2-web-interface/src/components/configurations/SidecarConfig.jsx
@@ -132,14 +132,14 @@ const SidecarConfig = createReactClass({
         </dl>
 
         <IfPermitted permissions="clusterconfigentry:edit">
-          <Button bsStyle="info" bsSize="xs" onClick={this._openModal}>Update</Button>
+          <Button bsStyle="info" bsSize="xs" onClick={this._openModal}>Edit configuration</Button>
         </IfPermitted>
 
         <BootstrapModalForm ref="configModal"
                             title="Update Sidecars System Configuration"
                             onSubmitForm={this._saveConfig}
                             onModalClose={this._resetConfig}
-                            submitButtonText="Save">
+                            submitButtonText="Update configuration">
           <fieldset>
             <ISODurationInput id="inactive-threshold-field"
                               duration={this.state.config.sidecar_inactive_threshold}

--- a/graylog2-web-interface/src/components/configurations/SidecarConfig.jsx
+++ b/graylog2-web-interface/src/components/configurations/SidecarConfig.jsx
@@ -16,18 +16,21 @@
  */
 import PropTypes from 'prop-types';
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import createReactClass from 'create-react-class';
 
 import { Button, BootstrapModalForm, Input } from 'components/bootstrap';
 import { IfPermitted, ISODurationInput } from 'components/common';
 import ObjectUtils from 'util/ObjectUtils';
 import ISODurationUtils from 'util/ISODurationUtils';
-import FormUtils from 'util/FormsUtils';
+import { getValueFromInput } from 'util/FormsUtils';
 import StringUtils from 'util/StringUtils';
 
 const SidecarConfig = createReactClass({
+  // eslint-disable-next-line react/no-unused-class-component-methods
   displayName: 'SidecarConfig',
 
+  // eslint-disable-next-line react/no-unused-class-component-methods
   propTypes: {
     config: PropTypes.shape({
       sidecar_expiration_threshold: PropTypes.string,
@@ -62,10 +65,12 @@ const SidecarConfig = createReactClass({
   },
 
   _openModal() {
+    // eslint-disable-next-line react/no-string-refs
     this.refs.configModal.open();
   },
 
   _closeModal() {
+    // eslint-disable-next-line react/no-string-refs
     this.refs.configModal.close();
   },
 
@@ -82,15 +87,17 @@ const SidecarConfig = createReactClass({
 
   _onUpdate(field) {
     return (value) => {
-      const update = ObjectUtils.clone(this.state.config);
+      this.setState(({ config }) => {
+        const update = ObjectUtils.clone(config);
 
-      if (typeof value === 'object') {
-        update[field] = FormUtils.getValueFromInput(value.target);
-      } else {
-        update[field] = value;
-      }
+        if (typeof value === 'object') {
+          update[field] = getValueFromInput(value.target);
+        } else {
+          update[field] = value;
+        }
 
-      this.setState({ config: update });
+        return ({ config: update });
+      });
     };
   },
 
@@ -135,6 +142,7 @@ const SidecarConfig = createReactClass({
           <Button bsStyle="info" bsSize="xs" onClick={this._openModal}>Edit configuration</Button>
         </IfPermitted>
 
+        {/* eslint-disable-next-line react/no-string-refs */}
         <BootstrapModalForm ref="configModal"
                             title="Update Sidecars System Configuration"
                             onSubmitForm={this._saveConfig}

--- a/graylog2-web-interface/src/components/configurations/UrlWhiteListConfig.tsx
+++ b/graylog2-web-interface/src/components/configurations/UrlWhiteListConfig.tsx
@@ -129,7 +129,7 @@ class UrlWhiteListConfig extends React.Component<Props, State> {
           </tbody>
         </Table>
         <IfPermitted permissions="urlwhitelist:write">
-          <Button bsStyle="info" bsSize="xs" onClick={this._openModal}>Update</Button>
+          <Button bsStyle="info" bsSize="xs" onClick={this._openModal}>Edit configuration</Button>
         </IfPermitted>
         <BootstrapModalForm ref={(configModal) => { this.configModal = configModal; }}
                             bsSize="lg"
@@ -137,7 +137,7 @@ class UrlWhiteListConfig extends React.Component<Props, State> {
                             onSubmitForm={this._saveConfig}
                             onModalClose={this._resetConfig}
                             submitButtonDisabled={!isValid}
-                            submitButtonText="Save">
+                            submitButtonText="Update configuration">
           <h3>Whitelist URLs</h3>
           <UrlWhiteListForm urls={entries} disabled={disabled} onUpdate={this._update} />
         </BootstrapModalForm>

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventDefinitionForm.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventDefinitionForm.jsx
@@ -19,8 +19,8 @@ import PropTypes from 'prop-types';
 import lodash from 'lodash';
 import { PluginStore } from 'graylog-web-plugin/plugin';
 
-import { Button, ButtonToolbar, Col, Row } from 'components/bootstrap';
-import { Wizard } from 'components/common';
+import { Button, Col, Row } from 'components/bootstrap';
+import { FormSubmit, Wizard } from 'components/common';
 
 import EventDetailsForm from './EventDetailsForm';
 import EventConditionForm from './EventConditionForm';
@@ -29,6 +29,14 @@ import NotificationsForm from './NotificationsForm';
 import EventDefinitionSummary from './EventDefinitionSummary';
 
 const STEP_KEYS = ['event-details', 'condition', 'fields', 'notifications', 'summary'];
+
+const getConditionPlugin = (type) => {
+  if (type === undefined) {
+    return {};
+  }
+
+  return PluginStore.exports('eventDefinitionTypes').find((edt) => edt.type === type) || {};
+};
 
 class EventDefinitionForm extends React.Component {
   static propTypes = {
@@ -75,25 +83,12 @@ class EventDefinitionForm extends React.Component {
     }
   };
 
-  getConditionPlugin = (type) => {
-    if (type === undefined) {
-      return {};
-    }
-
-    return PluginStore.exports('eventDefinitionTypes').find((edt) => edt.type === type) || {};
-  };
-
   renderButtons = (activeStep) => {
     if (activeStep === lodash.last(STEP_KEYS)) {
       const { onCancel } = this.props;
 
       return (
-        <div className="pull-right">
-          <ButtonToolbar>
-            <Button onClick={onCancel}>Cancel</Button>
-            <Button bsStyle="primary" onClick={this.handleSubmit}>Done</Button>
-          </ButtonToolbar>
-        </div>
+        <FormSubmit onCancel={onCancel} onSubmit={this.handleSubmit} submitButtonText="Create event definition" />
       );
     }
 
@@ -141,7 +136,7 @@ class EventDefinitionForm extends React.Component {
       currentUser,
     };
 
-    const eventDefinitionType = this.getConditionPlugin(eventDefinition.config.type);
+    const eventDefinitionType = getConditionPlugin(eventDefinition.config.type);
 
     const steps = [
       {

--- a/graylog2-web-interface/src/components/event-notifications/event-notification-form/EventNotificationForm.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-form/EventNotificationForm.jsx
@@ -19,8 +19,8 @@ import PropTypes from 'prop-types';
 import lodash from 'lodash';
 import { PluginStore } from 'graylog-web-plugin/plugin';
 
-import { Select, Spinner } from 'components/common';
-import { Alert, Button, ButtonToolbar, Col, ControlLabel, FormControl, FormGroup, HelpBlock, Row, Input } from 'components/bootstrap';
+import { FormSubmit, Select, Spinner } from 'components/common';
+import { Alert, Button, Col, ControlLabel, FormControl, FormGroup, HelpBlock, Row, Input } from 'components/bootstrap';
 import { getValueFromInput } from 'util/FormsUtils';
 
 const getNotificationPlugin = (type) => {
@@ -123,7 +123,7 @@ class EventNotificationForm extends React.Component {
 
     return (
       <Row>
-        <Col md={12}>
+        <Col lg={8}>
           <form onSubmit={this.handleSubmit} id={formId}>
             <Input id="notification-title"
                    name="title"
@@ -184,10 +184,9 @@ class EventNotificationForm extends React.Component {
             )}
 
             {!embedded && (
-              <ButtonToolbar>
-                <Button bsStyle="primary" type="submit" disabled={!isSubmitEnabled}>{action === 'create' ? 'Create' : 'Update'}</Button>
-                <Button onClick={onCancel}>Cancel</Button>
-              </ButtonToolbar>
+              <FormSubmit disabledSubmit={!isSubmitEnabled}
+                          submitButtonText={`${action === 'create' ? 'Create' : 'Update'} notification`}
+                          onCancel={onCancel} />
             )}
           </form>
         </Col>

--- a/graylog2-web-interface/src/components/inputs/CreateInputControl.jsx
+++ b/graylog2-web-interface/src/components/inputs/CreateInputControl.jsx
@@ -107,6 +107,7 @@ const CreateInputControl = createReactClass({
                    key="configuration-form-input"
                    configFields={selectedInputDefinition.requested_configuration}
                    title={<span>Launch new <em>{inputTypeName}</em> input</span>}
+                   submitButtonText="Launch Input"
                    helpBlock="Select a name of your new input that describes it."
                    typeName={selectedInput}
                    submitAction={this._createInput} />

--- a/graylog2-web-interface/src/components/inputs/CreateInputControl.jsx
+++ b/graylog2-web-interface/src/components/inputs/CreateInputControl.jsx
@@ -15,6 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import styled from 'styled-components';
@@ -31,6 +32,7 @@ const NewInputRow = styled(Row)`
 `;
 
 const CreateInputControl = createReactClass({
+  // eslint-disable-next-line react/no-unused-class-component-methods
   displayName: 'CreateInputControl',
   mixins: [Reflux.connect(InputTypesStore)],
 

--- a/graylog2-web-interface/src/components/inputs/InputForm.jsx
+++ b/graylog2-web-interface/src/components/inputs/InputForm.jsx
@@ -38,7 +38,8 @@ class InputForm extends React.Component {
     values: undefined,
   };
 
-  static state = {
+  // eslint-disable-next-line react/state-in-constructor
+  state = {
     global: this.props.globalValue !== undefined ? this.props.globalValue : false,
     node: this.props.nodeValue !== undefined ? this.props.nodeValue : undefined,
   };

--- a/graylog2-web-interface/src/components/inputs/InputForm.jsx
+++ b/graylog2-web-interface/src/components/inputs/InputForm.jsx
@@ -28,6 +28,7 @@ class InputForm extends React.Component {
     titleValue: PropTypes.string,
     submitAction: PropTypes.func.isRequired,
     values: PropTypes.object,
+    submitButtonText: PropTypes.string.isRequired,
   };
 
   state = {

--- a/graylog2-web-interface/src/components/inputs/InputForm.jsx
+++ b/graylog2-web-interface/src/components/inputs/InputForm.jsx
@@ -31,7 +31,14 @@ class InputForm extends React.Component {
     submitButtonText: PropTypes.string.isRequired,
   };
 
-  state = {
+  static defaultProps = {
+    globalValue: undefined,
+    nodeValue: undefined,
+    titleValue: undefined,
+    values: undefined,
+  };
+
+  static state = {
     global: this.props.globalValue !== undefined ? this.props.globalValue : false,
     node: this.props.nodeValue !== undefined ? this.props.nodeValue : undefined,
   };
@@ -49,15 +56,42 @@ class InputForm extends React.Component {
     this.props.submitAction(newData);
   };
 
+  // eslint-disable-next-line react/no-unused-class-component-methods
   open = () => {
     this.configurationForm.open();
   };
 
+  getValues = () => {
+    const { values } = this.props;
+
+    if (values) {
+      return values;
+    }
+
+    if (this.configurationForm) {
+      return this.configurationForm.getValue().configuration;
+    }
+
+    return {};
+  };
+
+  getTitleValue = () => {
+    const { titleValue } = this.props;
+
+    if (titleValue) {
+      return titleValue;
+    }
+
+    if (this.configurationForm) {
+      return this.configurationForm.getValue().titleValue;
+    }
+
+    return '';
+  };
+
   render() {
-    const values = this.props.values ? this.props.values
-      : (this.configurationForm ? this.configurationForm.getValue().configuration : {});
-    const titleValue = this.props.titleValue ? this.props.titleValue
-      : (this.configurationForm ? this.configurationForm.getValue().titleValue : '');
+    const values = this.getValues();
+    const titleValue = this.getTitleValue();
 
     return (
       <ConfigurationForm {...this.props}

--- a/graylog2-web-interface/src/components/inputs/InputForm.jsx
+++ b/graylog2-web-interface/src/components/inputs/InputForm.jsx
@@ -38,11 +38,14 @@ class InputForm extends React.Component {
     values: undefined,
   };
 
-  // eslint-disable-next-line react/state-in-constructor
-  state = {
-    global: this.props.globalValue !== undefined ? this.props.globalValue : false,
-    node: this.props.nodeValue !== undefined ? this.props.nodeValue : undefined,
-  };
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      global: this.props.globalValue !== undefined ? this.props.globalValue : false,
+      node: this.props.nodeValue !== undefined ? this.props.nodeValue : undefined,
+    };
+  }
 
   _handleChange = (field, value) => {
     const state = {};

--- a/graylog2-web-interface/src/components/inputs/InputListItem.jsx
+++ b/graylog2-web-interface/src/components/inputs/InputListItem.jsx
@@ -16,6 +16,7 @@
  */
 import PropTypes from 'prop-types';
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 
@@ -30,8 +31,10 @@ import { InputsActions } from 'stores/inputs/InputsStore';
 import { InputTypesStore } from 'stores/inputs/InputTypesStore';
 
 const InputListItem = createReactClass({
+  // eslint-disable-next-line react/no-unused-class-component-methods
   displayName: 'InputListItem',
 
+  // eslint-disable-next-line react/no-unused-class-component-methods
   propTypes: {
     input: PropTypes.object.isRequired,
     currentNode: PropTypes.object.isRequired,
@@ -41,6 +44,7 @@ const InputListItem = createReactClass({
   mixins: [PermissionsMixin, Reflux.connect(InputTypesStore)],
 
   _deleteInput() {
+    // eslint-disable-next-line no-alert
     if (window.confirm(`Do you really want to delete input '${this.props.input.title}'?`)) {
       InputsActions.delete(this.props.input);
     }

--- a/graylog2-web-interface/src/components/inputs/InputListItem.jsx
+++ b/graylog2-web-interface/src/components/inputs/InputListItem.jsx
@@ -163,6 +163,7 @@ const InputListItem = createReactClass({
                    typeName={input.type}
                    includeTitleField
                    submitAction={this._updateInput}
+                   submitButtonText="Update input"
                    values={input.attributes} />
       ) : null;
 

--- a/graylog2-web-interface/src/components/login/LoginForm.jsx
+++ b/graylog2-web-interface/src/components/login/LoginForm.jsx
@@ -17,7 +17,7 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 
-import { FormSubmit } from 'components/common';
+import { ModalSubmit } from 'components/common';
 import { Input } from 'components/bootstrap';
 import { SessionActions } from 'stores/sessions/SessionStore';
 
@@ -75,10 +75,10 @@ const LoginForm = ({ onErrorChange }) => {
              placeholder="Password"
              required />
 
-      <FormSubmit displayCancel={false}
-                  disabledSubmit={isLoading}
-                  submitLoadingText="Signing in..."
-                  submitButtonText="Sign in" />
+      <ModalSubmit displayCancel={false}
+                   disabledSubmit={isLoading}
+                   submitLoadingText="Signing in..."
+                   submitButtonText="Sign in" />
     </form>
   );
 };

--- a/graylog2-web-interface/src/components/login/LoginForm.jsx
+++ b/graylog2-web-interface/src/components/login/LoginForm.jsx
@@ -16,14 +16,10 @@
  */
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
-import styled from 'styled-components';
 
-import { Button, FormGroup, Input } from 'components/bootstrap';
+import { FormSubmit } from 'components/common';
+import { Input } from 'components/bootstrap';
 import { SessionActions } from 'stores/sessions/SessionStore';
-
-const StyledFormGroup = styled(FormGroup)`
-  margin-bottom: 0;
-`;
 
 const LoginForm = ({ onErrorChange }) => {
   const [isLoading, setIsLoading] = useState(false);
@@ -79,11 +75,10 @@ const LoginForm = ({ onErrorChange }) => {
              placeholder="Password"
              required />
 
-      <StyledFormGroup>
-        <Button type="submit" bsStyle="info" disabled={isLoading}>
-          {isLoading ? 'Signing in...' : 'Sign in'}
-        </Button>
-      </StyledFormGroup>
+      <FormSubmit displayCancel={false}
+                  disabledSubmit={isLoading}
+                  submitLoadingText="Signing in..."
+                  submitButtonText="Sign in" />
     </form>
   );
 };

--- a/graylog2-web-interface/src/components/login/LoginForm.jsx
+++ b/graylog2-web-interface/src/components/login/LoginForm.jsx
@@ -76,7 +76,7 @@ const LoginForm = ({ onErrorChange }) => {
              required />
 
       <ModalSubmit displayCancel={false}
-                   disabledSubmit={isLoading}
+                   isSubmitting={isLoading}
                    submitLoadingText="Signing in..."
                    submitButtonText="Sign in" />
     </form>

--- a/graylog2-web-interface/src/components/login/LoginForm.jsx
+++ b/graylog2-web-interface/src/components/login/LoginForm.jsx
@@ -33,7 +33,7 @@ const LoginForm = ({ onErrorChange }) => {
         promise.cancel();
       }
     };
-  }, []);
+  }, [promise]);
 
   const onSignInClicked = (event) => {
     event.preventDefault();

--- a/graylog2-web-interface/src/components/maps/configurations/GeoIpResolverConfig.tsx
+++ b/graylog2-web-interface/src/components/maps/configurations/GeoIpResolverConfig.tsx
@@ -17,7 +17,7 @@
 import React, { useEffect, useState } from 'react';
 import { Field, Form, Formik } from 'formik';
 
-import { IfPermitted, Select, TimeUnitInput } from 'components/common';
+import { IfPermitted, Select, TimeUnitInput, ModalSubmit } from 'components/common';
 import { Button, Col, Input, Modal, Row } from 'components/bootstrap';
 import FormikInput from 'components/common/FormikInput';
 import { DocumentationLink } from 'components/support';
@@ -129,7 +129,7 @@ const GeoIpResolverConfig = ({ config = defaultConfig, updateConfig }: Props) =>
                 onClick={() => {
                   setShowModal(true);
                 }}>
-          Update
+          Edit configuration
         </Button>
       </IfPermitted>
       <Modal show={showModal} onHide={resetConfig} aria-modal="true" aria-labelledby="dialog_label">
@@ -211,19 +211,10 @@ const GeoIpResolverConfig = ({ config = defaultConfig, updateConfig }: Props) =>
                   </Row>
                 </Modal.Body>
                 <Modal.Footer>
-                  <Button type="button"
-                          bsStyle="link"
-                          onClick={resetConfig}
-                          disabled={isSubmitting}
-                          aria-disabled={isSubmitting}>
-                    Close
-                  </Button>
-                  <Button type="submit"
-                          bsStyle="success"
-                          disabled={isSubmitting}
-                          aria-disabled={isSubmitting}>
-                    {isSubmitting ? 'Saving...' : 'Save'}
-                  </Button>
+                  <ModalSubmit onCancel={resetConfig}
+                               isSubmitting={isSubmitting}
+                               submitButtonText="Update configuration"
+                               submitLoadingText="Updating configuration..." />
                 </Modal.Footer>
               </Form>
             );

--- a/graylog2-web-interface/src/components/permissions/EntityShareModal.tsx
+++ b/graylog2-web-interface/src/components/permissions/EntityShareModal.tsx
@@ -78,7 +78,7 @@ const EntityShareModal = ({ description, entityId, entityType, entityTitle, enti
 
   return (
     <BootstrapModalConfirm confirmButtonDisabled={disableSubmit}
-                           confirmButtonText="Save"
+                           confirmButtonText="Update sharing"
                            onConfirm={_handleSave}
                            onModalClose={onClose}
                            showModal

--- a/graylog2-web-interface/src/components/streamrules/StreamRule.jsx
+++ b/graylog2-web-interface/src/components/streamrules/StreamRule.jsx
@@ -103,6 +103,8 @@ const StreamRule = ({ matchData, permissions, stream, streamRule, streamRuleType
                         onClose={() => setShowStreamRuleForm(false)}
                         streamRuleTypes={streamRuleTypes}
                         title="Edit Stream Rule"
+                        submitButtonText="Update Rule"
+                        submitLoadingText="Updating Rule..."
                         onSubmit={_onSubmit} />
       )}
       {description}

--- a/graylog2-web-interface/src/components/streamrules/StreamRuleForm.test.tsx
+++ b/graylog2-web-interface/src/components/streamrules/StreamRuleForm.test.tsx
@@ -22,10 +22,8 @@ import { MockStore } from 'helpers/mocking';
 import StreamRuleForm from './StreamRuleForm';
 
 jest.mock('components/common', () => ({
-  // eslint-disable-next-line react/prop-types
-  TypeAheadFieldInput: ({ defaultValue }) => (<div>{defaultValue}</div>),
-  // eslint-disable-next-line react/prop-types
-  Icon: ({ children }) => (<div>{children}</div>),
+  TypeAheadFieldInput: ({ defaultValue }: { defaultValue: React.ReactNode }) => (<div>{defaultValue}</div>),
+  Icon: ({ children }: { children: React.ReactNode }) => (<div>{children}</div>),
 }));
 
 jest.mock('stores/inputs/InputsStore', () => ({
@@ -36,10 +34,6 @@ jest.mock('stores/inputs/InputsStore', () => ({
 }));
 
 describe('StreamRuleForm', () => {
-  afterEach(() => {
-    cleanup();
-  });
-
   const streamRuleTypes = [
     { id: 1, short_desc: 'match exactly', long_desc: 'match exactly', name: 'Stream rule match exactly' },
     { id: 2, short_desc: 'match regular expression', long_desc: 'match regular expression', name: 'Stream rule match regular' },
@@ -50,6 +44,19 @@ describe('StreamRuleForm', () => {
     { id: 7, short_desc: 'always match', long_desc: 'always match', name: 'Stream rule always match' },
     { id: 8, short_desc: 'match input', long_desc: 'match input', name: 'Stream rule match input' },
   ];
+
+  const SUT = (props: Partial<React.ComponentProps<typeof StreamRuleForm>>) => (
+    <StreamRuleForm onSubmit={() => {}}
+                    streamRuleTypes={streamRuleTypes}
+                    submitButtonText="Update rule"
+                    submitLoadingText="Updating rule..."
+                    title="Bach"
+                    {...props} />
+  );
+
+  afterEach(() => {
+    cleanup();
+  });
 
   const getStreamRule = (type = 1) => {
     return {
@@ -63,22 +70,13 @@ describe('StreamRuleForm', () => {
   };
 
   it('should render an empty StreamRuleForm', () => {
-    const container = render(
-      <StreamRuleForm onSubmit={() => {}}
-                      streamRuleTypes={streamRuleTypes}
-                      title="Bach" />,
-    );
+    const container = render(<SUT />);
 
     expect(container).not.toBeNull();
   });
 
   it('should render an simple StreamRuleForm', () => {
-    const container = render(
-      <StreamRuleForm onSubmit={() => {}}
-                      streamRule={getStreamRule()}
-                      streamRuleTypes={streamRuleTypes}
-                      title="Bach" />,
-    );
+    const container = render(<SUT streamRule={getStreamRule()} />);
 
     expect(container).not.toBeNull();
   });
@@ -89,11 +87,9 @@ describe('StreamRuleForm', () => {
       { id: 'my-id', title: 'title', name: 'name' },
     ];
     const { getByTestId, getByText } = render(
-      <StreamRuleForm onSubmit={submit}
-                      streamRule={getStreamRule()}
-                      inputs={inputs}
-                      streamRuleTypes={streamRuleTypes}
-                      title="Bach" />,
+      <SUT onSubmit={submit}
+           streamRule={getStreamRule()}
+           inputs={inputs} />,
     );
 
     const ruleTypeSelection = getByTestId('rule-type-selection');

--- a/graylog2-web-interface/src/components/streamrules/StreamRuleForm.test.tsx
+++ b/graylog2-web-interface/src/components/streamrules/StreamRuleForm.test.tsx
@@ -94,7 +94,7 @@ describe('StreamRuleForm', () => {
 
     const ruleTypeSelection = getByTestId('rule-type-selection');
     fireEvent.change(ruleTypeSelection, { target: { name: 'type', value: 8 } });
-    const submitBtn = getByText('Save');
+    const submitBtn = getByText('Update rule');
     fireEvent.click(submitBtn);
 
     expect(submit).toHaveBeenCalledTimes(0);

--- a/graylog2-web-interface/src/components/streamrules/StreamRuleForm.tsx
+++ b/graylog2-web-interface/src/components/streamrules/StreamRuleForm.tsx
@@ -28,6 +28,19 @@ import * as FormsUtils from 'util/FormsUtils';
 import type { Store } from 'stores/StoreTypes';
 import { InputsActions, InputsStore } from 'stores/inputs/InputsStore';
 
+const formatStreamRuleType = (streamRuleType) => (
+  <option key={`streamRuleType${streamRuleType.id}`}
+          value={streamRuleType.id}>
+    {streamRuleType.short_desc}
+  </option>
+);
+
+const formatInputOptions = (input) => (
+  <option key={`input-${input.id}`} value={input.id}>
+    {input.title} ({input.name})
+  </option>
+);
+
 type StreamRule = {
   type: number,
   field: string,
@@ -46,11 +59,13 @@ type StreamRuleType = {
 
 type Props = {
   onSubmit: (streamRuleId: string | undefined | null, currentStreamRule: StreamRule) => void,
-  streamRule: StreamRule,
+  streamRule?: StreamRule,
   streamRuleTypes: Array<StreamRuleType>,
   title: string,
-  inputs: Array<unknown>,
+  inputs?: Array<unknown>,
   onClose: () => void,
+  submitButtonText: string
+  submitLoadingText: string
 };
 
 type State = {
@@ -72,6 +87,8 @@ class StreamRuleForm extends React.Component<Props, State> {
     streamRuleTypes: PropTypes.array.isRequired,
     title: PropTypes.string.isRequired,
     onClose: PropTypes.func,
+    submitButtonText: PropTypes.string.isRequired,
+    submitLoadingText: PropTypes.string.isRequired,
   };
 
   FIELD_PRESENCE_RULE_TYPE = 5;
@@ -135,13 +152,6 @@ class StreamRuleForm extends React.Component<Props, State> {
     onClose();
   };
 
-  _formatStreamRuleType = (streamRuleType) => (
-    <option key={`streamRuleType${streamRuleType.id}`}
-            value={streamRuleType.id}>
-      {streamRuleType.short_desc}
-    </option>
-  );
-
   handleChange = (event) => {
     const { streamRule } = this.state;
     const updatedStreamRule = { ...streamRule };
@@ -154,12 +164,6 @@ class StreamRuleForm extends React.Component<Props, State> {
 
     this.setState({ streamRule: updatedStreamRule });
   };
-
-  _formatInputOptions = (input) => (
-    <option key={`input-${input.id}`} value={input.id}>
-      {input.title} ({input.name})
-    </option>
-  );
 
   valueBox = () => {
     const { streamRule: { value, type }, error } = this.state;
@@ -185,7 +189,7 @@ class StreamRuleForm extends React.Component<Props, State> {
                  data-testid="input-selection"
                  onChange={this.handleChange}>
             <option value={this.PLACEHOLDER_INPUT}>Choose Input</option>
-            {inputs.map(this._formatInputOptions)}
+            {inputs.map(formatInputOptions)}
           </Input>
         );
       }
@@ -210,9 +214,9 @@ class StreamRuleForm extends React.Component<Props, State> {
   render() {
     const { streamRule } = this.state;
     const { type, inverted, description } = streamRule;
-    const { streamRuleTypes: ruleTypes, title, onClose, inputs } = this.props;
+    const { streamRuleTypes: ruleTypes, title, onClose, inputs, submitButtonText, submitLoadingText } = this.props;
 
-    const streamRuleTypes = ruleTypes.map(this._formatStreamRuleType);
+    const streamRuleTypes = ruleTypes.map(formatStreamRuleType);
     const fieldBox = this.fieldBox();
     const valueBox = this.valueBox();
 
@@ -222,7 +226,8 @@ class StreamRuleForm extends React.Component<Props, State> {
                           onCancel={onClose}
                           onModalClose={onClose}
                           onSubmitForm={this._onSubmit}
-                          submitButtonText="Save"
+                          submitButtonText={submitButtonText}
+                          submitLoadingText={submitLoadingText}
                           formProps={{ id: 'StreamRuleForm' }}>
         <div>
           <Col md={8}>

--- a/graylog2-web-interface/src/components/streamrules/StreamRulesEditor.jsx
+++ b/graylog2-web-interface/src/components/streamrules/StreamRulesEditor.jsx
@@ -34,7 +34,7 @@ const StreamAlertHeader = styled(Panel.Heading)`
   font-weight: bold;
 `;
 
-const MatchIcon = styled(({ empty, matches, ...props }) => <Icon {...props} />)(
+const MatchIcon = styled(({ empty: _empty, matches: _matches, ...props }) => <Icon {...props} />)(
   ({ empty, matches, theme }) => {
     const matchColor = matches ? theme.colors.variant.success : theme.colors.variant.danger;
 
@@ -48,6 +48,10 @@ const MatchIcon = styled(({ empty, matches, ...props }) => <Icon {...props} />)(
 const StyledSpinner = styled(Spinner)`
   margin-left: 10px;
 `;
+
+const getListClassName = (matchData) => {
+  return (matchData.matches ? 'success' : 'danger');
+};
 
 class StreamRulesEditor extends React.Component {
   static propTypes = {
@@ -123,10 +127,6 @@ class StreamRulesEditor extends React.Component {
     this.setState({ showStreamRuleForm: true });
   };
 
-  _getListClassName = (matchData) => {
-    return (matchData.matches ? 'success' : 'danger');
-  };
-
   _explainMatchResult = () => {
     const { matchData } = this.state;
 
@@ -156,7 +156,7 @@ class StreamRulesEditor extends React.Component {
   render() {
     const { matchData, stream, streamRuleTypes, showStreamRuleForm } = this.state;
     const { currentUser, messageId, index } = this.props;
-    const styles = (matchData ? this._getListClassName(matchData) : 'info');
+    const styles = (matchData ? getListClassName(matchData) : 'info');
 
     if (stream && streamRuleTypes) {
       return (

--- a/graylog2-web-interface/src/components/streamrules/StreamRulesEditor.jsx
+++ b/graylog2-web-interface/src/components/streamrules/StreamRulesEditor.jsx
@@ -182,6 +182,8 @@ class StreamRulesEditor extends React.Component {
                 <StreamRuleForm title="New Stream Rule"
                                 onClose={() => this.setState({ showStreamRuleForm: false })}
                                 streamRuleTypes={streamRuleTypes}
+                                submitButtonText="Create Rule"
+                                submitLoadingText="Creating Rule..."
                                 onSubmit={this._onStreamRuleFormSubmit} />
               )}
             </div>

--- a/graylog2-web-interface/src/components/streams/CreateStreamButton.jsx
+++ b/graylog2-web-interface/src/components/streams/CreateStreamButton.jsx
@@ -53,7 +53,8 @@ class CreateStreamButton extends React.Component {
           {buttonText}
         </Button>
         <StreamForm ref={(streamForm) => { this.streamForm = streamForm; }}
-                    title="Creating Stream"
+                    title="Create Stream"
+                    submitButtonText="Create stream"
                     indexSets={indexSets}
                     onSubmit={onSave} />
       </span>

--- a/graylog2-web-interface/src/components/streams/Stream.jsx
+++ b/graylog2-web-interface/src/components/streams/Stream.jsx
@@ -282,6 +282,8 @@ class Stream extends React.Component {
         {showStreamRuleForm && (
           <StreamRuleForm onClose={this._closeStreamRuleForm}
                           title="New Stream Rule"
+                          submitButtonText="Create Rule"
+                          submitLoadingText="Creating Rule..."
                           onSubmit={this._onSaveStreamRule}
                           streamRuleTypes={streamRuleTypes} />
         )}

--- a/graylog2-web-interface/src/components/streams/StreamControls.tsx
+++ b/graylog2-web-interface/src/components/streams/StreamControls.tsx
@@ -111,11 +111,13 @@ const StreamControls = ({
       <StreamForm ref={streamForm}
                   title="Editing Stream"
                   onSubmit={onUpdate}
+                  submitButtonText="Update stream"
                   stream={stream}
                   indexSets={indexSets} />
       <StreamForm ref={cloneForm}
                   title="Cloning Stream"
                   onSubmit={_onCloneSubmit}
+                  submitButtonText="Clone stream"
                   indexSets={indexSets} />
     </>
   );

--- a/graylog2-web-interface/src/components/streams/StreamForm.jsx
+++ b/graylog2-web-interface/src/components/streams/StreamForm.jsx
@@ -47,6 +47,7 @@ class StreamForm extends React.Component {
     onSubmit: PropTypes.func.isRequired,
     stream: PropTypes.object,
     title: PropTypes.string.isRequired,
+    submitButtonText: PropTypes.string.isRequired,
     indexSets: PropTypes.array.isRequired,
   };
 
@@ -138,14 +139,14 @@ class StreamForm extends React.Component {
   };
 
   render() {
+    const { title: propTitle, submitButtonText } = this.props;
     const { title, description, removeMatchesFromDefaultStream } = this.state;
-    const { title: propTitle } = this.props;
 
     return (
       <BootstrapModalForm ref={(c) => { this.modal = c; }}
                           title={propTitle}
                           onSubmitForm={this._onSubmit}
-                          submitButtonText="Save">
+                          submitButtonText={submitButtonText}>
         <Input id="Title"
                type="text"
                required

--- a/graylog2-web-interface/src/views/components/DashboardActionsMenu.test.tsx
+++ b/graylog2-web-interface/src/views/components/DashboardActionsMenu.test.tsx
@@ -108,7 +108,7 @@ describe('DashboardActionsMenu', () => {
     const saveDashboardModal = await screen.findByTestId('modal-form');
 
     const saveButton = within(saveDashboardModal).getByRole('button', {
-      name: /save/i,
+      name: /create dashboard/i,
       hidden: true,
     });
 
@@ -171,12 +171,12 @@ describe('DashboardActionsMenu', () => {
   });
 
   it('should open dashboard share modal', () => {
-    const { getByText } = render(<SUT />);
+    const { getByRole, getByText } = render(<SUT />);
     const openShareButton = getByText(/Share/i);
 
     userEvent.click(openShareButton);
 
-    expect(getByText(/Sharing/i)).not.toBeNull();
+    expect(getByRole('button', { name: /update sharing/i, hidden: true })).not.toBeNull();
   });
 
   it('should use FULL_MENU layout option by default and render all buttons', async () => {

--- a/graylog2-web-interface/src/views/components/DashboardActionsMenu.tsx
+++ b/graylog2-web-interface/src/views/components/DashboardActionsMenu.tsx
@@ -96,25 +96,25 @@ const DashboardActionsMenu = ({ view, isNewView, metadata }) => {
   return (
     <ButtonGroup>
       {showSaveButton && (
-      <Button onClick={() => onSaveView(view)}
-              disabled={isNewView || hasUndeclaredParameters || !allowedToEdit}
-              title="Save dashboard">
-        <Icon name="save" /> Save
-      </Button>
+        <Button onClick={() => onSaveView(view)}
+                disabled={isNewView || hasUndeclaredParameters || !allowedToEdit}
+                title="Save dashboard">
+          <Icon name="save" /> Save
+        </Button>
       )}
       {showSaveNewButton && (
-      <Button onClick={() => setSaveNewDashboardOpen(true)}
-              disabled={hasUndeclaredParameters}
-              title="Save as new dashboard">
-        <Icon name="copy" /> Save as
-      </Button>
+        <Button onClick={() => setSaveNewDashboardOpen(true)}
+                disabled={hasUndeclaredParameters}
+                title="Save as new dashboard">
+          <Icon name="copy" /> Save as
+        </Button>
       )}
       {showShareButton && (
-      <ShareButton entityType="dashboard"
-                   entityId={view.id}
-                   onClick={() => setShareViewOpen(true)}
-                   bsStyle="default"
-                   disabledInfo={isNewView && 'Only saved dashboards can be shared.'} />
+        <ShareButton entityType="dashboard"
+                     entityId={view.id}
+                     onClick={() => setShareViewOpen(true)}
+                     bsStyle="default"
+                     disabledInfo={isNewView && 'Only saved dashboards can be shared.'} />
       )}
       {showDropDownButton && (
         <DropdownButton title={<Icon name="ellipsis-h" />} id="query-tab-actions-dropdown" pullRight noCaret>
@@ -129,18 +129,20 @@ const DashboardActionsMenu = ({ view, isNewView, metadata }) => {
       )}
       {debugOpen && <DebugOverlay show onClose={() => setDebugOpen(false)} />}
       {saveNewDashboardOpen && (
-      <DashboardPropertiesModal show
-                                view={view.toBuilder().newId().build()}
-                                title="Save new dashboard"
-                                onClose={() => setSaveNewDashboardOpen(false)}
-                                onSave={(newDashboard) => _onSaveNewDashboard(newDashboard)} />
+        <DashboardPropertiesModal show
+                                  view={view.toBuilder().newId().build()}
+                                  title="Save new dashboard"
+                                  submitButtonText="Create dashboard"
+                                  onClose={() => setSaveNewDashboardOpen(false)}
+                                  onSave={(newDashboard) => _onSaveNewDashboard(newDashboard)} />
       )}
       {editDashboardOpen && (
-      <DashboardPropertiesModal show
-                                view={view}
-                                title="Editing dashboard"
-                                onClose={() => setEditDashboardOpen(false)}
-                                onSave={onSaveView} />
+        <DashboardPropertiesModal show
+                                  view={view}
+                                  title="Editing dashboard"
+                                  submitButtonText="Update dashboard"
+                                  onClose={() => setEditDashboardOpen(false)}
+                                  onSave={onSaveView} />
       )}
 
       {shareDashboardOpen && (

--- a/graylog2-web-interface/src/views/components/DashboardSearchBar.test.tsx
+++ b/graylog2-web-interface/src/views/components/DashboardSearchBar.test.tsx
@@ -98,7 +98,7 @@ describe('DashboardSearchBar', () => {
 
     userEvent.click(timeRangeInput);
     userEvent.click(await screen.findByRole('tab', { name: 'Relative' }));
-    userEvent.click(await screen.findByRole('button', { name: 'Apply' }));
+    userEvent.click(await screen.findByRole('button', { name: 'Update time range' }));
 
     const searchButton = await screen.findByRole('button', {
       name: /perform search \(changes were made after last search execution\)/i,

--- a/graylog2-web-interface/src/views/components/DebugOverlay.tsx
+++ b/graylog2-web-interface/src/views/components/DebugOverlay.tsx
@@ -42,7 +42,7 @@ const DebugOverlay = ({ currentView, searches, show, onClose }: Props) => (
                 value={JSON.stringify({ currentView, searches }, null, 2)} />
     </Modal.Body>
     <Modal.Footer>
-      <Button type="button" onClick={() => onClose()} bsStyle="primary">Close</Button>
+      <Button type="button" onClick={() => onClose()}>Close</Button>
     </Modal.Footer>
   </BootstrapModalWrapper>
 );

--- a/graylog2-web-interface/src/views/components/dashboard/BigDisplayModeConfiguration.tsx
+++ b/graylog2-web-interface/src/views/components/dashboard/BigDisplayModeConfiguration.tsx
@@ -65,7 +65,7 @@ const ConfigurationModal = ({ onSave, view, show, onClose }: ConfigurationModalP
     <BootstrapModalForm bsSize="large"
                         onModalClose={onClose}
                         onSubmitForm={_onSave}
-                        submitButtonText="Save"
+                        submitButtonText="Start full screen view"
                         title="Configuring Full Screen"
                         show={show}>
       <Input autoFocus

--- a/graylog2-web-interface/src/views/components/queries/QueryTitleEditModal.test.tsx
+++ b/graylog2-web-interface/src/views/components/queries/QueryTitleEditModal.test.tsx
@@ -60,14 +60,14 @@ describe('QueryTitleEditModal', () => {
   it('updates query title and closes', async () => {
     let modalRef;
     const onTitleChangeFn = jest.fn();
-    const { getByDisplayValue, getByText, queryByText } = render(
+    const { getByDisplayValue, getByRole, queryByText } = render(
       <QueryTitleEditModal ref={(ref) => { modalRef = ref; }}
                            onTitleChange={onTitleChangeFn} />,
     );
 
     openModal(modalRef);
     const titleInput = getByDisplayValue('CurrentTitle');
-    const saveButton = getByText('Save');
+    const saveButton = getByRole('button', { name: /update title/i, hidden: true });
 
     fireEvent.change(titleInput, { target: { value: 'NewTitle' } });
     fireEvent.click(saveButton);

--- a/graylog2-web-interface/src/views/components/queries/QueryTitleEditModal.test.tsx
+++ b/graylog2-web-interface/src/views/components/queries/QueryTitleEditModal.test.tsx
@@ -84,7 +84,7 @@ describe('QueryTitleEditModal', () => {
   it('closes on click on cancel', async () => {
     let modalRef;
     const onTitleChangeFn = jest.fn();
-    const { getByText, queryByText } = render(
+    const { getByText, queryByText, findByText } = render(
       <QueryTitleEditModal ref={(ref) => { modalRef = ref; }}
                            onTitleChange={onTitleChangeFn} />,
     );
@@ -92,7 +92,7 @@ describe('QueryTitleEditModal', () => {
     openModal(modalRef);
 
     // Modal should be visible
-    expect(queryByText(modalHeadline)).not.toBeInTheDocument();
+    await findByText(modalHeadline);
 
     // Modal should not be visible after click on cancel
     const cancelButton = getByText('Cancel');
@@ -100,7 +100,7 @@ describe('QueryTitleEditModal', () => {
     fireEvent.click(cancelButton);
 
     await waitFor(() => {
-      expect(queryByText(modalHeadline)).toBeNull();
+      expect(queryByText(modalHeadline)).not.toBeInTheDocument();
     });
   });
 });

--- a/graylog2-web-interface/src/views/components/queries/QueryTitleEditModal.test.tsx
+++ b/graylog2-web-interface/src/views/components/queries/QueryTitleEditModal.test.tsx
@@ -16,7 +16,7 @@
  */
 import * as React from 'react';
 import * as Immutable from 'immutable';
-import { render, fireEvent, waitFor } from 'wrappedTestingLibrary';
+import { render, fireEvent, waitFor, screen } from 'wrappedTestingLibrary';
 
 import QueryTitleEditModal from './QueryTitleEditModal';
 
@@ -29,7 +29,7 @@ describe('QueryTitleEditModal', () => {
     }
   };
 
-  it('shows after triggering open action', () => {
+  it('shows after triggering open action', async () => {
     let modalRef;
     const { queryByText } = render(
       <QueryTitleEditModal ref={(ref) => { modalRef = ref; }}
@@ -42,7 +42,7 @@ describe('QueryTitleEditModal', () => {
     openModal(modalRef);
 
     // Modal should be visible
-    expect(queryByText(modalHeadline)).not.toBeNull();
+    await screen.findByText(modalHeadline);
   });
 
   it('has correct initial input value', () => {
@@ -92,7 +92,7 @@ describe('QueryTitleEditModal', () => {
     openModal(modalRef);
 
     // Modal should be visible
-    expect(queryByText(modalHeadline)).not.toBeNull();
+    expect(queryByText(modalHeadline)).not.toBeInTheDocument();
 
     // Modal should not be visible after click on cancel
     const cancelButton = getByText('Cancel');

--- a/graylog2-web-interface/src/views/components/queries/QueryTitleEditModal.tsx
+++ b/graylog2-web-interface/src/views/components/queries/QueryTitleEditModal.tsx
@@ -77,7 +77,7 @@ class QueryTitleEditModal extends React.Component<Props, State> {
       <BootstrapModalForm ref={(modal) => { this.modal = modal; }}
                           title="Editing dashboard page title"
                           onSubmitForm={this._onDraftSave}
-                          submitButtonText="Save"
+                          submitButtonText="Update title"
                           bsSize="large">
         <Input autoFocus
                help="Enter a helpful dashboard page title. It has a maximum length of 40 characters."

--- a/graylog2-web-interface/src/views/components/queries/QueryTitleEditModal.tsx
+++ b/graylog2-web-interface/src/views/components/queries/QueryTitleEditModal.tsx
@@ -50,6 +50,7 @@ class QueryTitleEditModal extends React.Component<Props, State> {
     };
   }
 
+  // eslint-disable-next-line react/no-unused-class-component-methods
   open = (activeQueryTitle: string) => {
     this.setState({
       titleDraft: activeQueryTitle,

--- a/graylog2-web-interface/src/views/components/searchbar/TimeRangeInput.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/TimeRangeInput.test.tsx
@@ -82,7 +82,7 @@ describe('TimeRangeInput', () => {
     });
     fireEvent.change(fromValue, { target: { value: 30 } });
 
-    fireEvent.click(await screen.findByRole('button', { name: 'Apply' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Update time range' }));
 
     await waitFor(() => expect(onChange).toHaveBeenCalledWith({
       from: 1800,

--- a/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TimeRangeDropdown.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TimeRangeDropdown.test.tsx
@@ -76,7 +76,7 @@ describe('TimeRangeDropdown', () => {
   it('Clicking apply run handler', async () => {
     render(<TimeRangeDropdown {...defaultProps} />);
 
-    const applyButton = screen.getByRole('button', { name: /apply/i });
+    const applyButton = screen.getByRole('button', { name: /update time range/i });
     fireEvent.click(applyButton);
 
     await waitFor(() => expect(defaultProps.setCurrentTimeRange).toHaveBeenCalled());

--- a/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TimeRangeDropdown.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TimeRangeDropdown.tsx
@@ -21,7 +21,7 @@ import styled, { css } from 'styled-components';
 import moment from 'moment';
 
 import { Button, Col, Tabs, Tab, Row, Popover } from 'components/bootstrap';
-import { Icon, KeyCapture, FormSubmit } from 'components/common';
+import { Icon, KeyCapture, ModalSubmit } from 'components/common';
 import { availableTimeRangeTypes } from 'views/Constants';
 import type {
   AbsoluteTimeRange,
@@ -278,10 +278,10 @@ const TimeRangeDropdown = ({
                     <Timezone>All timezones using: <b>{userTimezone}</b></Timezone>
                   </Col>
                   <Col md={6}>
-                    <FormSubmit leftCol={noOverride && <Button bsStyle="link" onClick={handleNoOverride}>No Override</Button>}
-                                onCancel={handleCancel}
-                                disabledSubmit={!isValid || validatingKeyword}
-                                submitButtonText="Update time range" />
+                    <ModalSubmit leftCol={noOverride && <Button bsStyle="link" onClick={handleNoOverride}>No Override</Button>}
+                                 onCancel={handleCancel}
+                                 disabledSubmit={!isValid || validatingKeyword}
+                                 submitButtonText="Update time range" />
                   </Col>
                 </Row>
               </Form>

--- a/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TimeRangeDropdown.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TimeRangeDropdown.tsx
@@ -281,7 +281,7 @@ const TimeRangeDropdown = ({
                     <FormSubmit leftCol={noOverride && <Button bsStyle="link" onClick={handleNoOverride}>No Override</Button>}
                                 onCancel={handleCancel}
                                 disabledSubmit={!isValid || validatingKeyword}
-                                submitButtonText="Update search" />
+                                submitButtonText="Update time range" />
                   </Col>
                 </Row>
               </Form>

--- a/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TimeRangeDropdown.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TimeRangeDropdown.tsx
@@ -21,7 +21,7 @@ import styled, { css } from 'styled-components';
 import moment from 'moment';
 
 import { Button, Col, Tabs, Tab, Row, Popover } from 'components/bootstrap';
-import { Icon, KeyCapture } from 'components/common';
+import { Icon, KeyCapture, FormSubmit } from 'components/common';
 import { availableTimeRangeTypes } from 'views/Constants';
 import type {
   AbsoluteTimeRange,
@@ -142,10 +142,6 @@ const LimitLabel = styled.span(({ theme }) => css`
     color: ${theme.colors.variant.darkest.warning};
   }
 `);
-
-const CancelButton = styled(Button)`
-  margin-right: 6px;
-`;
 
 const timeRangeTypeTabs = ({ activeTab, limitDuration, setValidatingKeyword, tabs }: TimeRangeTabsArguments) => availableTimeRangeTypes
   .filter(({ type }) => tabs.includes(type))
@@ -282,13 +278,10 @@ const TimeRangeDropdown = ({
                     <Timezone>All timezones using: <b>{userTimezone}</b></Timezone>
                   </Col>
                   <Col md={6}>
-                    <div className="pull-right">
-                      {noOverride && (
-                        <Button bsStyle="link" onClick={handleNoOverride}>No Override</Button>
-                      )}
-                      <CancelButton bsStyle="default" onClick={handleCancel}>Cancel</CancelButton>
-                      <Button bsStyle="success" disabled={!isValid || validatingKeyword} type="submit">Apply</Button>
-                    </div>
+                    <FormSubmit leftCol={noOverride && <Button bsStyle="link" onClick={handleNoOverride}>No Override</Button>}
+                                onCancel={handleCancel}
+                                disabledSubmit={!isValid || validatingKeyword}
+                                submitButtonText="Update search" />
                   </Col>
                 </Row>
               </Form>

--- a/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TimerangeDropdown.relativeTimeRange.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TimerangeDropdown.relativeTimeRange.test.tsx
@@ -37,31 +37,31 @@ jest.mock('views/stores/SearchConfigStore', () => ({
 
 jest.mock('stores/tools/ToolsStore', () => ({}));
 
-const defaultProps = {
-  currentTimeRange: {
-    type: 'relative',
-    from: 300,
-  },
-  noOverride: false,
-  setCurrentTimeRange: jest.fn(),
-  toggleDropdownShow: jest.fn(),
-  position: 'bottom',
-  limitDuration: 259200,
-} as const;
-
-const TimeRangeDropdown = (allProps: TimeRangeDropdownProps) => (
-  <OriginalTimeRangeDropDown {...allProps} />
-);
-
 describe('TimeRangeDropdown relative time range', () => {
+  const defaultProps = {
+    currentTimeRange: {
+      type: 'relative',
+      from: 300,
+    },
+    noOverride: false,
+    setCurrentTimeRange: jest.fn(),
+    toggleDropdownShow: jest.fn(),
+    position: 'bottom',
+    limitDuration: 259200,
+  } as const;
+
+  const TimeRangeDropdown = (allProps: TimeRangeDropdownProps) => (
+    <OriginalTimeRangeDropDown {...allProps} />
+  );
+
+  const getSubmitButton = () => screen.getByRole('button', { name: /Update time range/i });
+
   it('display warning when emptying from range value input', async () => {
     render(<TimeRangeDropdown {...defaultProps} />);
 
     const fromRangeValueInput = screen.getByTitle('Set the from value');
-    const submitButton = screen.getByRole('button', {
-      name: /apply/i,
-    });
 
+    const submitButton = getSubmitButton();
     userEvent.type(fromRangeValueInput, '{backspace}');
 
     await screen.findByText('Cannot be empty.');
@@ -81,9 +81,7 @@ describe('TimeRangeDropdown relative time range', () => {
     render(<TimeRangeDropdown {...props} />);
 
     const toRangeValueInput = screen.getByTitle('Set the to value');
-    const submitButton = screen.getByRole('button', {
-      name: /apply/i,
-    });
+    const submitButton = getSubmitButton();
 
     userEvent.type(toRangeValueInput, '{backspace}');
 
@@ -107,9 +105,7 @@ describe('TimeRangeDropdown relative time range', () => {
 
     const fromRangeValueInput = screen.getByTitle('Set the from value');
     const toRangeValueInput = screen.getByTitle('Set the to value');
-    const submitButton = screen.getByRole('button', {
-      name: /apply/i,
-    });
+    const submitButton = getSubmitButton();
 
     userEvent.type(fromRangeValueInput, '{backspace}7');
     userEvent.type(toRangeValueInput, '{backspace}6');

--- a/graylog2-web-interface/src/views/components/searchbar/saved-search/SearchActionsMenu.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/saved-search/SearchActionsMenu.tsx
@@ -195,6 +195,7 @@ const SearchActionsMenu = () => {
         <ViewPropertiesModal show
                              view={view}
                              title="Editing saved search"
+                             submitButtonText="Update search"
                              onClose={toggleMetadataEdit}
                              onSave={onSaveView} />
       )}

--- a/graylog2-web-interface/src/views/components/views/DashboardPropertiesModal.test.tsx
+++ b/graylog2-web-interface/src/views/components/views/DashboardPropertiesModal.test.tsx
@@ -41,7 +41,8 @@ describe('DashboardPropertiesModal', () => {
     const titleInput = await screen.findByRole('textbox', { name: /title/i, hidden: true });
 
     await userEvent.type(titleInput, 'My title');
-    userEvent.click(await screen.findByRole('button', { name: 'Save', hidden: true }));
+
+    userEvent.click(await screen.findByRole('button', { name: /create dashboard/i, hidden: true }));
 
     await waitFor(() => {
       expect(onSave).toHaveBeenCalledWith(expect.objectContaining({

--- a/graylog2-web-interface/src/views/components/views/DashboardPropertiesModal.test.tsx
+++ b/graylog2-web-interface/src/views/components/views/DashboardPropertiesModal.test.tsx
@@ -29,7 +29,13 @@ describe('DashboardPropertiesModal', () => {
       .type(View.Type.Dashboard)
       .title('')
       .build();
-    render(<DashboardPropertiesModal onClose={jest.fn()} onSave={onSave} title="Saving new dashboard" view={view} show />);
+
+    render(<DashboardPropertiesModal onClose={jest.fn()}
+                                     onSave={onSave}
+                                     title="Saving new dashboard"
+                                     view={view}
+                                     submitButtonText="Create Dashboard"
+                                     show />);
 
     await screen.findByText('Saving new dashboard');
     const titleInput = await screen.findByRole('textbox', { name: /title/i, hidden: true });

--- a/graylog2-web-interface/src/views/components/views/DashboardPropertiesModal.tsx
+++ b/graylog2-web-interface/src/views/components/views/DashboardPropertiesModal.tsx
@@ -27,12 +27,13 @@ import useSaveViewFormControls from 'views/hooks/useSaveViewFormControls';
 type Props = {
   onClose: () => void,
   onSave: (view: View) => void,
+  show: boolean
+  submitButtonText: string,
   title: string,
   view: View,
-  show: boolean
 };
 
-const DashboardPropertiesModal = ({ onClose, onSave, show, view, title: modalTitle }: Props) => {
+const DashboardPropertiesModal = ({ onClose, onSave, show, view, title: modalTitle, submitButtonText }: Props) => {
   const [updatedDashboard, setUpdatedDashboard] = useState(view);
   const pluggableFormComponents = useSaveViewFormControls();
 
@@ -69,7 +70,7 @@ const DashboardPropertiesModal = ({ onClose, onSave, show, view, title: modalTit
                         title={modalTitle}
                         onCancel={onClose}
                         onSubmitForm={_onSave}
-                        submitButtonText="Save"
+                        submitButtonText={submitButtonText}
                         bsSize="large">
       <>
         <Input id="title"
@@ -104,6 +105,7 @@ DashboardPropertiesModal.propTypes = {
   onClose: PropTypes.func.isRequired,
   onSave: PropTypes.func.isRequired,
   show: PropTypes.bool.isRequired,
+  submitButtonText: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired,
   view: PropTypes.object.isRequired,
 };

--- a/graylog2-web-interface/src/views/components/widgets/CopyToDashboardForm.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/CopyToDashboardForm.test.tsx
@@ -15,7 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { render, fireEvent } from 'wrappedTestingLibrary';
+import { render, fireEvent, screen } from 'wrappedTestingLibrary';
 
 import mockAction from 'helpers/mocking/MockAction';
 import type { DashboardsStoreState } from 'views/stores/DashboardsStore';
@@ -55,6 +55,11 @@ describe('CopyToDashboardForm', () => {
     },
   };
 
+  const submitModal = () => {
+    const submitButton = screen.getByRole('button', { name: /copy widget/i, hidden: true });
+    fireEvent.click(submitButton);
+  };
+
   it('should render the modal minimal', () => {
     // @ts-ignore
     const { baseElement } = render(<CopyToDashboardForm />);
@@ -86,13 +91,13 @@ describe('CopyToDashboardForm', () => {
 
   it('should not handle onSubmit without selection', () => {
     const onSubmit = jest.fn();
-    const { getByText } = render(<CopyToDashboardForm dashboards={dashboardState}
-                                                      widgetId="widget-id"
-                                                      onCancel={() => {}}
-                                                      onSubmit={onSubmit} />);
-    const submitButton = getByText('Select');
 
-    fireEvent.click(submitButton);
+    render(<CopyToDashboardForm dashboards={dashboardState}
+                                widgetId="widget-id"
+                                onCancel={() => {}}
+                                onSubmit={onSubmit} />);
+
+    submitModal();
 
     expect(onSubmit).not.toHaveBeenCalled();
   });
@@ -106,9 +111,7 @@ describe('CopyToDashboardForm', () => {
     const firstView = getByText('view 1');
 
     fireEvent.click(firstView);
-    const submitButton = getByText('Select');
-
-    fireEvent.click(submitButton);
+    submitModal();
 
     expect(onSubmit).toHaveBeenCalledTimes(1);
     expect(onSubmit).toHaveBeenCalledWith('widget-id', 'view-1');

--- a/graylog2-web-interface/src/views/components/widgets/CopyToDashboardForm.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/CopyToDashboardForm.tsx
@@ -16,10 +16,10 @@
  */
 import React, { useEffect, useState, useCallback } from 'react';
 
-import { Modal, Button, ListGroup, ListGroupItem } from 'components/bootstrap';
+import { Modal, ListGroup, ListGroupItem } from 'components/bootstrap';
 import type { DashboardsStoreState } from 'views/stores/DashboardsStore';
 import connect from 'stores/connect';
-import { PaginatedList, SearchForm } from 'components/common';
+import { PaginatedList, SearchForm, ModalSubmit } from 'components/common';
 import { DashboardsActions, DashboardsStore } from 'views/stores/DashboardsStore';
 
 type Props = {
@@ -87,12 +87,11 @@ const CopyToDashboardForm = ({ widgetId, onCancel, dashboards: { list = [], pagi
         </PaginatedList>
       </Modal.Body>
       <Modal.Footer>
-        <Button bsStyle="primary"
-                disabled={selectedDashboard === null}
-                onClick={() => onSubmit(widgetId, selectedDashboard)}>
-          Select
-        </Button>
-        <Button onClick={onCancel}>Cancel</Button>
+        <ModalSubmit submitButtonText="Copy widget"
+                     disabledSubmit={selectedDashboard === null}
+                     submitButtonType="button"
+                     onSubmit={() => onSubmit(widgetId, selectedDashboard)}
+                     onCancel={onCancel} />
       </Modal.Footer>
     </Modal>
   );

--- a/graylog2-web-interface/src/views/components/widgets/MoveWidgetToTabModal.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/MoveWidgetToTabModal.tsx
@@ -48,7 +48,8 @@ const MoveWidgetToTabModal = ({ view, onCancel, onSubmit, widgetId }: Props) => 
   const { id: activeQuery } = useStore(CurrentQueryStore);
   const queryIds = useStore(QueryIdsStore);
   const onKeepCopy = useCallback((e) => setKeepCopy(e.target.checked), [setKeepCopy]);
-  const submit = useCallback(() => onSubmit(widgetId, selectedTab, keepCopy), [widgetId, selectedTab, keepCopy]);
+  const submit = useCallback(() => onSubmit(widgetId, selectedTab, keepCopy),
+    [onSubmit, widgetId, selectedTab, keepCopy]);
 
   const list = _tabList(view, queryIds.toArray()).filter(({ id }) => id !== activeQuery);
 

--- a/graylog2-web-interface/src/views/components/widgets/MoveWidgetToTabModal.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/MoveWidgetToTabModal.tsx
@@ -67,6 +67,7 @@ const MoveWidgetToTabModal = ({ view, onCancel, onSubmit, widgetId }: Props) => 
     <BootstrapModalForm show
                         onCancel={onCancel}
                         submitButtonDisabled={!selectedTab}
+                        submitButtonText={`${keepCopy ? 'Copy' : 'Move'} widget`}
                         onSubmitForm={submit}
                         title="Choose Target Page">
       {renderResult}

--- a/graylog2-web-interface/src/views/components/widgets/SaveOrCancelButtons.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/SaveOrCancelButtons.tsx
@@ -15,16 +15,10 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import styled from 'styled-components';
 import { useContext, useState } from 'react';
 
 import WidgetEditApplyAllChangesContext from 'views/components/contexts/WidgetEditApplyAllChangesContext';
-import { Spinner } from 'components/common';
-import { Button, ButtonToolbar } from 'components/bootstrap';
-
-const StyledButtonToolbar = styled(ButtonToolbar)`
-  margin-top: 6px;
-`;
+import { FormSubmit } from 'components/common';
 
 type Props = {
   onCancel: () => void,
@@ -48,12 +42,13 @@ const SaveOrCancelButtons = ({ onFinish, onCancel, disableSave = false }: Props)
   };
 
   return (
-    <StyledButtonToolbar className="pull-right">
-      <Button onClick={_onFinish} bsStyle="primary" disabled={disableSave}>
-        {isSubmitting ? <Spinner text="Applying Changes" delay={0} /> : 'Apply Changes'}
-      </Button>
-      <Button onClick={onCancel}>Cancel</Button>
-    </StyledButtonToolbar>
+    <FormSubmit submitButtonText="Apply changes"
+                submitLoadingText="Applying changes..."
+                onSubmit={_onFinish}
+                submitButtonType="button"
+                disabledSubmit={disableSave}
+                isSubmitting={isSubmitting}
+                onCancel={onCancel} />
   );
 };
 

--- a/graylog2-web-interface/src/views/components/widgets/SaveOrCancelButtons.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/SaveOrCancelButtons.tsx
@@ -18,7 +18,7 @@ import * as React from 'react';
 import { useContext, useState } from 'react';
 
 import WidgetEditApplyAllChangesContext from 'views/components/contexts/WidgetEditApplyAllChangesContext';
-import { FormSubmit } from 'components/common';
+import { ModalSubmit } from 'components/common';
 
 type Props = {
   onCancel: () => void,
@@ -42,13 +42,13 @@ const SaveOrCancelButtons = ({ onFinish, onCancel, disableSave = false }: Props)
   };
 
   return (
-    <FormSubmit submitButtonText="Apply changes"
-                submitLoadingText="Applying changes..."
-                onSubmit={_onFinish}
-                submitButtonType="button"
-                disabledSubmit={disableSave}
-                isSubmitting={isSubmitting}
-                onCancel={onCancel} />
+    <ModalSubmit submitButtonText="Apply changes"
+                 submitLoadingText="Applying changes..."
+                 onSubmit={_onFinish}
+                 submitButtonType="button"
+                 disabledSubmit={disableSave}
+                 isSubmitting={isSubmitting}
+                 onCancel={onCancel} />
   );
 };
 

--- a/graylog2-web-interface/src/views/components/widgets/Widget.aggregations.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/Widget.aggregations.test.tsx
@@ -163,6 +163,11 @@ describe('Aggregation Widget', () => {
 
   const findWidgetConfigSubmitButton = () => screen.findByRole('button', { name: 'Update Preview' });
 
+  const submitWidgetChanges = () => {
+    const saveButton = screen.getByRole('button', { name: /apply changes/i });
+    fireEvent.click(saveButton);
+  };
+
   describe('on a dashboard', () => {
     it('should apply not submitted widget search controls and aggregation elements changes when clicking on "Apply Changes"', async () => {
       const newSeries = Series.create('count').toBuilder().config(SeriesConfig.empty().toBuilder().name('Metric name').build()).build();
@@ -199,9 +204,7 @@ describe('Aggregation Widget', () => {
         name: /perform search \(changes were made after last search execution\)/i,
       });
 
-      // Submit all changes
-      const saveButton = screen.getByText('Apply Changes');
-      fireEvent.click(saveButton);
+      submitWidgetChanges();
 
       await waitFor(() => expect(WidgetActions.update).toHaveBeenCalledTimes(1));
 
@@ -231,15 +234,14 @@ describe('Aggregation Widget', () => {
       const timeRangeLivePreview = await screen.findByTestId('time-range-live-preview');
       await within(timeRangeLivePreview).findByText('2020-01-01 00:55:00.000');
 
-      const applyTimeRangeChangesButton = await screen.findByRole('button', { name: 'Apply' });
+      const applyTimeRangeChangesButton = await screen.findByRole('button', { name: 'Update time range' });
       userEvent.click(applyTimeRangeChangesButton);
 
       const timeRangeDisplay = await screen.findByLabelText('Search Time Range, Opens Time Range Selector On Click');
       await within(timeRangeDisplay).findByText('2020-01-01 00:55:00.000');
 
       // Submit all changes
-      const saveButton = screen.getByText('Apply Changes');
-      fireEvent.click(saveButton);
+      submitWidgetChanges();
 
       await waitFor(() => expect(WidgetActions.update).toHaveBeenCalledTimes(1));
 
@@ -273,9 +275,7 @@ describe('Aggregation Widget', () => {
 
       await findWidgetConfigSubmitButton();
 
-      // Submit all changes
-      const saveButton = screen.getByText('Apply Changes');
-      fireEvent.click(saveButton);
+      submitWidgetChanges();
 
       await waitFor(() => expect(WidgetActions.update).toHaveBeenCalledTimes(1));
 

--- a/graylog2-web-interface/src/views/components/widgets/Widget.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/Widget.test.tsx
@@ -133,6 +133,8 @@ describe('<Widget />', () => {
     </WidgetFocusContext.Provider>
   );
 
+  const getWidgetUpdateButton = () => screen.getByRole('button', { name: /apply changes/i });
+
   it('should render with empty props', async () => {
     asMock(useWidgetResults).mockReturnValue({ widgetData: undefined, error: undefined });
     render(<DummyWidget />);
@@ -266,10 +268,10 @@ describe('<Widget />', () => {
   it('updates focus mode, on widget edit save', async () => {
     const mockUnsetWidgetEditing = jest.fn();
     render(<DummyWidget editing unsetWidgetEditing={mockUnsetWidgetEditing} />);
-    const saveButton = screen.getByText('Apply Changes');
-    fireEvent.click(saveButton);
+    const updateWidgetButton = getWidgetUpdateButton();
+    fireEvent.click(updateWidgetButton);
 
-    await waitFor(() => expect(saveButton).not.toBeDisabled());
+    await waitFor(() => expect(updateWidgetButton).not.toBeDisabled());
 
     expect(mockUnsetWidgetEditing).toHaveBeenCalledTimes(1);
   });
@@ -325,11 +327,10 @@ describe('<Widget />', () => {
 
     expect(WidgetActions.updateConfig).toHaveBeenCalledWith('widgetId', { foo: 23 });
 
-    const saveButton = screen.getByText('Apply Changes');
+    const updateWidgetButton = getWidgetUpdateButton();
+    fireEvent.click(updateWidgetButton);
 
-    fireEvent.click(saveButton);
-
-    await waitFor(() => expect(saveButton).not.toBeDisabled());
+    await waitFor(() => expect(updateWidgetButton).not.toBeDisabled());
 
     expect(WidgetActions.update).not.toHaveBeenCalledWith('widgetId', { config: { foo: 42 }, id: 'widgetId', type: 'dummy' });
   });

--- a/graylog2-web-interface/src/views/components/widgets/WidgetActionsMenu.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/WidgetActionsMenu.test.tsx
@@ -263,7 +263,7 @@ describe('<WidgetActionsMenu />', () => {
       const view1ListItem = screen.getByText('view 1');
 
       fireEvent.click(view1ListItem);
-      const selectBtn = screen.getByText('Select');
+      const selectBtn = screen.getByRole('button', { name: /copy widget/i, hidden: true });
 
       fireEvent.click(selectBtn);
     };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

With this PR we are starting to unify the styling and placement of our form buttons. Currently their styling, placement and naming varies.

With these changes we are creating a `FormSubmit` and a `ModalSubmit` component.
The `FormSubmit` component should be used for forms on pages, while the `ModalSubmit` should be used for modals which contain a submit button.

By using these components in every suitable form and modal, we are able to change the form and modal submit and cancel button in one place.


With this PR we are also:
- defining more meaningful names for the submit buttons. Instead of `Save` or `Submit` we are using for example `Create stream`
- unifying the naming of the cancel button
- unifying the placement of submit buttons in forms on pages:

<img width="977" alt="image" src="https://user-images.githubusercontent.com/46300478/191743405-e7ecc52a-5350-4598-87c5-b5703d78cbfd.png">


Next steps:
- Implementing the `FormSubmit` and `ModalSubmit` components for more forms and modals.
- Describing the best practices in our UI documentation

/jenkins-pr-deps https://github.com/Graylog2/graylog-plugin-enterprise/pull/4089
