### PR TITLE
Set elasticsearch_index_optimization_jobs default to 10

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchConfiguration.java
@@ -125,7 +125,7 @@ public class ElasticsearchConfiguration {
     private Duration indexOptimizationTimeout = Duration.hours(1L);
 
     @Parameter(value = "elasticsearch_index_optimization_jobs", validator = PositiveIntegerValidator.class)
-    private int indexOptimizationJobs = 20;
+    private int indexOptimizationJobs = 10;
 
     @Parameter(value = "index_field_type_periodical_full_refresh_interval", validators = {PositiveDurationValidator.class})
     private Duration indexFieldTypePeriodicalFullRefreshInterval = Duration.minutes(5);

--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -417,8 +417,8 @@ elasticsearch_analyzer = standard
 
 # Maximum number of concurrently running index optimization (force merge) jobs.
 # If you are using lots of different index sets, you might want to increase that number.
-# Default: 20
-#elasticsearch_index_optimization_jobs = 20
+# Default: 10
+#elasticsearch_index_optimization_jobs = 10
 
 # Mute the logging-output of ES deprecation warnings during REST calls in the ES RestClient
 #elasticsearch_mute_deprecation_warnings = true

--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -417,6 +417,9 @@ elasticsearch_analyzer = standard
 
 # Maximum number of concurrently running index optimization (force merge) jobs.
 # If you are using lots of different index sets, you might want to increase that number.
+# This value should be set lower than elasticsearch_max_total_connections_per_route, otherwise index optimization
+# could deplete all the client connections to the search server and block new messages ingestion for prolonged
+# periods of time.
 # Default: 10
 #elasticsearch_index_optimization_jobs = 10
 


### PR DESCRIPTION
This PR sets the `elasticsearch_index_optimization_jobs` configuration value to 10 (originally 20), to avoid depleting all the elasticsearch/opensearch connections (`elasticsearch_max_total_connections_per_route`) available.

Fixes https://github.com/Graylog2/graylog2-server/issues/12025


## Motivation and Context
With default 20 threads of `elasticsearch_index_optimization_jobs` and default 20 threads for search-server clients, it could easily happen that all client threads are blocked by the optimization and the graylog server stops indexing new messages, as observed in https://github.com/Graylog2/graylog2-server/issues/12025

When we decrease the default optimize threads to 10, there will be still 10 client threads available for ingestion and other tasks.



## How Has This Been Tested?
Tested by the cloud team, see https://github.com/Graylog2/graylog2-server/issues/12025#issuecomment-1112959172



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

