### PR TITLE
Adding onBlur prop

### DIFF
--- a/graylog2-web-interface/src/components/common/SourceCodeEditor.jsx
+++ b/graylog2-web-interface/src/components/common/SourceCodeEditor.jsx
@@ -112,6 +112,8 @@ class SourceCodeEditor extends React.Component {
     onLoad: PropTypes.func,
     /** Function called when the value of the text changes. It receives the new value and an event as arguments. */
     onChange: PropTypes.func,
+    /** Function called when the editor loses focus. */
+    onBlur: PropTypes.func,
     /** Specifies if the editor should be in read-only mode. */
     readOnly: PropTypes.bool,
     /** Specifies if the editor should be resizable by the user. */
@@ -132,6 +134,7 @@ class SourceCodeEditor extends React.Component {
     innerRef: undefined,
     mode: 'text',
     onChange: () => {},
+    onBlur: () => {},
     onLoad: () => {},
     readOnly: false,
     resizable: true,
@@ -238,6 +241,7 @@ class SourceCodeEditor extends React.Component {
       innerRef,
       onLoad,
       onChange,
+      onBlur,
       readOnly,
       value,
     } = this.props;
@@ -305,6 +309,7 @@ class SourceCodeEditor extends React.Component {
                        height="100%"
                        onLoad={onLoad}
                        onChange={onChange}
+                       onBlur={onBlur}
                        onSelectionChange={this.handleSelectionChange}
                        readOnly={readOnly}
                        value={value}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Adding the onBlur prop that is supported by the react-ace editor to be used in the new sigma rules editor. Related PR here: https://github.com/Graylog2/graylog-plugin-enterprise/pull/4094

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

