### PR TITLE
Update to jackson 2.13

### DIFF
--- a/full-backend-tests/pom.xml
+++ b/full-backend-tests/pom.xml
@@ -140,6 +140,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-scala_3</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <scope>test</scope>

--- a/graylog2-server/pom.xml
+++ b/graylog2-server/pom.xml
@@ -181,8 +181,8 @@
         <dependency>
             <!-- Workaround for https://github.com/FasterXML/jackson-bom/pull/38 -->
             <groupId>com.fasterxml.jackson.module</groupId>
-            <artifactId>jackson-module-scala_2.13</artifactId>
-            <version>2.9.10</version>
+            <artifactId>jackson-module-scala_3</artifactId>
+            <version>2.13.4</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.jaxrs</groupId>

--- a/graylog2-server/pom.xml
+++ b/graylog2-server/pom.xml
@@ -179,6 +179,11 @@
             <artifactId>jackson-module-jsonSchema</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-scala_3</artifactId>
+            <version>2.13.4</version>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.jaxrs</groupId>
             <artifactId>jackson-jaxrs-json-provider</artifactId>
         </dependency>

--- a/graylog2-server/pom.xml
+++ b/graylog2-server/pom.xml
@@ -179,12 +179,6 @@
             <artifactId>jackson-module-jsonSchema</artifactId>
         </dependency>
         <dependency>
-            <!-- Workaround for https://github.com/FasterXML/jackson-bom/pull/38 -->
-            <groupId>com.fasterxml.jackson.module</groupId>
-            <artifactId>jackson-module-scala_3</artifactId>
-            <version>2.13.4</version>
-        </dependency>
-        <dependency>
             <groupId>com.fasterxml.jackson.jaxrs</groupId>
             <artifactId>jackson-jaxrs-json-provider</artifactId>
         </dependency>

--- a/graylog2-server/pom.xml
+++ b/graylog2-server/pom.xml
@@ -179,11 +179,6 @@
             <artifactId>jackson-module-jsonSchema</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.module</groupId>
-            <artifactId>jackson-module-scala_3</artifactId>
-            <version>2.13.4</version>
-        </dependency>
-        <dependency>
             <groupId>com.fasterxml.jackson.jaxrs</groupId>
             <artifactId>jackson-jaxrs-json-provider</artifactId>
         </dependency>

--- a/graylog2-server/src/main/java/org/graylog/plugins/beats/Beats2Codec.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/beats/Beats2Codec.java
@@ -70,7 +70,7 @@ public class Beats2Codec extends AbstractCodec {
         final JsonNode event;
         try {
             event = objectMapper.readTree(payload);
-            if (event == null) {
+            if (event == null || event.isMissingNode()) {
                 throw new IOException("null result");
             }
         } catch (IOException e) {

--- a/graylog2-server/src/main/java/org/graylog2/shared/bindings/providers/ObjectMapperProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/bindings/providers/ObjectMapperProvider.java
@@ -110,6 +110,7 @@ public class ObjectMapperProvider implements Provider<ObjectMapper> {
 
         this.objectMapper = mapper
                 .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+                .disable(SerializationFeature.WRITE_DURATIONS_AS_TIMESTAMPS)
                 .disable(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE)
                 .disable(DeserializationFeature.FAIL_ON_MISSING_EXTERNAL_TYPE_ID_PROPERTY)
                 .setPropertyNamingStrategy(new PropertyNamingStrategy.SnakeCaseStrategy())

--- a/graylog2-server/src/main/java/org/graylog2/shared/bindings/providers/ObjectMapperProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/bindings/providers/ObjectMapperProvider.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.databind.jsontype.NamedType;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 import com.fasterxml.jackson.databind.type.TypeFactory;
+import com.fasterxml.jackson.databind.util.StdDateFormat;
 import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.joda.JodaModule;
@@ -80,7 +81,7 @@ public class ObjectMapperProvider implements Provider<ObjectMapper> {
     private final LoadingCache<DateTimeZone, ObjectMapper> mapperByTimeZone = CacheBuilder.newBuilder()
             .maximumSize(DateTimeZone.getAvailableIDs().size())
             .build(
-                    new CacheLoader<DateTimeZone, ObjectMapper>() {
+                    new CacheLoader<>() {
                         @Override
                         public ObjectMapper load(@Nonnull DateTimeZone key) {
                             return objectMapper.copy().setTimeZone(key.toTimeZone());
@@ -114,6 +115,7 @@ public class ObjectMapperProvider implements Provider<ObjectMapper> {
                 .setPropertyNamingStrategy(new PropertyNamingStrategy.SnakeCaseStrategy())
                 .setSubtypeResolver(subtypeResolver)
                 .setTypeFactory(typeFactory)
+                .setDateFormat(new StdDateFormat().withColonInTimeZone(false))
                 .registerModule(new GuavaModule())
                 .registerModule(new JodaModule())
                 .registerModule(new Jdk8Module())

--- a/graylog2-server/src/test/java/org/graylog/events/contentpack/facade/EventDefinitionFacadeTest.java
+++ b/graylog2-server/src/test/java/org/graylog/events/contentpack/facade/EventDefinitionFacadeTest.java
@@ -100,14 +100,14 @@ public class EventDefinitionFacadeTest {
     @Rule
     public final MongoDBInstance mongodb = MongoDBInstance.createForClass();
 
-    private ObjectMapper objectMapper = new ObjectMapperProvider().get();
+    private ObjectMapper objectMapper;
 
     private EventDefinitionFacade facade;
 
     @Rule
     public final MockitoRule mockitoRule = MockitoJUnit.rule();
 
-    private MongoJackObjectMapperProvider mapperProvider = new MongoJackObjectMapperProvider(objectMapper);
+    private MongoJackObjectMapperProvider mapperProvider;
 
     @Mock
     private DBEventProcessorStateService stateService;
@@ -129,11 +129,14 @@ public class EventDefinitionFacadeTest {
     @Before
     @SuppressForbidden("Using Executors.newSingleThreadExecutor() is okay in tests")
     public void setUp() throws Exception {
+        objectMapper = new ObjectMapperProvider().get();
         objectMapper.registerSubtypes(
                 AggregationEventProcessorConfig.class,
                 PersistToStreamsStorageHandler.Config.class,
                 TemplateFieldValueProvider.Config.class,
                 AggregationEventProcessorConfigEntity.class);
+        mapperProvider = new MongoJackObjectMapperProvider(objectMapper);
+
         stateService = mock(DBEventProcessorStateService.class);
         jobDefinitionService = mock(DBJobDefinitionService.class);
         jobTriggerService = mock(DBJobTriggerService.class);

--- a/graylog2-server/src/test/java/org/graylog/events/contentpack/facade/NotificationFacadeTest.java
+++ b/graylog2-server/src/test/java/org/graylog/events/contentpack/facade/NotificationFacadeTest.java
@@ -73,7 +73,7 @@ public class NotificationFacadeTest {
     @Rule
     public final MongoDBInstance mongodb = MongoDBInstance.createForClass();
 
-    private ObjectMapper objectMapper = new ObjectMapperProvider().get();
+    private ObjectMapper objectMapper;
 
     private NotificationFacade facade;
 
@@ -98,17 +98,20 @@ public class NotificationFacadeTest {
     @Rule
     public final MockitoRule mockitoRule = MockitoJUnit.rule();
 
-    private MongoJackObjectMapperProvider mapperProvider = new MongoJackObjectMapperProvider(objectMapper);
+    private MongoJackObjectMapperProvider mapperProvider;
 
     @Before
     @SuppressForbidden("Using Executors.newSingleThreadExecutor() is okay in tests")
     public void setUp() throws Exception {
+        objectMapper = new ObjectMapperProvider().get();
         objectMapper.registerSubtypes(
                 EmailEventNotificationConfig.class,
                 EmailEventNotificationConfigEntity.class,
                 HttpEventNotificationConfigEntity.class,
                 HTTPEventNotificationConfig.class
         );
+        mapperProvider = new MongoJackObjectMapperProvider(objectMapper);
+
         jobDefinitionService = mock(DBJobDefinitionService.class);
         stateService = mock(DBEventProcessorStateService.class);
         eventDefinitionService = new DBEventDefinitionService(mongodb.mongoConnection(), mapperProvider, stateService, mock(EntityOwnershipService.class), null);

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/migrations/V20200204122000_MigrateUntypedViewsToDashboardsTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/migrations/V20200204122000_MigrateUntypedViewsToDashboardsTest.java
@@ -18,7 +18,6 @@ package org.graylog.plugins.views.migrations;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.util.StdDateFormat;
 import com.mongodb.BasicDBObject;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
@@ -74,8 +73,7 @@ public class V20200204122000_MigrateUntypedViewsToDashboardsTest {
     @Mock
     private ClusterConfigService clusterConfigService;
 
-    private final ObjectMapper objectMapper = new ObjectMapperProvider().get()
-            .setDateFormat(new StdDateFormat().withColonInTimeZone(false));
+    private final ObjectMapper objectMapper = new ObjectMapperProvider().get();
 
     private Migration migration;
     private MongoCollection<Document> viewsCollection;

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/migrations/V20200204122000_MigrateUntypedViewsToDashboardsTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/migrations/V20200204122000_MigrateUntypedViewsToDashboardsTest.java
@@ -18,6 +18,7 @@ package org.graylog.plugins.views.migrations;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.util.StdDateFormat;
 import com.mongodb.BasicDBObject;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
@@ -73,7 +74,8 @@ public class V20200204122000_MigrateUntypedViewsToDashboardsTest {
     @Mock
     private ClusterConfigService clusterConfigService;
 
-    private final ObjectMapper objectMapper = new ObjectMapperProvider().get();
+    private final ObjectMapper objectMapper = new ObjectMapperProvider().get()
+            .setDateFormat(new StdDateFormat().withColonInTimeZone(false));
 
     private Migration migration;
     private MongoCollection<Document> viewsCollection;

--- a/graylog2-server/src/test/java/org/graylog2/database/PaginatedDbServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/database/PaginatedDbServiceTest.java
@@ -26,7 +26,6 @@ import org.graylog.testing.mongodb.MongoDBInstance;
 import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mongojack.DBQuery;
@@ -56,7 +55,7 @@ public class PaginatedDbServiceTest {
         public String title;
 
         @JsonCreator
-        public TestDTO(@JsonProperty("id") String id, @JsonProperty("title") String title) {
+        public TestDTO(@JsonProperty("id") @Id String id, @JsonProperty("title") String title) {
             this.id = id;
             this.title = title;
         }

--- a/graylog2-server/src/test/java/org/graylog2/jackson/MongoJodaDateTimeSerializerTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/jackson/MongoJodaDateTimeSerializerTest.java
@@ -18,6 +18,7 @@ package org.graylog2.jackson;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.util.StdDateFormat;
 import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
@@ -26,7 +27,8 @@ import org.junit.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class MongoJodaDateTimeSerializerTest {
-    private final ObjectMapper objectMapper = new ObjectMapperProvider().get();
+    private final ObjectMapper objectMapper = new ObjectMapperProvider().get()
+            .setDateFormat(new StdDateFormat().withColonInTimeZone(false));
 
     @Test
     public void serializeZonedDateTime() throws Exception {

--- a/graylog2-server/src/test/java/org/graylog2/jackson/MongoJodaDateTimeSerializerTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/jackson/MongoJodaDateTimeSerializerTest.java
@@ -18,7 +18,6 @@ package org.graylog2.jackson;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.databind.util.StdDateFormat;
 import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
@@ -27,8 +26,7 @@ import org.junit.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class MongoJodaDateTimeSerializerTest {
-    private final ObjectMapper objectMapper = new ObjectMapperProvider().get()
-            .setDateFormat(new StdDateFormat().withColonInTimeZone(false));
+    private final ObjectMapper objectMapper = new ObjectMapperProvider().get();
 
     @Test
     public void serializeZonedDateTime() throws Exception {

--- a/graylog2-server/src/test/java/org/graylog2/jackson/MongoZonedDateTimeSerializerTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/jackson/MongoZonedDateTimeSerializerTest.java
@@ -18,6 +18,7 @@ package org.graylog2.jackson;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.util.StdDateFormat;
 import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
 import org.junit.Test;
 
@@ -27,7 +28,8 @@ import java.time.ZonedDateTime;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class MongoZonedDateTimeSerializerTest {
-    private final ObjectMapper objectMapper = new ObjectMapperProvider().get();
+    private final ObjectMapper objectMapper = new ObjectMapperProvider().get()
+            .setDateFormat(new StdDateFormat().withColonInTimeZone(false));
 
     @Test
     public void serializeZonedDateTime() throws Exception {

--- a/graylog2-server/src/test/java/org/graylog2/jackson/MongoZonedDateTimeSerializerTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/jackson/MongoZonedDateTimeSerializerTest.java
@@ -18,7 +18,6 @@ package org.graylog2.jackson;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.databind.util.StdDateFormat;
 import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
 import org.junit.Test;
 
@@ -28,8 +27,7 @@ import java.time.ZonedDateTime;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class MongoZonedDateTimeSerializerTest {
-    private final ObjectMapper objectMapper = new ObjectMapperProvider().get()
-            .setDateFormat(new StdDateFormat().withColonInTimeZone(false));
+    private final ObjectMapper objectMapper = new ObjectMapperProvider().get();
 
     @Test
     public void serializeZonedDateTime() throws Exception {

--- a/graylog2-server/src/test/java/org/graylog2/plugin/MessageSummaryTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/plugin/MessageSummaryTest.java
@@ -18,6 +18,7 @@ package org.graylog2.plugin;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.type.MapType;
+import com.fasterxml.jackson.datatype.joda.JodaModule;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
@@ -27,7 +28,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -91,7 +91,7 @@ public class MessageSummaryTest {
 
     @Test
     public void testJSONSerialization() throws Exception {
-        final ObjectMapper mapper = new ObjectMapper();
+        final ObjectMapper mapper = new ObjectMapper().registerModule(new JodaModule());
         final MapType valueType = mapper.getTypeFactory().constructMapType(HashMap.class, String.class, Object.class);
 
         final Map<String, Object> map = mapper.readValue(mapper.writeValueAsBytes(messageSummary), valueType);

--- a/graylog2-server/src/test/java/org/graylog2/plugin/MessageSummaryTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/plugin/MessageSummaryTest.java
@@ -18,10 +18,10 @@ package org.graylog2.plugin;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.type.MapType;
-import com.fasterxml.jackson.datatype.joda.JodaModule;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
+import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.junit.Before;
@@ -91,12 +91,12 @@ public class MessageSummaryTest {
 
     @Test
     public void testJSONSerialization() throws Exception {
-        final ObjectMapper mapper = new ObjectMapper().registerModule(new JodaModule());
+        final ObjectMapper mapper = new ObjectMapperProvider().get();
         final MapType valueType = mapper.getTypeFactory().constructMapType(HashMap.class, String.class, Object.class);
 
         final Map<String, Object> map = mapper.readValue(mapper.writeValueAsBytes(messageSummary), valueType);
 
-        assertEquals(Sets.newHashSet("id", "timestamp", "message", "index", "source", "streamIds", "fields"), map.keySet());
+        assertEquals(Sets.newHashSet("id", "timestamp", "message", "index", "source", "stream_ids", "fields"), map.keySet());
     }
 
     @Test

--- a/graylog2-server/src/test/java/org/graylog2/security/encryption/EncryptedValueTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/security/encryption/EncryptedValueTest.java
@@ -203,7 +203,7 @@ class EncryptedValueTest {
         }
 
         @JsonCreator
-        public static TestDTO create(@JsonProperty("id") String id, @JsonProperty("password_value") EncryptedValue passwordValue) {
+        public static TestDTO create(@JsonProperty("id") @Id String id, @JsonProperty("password_value") EncryptedValue passwordValue) {
             return new AutoValue_EncryptedValueTest_TestDTO(id, passwordValue);
         }
     }

--- a/pom.xml
+++ b/pom.xml
@@ -117,6 +117,8 @@
         <HdrHistogram.version>2.1.12</HdrHistogram.version>
         <hibernate-validator.version>6.1.2.Final</hibernate-validator.version>
         <hk2.version>2.6.1</hk2.version> <!-- The HK2 version should match the version being used by Jersey -->
+        <jackson.version>2.13.4</jackson.version>
+        <jadconfig.version>0.14.0</jadconfig.version>
         <jackson.version>2.9.10.20200411</jackson.version>
         <jadconfig.version>0.14.0</jadconfig.version>
         <java-semver.version>0.9.0</java-semver.version>

--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
         <HdrHistogram.version>2.1.12</HdrHistogram.version>
         <hibernate-validator.version>6.1.2.Final</hibernate-validator.version>
         <hk2.version>2.6.1</hk2.version> <!-- The HK2 version should match the version being used by Jersey -->
-        <jackson.version>2.13.4</jackson.version>
+        <jackson.version>2.13.4.20221013</jackson.version>
         <jadconfig.version>0.14.0</jadconfig.version>
         <java-semver.version>0.9.0</java-semver.version>
         <javax.annotation-api.version>1.3.2</javax.annotation-api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -119,8 +119,6 @@
         <hk2.version>2.6.1</hk2.version> <!-- The HK2 version should match the version being used by Jersey -->
         <jackson.version>2.13.4</jackson.version>
         <jadconfig.version>0.14.0</jadconfig.version>
-        <jackson.version>2.9.10.20200411</jackson.version>
-        <jadconfig.version>0.14.0</jadconfig.version>
         <java-semver.version>0.9.0</java-semver.version>
         <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
         <javax.el-api.version>3.0.0</javax.el-api.version>


### PR DESCRIPTION
Upgrade to the current Jackson version 2.13.4, while keeping everything else unchanged (as much as possible).
https://github.com/Graylog2/graylog-plugin-enterprise/issues/3674

**Details**

- If configuration of `ObjectMapper` is modified after first usage, changes may or may not take effect, and configuration calls themselves may fail [[link](https://fasterxml.github.io/jackson-databind/javadoc/2.13/com/fasterxml/jackson/databind/ObjectMapper.html)]. This behavior appears to have changed since version 2.9. It only affects a few tests which attempt to modify the mapper:
_graylog2-server/src/test/java/org/graylog/events/contentpack/facade/EventDefinitionFacadeTest.java
graylog2-server/src/test/java/org/graylog/events/contentpack/facade/NotificationFacadeTest.java_

- `DateTimeFormatter` now throws an exception for empty string, resulting in a JSON missing node that needs to be handled:
_graylog2-server/src/main/java/org/graylog/plugins/beats/Beats2Codec.java_

- Jackson 2.11 changed the default `DateTime` formatting for timezone offset to `hh:mm` instead of `hhmm` [[link](https://github.com/FasterXML/jackson-databind/issues/2643)]. We need to explicitly set the legacy format in the `ObjectMapper`.
_graylog2-server/src/main/java/org/graylog2/shared/bindings/providers/ObjectMapperProvider.java
graylog2-server/src/test/java/org/graylog/plugins/views/migrations/V20200204122000_MigrateUntypedViewsToDashboardsTest.java
graylog2-server/src/test/java/org/graylog2/jackson/MongoJodaDateTimeSerializerTest.java
graylog2-server/src/test/java/org/graylog2/jackson/MongoZonedDateTimeSerializerTest.java_

- Jackson no longer includes Joda date/time by default. The Joda module needs to be explicitly registered:
_graylog2-server/src/test/java/org/graylog2/plugin/MessageSummaryTest.java_

/jenkins-pr-deps Graylog2/graylog-plugin-enterprise#4099,Graylog2/graylog-plugin-enterprise-integrations#902