### PR TITLE
Hide rollup checkbox when groupings are deleted.

### DIFF
--- a/graylog2-web-interface/src/views/components/aggregationwizard/AggregationElementSelect.test.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/AggregationElementSelect.test.tsx
@@ -28,6 +28,7 @@ const aggregationElements: Array<AggregationElement> = [
     order: 1,
     allowCreate: () => true,
     component: () => <div />,
+    isEmpty: () => true,
   },
   {
     title: 'Sort',
@@ -35,6 +36,7 @@ const aggregationElements: Array<AggregationElement> = [
     order: 1,
     allowCreate: () => false,
     component: () => <div />,
+    isEmpty: () => true,
   },
 ];
 

--- a/graylog2-web-interface/src/views/components/aggregationwizard/AggregationElementSelect.test.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/AggregationElementSelect.test.tsx
@@ -21,15 +21,15 @@ import userEvent from '@testing-library/user-event';
 import AggregationElementSelect from './AggregationElementSelect';
 import type { AggregationElement } from './AggregationElementType';
 
-const aggregationElements: Array<AggregationElement> = [
+const aggregationElements = [
   {
     title: 'Metric',
-    key: 'metric',
+    key: 'metrics',
     order: 1,
     allowCreate: () => true,
     component: () => <div />,
     isEmpty: () => true,
-  },
+  } as AggregationElement<'metrics'>,
   {
     title: 'Sort',
     key: 'sort',
@@ -37,7 +37,7 @@ const aggregationElements: Array<AggregationElement> = [
     allowCreate: () => false,
     component: () => <div />,
     isEmpty: () => true,
-  },
+  } as AggregationElement<'sort'>,
 ];
 
 describe('AggregationElementSelect', () => {
@@ -53,7 +53,7 @@ describe('AggregationElementSelect', () => {
     await userEvent.click(await screen.findByRole('menuitem', { name: 'Metric' }));
 
     expect(onSelectMock).toHaveBeenCalledTimes(1);
-    expect(onSelectMock).toHaveBeenCalledWith('metric');
+    expect(onSelectMock).toHaveBeenCalledWith('metrics');
   });
 
   it('should not list already configured aggregation elements which can not be configured multiple times', async () => {

--- a/graylog2-web-interface/src/views/components/aggregationwizard/AggregationElementSelect.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/AggregationElementSelect.tsx
@@ -22,7 +22,7 @@ import type { AggregationElement } from './AggregationElementType';
 import type { WidgetConfigFormValues } from './WidgetConfigForm';
 
 type Props = {
-  aggregationElements: Array<AggregationElement>,
+  aggregationElements: Array<AggregationElement<keyof WidgetConfigFormValues>>,
   formValues: WidgetConfigFormValues,
   onSelect: (elementKey: string) => void,
 }

--- a/graylog2-web-interface/src/views/components/aggregationwizard/AggregationElementType.ts
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/AggregationElementType.ts
@@ -21,10 +21,10 @@ import type AggregationWidgetConfig from 'views/logic/aggregationbuilder/Aggrega
 
 import type { WidgetConfigFormValues, WidgetConfigValidationErrors } from './WidgetConfigForm';
 
-export type AggregationElement = {
+export type AggregationElement<T extends keyof WidgetConfigFormValues> = {
   sectionTitle?: string,
   title: string,
-  key: string,
+  key: keyof WidgetConfigFormValues,
   allowCreate: (formValues: WidgetConfigFormValues) => boolean,
   order: number,
   onRemove?: (index: number, formValues: WidgetConfigFormValues) => WidgetConfigFormValues,
@@ -32,7 +32,7 @@ export type AggregationElement = {
   fromConfig?: (config: AggregationWidgetConfig) => Partial<WidgetConfigFormValues>,
   onCreate?: (formValues: WidgetConfigFormValues) => WidgetConfigFormValues,
   onDeleteAll?: (formValues: WidgetConfigFormValues) => WidgetConfigFormValues,
-  isEmpty: (formValues: WidgetConfigFormValues) => boolean,
+  isEmpty: (formValues: WidgetConfigFormValues[T]) => boolean,
   component: React.ComponentType<{
     config: AggregationWidgetConfig,
     onConfigChange: (newConfig: AggregationWidgetConfig) => void

--- a/graylog2-web-interface/src/views/components/aggregationwizard/AggregationElementType.ts
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/AggregationElementType.ts
@@ -32,6 +32,7 @@ export type AggregationElement = {
   fromConfig?: (config: AggregationWidgetConfig) => Partial<WidgetConfigFormValues>,
   onCreate?: (formValues: WidgetConfigFormValues) => WidgetConfigFormValues,
   onDeleteAll?: (formValues: WidgetConfigFormValues) => WidgetConfigFormValues,
+  isEmpty: (formValues: WidgetConfigFormValues) => boolean,
   component: React.ComponentType<{
     config: AggregationWidgetConfig,
     onConfigChange: (newConfig: AggregationWidgetConfig) => void

--- a/graylog2-web-interface/src/views/components/aggregationwizard/AggregationWizard.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/AggregationWizard.tsx
@@ -26,7 +26,7 @@ import ElementsConfiguration from './ElementsConfiguration';
 import aggregationElements from './aggregationElementDefinitions';
 import VisualizationContainer from './VisualizationContainer';
 
-const aggregationElementsByKey = Object.fromEntries(aggregationElements.map((element) => ([element.key, element])));
+const aggregationElementsByKey = Object.fromEntries(aggregationElements.map((element) => [element.key, element]));
 
 const _initialFormValues = (config: AggregationWidgetConfig) => {
   return aggregationElements.reduce((formValues, element) => ({

--- a/graylog2-web-interface/src/views/components/aggregationwizard/ElementsConfiguration.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/ElementsConfiguration.tsx
@@ -16,7 +16,6 @@
  */
 import * as React from 'react';
 import { useFormikContext } from 'formik';
-import { isEmpty } from 'lodash';
 import styled from 'styled-components';
 
 import type AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
@@ -70,15 +69,14 @@ const ElementsConfiguration = ({ aggregationElementsByKey, config, onConfigChang
       )}>
         <div>
           {_sortConfiguredElements(values, aggregationElementsByKey).map(([elementKey, elementFormValues]) => {
-            const empty = isEmpty(elementFormValues);
-
             const aggregationElement = aggregationElementsByKey[elementKey];
 
             if (!aggregationElement) {
               throw new Error(`Aggregation element with key ${elementKey} is missing but configured for this widget.`);
             }
 
-            const ConfigurationSection = aggregationElement.component;
+            const { component: ConfigurationSection, isEmpty } = aggregationElement;
+            const empty = isEmpty(elementFormValues);
 
             return (
               <ElementConfigurationSection allowCreate={aggregationElement.allowCreate(values)}

--- a/graylog2-web-interface/src/views/components/aggregationwizard/ElementsConfiguration.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/ElementsConfiguration.tsx
@@ -34,9 +34,9 @@ const Container = styled.div`
 
 const _sortConfiguredElements = (
   values: WidgetConfigFormValues,
-  aggregationElementsByKey: { [elementKey: string]: AggregationElement },
+  aggregationElementsByKey: { [k: string]: AggregationElement<keyof WidgetConfigFormValues> },
 ) => Object.keys(aggregationElementsByKey)
-  .map((elementKey) => [elementKey, values[aggregationElementsByKey[elementKey].key]])
+  .map((elementKey: keyof WidgetConfigFormValues) => [elementKey, values[aggregationElementsByKey[elementKey].key]] as [keyof WidgetConfigFormValues, WidgetConfigFormValues[keyof WidgetConfigFormValues]])
   .sort(
     ([elementKey1], [elementKey2]) => (
       aggregationElementsByKey[elementKey1].order - aggregationElementsByKey[elementKey2].order
@@ -44,7 +44,7 @@ const _sortConfiguredElements = (
   );
 
 type Props = {
-  aggregationElementsByKey: { [elementKey: string]: AggregationElement }
+  aggregationElementsByKey: { [k: string]: AggregationElement<keyof WidgetConfigFormValues> },
   config: AggregationWidgetConfig,
   onConfigChange: (config: AggregationWidgetConfig) => void,
   onCreate: (

--- a/graylog2-web-interface/src/views/components/aggregationwizard/grouping/GroupingElement.ts
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/grouping/GroupingElement.ts
@@ -258,6 +258,7 @@ const GroupByElement: AggregationElement = {
   toConfig: (formValues: WidgetConfigFormValues, configBuilder: AggregationWidgetConfigBuilder) => groupByToConfig(formValues.groupBy, configBuilder),
   component: GroupingsConfiguration,
   validate: validateGroupings,
+  isEmpty: (formValues: WidgetConfigFormValues) => (formValues?.groupBy?.groupings ?? []).length === 0,
 };
 
 export default GroupByElement;

--- a/graylog2-web-interface/src/views/components/aggregationwizard/grouping/GroupingElement.ts
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/grouping/GroupingElement.ts
@@ -207,7 +207,7 @@ export const createEmptyGrouping = () => addRandomId<ValuesGrouping>({
   },
 });
 
-const GroupByElement: AggregationElement = {
+const GroupByElement: AggregationElement<'groupBy'> = {
   sectionTitle: 'Group By',
   title: 'Grouping',
   key: 'groupBy',
@@ -258,7 +258,7 @@ const GroupByElement: AggregationElement = {
   toConfig: (formValues: WidgetConfigFormValues, configBuilder: AggregationWidgetConfigBuilder) => groupByToConfig(formValues.groupBy, configBuilder),
   component: GroupingsConfiguration,
   validate: validateGroupings,
-  isEmpty: (formValues: WidgetConfigFormValues) => (formValues?.groupBy?.groupings ?? []).length === 0,
+  isEmpty: (formValues: WidgetConfigFormValues['groupBy']) => (formValues?.groupings ?? []).length === 0,
 };
 
 export default GroupByElement;

--- a/graylog2-web-interface/src/views/components/aggregationwizard/grouping/GroupingsConfiguration.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/grouping/GroupingsConfiguration.tsx
@@ -69,7 +69,7 @@ const GroupingsConfiguration = () => {
     setValues(GroupingElement.onRemove(index, values));
   }, [setValues, values]);
 
-  const isEmpty = groupBy?.groupings?.length === 0 ?? true;
+  const isEmpty = (groupBy?.groupings ?? []).length === 0;
 
   const hasValuesRowPivots = groupBy?.groupings?.find(({ direction, field }) => (direction === 'row' && field?.type === 'values')) !== undefined;
   const hasValuesColumnPivots = groupBy?.groupings?.find(({ direction, field }) => (direction === 'column' && field?.type === 'values')) !== undefined;

--- a/graylog2-web-interface/src/views/components/aggregationwizard/grouping/GroupingsConfiguration.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/grouping/GroupingsConfiguration.tsx
@@ -64,7 +64,7 @@ const GroupingsConfiguration = () => {
     setValues(GroupingElement.onRemove(index, values));
   }, [setValues, values]);
 
-  const isEmpty = !groupBy?.groupings;
+  const isEmpty = groupBy?.groupings?.length === 0 ?? true;
 
   const hasValuesRowPivots = groupBy?.groupings?.find(({ direction, field }) => (direction === 'row' && field?.type === 'values')) !== undefined;
   const hasValuesColumnPivots = groupBy?.groupings?.find(({ direction, field }) => (direction === 'column' && field?.type === 'values')) !== undefined;

--- a/graylog2-web-interface/src/views/components/aggregationwizard/grouping/GroupingsConfiguration.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/grouping/GroupingsConfiguration.tsx
@@ -98,7 +98,7 @@ const GroupingsConfiguration = () => {
             <Field name="groupBy.columnRollup">
               {({ field: { name, onChange, value } }) => (
                 <RollupColumnsCheckbox onChange={() => onChange({ target: { name, value: !groupBy?.columnRollup } })}
-                                       checked={value}
+                                       checked={value ?? false}
                                        disabled={disableColumnRollup}>
                   <RollupColumnsLabel>
                     Rollup Columns

--- a/graylog2-web-interface/src/views/components/aggregationwizard/grouping/GroupingsConfiguration.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/grouping/GroupingsConfiguration.tsx
@@ -39,7 +39,12 @@ const RollupColumnsLabel = styled.div`
   align-items: center;
 `;
 
-const RollupHoverForHelp = styled((props) => <HoverForHelp {...props} />)`
+type RollupHoverForHelpProps = {
+  children: React.ReactNode,
+  title: string,
+};
+
+const RollupHoverForHelp = styled((props: RollupHoverForHelpProps) => <HoverForHelp {...props} />)`
   margin-left: 5px;
 `;
 

--- a/graylog2-web-interface/src/views/components/aggregationwizard/metric/MetricElement.ts
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/metric/MetricElement.ts
@@ -108,6 +108,7 @@ const MetricElement: AggregationElement = {
   })),
   component: MetricsConfiguration,
   validate: validateMetrics,
+  isEmpty: (formValues: WidgetConfigFormValues) => (formValues?.metrics ?? []).length === 0,
 };
 
 export default MetricElement;

--- a/graylog2-web-interface/src/views/components/aggregationwizard/metric/MetricElement.ts
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/metric/MetricElement.ts
@@ -91,7 +91,7 @@ const seriesToMetrics = (series: Array<Series>) => series.map((s: Series) => {
   return metric;
 });
 
-const MetricElement: AggregationElement = {
+const MetricElement: AggregationElement<'metrics'> = {
   sectionTitle: 'Metrics',
   title: 'Metric',
   key: 'metrics',
@@ -108,7 +108,7 @@ const MetricElement: AggregationElement = {
   })),
   component: MetricsConfiguration,
   validate: validateMetrics,
-  isEmpty: (formValues: WidgetConfigFormValues) => (formValues?.metrics ?? []).length === 0,
+  isEmpty: (formValues: WidgetConfigFormValues['metrics']) => (formValues ?? []).length === 0,
 };
 
 export default MetricElement;

--- a/graylog2-web-interface/src/views/components/aggregationwizard/sort/SortElement.ts
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/sort/SortElement.ts
@@ -92,7 +92,7 @@ const formValueTypeToConfigType = (type: 'groupBy' | 'metric') => {
   }
 };
 
-const SortElement: AggregationElement = {
+const SortElement: AggregationElement<'sort'> = {
   title: 'Sort',
   key: 'sort',
   order: 3,
@@ -119,7 +119,7 @@ const SortElement: AggregationElement = {
     sort: formValues.sort.filter((_value, i) => index !== i),
   })),
   validate: validateSorts,
-  isEmpty: (formValues: WidgetConfigFormValues) => (formValues?.sort ?? []).length === 0,
+  isEmpty: (formValues: WidgetConfigFormValues['sort']) => (formValues ?? []).length === 0,
 };
 
 export default SortElement;

--- a/graylog2-web-interface/src/views/components/aggregationwizard/sort/SortElement.ts
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/sort/SortElement.ts
@@ -119,6 +119,7 @@ const SortElement: AggregationElement = {
     sort: formValues.sort.filter((_value, i) => index !== i),
   })),
   validate: validateSorts,
+  isEmpty: (formValues: WidgetConfigFormValues) => (formValues?.sort ?? []).length === 0,
 };
 
 export default SortElement;

--- a/graylog2-web-interface/src/views/components/aggregationwizard/visualization/VisualizationElement.ts
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/visualization/VisualizationElement.ts
@@ -101,7 +101,7 @@ const validate = (formValues: WidgetConfigFormValues) => {
     : {};
 };
 
-const VisualizationElement: AggregationElement = {
+const VisualizationElement: AggregationElement<'visualization'> = {
   title: 'Visualization',
   key: 'visualization',
   order: 4,

--- a/graylog2-web-interface/src/views/components/aggregationwizard/visualization/VisualizationElement.ts
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/visualization/VisualizationElement.ts
@@ -110,6 +110,7 @@ const VisualizationElement: AggregationElement = {
   fromConfig,
   toConfig,
   validate,
+  isEmpty: () => false,
 };
 
 export default VisualizationElement;


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Prior to this PR, when deleting the last grouping in the aggregation builder, the rollup checkbox was still shown. This PR is fixing this.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.