### PR TITLE
Ensure message details do not scroll over message table header.

### DIFF
--- a/graylog2-web-interface/src/views/components/widgets/MessageTable.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageTable.tsx
@@ -83,6 +83,7 @@ const TableHead = styled.thead(({ theme }) => css`
   color: ${theme.utils.readableColor(theme.colors.gray[90])};
   position: sticky;
   top: 0;
+  z-index: 1;
   
   && > tr > th {
     min-width: 50px;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

When opening the message details of a message in the message table widget, they can scroll over the message table header:
![image](https://user-images.githubusercontent.com/46300478/193054635-af7caeff-3904-4c03-a480-44c572edbe02.png)

This can be fixed easily by changing the header `z-index`.
