### PR TITLE
Fix mobile menu collapse behavior

### DIFF
--- a/graylog2-web-interface/src/components/navigation/Navigation.tsx
+++ b/graylog2-web-interface/src/components/navigation/Navigation.tsx
@@ -131,7 +131,7 @@ const Navigation = React.memo(({ pathname }: Props) => {
   const pluginItems = PluginStore.exports('navigationItems');
 
   return (
-    <StyledNavbar fluid fixedTop>
+    <StyledNavbar fluid fixedTop collapseOnSelect>
       <Navbar.Header>
         <Navbar.Brand>
           <LinkContainer relativeActive to={Routes.STARTPAGE}>
@@ -142,9 +142,8 @@ const Navigation = React.memo(({ pathname }: Props) => {
         <DevelopmentHeaderBadge smallScreen />
         {pluginItems.map(({ key, component: Item }) => <Item key={key} smallScreen />)}
       </Navbar.Header>
-
       <Navbar.Collapse>
-        <Nav navbar className="navbar-main">
+        <Nav className="navbar-main">
           <LinkContainer relativeActive to={Routes.SEARCH}>
             <NavItem to="search">Search</NavItem>
           </LinkContainer>
@@ -168,7 +167,7 @@ const Navigation = React.memo(({ pathname }: Props) => {
 
         <NotificationBadge />
 
-        <Nav navbar pullRight className="header-meta-nav">
+        <Nav pullRight className="header-meta-nav">
           {AppConfig.isCloud() ? (
             <GlobalThroughput disabled />
           ) : (


### PR DESCRIPTION
This is a simple UI improvement when our mobile navigation menu is clicked it should auto-collapse.

## Description
- `Navbar` component was missing the collapseOnSelect Prop
- The `Nav` components had the `navbar` prop which is added by default when using `Nav` inside `Navbar`

## Motivation and Context
Quality of life improvement.

## How Has This Been Tested?
This was tested locally.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

