### PR TITLE
Use BouncyCastle provider in AESTools (#13580)

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/security/AESTools.java
+++ b/graylog2-server/src/main/java/org/graylog2/security/AESTools.java
@@ -17,6 +17,7 @@
 package org.graylog2.security;
 
 import org.apache.shiro.codec.Hex;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.cryptomator.siv.SivMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,6 +38,11 @@ public class AESTools {
 
     private static final SivMode SIV_MODE = new SivMode();
 
+    // We use the Bouncy Castle provider to ensure the availability of the ISO10126 padding on FIPS enabled JVM
+    // environments. See: https://github.com/Graylog2/graylog2-server/issues/13525
+    private static final BouncyCastleProvider CIPHER_PROVIDER = new BouncyCastleProvider();
+    private static final String CIPHER_TRANSFORMATION = "AES/CBC/ISO10126Padding";
+
     /**
      * Encrypt the given plain text value with the given encryption key and salt using AES CBC.
      * If the supplied encryption key is not of 16, 24 or 32 bytes length, it will be truncated or padded to the next
@@ -54,7 +60,7 @@ public class AESTools {
         checkNotNull(salt, "Salt must not be null.");
         try {
             @SuppressWarnings("CIPHER_INTEGRITY")
-            Cipher cipher = Cipher.getInstance("AES/CBC/ISO10126Padding", "SunJCE");
+            Cipher cipher = Cipher.getInstance(CIPHER_TRANSFORMATION, CIPHER_PROVIDER);
             SecretKeySpec key = new SecretKeySpec(adjustToIdealKeyLength(encryptionKey), "AES");
             cipher.init(Cipher.ENCRYPT_MODE, key, new IvParameterSpec(salt.getBytes("UTF-8")));
             return Hex.encodeToString(cipher.doFinal(plainText.getBytes("UTF-8")));
@@ -82,7 +88,7 @@ public class AESTools {
         checkNotNull(salt, "Salt must not be null.");
         try {
             @SuppressWarnings("CIPHER_INTEGRITY")
-            Cipher cipher = Cipher.getInstance("AES/CBC/ISO10126Padding", "SunJCE");
+            Cipher cipher = Cipher.getInstance(CIPHER_TRANSFORMATION, CIPHER_PROVIDER);
             SecretKeySpec key = new SecretKeySpec(adjustToIdealKeyLength(encryptionKey), "AES");
             cipher.init(Cipher.DECRYPT_MODE, key, new IvParameterSpec(salt.getBytes("UTF-8")));
             return new String(cipher.doFinal(Hex.decode(cipherText)), "UTF-8");

--- a/graylog2-server/src/test/java/org/graylog2/security/AESToolsTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/security/AESToolsTest.java
@@ -39,6 +39,19 @@ public class AESToolsTest {
     }
 
     @Test
+    public void testDecryptStaticCipherText() {
+        // The cipherText was encrypted using an AES/CBC/ISO10126Padding transformation.
+        // If this test fails, we changed the transformation. If the change was intentional, this test must
+        // be updated, and we need to create a migration to re-encrypt all existing secrets in the database.
+        // Otherwise, existing secrets cannot be decrypted anymore!
+        final String cipherText = "374219db59516b706234a60dd9a7e1e2";
+        final String salt = "53569ac046df1097";
+
+        final String decrypt = AESTools.decrypt(cipherText, "1234567890123456", salt);
+        Assert.assertEquals("I am secret", decrypt);
+    }
+
+    @Test
     public void testEncryptDecryptWithKeyBeingLargerThan32Bytes() {
         byte[] iv = new byte[8];
         new SecureRandom().nextBytes(iv);


### PR DESCRIPTION
Using the Bouncy Castle provider fixes problems in FIPS-enabled JVM environments where the "SunJCE" provider is not present, and the other available providers don't implement the "ISO10126Padding" transformation for "AES/CBC".

Fixes #13525

(cherry picked from commit 3703435c948f197e95d60ab94eddb828a16eb2bc)