### PR TITLE
Add focus to metrics field. Add sticky header

### DIFF
--- a/graylog2-web-interface/src/components/common/Select/Select.tsx
+++ b/graylog2-web-interface/src/components/common/Select/Select.tsx
@@ -223,6 +223,7 @@ export type Props<OptionValue> = {
   delimiter?: string,
   disabled?: boolean,
   displayKey: string,
+  forwardedRef?: React.Ref<React.ComponentType>,
   id?: string,
   ignoreAccents?: boolean,
   inputId?: string,
@@ -411,6 +412,7 @@ class Select<OptionValue> extends React.Component<Props<OptionValue>, State> {
     loadOptions: undefined,
     // ref: undefined,
     menuPortalTarget: undefined,
+    forwardedRef: undefined,
   };
 
   constructor(props: Props<OptionValue>) {
@@ -600,10 +602,10 @@ class Select<OptionValue> extends React.Component<Props<OptionValue>, State> {
     };
 
     if (allowCreate) {
-      return <CreatableSelect {...selectProps} />;
+      return <CreatableSelect ref={rest.forwardedRef} {...selectProps} />;
     }
 
-    return <ReactSelect {...selectProps} />;
+    return <ReactSelect ref={rest.forwardedRef} {...selectProps} />;
   }
 }
 

--- a/graylog2-web-interface/src/views/components/aggregationwizard/ElementConfigurationSection.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/ElementConfigurationSection.tsx
@@ -67,8 +67,11 @@ const Header = styled.div(({ theme, $isEmpty }: { theme: DefaultTheme, $isEmpty:
   margin-bottom: 1px;
   min-height: 26px;
   font-weight: bold;
-  position: relative;
-
+  background-color: ${theme.colors.global.contentBackground};
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  
   ::before {
     content: ' ';
     top: 50%;

--- a/graylog2-web-interface/src/views/components/aggregationwizard/FieldSelect.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/FieldSelect.tsx
@@ -34,11 +34,12 @@ type Props = {
   name: string,
   onChange: (changeEvent: { target: { name: string, value: string } }) => void,
   value: string | undefined,
+  selectRef: React.Ref<React.ComponentType>
 }
 
 const sortByLabel = ({ label: label1 }: { label: string }, { label: label2 }: { label: string }) => defaultCompare(label1, label2);
 
-const FieldSelect = ({ name, id, error, clearable, value, onChange, label, ariaLabel }: Props) => {
+const FieldSelect = ({ name, id, error, clearable, value, onChange, label, ariaLabel, selectRef }: Props) => {
   const { activeQuery } = useStore(ViewMetadataStore);
   const fieldTypes = useContext(FieldTypesContext);
   const fieldTypeOptions = useMemo(() => fieldTypes.queryFields
@@ -55,6 +56,8 @@ const FieldSelect = ({ name, id, error, clearable, value, onChange, label, ariaL
            labelClassName="col-sm-3"
            wrapperClassName="col-sm-9">
       <Select options={fieldTypeOptions}
+              inputId={`select-${id}`}
+              forwardedRef={selectRef}
               clearable={clearable}
               name={name}
               value={value}

--- a/graylog2-web-interface/src/views/components/aggregationwizard/FieldSelect.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/FieldSelect.tsx
@@ -34,7 +34,7 @@ type Props = {
   name: string,
   onChange: (changeEvent: { target: { name: string, value: string } }) => void,
   value: string | undefined,
-  selectRef: React.Ref<React.ComponentType>
+  selectRef?: React.Ref<React.ComponentType>
 }
 
 const sortByLabel = ({ label: label1 }: { label: string }, { label: label2 }: { label: string }) => defaultCompare(label1, label2);
@@ -74,6 +74,7 @@ FieldSelect.defaultProps = {
   clearable: false,
   error: undefined,
   ariaLabel: undefined,
+  selectRef: undefined,
 };
 
 export default FieldSelect;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR set focus on metric field input after selecting the metrics function. 
Also adds a sticky header to  ElementConfigurationSection, this will help the user to add new fields faster and also to understand in which section the user is when there are a lot of fields 

## Motivation and Context
fix: [#12969](https://github.com/Graylog2/graylog2-server/issues/12969)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

