### PR TITLE
Fix auto completions for dark mode

### DIFF
--- a/graylog2-web-interface/src/theme/GlobalThemeStyles.js
+++ b/graylog2-web-interface/src/theme/GlobalThemeStyles.js
@@ -130,7 +130,7 @@ const GlobalThemeStyles = createGlobalStyle(({ theme }) => css`
       border-color: ${theme.colors.input.borderFocus};
       box-shadow: ${theme.colors.input.boxShadow};
     }
-    
+
     &[disabled],
     &[readonly],
     fieldset[disabled] & {
@@ -138,7 +138,7 @@ const GlobalThemeStyles = createGlobalStyle(({ theme }) => css`
       color: ${theme.colors.input.colorDisabled};
     }
   }
-  
+
   textarea {
     max-width: 100%;
   }
@@ -587,12 +587,12 @@ const GlobalThemeStyles = createGlobalStyle(({ theme }) => css`
     vertical-align: middle;
     width: auto;
   }
-  
+
   .typeahead-wrapper .tt-menu {
     background-color: ${theme.colors.global.contentBackground};
     box-shadow: 0 3px 3px ${theme.colors.global.navigationBoxShadow};
     color: ${theme.colors.global.textDefault};
-    
+
     .tt-suggestion:hover,
     .tt-suggestion.tt-cursor {
       color: ${theme.colors.variant.darkest.info};
@@ -605,7 +605,7 @@ const GlobalThemeStyles = createGlobalStyle(({ theme }) => css`
     display: inline-block;
     margin: 0;
   }
-  
+
   .form-control-feedback {
     line-height: inherit;
     display: flex;
@@ -673,6 +673,17 @@ const GlobalThemeStyles = createGlobalStyle(({ theme }) => css`
   .ace_editor.ace_autocomplete.ace-queryinput {
     width: 600px !important;
     margin-top: 6px;
+    background-color: ${theme.colors.input.background};
+    color: ${theme.colors.input.color};
+  }
+
+  .ace_editor.ace_autocomplete .ace_marker-layer .ace_active-line {
+    background-color: ${theme.utils.opacify(theme.colors.variant.info, 0.70)};
+    color: ${theme.colors.input.colorDisabled};
+  }
+
+  .ace_editor.ace_autocomplete .ace_text-layer .ace_completion-highlight {
+    color: ${theme.colors.variant.info};
   }
 
   code {
@@ -685,7 +696,7 @@ const GlobalThemeStyles = createGlobalStyle(({ theme }) => css`
     background-color: ${theme.colors.variant.lightest.default};
     border-color: ${theme.colors.variant.lighter.default};
   }
-  
+
   input[type="range"],
   input[type="range"]:focus {
     box-shadow: none;

--- a/graylog2-web-interface/src/theme/utils/opacify.ts
+++ b/graylog2-web-interface/src/theme/utils/opacify.ts
@@ -16,11 +16,9 @@
  */
 import chroma from 'chroma-js';
 
-export type Opacify = {
-  (string, number): string,
-};
+export type Opacify = (color: string, amount:number) => string;
 
-function opacify(color: string, amount: number): string {
+const opacify: Opacify = (color, amount) => {
   /**
    * Increases the opacity of a color. Its range for the amount is between 0 to 1.
    *
@@ -33,9 +31,14 @@ function opacify(color: string, amount: number): string {
   }
 
   const parsedAlpha = chroma(color).alpha();
-  const newAlpha = (parsedAlpha * 100 + amount * 100) / 100;
+
+  /*
+   * NOTE: the reason for the over complication of the math is to account for rounding issues.
+   * example: without the multiplier and divisor 1 - .7 returns 0.30000000000000004
+  */
+  const newAlpha = ((parsedAlpha * 100) - (amount * 100)) / 100;
 
   return chroma(color).alpha(newAlpha).css();
-}
+};
 
 export default opacify;


### PR DESCRIPTION
Issue #13101 Fix auto-complete/suggestions to be consistent in dark mode.

## Description
- Updated `GlobalThemeStyles.js` to override default styles and use our theme object
- Updated opacify util to function properly
- Removed unused type from Opacify (looked incorrect as it was)

## Motivation and Context
Inconsistent UI in dark mode for our ACE editor auto-complete/suggestions

## How Has This Been Tested?
Tested locally

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/3578720/194096067-9cb11b83-2fdc-4408-af18-168bdf776635.png)
![image (1)](https://user-images.githubusercontent.com/3578720/194096389-e190cad6-224a-436e-9c93-c1c8ae8188e1.png)


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

