### PR TITLE
Use collector DB ID instead of entity ID when creating Sidecar Configs

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/SidecarCollectorConfigurationFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/SidecarCollectorConfigurationFacade.java
@@ -23,6 +23,7 @@ import com.google.common.graph.Graph;
 import com.google.common.graph.GraphBuilder;
 import com.google.common.graph.ImmutableGraph;
 import com.google.common.graph.MutableGraph;
+import org.graylog.plugins.sidecar.rest.models.Collector;
 import org.graylog.plugins.sidecar.rest.models.Configuration;
 import org.graylog.plugins.sidecar.services.ConfigurationService;
 import org.graylog2.contentpacks.EntityDescriptorIds;
@@ -37,6 +38,7 @@ import org.graylog2.contentpacks.model.entities.NativeEntity;
 import org.graylog2.contentpacks.model.entities.NativeEntityDescriptor;
 import org.graylog2.contentpacks.model.entities.SidecarCollectorConfigurationEntity;
 import org.graylog2.contentpacks.model.entities.references.ValueReference;
+import org.graylog2.shared.utilities.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -83,16 +85,24 @@ public class SidecarCollectorConfigurationFacade implements EntityFacade<Configu
                                                           Map<EntityDescriptor, Object> nativeEntities,
                                                           String username) {
         if (entity instanceof EntityV1) {
-            return decode((EntityV1) entity, parameters);
+            return decode((EntityV1) entity, parameters, nativeEntities);
         } else {
             throw new IllegalArgumentException("Unsupported entity version: " + entity.getClass());
         }
     }
 
-    private NativeEntity<Configuration> decode(EntityV1 entity, Map<String, ValueReference> parameters) {
+    private NativeEntity<Configuration> decode(EntityV1 entity, Map<String, ValueReference> parameters, Map<EntityDescriptor, Object> nativeEntities) {
         final SidecarCollectorConfigurationEntity configurationEntity = objectMapper.convertValue(entity.data(), SidecarCollectorConfigurationEntity.class);
+        // Configuration needs to reference the DB ID of the Collector and not the logical ID
+        String collectorEntityId = configurationEntity.collectorId().asString(parameters);
+        String collectorDbId = nativeEntities.entrySet().stream()
+                .filter(entry -> entry.getKey().id().id().equals(collectorEntityId))
+                .map(Map.Entry::getValue)
+                .map(collector -> ((Collector) collector).id())
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException(StringUtils.f("Unable to find database ID of Collector with logical ID [%s]", collectorEntityId)));
         final Configuration configuration = Configuration.create(
-                configurationEntity.collectorId().asString(parameters),
+                collectorDbId,
                 configurationEntity.title().asString(parameters),
                 configurationEntity.color().asString(parameters),
                 configurationEntity.template().asString(parameters));


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Uses the database ID of the collector when recreating SidecarCollectorConfigurations from a Content Pack instead of the logical ID. 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #12778
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Followed steps to recreate the bug and was able to successfully install the referenced content pack after these changes. Installing this [content pack](https://github.com/Graylog2/graylog2-server/files/9736305/recreate-12778-content-pack.json.txt) should make the Sidecar config page inaccessible in the latest master code. After uninstalling the content pack, pulling these changes, and reinstalling the content pack, it should be back viewable.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

