### PR TITLE
Improve styling of row/column limit settings.

### DIFF
--- a/graylog2-web-interface/src/views/components/aggregationwizard/grouping/GroupingsConfiguration.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/grouping/GroupingsConfiguration.tsx
@@ -17,7 +17,7 @@
 import * as React from 'react';
 import { useCallback } from 'react';
 import { useFormikContext, FieldArray, Field } from 'formik';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
 import { HoverForHelp, SortableList, FormikFormGroup } from 'components/common';
 import { Checkbox } from 'components/bootstrap';
@@ -50,6 +50,13 @@ type GroupingsItemProps = Omit<React.ComponentProps<typeof ElementConfigurationC
   /* eslint-enable react/no-unused-prop-types */
 };
 
+const SettingsSeparator = styled.hr(({ theme }) => css`
+  border-style: dashed;
+  border-color: ${theme.colors.variant.lighter.default};
+  margin-top: 5px;
+  margin-bottom: 5px;
+`);
+
 const GroupingsConfiguration = () => {
   const { values: { groupBy }, values, setValues, setFieldValue } = useFormikContext<WidgetConfigFormValues>();
   const disableColumnRollup = !groupBy?.groupings?.find(({ direction }) => direction === 'column');
@@ -77,22 +84,6 @@ const GroupingsConfiguration = () => {
 
   return (
     <>
-      {!isEmpty && (
-        <Field name="groupBy.columnRollup">
-          {({ field: { name, onChange, value } }) => (
-            <RollupColumnsCheckbox onChange={() => onChange({ target: { name, value: !groupBy?.columnRollup } })}
-                                   checked={value}
-                                   disabled={disableColumnRollup}>
-              <RollupColumnsLabel>
-                Rollup Columns
-                <RollupHoverForHelp title="Rollup Columns">
-                  When rollup is enabled, an additional trace totalling individual subtraces will be included.
-                </RollupHoverForHelp>
-              </RollupColumnsLabel>
-            </RollupColumnsCheckbox>
-          )}
-        </Field>
-      )}
       <FieldArray name="groupBy.groupings"
                   validateOnChange={false}
                   render={() => (
@@ -100,21 +91,38 @@ const GroupingsConfiguration = () => {
                                   onMoveItem={(newGroupings) => setFieldValue('groupBy.groupings', newGroupings)}
                                   customListItemRender={GroupingsItem} />
                   )} />
-      {hasValuesRowPivots && (
-        <ElementConfigurationContainer elementTitle="Row Limit">
-          <FormikFormGroup label="Row Limit"
-                           name="groupBy.rowLimit"
-                           type="number"
-                           bsSize="small" />
-        </ElementConfigurationContainer>
-      )}
-      {hasValuesColumnPivots && (
-        <ElementConfigurationContainer elementTitle="Column Limit">
-          <FormikFormGroup label="Column Limit"
-                           name="groupBy.columnLimit"
-                           type="number"
-                           bsSize="small" />
-        </ElementConfigurationContainer>
+      {!isEmpty && (
+        <>
+          <SettingsSeparator />
+          <ElementConfigurationContainer elementTitle="Settings">
+            <Field name="groupBy.columnRollup">
+              {({ field: { name, onChange, value } }) => (
+                <RollupColumnsCheckbox onChange={() => onChange({ target: { name, value: !groupBy?.columnRollup } })}
+                                       checked={value}
+                                       disabled={disableColumnRollup}>
+                  <RollupColumnsLabel>
+                    Rollup Columns
+                    <RollupHoverForHelp title="Rollup Columns">
+                      When rollup is enabled, an additional trace totalling individual subtraces will be included.
+                    </RollupHoverForHelp>
+                  </RollupColumnsLabel>
+                </RollupColumnsCheckbox>
+              )}
+            </Field>
+            {hasValuesRowPivots && (
+            <FormikFormGroup label="Row Limit"
+                             name="groupBy.rowLimit"
+                             type="number"
+                             bsSize="small" />
+            )}
+            {hasValuesColumnPivots && (
+            <FormikFormGroup label="Column Limit"
+                             name="groupBy.columnLimit"
+                             type="number"
+                             bsSize="small" />
+            )}
+          </ElementConfigurationContainer>
+        </>
       )}
     </>
   );


### PR DESCRIPTION
**Note:** This is based on #13855 and requires it to be merged first.
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is improving the styling of the global row/column limit inputs.  It wraps them in a single settings box, together with the rollup checkbox.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/41929/194869564-8b33c031-4156-4a4f-aaab-234df41a6f5c.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.