### PR TITLE
Show in field select if fields are qualified for metric function.

### DIFF
--- a/graylog2-web-interface/src/views/components/aggregationwizard/FieldSelect.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/FieldSelect.tsx
@@ -28,6 +28,7 @@ import { ViewMetadataStore } from 'views/stores/ViewMetadataStore';
 import type { Property } from 'views/logic/fieldtypes/FieldType';
 import type FieldTypeMapping from 'views/logic/fieldtypes/FieldTypeMapping';
 import FieldTypeIcon from 'views/components/sidebar/fields/FieldTypeIcon';
+import type FieldType from 'views/logic/fieldtypes/FieldType';
 
 type Props = {
   ariaLabel?: string,
@@ -59,7 +60,7 @@ const UnqualifiedOption = styled.span(({ theme }) => css`
 type OptionRendererProps = {
   label: string,
   qualified: boolean,
-  type: string,
+  type: FieldType,
 };
 
 const OptionRenderer = ({ label, qualified, type }: OptionRendererProps) => {

--- a/graylog2-web-interface/src/views/components/aggregationwizard/FieldSelect.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/FieldSelect.tsx
@@ -17,6 +17,7 @@
 import * as React from 'react';
 import { useContext, useMemo } from 'react';
 import * as Immutable from 'immutable';
+import styled, { css } from 'styled-components';
 
 import { defaultCompare } from 'logic/DefaultCompare';
 import FieldTypesContext from 'views/components/contexts/FieldTypesContext';
@@ -26,6 +27,7 @@ import { useStore } from 'stores/connect';
 import { ViewMetadataStore } from 'views/stores/ViewMetadataStore';
 import type { Property } from 'views/logic/fieldtypes/FieldType';
 import type FieldTypeMapping from 'views/logic/fieldtypes/FieldTypeMapping';
+import FieldTypeIcon from 'views/components/sidebar/fields/FieldTypeIcon';
 
 type Props = {
   ariaLabel?: string,
@@ -50,15 +52,30 @@ const hasProperty = (fieldType: FieldTypeMapping, properties: Array<Property>) =
     .find((result) => result === false) === undefined;
 };
 
+const UnqualifiedOption = styled.span(({ theme }) => css`
+  color: ${theme.colors.variant.light.default};
+`);
+
+type OptionRendererProps = {
+  label: string,
+  qualified: boolean,
+  type: string,
+};
+
+const OptionRenderer = ({ label, qualified, type }: OptionRendererProps) => {
+  const children = <><FieldTypeIcon type={type} /> {label}</>;
+
+  return qualified ? <span>{children}</span> : <UnqualifiedOption>{children}</UnqualifiedOption>;
+};
+
 const FieldSelect = ({ name, id, error, clearable, value, onChange, label, ariaLabel, selectRef, properties }: Props) => {
   const { activeQuery } = useStore(ViewMetadataStore);
   const fieldTypes = useContext(FieldTypesContext);
   const fieldTypeOptions = useMemo(() => fieldTypes.queryFields
     .get(activeQuery, Immutable.List())
-    .map((fieldType) => ({ label: fieldType.name, value: fieldType.name, disabled: properties ? !hasProperty(fieldType, properties) : false }))
+    .map((fieldType) => ({ label: fieldType.name, value: fieldType.name, type: fieldType.type, qualified: properties ? hasProperty(fieldType, properties) : true }))
     .toArray()
-    .sort(sortByLabel),
-  [activeQuery, fieldTypes.queryFields, properties]);
+    .sort(sortByLabel), [activeQuery, fieldTypes.queryFields, properties]);
 
   return (
     <Input id={id}
@@ -70,9 +87,11 @@ const FieldSelect = ({ name, id, error, clearable, value, onChange, label, ariaL
               inputId={`select-${id}`}
               forwardedRef={selectRef}
               clearable={clearable}
+              placeholder="Select field"
               name={name}
               value={value}
               aria-label={ariaLabel}
+              optionRenderer={OptionRenderer}
               size="small"
               menuPortalTarget={document.body}
               onChange={(newValue: string) => onChange({ target: { name, value: newValue } })} />

--- a/graylog2-web-interface/src/views/components/aggregationwizard/metric/MetricConfiguration.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/metric/MetricConfiguration.tsx
@@ -25,6 +25,7 @@ import { useStore } from 'stores/connect';
 import AggregationFunctionsStore from 'views/stores/AggregationFunctionsStore';
 import type { WidgetConfigFormValues } from 'views/components/aggregationwizard/WidgetConfigForm';
 import { InputOptionalInfo as Opt, FormikInput } from 'components/common';
+import { Properties } from 'views/logic/fieldtypes/FieldType';
 
 import FieldSelect from '../FieldSelect';
 
@@ -49,6 +50,11 @@ const Metric = ({ index }: Props) => {
   const isFieldRequired = currentFunction !== 'count';
 
   const isPercentile = currentFunction === 'percentile';
+  const requiresNumericField = !['card', 'count', 'latest'].includes(currentFunction);
+  const requiredProperties = requiresNumericField
+    ? [Properties.Numeric]
+    : [];
+
   const [functionIsSettled, setFunctionIsSettled] = useState<boolean>(false);
   const onFunctionChange = useCallback((newValue) => {
     setFieldValue(`metrics.${index}.function`, newValue);
@@ -91,6 +97,7 @@ const Metric = ({ index }: Props) => {
                        onChange={onChange}
                        error={error}
                        clearable={!isFieldRequired}
+                       properties={requiredProperties}
                        name={name}
                        value={value}
                        ariaLabel="Select a field" />

--- a/graylog2-web-interface/src/views/components/sidebar/fields/FieldTypeIcon.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/fields/FieldTypeIcon.tsx
@@ -16,6 +16,7 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
+import styled from 'styled-components';
 
 import { Icon } from 'components/common';
 import FieldType from 'views/logic/fieldtypes/FieldType';
@@ -44,16 +45,32 @@ const iconClass = (type: string) => {
   }
 };
 
+const IconWrapper = styled.div`
+  display: inline-flex;
+  min-width: 20px;
+  justify-content: center;
+  align-items: center;
+  vertical-align: -2px;
+`;
+
 type Props = {
   type: FieldType,
+  monospace: boolean,
 };
 
-const FieldTypeIcon = ({ type }: Props) => {
-  return <Icon name={iconClass(type.type)} className={styles.fieldTypeIcon} />;
+const FieldTypeIcon = ({ type, monospace }: Props) => {
+  const icon = <Icon name={iconClass(type.type)} className={styles.fieldTypeIcon} />;
+
+  return monospace ? <IconWrapper>{icon}</IconWrapper> : icon;
 };
 
 FieldTypeIcon.propTypes = {
   type: PropTypes.instanceOf(FieldType).isRequired,
+  monospace: PropTypes.bool,
+};
+
+FieldTypeIcon.defaultProps = {
+  monospace: true,
 };
 
 export default FieldTypeIcon;

--- a/graylog2-web-interface/src/views/components/sidebar/fields/FieldTypeIcon.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/fields/FieldTypeIcon.tsx
@@ -44,7 +44,11 @@ const iconClass = (type: string) => {
   }
 };
 
-const FieldTypeIcon = ({ type }: { type: string }) => {
+type Props = {
+  type: FieldType,
+};
+
+const FieldTypeIcon = ({ type }: Props) => {
   return <Icon name={iconClass(type.type)} className={styles.fieldTypeIcon} />;
 };
 

--- a/graylog2-web-interface/src/views/components/sidebar/fields/FieldTypeIcon.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/fields/FieldTypeIcon.tsx
@@ -22,7 +22,7 @@ import FieldType from 'views/logic/fieldtypes/FieldType';
 
 import styles from './FieldTypeIcon.css';
 
-const iconClass = (type) => {
+const iconClass = (type: string) => {
   switch (type) {
     case 'string':
       return 'font';
@@ -44,7 +44,7 @@ const iconClass = (type) => {
   }
 };
 
-const FieldTypeIcon = ({ type }) => {
+const FieldTypeIcon = ({ type }: { type: string }) => {
   return <Icon name={iconClass(type.type)} className={styles.fieldTypeIcon} />;
 };
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Most of the metric functions of an aggregation require the target field to be numeric. If a non-numeric field is selected, the search is executed but returns an error. 

To aid the user in selecting a qualifying field, this PR is now

  - graying out fields which are non-numeric if a numeric field is requested, but still allows the user to select them
  - shows an icon next to the field name to indicate the field's type

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/41929/194892812-9acb05f8-fb17-4f16-b013-2c85f2f03ef6.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.