### PR TITLE
Backport LockService dependency for issue #1059

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/cluster/lock/LockServiceModule.java
+++ b/graylog2-server/src/main/java/org/graylog2/cluster/lock/LockServiceModule.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.cluster.lock;
+
+import com.google.inject.Scopes;
+import org.graylog2.plugin.PluginModule;
+
+public class LockServiceModule extends PluginModule {
+    @Override
+    protected void configure() {
+        bind(LockService.class).to(MongoLockService.class).in(Scopes.SINGLETON);
+    }
+}


### PR DESCRIPTION
LockServiceModule is required for backporting the fix for `cloud set-license` #1059.