### PR TITLE
Fix empty Sidecar Collector content pack export when optional fields are not provided

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/SidecarCollectorFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/SidecarCollectorFacade.java
@@ -65,10 +65,9 @@ public class SidecarCollectorFacade implements EntityFacade<Collector> {
                 ValueReference.of(collector.serviceType()),
                 ValueReference.of(collector.nodeOperatingSystem()),
                 ValueReference.of(collector.executablePath()),
-                ValueReference.of(collector.executeParameters()),
-                ValueReference.of(collector.validationParameters()),
-                ValueReference.of(collector.defaultTemplate())
-        );
+                collector.executeParameters() != null ? ValueReference.of(collector.executeParameters()) : null,
+                collector.validationParameters() != null ? ValueReference.of(collector.validationParameters()) : null,
+                collector.defaultTemplate() != null ? ValueReference.of(collector.defaultTemplate()) : null);
 
         final JsonNode data = objectMapper.convertValue(collectorEntity, JsonNode.class);
         return EntityV1.builder()

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/SidecarCollectorEntity.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/SidecarCollectorEntity.java
@@ -23,6 +23,8 @@ import com.google.auto.value.AutoValue;
 import org.graylog.autovalue.WithBeanGetter;
 import org.graylog2.contentpacks.model.entities.references.ValueReference;
 
+import javax.annotation.Nullable;
+
 @JsonAutoDetect
 @AutoValue
 @WithBeanGetter
@@ -39,12 +41,15 @@ public abstract class SidecarCollectorEntity {
     @JsonProperty("executable_path")
     public abstract ValueReference executablePath();
 
+    @Nullable
     @JsonProperty("execute_parameters")
     public abstract ValueReference executeParameters();
 
+    @Nullable
     @JsonProperty("validation_parameters")
     public abstract ValueReference validationParameters();
 
+    @Nullable
     @JsonProperty("default_template")
     public abstract ValueReference defaultTemplate();
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixes empty Sidecar Collector content pack export when optional fields are not provided. Discovered while working on/testing https://github.com/Graylog2/graylog2-server/pull/13632#pullrequestreview-1136269088

When exporting a content pack containing a sidecar collector (that has missing optional fields such as `Execute Parameters` or `Parameters for Configuration Validation`), the export to a content pack should be successful.

When the issue would happen, the content pack export appears to be successful, but instead produces a content pack with an empty `entites` array. This error is logged to the server log:

```
java.lang.NullPointerException: Null value
	at org.graylog2.contentpacks.model.entities.references.AutoValue_ValueReference$Builder.value(AutoValue_ValueReference.java:79) ~[classes/:?]
	at org.graylog2.contentpacks.model.entities.references.ValueReference.of(ValueReference.java:224) ~[classes/:?]
	at org.graylog2.contentpacks.facades.SidecarCollectorFacade.exportNativeEntity(SidecarCollectorFacade.java:68) ~[classes/:?]
	at org.graylog2.contentpacks.facades.SidecarCollectorFacade.exportEntity(SidecarCollectorFacade.java:165) ~[classes/:?]
	at org.graylog2.contentpacks.ContentPackService.collectEntities(ContentPackService.java:370) ~[classes/:?]
	at org.graylog2.rest.resources.system.contentpacks.CatalogResource.resolveEntities(CatalogResource.java:77) ~[classes/:?]
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?]
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77) ~[?:?]
	at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
	at java.lang.reflect.Method.invoke(Method.java:568) ~[?:?]
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This will avoid an unexpected empty content pack for users when those optional collector fields are empty.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Exporting a content pack without the optional fields, and verifying that it imports successfully. 

## Screenshots (if appropriate):
Collector page for reference: 
![image](https://user-images.githubusercontent.com/3423655/194912498-d20f37a5-0b58-4f68-a9a4-93a522b9d026.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

