### PR TITLE
Validation of index prefix name length

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/indexset/IndexSetConfig.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indexset/IndexSetConfig.java
@@ -27,6 +27,7 @@ import org.graylog.autovalue.WithBeanGetter;
 import org.graylog2.indexer.MessageIndexTemplateProvider;
 import org.graylog2.plugin.indexer.retention.RetentionStrategyConfig;
 import org.graylog2.plugin.indexer.rotation.RotationStrategyConfig;
+import org.graylog2.validation.SizeInBytes;
 import org.joda.time.Duration;
 import org.mongojack.Id;
 import org.mongojack.ObjectId;
@@ -85,6 +86,7 @@ public abstract class IndexSetConfig implements Comparable<IndexSetConfig> {
     @JsonProperty(FIELD_INDEX_PREFIX)
     @NotBlank
     @Pattern(regexp = INDEX_PREFIX_REGEX)
+    @SizeInBytes(message = "Index prefix must have a length in bytes between {min} and {max}", min = 1, max = 250)
     public abstract String indexPrefix();
 
     @JsonProperty("index_match_pattern")

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/responses/IndexSetSummary.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/responses/IndexSetSummary.java
@@ -24,6 +24,7 @@ import org.graylog.autovalue.WithBeanGetter;
 import org.graylog2.indexer.indexset.IndexSetConfig;
 import org.graylog2.plugin.indexer.retention.RetentionStrategyConfig;
 import org.graylog2.plugin.indexer.rotation.RotationStrategyConfig;
+import org.graylog2.validation.SizeInBytes;
 import org.joda.time.Duration;
 
 import javax.annotation.Nullable;
@@ -61,6 +62,7 @@ public abstract class IndexSetSummary {
 
     @JsonProperty("index_prefix")
     @Pattern(regexp = IndexSetConfig.INDEX_PREFIX_REGEX)
+    @SizeInBytes(message = "Index prefix must have a length in bytes between {min} and {max}", min = 1, max = 250)
     public abstract String indexPrefix();
 
     @JsonProperty("shards")

--- a/graylog2-server/src/main/java/org/graylog2/validation/SizeInBytes.java
+++ b/graylog2-server/src/main/java/org/graylog2/validation/SizeInBytes.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog2.validation;
 
 import javax.validation.Constraint;

--- a/graylog2-server/src/main/java/org/graylog2/validation/SizeInBytes.java
+++ b/graylog2-server/src/main/java/org/graylog2/validation/SizeInBytes.java
@@ -1,0 +1,32 @@
+package org.graylog2.validation;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.CONSTRUCTOR;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE_USE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE})
+@Retention(RUNTIME)
+@Documented
+@Constraint(validatedBy = {SizeInBytesValidator.class})
+public @interface SizeInBytes {
+
+    String message() default "{javax.validation.constraints.Size.message}";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+
+    int min() default 0;
+
+    int max() default Integer.MAX_VALUE;
+}

--- a/graylog2-server/src/main/java/org/graylog2/validation/SizeInBytesValidator.java
+++ b/graylog2-server/src/main/java/org/graylog2/validation/SizeInBytesValidator.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog2.validation;
 
 import javax.validation.ConstraintValidator;

--- a/graylog2-server/src/main/java/org/graylog2/validation/SizeInBytesValidator.java
+++ b/graylog2-server/src/main/java/org/graylog2/validation/SizeInBytesValidator.java
@@ -1,0 +1,27 @@
+package org.graylog2.validation;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import java.nio.charset.StandardCharsets;
+
+public class SizeInBytesValidator implements ConstraintValidator<SizeInBytes, String> {
+    private int min;
+    private int max;
+
+    @Override
+    public void initialize(final SizeInBytes annotation) {
+        this.min = annotation.min();
+        this.max = annotation.max();
+    }
+
+    @Override
+    public boolean isValid(final String object,
+                           final ConstraintValidatorContext constraintContext) {
+        if (object == null) {
+            return true;
+        }
+
+        final int lengthInBytes = object.getBytes(StandardCharsets.UTF_8).length;
+        return lengthInBytes >= this.min && lengthInBytes <= this.max;
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/validation/SizeInBytesValidatorTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/validation/SizeInBytesValidatorTest.java
@@ -19,17 +19,14 @@ package org.graylog2.validation;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
 
 @ExtendWith(MockitoExtension.class)
 class SizeInBytesValidatorTest {
-
-    @Mock
-    SizeInBytes annotation;
 
     SizeInBytesValidator toTest;
 
@@ -45,33 +42,34 @@ class SizeInBytesValidatorTest {
 
     @Test
     void tooShortObjectIsInvalid() {
-        doReturn(3).when(annotation).min();
-        toTest.initialize(annotation);
+        toTest.initialize(mockSizeInBytesAnnotation(3, 1000));
         assertThat(toTest.isValid("oh", null)).isFalse();
     }
 
     @Test
     void tooLongObjectIsInvalid() {
-        doReturn(7).when(annotation).max();
-        toTest.initialize(annotation);
+        toTest.initialize(mockSizeInBytesAnnotation(0, 7));
         assertThat(toTest.isValid("Caramba!", null)).isFalse();
     }
 
     @Test
     void properObjectIsValid() {
-        doReturn(10).when(annotation).max();
-        doReturn(5).when(annotation).min();
-        toTest.initialize(annotation);
+        toTest.initialize(mockSizeInBytesAnnotation(5, 10));
         assertThat(toTest.isValid("Caramba!", null)).isTrue();
     }
 
     @Test
     void validatesByteLengthNotStringLength() {
-        doReturn(10).when(annotation).max();
-        doReturn(5).when(annotation).min();
-        toTest.initialize(annotation);
+        toTest.initialize(mockSizeInBytesAnnotation(5, 10));
         //4 Polish letters used, increasing byte-size by 4 bytes
         assertThat(toTest.isValid("Gżegżółka", null)).isFalse();
+    }
+
+    private SizeInBytes mockSizeInBytesAnnotation(final int minValue, final int maxValue) {
+        final SizeInBytes mock = mock(SizeInBytes.class);
+        doReturn(minValue).when(mock).min();
+        doReturn(maxValue).when(mock).max();
+        return mock;
     }
 
 }

--- a/graylog2-server/src/test/java/org/graylog2/validation/SizeInBytesValidatorTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/validation/SizeInBytesValidatorTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.validation;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.doReturn;
+
+@ExtendWith(MockitoExtension.class)
+class SizeInBytesValidatorTest {
+
+    @Mock
+    SizeInBytes annotation;
+
+    SizeInBytesValidator toTest;
+
+    @BeforeEach
+    void setUp() {
+        toTest = new SizeInBytesValidator();
+    }
+
+    @Test
+    void nullObjectIsValid() {
+        assertThat(toTest.isValid(null, null)).isTrue();
+    }
+
+    @Test
+    void tooShortObjectIsInvalid() {
+        doReturn(3).when(annotation).min();
+        toTest.initialize(annotation);
+        assertThat(toTest.isValid("oh", null)).isFalse();
+    }
+
+    @Test
+    void tooLongObjectIsInvalid() {
+        doReturn(7).when(annotation).max();
+        toTest.initialize(annotation);
+        assertThat(toTest.isValid("Caramba!", null)).isFalse();
+    }
+
+    @Test
+    void properObjectIsValid() {
+        doReturn(10).when(annotation).max();
+        doReturn(5).when(annotation).min();
+        toTest.initialize(annotation);
+        assertThat(toTest.isValid("Caramba!", null)).isTrue();
+    }
+
+    @Test
+    void validatesByteLengthNotStringLength() {
+        doReturn(10).when(annotation).max();
+        doReturn(5).when(annotation).min();
+        toTest.initialize(annotation);
+        //4 Polish letters used, increasing byte-size by 4 bytes
+        assertThat(toTest.isValid("Gżegżółka", null)).isFalse();
+    }
+
+}

--- a/graylog2-server/src/test/java/org/graylog2/validation/SizeInBytesValidatorTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/validation/SizeInBytesValidatorTest.java
@@ -18,17 +18,14 @@ package org.graylog2.validation;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 
-@ExtendWith(MockitoExtension.class)
 class SizeInBytesValidatorTest {
 
-    SizeInBytesValidator toTest;
+    private SizeInBytesValidator toTest;
 
     @BeforeEach
     void setUp() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Both ES and OS require index name to have length (int bytes!) shorter than 255.
Validation has been added for index name prefix, so that it is shorter than 250 in bytes (5 bytes reserved for appended numbers).
Requires fixing #13657 to fully see the benefits of the change.

## Motivation and Context
1. Index name prefix has not been validated so far.
2. Providing too long index prefix name will cause a lot of exceptions.
3. This change may limit a probability of seeing this bug once again - #10187



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

