### PR TITLE
Use typed routes and add streams option to search query route

### DIFF
--- a/graylog2-web-interface/src/components/sidecars/sidecars/SidecarRow.jsx
+++ b/graylog2-web-interface/src/components/sidecars/sidecars/SidecarRow.jsx
@@ -106,7 +106,7 @@ class SidecarRow extends React.Component {
             <LinkContainer to={`${Routes.SYSTEM.SIDECARS.ADMINISTRATION}?node_id=${sidecar.node_id}`}>
               <Button bsSize="xsmall" bsStyle="info">Manage sidecar</Button>
             </LinkContainer>
-            <LinkContainer to={Routes.search_with_query(`gl2_source_collector:${sidecar.node_id}`, 'relative', 604800)}>
+            <LinkContainer to={Routes.search_with_query(`gl2_source_collector:${sidecar.node_id}`, 'relative', { relative: 604800 })}>
               <Button bsSize="xsmall" bsStyle="info">Show messages</Button>
             </LinkContainer>
           </ButtonToolbar>

--- a/graylog2-web-interface/src/routing/Routes.ts
+++ b/graylog2-web-interface/src/routing/Routes.ts
@@ -32,6 +32,14 @@ type RoutesKeywordTimeRange = {
   keyword: string
 };
 type RoutesTimeRange = RoutesRelativeTimeRange | RoutesAbsoluteTimeRange | RoutesKeywordTimeRange;
+type SearchQueryParams = {
+  q: string,
+  relative?: number,
+  from?: string,
+  to?: string,
+  keyword?: string,
+  streams?: string,
+}
 
 const Routes = {
   STARTPAGE: '/',
@@ -170,14 +178,31 @@ const Routes = {
     VIEWID: (id: string) => `${viewsPath}/${id}`,
   },
   EXTENDEDSEARCH: extendedSearchPath,
-  search_with_query: (query: string, rangeType: TimeRangeTypes, timeRange: RoutesTimeRange) => {
+  search_with_query: (query: string, rangeType: TimeRangeTypes, timeRange: RoutesTimeRange, streams?: string[]) => {
     const route = new URI(Routes.SEARCH);
-    const queryParams = {
+    const queryParams: SearchQueryParams = {
       q: query,
     };
 
     if (rangeType && timeRange) {
-      queryParams[rangeType] = timeRange;
+      switch (rangeType) {
+        case 'relative':
+          queryParams.relative = (<RoutesRelativeTimeRange>timeRange).relative;
+          break;
+        case 'absolute':
+          queryParams.from = (<RoutesAbsoluteTimeRange>timeRange).from;
+          queryParams.to = (<RoutesAbsoluteTimeRange>timeRange).to;
+          break;
+        case 'keyword':
+          queryParams.keyword = (<RoutesKeywordTimeRange>timeRange).keyword;
+          break;
+        default:
+          throw new Error(`Invalid range type: ${rangeType}.`);
+      }
+    }
+
+    if (streams) {
+      queryParams.streams = streams.join(',');
     }
 
     route.query(queryParams);


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Refactors the `Routes.search_with_query` function to correctly use `RoutesTimeRange` parameter as well as add support for streams. 

/jenkins-pr-deps Graylog2/graylog-plugin-collector#210
/jenkins-pr-deps Graylog2/graylog-plugin-enterprise#4170
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Though the function parameters required a `RoutesTimeRange` object, the code itself was not using the object and just expecting a number to be passed in. The function also lacked support for streams, which are another valid search query param. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
local dev env using the new function 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

