### PR TITLE
Sidecar Collector: Fix empty content pack export when optional fields are blank (Backport of #13645)

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/SidecarCollectorFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/SidecarCollectorFacade.java
@@ -65,10 +65,9 @@ public class SidecarCollectorFacade implements EntityFacade<Collector> {
                 ValueReference.of(collector.serviceType()),
                 ValueReference.of(collector.nodeOperatingSystem()),
                 ValueReference.of(collector.executablePath()),
-                ValueReference.of(collector.executeParameters()),
-                ValueReference.of(collector.validationParameters()),
-                ValueReference.of(collector.defaultTemplate())
-        );
+                collector.executeParameters() != null ? ValueReference.of(collector.executeParameters()) : null,
+                collector.validationParameters() != null ? ValueReference.of(collector.validationParameters()) : null,
+                ValueReference.of(collector.defaultTemplate()));
 
         final JsonNode data = objectMapper.convertValue(collectorEntity, JsonNode.class);
         return EntityV1.builder()
@@ -98,8 +97,8 @@ public class SidecarCollectorFacade implements EntityFacade<Collector> {
                 .serviceType(collectorEntity.serviceType().asString(parameters))
                 .nodeOperatingSystem(collectorEntity.nodeOperatingSystem().asString(parameters))
                 .executablePath(collectorEntity.executablePath().asString(parameters))
-                .executeParameters(collectorEntity.executeParameters().asString(parameters))
-                .validationParameters(collectorEntity.validationParameters().asString(parameters))
+                .executeParameters(collectorEntity.executeParameters() != null ? collectorEntity.executeParameters().asString(parameters) : null)
+                .validationParameters(collectorEntity.validationParameters() != null ? collectorEntity.validationParameters().asString(parameters) : null)
                 .defaultTemplate(collectorEntity.defaultTemplate().asString(parameters))
                 .build();
 

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/SidecarCollectorEntity.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/SidecarCollectorEntity.java
@@ -23,6 +23,8 @@ import com.google.auto.value.AutoValue;
 import org.graylog.autovalue.WithBeanGetter;
 import org.graylog2.contentpacks.model.entities.references.ValueReference;
 
+import javax.annotation.Nullable;
+
 @JsonAutoDetect
 @AutoValue
 @WithBeanGetter
@@ -39,9 +41,11 @@ public abstract class SidecarCollectorEntity {
     @JsonProperty("executable_path")
     public abstract ValueReference executablePath();
 
+    @Nullable
     @JsonProperty("execute_parameters")
     public abstract ValueReference executeParameters();
 
+    @Nullable
     @JsonProperty("validation_parameters")
     public abstract ValueReference validationParameters();
 


### PR DESCRIPTION
Sidecar Collector: Fix empty content pack export when optional fields are blank (Backport of #13645)

* Fixes empty content pack issue for collectors

* Add null checks when decoding entity

Also remove null support for the template. The frontend always leaves this field non-null.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

