### PR TITLE
Define new colors for search query syntax highlighting.

### DIFF
--- a/graylog2-web-interface/src/views/components/searchbar/queryinput/StyledAceEditor.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/queryinput/StyledAceEditor.jsx
@@ -44,6 +44,10 @@ const StyledAceEditor = styled(AceEditor).attrs(({ aceTheme, theme, $height }) =
       color: ${$scTheme.utils.contrastingColor($scTheme.colors.input.background, 'AAA')};
     }
 
+    .ace_line {
+      color: ${$scTheme.colors.variant.dark.primary};
+    }
+
     .ace_print-margin {
       width: 1px;
       background: ${$scTheme.colors.input.background};
@@ -92,11 +96,15 @@ const StyledAceEditor = styled(AceEditor).attrs(({ aceTheme, theme, $height }) =
     .ace_storage,
     .ace_storage.ace_type,
     .ace_support.ace_type {
-      color: ${$scTheme.colors.variant.info};
+      color: ${$scTheme.colors.variant.light.primary};
+    }
+
+    .ace_lparen, .ace_rparen {
+      color: ${$scTheme.colors.variant.light.primary};
     }
 
     .ace_keyword.ace_operator {
-      color: ${$scTheme.colors.global.textDefault};
+      color: ${$scTheme.colors.variant.dark.primary};
     }
 
     .ace_constant.ace_character,
@@ -131,7 +139,7 @@ const StyledAceEditor = styled(AceEditor).attrs(({ aceTheme, theme, $height }) =
     .ace_support.ace_function,
     .ace_variable,
     .ace_term {
-      color: ${$scTheme.colors.variant.darker.info};
+      color: ${$scTheme.colors.variant.info};
     }
 
     .ace_support.ace_class,
@@ -142,7 +150,7 @@ const StyledAceEditor = styled(AceEditor).attrs(({ aceTheme, theme, $height }) =
     .ace_heading,
     .ace_markup.ace_heading,
     .ace_string {
-      color: ${$scTheme.colors.variant.dark.success};
+      color: ${$scTheme.colors.variant.info};
     }
 
     .ace_entity.ace_name.ace_tag,
@@ -191,6 +199,8 @@ const StyledAceEditor = styled(AceEditor).attrs(({ aceTheme, theme, $height }) =
 
     .ace_marker.ace_validation_warning {
       border-color: ${$scTheme.colors.variant.dark.warning};
+      
+      
     }
   }
 `);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

With this PR we are adjusting the search query syntax highlighting colors. We tried to:
- color the operators in a way that they clearly separate the resulting blocks
- color the field values in a way that have more focus and it is easier to extract them / understand which messages the searchtargeting.
- color the field names in a way that they are more subtle.

Before (4.3)
![image](https://user-images.githubusercontent.com/46300478/195638368-f6848d35-4fc3-4b3a-a452-db0eff532a7b.png)

After 
<img alt="image" src="https://user-images.githubusercontent.com/46300478/195638483-ffb647eb-ac5b-4589-9f71-07d948ff1272.png">
