### PR TITLE
Fixing latest aggregation if field is not present in time range. (backport of #13640 for 4.3)

### DIFF
--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/series/ESLatestHandler.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/series/ESLatestHandler.java
@@ -59,6 +59,6 @@ public class ESLatestHandler extends ESPivotSeriesSpecHandler<Latest, TopHits> {
                 .map(SearchHit::getSourceAsMap)
                 .map(source -> source.get(pivotSpec.field()))
                 .map(value -> Value.create(pivotSpec.id(), Latest.NAME, value));
-        return latestValue.stream();
+        return latestValue.map(Stream::of).orElse(Stream.empty());
     }
 }

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/series/ESLatestHandler.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/series/ESLatestHandler.java
@@ -54,10 +54,11 @@ public class ESLatestHandler extends ESPivotSeriesSpecHandler<Latest, TopHits> {
                                         ESGeneratedQueryContext esGeneratedQueryContext) {
         final Optional<Value> latestValue = Optional.ofNullable(latestAggregation.getHits())
                 .map(SearchHits::getHits)
+                .filter(hits -> hits.length > 0)
                 .map(hits -> hits[0])
                 .map(SearchHit::getSourceAsMap)
                 .map(source -> source.get(pivotSpec.field()))
                 .map(value -> Value.create(pivotSpec.id(), Latest.NAME, value));
-        return latestValue.map(Stream::of).orElse(Stream.empty());
+        return latestValue.stream();
     }
 }


### PR DESCRIPTION
_Please note, this is a backport of #13640 for 4.3._

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is fixing the `latest` aggregation for cases where no document with the field is present in the time range.

Code-wise, it checks if the list of hits returned has at least one element before trying to extract it.

Fixes #13593.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.