### PR TITLE
default retention time & max value via config

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -137,3 +137,7 @@ The Page permissions remain unchanged but this could affect the workflow for use
 On new Graylog installations, the default archiving configuration will now 
 store archives under the `data_dir` instead of `/tmp/graylog-archives`. 
 (The `data_dir` is configured in graylog.conf and defaults to `/var/lib/graylog-server`)
+
+### Configuring archive retention Time and max value
+It is now possible to configure default archive retention time and a limit via config flags
+`default_archive_retention_time` & `max_archive_retention_time`.

--- a/graylog2-server/src/main/java/org/graylog2/Configuration.java
+++ b/graylog2-server/src/main/java/org/graylog2/Configuration.java
@@ -213,6 +213,12 @@ public class Configuration extends BaseConfiguration {
     @Parameter(value = "lock_service_lock_ttl", converter = JavaDurationConverter.class)
     private java.time.Duration lockServiceLockTTL = MongoLockService.MIN_LOCK_TTL;
 
+    @Parameter(value = "default_archive_retention_time", validators = {PositiveIntegerValidator.class})
+    private int defaultArchiveRetentionTime = 0;
+
+    @Parameter(value = "max_archive_retention_time", validators = {PositiveIntegerValidator.class})
+    private int maxArchiveRetentionTime = 0;
+
     /**
      * @deprecated Use {@link #isLeader()} instead.
      */
@@ -443,6 +449,14 @@ public class Configuration extends BaseConfiguration {
     @Deprecated
     public Set<String> getEnabledTlsProtocols() {
         return enabledTlsProtocols;
+    }
+
+    public int getDefaultArchiveRetentionTime() {
+        return defaultArchiveRetentionTime;
+    }
+
+    public int getMaxArchiveRetentionTime() {
+        return maxArchiveRetentionTime;
     }
 
     @ValidatorMethod


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added following config flags: default_archive_retention_time (to set retention time on new installations, 0 or no setting means feature is off)  & max_archive_retention_time (limit max retention time) 

Graylog2/graylog-plugin-enterprise#4113

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
With https://github.com/Graylog2/graylog-plugin-enterprise/issues/3514 we introduced a feature to set a retentionTime on archive configurations (per index set), to allow an automatic clean up of old archives.

What would be useful in addition is to support setting a default and a max retention value (in the server config), so that a Graylog administrator could set these.

The retentionTime value entered by the user in the UI (or via the API) should be validated against a configured max value.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally with max set, default set and later on overwritting it via ui
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.


