### PR TITLE
Preventing index field type polling running twice for the same index.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/IndexFieldTypePollerPeriodical.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/IndexFieldTypePollerPeriodical.java
@@ -218,6 +218,9 @@ public class IndexFieldTypePollerPeriodical extends Periodical {
     }
 
     private boolean needsFullRefresh() {
+        if (fullRefreshInterval.toSeconds() == 0) {
+            return false;
+        }
         Instant nextFullRefresh = lastFullRefresh.plusSeconds(fullRefreshInterval.toSeconds());
         return !Instant.now().isBefore(nextFullRefresh);
     }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/IndexFieldTypePollerPeriodical.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/IndexFieldTypePollerPeriodical.java
@@ -16,9 +16,11 @@
  */
 package org.graylog2.indexer.fieldtypes;
 
+import com.google.common.base.Stopwatch;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
+import org.apache.mina.util.ConcurrentHashSet;
 import org.graylog2.indexer.IndexSet;
 import org.graylog2.indexer.MongoIndexSet;
 import org.graylog2.indexer.cluster.Cluster;
@@ -44,6 +46,7 @@ import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
@@ -66,6 +69,7 @@ public class IndexFieldTypePollerPeriodical extends Periodical {
     private volatile Set<IndexSetConfig> allIndexSetConfigs;
     private volatile Instant lastFullRefresh = Instant.MIN;
     private final ConcurrentHashMap<String, Instant> lastPoll = new ConcurrentHashMap<>();
+    private final ConcurrentHashSet<String> pollInProgress = new ConcurrentHashSet<>();
 
     @Inject
     public IndexFieldTypePollerPeriodical(final IndexFieldTypePoller poller,
@@ -164,13 +168,15 @@ public class IndexFieldTypePollerPeriodical extends Periodical {
         indexSetConfigs.stream()
                 .filter(config -> !config.fieldTypeRefreshInterval().equals(Duration.ZERO))
                 .filter(IndexSetConfig::isWritable)
-                .filter(config -> {
+                .forEach(config -> {
                     final Instant previousPoll = lastPoll.getOrDefault(config.id(), Instant.MIN);
                     final Instant nextPoll = previousPoll.plusSeconds(
                             config.fieldTypeRefreshInterval().getStandardSeconds());
-                    return !Instant.now().isBefore(nextPoll);
-                })
-                .forEach(this::poll);
+                    if (!Instant.now().isBefore(nextPoll)) {
+                        LOG.debug("Index set <{}> needs update, current polls in progress: {}", config.title(), this.pollInProgress);
+                        this.poll(config);
+                    }
+                });
     }
 
     private void poll(IndexSetConfig indexSetConfig) {
@@ -178,6 +184,14 @@ public class IndexFieldTypePollerPeriodical extends Periodical {
         final String indexSetId = indexSetConfig.id();
 
         scheduler.submit(() -> {
+            if (this.pollInProgress.contains(indexSetId)) {
+                LOG.info("Poll for index set <{}> is already in progress", indexSetTitle);
+                return;
+            }
+            LOG.info("Starting poll for index set <{}>, current polls in progress {}", indexSetTitle, this.pollInProgress);
+            this.pollInProgress.add(indexSetId);
+
+            final Stopwatch stopwatch = Stopwatch.createStarted();
             try {
                 final MongoIndexSet indexSet = mongoIndexSetFactory.create(indexSetConfig);
                 // Only check the active write index on a regular basis, the others don't change anymore
@@ -195,7 +209,10 @@ public class IndexFieldTypePollerPeriodical extends Periodical {
             } catch (Exception e) {
                 LOG.error("Couldn't update field types for index set <{}/{}>", indexSetTitle, indexSetId, e);
             } finally {
+                this.pollInProgress.remove(indexSetId);
                 lastPoll.put(indexSetId, Instant.now());
+                stopwatch.stop();
+                LOG.debug("Polling index set <{}> took {}ms", indexSetTitle, stopwatch.elapsed(TimeUnit.MILLISECONDS));
             }
         });
     }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/IndexFieldTypePollerPeriodical.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/IndexFieldTypePollerPeriodical.java
@@ -185,14 +185,14 @@ public class IndexFieldTypePollerPeriodical extends Periodical {
 
         scheduler.submit(() -> {
             if (this.pollInProgress.contains(indexSetId)) {
-                LOG.info("Poll for index set <{}> is already in progress", indexSetTitle);
+                LOG.debug("Poll for index set <{}> is already in progress", indexSetTitle);
                 return;
             }
-            LOG.info("Starting poll for index set <{}>, current polls in progress {}", indexSetTitle, this.pollInProgress);
-            this.pollInProgress.add(indexSetId);
+            LOG.debug("Starting poll for index set <{}>, current polls in progress {}", indexSetTitle, this.pollInProgress);
 
             final Stopwatch stopwatch = Stopwatch.createStarted();
             try {
+                this.pollInProgress.add(indexSetId);
                 final MongoIndexSet indexSet = mongoIndexSetFactory.create(indexSetConfig);
                 // Only check the active write index on a regular basis, the others don't change anymore
                 final String activeWriteIndex = indexSet.getActiveWriteIndex();

--- a/graylog2-server/src/test/java/org/graylog2/indexer/fieldtypes/IndexFieldTypePollerPeriodicalTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/fieldtypes/IndexFieldTypePollerPeriodicalTest.java
@@ -19,19 +19,38 @@ package org.graylog2.indexer.fieldtypes;
 import com.github.joschi.jadconfig.util.Duration;
 import com.google.common.eventbus.EventBus;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import org.graylog2.indexer.IndexSet;
 import org.graylog2.indexer.MongoIndexSet;
 import org.graylog2.indexer.cluster.Cluster;
+import org.graylog2.indexer.indexset.IndexSetConfig;
 import org.graylog2.indexer.indexset.IndexSetService;
 import org.graylog2.indexer.indices.Indices;
+import org.graylog2.indexer.retention.strategies.NoopRetentionStrategy;
+import org.graylog2.indexer.retention.strategies.NoopRetentionStrategyConfig;
+import org.graylog2.indexer.rotation.strategies.MessageCountRotationStrategy;
+import org.graylog2.indexer.rotation.strategies.MessageCountRotationStrategyConfig;
 import org.graylog2.plugin.ServerStatus;
+import org.graylog2.plugin.indexer.retention.RetentionStrategy;
 import org.graylog2.plugin.lifecycles.Lifecycle;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.locks.ReentrantLock;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
@@ -51,7 +70,7 @@ class IndexFieldTypePollerPeriodicalTest {
     );
 
     @BeforeEach
-    void setUp() throws Exception {
+    void setUp() {
         this.periodical = new IndexFieldTypePollerPeriodical(indexFieldTypePoller,
                 indexFieldTypesService,
                 indexSetService,
@@ -62,14 +81,55 @@ class IndexFieldTypePollerPeriodicalTest {
                 serverStatus,
                 Duration.minutes(5),
                 scheduler);
+        when(serverStatus.getLifecycle()).thenReturn(Lifecycle.RUNNING);
+        when(cluster.isConnected()).thenReturn(true);
     }
 
     @Test
-    void scheduledExecutionIsSkippedWhenServerIsNotRunning() throws InterruptedException {
+    void scheduledExecutionIsSkippedWhenServerIsNotRunning() {
         when(serverStatus.getLifecycle()).thenReturn(Lifecycle.HALTING);
 
         periodical.doRun();
 
         verifyNoInteractions(cluster);
+    }
+
+    @Test
+    void noConcurrentPollingForFieldTypes() {
+        final IndexSetConfig indexSet = IndexSetConfig.builder()
+                .id("indexSet1")
+                .title("Test Index Set")
+                .indexPrefix("test")
+                .shards(2)
+                .creationDate(ZonedDateTime.now())
+                .indexAnalyzer("standard")
+                .indexTemplateName("test")
+                .indexOptimizationMaxNumSegments(2048)
+                .indexOptimizationDisabled(false)
+                .fieldTypeRefreshInterval(org.joda.time.Duration.standardSeconds(1))
+                .retentionStrategy(NoopRetentionStrategyConfig.createDefault())
+                .replicas(1)
+                .rotationStrategy(MessageCountRotationStrategyConfig.createDefault())
+                .build();
+        final List<IndexSetConfig> indexSets = List.of(indexSet);
+        when(indexSetService.findAll()).thenReturn(indexSets);
+
+        final MongoIndexSet mongoIndexSet = mock(MongoIndexSet.class);
+        when(mongoIndexSet.getActiveWriteIndex()).thenReturn("test_0");
+        when(mongoIndexSetFactory.create(eq(indexSet))).thenReturn(mongoIndexSet);
+
+        final ReentrantLock lock = new ReentrantLock();
+        lock.lock();
+        when(indexFieldTypePoller.pollIndex(anyString(), anyString()))
+                .thenAnswer((Answer<Optional<IndexFieldTypesDTO>>) invocationOnMock -> {
+                    lock.lock();
+                    return Optional.empty();
+                });
+
+        periodical.doRun();
+        periodical.doRun();
+        lock.unlock();
+
+        verify(indexFieldTypePoller, times(1)).poll(any(IndexSet.class), anySet());
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/indexer/fieldtypes/IndexFieldTypePollerPeriodicalTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/fieldtypes/IndexFieldTypePollerPeriodicalTest.java
@@ -65,7 +65,7 @@ class IndexFieldTypePollerPeriodicalTest {
     @SuppressWarnings("UnstableApiUsage")
     private final EventBus eventBus = mock(EventBus.class);
     private final ServerStatus serverStatus = mock(ServerStatus.class);
-    private final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor(
+    private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(2,
             new ThreadFactoryBuilder().setNameFormat("index-field-type-poller-periodical-test-%d").build()
     );
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Prior to this change, when polling the field types of an index set took longer than 1 second, a second polling job was submitted to the executor, running in parallel. If it took longer than 2s, a third one is started, and so on.

In order to prevent this, a very simple locking mechanism is implemented, where a running polling job adds the current index set's id to a concurrent hash set, removing it when finished (or failing).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.