### PR TITLE
Update to jersey 2.37

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@
         <jbcrypt.version>0.4</jbcrypt.version>
         <jcip-annotations.version>1.0</jcip-annotations.version>
         <jdot.version>1.0</jdot.version>
-        <jersey.version>2.32</jersey.version>
+        <jersey.version>2.37</jersey.version>
         <jmte.version>5.0.0</jmte.version>
         <joda-time.version>2.10.6</joda-time.version>
         <jool.version>0.9.14</jool.version>


### PR DESCRIPTION
which is the latest 2.x version.
This is needed for Java 17 support:
 https://github.com/eclipse-ee4j/jersey/pull/4754
 
 Without this change, starting the jersey service in the forwarder terminates with
 `jersey.repackaged.org.objectweb.asm.ClassReader: Unsupported class file major version 61`
