### PR TITLE
Adjust page size for pagination on event definitions

### DIFF
--- a/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitions.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitions.tsx
@@ -69,7 +69,7 @@ type Props = {
   onDisable: (eventDefinition: EventDefinition) => void,
 };
 
-export const PAGE_SIZES = [10, 25, 50];
+export const PAGE_SIZES = [10, 50, 100];
 
 const EventDefinitions = ({ eventDefinitions, context, pagination, query, onPageChange, onQueryChange, onDelete, onCopy, onEnable, onDisable }: Props) => {
   if (pagination.grandTotal === 0) {


### PR DESCRIPTION
As requested in the issue https://github.com/Graylog2/graylog2-server/issues/13305, here are the options for pagination in Event Definitions adjusted to 10, 50 and 100.

## Description

Fix https://github.com/Graylog2/graylog2-server/issues/13305

## Screenshots (if appropriate):

![Screenshot 2022-10-18 at 12 03 01](https://user-images.githubusercontent.com/92227/196400567-073a387e-3dd4-4c39-af69-b20a0857aac9.png)

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

