### PR TITLE
Seach request building is done in one place, is not split between fac…

### DIFF
--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/Paginate.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/Paginate.java
@@ -1,4 +1,0 @@
-package org.graylog.storage.elasticsearch7;
-
-public class Paginate {
-}

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/Paginate.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/Paginate.java
@@ -1,0 +1,4 @@
+package org.graylog.storage.elasticsearch7;
+
+public class Paginate {
+}

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/Scroll.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/Scroll.java
@@ -42,14 +42,8 @@ public class Scroll {
 
     public ScrollResult scroll(ScrollCommand scrollCommand) {
         final SearchSourceBuilder searchQuery = searchRequestFactory.create(scrollCommand);
-
-        searchQuery.fetchSource(scrollCommand.fields().toArray(new String[0]), new String[0]);
-        scrollCommand.batchSize()
-                .ifPresent(batchSize -> searchQuery.size(Math.toIntExact(batchSize)));
         final SearchRequest request = scrollBuilder(searchQuery, scrollCommand.indices());
-
         final SearchResponse result = client.singleSearch(request, "Unable to perform scroll search");
-
         return scrollResultFactory.create(result, searchQuery.toString(), DEFAULT_SCROLLTIME, scrollCommand.fields(), scrollCommand.limit().orElse(-1));
     }
 

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/SearchRequestFactory.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/SearchRequestFactory.java
@@ -57,8 +57,12 @@ public class SearchRequestFactory {
         return create(SearchCommand.from(config));
     }
 
-    public SearchSourceBuilder create(ScrollCommand scrollCommand) {
-        return create(SearchCommand.from(scrollCommand));
+    public SearchSourceBuilder create(final ScrollCommand scrollCommand) {
+        final SearchSourceBuilder searchSourceBuilder = create(SearchCommand.from(scrollCommand));
+        searchSourceBuilder.fetchSource(scrollCommand.fields().toArray(new String[0]), new String[0]);
+        scrollCommand.batchSize()
+                .ifPresent(batchSize -> searchSourceBuilder.size(Math.toIntExact(batchSize)));
+        return searchSourceBuilder;
     }
 
     public SearchSourceBuilder create(SearchCommand searchCommand) {

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/SearchRequestFactoryTest.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/SearchRequestFactoryTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.graylog2.utilities.AssertJsonPath.assertJsonPath;
@@ -65,5 +66,38 @@ class SearchRequestFactoryTest {
                 .build());
 
         assertThat(search.toString()).doesNotContain("\"highlight\":");
+    }
+
+    @Test
+    void searchIncludesProperSourceFields() {
+        final SearchSourceBuilder search = this.searchRequestFactory.create(ScrollCommand.builder()
+                .indices(Collections.singleton("graylog_0"))
+                .range(AbsoluteRange.create(
+                        DateTime.parse("2020-07-23T11:03:32.243Z"),
+                        DateTime.parse("2020-07-23T11:08:32.243Z")
+                ))
+                .fields(List.of("foo", "bar"))
+                .build());
+
+        assertJsonPath(search, request -> {
+            request.jsonPathAsListOf("$._source.includes", String.class)
+                    .containsExactly("foo", "bar");
+            request.jsonPathAsListOf("$._source.excludes", String.class)
+                    .isEmpty();
+        });
+    }
+
+    @Test
+    void searchIncludesSize() {
+        final SearchSourceBuilder search = this.searchRequestFactory.create(ScrollCommand.builder()
+                .indices(Collections.singleton("graylog_0"))
+                .range(AbsoluteRange.create(
+                        DateTime.parse("2020-07-23T11:03:32.243Z"),
+                        DateTime.parse("2020-07-23T11:08:32.243Z")
+                ))
+                .batchSize(42)
+                .build());
+
+        assertThat(search.toString()).contains("\"size\":42");
     }
 }

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/Scroll.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/Scroll.java
@@ -42,14 +42,8 @@ public class Scroll {
 
     public ScrollResult scroll(ScrollCommand scrollCommand) {
         final SearchSourceBuilder searchQuery = searchRequestFactory.create(scrollCommand);
-
-        searchQuery.fetchSource(scrollCommand.fields().toArray(new String[0]), new String[0]);
-        scrollCommand.batchSize()
-                .ifPresent(batchSize -> searchQuery.size(Math.toIntExact(batchSize)));
         final SearchRequest request = scrollBuilder(searchQuery, scrollCommand.indices());
-
         final SearchResponse result = client.singleSearch(request, "Unable to perform scroll search");
-
         return scrollResultFactory.create(result, searchQuery.toString(), DEFAULT_SCROLLTIME, scrollCommand.fields(), scrollCommand.limit().orElse(-1));
     }
 

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/SearchRequestFactory.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/SearchRequestFactory.java
@@ -57,8 +57,12 @@ public class SearchRequestFactory {
         return create(SearchCommand.from(config));
     }
 
-    public SearchSourceBuilder create(ScrollCommand scrollCommand) {
-        return create(SearchCommand.from(scrollCommand));
+    public SearchSourceBuilder create(final ScrollCommand scrollCommand) {
+        final SearchSourceBuilder searchSourceBuilder = create(SearchCommand.from(scrollCommand));
+        searchSourceBuilder.fetchSource(scrollCommand.fields().toArray(new String[0]), new String[0]);
+        scrollCommand.batchSize()
+                .ifPresent(batchSize -> searchSourceBuilder.size(Math.toIntExact(batchSize)));
+        return searchSourceBuilder;
     }
 
     public SearchSourceBuilder create(SearchCommand searchCommand) {

--- a/graylog-storage-opensearch2/src/test/java/org/graylog/storage/opensearch2/SearchRequestFactoryTest.java
+++ b/graylog-storage-opensearch2/src/test/java/org/graylog/storage/opensearch2/SearchRequestFactoryTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.graylog2.utilities.AssertJsonPath.assertJsonPath;
@@ -65,5 +66,38 @@ class SearchRequestFactoryTest {
                 .build());
 
         assertThat(search.toString()).doesNotContain("\"highlight\":");
+    }
+
+    @Test
+    void searchIncludesProperSourceFields() {
+        final SearchSourceBuilder search = this.searchRequestFactory.create(ScrollCommand.builder()
+                .indices(Collections.singleton("graylog_0"))
+                .range(AbsoluteRange.create(
+                        DateTime.parse("2020-07-23T11:03:32.243Z"),
+                        DateTime.parse("2020-07-23T11:08:32.243Z")
+                ))
+                .fields(List.of("foo", "bar"))
+                .build());
+
+        assertJsonPath(search, request -> {
+            request.jsonPathAsListOf("$._source.includes", String.class)
+                    .containsExactly("foo", "bar");
+            request.jsonPathAsListOf("$._source.excludes", String.class)
+                    .isEmpty();
+        });
+    }
+
+    @Test
+    void searchIncludesSize() {
+        final SearchSourceBuilder search = this.searchRequestFactory.create(ScrollCommand.builder()
+                .indices(Collections.singleton("graylog_0"))
+                .range(AbsoluteRange.create(
+                        DateTime.parse("2020-07-23T11:03:32.243Z"),
+                        DateTime.parse("2020-07-23T11:08:32.243Z")
+                ))
+                .batchSize(42)
+                .build());
+
+        assertThat(search.toString()).contains("\"size\":42");
     }
 }


### PR DESCRIPTION
…tory and Scroll class anymore

<!--- Provide a general summary of your changes in the Title above -->

## Description
Seach request building is done in one place, is not split between factory and Scroll class anymore

## Motivation and Context
Some refactoring will make it easier to replace "scroll" approach with "search after" approach, as requested in #12996

## How Has This Been Tested?
Unit tests have been added.



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

