### PR TITLE
Backport adjust page sizes for Event Definitions

### DIFF
--- a/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitions.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitions.jsx
@@ -106,7 +106,7 @@ class EventDefinitions extends React.Component {
 
           <PaginatedList activePage={pagination.page}
                          pageSize={pagination.pageSize}
-                         pageSizes={[10, 25, 50]}
+                         pageSizes={[10, 50, 100]}
                          totalItems={pagination.total}
                          onChange={onPageChange}>
             <div className={styles.definitionList}>


### PR DESCRIPTION
Issue: https://github.com/Graylog2/graylog2-server/issues/13305
PR: https://github.com/Graylog2/graylog2-server/pull/13717

## Description

Backport adding more options for the pagination on Event Definitions

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

