### PR TITLE
Implement new headline font for login screen headline.

### DIFF
--- a/graylog2-web-interface/src/components/login/LoginBox.jsx
+++ b/graylog2-web-interface/src/components/login/LoginBox.jsx
@@ -46,29 +46,22 @@ const LoginCol = styled(Col)(({ theme }) => css`
   border: 1px solid ${theme.colors.variant.light.default};
   border-radius: 4px;
   box-shadow: 0 0 21px ${theme.colors.global.navigationBoxShadow};
-  
-  legend {
-    color: ${theme.colors.variant.darker.default};
-    border-color: ${theme.colors.variant.dark.default};
-  }
 `);
 
-const LoginBox = ({ children }) => {
-  return (
-    <Wrapper className="container">
-      <Row>
-        <Col md={8} mdOffset={2}>
-          <PublicNotifications readFromConfig />
-        </Col>
-      </Row>
-      <Row>
-        <LoginCol md={4} mdOffset={4} xs={6} xsOffset={3}>
-          {children}
-        </LoginCol>
-      </Row>
-    </Wrapper>
-  );
-};
+const LoginBox = ({ children }) => (
+  <Wrapper className="container">
+    <Row>
+      <Col md={8} mdOffset={2}>
+        <PublicNotifications readFromConfig />
+      </Col>
+    </Row>
+    <Row>
+      <LoginCol md={4} mdOffset={4} xs={6} xsOffset={3}>
+        {children}
+      </LoginCol>
+    </Row>
+  </Wrapper>
+);
 
 LoginBox.propTypes = {
   children: PropTypes.node.isRequired,

--- a/graylog2-web-interface/src/components/login/LoginHeader.tsx
+++ b/graylog2-web-interface/src/components/login/LoginHeader.tsx
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import styled from 'styled-components';
+
+import { Icon } from 'components/common';
+
+const Header = styled.h1`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 21px;
+  margin-top: 6px;
+`;
+
+const HeaderIcon = styled(Icon)`
+  margin-right: 9px;
+`;
+
+const LoginHeader = () => (
+  <Header>
+    <HeaderIcon name="users" />Welcome to Graylog
+  </Header>
+);
+
+export default LoginHeader;

--- a/graylog2-web-interface/src/components/login/__snapshots__/LoginBox.test.jsx.snap
+++ b/graylog2-web-interface/src/components/login/__snapshots__/LoginBox.test.jsx.snap
@@ -45,11 +45,6 @@ exports[`LoginBox renders a button after the input if buttonAfter is passed 1`] 
   box-shadow: 0 0 21px rgba(245,246,248,0.5);
 }
 
-.c2 legend {
-  color: #67717f;
-  border-color: #8894a7;
-}
-
 <div>
   <div
     class="c0 container"

--- a/graylog2-web-interface/src/pages/LoadingPage.tsx
+++ b/graylog2-web-interface/src/pages/LoadingPage.tsx
@@ -18,9 +18,10 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import { createGlobalStyle } from 'styled-components';
 
-import { DocumentTitle, Spinner, Icon } from 'components/common';
+import { DocumentTitle, Spinner } from 'components/common';
 import LoginBox from 'components/login/LoginBox';
 import authStyles from 'theme/styles/authStyles';
+import LoginHeader from 'components/login/LoginHeader';
 
 type Props = {
   text: string,
@@ -35,7 +36,7 @@ const LoadingPage = ({ text }: Props) => {
     <DocumentTitle title="Loading...">
       <LoadingPageStyles />
       <LoginBox>
-        <legend><Icon name="users" /> Welcome to Graylog</legend>
+        <LoginHeader />
         <p>
           <Spinner text={text} delay={0} />
         </p>

--- a/graylog2-web-interface/src/pages/LoginPage.jsx
+++ b/graylog2-web-interface/src/pages/LoginPage.jsx
@@ -21,7 +21,7 @@ import styled, { createGlobalStyle } from 'styled-components';
 import { useQuery } from '@tanstack/react-query';
 import { ErrorBoundary } from 'react-error-boundary';
 
-import { DocumentTitle, Icon } from 'components/common';
+import { DocumentTitle } from 'components/common';
 import { Alert, Button } from 'components/bootstrap';
 import LoginForm from 'components/login/LoginForm';
 import LoginBox from 'components/login/LoginBox';
@@ -30,6 +30,7 @@ import AuthenticationDomain from 'domainActions/authentication/AuthenticationDom
 import AppConfig from 'util/AppConfig';
 import { LOGIN_INITIALIZING_STATE, LOGIN_INITIALIZED_STATE } from 'logic/authentication/constants';
 import { SessionActions } from 'stores/sessions/SessionStore';
+import LoginHeader from 'components/login/LoginHeader';
 
 import LoadingPage from './LoadingPage';
 
@@ -166,7 +167,7 @@ const LoginPage = () => {
   return (
     <DocumentTitle title="Sign in">
       <LoginBox>
-        <legend><Icon name="users" /> Welcome to Graylog</legend>
+        <LoginHeader />
         <LoginPageStyles />
         {formatLastError()}
         {renderLoginForm()}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

We recently changed the font family for h1 and h2. With this PR we are implementing the headline font for the login screen headline as well.

## Screenshots (if appropriate):

Before:
<img width="532" alt="image" src="https://user-images.githubusercontent.com/46300478/196634637-7254d9ae-2943-4564-b38f-2200feeb2e47.png">

After:
<img width="506" alt="image" src="https://user-images.githubusercontent.com/46300478/196634220-40435586-1f6b-4e1c-8d60-3c0578c284a1.png">
