### PR TITLE
Reordering of tabs in dashboards

### DIFF
--- a/graylog2-web-interface/src/views/actions/QueriesActions.ts
+++ b/graylog2-web-interface/src/views/actions/QueriesActions.ts
@@ -35,6 +35,7 @@ type QueriesActionsType = RefluxActions<{
   timerange: (queryId: QueryId, newTimeRange: TimeRange) => Promise<QueriesList>,
   update: (queryId: QueryId, query: Query) => Promise<QueriesList>,
   forceUpdate: (queryId: QueryId, query: Query) => Promise<QueriesList>,
+  setOrder: (newOrder: Immutable.OrderedSet<{ id: QueryId}>) => Promise<QueriesList>,
 }>;
 
 // eslint-disable-next-line import/prefer-default-export
@@ -50,5 +51,6 @@ export const QueriesActions: QueriesActionsType = singletonActions(
     timerange: { asyncResult: true },
     update: { asyncResult: true },
     forceUpdate: { asyncResult: true },
+    setOrder: { asyncResult: true },
   }),
 );

--- a/graylog2-web-interface/src/views/components/AdaptableQueryTabs.test.tsx
+++ b/graylog2-web-interface/src/views/components/AdaptableQueryTabs.test.tsx
@@ -15,7 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 
-import { render, screen, waitFor } from 'wrappedTestingLibrary';
+import { render, screen } from 'wrappedTestingLibrary';
 import React from 'react';
 import Immutable, { Map } from 'immutable';
 import userEvent from '@testing-library/user-event';
@@ -171,10 +171,10 @@ describe('AdaptableQueryTabs', () => {
         name: 'Page#5',
       });
 
-      expect(screen.getByRole(mainTabRole, {
+      await screen.findByRole(mainTabRole, {
         name: 'Page#5',
         hidden: true,
-      })).toBeInTheDocument();
+      });
     });
   });
 
@@ -199,7 +199,7 @@ describe('AdaptableQueryTabs', () => {
     });
     userEvent.click(tab2);
 
-    await waitFor(() => expect(onSelectStub).toHaveBeenCalledTimes(1));
+    await expect(onSelectStub).toHaveBeenCalledTimes(1);
 
     expect(onSelectStub).toHaveBeenCalledWith('query-id-2');
   });
@@ -216,7 +216,7 @@ describe('AdaptableQueryTabs', () => {
     });
     userEvent.click(tab4);
 
-    await waitFor(() => expect(onSelectStub).toHaveBeenCalledTimes(1));
+    await expect(onSelectStub).toHaveBeenCalledTimes(1);
 
     expect(onSelectStub).toHaveBeenCalledWith('query-id-4');
   });
@@ -228,7 +228,7 @@ describe('AdaptableQueryTabs', () => {
     const createTabButton = await screen.findByTitle('Create New Page');
     userEvent.click(createTabButton);
 
-    await waitFor(() => expect(onSelectStub).toHaveBeenCalledTimes(1));
+    await expect(onSelectStub).toHaveBeenCalledTimes(1);
 
     expect(onSelectStub).toHaveBeenCalledWith('new');
   });

--- a/graylog2-web-interface/src/views/components/AdaptableQueryTabs.test.tsx
+++ b/graylog2-web-interface/src/views/components/AdaptableQueryTabs.test.tsx
@@ -155,6 +155,7 @@ describe('AdaptableQueryTabs', () => {
         name: 'Tab 4',
       });
 
+      // eslint-disable-next-line testing-library/no-node-access
       expect(newActiveTab.parentNode).toHaveClass('active');
     });
 
@@ -185,6 +186,7 @@ describe('AdaptableQueryTabs', () => {
     });
 
     expect(tab2).toBeVisible();
+    // eslint-disable-next-line testing-library/no-node-access
     expect(tab2.parentNode).toHaveClass('active');
   });
 
@@ -223,7 +225,7 @@ describe('AdaptableQueryTabs', () => {
     const onSelectStub = jest.fn((id: string) => Promise.resolve(id));
     render(<AdaptableQueryTabs {...DEFAULT_PROPS} onSelect={onSelectStub} />);
 
-    const createTabButton = await screen.findByTitle('Create New Tab');
+    const createTabButton = await screen.findByTitle('Create New Page');
     userEvent.click(createTabButton);
 
     await waitFor(() => expect(onSelectStub).toHaveBeenCalledTimes(1));

--- a/graylog2-web-interface/src/views/components/AdaptableQueryTabs.tsx
+++ b/graylog2-web-interface/src/views/components/AdaptableQueryTabs.tsx
@@ -25,8 +25,10 @@ import { ModifiedNavDropdown as NavDropdown } from 'components/bootstrap/NavDrop
 import type { QueryId } from 'views/logic/queries/Query';
 import type QueryTitleEditModal from 'views/components/queries/QueryTitleEditModal';
 import { Nav, NavItem, MenuItem } from 'components/bootstrap';
-import { Icon } from 'components/common';
+import { Icon, IconButton } from 'components/common';
 import QueryTitle from 'views/components/queries/QueryTitle';
+import type { ListItemType } from 'components/common/SortableList/ListItem';
+import AdaptableQueryTabsConfiguration from 'views/components/AdaptableQueryTabsConfiguration';
 
 import type { QueryTabsProps } from './QueryTabs';
 
@@ -38,13 +40,20 @@ interface Props extends QueryTabsProps {
 interface TabsTypes {
   navItems: Array<ReactNode>,
   menuItems: Array<ReactNode>,
-  lockedItems: Array<ReactNode>
+  lockedItems: Array<ReactNode>,
+  queriesList: Array<ListItemType>,
 }
 
 const CLASS_HIDDEN = 'hidden';
 const CLASS_LOCKED = 'locked';
 const CLASS_ACTIVE = 'active';
 const NAV_PADDING = 15;
+
+const Container = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
 
 const StyledQueryNav = styled(Nav)(({ theme }) => css`
   &.nav.nav-tabs {
@@ -164,11 +173,12 @@ const adjustTabsVisibility = (maxWidth, lockedTab, setLockedTab) => {
 const AdaptableQueryTabs = ({ maxWidth, queries, titles, selectedQueryId, onRemove, onSelect, queryTitleEditModal }: Props) => {
   const [openedMore, setOpenedMore] = useState<boolean>(false);
   const [lockedTab, setLockedTab] = useState<QueryId>();
-
+  const [showConfigurationModal, setShowConfigurationModal] = useState<boolean>(false);
   const currentTabs = useMemo((): TabsTypes => {
     const navItems = [];
     const menuItems = [];
     const lockedItems = [];
+    const queriesList = [];
 
     queries.keySeq().forEach((id, idx) => {
       const openTitleEditModal = (activeQueryTitle: string) => {
@@ -219,9 +229,14 @@ const AdaptableQueryTabs = ({ maxWidth, queries, titles, selectedQueryId, onRemo
           {tabTitle}
         </NavItem>
       ));
+
+      queriesList.push({
+        id,
+        title,
+      });
     });
 
-    return { navItems, menuItems, lockedItems };
+    return { navItems, menuItems, lockedItems, queriesList };
   }, [lockedTab, onRemove, onSelect, queries, queryTitleEditModal, selectedQueryId, titles]);
 
   useEffect(() => {
@@ -229,32 +244,40 @@ const AdaptableQueryTabs = ({ maxWidth, queries, titles, selectedQueryId, onRemo
   }, [maxWidth, lockedTab, selectedQueryId]);
 
   return (
-    <StyledQueryNav bsStyle="tabs" activeKey={selectedQueryId} id="dashboard-tabs">
-      {currentTabs.navItems}
+    <Container>
+      <StyledQueryNav bsStyle="tabs" activeKey={selectedQueryId} id="dashboard-tabs">
+        {currentTabs.navItems}
 
-      <NavDropdown eventKey="more"
-                   title={<Icon name="ellipsis-h" />}
-                   className="query-tabs-more"
-                   id="query-tabs-more"
-                   aria-label="More Dashboard Tabs"
-                   noCaret
-                   pullRight
-                   active={openedMore}
-                   open={openedMore}
-                   onToggle={(isOpened) => setOpenedMore(isOpened)}>
-        {currentTabs.menuItems}
-      </NavDropdown>
+        <NavDropdown eventKey="more"
+                     title={<Icon name="ellipsis-h" />}
+                     className="query-tabs-more"
+                     id="query-tabs-more"
+                     aria-label="More Dashboard Tabs"
+                     noCaret
+                     pullRight
+                     active={openedMore}
+                     open={openedMore}
+                     onToggle={(isOpened) => setOpenedMore(isOpened)}>
+          {currentTabs.menuItems}
+        </NavDropdown>
 
-      {currentTabs.lockedItems}
+        {currentTabs.lockedItems}
 
-      <NavItem key="new"
-               eventKey="new"
-               title="Create New Tab"
-               onClick={() => onSelect('new')}
-               className="query-tabs-new">
-        <Icon name="plus" />
-      </NavItem>
-    </StyledQueryNav>
+        <NavItem key="new"
+                 eventKey="new"
+                 title="Create New Tab"
+                 onClick={() => onSelect('new')}
+                 className="query-tabs-new">
+          <Icon name="plus" />
+        </NavItem>
+      </StyledQueryNav>
+      <IconButton name="cog" onClick={() => setShowConfigurationModal(true)} />
+      {showConfigurationModal && (
+      <AdaptableQueryTabsConfiguration show={showConfigurationModal}
+                                       setShow={setShowConfigurationModal}
+                                       queriesList={currentTabs.queriesList} />
+      )}
+    </Container>
   );
 };
 

--- a/graylog2-web-interface/src/views/components/AdaptableQueryTabs.tsx
+++ b/graylog2-web-interface/src/views/components/AdaptableQueryTabs.tsx
@@ -252,7 +252,7 @@ const AdaptableQueryTabs = ({ maxWidth, queries, titles, selectedQueryId, onRemo
                      title={<Icon name="ellipsis-h" />}
                      className="query-tabs-more"
                      id="query-tabs-more"
-                     aria-label="More Dashboard Tabs"
+                     aria-label="More Dashboard Pages"
                      noCaret
                      pullRight
                      active={openedMore}
@@ -265,13 +265,13 @@ const AdaptableQueryTabs = ({ maxWidth, queries, titles, selectedQueryId, onRemo
 
         <NavItem key="new"
                  eventKey="new"
-                 title="Create New Tab"
+                 title="Create New Page"
                  onClick={() => onSelect('new')}
                  className="query-tabs-new">
           <Icon name="plus" />
         </NavItem>
       </StyledQueryNav>
-      <IconButton name="cog" onClick={() => setShowConfigurationModal(true)} />
+      <IconButton title="Open pages configuration" name="cog" onClick={() => setShowConfigurationModal(true)} />
       {showConfigurationModal && (
       <AdaptableQueryTabsConfiguration show={showConfigurationModal}
                                        setShow={setShowConfigurationModal}

--- a/graylog2-web-interface/src/views/components/AdaptableQueryTabsConfiguration.test.tsx
+++ b/graylog2-web-interface/src/views/components/AdaptableQueryTabsConfiguration.test.tsx
@@ -47,20 +47,20 @@ describe('AdaptableQueryTabsConfiguration', () => {
     ViewStatesActions.patchQueriesTitle = mockAction(jest.fn(() => Promise.resolve(ViewState.create())));
   });
 
-  it('display modal window', async () => {
+  it('should display modal window', async () => {
     renderConfiguration();
 
     await screen.findByText('Update Dashboard Pages Configuration');
   });
 
-  it('display list of tabs', async () => {
+  it('should display list of tabs', async () => {
     renderConfiguration();
 
-    await expect(await screen.findByText('Query Title 1')).toBeInTheDocument();
-    await expect(await screen.findByText('Query Title 2')).toBeInTheDocument();
+    await screen.findByText('Query Title 1');
+    await screen.findByText('Query Title 2');
   });
 
-  it('on submit run setOrder and patchQueriesTitle with correct tab order and titles', async () => {
+  it('should run setOrder and patchQueriesTitle with correct tab order and titles on submit', async () => {
     renderConfiguration();
     const submitButton = await screen.findByTitle('Update configuration');
     userEvent.click(submitButton);

--- a/graylog2-web-interface/src/views/components/AdaptableQueryTabsConfiguration.test.tsx
+++ b/graylog2-web-interface/src/views/components/AdaptableQueryTabsConfiguration.test.tsx
@@ -50,7 +50,7 @@ describe('AdaptableQueryTabsConfiguration', () => {
   it('display modal window', async () => {
     renderConfiguration();
 
-    await expect(await screen.findByText('Update Dashboard Tabs Configuration')).toBeInTheDocument();
+    await screen.findByText('Update Dashboard Pages Configuration');
   });
 
   it('display list of tabs', async () => {

--- a/graylog2-web-interface/src/views/components/AdaptableQueryTabsConfiguration.test.tsx
+++ b/graylog2-web-interface/src/views/components/AdaptableQueryTabsConfiguration.test.tsx
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+
+import { render, screen } from 'wrappedTestingLibrary';
+import React from 'react';
+import Immutable from 'immutable';
+import userEvent from '@testing-library/user-event';
+
+import AdaptableQueryTabsConfiguration from 'views/components/AdaptableQueryTabsConfiguration';
+import mockAction from 'helpers/mocking/MockAction';
+import { QueriesActions } from 'views/actions/QueriesActions';
+import { ViewStatesActions } from 'views/stores/ViewStatesStore';
+import ViewState from 'views/logic/views/ViewState';
+
+jest.mock('views/stores/QueriesStore', () => ({ QueriesActions: {} }));
+jest.mock('views/stores/ViewStatesStore', () => ({ ViewStatesActions: {} }));
+
+const setShow = jest.fn();
+
+describe('AdaptableQueryTabsConfiguration', () => {
+  const renderConfiguration = () => render(
+    <AdaptableQueryTabsConfiguration show
+                                     setShow={setShow}
+                                     queriesList={
+        [
+          { id: 'queryId-1', title: 'Query Title 1' },
+          { id: 'queryId-2', title: 'Query Title 2' },
+        ]
+} />);
+
+  beforeEach(() => {
+    QueriesActions.setOrder = mockAction(jest.fn(() => Promise.resolve(Immutable.OrderedMap())));
+    ViewStatesActions.patchQueriesTitle = mockAction(jest.fn(() => Promise.resolve(ViewState.create())));
+  });
+
+  it('display modal window', async () => {
+    renderConfiguration();
+
+    await expect(await screen.findByText('Update Dashboard Tabs Configuration')).toBeInTheDocument();
+  });
+
+  it('display list of tabs', async () => {
+    renderConfiguration();
+
+    await expect(await screen.findByText('Query Title 1')).toBeInTheDocument();
+    await expect(await screen.findByText('Query Title 2')).toBeInTheDocument();
+  });
+
+  it('on submit run setOrder and patchQueriesTitle with correct tab order and titles', async () => {
+    renderConfiguration();
+    const submitButton = await screen.findByTitle('Update configuration');
+    userEvent.click(submitButton);
+
+    await expect(QueriesActions.setOrder).toHaveBeenCalledWith(Immutable.OrderedSet([
+      { id: 'queryId-1', title: 'Query Title 1' },
+      { id: 'queryId-2', title: 'Query Title 2' },
+    ]));
+
+    await expect(ViewStatesActions.patchQueriesTitle).toHaveBeenCalledWith(Immutable.Set([
+      { queryId: 'queryId-1', titlesMap: Immutable.Map({ tab: Immutable.Map({ title: 'Query Title 1' }) }) },
+      { queryId: 'queryId-2', titlesMap: Immutable.Map({ tab: Immutable.Map({ title: 'Query Title 2' }) }) },
+    ]));
+  });
+});

--- a/graylog2-web-interface/src/views/components/AdaptableQueryTabsConfiguration.tsx
+++ b/graylog2-web-interface/src/views/components/AdaptableQueryTabsConfiguration.tsx
@@ -20,12 +20,12 @@ import type { Dispatch, SetStateAction } from 'react';
 import { useCallback, useState } from 'react';
 import { OrderedSet, Map, Set } from 'immutable';
 
-import BootstrapModalForm from 'components/bootstrap/BootstrapModalForm';
+import BootstrapModalConfirm from 'components/bootstrap/BootstrapModalConfirm';
 import { QueriesActions } from 'views/actions/QueriesActions';
 import { SortableList } from 'components/common';
 import type { ListItemType } from 'components/common/SortableList/ListItem';
 import { ViewStatesActions } from 'views/stores/ViewStatesStore';
-import type { TitlesMap, TitleType } from 'views/stores/TitleTypes';
+import type { TitleType } from 'views/stores/TitleTypes';
 import type { QueryId } from 'views/logic/queries/Query';
 import TitleTypes from 'views/stores/TitleTypes';
 
@@ -37,37 +37,38 @@ type Props = {
 
 const AdaptableQueryTabsConfiguration = ({ show, setShow, queriesList }: Props) => {
   const [orderedQueriesList, setOrderedQueriesList] = useState<Array<ListItemType>>(queriesList);
-  const onSubmitTabsConfiguration = useCallback(() => {
+  const onConfirmPagesConfiguration = useCallback(() => {
     QueriesActions.setOrder(OrderedSet(orderedQueriesList)).then(() => {
-      let newTitles = Set<{ queryId: QueryId, titlesMap: TitlesMap}>([]);
-
-      orderedQueriesList.forEach(({ id: queryId, title }: {
+      const newTitles = orderedQueriesList.map(({ id: queryId, title }: {
         id: QueryId, title: string
       }) => {
         const titleMap = Map<string, string>({ title });
         const titlesMap = Map<TitleType, Map<string, string>>({ [TitleTypes.Tab]: titleMap });
-        newTitles = newTitles.add({ queryId, titlesMap });
+
+        return ({ queryId, titlesMap });
       });
 
-      ViewStatesActions.patchQueriesTitle(newTitles);
+      ViewStatesActions.patchQueriesTitle(Set(newTitles));
       setShow(false);
     });
   }, [orderedQueriesList, setShow]);
-  const onTabsConfigurationModalClose = useCallback(() => setShow(false), [setShow]);
+  const onPagesConfigurationModalClose = useCallback(() => setShow(false), [setShow]);
   const updateTabSorting = useCallback((order) => {
     setOrderedQueriesList(order);
   }, [setOrderedQueriesList]);
 
   return (
-    <BootstrapModalForm show={show}
-                        title="Update Dashboard Tabs Configuration"
-                        onSubmitForm={onSubmitTabsConfiguration}
-                        onModalClose={onTabsConfigurationModalClose}
-                        submitButtonText="Update configuration">
-      <h3>Order</h3>
-      <p>Use drag and drop to change the execution order of the dashboard tabs.</p>
-      <SortableList items={orderedQueriesList} onMoveItem={updateTabSorting} displayOverlayInPortal />
-    </BootstrapModalForm>
+    <BootstrapModalConfirm showModal={show}
+                           title="Update Dashboard Pages Configuration"
+                           onConfirm={onConfirmPagesConfiguration}
+                           onModalClose={onPagesConfigurationModalClose}
+                           confirmButtonText="Update configuration">
+      <>
+        <h3>Order</h3>
+        <p>Use drag and drop to change the execution order of the dashboard pages.</p>
+        <SortableList items={orderedQueriesList} onMoveItem={updateTabSorting} displayOverlayInPortal />
+      </>
+    </BootstrapModalConfirm>
   );
 };
 

--- a/graylog2-web-interface/src/views/components/AdaptableQueryTabsConfiguration.tsx
+++ b/graylog2-web-interface/src/views/components/AdaptableQueryTabsConfiguration.tsx
@@ -1,0 +1,57 @@
+import * as React from 'react';
+import type { Dispatch, SetStateAction } from 'react';
+import { useCallback, useState } from 'react';
+import { OrderedSet, Map, Set } from 'immutable';
+
+import BootstrapModalForm from 'components/bootstrap/BootstrapModalForm';
+import { QueriesActions } from 'views/actions/QueriesActions';
+import { SortableList } from 'components/common';
+import type { ListItemType } from 'components/common/SortableList/ListItem';
+import { ViewStatesActions } from 'views/stores/ViewStatesStore';
+import type { TitlesMap, TitleType } from 'views/stores/TitleTypes';
+import type { QueryId } from 'views/logic/queries/Query';
+import TitleTypes from 'views/stores/TitleTypes';
+
+type Props = {
+  show: boolean,
+  setShow: Dispatch<SetStateAction<boolean>>,
+  queriesList: Array<ListItemType>
+}
+
+const AdaptableQueryTabsConfiguration = ({ show, setShow, queriesList }: Props) => {
+  const [orderedQueriesList, setOrderedQueriesList] = useState<Array<ListItemType>>(queriesList);
+  const onSubmitTabsConfiguration = useCallback(() => {
+    QueriesActions.setOrder(OrderedSet(orderedQueriesList)).then(() => {
+      let newTitles = Set<{ queryId: QueryId, titlesMap: TitlesMap}>([]);
+
+      orderedQueriesList.forEach(({ id: queryId, title }: {
+        id: QueryId, title: string
+      }) => {
+        const titleMap = Map<string, string>({ title });
+        const titlesMap = Map<TitleType, Map<string, string>>({ [TitleTypes.Tab]: titleMap });
+        newTitles = newTitles.add({ queryId, titlesMap });
+      });
+
+      ViewStatesActions.patchQueriesTitle(newTitles);
+      setShow(false);
+    });
+  }, [orderedQueriesList, setShow]);
+  const onTabsConfigurationModalClose = useCallback(() => setShow(false), [setShow]);
+  const updateTabSorting = useCallback((order) => {
+    setOrderedQueriesList(order);
+  }, [setOrderedQueriesList]);
+
+  return (
+    <BootstrapModalForm show={show}
+                        title="Update Dashboard Tabs Configuration"
+                        onSubmitForm={onSubmitTabsConfiguration}
+                        onModalClose={onTabsConfigurationModalClose}
+                        submitButtonText="Update configuration">
+      <h3>Order</h3>
+      <p>Use drag and drop to change the execution order of the dashboard tabs.</p>
+      <SortableList items={orderedQueriesList} onMoveItem={updateTabSorting} displayOverlayInPortal />
+    </BootstrapModalForm>
+  );
+};
+
+export default AdaptableQueryTabsConfiguration;

--- a/graylog2-web-interface/src/views/components/AdaptableQueryTabsConfiguration.tsx
+++ b/graylog2-web-interface/src/views/components/AdaptableQueryTabsConfiguration.tsx
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+
 import * as React from 'react';
 import type { Dispatch, SetStateAction } from 'react';
 import { useCallback, useState } from 'react';

--- a/graylog2-web-interface/src/views/stores/QueriesStore.ts
+++ b/graylog2-web-interface/src/views/stores/QueriesStore.ts
@@ -94,6 +94,16 @@ export const QueriesStore: QueriesStoreType = singletonStore(
       return promise;
     },
 
+    setOrder(newOrder: Immutable.OrderedSet<{ id: QueryId }>) {
+      const newQueries = newOrder.map(({ id }) => {
+        return this.queries.get(id);
+      });
+      const promise: Promise<QueriesList> = this._propagateQueryChange(newQueries).then(() => newQueries);
+
+      QueriesActions.setOrder.promise(promise);
+
+      return promise;
+    },
     // Similar to the update action, but it is skipping the equality check.
     forceUpdate(queryId: QueryId, query: Query) {
       const newQueries = this.queries.set(queryId, query);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR adds a Tabs Configuration component where users can reorder tabs as they like. In the future, we can add to this component more actions, like deleting tab or renaming tab e.t.c
As we have generic tab names for unnamed tabs ( `Page ${index}`) we have to keep old names after reordering. To solve this, we also set the generic names as static names after submitting the order. F.e. if the tab has the name `Page 1 `and then moved to position 4 it will have the name `Page 1 `

## Motivation and Context
fix: https://github.com/Graylog2/graylog2-server/issues/7470

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

