### PR TITLE
Fix search form width bug

### DIFF
--- a/graylog2-web-interface/src/components/common/SearchForm.jsx
+++ b/graylog2-web-interface/src/components/common/SearchForm.jsx
@@ -52,10 +52,6 @@ const StyledInput = styled.input(({ queryWidth }) => `
   width: ${queryWidth} !important;
 `);
 
-const StyledInputContainer = styled.div(({ queryContainerWidth }) => `
-  width: ${queryContainerWidth} !important;
-`);
-
 /**
  * Component that renders a customizable search form. The component
  * supports a loading state, adding children next to the form, and
@@ -87,8 +83,6 @@ class SearchForm extends React.Component {
     wrapperClass: PropTypes.string,
     /** Width to use in the search field. */
     queryWidth: PropTypes.any,
-    /** Width to use in the search field container. */
-    queryContainerWidth: PropTypes.any,
     /** Top margin to use in the search form container. */
     topMargin: PropTypes.number,
     /** Separation between search field and buttons. */
@@ -140,7 +134,6 @@ class SearchForm extends React.Component {
     placeholder: 'Enter search query...',
     wrapperClass: 'search',
     queryWidth: 'auto',
-    queryContainerWidth: 'auto',
     topMargin: 15,
     buttonLeftMargin: 5,
     searchBsStyle: 'default',
@@ -235,7 +228,6 @@ class SearchForm extends React.Component {
     const {
       queryHelpComponent,
       queryWidth,
-      queryContainerWidth,
       focusAfterMount,
       children,
       className,
@@ -257,7 +249,7 @@ class SearchForm extends React.Component {
       <StyledContainer className={`${wrapperClass} ${className}`} topMargin={topMargin}>
         <form className="form-inline" onSubmit={this._onSearch}>
           <FormContent buttonLeftMargin={buttonLeftMargin}>
-            <StyledInputContainer className={`form-group ${queryHelpComponent ? 'has-feedback' : ''}`} queryContainerWidth={queryContainerWidth}>
+            <div className={`form-group ${queryHelpComponent ? 'has-feedback' : ''}`}>
               {label && (
                 <label htmlFor="common-search-form-query-input" className="control-label">
                   {label}
@@ -277,7 +269,7 @@ class SearchForm extends React.Component {
               {queryHelpComponent && (
                 <HelpFeedback className="form-control-feedback">{queryHelpComponent}</HelpFeedback>
               )}
-            </StyledInputContainer>
+            </div>
 
             {onSearch && (
               <Button bsStyle={searchBsStyle}

--- a/graylog2-web-interface/src/components/common/SearchForm.jsx
+++ b/graylog2-web-interface/src/components/common/SearchForm.jsx
@@ -49,11 +49,11 @@ const StyledContainer = styled.div(({ topMargin }) => `
 `);
 
 const StyledInput = styled.input(({ queryWidth }) => `
-  width: ${queryWidth};
+  width: ${queryWidth} !important;
 `);
 
-const StyledInputContainer = styled.div(({ queryWidth }) => `
-  width: ${queryWidth};
+const StyledInputContainer = styled.div(({ queryContainerWidth }) => `
+  width: ${queryContainerWidth} !important;
 `);
 
 /**
@@ -87,6 +87,8 @@ class SearchForm extends React.Component {
     wrapperClass: PropTypes.string,
     /** Width to use in the search field. */
     queryWidth: PropTypes.any,
+    /** Width to use in the search field container. */
+    queryContainerWidth: PropTypes.any,
     /** Top margin to use in the search form container. */
     topMargin: PropTypes.number,
     /** Separation between search field and buttons. */
@@ -138,6 +140,7 @@ class SearchForm extends React.Component {
     placeholder: 'Enter search query...',
     wrapperClass: 'search',
     queryWidth: 'auto',
+    queryContainerWidth: 'auto',
     topMargin: 15,
     buttonLeftMargin: 5,
     searchBsStyle: 'default',
@@ -232,6 +235,7 @@ class SearchForm extends React.Component {
     const {
       queryHelpComponent,
       queryWidth,
+      queryContainerWidth,
       focusAfterMount,
       children,
       className,
@@ -253,7 +257,7 @@ class SearchForm extends React.Component {
       <StyledContainer className={`${wrapperClass} ${className}`} topMargin={topMargin}>
         <form className="form-inline" onSubmit={this._onSearch}>
           <FormContent buttonLeftMargin={buttonLeftMargin}>
-            <StyledInputContainer className={`form-group ${queryHelpComponent ? 'has-feedback' : ''}`} queryWidth={queryWidth}>
+            <StyledInputContainer className={`form-group ${queryHelpComponent ? 'has-feedback' : ''}`} queryContainerWidth={queryContainerWidth}>
               {label && (
                 <label htmlFor="common-search-form-query-input" className="control-label">
                   {label}

--- a/graylog2-web-interface/src/components/sidecars/administration/CollectorConfigurationModal.tsx
+++ b/graylog2-web-interface/src/components/sidecars/administration/CollectorConfigurationModal.tsx
@@ -214,7 +214,11 @@ const CollectorConfigurationModal = ({
         </ModalTitle>
       </Modal.Header>
       <Modal.Body>
-        <SearchForm query={searchQuery} onQueryChange={(q) => setSearchQuery(q)} topMargin={0} queryWidth="100%" />
+        <SearchForm query={searchQuery}
+                    queryWidth="100%"
+                    queryContainerWidth="100%"
+                    onQueryChange={(q) => setSearchQuery(q)}
+                    topMargin={0} />
         <ConfigurationContainer>
           <ConfigurationTable className="table-condensed table-hover">
             <tbody>

--- a/graylog2-web-interface/src/components/sidecars/administration/CollectorConfigurationModal.tsx
+++ b/graylog2-web-interface/src/components/sidecars/administration/CollectorConfigurationModal.tsx
@@ -104,6 +104,12 @@ const ModalSubTitle = styled.div`
   text-overflow: ellipsis;
 `;
 
+const StyledSearchForm = styled(SearchForm)`
+  .form-group, .query {
+    width: 100% !important;
+  }
+`;
+
 const getFilterQuery = (_query: string) => {
   try {
     return new RegExp(_query, 'i');
@@ -214,11 +220,9 @@ const CollectorConfigurationModal = ({
         </ModalTitle>
       </Modal.Header>
       <Modal.Body>
-        <SearchForm query={searchQuery}
-                    queryWidth="100%"
-                    queryContainerWidth="100%"
-                    onQueryChange={(q) => setSearchQuery(q)}
-                    topMargin={0} />
+        <StyledSearchForm query={searchQuery}
+                          onQueryChange={(q) => setSearchQuery(q)}
+                          topMargin={0} />
         <ConfigurationContainer>
           <ConfigurationTable className="table-condensed table-hover">
             <tbody>


### PR DESCRIPTION
## Description
Before one shared prop **queryWidth** was used for both the input width and its container width which caused a bug in /alert page's search form. Now this PR fixes that by adding a different prop for the container's width: **queryContainerWidth**.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fixes #13752

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

