### PR TITLE
Allow `Show Top Values` action for enumerable compound fields.

### DIFF
--- a/graylog2-web-interface/src/views/bindings.fieldActions.test.tsx
+++ b/graylog2-web-interface/src/views/bindings.fieldActions.test.tsx
@@ -41,7 +41,7 @@ describe('Views bindings field actions', () => {
   };
   const findAction = (type: string): ActionDefinition<{ analysisDisabledFields?: Array<string> }> => fieldActions.find((binding) => binding.type === type);
 
-  describe('Aggregate', () => {
+  describe('Show top values', () => {
     const action = findAction('aggregate');
     const { isEnabled } = action;
 
@@ -70,6 +70,15 @@ describe('Views bindings field actions', () => {
         type: FieldType.create('string', [Properties.Compound]),
       }))
         .toEqual(false);
+    });
+
+    it('should be enabled for compound fields if they are enumerable', () => {
+      expect(isEnabled({
+        ...defaultArguments,
+        field: 'something',
+        type: FieldType.create('compound(int,long)', [Properties.Compound, Properties.Enumerable]),
+      }))
+        .toEqual(true);
     });
 
     it('should be disabled for decorated fields', () => {
@@ -123,7 +132,7 @@ describe('Views bindings field actions', () => {
         .toEqual(true);
     });
 
-    it('should be disabled when field analisys is disabled', () => {
+    it('should be disabled when field analysis is disabled', () => {
       expect(isEnabled({
         ...defaultArguments,
         field: 'something',

--- a/graylog2-web-interface/src/views/bindings.tsx
+++ b/graylog2-web-interface/src/views/bindings.tsx
@@ -224,7 +224,7 @@ const exports: PluginExports = {
         field,
         type,
         contexts: { analysisDisabledFields },
-      }) => (!isFunction(field) && !type.isCompound() && !type.isDecorated() && !isAnalysisDisabled(field, analysisDisabledFields))),
+      }) => (!isFunction(field) && type.isEnumerable() && !type.isDecorated() && !isAnalysisDisabled(field, analysisDisabledFields))),
       resetFocus: true,
     },
     {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

**Note:** This should be backported to `4.3`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Prior to this PR, the `Show top values` action was disabled when the field it is triggered on is a compound field. This is too strict, because if all of the field types composing this compound field type are enumerable, then it is also possible to show the top values.

This PR is now changing the predicate to check if the field type is enumerable instead of if it is a compound type.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.