### PR TITLE
Improve navigation active state indicator styles.

### DIFF
--- a/graylog2-web-interface/src/components/bootstrap/NavDropdown.jsx
+++ b/graylog2-web-interface/src/components/bootstrap/NavDropdown.jsx
@@ -21,9 +21,9 @@ import { NavDropdown as BootstrapNavDropdown } from 'react-bootstrap';
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
 
-import menuItemStyles from './styles/menuItem';
+import NavItemStateIndicator from 'components/common/NavItemStateIndicator';
 
-import NavItemStateIndicator from '../common/NavItemStateIndicator';
+import menuItemStyles from './styles/menuItem';
 
 class ModifiedBootstrapNavDropdown extends BootstrapNavDropdown {
   // eslint-disable-next-line class-methods-use-this

--- a/graylog2-web-interface/src/components/bootstrap/NavDropdown.jsx
+++ b/graylog2-web-interface/src/components/bootstrap/NavDropdown.jsx
@@ -23,6 +23,8 @@ import PropTypes from 'prop-types';
 
 import menuItemStyles from './styles/menuItem';
 
+import NavItemStateIndicator from '../common/NavItemStateIndicator';
+
 class ModifiedBootstrapNavDropdown extends BootstrapNavDropdown {
   // eslint-disable-next-line class-methods-use-this
   isActive({ props }, activeKey, activeHref) {
@@ -50,7 +52,11 @@ const StyledNavDropdown = styled(BootstrapNavDropdown)`
 const NavDropdown = ({ inactiveTitle, title, ...props }) => {
   const isActive = inactiveTitle ? inactiveTitle !== title : undefined;
 
-  return <StyledNavDropdown {...props} title={title} active={isActive} />;
+  return (
+    <StyledNavDropdown {...props}
+                       title={<NavItemStateIndicator>{title}</NavItemStateIndicator>}
+                       active={isActive} />
+  );
 };
 
 NavDropdown.propTypes = {

--- a/graylog2-web-interface/src/components/bootstrap/NavItem.tsx
+++ b/graylog2-web-interface/src/components/bootstrap/NavItem.tsx
@@ -18,7 +18,15 @@ import * as React from 'react';
 // eslint-disable-next-line no-restricted-imports
 import { NavItem as BootstrapNavItem } from 'react-bootstrap';
 
-const NavItem = (props: React.ComponentProps<typeof NavItem>) => <BootstrapNavItem {...props} />;
+import NavItemStateIndicator from 'components/common/NavItemStateIndicator';
+
+const NavItem = ({ children, ...props }: React.ComponentProps<typeof NavItem>) => (
+  <BootstrapNavItem {...props}>
+    <NavItemStateIndicator>
+      {children}
+    </NavItemStateIndicator>
+  </BootstrapNavItem>
+);
 
 NavItem.displayName = 'NavItem';
 

--- a/graylog2-web-interface/src/components/bootstrap/Navbar.jsx
+++ b/graylog2-web-interface/src/components/bootstrap/Navbar.jsx
@@ -47,22 +47,18 @@ const Navbar = styled(BootstrapNavbar)(({ theme }) => css`
       &:hover,
       &:focus {
         color: ${theme.colors.variant.darker.default};
-        background-color: ${theme.colors.variant.lightest.default};
+        background-color: transparent;
       }
     }
 
     > .active > a,
     > .active > .btn-link {
-      color: ${theme.colors.variant.darkest.default};
-      background-color: ${theme.colors.gray[90]};
+      color: ${theme.colors.global.textDefault};
+      background-color: transparent;
       
-      &:hover {
+      &:hover, &:focus {
         color: ${theme.colors.variant.darkest.default};
-        background-color: ${theme.colors.gray[80]};
-      }
-
-      &:focus {
-        background-color: ${theme.colors.gray[90]};
+        background-color: transparent;
       }
     }
 
@@ -82,7 +78,7 @@ const Navbar = styled(BootstrapNavbar)(({ theme }) => css`
       &:hover,
       &:focus {
         color: ${theme.colors.variant.darkest.default};
-        background-color: ${theme.colors.gray[90]};
+        background-color: transparent;
       }
     }
 
@@ -94,7 +90,7 @@ const Navbar = styled(BootstrapNavbar)(({ theme }) => css`
         &:hover,
         &:focus {
           color: ${theme.colors.variant.darker.default};
-          background-color: ${theme.colors.variant.lightest.default};
+          background-color: transparent;
         }
       }
 

--- a/graylog2-web-interface/src/components/common/NavItemStateIndicator.tsx
+++ b/graylog2-web-interface/src/components/common/NavItemStateIndicator.tsx
@@ -21,7 +21,7 @@ import styled, { css } from 'styled-components';
 const indicatorClassName = 'nav-item-state-indicator';
 const indicatorPseudoElement = ':before';
 
-export const itemStateIndicatorSelector = `.${indicatorClassName}${indicatorPseudoElement}`;
+const itemStateIndicatorSelector = `.${indicatorClassName}${indicatorPseudoElement}`;
 
 export const hoverIndicatorStyles = (theme: DefaultTheme) => css`
   ${itemStateIndicatorSelector} {
@@ -30,7 +30,7 @@ export const hoverIndicatorStyles = (theme: DefaultTheme) => css`
 `;
 
 export const activeIndicatorStyles = (theme: DefaultTheme) => css`
-  ${itemStateIndicatorSelector}  {
+  ${itemStateIndicatorSelector} {
     border-color: ${theme.colors.gray[50]}; 
   }
 `;
@@ -39,7 +39,7 @@ const Container = styled.div`
   display: inline;
   position: relative;
   
-  :before {
+  ${indicatorPseudoElement} {
     content: ' ';
     position: absolute;
     border-bottom: 1px solid transparent;

--- a/graylog2-web-interface/src/components/common/NavItemStateIndicator.tsx
+++ b/graylog2-web-interface/src/components/common/NavItemStateIndicator.tsx
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import React from 'react';
+import type { DefaultTheme } from 'styled-components';
+import styled, { css } from 'styled-components';
+
+const indicatorClassName = 'nav-item-state-indicator';
+const indicatorPseudoElement = ':before';
+
+export const itemStateIndicatorSelector = `.${indicatorClassName}${indicatorPseudoElement}`;
+
+export const hoverIndicatorStyles = (theme: DefaultTheme) => css`
+  ${itemStateIndicatorSelector} {
+    border-color: ${theme.colors.gray[70]}; 
+  }
+`;
+
+export const activeIndicatorStyles = (theme: DefaultTheme) => css`
+  ${itemStateIndicatorSelector}  {
+    border-color: ${theme.colors.gray[50]}; 
+  }
+`;
+
+const Container = styled.div`
+  display: inline;
+  position: relative;
+  
+  :before {
+    content: ' ';
+    position: absolute;
+    border-bottom: 1px solid transparent;
+    left: 0;
+    width: 100%;
+    bottom: -4px;
+  }
+`;
+
+/**
+ * Component that wraps and render a `Select` where multiple options can be selected. It passes all
+ * props to the underlying `Select` component, so please look there to find more information about them.
+ */
+const NavItemStateIndicator = ({ children }: { children: React.ReactNode }) => (
+  <Container className={indicatorClassName}>
+    {children}
+  </Container>
+);
+
+export default NavItemStateIndicator;

--- a/graylog2-web-interface/src/components/common/NavItemStateIndicator.tsx
+++ b/graylog2-web-interface/src/components/common/NavItemStateIndicator.tsx
@@ -50,8 +50,7 @@ const Container = styled.div`
 `;
 
 /**
- * Component that wraps and render a `Select` where multiple options can be selected. It passes all
- * props to the underlying `Select` component, so please look there to find more information about them.
+ * This component provides styling for navigation item states like active and hover.
  */
 const NavItemStateIndicator = ({ children }: { children: React.ReactNode }) => (
   <Container className={indicatorClassName}>

--- a/graylog2-web-interface/src/components/common/PageNavigation.tsx
+++ b/graylog2-web-interface/src/components/common/PageNavigation.tsx
@@ -20,6 +20,10 @@ import styled, { css } from 'styled-components';
 import { Button, ButtonToolbar } from 'components/bootstrap';
 import { LinkContainer } from 'components/common/router';
 import { IfPermitted } from 'components/common';
+import NavItemStateIndicator, {
+  hoverIndicatorStyles,
+  activeIndicatorStyles,
+} from 'components/common/NavItemStateIndicator';
 
 const Container = styled(ButtonToolbar)`
   margin-bottom: 10px;
@@ -35,10 +39,23 @@ const StyledButton = styled(Button)(({ theme }) => css`
     :hover, :focus {
       text-decoration: none;  
     }
-    
+
+    :hover {
+      ${hoverIndicatorStyles(theme)}
+    }
+
+    .state-indicator {
+      position: relative;
+    }
+
     &.active {
       color: ${theme.colors.global.textDefault};
-      border-bottom: 1px solid ${theme.colors.variant.primary};
+
+      ${activeIndicatorStyles(theme)}
+
+      :hover, :focus {
+        ${activeIndicatorStyles(theme)}
+      }
     }
   }
 `);
@@ -72,7 +89,11 @@ const PageNavigation = ({ items }: Props) => (
       return (
         <IfPermitted permissions={permissions ?? []} key={path}>
           <LinkContainer to={path} relativeActive={!exactPathMatch}>
-            <StyledButton bsStyle="link">{title}</StyledButton>
+            <StyledButton bsStyle="link">
+              <NavItemStateIndicator>
+                {title}
+              </NavItemStateIndicator>
+            </StyledButton>
           </LinkContainer>
         </IfPermitted>
       );

--- a/graylog2-web-interface/src/components/common/PageNavigation.tsx
+++ b/graylog2-web-interface/src/components/common/PageNavigation.tsx
@@ -44,10 +44,6 @@ const StyledButton = styled(Button)(({ theme }) => css`
       ${hoverIndicatorStyles(theme)}
     }
 
-    .state-indicator {
-      position: relative;
-    }
-
     &.active {
       color: ${theme.colors.global.textDefault};
 

--- a/graylog2-web-interface/src/components/common/Wizard.test.jsx
+++ b/graylog2-web-interface/src/components/common/Wizard.test.jsx
@@ -66,7 +66,7 @@ describe('<Wizard />', () => {
     it('should render step 2 when clicked on step 2', () => {
       const wrapper = mount(<Wizard steps={steps} />);
 
-      wrapper.find('a[children="Title2"]').simulate('click');
+      wrapper.find('div[children="Title2"]').simulate('click');
 
       expect(wrapper.find('div[children="Component1"]').exists()).toBe(false);
       expect(wrapper.find('div[children="Component2"]').exists()).toBe(true);
@@ -199,7 +199,7 @@ describe('<Wizard />', () => {
     expect(wrapper.find('div[children="Component2"]').exists()).toBe(false);
     expect(wrapper.find('div[children="Component3"]').exists()).toBe(false);
 
-    wrapper.find('a[children="Title2"]').simulate('click');
+    wrapper.find('div[children="Title2"]').simulate('click');
 
     expect(wrapper.find('div[children="Component1"]').exists()).toBe(true);
     expect(wrapper.find('div[children="Component2"]').exists()).toBe(false);

--- a/graylog2-web-interface/src/components/navigation/Navigation.styles.jsx
+++ b/graylog2-web-interface/src/components/navigation/Navigation.styles.jsx
@@ -18,6 +18,10 @@ import styled, { css } from 'styled-components';
 
 import { Navbar } from 'components/bootstrap';
 import { NAV_ITEM_HEIGHT } from 'theme/constants';
+import {
+  hoverIndicatorStyles,
+  activeIndicatorStyles,
+} from 'components/common/NavItemStateIndicator';
 
 const StyledNavbar = styled(Navbar)(({ theme }) => css`
   .dev-badge-wrap > a {
@@ -29,11 +33,25 @@ const StyledNavbar = styled(Navbar)(({ theme }) => css`
     margin: 0 10px;
   }
 
-  &.navbar-default .navbar-main > li > a {
-    font-family: ${theme.fonts.family.navigation};
-    font-size: ${theme.fonts.size.navigation};
+  &.navbar-default .navbar-main > li {
+    > a {
+      font-family: ${theme.fonts.family.navigation};
+      font-size: ${theme.fonts.size.navigation};
+    }
+
+    &:hover {
+      ${hoverIndicatorStyles(theme)}
+    }
+
+    &.active {
+      ${activeIndicatorStyles(theme)}
+
+      :hover, :focus {
+        ${activeIndicatorStyles(theme)}
+      }
+    }
   }
-  
+
   .dropdown-menu li {
     &:not(.dropdown-header) {
       font-family: ${theme.fonts.family.navigation};
@@ -43,9 +61,7 @@ const StyledNavbar = styled(Navbar)(({ theme }) => css`
     a {
       padding: 6px 20px;
     }
-  }  
-
-  
+  }
 
   @media (max-width: 991px) {
     .small-scrn-badge {

--- a/graylog2-web-interface/src/components/navigation/SystemMenu.test.tsx
+++ b/graylog2-web-interface/src/components/navigation/SystemMenu.test.tsx
@@ -19,6 +19,7 @@ import * as Immutable from 'immutable';
 import { mount } from 'wrappedEnzyme';
 import { useLocation } from 'react-router-dom';
 import type { Location } from 'history';
+import type { ReactWrapper } from 'enzyme';
 
 import { asMock } from 'helpers/mocking';
 import useCurrentUser from 'hooks/useCurrentUser';
@@ -151,6 +152,10 @@ describe('SystemMenu', () => {
   });
 
   describe('sets a location-specific title for the dropdown', () => {
+    const getDropdownTitle = (wrapper: ReactWrapper) => wrapper.find('NavDropdown')
+      .at(1)
+      .prop<React.ReactElement>('title')
+      .props.children;
     let SystemMenu;
 
     beforeEach(() => {
@@ -170,21 +175,21 @@ describe('SystemMenu', () => {
     it('uses a default title if location is not matched', () => {
       const wrapper = mount(<SystemMenu />);
 
-      expect(wrapper.find('NavDropdown').at(1)).toHaveProp('title', 'System');
+      expect(getDropdownTitle(wrapper)).toBe('System');
     });
 
     it('uses a custom title if location is matched', () => {
       asMock(useLocation).mockReturnValue({ pathname: '/system/overview' } as Location<{ pathname: string }>);
       const wrapper = mount(<SystemMenu />);
 
-      expect(wrapper.find('NavDropdown').at(1)).toHaveProp('title', 'System / Overview');
+      expect(getDropdownTitle(wrapper)).toBe('System / Overview');
     });
 
     it('uses a custom title for a plugin route if location is matched', () => {
       asMock(useLocation).mockReturnValue({ pathname: '/system/licenses' } as Location<{ pathname: string }>);
       const wrapper = mount(<SystemMenu />);
 
-      expect(wrapper.find('NavDropdown').at(1)).toHaveProp('title', 'System / Licenses');
+      expect(getDropdownTitle(wrapper)).toBe('System / Licenses');
     });
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Currently the active state indicator in the navigation is not ideal, especially with the dark mode version. With this PR we are changing the way we display the active and hover state.

Before:

<img width="467" alt="image" src="https://user-images.githubusercontent.com/46300478/197814609-a6e8873b-3e20-45b4-aaa4-8021b0ccb1a3.png">

<img width="466" alt="image" src="https://user-images.githubusercontent.com/46300478/197814532-8e7ee49b-de40-4910-bd38-6a22da6230eb.png">



After:

<img width="467" alt="image" src="https://user-images.githubusercontent.com/46300478/197814199-69c91958-9a36-4a61-94e8-3609ac79dac6.png">

<img width="466" alt="image" src="https://user-images.githubusercontent.com/46300478/197814425-463dcb15-796e-48dc-b3b1-f09feb2b8c4a.png">





Fixes: https://github.com/Graylog2/graylog2-server/issues/13773