### PR TITLE
Removed pivot limits from contentpack

### DIFF
--- a/graylog2-server/src/main/resources/org/graylog2/migrations/V20191219090834_AddSourcesPage_Content_Pack.json
+++ b/graylog2-server/src/main/resources/org/graylog2/migrations/V20191219090834_AddSourcesPage_Content_Pack.json
@@ -86,8 +86,7 @@
                   "row_groups": [
                     {
                       "type": "values",
-                      "field": "source",
-                      "limit": 10
+                      "field": "source"
                     }
                   ],
                   "type": "pivot",
@@ -121,8 +120,7 @@
                   "row_groups": [
                     {
                       "type": "values",
-                      "field": "source",
-                      "limit": 15
+                      "field": "source"
                     }
                   ],
                   "type": "pivot",
@@ -179,7 +177,6 @@
                       "field": "source",
                       "type": "values",
                       "config": {
-                        "limit": 15
                       }
                     }
                   ],
@@ -262,7 +259,6 @@
                       "field": "source",
                       "type": "values",
                       "config": {
-                        "limit": 10
                       }
                     }
                   ],


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR removes the `limits` from the pivots in the given contentpack. The structure changed because of changes in the pivots dto. 
If you start with an empty MongoDB, this leads to errors.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

