### PR TITLE
Remove erronous exception logging

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/ContentPackService.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/ContentPackService.java
@@ -185,8 +185,7 @@ public class ContentPackService {
                 final NativeEntity<Stream> streamNativeEntity = streamFacade.findExisting(streamEntity, Collections.emptyMap()).get();
                 entities.put(streamEntityDescriptor, streamNativeEntity.entity());
             } catch (Exception e) {
-                e.printStackTrace();
-                LOG.debug("Failed to load system stream <{}>", id);
+                LOG.debug("Failed to load system stream <{}>", id, e);
             }
         }
         return entities;


### PR DESCRIPTION
refs #13398 

Old migrations are trying to install content packs. This happens before the migration that adds the events streams (`000000000000002`, `0000000000003`) has run. 
I think we can ignore this error for now. But maybe we should handle this a little better.

Fixes #13793 