### PR TITLE
Do not render pluggable search bar controls container, when it does not contain content.

### DIFF
--- a/graylog2-web-interface/src/views/components/searchbar/PluggableSearchBarControls.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/PluggableSearchBarControls.test.tsx
@@ -17,6 +17,7 @@
 import * as React from 'react';
 import { render, screen } from 'wrappedTestingLibrary';
 
+import Store from 'logic/local-storage/Store';
 import asMock from 'helpers/mocking/AsMock';
 import usePluginEntities from 'hooks/usePluginEntities';
 
@@ -25,15 +26,23 @@ import PluggableSearchBarControls from './PluggableSearchBarControls';
 jest.mock('hooks/usePluginEntities');
 jest.mock('hooks/useFeature', () => (key) => key === 'search_filter');
 
+jest.mock('logic/local-storage/Store', () => ({
+  get: jest.fn(),
+  set: jest.fn(),
+}));
+
 describe('PluggableSearchBarControls', () => {
-  const createPluggableSearchBarControl = (overrides = {}) => {
-    return () => ({
-      id: 'example-component',
-      placement: 'right',
-      component: () => <div>Example Component</div>,
-      ...overrides,
-    });
-  };
+  beforeEach(() => {
+    asMock(usePluginEntities).mockReturnValue([]);
+    Store.get.mockReturnValue(false);
+  });
+
+  const createPluggableSearchBarControl = (overrides = {}) => () => ({
+    id: 'example-component',
+    placement: 'right',
+    component: () => <div>Example Component</div>,
+    ...overrides,
+  });
 
   it('should render left search bar controls from plugins', () => {
     const example = createPluggableSearchBarControl({ placement: 'left' });
@@ -65,5 +74,20 @@ describe('PluggableSearchBarControls', () => {
     render(<PluggableSearchBarControls />);
 
     expect(screen.queryByText('Filters')).not.toBeInTheDocument();
+  });
+
+  it('should not render anything when there are no pluggable controls and search filter preview is hidden', () => {
+    Store.get.mockReturnValue(true);
+    const { container } = render(<PluggableSearchBarControls />);
+
+    // eslint-disable-next-line testing-library/no-node-access
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('should not render anything when there are no pluggable controls and `showLeftControls` is `false`', () => {
+    const { container } = render(<PluggableSearchBarControls showLeftControls={false} />);
+
+    // eslint-disable-next-line testing-library/no-node-access
+    expect(container.firstChild).toBeNull();
   });
 });

--- a/graylog2-web-interface/src/views/components/searchbar/PluggableSearchBarControls.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/PluggableSearchBarControls.tsx
@@ -84,7 +84,7 @@ type Props = {
 }
 
 const PluggableSearchBarControls = ({ showLeftControls, showRightControls }: Props) => {
-  const [hidePluggableControlsPreview, setHidePluggableControlsPreview] = useState(!!Store.get(PLUGGABLE_CONTROLS_HIDDEN_KEY));
+  const [hidePluggableControlsPreview, setHidePluggableControlsPreview] = useState(() => !!Store.get(PLUGGABLE_CONTROLS_HIDDEN_KEY));
   const { leftControls, rightControls } = usePluggableControls();
   const hasSearchFilterFeatureFlag = useFeature('search_filter');
   const hasPluggableControls = !!(leftControls?.length || rightControls?.length);

--- a/graylog2-web-interface/src/views/components/searchbar/PluggableSearchBarControls.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/PluggableSearchBarControls.tsx
@@ -54,7 +54,7 @@ const componentHasContent = ({
   hasPluggableControls,
   hasSearchFilterFeatureFlag,
   hasLeftColFallback,
-  rightColFallback,
+  hasRightColFallback,
 }:{
   hidePluggableControlsPreview: boolean,
   showLeftControls: boolean,
@@ -62,7 +62,7 @@ const componentHasContent = ({
   hasPluggableControls: boolean,
   hasSearchFilterFeatureFlag: boolean,
   hasLeftColFallback?: boolean,
-  rightColFallback?: boolean
+  hasRightColFallback?: boolean
 }) => {
   if (hasPluggableControls) {
     return true;
@@ -73,7 +73,7 @@ const componentHasContent = ({
   }
 
   const shouldShowLeftCol = showLeftControls && hasLeftColFallback && hasSearchFilterFeatureFlag;
-  const shouldShowRightCol = showRightControls && !!rightColFallback;
+  const shouldShowRightCol = showRightControls && !!hasRightColFallback;
 
   return shouldShowLeftCol || shouldShowRightCol;
 };


### PR DESCRIPTION
_Please note this PR should be backported for 4.4_

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

We want to render the pluggable search bar container only when it contains content. Currently this does not work on the dashboard, when no valid enterprise license is configured.

<img width="269" alt="image" src="https://user-images.githubusercontent.com/46300478/198232790-b00a0c7c-eb4c-4ac6-b098-ea6869b4c746.png">

With this PR we are improving the related logic.

After:
<img width="196" alt="image" src="https://user-images.githubusercontent.com/46300478/198233134-826d6395-9633-48a0-83a2-ca80d4a89f73.png">

