### PR TITLE
Retrieve suggestions only for streams of request.

### DIFF
--- a/full-backend-tests/src/test/java/org/graylog/plugins/views/SuggestionResourceIT.java
+++ b/full-backend-tests/src/test/java/org/graylog/plugins/views/SuggestionResourceIT.java
@@ -19,27 +19,35 @@ package org.graylog.plugins.views;
 import io.restassured.response.ValidatableResponse;
 import io.restassured.specification.RequestSpecification;
 import org.graylog.testing.completebackend.GraylogBackend;
+import org.graylog.testing.containermatrix.SearchServer;
 import org.graylog.testing.containermatrix.annotations.ContainerMatrixTest;
 import org.graylog.testing.containermatrix.annotations.ContainerMatrixTestsConfiguration;
 import org.graylog.testing.utils.GelfInputUtils;
+import org.graylog.testing.utils.IndexSetUtils;
 import org.graylog.testing.utils.SearchUtils;
-import org.hamcrest.Matchers;
+import org.graylog.testing.utils.StreamUtils;
+import org.graylog2.plugin.streams.StreamRuleType;
 import org.junit.jupiter.api.BeforeAll;
 
+import java.util.Map;
+import java.util.Set;
+
 import static io.restassured.RestAssured.given;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.graylog.testing.completebackend.Lifecycle.VM;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.core.IsEqual.equalTo;
 
-@ContainerMatrixTestsConfiguration(serverLifecycle = VM)
+@ContainerMatrixTestsConfiguration(serverLifecycle = VM, searchVersions = SearchServer.ES7)
 public class SuggestionResourceIT {
 
     static final int GELF_HTTP_PORT = 12201;
 
     private final GraylogBackend sut;
     private final RequestSpecification requestSpec;
+
+    private String stream1Id;
+    private String stream2Id;
 
     public SuggestionResourceIT(GraylogBackend sut, RequestSpecification requestSpec) {
         this.sut = sut;
@@ -49,19 +57,27 @@ public class SuggestionResourceIT {
     @BeforeAll
     public void init() {
         int mappedPort = sut.mappedPortFor(GELF_HTTP_PORT);
+        final String defaultIndexSetId = IndexSetUtils.defaultIndexSetId(requestSpec);
+        this.stream1Id = StreamUtils.createStream(requestSpec, "Stream #1", defaultIndexSetId, new StreamUtils.StreamRule(StreamRuleType.EXACT.toInteger(), "stream1", "target_stream", false));
+        this.stream2Id = StreamUtils.createStream(requestSpec, "Stream #2", defaultIndexSetId, new StreamUtils.StreamRule(StreamRuleType.EXACT.toInteger(), "stream2", "target_stream", false));
+
         GelfInputUtils.createGelfHttpInput(mappedPort, GELF_HTTP_PORT, requestSpec);
         GelfInputUtils.postMessage(mappedPort,
-                "{\"short_message\":\"SuggestionResourceIT#1\", \"host\":\"example.org\", \"facility\":\"junit\"}",
+                "{\"short_message\":\"SuggestionResourceIT#1\", \"host\":\"example.org\", \"facility\":\"junit\", \"_target_stream\": \"stream1\"}",
                 requestSpec);
         GelfInputUtils.postMessage(mappedPort,
-                "{\"short_message\":\"SuggestionResourceIT#2\", \"host\":\"example.org\", \"facility\":\"test\"}",
+                "{\"short_message\":\"SuggestionResourceIT#2\", \"host\":\"example.org\", \"facility\":\"test\", \"_target_stream\": \"stream1\"}",
                 requestSpec);
         GelfInputUtils.postMessage(mappedPort,
-                "{\"short_message\":\"SuggestionResourceIT#3\", \"host\":\"example.org\", \"facility\":\"test\"}",
+                "{\"short_message\":\"SuggestionResourceIT#3\", \"host\":\"example.org\", \"facility\":\"test\", \"_target_stream\": \"stream1\"}",
+                requestSpec);
+        GelfInputUtils.postMessage(mappedPort,
+                "{\"short_message\":\"SuggestionResourceIT#4\", \"host\":\"foreign.org\", \"facility\":\"test\", \"_target_stream\": \"stream2\"}",
                 requestSpec);
          SearchUtils.waitForMessage(requestSpec, "SuggestionResourceIT#1");
          SearchUtils.waitForMessage(requestSpec, "SuggestionResourceIT#2");
          SearchUtils.waitForMessage(requestSpec, "SuggestionResourceIT#3");
+         SearchUtils.waitForMessage(requestSpec, "SuggestionResourceIT#4");
     }
 
     @ContainerMatrixTest
@@ -74,7 +90,38 @@ public class SuggestionResourceIT {
                 .then()
                 .statusCode(200);
         validatableResponse.assertThat().body("suggestions.value[0]", equalTo("test"));
-        validatableResponse.assertThat().body("suggestions.occurrence[0]", greaterThanOrEqualTo(2));
+        validatableResponse.assertThat().body("suggestions.occurrence[0]", greaterThanOrEqualTo(3));
+    }
+
+    @ContainerMatrixTest
+    void testSuggestionsAreLimitedToStream() {
+        final ValidatableResponse validatableResponse = given()
+                .spec(requestSpec)
+                .when()
+                .body(Map.of(
+                        "field", "source",
+                        "input", "",
+                        "streams", Set.of(stream1Id)
+                ))
+                .post("/search/suggest")
+                .then()
+                .statusCode(200);
+        validatableResponse.assertThat().body("suggestions.value[0]", equalTo("example.org"));
+        validatableResponse.assertThat().body("suggestions.occurrence[0]", equalTo(3));
+
+        final ValidatableResponse validatableResponse2 = given()
+                .spec(requestSpec)
+                .when()
+                .body(Map.of(
+                        "field", "source",
+                        "input", "",
+                        "streams", Set.of(stream2Id)
+                ))
+                .post("/search/suggest")
+                .then()
+                .statusCode(200);
+        validatableResponse2.assertThat().body("suggestions.value[0]", equalTo("foreign.org"));
+        validatableResponse2.assertThat().body("suggestions.occurrence[0]", equalTo(1));
     }
 
     @ContainerMatrixTest

--- a/full-backend-tests/src/test/java/org/graylog/plugins/views/SuggestionResourceIT.java
+++ b/full-backend-tests/src/test/java/org/graylog/plugins/views/SuggestionResourceIT.java
@@ -38,7 +38,7 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.core.IsEqual.equalTo;
 
-@ContainerMatrixTestsConfiguration(serverLifecycle = VM, searchVersions = SearchServer.ES7)
+@ContainerMatrixTestsConfiguration(serverLifecycle = VM, searchVersions = { SearchServer.ES7, SearchServer.OS2 })
 public class SuggestionResourceIT {
 
     static final int GELF_HTTP_PORT = 12201;

--- a/full-backend-tests/src/test/java/org/graylog/testing/utils/IndexSetUtils.java
+++ b/full-backend-tests/src/test/java/org/graylog/testing/utils/IndexSetUtils.java
@@ -1,0 +1,22 @@
+package org.graylog.testing.utils;
+
+import io.restassured.specification.RequestSpecification;
+
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+
+public class IndexSetUtils {
+    private IndexSetUtils() {}
+
+    public static String defaultIndexSetId(RequestSpecification requestSpec) {
+        return given()
+                .spec(requestSpec)
+                .when()
+                .get("/system/indices/index_sets")
+                .then()
+                .statusCode(200)
+                .assertThat()
+                .extract().body().jsonPath().getString("index_sets.find { it.default == true }.id");
+    }
+}

--- a/full-backend-tests/src/test/java/org/graylog/testing/utils/IndexSetUtils.java
+++ b/full-backend-tests/src/test/java/org/graylog/testing/utils/IndexSetUtils.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog.testing.utils;
 
 import io.restassured.specification.RequestSpecification;

--- a/full-backend-tests/src/test/java/org/graylog/testing/utils/StreamUtils.java
+++ b/full-backend-tests/src/test/java/org/graylog/testing/utils/StreamUtils.java
@@ -1,0 +1,46 @@
+package org.graylog.testing.utils;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.restassured.specification.RequestSpecification;
+
+import java.util.Collection;
+import java.util.List;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.notNullValue;
+
+public final class StreamUtils {
+    private StreamUtils() {}
+
+    public record StreamRule(@JsonProperty("type") int type,
+                             @JsonProperty("value") String value,
+                             @JsonProperty("field") String field,
+                             @JsonProperty("inverted") boolean inverted) {}
+    record CreateStreamRequest(@JsonProperty("title") String title,
+                               @JsonProperty("rules") Collection<StreamRule> streamRules,
+                               @JsonProperty("index_set_id") String indexSetId) {}
+
+    public static String createStream(RequestSpecification requestSpec, String title, String indexSetId, StreamRule... streamRules) {
+        final CreateStreamRequest body = new CreateStreamRequest(title, List.of(streamRules), indexSetId);
+        final String streamId = given()
+                .spec(requestSpec)
+                .when()
+                .body(body)
+                .post("/streams")
+                .then()
+                .log().ifError()
+                .statusCode(201)
+                .assertThat().body("stream_id", notNullValue())
+                .extract().body().jsonPath().getString("stream_id");
+
+        given()
+                .spec(requestSpec)
+                .when()
+                .post("/streams/" + streamId + "/resume")
+                .then()
+                .log().ifError()
+                .statusCode(204);
+
+        return streamId;
+    }
+}

--- a/full-backend-tests/src/test/java/org/graylog/testing/utils/StreamUtils.java
+++ b/full-backend-tests/src/test/java/org/graylog/testing/utils/StreamUtils.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog.testing.utils;
 
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/QuerySuggestionsOS2.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/QuerySuggestionsOS2.java
@@ -24,6 +24,7 @@ import org.graylog.plugins.views.search.engine.suggestions.SuggestionRequest;
 import org.graylog.plugins.views.search.engine.suggestions.SuggestionResponse;
 import org.graylog.shaded.opensearch2.org.opensearch.action.search.SearchRequest;
 import org.graylog.shaded.opensearch2.org.opensearch.action.search.SearchResponse;
+import org.graylog.shaded.opensearch2.org.opensearch.index.query.BoolQueryBuilder;
 import org.graylog.shaded.opensearch2.org.opensearch.index.query.QueryBuilders;
 import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.AggregationBuilders;
 import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.bucket.terms.ParsedStringTerms;
@@ -33,6 +34,7 @@ import org.graylog.shaded.opensearch2.org.opensearch.search.suggest.SuggestBuild
 import org.graylog.shaded.opensearch2.org.opensearch.search.suggest.term.TermSuggestion;
 import org.graylog.shaded.opensearch2.org.opensearch.search.suggest.term.TermSuggestionBuilder;
 import org.graylog.storage.opensearch2.errors.ResponseError;
+import org.graylog2.plugin.Message;
 
 import javax.inject.Inject;
 import java.util.List;
@@ -55,8 +57,11 @@ public class QuerySuggestionsOS2 implements QuerySuggestionsService {
     public SuggestionResponse suggest(SuggestionRequest req) {
         final Set<String> affectedIndices = indexLookup.indexNamesForStreamsInTimeRange(req.streams(), req.timerange());
         final TermSuggestionBuilder suggestionBuilder = SuggestBuilders.termSuggestion(req.field()).text(req.input()).size(req.size());
+        final BoolQueryBuilder query = QueryBuilders.boolQuery()
+                .must(QueryBuilders.termsQuery(Message.FIELD_STREAMS, req.streams()))
+                .must(QueryBuilders.prefixQuery(req.field(), req.input()));
         final SearchSourceBuilder search = new SearchSourceBuilder()
-                .query(QueryBuilders.prefixQuery(req.field(), req.input()))
+                .query(query)
                 .size(0)
                 .aggregation(AggregationBuilders.terms("fieldvalues").field(req.field()).size(req.size()))
                 .suggest(new SuggestBuilder().addSuggestion("corrections", suggestionBuilder));

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SuggestionsResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SuggestionsResource.java
@@ -109,6 +109,6 @@ public class SuggestionsResource extends RestResource implements PluginRestResou
     }
 
     private ImmutableSet<String> loadAllAllowedStreamsForUser(SearchUser searchUser) {
-        return permittedStreams.load(searchUser::canReadStream);
+        return permittedStreams.load(searchUser);
     }
 }


### PR DESCRIPTION
**Note:** This PR needs to be backported to `4.3`.
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Prior to this PR, the query suggestion endpoint checked permissions of the streams specified, but it did not generate a filter limiting the search to the specified streams. This could results in the disclosure of field values which are part of the same index set, but different streams.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.