### PR TITLE
Fail IT tests if a container fails during startup

### DIFF
--- a/graylog2-server/src/main/resources/org/graylog2/migrations/V20191219090834_AddSourcesPage_Content_Pack.json
+++ b/graylog2-server/src/main/resources/org/graylog2/migrations/V20191219090834_AddSourcesPage_Content_Pack.json
@@ -178,9 +178,6 @@
                     {
                       "field": "source",
                       "type": "values",
-                      "config": {
-                        "limit": 15
-                      }
                     }
                   ],
                   "series": [

--- a/graylog2-server/src/main/resources/org/graylog2/migrations/V20191219090834_AddSourcesPage_Content_Pack.json
+++ b/graylog2-server/src/main/resources/org/graylog2/migrations/V20191219090834_AddSourcesPage_Content_Pack.json
@@ -178,6 +178,9 @@
                     {
                       "field": "source",
                       "type": "values",
+                      "config": {
+                        "limit": 15
+                      }
                     }
                   ],
                   "series": [

--- a/graylog2-server/src/test/java/org/junit/platform/engine/support/hierarchical/ContainerMatrixHierarchicalTestEngine.java
+++ b/graylog2-server/src/test/java/org/junit/platform/engine/support/hierarchical/ContainerMatrixHierarchicalTestEngine.java
@@ -80,9 +80,12 @@ public abstract class ContainerMatrixHierarchicalTestEngine<C extends EngineExec
                 if (Lifecycle.VM.equals(containerMatrixTestsDescriptor.getLifecycle())) {
                     try (ContainerizedGraylogBackend backend = ContainerizedGraylogBackend.createStarted(esVersion, mongoVersion, extraPorts, mongoDBFixtures, pluginJarsProvider, mavenProjectDirProvider, enabledFeatureFlags, ContainerMatrixTestsConfiguration.defaultImportLicenses, withEnabledMailServer)) {
                         RequestSpecification specification = requestSpec(backend);
-                        this.execute(request, ((ContainerMatrixTestsDescriptor) descriptor).getChildren(), backend, specification);
+                        this.execute(request, descriptor.getChildren(), backend, specification);
                     } catch (Exception exception) {
-                        throw new JUnitException("Error executing tests for engine " + getId(), exception);
+                        /* Fail hard if the containerized backend failed to start. */
+                        LOG.error("Failed container startup? Error executing tests for engine " + getId(), exception);
+                        System.exit(1);
+//                        throw new JUnitException("Error executing tests for engine " + getId(), exception);
                     }
                 } else if (Lifecycle.CLASS.equals(containerMatrixTestsDescriptor.getLifecycle())) {
                     for (TestDescriptor td : containerMatrixTestsDescriptor.getChildren()) {
@@ -96,7 +99,10 @@ public abstract class ContainerMatrixHierarchicalTestEngine<C extends EngineExec
                             RequestSpecification specification = requestSpec(backend);
                             this.execute(request, Collections.singleton(td), backend, specification);
                         } catch (Exception exception) {
-                            throw new JUnitException("Error executing tests for engine " + getId(), exception);
+                            /* Fail hard if the containerized backend failed to start. */
+                            LOG.error("Failed container startup? Error executing tests for engine " + getId(), exception);
+                            System.exit(1);
+//                          throw new JUnitException("Error executing tests for engine " + getId(), exception);
                         }
                     }
                 } else {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
fixes #13804

Default handling from the `HierarchicalTestEngine` from JUnit5 is to throw an Exception at the point of change.
This leads to a warning in the failsafe plugin, not an error. The assumption in JUnit5 is probably that no errors should occur at this point or that the problem is handled otherwise.

This fix fails hard with `System.exit(1);` so that mvn picks up the failure on Jenkins/Github Actions.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

