### PR TITLE
Let integration tests fail if container does not start.

### DIFF
--- a/graylog2-server/src/main/resources/org/graylog2/migrations/V20191219090834_AddSourcesPage_Content_Pack.json
+++ b/graylog2-server/src/main/resources/org/graylog2/migrations/V20191219090834_AddSourcesPage_Content_Pack.json
@@ -178,9 +178,6 @@
                     {
                       "field": "source",
                       "type": "values",
-                      "config": {
-                        "limit": 15
-                      }
                     }
                   ],
                   "series": [

--- a/graylog2-server/src/test/java/org/junit/platform/engine/support/hierarchical/ContainerMatrixHierarchicalTestEngine.java
+++ b/graylog2-server/src/test/java/org/junit/platform/engine/support/hierarchical/ContainerMatrixHierarchicalTestEngine.java
@@ -80,9 +80,12 @@ public abstract class ContainerMatrixHierarchicalTestEngine<C extends EngineExec
                 if (Lifecycle.VM.equals(containerMatrixTestsDescriptor.getLifecycle())) {
                     try (ContainerizedGraylogBackend backend = ContainerizedGraylogBackend.createStarted(esVersion, mongoVersion, extraPorts, mongoDBFixtures, pluginJarsProvider, mavenProjectDirProvider, enabledFeatureFlags, ContainerMatrixTestsConfiguration.defaultImportLicenses, withEnabledMailServer)) {
                         RequestSpecification specification = requestSpec(backend);
-                        this.execute(request, ((ContainerMatrixTestsDescriptor) descriptor).getChildren(), backend, specification);
+                        this.execute(request, descriptor.getChildren(), backend, specification);
                     } catch (Exception exception) {
-                        throw new JUnitException("Error executing tests for engine " + getId(), exception);
+                        /* Fail hard if the containerized backend failed to start. */
+                        LOG.error("Failed container startup? Error executing tests for engine " + getId(), exception);
+                        System.exit(1);
+//                        throw new JUnitException("Error executing tests for engine " + getId(), exception);
                     }
                 } else if (Lifecycle.CLASS.equals(containerMatrixTestsDescriptor.getLifecycle())) {
                     for (TestDescriptor td : containerMatrixTestsDescriptor.getChildren()) {
@@ -96,7 +99,10 @@ public abstract class ContainerMatrixHierarchicalTestEngine<C extends EngineExec
                             RequestSpecification specification = requestSpec(backend);
                             this.execute(request, Collections.singleton(td), backend, specification);
                         } catch (Exception exception) {
-                            throw new JUnitException("Error executing tests for engine " + getId(), exception);
+                            /* Fail hard if the containerized backend failed to start. */
+                            LOG.error("Failed container startup? Error executing tests for engine " + getId(), exception);
+                            System.exit(1);
+//                          throw new JUnitException("Error executing tests for engine " + getId(), exception);
                         }
                     }
                 } else {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Prior to this PR, when the Graylog container which is started as part of the `full-backend-tests` module's tests does not start successfully, tests were skipped and the build was green. This was hiding potentially severe issues with the server in the build.

This change is now letting the initial test which caused the server to start fail and memoizes the state to let subsequent tests fail early.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.