### PR TITLE
Support deleting and renaming dashboard pages inside pages configuration modal.

### DIFF
--- a/graylog2-web-interface/src/components/common/SortableList/List.tsx
+++ b/graylog2-web-interface/src/components/common/SortableList/List.tsx
@@ -20,6 +20,7 @@ import type { ListItemType, CustomContentRender, CustomListItemRender } from './
 import SortableListItem from './SortableListItem';
 
 export type Props<ItemType extends ListItemType> = {
+  alignItemContent?: 'flex-start' | 'center',
   customContentRender?: CustomContentRender<ItemType>,
   customListItemRender?: CustomListItemRender<ItemType>,
   disableDragging?: boolean,
@@ -28,15 +29,17 @@ export type Props<ItemType extends ListItemType> = {
 }
 
 const List = <ItemType extends ListItemType>({
+  alignItemContent,
   customContentRender,
   customListItemRender,
   disableDragging,
   displayOverlayInPortal,
-  items,
+  items = [],
 }: Props<ItemType>) => (
   <>
     {items.map((item, index) => (
-      <SortableListItem item={item}
+      <SortableListItem alignItemContent={alignItemContent}
+                        item={item}
                         index={index}
                         key={item.id}
                         customContentRender={customContentRender}
@@ -48,10 +51,11 @@ const List = <ItemType extends ListItemType>({
   );
 
 List.defaultProps = {
+  displayOverlayInPortal: true,
+  alignItemContent: undefined,
   disableDragging: false,
   customContentRender: undefined,
   customListItemRender: undefined,
-  items: [],
 };
 
 export default React.memo(List);

--- a/graylog2-web-interface/src/components/common/SortableList/List.tsx
+++ b/graylog2-web-interface/src/components/common/SortableList/List.tsx
@@ -51,7 +51,7 @@ const List = <ItemType extends ListItemType>({
   );
 
 List.defaultProps = {
-  displayOverlayInPortal: true,
+  displayOverlayInPortal: false,
   alignItemContent: undefined,
   disableDragging: false,
   customContentRender: undefined,

--- a/graylog2-web-interface/src/components/common/SortableList/ListItem.tsx
+++ b/graylog2-web-interface/src/components/common/SortableList/ListItem.tsx
@@ -66,7 +66,7 @@ type Props<ItemType extends ListItemType> = {
 
 const StyledListGroupItem = styled(ListGroupItem)`
   display: flex;
-  align-items: flex-start;
+  align-items: center;
 `;
 
 const DragHandle = styled.div`

--- a/graylog2-web-interface/src/components/common/SortableList/ListItem.tsx
+++ b/graylog2-web-interface/src/components/common/SortableList/ListItem.tsx
@@ -16,7 +16,7 @@
  */
 import * as React from 'react';
 import { forwardRef } from 'react';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import type { DraggableProvidedDraggableProps, DraggableProvidedDragHandleProps } from 'react-beautiful-dnd';
 
 import { ListGroupItem } from 'components/bootstrap';
@@ -53,6 +53,7 @@ export type CustomContentRender<ItemType extends ListItemType> = ({
 }) => React.ReactNode;
 
 type Props<ItemType extends ListItemType> = {
+  alignItemContent?: 'flex-start' | 'center'
   className?: string,
   customListItemRender?: CustomListItemRender<ItemType>,
   customContentRender?: CustomContentRender<ItemType>,
@@ -64,16 +65,17 @@ type Props<ItemType extends ListItemType> = {
   item: ItemType,
 };
 
-const StyledListGroupItem = styled(ListGroupItem)`
+const StyledListGroupItem = styled(ListGroupItem)(({ $alignItemContent }: { $alignItemContent: 'flex-start' | 'center' }) => css`
   display: flex;
-  align-items: center;
-`;
+  align-items: ${$alignItemContent};
+`);
 
 const DragHandle = styled.div`
   margin-right: 5px;
 `;
 
 const ListItem = forwardRef(<ItemType extends ListItemType>({
+  alignItemContent,
   item,
   index,
   className,
@@ -85,33 +87,39 @@ const ListItem = forwardRef(<ItemType extends ListItemType>({
 }: Props<ItemType>, ref) => {
   const itemContent = customContentRender ? customContentRender({ item, index }) : item.title;
 
+  if (customListItemRender) {
+    return (
+      <>
+        {customListItemRender({
+          className,
+          disableDragging,
+          draggableProps: draggableProps,
+          dragHandleProps: dragHandleProps,
+          index,
+          item,
+          ref,
+        })}
+      </>
+    );
+  }
+
   return (
-    <>{customListItemRender
-      ? customListItemRender({
-        className,
-        disableDragging,
-        draggableProps: draggableProps,
-        dragHandleProps: dragHandleProps,
-        index,
-        item,
-        ref,
-      }) : (
-        <StyledListGroupItem ref={ref}
-                             className={className}
-                             containerProps={{ ...draggableProps }}>
-          {!disableDragging && (
-            <DragHandle {...dragHandleProps} data-testid={`sortable-item-${item.id}`}>
-              <Icon name="bars" />
-            </DragHandle>
-          )}
-          {itemContent}
-        </StyledListGroupItem>
+    <StyledListGroupItem $alignItemContent={alignItemContent}
+                         ref={ref}
+                         className={className}
+                         containerProps={{ ...draggableProps }}>
+      {!disableDragging && (
+        <DragHandle {...dragHandleProps} data-testid={`sortable-item-${item.id}`}>
+          <Icon name="bars" />
+        </DragHandle>
       )}
-    </>
+      {itemContent}
+    </StyledListGroupItem>
   );
 });
 
 ListItem.defaultProps = {
+  alignItemContent: 'flex-start',
   className: undefined,
   disableDragging: false,
   customListItemRender: undefined,

--- a/graylog2-web-interface/src/components/common/SortableList/SortableList.tsx
+++ b/graylog2-web-interface/src/components/common/SortableList/SortableList.tsx
@@ -125,7 +125,7 @@ SortableList.defaultProps = {
   alignItemContent: undefined,
   items: [],
   disableDragging: false,
-  displayOverlayInPortal: true,
+  displayOverlayInPortal: false,
   customContentRender: undefined,
   customListItemRender: undefined,
 };

--- a/graylog2-web-interface/src/components/common/SortableList/SortableList.tsx
+++ b/graylog2-web-interface/src/components/common/SortableList/SortableList.tsx
@@ -15,8 +15,10 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
+import type { DropResult } from 'react-beautiful-dnd';
 import { DragDropContext, Droppable } from 'react-beautiful-dnd';
 import PropTypes from 'prop-types';
+import { useCallback } from 'react';
 
 import type { ListItemType, CustomContentRender, CustomListItemRender } from './ListItem';
 import List from './List';
@@ -55,7 +57,7 @@ const SortableList = <ItemType extends ListItemType>({
   items,
   onMoveItem,
 }: Props<ItemType>) => {
-  const onDragEnd = (result) => {
+  const onDragEnd = useCallback((result: DropResult) => {
     if (!result.destination) {
       return;
     }
@@ -69,7 +71,7 @@ const SortableList = <ItemType extends ListItemType>({
 
       onMoveItem(newList, result.source.index, result.destination.index);
     }
-  };
+  }, [items, onMoveItem]);
 
   return (
     <DragDropContext onDragEnd={onDragEnd}>

--- a/graylog2-web-interface/src/components/common/SortableList/SortableList.tsx
+++ b/graylog2-web-interface/src/components/common/SortableList/SortableList.tsx
@@ -19,7 +19,6 @@ import { DragDropContext, Droppable } from 'react-beautiful-dnd';
 import PropTypes from 'prop-types';
 
 import type { ListItemType, CustomContentRender, CustomListItemRender } from './ListItem';
-// import SortableListItem from './SortableListItem';
 import List from './List';
 
 const reorder = <ItemType extends ListItemType>(list: Array<ItemType>, startIndex, endIndex) => {
@@ -31,6 +30,7 @@ const reorder = <ItemType extends ListItemType>(list: Array<ItemType>, startInde
 };
 
 export type Props<ItemType extends ListItemType> = {
+  alignItemContent?: 'flex-start' | 'center',
   customContentRender?: CustomContentRender<ItemType>,
   customListItemRender?: CustomListItemRender<ItemType>,
   disableDragging?: boolean,
@@ -47,6 +47,7 @@ export type Props<ItemType extends ListItemType> = {
  * This way consumers can add or remove items easily.
  */
 const SortableList = <ItemType extends ListItemType>({
+  alignItemContent,
   customContentRender,
   customListItemRender,
   disableDragging,
@@ -76,7 +77,8 @@ const SortableList = <ItemType extends ListItemType>({
         {({ droppableProps, innerRef, placeholder }) => (
           <div {...droppableProps}
                ref={innerRef}>
-            <List items={items}
+            <List alignItemContent={alignItemContent}
+                  items={items}
                   disableDragging={disableDragging}
                   displayOverlayInPortal={displayOverlayInPortal}
                   customContentRender={customContentRender}
@@ -118,8 +120,10 @@ SortableList.propTypes = {
 };
 
 SortableList.defaultProps = {
+  alignItemContent: undefined,
   items: [],
   disableDragging: false,
+  displayOverlayInPortal: true,
   customContentRender: undefined,
   customListItemRender: undefined,
 };

--- a/graylog2-web-interface/src/components/common/SortableList/SortableListItem.tsx
+++ b/graylog2-web-interface/src/components/common/SortableList/SortableListItem.tsx
@@ -24,6 +24,7 @@ import ListItem from './ListItem';
 import type { ListItemType, CustomContentRender, CustomListItemRender } from './ListItem';
 
 type Props<ItemType extends ListItemType> = {
+  alignItemContent?: 'flex-start' | 'center'
   className?: string,
   customListItemRender?: CustomListItemRender<ItemType>,
   customContentRender?: CustomContentRender<ItemType>,
@@ -38,6 +39,7 @@ const StyledListItem = styled(ListItem)(({ $isDragging }: { $isDragging: boolean
 `);
 
 const SortableListItem = <ItemType extends ListItemType>({
+  alignItemContent,
   className,
   customContentRender,
   customListItemRender,
@@ -49,7 +51,8 @@ const SortableListItem = <ItemType extends ListItemType>({
   <Draggable draggableId={item.id} index={index}>
     {({ draggableProps, dragHandleProps, innerRef }, { isDragging }) => {
       const listItem = (
-        <StyledListItem item={item}
+        <StyledListItem alignItemContent={alignItemContent}
+                        item={item}
                         index={index}
                         className={className}
                         ref={innerRef}
@@ -70,6 +73,7 @@ const SortableListItem = <ItemType extends ListItemType>({
   );
 
 SortableListItem.defaultProps = {
+  alignItemContent: undefined,
   className: undefined,
   customContentRender: undefined,
   customListItemRender: undefined,

--- a/graylog2-web-interface/src/views/actions/QueriesActions.ts
+++ b/graylog2-web-interface/src/views/actions/QueriesActions.ts
@@ -35,7 +35,7 @@ type QueriesActionsType = RefluxActions<{
   timerange: (queryId: QueryId, newTimeRange: TimeRange) => Promise<QueriesList>,
   update: (queryId: QueryId, query: Query) => Promise<QueriesList>,
   forceUpdate: (queryId: QueryId, query: Query) => Promise<QueriesList>,
-  setOrder: (newOrder: Immutable.OrderedSet<{ id: QueryId}>) => Promise<QueriesList>,
+  setOrder: (newOrder: Immutable.OrderedSet<QueryId>) => Promise<QueriesList>,
 }>;
 
 // eslint-disable-next-line import/prefer-default-export

--- a/graylog2-web-interface/src/views/components/AdaptableQueryTabs.test.tsx
+++ b/graylog2-web-interface/src/views/components/AdaptableQueryTabs.test.tsx
@@ -37,11 +37,12 @@ const DEFAULT_PROPS = {
   maxWidth: 500,
   queries: Immutable.OrderedSet(['query-id-1', 'query-id-2', 'query-id-3', 'query-id-4']),
   titles: Immutable.Map<string, string>([['query-id-1', 'Tab 1'], ['query-id-2', 'Tab 2'], ['query-id-3', 'Tab 3'], ['query-id-4', 'Tab 4']]),
-  selectedQueryId: 'query-id-1',
   onRemove: () => Promise.resolve(),
   onTitleChange: () => Promise.resolve(Map(['tab', Map(['query-id-1', 'Tab 1'])]) as TitlesMap),
   onSelect: (id: string) => Promise.resolve(id),
   queryTitleEditModal: React.createRef<QueryTitleEditModal>(),
+  activeQueryId: 'query-id-1',
+  dashboardId: 'dashboard-id',
 };
 
 describe('AdaptableQueryTabs', () => {
@@ -149,7 +150,7 @@ describe('AdaptableQueryTabs', () => {
 
       await finishInitialRender();
 
-      rerender(<AdaptableQueryTabs {...DEFAULT_PROPS} selectedQueryId="query-id-4" />);
+      rerender(<AdaptableQueryTabs {...DEFAULT_PROPS} activeQueryId="query-id-4" />);
 
       const newActiveTab = await screen.findByRole(mainTabRole, {
         name: 'Tab 4',
@@ -179,7 +180,7 @@ describe('AdaptableQueryTabs', () => {
   });
 
   it('displays active tab', () => {
-    render(<AdaptableQueryTabs {...DEFAULT_PROPS} selectedQueryId="query-id-2" />);
+    render(<AdaptableQueryTabs {...DEFAULT_PROPS} activeQueryId="query-id-2" />);
 
     const tab2 = screen.getByRole(mainTabRole, {
       name: 'Tab 2',

--- a/graylog2-web-interface/src/views/components/AdaptableQueryTabs.tsx
+++ b/graylog2-web-interface/src/views/components/AdaptableQueryTabs.tsx
@@ -29,7 +29,6 @@ import { Nav, NavItem, MenuItem } from 'components/bootstrap';
 import { Icon, IconButton } from 'components/common';
 import QueryTitle from 'views/components/queries/QueryTitle';
 import AdaptableQueryTabsConfiguration from 'views/components/AdaptableQueryTabsConfiguration';
-import type { ListItemType } from 'components/common/SortableList/ListItem';
 
 import type { QueryTabsProps } from './QueryTabs';
 
@@ -42,7 +41,7 @@ interface TabsTypes {
   navItems: OrderedSet<ReactNode>,
   menuItems: OrderedSet<ReactNode>,
   lockedItems: OrderedSet<ReactNode>,
-  queriesList: OrderedSet<ListItemType>,
+  queriesList: OrderedSet<{ id: string, title: string }>,
 }
 
 const CLASS_HIDDEN = 'hidden';
@@ -171,7 +170,7 @@ const adjustTabsVisibility = (maxWidth, lockedTab, setLockedTab) => {
   }
 };
 
-const AdaptableQueryTabs = ({ maxWidth, queries, titles, selectedQueryId, onRemove, onSelect, queryTitleEditModal }: Props) => {
+const AdaptableQueryTabs = ({ maxWidth, queries, titles, activeQueryId, onRemove, onSelect, queryTitleEditModal, dashboardId }: Props) => {
   const [openedMore, setOpenedMore] = useState<boolean>(false);
   const [lockedTab, setLockedTab] = useState<QueryId>();
   const [showConfigurationModal, setShowConfigurationModal] = useState<boolean>(false);
@@ -179,7 +178,7 @@ const AdaptableQueryTabs = ({ maxWidth, queries, titles, selectedQueryId, onRemo
     let navItems = OrderedSet();
     let menuItems = OrderedSet();
     let lockedItems = OrderedSet();
-    let queriesList = OrderedSet<ListItemType>();
+    let queriesList = OrderedSet<{ id: string, title: string }>();
 
     queries.keySeq().forEach((id, idx) => {
       const openTitleEditModal = (activeQueryTitle: string) => {
@@ -190,7 +189,7 @@ const AdaptableQueryTabs = ({ maxWidth, queries, titles, selectedQueryId, onRemo
 
       const title = titles.get(id, `Page#${idx + 1}`);
       const tabTitle = (
-        <QueryTitle active={id === selectedQueryId}
+        <QueryTitle active={id === activeQueryId}
                     id={id}
                     onClose={() => onRemove(id)}
                     openEditModal={openTitleEditModal}
@@ -236,15 +235,15 @@ const AdaptableQueryTabs = ({ maxWidth, queries, titles, selectedQueryId, onRemo
     });
 
     return { navItems, menuItems, lockedItems, queriesList };
-  }, [lockedTab, onRemove, onSelect, queries, queryTitleEditModal, selectedQueryId, titles]);
+  }, [lockedTab, onRemove, onSelect, queries, queryTitleEditModal, activeQueryId, titles]);
 
   useEffect(() => {
     adjustTabsVisibility(maxWidth, lockedTab, setLockedTab);
-  }, [maxWidth, lockedTab, selectedQueryId]);
+  }, [maxWidth, lockedTab, activeQueryId]);
 
   return (
     <Container>
-      <StyledQueryNav bsStyle="tabs" activeKey={selectedQueryId} id="dashboard-tabs">
+      <StyledQueryNav bsStyle="tabs" activeKey={activeQueryId} id="dashboard-tabs">
         {currentTabs.navItems}
 
         <NavDropdown eventKey="more"
@@ -274,7 +273,9 @@ const AdaptableQueryTabs = ({ maxWidth, queries, titles, selectedQueryId, onRemo
       {showConfigurationModal && (
         <AdaptableQueryTabsConfiguration show={showConfigurationModal}
                                          setShow={setShowConfigurationModal}
-                                         queriesList={currentTabs.queriesList} />
+                                         queriesList={currentTabs.queriesList}
+                                         activeQueryId={activeQueryId}
+                                         dashboardId={dashboardId} />
       )}
     </Container>
   );
@@ -284,7 +285,7 @@ AdaptableQueryTabs.propTypes = {
   maxWidth: PropTypes.number.isRequired,
   queries: ImmutablePropTypes.orderedSetOf(PropTypes.string).isRequired,
   titles: PropTypes.object.isRequired,
-  selectedQueryId: PropTypes.string.isRequired,
+  activeQueryId: PropTypes.string.isRequired,
   onRemove: PropTypes.func.isRequired,
   onSelect: PropTypes.func.isRequired,
   queryTitleEditModal: PropTypes.oneOfType([

--- a/graylog2-web-interface/src/views/components/AdaptableQueryTabs.tsx
+++ b/graylog2-web-interface/src/views/components/AdaptableQueryTabs.tsx
@@ -20,6 +20,7 @@ import type { ReactNode } from 'react';
 import { useEffect, useMemo, useState } from 'react';
 import styled, { css } from 'styled-components';
 import ImmutablePropTypes from 'react-immutable-proptypes';
+import { OrderedSet } from 'immutable';
 
 import { ModifiedNavDropdown as NavDropdown } from 'components/bootstrap/NavDropdown';
 import type { QueryId } from 'views/logic/queries/Query';
@@ -27,8 +28,8 @@ import type QueryTitleEditModal from 'views/components/queries/QueryTitleEditMod
 import { Nav, NavItem, MenuItem } from 'components/bootstrap';
 import { Icon, IconButton } from 'components/common';
 import QueryTitle from 'views/components/queries/QueryTitle';
-import type { ListItemType } from 'components/common/SortableList/ListItem';
 import AdaptableQueryTabsConfiguration from 'views/components/AdaptableQueryTabsConfiguration';
+import type { ListItemType } from 'components/common/SortableList/ListItem';
 
 import type { QueryTabsProps } from './QueryTabs';
 
@@ -38,10 +39,10 @@ interface Props extends QueryTabsProps {
 }
 
 interface TabsTypes {
-  navItems: Array<ReactNode>,
-  menuItems: Array<ReactNode>,
-  lockedItems: Array<ReactNode>,
-  queriesList: Array<ListItemType>,
+  navItems: OrderedSet<ReactNode>,
+  menuItems: OrderedSet<ReactNode>,
+  lockedItems: OrderedSet<ReactNode>,
+  queriesList: OrderedSet<ListItemType>,
 }
 
 const CLASS_HIDDEN = 'hidden';
@@ -175,10 +176,10 @@ const AdaptableQueryTabs = ({ maxWidth, queries, titles, selectedQueryId, onRemo
   const [lockedTab, setLockedTab] = useState<QueryId>();
   const [showConfigurationModal, setShowConfigurationModal] = useState<boolean>(false);
   const currentTabs = useMemo((): TabsTypes => {
-    const navItems = [];
-    const menuItems = [];
-    const lockedItems = [];
-    const queriesList = [];
+    let navItems = OrderedSet();
+    let menuItems = OrderedSet();
+    let lockedItems = OrderedSet();
+    let queriesList = OrderedSet<ListItemType>();
 
     queries.keySeq().forEach((id, idx) => {
       const openTitleEditModal = (activeQueryTitle: string) => {
@@ -197,7 +198,7 @@ const AdaptableQueryTabs = ({ maxWidth, queries, titles, selectedQueryId, onRemo
                     title={title} />
       );
 
-      navItems.push(lockedTab === id ? null : (
+      navItems = navItems.add(lockedTab === id ? null : (
         <NavItem eventKey={id}
                  key={id}
                  data-tab-id={id}
@@ -209,18 +210,19 @@ const AdaptableQueryTabs = ({ maxWidth, queries, titles, selectedQueryId, onRemo
         </NavItem>
       ));
 
-      menuItems.push(lockedTab === id ? null : (
+      menuItems = menuItems.add(lockedTab === id ? null : (
         <MenuItem eventKey={id}
                   key={id}
                   data-tab-id={id}
                   onClick={() => {
                     setLockedTab(id);
                     onSelect(id);
-                  }}>{tabTitle}
+                  }}>
+          {tabTitle}
         </MenuItem>
       ));
 
-      lockedItems.push(lockedTab !== id ? null : (
+      lockedItems = lockedItems.add(lockedTab !== id ? null : (
         <NavItem eventKey={id}
                  key={id}
                  data-tab-id={id}
@@ -230,10 +232,7 @@ const AdaptableQueryTabs = ({ maxWidth, queries, titles, selectedQueryId, onRemo
         </NavItem>
       ));
 
-      queriesList.push({
-        id,
-        title,
-      });
+      queriesList = queriesList.add({ id, title });
     });
 
     return { navItems, menuItems, lockedItems, queriesList };
@@ -273,9 +272,9 @@ const AdaptableQueryTabs = ({ maxWidth, queries, titles, selectedQueryId, onRemo
       </StyledQueryNav>
       <IconButton title="Open pages configuration" name="cog" onClick={() => setShowConfigurationModal(true)} />
       {showConfigurationModal && (
-      <AdaptableQueryTabsConfiguration show={showConfigurationModal}
-                                       setShow={setShowConfigurationModal}
-                                       queriesList={currentTabs.queriesList} />
+        <AdaptableQueryTabsConfiguration show={showConfigurationModal}
+                                         setShow={setShowConfigurationModal}
+                                         queriesList={currentTabs.queriesList} />
       )}
     </Container>
   );

--- a/graylog2-web-interface/src/views/components/AdaptableQueryTabsConfiguration.test.tsx
+++ b/graylog2-web-interface/src/views/components/AdaptableQueryTabsConfiguration.test.tsx
@@ -40,6 +40,18 @@ jest.mock('views/stores/ViewStatesStore', () => ({
 const setShow = jest.fn();
 
 describe('AdaptableQueryTabsConfiguration', () => {
+  let oldConfirm;
+
+  beforeEach(() => {
+    oldConfirm = window.confirm;
+    window.confirm = jest.fn(() => true);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    window.confirm = oldConfirm;
+  });
+
   const renderConfiguration = () => render(
     <AdaptableQueryTabsConfiguration show
                                      setShow={setShow}
@@ -79,6 +91,25 @@ describe('AdaptableQueryTabsConfiguration', () => {
     await expect(ViewStatesActions.patchQueriesTitle).toHaveBeenCalledWith(Immutable.OrderedSet([
       { queryId: 'queryId-1', titlesMap: Immutable.Map({ tab: Immutable.Map({ title: 'Query Title 1' }) }) },
       { queryId: 'queryId-2', titlesMap: Immutable.Map({ tab: Immutable.Map({ title: 'Query Title 2' }) }) },
+    ]));
+  });
+
+  it('should remove dashboard page', async () => {
+    renderConfiguration();
+    const deleteButton = await screen.findByRole('button', {
+      name: /remove page query title 2/i,
+      hidden: true,
+    });
+
+    userEvent.click(deleteButton);
+
+    const submitButton = await screen.findByTitle('Update configuration');
+    userEvent.click(submitButton);
+
+    await expect(QueriesActions.setOrder).toHaveBeenCalledWith(Immutable.OrderedSet(['queryId-1']));
+
+    await expect(ViewStatesActions.patchQueriesTitle).toHaveBeenCalledWith(Immutable.OrderedSet([
+      { queryId: 'queryId-1', titlesMap: Immutable.Map({ tab: Immutable.Map({ title: 'Query Title 1' }) }) },
     ]));
   });
 });

--- a/graylog2-web-interface/src/views/components/AdaptableQueryTabsConfiguration.test.tsx
+++ b/graylog2-web-interface/src/views/components/AdaptableQueryTabsConfiguration.test.tsx
@@ -17,9 +17,10 @@
 
 import { render, screen } from 'wrappedTestingLibrary';
 import React from 'react';
-import Immutable, { OrderedSet } from 'immutable';
+import Immutable, { OrderedSet, Map as MockMap } from 'immutable';
 import userEvent from '@testing-library/user-event';
 
+import { MockStore } from 'helpers/mocking';
 import AdaptableQueryTabsConfiguration from 'views/components/AdaptableQueryTabsConfiguration';
 import mockAction from 'helpers/mocking/MockAction';
 import { QueriesActions } from 'views/actions/QueriesActions';
@@ -28,6 +29,13 @@ import ViewState from 'views/logic/views/ViewState';
 
 jest.mock('views/stores/QueriesStore', () => ({ QueriesActions: {} }));
 jest.mock('views/stores/ViewStatesStore', () => ({ ViewStatesActions: {} }));
+
+jest.mock('views/stores/ViewStatesStore', () => ({
+  ViewStatesActions: {
+    patchQueriesTitle: jest.fn(() => Promise.resolve()),
+  },
+  ViewStatesStore: MockStore(['getInitialState', () => MockMap()]),
+}));
 
 const setShow = jest.fn();
 
@@ -66,12 +74,9 @@ describe('AdaptableQueryTabsConfiguration', () => {
     const submitButton = await screen.findByTitle('Update configuration');
     userEvent.click(submitButton);
 
-    await expect(QueriesActions.setOrder).toHaveBeenCalledWith(Immutable.OrderedSet([
-      { id: 'queryId-1', title: 'Query Title 1' },
-      { id: 'queryId-2', title: 'Query Title 2' },
-    ]));
+    await expect(QueriesActions.setOrder).toHaveBeenCalledWith(Immutable.OrderedSet(['queryId-1', 'queryId-2']));
 
-    await expect(ViewStatesActions.patchQueriesTitle).toHaveBeenCalledWith(Immutable.Set([
+    await expect(ViewStatesActions.patchQueriesTitle).toHaveBeenCalledWith(Immutable.OrderedSet([
       { queryId: 'queryId-1', titlesMap: Immutable.Map({ tab: Immutable.Map({ title: 'Query Title 1' }) }) },
       { queryId: 'queryId-2', titlesMap: Immutable.Map({ tab: Immutable.Map({ title: 'Query Title 2' }) }) },
     ]));

--- a/graylog2-web-interface/src/views/components/AdaptableQueryTabsConfiguration.test.tsx
+++ b/graylog2-web-interface/src/views/components/AdaptableQueryTabsConfiguration.test.tsx
@@ -17,7 +17,7 @@
 
 import { render, screen } from 'wrappedTestingLibrary';
 import React from 'react';
-import Immutable from 'immutable';
+import Immutable, { OrderedSet } from 'immutable';
 import userEvent from '@testing-library/user-event';
 
 import AdaptableQueryTabsConfiguration from 'views/components/AdaptableQueryTabsConfiguration';
@@ -35,12 +35,13 @@ describe('AdaptableQueryTabsConfiguration', () => {
   const renderConfiguration = () => render(
     <AdaptableQueryTabsConfiguration show
                                      setShow={setShow}
-                                     queriesList={
-        [
-          { id: 'queryId-1', title: 'Query Title 1' },
-          { id: 'queryId-2', title: 'Query Title 2' },
-        ]
-} />);
+                                     activeQueryId="queryId-1"
+                                     dashboardId="dashboard-id"
+                                     queriesList={OrderedSet(
+                                       [
+                                         { id: 'queryId-1', title: 'Query Title 1' },
+                                         { id: 'queryId-2', title: 'Query Title 2' },
+                                       ])} />);
 
   beforeEach(() => {
     QueriesActions.setOrder = mockAction(jest.fn(() => Promise.resolve(Immutable.OrderedMap())));

--- a/graylog2-web-interface/src/views/components/AdaptableQueryTabsConfiguration.tsx
+++ b/graylog2-web-interface/src/views/components/AdaptableQueryTabsConfiguration.tsx
@@ -17,7 +17,7 @@
 import * as React from 'react';
 import type { Dispatch, SetStateAction } from 'react';
 import { useCallback, useState, useContext } from 'react';
-import { OrderedSet, Map, Set, List } from 'immutable';
+import { OrderedSet, Map, List } from 'immutable';
 import styled from 'styled-components';
 
 import BootstrapModalConfirm from 'components/bootstrap/BootstrapModalConfirm';
@@ -98,7 +98,7 @@ const AdaptableQueryTabsConfiguration = ({ show, setShow, queriesList, dashboard
         return ({ queryId: id, titlesMap });
       });
 
-      ViewStatesActions.patchQueriesTitle(Set(newTitles));
+      ViewStatesActions.patchQueriesTitle(OrderedSet(newTitles));
       setShow(false);
     });
   }, [orderedQueriesList, queriesList, activeQueryId, setDashboardPage, setShow]);

--- a/graylog2-web-interface/src/views/components/AdaptableQueryTabsConfiguration.tsx
+++ b/graylog2-web-interface/src/views/components/AdaptableQueryTabsConfiguration.tsx
@@ -14,38 +14,62 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-
 import * as React from 'react';
 import type { Dispatch, SetStateAction } from 'react';
 import { useCallback, useState } from 'react';
 import { OrderedSet, Map, Set } from 'immutable';
+import styled from 'styled-components';
 
 import BootstrapModalConfirm from 'components/bootstrap/BootstrapModalConfirm';
 import { QueriesActions } from 'views/actions/QueriesActions';
-import { SortableList } from 'components/common';
+import { SortableList, IconButton } from 'components/common';
 import type { ListItemType } from 'components/common/SortableList/ListItem';
 import { ViewStatesActions } from 'views/stores/ViewStatesStore';
 import type { TitleType } from 'views/stores/TitleTypes';
-import type { QueryId } from 'views/logic/queries/Query';
 import TitleTypes from 'views/stores/TitleTypes';
+import EditableTitle from 'views/components/common/EditableTitle';
+
+const ListItemContainer = styled.div`
+  display: flex;
+  justify-content: space-between;
+  flex: 1;
+`;
+
+const ListItem = ({
+  item: { id, title },
+  onRemove,
+  onUpdateTitle,
+}: {
+  item: { id: string, title?: string },
+  onUpdateTitle: (id: string, title: string) => void,
+  onRemove: (id: string) => void,
+}) => {
+  return (
+    <ListItemContainer>
+      <EditableTitle key={title} disabled={!onUpdateTitle} value={title} onChange={(newTitle) => onUpdateTitle(id, newTitle)} />
+      <div>
+        {/* <IconButton title={`Edit title for page ${title}`} name="edit" onClick={() => {}} /> */}
+        <IconButton title={`Remove page ${title}`} name="trash" onClick={() => onRemove(id)} />
+      </div>
+    </ListItemContainer>
+  );
+};
 
 type Props = {
   show: boolean,
   setShow: Dispatch<SetStateAction<boolean>>,
-  queriesList: Array<ListItemType>
+  queriesList: OrderedSet<ListItemType>
 }
 
 const AdaptableQueryTabsConfiguration = ({ show, setShow, queriesList }: Props) => {
-  const [orderedQueriesList, setOrderedQueriesList] = useState<Array<ListItemType>>(queriesList);
+  const [orderedQueriesList, setOrderedQueriesList] = useState<OrderedSet<ListItemType>>(queriesList);
   const onConfirmPagesConfiguration = useCallback(() => {
-    QueriesActions.setOrder(OrderedSet(orderedQueriesList)).then(() => {
-      const newTitles = orderedQueriesList.map(({ id: queryId, title }: {
-        id: QueryId, title: string
-      }) => {
+    QueriesActions.setOrder(OrderedSet(orderedQueriesList.map(({ id }) => id))).then(() => {
+      const newTitles = orderedQueriesList.map(({ id, title }) => {
         const titleMap = Map<string, string>({ title });
         const titlesMap = Map<TitleType, Map<string, string>>({ [TitleTypes.Tab]: titleMap });
 
-        return ({ queryId, titlesMap });
+        return ({ queryId: id, titlesMap });
       });
 
       ViewStatesActions.patchQueriesTitle(Set(newTitles));
@@ -53,9 +77,27 @@ const AdaptableQueryTabsConfiguration = ({ show, setShow, queriesList }: Props) 
     });
   }, [orderedQueriesList, setShow]);
   const onPagesConfigurationModalClose = useCallback(() => setShow(false), [setShow]);
-  const updateTabSorting = useCallback((order) => {
-    setOrderedQueriesList(order);
+  const updatePageSorting = useCallback((order: Array<ListItemType>) => {
+    setOrderedQueriesList(OrderedSet(order));
   }, [setOrderedQueriesList]);
+
+  const updatePageTitle = (id: string, title: string) => {
+    setOrderedQueriesList((currentQueries) => (
+      OrderedSet(currentQueries.map((query) => {
+        if (query.id === id) {
+          return { id, title };
+        }
+
+        return query;
+      }))),
+    );
+  };
+
+  const removePage = (id: string) => {
+    setOrderedQueriesList((currentQueries) => (
+      OrderedSet(currentQueries.filter((query) => query.id !== id))),
+    );
+  };
 
   return (
     <BootstrapModalConfirm showModal={show}
@@ -65,8 +107,14 @@ const AdaptableQueryTabsConfiguration = ({ show, setShow, queriesList }: Props) 
                            confirmButtonText="Update configuration">
       <>
         <h3>Order</h3>
-        <p>Use drag and drop to change the execution order of the dashboard pages.</p>
-        <SortableList items={orderedQueriesList} onMoveItem={updateTabSorting} displayOverlayInPortal />
+        <p>
+          Use drag and drop to change the execution order of the dashboard pages.
+          Click on a dashboard title to change it.
+        </p>
+        <SortableList items={orderedQueriesList.toArray()}
+                      onMoveItem={updatePageSorting}
+                      displayOverlayInPortal
+                      customContentRender={({ item }) => <ListItem item={item} onUpdateTitle={updatePageTitle} onRemove={removePage} />} />
       </>
     </BootstrapModalConfirm>
   );

--- a/graylog2-web-interface/src/views/components/AdaptableQueryTabsConfiguration.tsx
+++ b/graylog2-web-interface/src/views/components/AdaptableQueryTabsConfiguration.tsx
@@ -41,6 +41,7 @@ const ListItemContainer = styled.div`
   display: flex;
   justify-content: space-between;
   flex: 1;
+  overflow: hidden;
 `;
 
 const ListItem = ({
@@ -150,11 +151,12 @@ const AdaptableQueryTabsConfiguration = ({ show, setShow, queriesList, dashboard
         <h3>Order</h3>
         <p>
           Use drag and drop to change the execution order of the dashboard pages.
-          Click on a dashboard title to change it.
+          Double-click on a dashboard title to change it.
         </p>
         <SortableList<PageListItem> items={orderedQueriesList.toArray()}
                                     onMoveItem={updatePageSorting}
                                     displayOverlayInPortal
+                                    alignItemContent="center"
                                     customContentRender={customListItemRender} />
       </>
     </BootstrapModalConfirm>

--- a/graylog2-web-interface/src/views/components/AdaptableQueryTabsConfiguration.tsx
+++ b/graylog2-web-interface/src/views/components/AdaptableQueryTabsConfiguration.tsx
@@ -79,7 +79,7 @@ const AdaptableQueryTabsConfiguration = ({ show, setShow, queriesList, dashboard
   const widgetIds = useWidgetIds();
   const { setDashboardPage } = useContext(DashboardPageContext);
   const [orderedQueriesList, setOrderedQueriesList] = useState<OrderedSet<PageListItem>>(queriesList);
-  const disablePageDelete = queriesList.size <= 1;
+  const disablePageDelete = orderedQueriesList.size <= 1;
   const onConfirmPagesConfiguration = useCallback(() => {
     const isActiveQueryDeleted = !orderedQueriesList.find(({ id }) => id === activeQueryId);
 

--- a/graylog2-web-interface/src/views/components/QueryTabs.tsx
+++ b/graylog2-web-interface/src/views/components/QueryTabs.tsx
@@ -24,8 +24,8 @@ import { Col, Row } from 'components/bootstrap';
 import type { QueryId } from 'views/logic/queries/Query';
 import type Query from 'views/logic/queries/Query';
 import type { TitlesMap } from 'views/stores/TitleTypes';
-import type ViewState from 'views/logic/views/ViewState';
 import ElementDimensions from 'components/common/ElementDimensions';
+import type ViewState from 'views/logic/views/ViewState';
 
 import QueryTitleEditModal from './queries/QueryTitleEditModal';
 import AdaptableQueryTabs from './AdaptableQueryTabs';
@@ -35,11 +35,12 @@ export interface QueryTabsProps {
   onSelect: (queryId: string) => Promise<Query> | Promise<string>,
   onTitleChange: (queryId: string, newTitle: string) => Promise<TitlesMap>,
   queries: Immutable.OrderedSet<QueryId>,
-  selectedQueryId: string,
+  activeQueryId: string,
   titles: Immutable.Map<string, string>,
+  dashboardId: string,
 }
 
-const QueryTabs = ({ onRemove, onSelect, onTitleChange, queries, selectedQueryId, titles }: QueryTabsProps) => {
+const QueryTabs = ({ onRemove, onSelect, onTitleChange, queries, activeQueryId, titles, dashboardId }: QueryTabsProps) => {
   const queryTitleEditModal = useRef<QueryTitleEditModal | undefined | null>();
 
   return (
@@ -49,8 +50,9 @@ const QueryTabs = ({ onRemove, onSelect, onTitleChange, queries, selectedQueryId
           {({ width }) => (width ? (
             <AdaptableQueryTabs maxWidth={width}
                                 queries={queries}
+                                dashboardId={dashboardId}
                                 titles={titles}
-                                selectedQueryId={selectedQueryId}
+                                activeQueryId={activeQueryId}
                                 onRemove={onRemove}
                                 onSelect={onSelect}
                                 queryTitleEditModal={queryTitleEditModal}
@@ -63,7 +65,7 @@ const QueryTabs = ({ onRemove, onSelect, onTitleChange, queries, selectedQueryId
           due to the react bootstrap tabs keybindings.
           The input would always lose the focus when using the arrow keys.
         */}
-        <QueryTitleEditModal onTitleChange={(newTitle: string) => onTitleChange(selectedQueryId, newTitle)}
+        <QueryTitleEditModal onTitleChange={(newTitle: string) => onTitleChange(activeQueryId, newTitle)}
                              ref={queryTitleEditModal} />
       </Col>
     </Row>
@@ -75,7 +77,7 @@ QueryTabs.propTypes = {
   onSelect: PropTypes.func.isRequired,
   onTitleChange: PropTypes.func.isRequired,
   queries: ImmutablePropTypes.orderedSetOf(PropTypes.string).isRequired,
-  selectedQueryId: PropTypes.string.isRequired,
+  activeQueryId: PropTypes.string.isRequired,
   titles: PropTypes.object.isRequired,
 };
 

--- a/graylog2-web-interface/src/views/components/queries/QueryTitle.tsx
+++ b/graylog2-web-interface/src/views/components/queries/QueryTitle.tsx
@@ -22,9 +22,9 @@ import styled, { css } from 'styled-components';
 import { MenuItem } from 'components/bootstrap';
 import { QueriesActions } from 'views/stores/QueriesStore';
 import type { QueryId } from 'views/logic/queries/Query';
-import type ViewState from 'views/logic/views/ViewState';
 import type { QueriesList } from 'views/actions/QueriesActions';
 import DashboardPageContext from 'views/components/contexts/DashboardPageContext';
+import type ViewState from 'views/logic/views/ViewState';
 
 import QueryActionDropdown from './QueryActionDropdown';
 

--- a/graylog2-web-interface/src/views/logic/views/ConfirmDeletingDashboardPage.ts
+++ b/graylog2-web-interface/src/views/logic/views/ConfirmDeletingDashboardPage.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import { PluginStore } from 'graylog-web-plugin/plugin';
+import type { List, Map } from 'immutable';
+
+import iterateConfirmationHooks from 'views/hooks/IterateConfirmationHooks';
+
+// eslint-disable-next-line no-alert
+const defaultConfirm = async () => window.confirm('Do you really want to delete this dashboard page?');
+
+const ConfirmDeletingDashboardPage = async (dashboardId: string, activeQueryId: string, widgetIds: Map<string, List<string>>) => {
+  const _widgetIds = widgetIds.map((ids) => ids.toArray()).toObject();
+  const deletingDashboardPageHooks = PluginStore.exports('views.hooks.confirmDeletingDashboardPage');
+  const result = await iterateConfirmationHooks([...deletingDashboardPageHooks, defaultConfirm], dashboardId, activeQueryId, _widgetIds);
+
+  return result;
+};
+
+export default ConfirmDeletingDashboardPage;

--- a/graylog2-web-interface/src/views/logic/views/FindNewActiveQuery.ts
+++ b/graylog2-web-interface/src/views/logic/views/FindNewActiveQuery.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+
+// Returns a new query ID, in case the active query gets deleted.
+import type { List } from 'immutable';
+
+const FindNewActiveQueryId = (queryIds: List<string>, activeQueryId: string) => {
+  const currentQueryIdIndex = queryIds.indexOf(activeQueryId);
+  const newQueryIdIndex = Math.min(0, currentQueryIdIndex - 1);
+
+  return queryIds.filter((queryId) => (queryId !== activeQueryId))
+    .get(newQueryIdIndex);
+};
+
+export default FindNewActiveQueryId;

--- a/graylog2-web-interface/src/views/stores/QueriesStore.ts
+++ b/graylog2-web-interface/src/views/stores/QueriesStore.ts
@@ -94,8 +94,8 @@ export const QueriesStore: QueriesStoreType = singletonStore(
       return promise;
     },
 
-    setOrder(newOrder: Immutable.OrderedSet<{ id: QueryId }>) {
-      const newQueries = newOrder.map(({ id }) => {
+    setOrder(newOrderedQueryIds: Immutable.OrderedSet<QueryId>) {
+      const newQueries = newOrderedQueryIds.map((id) => {
         return this.queries.get(id);
       });
       const promise: Promise<QueriesList> = this._propagateQueryChange(newQueries).then(() => newQueries);

--- a/graylog2-web-interface/src/views/stores/ViewStatesStore.ts
+++ b/graylog2-web-interface/src/views/stores/ViewStatesStore.ts
@@ -17,7 +17,7 @@
 import Reflux from 'reflux';
 import * as Immutable from 'immutable';
 import { get, isEqualWith } from 'lodash';
-import type { Set } from 'immutable';
+import type { OrderedSet } from 'immutable';
 
 import type { RefluxActions } from 'stores/StoreTypes';
 import type { QueryId } from 'views/logic/queries/Query';
@@ -32,7 +32,7 @@ type ViewStatesActionsTypes = RefluxActions<{
   duplicate: (queryId: QueryId) => Promise<ViewState>,
   remove: (queryId: QueryId) => Promise<ViewState>,
   update: (queryId: QueryId, viewState: ViewState) => Promise<ViewState>,
-  patchQueriesTitle: (newQueriesTitle: Set<{ queryId: QueryId, titlesMap: TitlesMap}>) => Promise<ViewState>,
+  patchQueriesTitle: (newQueriesTitle: OrderedSet<{ queryId: QueryId, titlesMap: TitlesMap}>) => Promise<ViewState>,
 }>;
 
 export const ViewStatesActions: ViewStatesActionsTypes = singletonActions(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

With https://github.com/Graylog2/graylog2-server/pull/13744 we implemented a dashboard pages configuration modal which allows reordering the dashboard pages. With this PR we are extending the modal to allow deleting and renaming pages.

Fixes:  #13772

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
