### PR TITLE
Take into account if "Always match" rule is inverted.

### DIFF
--- a/changelog/unreleased/issue-13819.toml
+++ b/changelog/unreleased/issue-13819.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Take into account if \"Always match\" rule is inverted. Previously it was ignored for this rule type."
+
+issues = ["13819"]
+pulls = ["13847"]

--- a/graylog2-server/src/main/java/org/graylog2/streams/matchers/AlwaysMatcher.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/matchers/AlwaysMatcher.java
@@ -19,9 +19,15 @@ package org.graylog2.streams.matchers;
 import org.graylog2.plugin.Message;
 import org.graylog2.plugin.streams.StreamRule;
 
+import java.util.Optional;
+
 public class AlwaysMatcher implements StreamRuleMatcher {
     @Override
     public boolean match(Message msg, StreamRule rule) {
-        return true;
+        return Optional.ofNullable(rule.getInverted())
+                // When this rule is inverted, it should never match
+                .map(inverted -> !inverted)
+                // If `inverted` is `null`, we always return `true`
+                .orElse(true);
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/streams/matchers/AlwaysMatcherTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/streams/matchers/AlwaysMatcherTest.java
@@ -22,18 +22,32 @@ import org.joda.time.DateTimeZone;
 import org.junit.Test;
 
 import java.util.Collections;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class AlwaysMatcherTest {
+    private static final Message message = new Message("Test", "source", new DateTime(2016, 9, 7, 0, 0, DateTimeZone.UTC));
+    private static final AlwaysMatcher matcher = new AlwaysMatcher();
+
     @Test
     public void matchAlwaysReturnsTrue() throws Exception {
-        final AlwaysMatcher matcher = new AlwaysMatcher();
-        assertThat(matcher.match(null, null)).isTrue();
         assertThat(matcher.match(
-                new Message("Test", "source", new DateTime(2016, 9, 7, 0, 0, DateTimeZone.UTC)),
-                new StreamRuleMock(Collections.singletonMap("_id", "stream-rule-id"))))
+                message,
+                new StreamRuleMock(Map.of("_id", "stream-rule-id"))))
                 .isTrue();
+        assertThat(matcher.match(
+                message,
+                new StreamRuleMock(Map.of("_id", "stream-rule-id", "inverted", false))))
+                .isTrue();
+    }
+
+    @Test
+    public void matchAlwaysReturnsFalseIfInverted() throws Exception {
+        assertThat(matcher.match(
+                message,
+                new StreamRuleMock(Map.of("_id", "stream-rule-id", "inverted", true))))
+                .isFalse();
     }
 
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Prior to this PR, the "Always match" rule always matched, regardless if it was inverted or not. This change is now taking the value of the `inverted` field into account.

Fixes #13819.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.