### PR TITLE
Improve search bar time range font style.

### DIFF
--- a/graylog2-web-interface/src/views/components/searchbar/TimeRangeDisplay.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/TimeRangeDisplay.tsx
@@ -114,11 +114,11 @@ const TimeRangeDisplay = ({ timerange, toggleDropdownShow }: Props) => {
   return (
     <TimeRangeWrapper aria-label="Search Time Range, Opens Time Range Selector On Click" role="button" onClick={toggleDropdownShow}>
       {!(timerange && 'type' in timerange)
-        ? <span><code>No Override</code></span>
+        ? <span>No Override</span>
         : (
           <>
-            <span data-testid="from"><strong>From</strong>: <code>{from}</code></span>
-            <span data-testid="to"><strong>Until</strong>: <code>{until}</code></span>
+            <span data-testid="from">From: <strong>{from}</strong></span>
+            <span data-testid="to">Until: <strong>{until}</strong></span>
           </>
         )}
     </TimeRangeWrapper>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

With this PR we are removing the mono font from the search bar time range. This way we unify it with most other elements in the search bar and the preview in the time range picker.
Instead of highlighting the description `From` and `To` we are now highlighting the actual time, similar to the time range preview in the time range picker.

Before:
![image](https://user-images.githubusercontent.com/46300478/199490848-22b5d32e-e7d4-4cd9-980f-f8ce9408a63e.png)
![image](https://user-images.githubusercontent.com/46300478/199490925-46aa02f4-b8c0-46df-8e79-84fd5fbaa04c.png)


After:
![image](https://user-images.githubusercontent.com/46300478/199490740-de343b29-b391-482d-a457-ad1184c0a631.png)
![image](https://user-images.githubusercontent.com/46300478/199490803-45aa1b15-a3de-40cb-908a-3bb6a4f2c144.png)
