### PR TITLE
Extract updated value from target before it is synthesized.

### DIFF
--- a/graylog2-web-interface/src/components/configurations/SidecarConfig.jsx
+++ b/graylog2-web-interface/src/components/configurations/SidecarConfig.jsx
@@ -87,14 +87,12 @@ const SidecarConfig = createReactClass({
 
   _onUpdate(field) {
     return (value) => {
+      const newValue = typeof value === 'object' ? getValueFromInput(value.target) : value;
+
       this.setState(({ config }) => {
         const update = ObjectUtils.clone(config);
 
-        if (typeof value === 'object') {
-          update[field] = getValueFromInput(value.target);
-        } else {
-          update[field] = value;
-        }
+        update[field] = newValue;
 
         return ({ config: update });
       });

--- a/graylog2-web-interface/src/components/configurations/SidecarConfig.test.tsx
+++ b/graylog2-web-interface/src/components/configurations/SidecarConfig.test.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react';
+import { fireEvent, render, screen, waitFor } from 'wrappedTestingLibrary';
+
+import SidecarConfig from './SidecarConfig';
+
+describe('SidecarConfig', () => {
+  it('updates config after change', async () => {
+    const updateConfig = jest.fn(() => Promise.resolve());
+    render(<SidecarConfig updateConfig={updateConfig} />);
+
+    const openButton = await screen.findByRole('button', { name: /edit configuration/i });
+    fireEvent.click(openButton);
+
+    fireEvent.click(await screen.findByRole('checkbox', {
+      name: /override sidecar configuration/i,
+      hidden: true,
+    }));
+
+    fireEvent.click(await screen.findByRole('button', {
+      name: /update configuration/i,
+      hidden: true,
+    }));
+
+    await waitFor(() => { expect(updateConfig).toHaveBeenCalledWith(expect.objectContaining({ sidecar_configuration_override: true })); });
+  });
+});

--- a/graylog2-web-interface/src/components/configurations/SidecarConfig.test.tsx
+++ b/graylog2-web-interface/src/components/configurations/SidecarConfig.test.tsx
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 import * as React from 'react';
 import { fireEvent, render, screen, waitFor } from 'wrappedTestingLibrary';
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

In #13513, the `setState`-call of the `_onUpdate` function was extended to use a callback instead of a value. Extracting the new value from the event was also moved into the `setState`-callback. Unfortunately, at this point the event is already synthesized for performance reasons and target value extraction fails.

This PR is now moving target value extraction out of the scope of the `setState`-call to fix this.

Fixes #13867.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.