### PR TITLE
Add text field attribute to hide sensitive input config

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/inputs/transports/KafkaTransport.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/transports/KafkaTransport.java
@@ -574,8 +574,9 @@ public class KafkaTransport extends ThrottleableTransport {
                     "A newline separated list of Kafka properties. (e.g.: \"ssl.keystore.location=/etc/graylog/server/kafka.keystore.jks\").",
                     ConfigurationField.Optional.OPTIONAL,
                     ConfigurationField.PLACE_AT_END_POSITION,
-                    TextField.Attribute.TEXTAREA
-                    ));
+                    TextField.Attribute.TEXTAREA,
+                    TextField.Attribute.IS_SENSITIVE
+            ));
 
             return cr;
         }

--- a/graylog2-server/src/main/java/org/graylog2/plugin/configuration/fields/TextField.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/configuration/fields/TextField.java
@@ -26,7 +26,8 @@ public class TextField extends AbstractConfigurationField {
 
     public enum Attribute {
         IS_PASSWORD,
-        TEXTAREA
+        TEXTAREA,
+        IS_SENSITIVE
     }
 
     private String defaultValue;

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/inputs/AbstractInputsResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/inputs/AbstractInputsResource.java
@@ -73,11 +73,13 @@ public class AbstractInputsResource extends RestResource {
                         HashMap::new,
                         (map, entry) -> {
                             final ConfigurationField field = configurationRequest.getField(entry.getKey());
-                            if (field instanceof TextField) {
-                                final TextField textField = (TextField) field;
-                                if (textField.getAttributes().contains(TextField.Attribute.IS_PASSWORD.toString().toLowerCase(Locale.ENGLISH))
-                                        && !Strings.isNullOrEmpty((String) entry.getValue())) {
+                            if (field instanceof TextField && !Strings.isNullOrEmpty((String) entry.getValue())) {
+                                if (isPassword(field)) {
                                     map.put(entry.getKey(), "<password set>");
+                                    return;
+                                }
+                                if (isSensitive(field)) {
+                                    map.put(entry.getKey(), "<value hidden>");
                                     return;
                                 }
                             }
@@ -85,5 +87,13 @@ public class AbstractInputsResource extends RestResource {
                         },
                         HashMap::putAll
                 );
+    }
+
+    private static boolean isPassword(ConfigurationField field) {
+        return field.getAttributes().contains(TextField.Attribute.IS_PASSWORD.toString().toLowerCase(Locale.ENGLISH));
+    }
+
+    private static boolean isSensitive(ConfigurationField field) {
+        return field.getAttributes().contains(TextField.Attribute.IS_SENSITIVE.toString().toLowerCase(Locale.ENGLISH));
     }
 }

--- a/graylog2-web-interface/src/components/configurationforms/ConfigurationWell.jsx
+++ b/graylog2-web-interface/src/components/configurationforms/ConfigurationWell.jsx
@@ -66,7 +66,8 @@ class ConfigurationWell extends React.Component {
       const value = config[key];
       const requestedConfiguration = (typeDefinition && typeDefinition.requested_configuration ? typeDefinition.requested_configuration[key] : undefined);
 
-      if (requestedConfiguration && requestedConfiguration.attributes.indexOf('is_password') > -1) {
+      if (requestedConfiguration
+        && (requestedConfiguration.attributes.indexOf('is_password') > -1 || requestedConfiguration.attributes.indexOf('is_sensitive') > -1)) {
         return this._formatPasswordField(value, key);
       }
 

--- a/graylog2-web-interface/src/components/configurationforms/types.ts
+++ b/graylog2-web-interface/src/components/configurationforms/types.ts
@@ -15,7 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 type NumberFieldAttributes = 'only_negative' | 'only_positive' | 'is_port_number';
-type TextFieldAttributes = 'is_password' | 'textarea';
+type TextFieldAttributes = 'is_password' | 'textarea' | 'is_sensitive';
 type ListFieldAttributes = 'allow_create';
 
 export type NumberField = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds an `is_sensitive` attribute to hide input config in the same way as the `is_password` attribute. Enables masking of sensitive values not only for password fields.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #13383 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Set `custom_properties` in Kafka input config and checked that
- it's shown in plaintext when editing the input
- it's shown as `********` on the inputs overview page
- when the user does not have the `inputs:edit` permission, the field's value is masked with `<value hidden>` in the response to `GET /api/system/inputs`

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

