### PR TITLE
backport: Hide Hostname on Cloud (#13234)

### DIFF
--- a/graylog2-web-interface/src/components/common/LinkToNode.jsx
+++ b/graylog2-web-interface/src/components/common/LinkToNode.jsx
@@ -15,14 +15,14 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import PropTypes from 'prop-types';
-import React from 'react';
-import createReactClass from 'create-react-class';
-import Reflux from 'reflux';
+import * as React from 'react';
 
 import { Link } from 'components/common/router';
 import Routes from 'routing/Routes';
 import AppConfig from 'util/AppConfig';
+import HideOnCloud from 'util/conditional/HideOnCloud';
 import { NodesStore } from 'stores/nodes/NodesStore';
+import connect from 'stores/connect';
 
 import Icon from './Icon';
 import Spinner from './Spinner';
@@ -35,22 +35,22 @@ import Spinner from './Spinner';
  *
  * All this information will be obtained from the `NodesStore`.
  */
-const LinkToNode = createReactClass({
-  displayName: 'LinkToNode',
 
-  propTypes: {
+class LinkToNode extends React.PureComponent {
+  static propTypes = {
     /** Node ID that will be used to generate the link. */
     nodeId: PropTypes.string.isRequired,
-  },
-
-  mixins: [Reflux.connect(NodesStore)],
+    nodes: PropTypes.object,
+  };
 
   render() {
-    if (!this.state.nodes) {
+    const { nodes } = this.props;
+
+    if (!nodes) {
       return <Spinner />;
     }
 
-    const node = this.state.nodes[this.props.nodeId];
+    const node = nodes[this.props.nodeId];
 
     if (node) {
       const iconName = node.is_leader ? 'star' : 'code-branch';
@@ -61,7 +61,7 @@ const LinkToNode = createReactClass({
         <>
           <Icon name={iconName} className={iconClass} title={iconTitle} />
           {' '}
-          {node.short_node_id} / {node.hostname}
+          {node.short_node_id}<HideOnCloud> / {node.hostname}</HideOnCloud>
         </>
       );
 
@@ -75,7 +75,15 @@ const LinkToNode = createReactClass({
     }
 
     return <i>Unknown Node</i>;
-  },
-});
+  }
+}
 
-export default LinkToNode;
+LinkToNode.defaultProps = {
+  nodes: undefined,
+};
+
+export default connect(
+  LinkToNode,
+  { nodeStore: NodesStore },
+  ({ nodeStore, ...rest }) => ({ ...rest, nodes: nodeStore.nodes }),
+);


### PR DESCRIPTION
* feat: Hide Hostname on Cloud, refactor to use React.Component

closes graylog-plugin-cloud/#1040

* fix: switch to PureComponent

* refactor: change import to alias, use nodes instead of nodeStore directly

* fix: make nodes optional

(cherry picked from commit 09e8c90b7f851cc7a060408f1ff3100a30e40210)


