### PR TITLE
Revert WRITE_DURATIONS_AS_TIMESTAMPS serialization feature

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/shared/bindings/providers/ObjectMapperProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/bindings/providers/ObjectMapperProvider.java
@@ -110,7 +110,6 @@ public class ObjectMapperProvider implements Provider<ObjectMapper> {
 
         this.objectMapper = mapper
                 .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
-                .disable(SerializationFeature.WRITE_DURATIONS_AS_TIMESTAMPS)
                 .disable(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE)
                 .disable(DeserializationFeature.FAIL_ON_MISSING_EXTERNAL_TYPE_ID_PROPERTY)
                 .setPropertyNamingStrategy(new PropertyNamingStrategy.SnakeCaseStrategy())


### PR DESCRIPTION
Resolves #13868

A bit puzzling, since at the time of #13541 we most definitely needed this in order to get unit tests to pass. I am guessing the Mongojack update made this setting unnecessary. 

For reference, here is a discussion of this setting:
https://github.com/FasterXML/jackson-modules-java8/pull/75