### PR TITLE
Disallow exporting non-exportable Event Definitions in Content Packs

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/events/contentpack/facade/EventDefinitionFacade.java
+++ b/graylog2-server/src/main/java/org/graylog/events/contentpack/facade/EventDefinitionFacade.java
@@ -172,6 +172,7 @@ public class EventDefinitionFacade implements EntityFacade<EventDefinitionDto> {
     @Override
     public Set<EntityExcerpt> listEntityExcerpts() {
         return eventDefinitionService.streamAll()
+                .filter(ed -> ed.config().isContentPackExportable())
                 .map(this::createExcerpt)
                 .collect(Collectors.toSet());
     }

--- a/graylog2-server/src/main/java/org/graylog/events/processor/EventProcessorConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/events/processor/EventProcessorConfig.java
@@ -73,6 +73,16 @@ public interface EventProcessorConfig extends ContentPackable<EventProcessorConf
         return Collections.emptySet();
     }
 
+    /**
+     * Returns whether this config type is allowed to be exported in a Content Pack.
+     *
+     * @return whether the config type can be exported in a Content Pack
+     */
+    @JsonIgnore
+    default boolean isContentPackExportable() {
+        return true;
+    }
+
     interface Builder<SELF> {
         @JsonProperty(TYPE_FIELD)
         SELF type(String type);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Enables controlling what Event Definition config types are able to be exported to a Content Pack.
Sigma Event Definition config specific changes are in: https://github.com/Graylog2/graylog-plugin-enterprise/pull/4304

## Description
<!--- Describe your changes in detail -->
With the introduction of Sigma Rule Event Definitions, there are some there are some types of Event Definitions that should not be able to be exported to Content Packs. This change creates an `isContentPackExportable()` function in the  `EventProcessorConfig` interface, which defaults to true but allows sub-classes to override to false. This is then checked in the `EventDefinitionFacade` when providing the list of exportable Event Definitions to the User.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Sigma Rule Event Definitions are not meant to be exportable to Content Packs as exporting Rules will be done using the Sigma Rule Entities themselves, and exporting a Content Pack with Sigma Rule Event Definitions causes the export to fail.

Addresses: https://github.com/Graylog2/graylog-plugin-enterprise/issues/4292

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally with development environment and unit testing.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.

