### PR TITLE
Simple fix for log messages endpoint

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/models/system/loggers/responses/InternalLogMessage.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/system/loggers/responses/InternalLogMessage.java
@@ -38,7 +38,7 @@ public abstract class InternalLogMessage {
     public abstract String message();
 
     @JsonProperty("class_name")
-    @NotEmpty
+    @Nullable
     public abstract String className();
 
     @JsonProperty
@@ -67,7 +67,7 @@ public abstract class InternalLogMessage {
 
     @JsonCreator
     public static InternalLogMessage create(@JsonProperty("message") @NotEmpty String message,
-                                            @JsonProperty("class_name") @NotEmpty String className,
+                                            @JsonProperty("class_name") @Nullable String className,
                                             @JsonProperty("level") @NotEmpty String level,
                                             @JsonProperty("marker") @Nullable String marker,
                                             @JsonProperty("timestamp") @NotNull DateTime timestamp,

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/logs/LoggersResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/logs/LoggersResource.java
@@ -35,6 +35,7 @@ import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.LoggerConfig;
 import org.apache.logging.log4j.core.impl.ThrowableProxy;
+import org.apache.logging.log4j.util.ReadOnlyStringMap;
 import org.apache.shiro.authz.annotation.RequiresAuthentication;
 import org.apache.shiro.authz.annotation.RequiresPermissions;
 import org.graylog2.audit.AuditEventTypes;
@@ -69,6 +70,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 
 @RequiresAuthentication
 @Api(value = "System/Loggers", description = "Internal Graylog loggers")
@@ -257,7 +259,7 @@ public class LoggersResource extends RestResource {
                     new DateTime(event.getTimeMillis(), DateTimeZone.UTC),
                     throwable,
                     event.getThreadName(),
-                    event.getContextData().toMap()
+                    Optional.ofNullable(event.getContextData()).map(ReadOnlyStringMap::toMap).orElse(Map.of())
             ));
         }
 


### PR DESCRIPTION
Just to make it work again. We need to investigate why the class_name is not there anymore.
It probably got broken due to an log4j update.
