### PR TITLE
LDAP testcontainer: specify custom LDIF on container creation

### DIFF
--- a/graylog2-server/src/test/java/org/graylog/security/authservice/ldap/UnboundLDAPConnectorTestTLSIT.java
+++ b/graylog2-server/src/test/java/org/graylog/security/authservice/ldap/UnboundLDAPConnectorTestTLSIT.java
@@ -55,7 +55,7 @@ public class UnboundLDAPConnectorTestTLSIT {
     private static final int DEFAULT_TIMEOUT = 60 * 1000;
 
     @Container
-    private static final OpenLDAPContainer container = OpenLDAPContainer.createWithTLS();
+    private static final OpenLDAPContainer container = OpenLDAPContainer.createWithTLS(LDAPTestUtils.NESTED_GROUPS_LDIF);
 
     private TrustManagerProvider trustManagerProvider;
 

--- a/graylog2-server/src/test/java/org/graylog/testing/ldap/OpenLDAPContainer.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/ldap/OpenLDAPContainer.java
@@ -40,12 +40,12 @@ public class OpenLDAPContainer extends GenericContainer<OpenLDAPContainer> {
     private static final String BIND_DN = "cn=admin,dc=example,dc=com";
     private static final String BIND_PASSWORD = "admin";
 
-    public static OpenLDAPContainer create() {
-        return new OpenLDAPContainer();
+    public static OpenLDAPContainer create(String customLdifPath) {
+        return new OpenLDAPContainer(customLdifPath);
     }
 
-    public static OpenLDAPContainer createWithTLS() {
-        return new OpenLDAPContainer()
+    public static OpenLDAPContainer createWithTLS(String customLdifPath) {
+        return new OpenLDAPContainer(customLdifPath)
                 .withEnv("LDAP_TLS", "true")
                 .withEnv("LDAP_TLS_VERIFY_CLIENT", "allow")
                 .withEnv("LDAP_TLS_CRT_FILENAME", "server-cert.pem")
@@ -59,7 +59,7 @@ public class OpenLDAPContainer extends GenericContainer<OpenLDAPContainer> {
                 .withExposedPorts(PORT, TLS_PORT);
     }
 
-    public OpenLDAPContainer() {
+    public OpenLDAPContainer(String customLdifPath) {
         super(IMAGE_NAME);
 
         waitingFor(Wait.forLogMessage(".*slapd starting.*", 1));
@@ -68,7 +68,7 @@ public class OpenLDAPContainer extends GenericContainer<OpenLDAPContainer> {
         withEnv("LDAP_DOMAIN", "example.com");
         withEnv("LDAP_TLS", "false");
         withFileSystemBind(
-                LDAPTestUtils.getResourcePath(LDAPTestUtils.NESTED_GROUPS_LDIF),
+                LDAPTestUtils.getResourcePath(customLdifPath),
                 "/container/service/slapd/assets/config/bootstrap/ldif/custom/custom.ldif",
                 BindMode.READ_ONLY
         );

--- a/graylog2-server/src/test/resources/org/graylog/testing/ldap/ldif/nested-groups.ldif
+++ b/graylog2-server/src/test/resources/org/graylog/testing/ldap/ldif/nested-groups.ldif
@@ -43,6 +43,16 @@ cn: Senior Operations
 description: All of senior operations
 member: cn=Jane Doe,ou=People,dc=example,dc=com
 
+dn: cn=QA,ou=Groups,dc=example,dc=com
+objectClass: groupOfUniqueNames
+cn: IT
+uniqueMember: cn=Manual Testers,ou=Groups,dc=example,dc=com
+
+dn: cn=Manual Testers,ou=Groups,dc=example,dc=com
+objectClass: groupOfUniqueNames
+cn: IT
+uniqueMember: cn=Peter Parker,ou=People,dc=example,dc=com
+
 #### People ##########################################################
 # The password for all accounts is: pass
 dn: cn=Jane Doe,ou=People,dc=example,dc=com
@@ -79,4 +89,13 @@ gn: Bob
 sn: Barker
 mail: bob@example.com
 uid: bob
+userPassword:: e1NTSEF9VUFZMldUVEk3S1BHbjJ6UFRvaFdRMVNZTUswNWVrMHU=
+
+dn: cn=Peter Parker,ou=People,dc=example,dc=com
+objectClass: inetOrgPerson
+cn: Peter Parker
+gn: Peter
+sn: Parker
+mail: peter@example.com
+uid: peter
 userPassword:: e1NTSEF9VUFZMldUVEk3S1BHbjJ6UFRvaFdRMVNZTUswNWVrMHU=


### PR DESCRIPTION
By specifying the custom LDIF on container creation, tests can use different directory content instead of having the "nested groups" content hard coded.

/jenkins-pr-deps Graylog2/graylog-plugin-enterprise#4307
/nocl