### PR TITLE
Limits the number of unknown field validation messages

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/validation/validators/util/UnknownFieldsListLimiter.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/validation/validators/util/UnknownFieldsListLimiter.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.views.search.validation.validators.util;
+
+import org.graylog.plugins.views.search.validation.ParsedTerm;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class UnknownFieldsListLimiter {
+
+    public List<ParsedTerm> filterElementsContainingUsefulInformation(final Map<String, List<ParsedTerm>> parsedTermsGroupedByField) {
+        return parsedTermsGroupedByField.values()
+                .stream()
+                .map(this::filterElementsContainingUsefulInformation)
+                .flatMap(Collection::stream)
+                .collect(Collectors.toList());
+    }
+
+    private List<ParsedTerm> filterElementsContainingUsefulInformation(final List<ParsedTerm> fieldTerms) {
+        if (fieldTerms.size() < 2) {
+            return fieldTerms;
+        } else {
+            if (fieldTerms.stream().anyMatch(parsedTerm -> parsedTerm.keyToken().isPresent())) {
+                //there is positional info - return only ParsedTerm instances with position
+                return fieldTerms.stream().filter(parsedTerm -> parsedTerm.keyToken().isPresent()).toList();
+            } else {
+                //no positional info - it is enough to return a single ParsedTerm instance
+                return List.of(fieldTerms.get(0));
+            }
+        }
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/validation/validators/util/UnknownFieldsListLimiterTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/validation/validators/util/UnknownFieldsListLimiterTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.views.search.validation.validators.util;
+
+import org.apache.lucene.queryparser.classic.Token;
+import org.graylog.plugins.views.search.validation.ImmutableToken;
+import org.graylog.plugins.views.search.validation.ParsedTerm;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UnknownFieldsListLimiterTest {
+
+    private UnknownFieldsListLimiter toTest;
+
+    @BeforeEach
+    void setUp() {
+        toTest = new UnknownFieldsListLimiter();
+    }
+
+    @Test
+    void doesNothingOnEmptyInput() {
+        assertThat(toTest.filterElementsContainingUsefulInformation(Map.of()))
+                .isEmpty();
+    }
+
+    @Test
+    void doesNotLimitOnSingleElement() {
+        final Map<String, List<ParsedTerm>> fieldTerms = Map.of("field", List.of(
+                ParsedTerm.create("field", "oh!")
+        ));
+        assertThat(toTest.filterElementsContainingUsefulInformation(fieldTerms))
+                .hasSize(1)
+                .contains(ParsedTerm.create("field", "oh!"));
+    }
+
+    @Test
+    void limitsToOneTermOnlyIfMultipleTermsWithoutPosition() {
+        final Map<String, List<ParsedTerm>> fieldTerms = Map.of("field", List.of(
+                ParsedTerm.create("field", "oh!"),
+                ParsedTerm.create("field", "ah!"),
+                ParsedTerm.create("field", "eh!")
+        ));
+        assertThat(toTest.filterElementsContainingUsefulInformation(fieldTerms))
+                .hasSize(1)
+                .contains(ParsedTerm.create("field", "oh!"));
+    }
+
+    @Test
+    void limitsToPositionalTermsIfTheyArePresent() {
+        final Token token1 = new Token(1, "token1");
+        token1.beginLine = 1;
+        token1.beginColumn = 1;
+        token1.endLine = 1;
+        token1.endColumn = 6;
+        final ParsedTerm positionalTerm1 = ParsedTerm.builder().field("field").value("nvmd").keyToken(ImmutableToken.create(token1)).build();
+        final Token token2 = new Token(1, "token2");
+        token1.beginLine = 1;
+        token1.beginColumn = 11;
+        token1.endLine = 1;
+        token1.endColumn = 16;
+        final ParsedTerm positionalTerm2 = ParsedTerm.builder().field("field").value("nvmd").keyToken(ImmutableToken.create(token2)).build();
+
+        final Map<String, List<ParsedTerm>> fieldTerms = Map.of(
+                "field", List.of(
+                        positionalTerm1,
+                        ParsedTerm.create("field", "ah!"),
+                        positionalTerm2,
+                        ParsedTerm.create("field", "eh!")
+                )
+        );
+        assertThat(toTest.filterElementsContainingUsefulInformation(fieldTerms))
+                .hasSize(2)
+                .contains(positionalTerm1, positionalTerm2);
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
See #13818.
From now on, if there are multiple messages about the same unknown field:
1. If they have no associated token/positional info, only the first one will be returned.
2. If they have associated token/positional info, the ones without positional info will be filtered out.

In the second scenario, there is a place of further improvement on FE side -> FE could collect positional info from the messages, in order to underline unknown fields properly, but visualize only one message.
/nocl

## Motivation and Context
A need to do something with #13818.

## How Has This Been Tested?
Unit tests have been added.
It was tested manually.

## Screenshots (if appropriate):
With original query example invented by Marco:
`((TargetFilename: ("\/etc\/cron.d\/"*) OR ("\/etc\/cron.daily\/"*) OR ("\/etc\/cron.hourly\/"*) OR ("\/etc\/cron.monthly\/"*) OR ("\/etc\/cron.weekly\/"*) OR ("\/var\/spool\/cron\/crontabs\/"*)) OR (TargetFilename: (*"\/etc\/cron.allow"*) OR (*"\/etc\/cron.deny"*) OR (*"\/etc\/crontab"*)))`

Before we got:
![original](https://user-images.githubusercontent.com/100699120/200808947-bb7c743f-30f0-4d35-9062-75aaf1e4e90e.png)

Now we have:
![Screenshot 2022-11-09 at 11-39-21 Graylog - Unsaved Search](https://user-images.githubusercontent.com/100699120/200808989-1f84eb05-da94-4f13-a8d5-7d12e70e500e.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

