### PR TITLE
Deduplicating "Unknown field" warnings for search query.

### DIFF
--- a/graylog2-web-interface/src/views/components/searchbar/queryvalidation/QueryValidation.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/queryvalidation/QueryValidation.test.tsx
@@ -144,4 +144,38 @@ describe('QueryValidation', () => {
 
     await waitFor(() => expect(screen.getAllByText('Parse Exception')).toHaveLength(1));
   });
+
+  it('should deduplicate "unknown field" errors referring to same field name', async () => {
+    const validationErrorForUnknownField: QueryValidationState = {
+      status: 'WARNING',
+      explanations: [{
+        id: 'foo',
+        errorType: 'UNKNOWN_FIELD',
+        beginLine: 1,
+        beginColumn: 2,
+        endLine: 1,
+        endColumn: 16,
+        errorTitle: 'Unknown field',
+        errorMessage: 'Query contains unknown field: TargetFilename',
+        relatedProperty: 'TargetFilename',
+      }, {
+        id: 'bar',
+        errorType: 'UNKNOWN_FIELD',
+        beginLine: 1,
+        beginColumn: 193,
+        endLine: 1,
+        endColumn: 207,
+        errorTitle: 'Unknown field',
+        errorMessage: 'Query contains unknown field: TargetFilename',
+        relatedProperty: 'TargetFilename',
+      }],
+    };
+    render(<SUT error={validationErrorForUnknownField} />);
+
+    await openExplanation();
+
+    const explanations = await screen.findAllByText(/Query contains unknown field: TargetFilename/i);
+
+    expect(explanations.length).toBe(1);
+  });
 });


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is improving the display of query validation warnings by showing only a single literal warning message for every unknown field.  Positional indicatiors (yellow dots below every usage of the unknown field) will still be present. This cleans up the list of validation messages, as there is no additional value in showing it for every usage.

/nocl

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.