### PR TITLE
Fixing bottom margin for event definition wizard.

### DIFF
--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventDefinitionForm.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventDefinitionForm.jsx
@@ -18,6 +18,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import lodash from 'lodash';
 import { PluginStore } from 'graylog-web-plugin/plugin';
+import styled from 'styled-components';
 
 import { Button, Col, Row } from 'components/bootstrap';
 import { ModalSubmit, Wizard } from 'components/common';
@@ -37,6 +38,10 @@ const getConditionPlugin = (type) => {
 
   return PluginStore.exports('eventDefinitionTypes').find((edt) => edt.type === type) || {};
 };
+
+const WizardContainer = styled.div`
+  margin-bottom: 10px;
+`;
 
 class EventDefinitionForm extends React.Component {
   static propTypes = {
@@ -177,13 +182,15 @@ class EventDefinitionForm extends React.Component {
     return (
       <Row>
         <Col md={12}>
-          <Wizard steps={steps}
-                  activeStep={activeStep}
-                  onStepChange={this.handleStepChange}
-                  horizontal
-                  justified
-                  containerClassName=""
-                  hidePreviousNextButtons />
+          <WizardContainer>
+            <Wizard steps={steps}
+                    activeStep={activeStep}
+                    onStepChange={this.handleStepChange}
+                    horizontal
+                    justified
+                    containerClassName=""
+                    hidePreviousNextButtons />
+          </WizardContainer>
           {this.renderButtons(activeStep, eventDefinition?.id)}
         </Col>
       </Row>


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This is a tiny cosmetic fix for the event definition wizard. Prior to this change, a bottom margin was missing, leading to buttons being tucked on top of each other.

/nocl

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

Before:

![image](https://user-images.githubusercontent.com/41929/201033777-e29f7c5d-362e-4023-adc8-be1aef88060a.png)
![image](https://user-images.githubusercontent.com/41929/201033815-1b074ca9-bbd4-452a-96f2-268cdf133dde.png)

After:

![image](https://user-images.githubusercontent.com/41929/201033602-f7aa7278-e484-4812-a6b5-4842796f7352.png)
![image](https://user-images.githubusercontent.com/41929/201033653-b1fcef2d-f0a7-474a-8362-da97e2d09573.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.