### PR TITLE
Latest aggregation fetches only needed field

### DIFF
--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/series/ESLatestHandler.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/series/ESLatestHandler.java
@@ -39,7 +39,10 @@ public class ESLatestHandler extends ESPivotSeriesSpecHandler<Latest, TopHits> {
     @Nonnull
     @Override
     public Optional<AggregationBuilder> doCreateAggregation(String name, Pivot pivot, Latest latestSpec, ESSearchTypeHandler<Pivot> searchTypeHandler, ESGeneratedQueryContext queryContext) {
-        final TopHitsAggregationBuilder latest = AggregationBuilders.topHits(name).size(1).sort(SortBuilders.fieldSort("timestamp").order(SortOrder.DESC));
+        final TopHitsAggregationBuilder latest = AggregationBuilders.topHits(name)
+                .size(1)
+                .fetchSource(latestSpec.field(), null)
+                .sort(SortBuilders.fieldSort("timestamp").order(SortOrder.DESC));
         record(queryContext, pivot, latestSpec, name, TopHits.class);
         return Optional.of(latest);
     }


### PR DESCRIPTION
## Description
Latest aggregation now fetches only single, needed, defined field, ignoring other fields of the message. They have not been used anyway.
/nocl

Before, the response from ES/OS contained results with all fields of a message, i.e.:
```"5ea433d2-54b2-4f78-97e9-4468a2fdf20b-series-latest(took_ms)" : {
                  "hits" : {
                    "total" : {
                      "value" : 141156,
                      "relation" : "eq"
                    },
                    "max_score" : null,
                    "hits" : [
                      {
                        "_index" : "graylog_5",
                        "_type" : "_doc",
                        "_id" : "078ddcf1-4edd-11ed-895d-a6a2a5c176fa",
                        "_score" : null,
                        "_source" : {
                          "sequence_nr" : 6901,
                          "ingest_time" : "2022-10-18T12:04:33.957Z",
                          "took_ms" : 61,
                          "source" : "example.org",
                          "ingest_time_minute" : 4,
                          "gl2_source_input" : "6225bcec9d44357e84102f4a",
                          "ingest_time_day" : 18,
                          "http_method" : "DELETE",
                          "ingest_time_hour" : 12,
                          "action" : "login",
                          "gl2_source_node" : "c04934d6-4e4d-4f08-a5bc-3ca55cee10f5",
                          "ingest_time_epoch" : 1666094673957,
                          "timestamp" : "2022-10-18 12:04:33.957",
                          "controller" : "LoginController",
                          "gl2_accounted_message_size" : 465,
                          "resource" : "/login",
                          "ticks" : 22086371758132,
                          "streams" : [
                            "000000000000000000000001"
                          ],
                          "gl2_message_id" : "01GFNFPC20JEMJ63P114WDERK5",
                          "message" : "2022-10-18T12:04:33.957Z DELETE /login [204] 61ms",
                          "ingest_time_second" : 33,
                          "ingest_time_month" : 10,
                          "user_id" : 6469981,
                          "ingest_time_year" : 2022,
                          "http_response_code" : 204
                        },
                        "sort" : [
                          1666094673957
                        ]
                      }
                    ]
                  }
                }
```
Messages can have even more fields and latest metric can be used on multiple levels of aggregation, so there is a place to save quite a few bytes..


Now result is much shorter, without unnecessary fields:
```                "5ea433d2-54b2-4f78-97e9-4468a2fdf20b-series-latest(took_ms)" : {
                  "hits" : {
                    "total" : {
                      "value" : 141156,
                      "relation" : "eq"
                    },
                    "max_score" : null,
                    "hits" : [
                      {
                        "_index" : "graylog_5",
                        "_type" : "_doc",
                        "_id" : "078ddcf1-4edd-11ed-895d-a6a2a5c176fa",
                        "_score" : null,
                        "_source" : {
                          "took_ms" : 61
                        },
                        "sort" : [
                          1666094673957
                        ]
                      }
                    ]
                  }
                }
```

## Motivation and Context
We do not want to send unnecessary data in JSON response.




## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

