### PR TITLE
Always serialize joda Durations as milliseconds

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/jackson/JodaDurationCompatSerializer.java
+++ b/graylog2-server/src/main/java/org/graylog2/jackson/JodaDurationCompatSerializer.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.jackson;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.datatype.joda.ser.DurationSerializer;
+import org.joda.time.Duration;
+
+import java.io.IOException;
+
+/**
+ * A Joda DurationSerializer that ignores the {@link com.fasterxml.jackson.databind.SerializationFeature.WRITE_DURATIONS_AS_TIMESTAMPS}
+ * setting and always serializes Durations to milliseconds.
+ * This became necessary with the Jackson 2.13 update, which forced us to disable WRITE_DURATIONS_AS_TIMESTAMPS to
+ * have {@link java.time.Duration} objects serialized as strings.
+ */
+public class JodaDurationCompatSerializer extends DurationSerializer {
+    @Override
+    public void serialize(Duration value, JsonGenerator gen, SerializerProvider provider) throws IOException {
+        // Always write as milliseconds, regardless of SerializationFeature.WRITE_DURATIONS_AS_TIMESTAMPS
+        gen.writeNumber(value.getMillis());
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/shared/bindings/providers/ObjectMapperProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/bindings/providers/ObjectMapperProvider.java
@@ -43,6 +43,7 @@ import org.graylog.grn.GRNRegistry;
 import org.graylog2.database.ObjectIdSerializer;
 import org.graylog2.jackson.AutoValueSubtypeResolver;
 import org.graylog2.jackson.DeserializationProblemHandlerModule;
+import org.graylog2.jackson.JodaDurationCompatSerializer;
 import org.graylog2.jackson.JodaTimePeriodKeyDeserializer;
 import org.graylog2.jackson.SemverDeserializer;
 import org.graylog2.jackson.SemverRequirementDeserializer;
@@ -59,6 +60,7 @@ import org.graylog2.shared.jackson.SizeSerializer;
 import org.graylog2.shared.plugins.GraylogClassLoader;
 import org.graylog2.shared.rest.RangeJsonSerializer;
 import org.joda.time.DateTimeZone;
+import org.joda.time.Duration;
 import org.joda.time.Period;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -110,6 +112,7 @@ public class ObjectMapperProvider implements Provider<ObjectMapper> {
 
         this.objectMapper = mapper
                 .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+                .disable(SerializationFeature.WRITE_DURATIONS_AS_TIMESTAMPS)
                 .disable(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE)
                 .disable(DeserializationFeature.FAIL_ON_MISSING_EXTERNAL_TYPE_ID_PROPERTY)
                 .setPropertyNamingStrategy(new PropertyNamingStrategy.SnakeCaseStrategy())
@@ -131,6 +134,7 @@ public class ObjectMapperProvider implements Provider<ObjectMapper> {
                         .addSerializer(new VersionSerializer())
                         .addSerializer(new SemverSerializer())
                         .addSerializer(new SemverRequirementSerializer())
+                        .addSerializer(Duration.class, new JodaDurationCompatSerializer())
                         .addSerializer(GRN.class, new ToStringSerializer())
                         .addSerializer(EncryptedValue.class, new EncryptedValueSerializer())
                         .addDeserializer(Version.class, new VersionDeserializer())

--- a/graylog2-server/src/test/java/org/graylog2/shared/bindings/providers/ObjectMapperProviderTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/shared/bindings/providers/ObjectMapperProviderTest.java
@@ -16,6 +16,7 @@
  */
 package org.graylog2.shared.bindings.providers;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import org.joda.time.DateTime;
@@ -58,5 +59,16 @@ class ObjectMapperProviderTest {
         assertThat(mappers).hasSameSizeAs(availableZones);
     }
 
+    @Test
+    void durationSerialization() throws JsonProcessingException {
+        final ObjectMapperProvider omp = new ObjectMapperProvider();
+        final ObjectMapper objectMapper = omp.get();
+
+        final String javaDuration = objectMapper.writeValueAsString(java.time.Duration.ofSeconds(10));
+        final String jodaDuration = objectMapper.writeValueAsString(org.joda.time.Duration.standardSeconds(10));
+
+        assertThat(javaDuration).isEqualTo("\"PT10S\"");
+        assertThat(jodaDuration).isEqualTo("10000");
+    }
 
 }


### PR DESCRIPTION
Add a  Joda DurationSerializer that ignores the `SerializationFeature.WRITE_DURATIONS_AS_TIMESTAMPS` setting and always serializes `org.joda.time.Duration` to milliseconds. This became necessary with the Jackson 2.13 update, which forced us to disable `WRITE_DURATIONS_AS_TIMESTAMPS` to have `java.time.Duration` objects serialized as strings.

#Fixes https://github.com/Graylog2/graylog-plugin-enterprise/issues/4320

/nocl