### PR TITLE
Conditionally hide edit button for permission config

### DIFF
--- a/changelog/unreleased/issue-12090.toml
+++ b/changelog/unreleased/issue-12090.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Hide edit button for permissions config if the user doesn't have edit permissions."
+
+issues = ["12090"]
+pulls = ["13939"]

--- a/graylog2-web-interface/src/components/configurations/PermissionsConfig.tsx
+++ b/graylog2-web-interface/src/components/configurations/PermissionsConfig.tsx
@@ -24,7 +24,7 @@ import type { PermissionsConfigType } from 'src/stores/configurations/Configurat
 import { Button, Col, Modal, Row } from 'components/bootstrap';
 import FormikInput from 'components/common/FormikInput';
 import Spinner from 'components/common/Spinner';
-import { InputDescription, ModalSubmit } from 'components/common';
+import { InputDescription, ModalSubmit, IfPermitted } from 'components/common';
 
 type Props = {
   config: PermissionsConfigType,
@@ -74,16 +74,18 @@ const PermissionsConfig = ({ config, updateConfig }: Props) => {
             <dd>{config.allow_sharing_with_users ? 'Enabled' : 'Disabled'}</dd>
           </StyledDefList>
 
-          <p>
-            <Button type="button"
-                    bsSize="xs"
-                    bsStyle="info"
-                    onClick={() => {
-                      setShowModal(true);
-                    }}>
-              Edit configuration
-            </Button>
-          </p>
+          <IfPermitted permissions="clusterconfigentry:edit">
+            <p>
+              <Button type="button"
+                      bsSize="xs"
+                      bsStyle="info"
+                      onClick={() => {
+                        setShowModal(true);
+                      }}>
+                Edit configuration
+              </Button>
+            </p>
+          </IfPermitted>
 
           <Modal show={showModal} onHide={_resetConfig} aria-modal="true" aria-labelledby="dialog_label">
             <Formik onSubmit={_saveConfig} initialValues={config}>


### PR DESCRIPTION
Hide the edit button for the permission config on the configuration page if the user does not have the required edit permission.

Fixes #12090 
