### PR TITLE
Events: change default for `search_within_ms` and `execute_every_ms` to 5 mins

### DIFF
--- a/changelog/unreleased/pr-13943.toml
+++ b/changelog/unreleased/pr-13943.toml
@@ -1,0 +1,5 @@
+type = "changed"
+message = "Change default of search window and execution frequency for new event filters from 1 to 5 minutes."
+
+issues = ["Graylog2/graylog-plugin-enterprise#3740"]
+pulls = ["13943"]

--- a/changelog/unreleased/pr-13943.toml
+++ b/changelog/unreleased/pr-13943.toml
@@ -1,5 +1,5 @@
 type = "changed"
-message = "Change default of search window and execution frequency for new event filters from 1 to 5 minutes."
+message = "Change default of search window and execution frequency for new event configurations from 1 to 5 minutes."
 
 issues = ["Graylog2/graylog-plugin-enterprise#3740"]
-pulls = ["13943"]
+pulls = ["13943", "Graylog2/graylog-plugin-enterprise#4343"]

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterAggregationForm.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterAggregationForm.jsx
@@ -34,8 +34,8 @@ const initialFilterConfig = {
   query: '',
   query_parameters: [],
   streams: [],
-  search_within_ms: 60 * 1000,
-  execute_every_ms: 60 * 1000,
+  search_within_ms: 5 * 60 * 1000,
+  execute_every_ms: 5 * 60 * 1000,
 };
 
 const initialAggregationConfig = {

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterAggregationForm.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterAggregationForm.jsx
@@ -115,12 +115,6 @@ class FilterAggregationForm extends React.Component {
     this.setState(stateChange);
   };
 
-  handleChange = (event) => {
-    const { name } = event.target;
-
-    this.propagateChange(name, FormsUtils.getValueFromInput(event.target));
-  };
-
   render() {
     const { conditionType } = this.state;
     const { entityTypes, eventDefinition, streams, validation, currentUser } = this.props;


### PR DESCRIPTION
Changes the default values for `search_within_ms` and `execute_every_ms` from one minute to five minutes.

The previous default of one minute leads to a rather high frequency of event generation runs. A default of five minutes seems to be a good default for most users to start with.

Fixes https://github.com/Graylog2/graylog-plugin-enterprise/issues/3740