### PR TITLE
Avoid using clipboard API when it is not present.

### DIFF
--- a/graylog2-web-interface/src/util/copyToClipboard.ts
+++ b/graylog2-web-interface/src/util/copyToClipboard.ts
@@ -14,8 +14,24 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
+
+// Simple fallback if the clipboard API does not exist/is inaccessible
+const legacyWriteText = (str: string) => {
+  const listener = (e: ClipboardEvent) => {
+    e.clipboardData.setData('text/plain', str);
+    e.preventDefault();
+  };
+
+  document.addEventListener('copy', listener);
+  document.execCommand('copy');
+  document.removeEventListener('copy', listener);
+};
+
 // Compatibility is sufficient. We not support IE or outdated iOS.
 // eslint-disable-next-line compat/compat
-const copyToClipboard = (text: string) => navigator.clipboard.writeText(text);
+const copyToClipboard = (text: string) => (navigator.clipboard && window.isSecureContext
+  // eslint-disable-next-line compat/compat
+  ? navigator.clipboard.writeText(text)
+  : legacyWriteText(text));
 
 export default copyToClipboard;


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

In some cases (very old browsers or insecure contexts: when the document is not served over HTTPS), the clipboard API is inaccessible and therefore `navigator.clipboard` is `undefined`, resulting in an exception being thrown when something is copied to the clipboard.

This PR is now adding a check if the clipboard API is present and uses a workaround if not.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.