### PR TITLE
Preserve JSON types in flatten_json function

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -43,6 +43,11 @@ It is now possible to change this behavior. When configuration property `stream_
 If all of your streams go to dedicated, separate index sets, it is advised to keep the default value of `stream_aware_field_types` property (`false`). It will decrease the load on ES/OS and stream separation across index sets already helps with showing proper fields for a query.
 On the other hand, if multiple streams go to the same index sets, and you want precise field types and suggestions, you should set it to `true`. Consider monitoring your ES/OS load after that change, especially when using huge numbers of fields and streams. 
 
+## Breaking changes to pipeline functions
+`flatten_json` now preserves the original type of the extracted values, instead
+of converting them to string. An optional flag is provided, so existing rules can 
+continue using the legacy behavior.
+
 ## API Endpoint Deprecations
 
 The following API endpoints are deprecated beginning with 5.0.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -11,6 +11,10 @@ Please make sure to create a MongoDB database backup before starting the upgrade
 * Support for Elasticsearch 6.X has been removed! Please use either Elasticsearch 7.10.2 or, preferably, latest OpenSearch.
 * Graylog 5 needs at least MongoDB 5.0. Our recommended upgrade path is to first bring your MongoDB to 5.0 and then perform the Graylog upgrade.
   Hint: Graylog 4.3.x does support MongoDB 5.0, which allows for a seamless upgrade path.
+* `flatten_json` now preserves the original type of the extracted values, instead
+of converting them to string. An optional flag is provided so existing rules can
+continue using the legacy behavior.
+
 
 ## Disallowing embedding the frontend by default
 
@@ -42,11 +46,6 @@ It is now possible to change this behavior. When configuration property `stream_
 
 If all of your streams go to dedicated, separate index sets, it is advised to keep the default value of `stream_aware_field_types` property (`false`). It will decrease the load on ES/OS and stream separation across index sets already helps with showing proper fields for a query.
 On the other hand, if multiple streams go to the same index sets, and you want precise field types and suggestions, you should set it to `true`. Consider monitoring your ES/OS load after that change, especially when using huge numbers of fields and streams. 
-
-## Breaking changes to pipeline functions
-`flatten_json` now preserves the original type of the extracted values, instead
-of converting them to string. An optional flag is provided, so existing rules can 
-continue using the legacy behavior.
 
 ## API Endpoint Deprecations
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -11,7 +11,7 @@ Please make sure to create a MongoDB database backup before starting the upgrade
 * Support for Elasticsearch 6.X has been removed! Please use either Elasticsearch 7.10.2 or, preferably, latest OpenSearch.
 * Graylog 5 needs at least MongoDB 5.0. Our recommended upgrade path is to first bring your MongoDB to 5.0 and then perform the Graylog upgrade.
   Hint: Graylog 4.3.x does support MongoDB 5.0, which allows for a seamless upgrade path.
-* `flatten_json` now preserves the original type of the extracted values, instead
+* The `flatten_json` pipeline function now preserves the original type of the extracted values, instead
 of converting them to string. An optional flag is provided so existing rules can
 continue using the legacy behavior.
 

--- a/changelog/unreleased/issue-13888.toml
+++ b/changelog/unreleased/issue-13888.toml
@@ -1,7 +1,7 @@
 # Entry type according to https://keepachangelog.com/en/1.0.0/
 # One of: a(dded), c(hanged), d(eprecated), r(emoved), f(ixed), s(ecurity)
 type = "fixed"
-message = "Pipeline function flatten_json respects the original JSON types. An optional parameter is provided for back-compat."
+message = "The pipeline function flatten_json now respects the original JSON types. An optional parameter is provided for backwards compatibility."
 
 issues = ["13888"]
 pulls = ["13947"]

--- a/changelog/unreleased/issue-13888.toml
+++ b/changelog/unreleased/issue-13888.toml
@@ -1,7 +1,7 @@
 # Entry type according to https://keepachangelog.com/en/1.0.0/
 # One of: a(dded), c(hanged), d(eprecated), r(emoved), f(ixed), s(ecurity)
 type = "fixed"
-message = "Pipeline function flatten_json respects the original JSON types"
+message = "Pipeline function flatten_json respects the original JSON types. An optional parameter is provided for back-compat."
 
 issues = ["13888"]
 pulls = ["13947"]

--- a/changelog/unreleased/issue-13888.toml
+++ b/changelog/unreleased/issue-13888.toml
@@ -1,0 +1,7 @@
+# Entry type according to https://keepachangelog.com/en/1.0.0/
+# One of: a(dded), c(hanged), d(eprecated), r(emoved), f(ixed), s(ecurity)
+type = "fixed"
+message = "Pipeline function flatten_json respects the original JSON types"
+
+issues = ["13888"]
+pulls = ["13947"]

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/json/JsonFlatten.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/json/JsonFlatten.java
@@ -64,7 +64,7 @@ public class JsonFlatten extends AbstractFunction<JsonNode> {
         this.objectMapper = objectMapper;
         valueParam = ParameterDescriptor.string("value").description("The string to parse as a JSON tree").build();
         arrayHandlerParam = ParameterDescriptor.string("array_handler").description("Determines how arrays are processed").build();
-        stringifyParam = ParameterDescriptor.bool("stringify").description("Convert all extracted values to strings").build();
+        stringifyParam = ParameterDescriptor.bool("stringify").optional().description("Convert all extracted values to strings").build();
     }
 
     @Override
@@ -99,7 +99,7 @@ public class JsonFlatten extends AbstractFunction<JsonNode> {
                 .name(NAME)
                 .returnType(JsonNode.class)
                 .params(of(
-                        valueParam, arrayHandlerParam
+                        valueParam, arrayHandlerParam, stringifyParam
                 ))
                 .description("Parses a string as a JSON tree, while flattening all containers to a single level")
                 .build();

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/json/JsonFlatten.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/json/JsonFlatten.java
@@ -57,30 +57,33 @@ public class JsonFlatten extends AbstractFunction<JsonNode> {
     private final ObjectMapper objectMapper;
     private final ParameterDescriptor<String, String> valueParam;
     private final ParameterDescriptor<String, String> arrayHandlerParam;
+    private final ParameterDescriptor<Boolean, Boolean> stringifyParam;
 
     @Inject
     public JsonFlatten(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
         valueParam = ParameterDescriptor.string("value").description("The string to parse as a JSON tree").build();
         arrayHandlerParam = ParameterDescriptor.string("array_handler").description("Determines how arrays are processed").build();
+        stringifyParam = ParameterDescriptor.bool("stringify").description("Convert all extracted values to strings").build();
     }
 
     @Override
     public JsonNode evaluate(FunctionArgs args, EvaluationContext context) {
         final String value = valueParam.required(args, context);
         final String arrayHandler = arrayHandlerParam.required(args, context);
+        final boolean stringify = stringifyParam.optional(args, context).orElse(false);
 
         try {
             switch (arrayHandler) {
                 case OPTION_IGNORE:
                     // ignore all top-level arrays
-                    return JsonUtils.extractJson(value, objectMapper, FLAGS_IGNORE);
+                    return JsonUtils.extractJson(value, objectMapper, FLAGS_IGNORE, stringify);
                 case OPTION_JSON:
                     // return top-level arrays as valid JSON strings
-                    return JsonUtils.extractJson(value, objectMapper, FLAGS_JSON);
+                    return JsonUtils.extractJson(value, objectMapper, FLAGS_JSON, stringify);
                 case OPTION_FLATTEN:
                     // explode all arrays and objects into top-level key/values
-                    return JsonUtils.extractJson(value, objectMapper, FLAGS_FLATTEN);
+                    return JsonUtils.extractJson(value, objectMapper, FLAGS_FLATTEN, stringify);
                 default:
                     LOG.warn("Unknown parameter array_handler: {}", arrayHandler);
             }

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/json/JsonUtils.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/json/JsonUtils.java
@@ -31,8 +31,6 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
-import java.math.BigDecimal;
-import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -53,7 +51,7 @@ public class JsonUtils {
     }
 
     public static JsonNode extractJson(
-            String value, ObjectMapper mapper, ExtractFlags extractFlags, Boolean stringify)
+            String value, ObjectMapper mapper, ExtractFlags extractFlags, boolean stringify)
             throws IOException {
         if (isNullOrEmpty(value)) {
             throw new IOException("null result");
@@ -66,36 +64,11 @@ public class JsonUtils {
                 if (stringify) {
                     resultRoot.put(entry.key(), entry.value().toString());
                 } else {
-                    putNodeWithType(resultRoot, entry.key(), entry.value());
+                    resultRoot.putPOJO(entry.key(), entry.value());
                 }
             }
         }
         return resultRoot;
-    }
-
-    private static void putNodeWithType(ObjectNode node, String key, Object value) {
-        if (value instanceof Short) {
-            node.put(key, (Short) value);
-        } else if (value instanceof Integer) {
-            node.put(key, (Integer) value);
-        } else if (value instanceof Long) {
-            node.put(key, (Long) value);
-        } else if (value instanceof Float) {
-            node.put(key, (Float) value);
-        } else if (value instanceof Double) {
-            node.put(key, (Double) value);
-        } else if (value instanceof BigDecimal) {
-            node.put(key, (BigDecimal) value);
-        } else if (value instanceof BigInteger) {
-            node.put(key, (BigInteger) value);
-        } else if (value instanceof String) {
-            node.put(key, (String) value);
-        } else if (value instanceof Boolean) {
-            node.put(key, (Boolean) value);
-        } else {
-            LOG.debug("Unknown type \"{}\" in key \"{}\"", value.getClass(), key);
-            node.put(key, value.toString());
-        }
     }
 
     private static Collection<Entry> parseValue(

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/json/JsonUtils.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/json/JsonUtils.java
@@ -200,27 +200,17 @@ public class JsonUtils {
     @AutoValue
     protected abstract static class ExtractFlags {
         public abstract boolean flattenObjects();
-
         public abstract boolean escapeArrays();
-
         public abstract boolean deleteArrays();
-
-        public abstract boolean stringifyValues();
-
         public static Builder builder() {
-            return new AutoValue_JsonUtils_ExtractFlags.Builder().stringifyValues(false);
+            return new AutoValue_JsonUtils_ExtractFlags.Builder();
         }
 
         @AutoValue.Builder
         public abstract static class Builder {
             public abstract Builder flattenObjects(boolean flattenObjects);
-
             public abstract Builder escapeArrays(boolean escapeArrays);
-
             public abstract Builder deleteArrays(boolean deleteArrays);
-
-            public abstract Builder stringifyValues(boolean stringifyValues);
-
             public abstract JsonUtils.ExtractFlags build();
         }
     }

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/json/JsonUtils.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/json/JsonUtils.java
@@ -53,7 +53,7 @@ public class JsonUtils {
     }
 
     public static JsonNode extractJson(
-            String value, ObjectMapper mapper, ExtractFlags extractFlags)
+            String value, ObjectMapper mapper, ExtractFlags extractFlags, Boolean stringify)
             throws IOException {
         if (isNullOrEmpty(value)) {
             throw new IOException("null result");
@@ -63,7 +63,11 @@ public class JsonUtils {
         ObjectNode resultRoot = mapper.createObjectNode();
         for (Map.Entry<String, Object> mapEntry : json.entrySet()) {
             for (Entry entry : parseValue(mapEntry.getKey(), mapEntry.getValue(), mapper, extractFlags)) {
-                putNodeWithType(resultRoot, entry.key(), entry.value());
+                if (stringify) {
+                    resultRoot.put(entry.key(), entry.value().toString());
+                } else {
+                    putNodeWithType(resultRoot, entry.key(), entry.value());
+                }
             }
         }
         return resultRoot;
@@ -196,17 +200,27 @@ public class JsonUtils {
     @AutoValue
     protected abstract static class ExtractFlags {
         public abstract boolean flattenObjects();
+
         public abstract boolean escapeArrays();
+
         public abstract boolean deleteArrays();
+
+        public abstract boolean stringifyValues();
+
         public static Builder builder() {
-            return new AutoValue_JsonUtils_ExtractFlags.Builder();
+            return new AutoValue_JsonUtils_ExtractFlags.Builder().stringifyValues(false);
         }
 
         @AutoValue.Builder
         public abstract static class Builder {
             public abstract Builder flattenObjects(boolean flattenObjects);
+
             public abstract Builder escapeArrays(boolean escapeArrays);
+
             public abstract Builder deleteArrays(boolean deleteArrays);
+
+            public abstract Builder stringifyValues(boolean stringifyValues);
+
             public abstract JsonUtils.ExtractFlags build();
         }
     }

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/json/JsonUtils.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/json/JsonUtils.java
@@ -31,6 +31,8 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -61,10 +63,35 @@ public class JsonUtils {
         ObjectNode resultRoot = mapper.createObjectNode();
         for (Map.Entry<String, Object> mapEntry : json.entrySet()) {
             for (Entry entry : parseValue(mapEntry.getKey(), mapEntry.getValue(), mapper, extractFlags)) {
-                resultRoot.put(entry.key(), entry.value().toString());
+                putNodeWithType(resultRoot, entry.key(), entry.value());
             }
         }
         return resultRoot;
+    }
+
+    private static void putNodeWithType(ObjectNode node, String key, Object value) {
+        if (value instanceof Short) {
+            node.put(key, (Short) value);
+        } else if (value instanceof Integer) {
+            node.put(key, (Integer) value);
+        } else if (value instanceof Long) {
+            node.put(key, (Long) value);
+        } else if (value instanceof Float) {
+            node.put(key, (Float) value);
+        } else if (value instanceof Double) {
+            node.put(key, (Double) value);
+        } else if (value instanceof BigDecimal) {
+            node.put(key, (BigDecimal) value);
+        } else if (value instanceof BigInteger) {
+            node.put(key, (BigInteger) value);
+        } else if (value instanceof String) {
+            node.put(key, (String) value);
+        } else if (value instanceof Boolean) {
+            node.put(key, (Boolean) value);
+        } else {
+            LOG.debug("Unknown type \"{}\" in key \"{}\"", value.getClass(), key);
+            node.put(key, value.toString());
+        }
     }
 
     private static Collection<Entry> parseValue(

--- a/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/functions/JsonUtilsTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/functions/JsonUtilsTest.java
@@ -35,12 +35,12 @@ public class JsonUtilsTest {
 
         // delete all top-level arrays
         String expected = "{\"k0\":\"v0\"}";
-        JsonNode result = JsonUtils.extractJson(jsonString, mapper, JsonFlatten.FLAGS_IGNORE);
+        JsonNode result = JsonUtils.extractJson(jsonString, mapper, JsonFlatten.FLAGS_IGNORE, false);
         assertThat(mapper.writeValueAsString(result)).isEqualTo(expected);
 
         // serialize arrays into valid JSON with escaping; retain empty arrays
         expected = "{\"k0\":\"v0\",\"arr1\":\"[\\\"a1\\\",[\\\"a21\\\",\\\"a22\\\"],[],\\\"a2\\\"]\"}";
-        result = JsonUtils.extractJson(jsonString, mapper, JsonFlatten.FLAGS_JSON);
+        result = JsonUtils.extractJson(jsonString, mapper, JsonFlatten.FLAGS_JSON, false);
         assertThat(mapper.writeValueAsString(result)).isEqualTo(expected);
     }
 
@@ -50,7 +50,7 @@ public class JsonUtilsTest {
 
         // flatten objects by concatenating keys
         String expected = "{\"k0\":\"v0\",\"obj1_k1\":\"v1\",\"obj1_obj11_k11\":\"v11\",\"obj1_obj11_obj111_k111\":\"v111\"}";
-        JsonNode result = JsonUtils.extractJson(jsonString, mapper, JsonFlatten.FLAGS_IGNORE);
+        JsonNode result = JsonUtils.extractJson(jsonString, mapper, JsonFlatten.FLAGS_IGNORE, false);
         assertThat(mapper.writeValueAsString(result)).isEqualTo(expected);
     }
 
@@ -60,7 +60,7 @@ public class JsonUtilsTest {
 
         // flatten objects by concatenating keys
         String expected = "{\"k0\":\"v0\",\"arr1_0_k11\":\"v11\",\"arr1_0_k12\":12,\"arr1_1_k21\":\"v21\"}";
-        JsonNode result = JsonUtils.extractJson(jsonString, mapper, JsonFlatten.FLAGS_FLATTEN);
+        JsonNode result = JsonUtils.extractJson(jsonString, mapper, JsonFlatten.FLAGS_FLATTEN, false);
         assertThat(mapper.writeValueAsString(result)).isEqualTo(expected);
     }
 
@@ -70,7 +70,7 @@ public class JsonUtilsTest {
 
         // flatten objects by concatenating keys
         String expected = "{\"string\":\"s0\",\"arr1_0_int\":1,\"arr1_0_float\":1.2,\"arr1_1_bool\":true}";
-        JsonNode result = JsonUtils.extractJson(jsonString, mapper, JsonFlatten.FLAGS_FLATTEN);
+        JsonNode result = JsonUtils.extractJson(jsonString, mapper, JsonFlatten.FLAGS_FLATTEN, false);
         assertThat(mapper.writeValueAsString(result)).isEqualTo(expected);
     }
 
@@ -178,5 +178,14 @@ public class JsonUtilsTest {
         node = mapper.readTree(jsonString);
         JsonUtils.deleteBelow(node, 3);
         assertThat(mapper.writeValueAsString(node)).isEqualTo(expected);
+    }
+
+    @Test
+    public void testStringify() throws IOException {
+        String jsonString = "{\"bool\":true,\"arr1\":[{\"int\":1,\"float\":1.2},{\"bool\":true}]}";
+
+        String expected = "{\"bool\":\"true\",\"arr1_0_int\":\"1\",\"arr1_0_float\":\"1.2\",\"arr1_1_bool\":\"true\"}";
+        JsonNode result = JsonUtils.extractJson(jsonString, mapper, JsonFlatten.FLAGS_FLATTEN, true);
+        assertThat(mapper.writeValueAsString(result)).isEqualTo(expected);
     }
 }

--- a/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/functions/JsonUtilsTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/functions/JsonUtilsTest.java
@@ -56,10 +56,20 @@ public class JsonUtilsTest {
 
     @Test
     public void extractArrayOfObjects() throws IOException {
-        String jsonString = "{\"k0\":\"v0\",\"arr1\":[{\"k11\":\"v11\",\"k12\":\"v12\"},{\"k21\":\"v21\"}]}";
+        String jsonString = "{\"k0\":\"v0\",\"arr1\":[{\"k11\":\"v11\",\"k12\":12},{\"k21\":\"v21\"}]}";
 
         // flatten objects by concatenating keys
-        String expected = "{\"k0\":\"v0\",\"arr1_0_k11\":\"v11\",\"arr1_0_k12\":\"v12\",\"arr1_1_k21\":\"v21\"}";
+        String expected = "{\"k0\":\"v0\",\"arr1_0_k11\":\"v11\",\"arr1_0_k12\":12,\"arr1_1_k21\":\"v21\"}";
+        JsonNode result = JsonUtils.extractJson(jsonString, mapper, JsonFlatten.FLAGS_FLATTEN);
+        assertThat(mapper.writeValueAsString(result)).isEqualTo(expected);
+    }
+
+    @Test
+    public void preserveTypes() throws IOException {
+        String jsonString = "{\"string\":\"s0\",\"arr1\":[{\"int\":1,\"float\":1.2},{\"bool\":true}]}";
+
+        // flatten objects by concatenating keys
+        String expected = "{\"string\":\"s0\",\"arr1_0_int\":1,\"arr1_0_float\":1.2,\"arr1_1_bool\":true}";
         JsonNode result = JsonUtils.extractJson(jsonString, mapper, JsonFlatten.FLAGS_FLATTEN);
         assertThat(mapper.writeValueAsString(result)).isEqualTo(expected);
     }


### PR DESCRIPTION
Fixes #13888

Pipeline function `flatten_json` returns all of the extracted values as strings, regardless of original JSON type. 
We now honor the type.

See the associated issue for details and examples.