### PR TITLE
Check if field is present in document when aggregating.

### DIFF
--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/buckets/ESValuesHandler.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/buckets/ESValuesHandler.java
@@ -106,8 +106,8 @@ public class ESValuesHandler extends ESPivotBucketSpecHandler<Values> {
     private Script scriptForPivots(Collection<? extends BucketSpec> pivots) {
         final String scriptSource = Joiner.on(KEY_SEPARATOR_PHRASE).join(pivots.stream()
                 .map(bucket -> """
-                        String.valueOf((doc.containsKey('%s') && doc['%s'].size() > 0) ? doc['%s'].value : "%s")
-                        """.formatted(bucket.field(), bucket.field(), bucket.field(), MissingBucketConstants.MISSING_BUCKET_NAME))
+                        String.valueOf((doc.containsKey('%1$s') && doc['%1$s'].size() > 0) ? doc['%1$s'].value : "%2$s")
+                        """.formatted(bucket.field(), MissingBucketConstants.MISSING_BUCKET_NAME))
                 .collect(Collectors.toList()));
         return new Script(scriptSource);
     }

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/buckets/ESValuesHandler.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/buckets/ESValuesHandler.java
@@ -105,24 +105,11 @@ public class ESValuesHandler extends ESPivotBucketSpecHandler<Values> {
 
     private Script scriptForPivots(Collection<? extends BucketSpec> pivots) {
         final String scriptSource = Joiner.on(KEY_SEPARATOR_PHRASE).join(pivots.stream()
-                .map(bucket -> "String.valueOf((" + documentHasField(bucket.field())
-                        + " && " + fieldHasValues(bucket.field())
-                        + ") ? " + getFieldValue(bucket.field())
-                        + " : \"" + MissingBucketConstants.MISSING_BUCKET_NAME + "\")")
+                .map(bucket -> """
+                        String.valueOf((doc.containsKey('%s') && doc['%s'].size() > 0) ? doc['%s'].value : "%s")
+                        """.formatted(bucket.field(), bucket.field(), bucket.field(), MissingBucketConstants.MISSING_BUCKET_NAME))
                 .collect(Collectors.toList()));
         return new Script(scriptSource);
-    }
-
-    private String documentHasField(String fieldName) {
-        return "doc.containsKey('" + fieldName + "')";
-    }
-
-    private String fieldHasValues(String fieldName) {
-        return "doc['" + fieldName + "'].size() > 0";
-    }
-
-    private String getFieldValue(String fieldName) {
-        return "doc['" + fieldName + "'].value";
     }
 
     @Override

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/buckets/OSValuesHandler.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/buckets/OSValuesHandler.java
@@ -127,8 +127,8 @@ public class OSValuesHandler extends OSPivotBucketSpecHandler<Values> {
     private Script scriptForPivots(Collection<? extends BucketSpec> pivots) {
         final String scriptSource = Joiner.on(KEY_SEPARATOR_PHRASE).join(pivots.stream()
                 .map(bucket -> """
-                        String.valueOf((doc.containsKey('%s') && doc['%s'].size() > 0) ? doc['%s'].value : "%s")
-                        """.formatted(bucket.field(), bucket.field(), bucket.field(), MissingBucketConstants.MISSING_BUCKET_NAME))
+                        String.valueOf((doc.containsKey('%1$s') && doc['%1$s'].size() > 0) ? doc['%1$s'].value : "%2$s")
+                        """.formatted(bucket.field(), MissingBucketConstants.MISSING_BUCKET_NAME))
                 .collect(Collectors.toList()));
         return new Script(scriptSource);
     }

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/buckets/OSValuesHandler.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/buckets/OSValuesHandler.java
@@ -126,24 +126,11 @@ public class OSValuesHandler extends OSPivotBucketSpecHandler<Values> {
 
     private Script scriptForPivots(Collection<? extends BucketSpec> pivots) {
         final String scriptSource = Joiner.on(KEY_SEPARATOR_PHRASE).join(pivots.stream()
-                .map(bucket -> "String.valueOf((" + documentHasField(bucket.field())
-                        + " && " + fieldHasValues(bucket.field())
-                        + ") ? " + getFieldValue(bucket.field())
-                        + " : \"" + MissingBucketConstants.MISSING_BUCKET_NAME + "\")")
+                .map(bucket -> """
+                        String.valueOf((doc.containsKey('%s') && doc['%s'].size() > 0) ? doc['%s'].value : "%s")
+                        """.formatted(bucket.field(), bucket.field(), bucket.field(), MissingBucketConstants.MISSING_BUCKET_NAME))
                 .collect(Collectors.toList()));
         return new Script(scriptSource);
-    }
-
-    private String documentHasField(String fieldName) {
-        return "doc.containsKey('" + fieldName + "')";
-    }
-
-    private String fieldHasValues(String fieldName) {
-        return "doc['" + fieldName + "'].size() > 0";
-    }
-
-    private String getFieldValue(String fieldName) {
-        return "doc['" + fieldName + "'].value";
     }
 
     @Override


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is fixing an issue with the scripted terms aggregation we are generating. When multiple indices are involved, one (or more) might lack the field mapping for one (or more) of the pivot fields involved. This results in an exception like this one:

```
Elasticsearch exception [type=illegal_argument_exception, reason=No field found for [took_ms_int] in mapping with types []]
```

This PR is now adding a check (`doc.containsKey('field')`) for the field presence in the current document to avoid this.

/nocl
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.