### PR TITLE
Isolate exceptions during search type result extraction.

### DIFF
--- a/changelog/unreleased/pr-13955.toml
+++ b/changelog/unreleased/pr-13955.toml
@@ -1,0 +1,4 @@
+type = "fixed"
+message = "Isolate errors in result extraction to search type(s) causing it"
+
+pulls = ["13955"]

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackend.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackend.java
@@ -276,7 +276,7 @@ public class ElasticsearchBackend implements QueryBackend<ESGeneratedQueryContex
                         resultsMap.put(searchTypeId, searchTypeResult);
                     }
                 } catch (Exception e) {
-                    LOG.debug("Unable to extract results: ", e);
+                    LOG.warn("Unable to extract results: ", e);
                     queryContext.addError(new SearchTypeError(query, searchTypeId, e));
                 }
             }

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackend.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackend.java
@@ -28,6 +28,7 @@ import org.graylog.plugins.views.search.elasticsearch.IndexLookup;
 import org.graylog.plugins.views.search.engine.BackendQuery;
 import org.graylog.plugins.views.search.engine.QueryBackend;
 import org.graylog.plugins.views.search.errors.SearchError;
+import org.graylog.plugins.views.search.errors.SearchException;
 import org.graylog.plugins.views.search.errors.SearchTypeError;
 import org.graylog.plugins.views.search.errors.SearchTypeErrorParser;
 import org.graylog.plugins.views.search.filter.AndFilter;
@@ -269,9 +270,14 @@ public class ElasticsearchBackend implements QueryBackend<ESGeneratedQueryContex
                 ElasticsearchException e = checkForFailedShards(multiSearchResponse).get();
                 queryContext.addError(SearchTypeErrorParser.parse(query, searchTypeId, e));
             } else {
-                final SearchType.Result searchTypeResult = handler.extractResult(job, query, searchType, multiSearchResponse.getResponse(), queryContext);
-                if (searchTypeResult != null) {
-                    resultsMap.put(searchTypeId, searchTypeResult);
+                try {
+                    final SearchType.Result searchTypeResult = handler.extractResult(job, query, searchType, multiSearchResponse.getResponse(), queryContext);
+                    if (searchTypeResult != null) {
+                        resultsMap.put(searchTypeId, searchTypeResult);
+                    }
+                } catch (Exception e) {
+                    LOG.debug("Unable to extract results: ", e);
+                    queryContext.addError(new SearchTypeError(query, searchTypeId, e));
                 }
             }
         }

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/OpenSearchBackend.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/OpenSearchBackend.java
@@ -275,7 +275,7 @@ public class OpenSearchBackend implements QueryBackend<OSGeneratedQueryContext> 
                         resultsMap.put(searchTypeId, searchTypeResult);
                     }
                 } catch (Exception e) {
-                    LOG.debug("Unable to extract results: ", e);
+                    LOG.warn("Unable to extract results: ", e);
                     queryContext.addError(new SearchTypeError(query, searchTypeId, e));
                 }
 

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/OpenSearchBackend.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/OpenSearchBackend.java
@@ -269,10 +269,16 @@ public class OpenSearchBackend implements QueryBackend<OSGeneratedQueryContext> 
                 ElasticsearchException e = checkForFailedShards(multiSearchResponse).get();
                 queryContext.addError(SearchTypeErrorParser.parse(query, searchTypeId, e));
             } else {
-                final SearchType.Result searchTypeResult = handler.extractResult(job, query, searchType, multiSearchResponse.getResponse(), queryContext);
-                if (searchTypeResult != null) {
-                    resultsMap.put(searchTypeId, searchTypeResult);
+                try {
+                    final SearchType.Result searchTypeResult = handler.extractResult(job, query, searchType, multiSearchResponse.getResponse(), queryContext);
+                    if (searchTypeResult != null) {
+                        resultsMap.put(searchTypeId, searchTypeResult);
+                    }
+                } catch (Exception e) {
+                    LOG.debug("Unable to extract results: ", e);
+                    queryContext.addError(new SearchTypeError(query, searchTypeId, e));
                 }
+
             }
         }
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/engine/SearchTypeHandler.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/engine/SearchTypeHandler.java
@@ -54,7 +54,7 @@ public interface SearchTypeHandler<S extends SearchType, Q, R> {
         } catch (SearchException e) {
             throw e;
         } catch (Throwable t) {
-            throw new SearchException(new SearchTypeError(query, searchType.id(), t));
+            throw new SearchException(new SearchTypeError(query, searchType.id(), t), t);
         }
     }
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/errors/SearchException.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/errors/SearchException.java
@@ -24,6 +24,11 @@ public class SearchException extends RuntimeException {
         this.error = error;
     }
 
+    public SearchException(SearchError error, Throwable t) {
+        super(t);
+        this.error = error;
+    }
+
     public SearchError error() {
         return error;
     }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR makes sure that if an exception is being thrown during extracting the results for a search type, it will be caught, added as as earch type error to the search result and extraction for other search types will be continued (similar to what we do already during search _generation_).

This prevents the error being handled as a fatal one (affecting the complete search), so other results will still be returned.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

Before:
![image](https://user-images.githubusercontent.com/41929/201625020-f5f360c7-cc18-4b20-b5f5-4e8531f02060.png)

After:
![image](https://user-images.githubusercontent.com/41929/201624786-f9deb3bf-2004-4fc5-a44a-331092c877ef.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.