### PR TITLE
Change default values for `http_thread_pool_size` and `proxied_requests_thread_pool_size`

### DIFF
--- a/changelog/unreleased/pr-13960.toml
+++ b/changelog/unreleased/pr-13960.toml
@@ -1,0 +1,5 @@
+type = "changed"
+message = "Change default value for `http_thread_pool_size` and `proxied_requests_thread_pool_size` to 64."
+
+issues = ["Graylog2/graylog-plugin-enterprise#4325"]
+pulls = ["13960"]

--- a/graylog2-server/src/main/java/org/graylog2/configuration/HttpConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/HttpConfiguration.java
@@ -63,7 +63,7 @@ public class HttpConfiguration {
     private int httpMaxHeaderSize = 8192;
 
     @Parameter(value = "http_thread_pool_size", required = true, validator = PositiveIntegerValidator.class)
-    private int httpThreadPoolSize = 16;
+    private int httpThreadPoolSize = 64;
 
     @Parameter(value = "http_selector_runners_count", required = true, validator = PositiveIntegerValidator.class)
     private int httpSelectorRunnersCount = 1;

--- a/graylog2-server/src/main/java/org/graylog2/plugin/BaseConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/BaseConfiguration.java
@@ -103,7 +103,7 @@ public abstract class BaseConfiguration extends PathConfiguration {
     private String installationSource = "unknown";
 
     @Parameter(value = "proxied_requests_thread_pool_size", required = true, validator = PositiveIntegerValidator.class)
-    private int proxiedRequestsThreadPoolSize = 32;
+    private int proxiedRequestsThreadPoolSize = 64;
 
     public int getProcessBufferProcessors() {
         return processBufferProcessors;

--- a/graylog2-server/src/main/java/org/graylog2/shared/bindings/providers/ProxiedRequestsExecutorService.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/bindings/providers/ProxiedRequestsExecutorService.java
@@ -16,6 +16,8 @@
  */
 package org.graylog2.shared.bindings.providers;
 
+import com.codahale.metrics.InstrumentedExecutorService;
+import com.codahale.metrics.MetricRegistry;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.graylog2.plugin.Tools;
 import org.graylog2.shared.rest.resources.ProxiedResource;
@@ -27,24 +29,33 @@ import javax.inject.Provider;
 import javax.inject.Singleton;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+
+import static com.codahale.metrics.MetricRegistry.name;
 
 @Singleton
 public class ProxiedRequestsExecutorService implements Provider<ExecutorService> {
     private final int proxiedRequestsMaxThreads;
+    private final MetricRegistry metricRegistry;
 
     @Inject
-    public ProxiedRequestsExecutorService(@Named("proxied_requests_thread_pool_size") int proxiedRequestsMaxThreads) {
+    public ProxiedRequestsExecutorService(@Named("proxied_requests_thread_pool_size") int proxiedRequestsMaxThreads,
+                                          MetricRegistry metricRegistry) {
         this.proxiedRequestsMaxThreads = proxiedRequestsMaxThreads;
+        this.metricRegistry = metricRegistry;
     }
 
     @Override
     public ExecutorService get() {
-        return Executors.newFixedThreadPool(proxiedRequestsMaxThreads,
-            new ThreadFactoryBuilder()
+        final ThreadFactory threadFactory = new ThreadFactoryBuilder()
                 .setNameFormat("proxied-requests-pool-%d")
                 .setDaemon(true)
-                .setUncaughtExceptionHandler(new Tools.LogUncaughtExceptionHandler(LoggerFactory.getLogger(ProxiedResource.class.getName())))
-                .build()
-        );
+                .setUncaughtExceptionHandler(
+                        new Tools.LogUncaughtExceptionHandler(LoggerFactory.getLogger(ProxiedResource.class.getName())))
+                .build();
+        return new InstrumentedExecutorService(
+                Executors.newFixedThreadPool(proxiedRequestsMaxThreads, threadFactory),
+                metricRegistry,
+                name(this.getClass()));
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/shared/bindings/providers/ProxiedRequestsExecutorService.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/bindings/providers/ProxiedRequestsExecutorService.java
@@ -56,6 +56,6 @@ public class ProxiedRequestsExecutorService implements Provider<ExecutorService>
         return new InstrumentedExecutorService(
                 Executors.newFixedThreadPool(proxiedRequestsMaxThreads, threadFactory),
                 metricRegistry,
-                name(this.getClass()));
+                name(this.getClass(), "http-proxied-requests-executor"));
     }
 }

--- a/graylog2-server/src/main/resources/prometheus-exporter.yml
+++ b/graylog2-server/src/main/resources/prometheus-exporter.yml
@@ -1246,7 +1246,7 @@ metric_mappings:
       - "type"
       - "enabled"
 
-  - metric_name: "proxied_requests_executor_service"
-    match_pattern: "org.graylog2.shared.bindings.providers.ProxiedRequestsExecutorService.*"
+  - metric_name: "http_proxied_requests_executor"
+    match_pattern: "org.graylog2.shared.bindings.providers.ProxiedRequestsExecutorService.http-proxied-requests-executor.*"
     wildcard_extract_labels:
       - "type"

--- a/graylog2-server/src/main/resources/prometheus-exporter.yml
+++ b/graylog2-server/src/main/resources/prometheus-exporter.yml
@@ -1245,3 +1245,8 @@ metric_mappings:
     wildcard_extract_labels:
       - "type"
       - "enabled"
+
+  - metric_name: "proxied_requests_executor_service"
+    match_pattern: "org.graylog2.shared.bindings.providers.ProxiedRequestsExecutorService.*"
+    wildcard_extract_labels:
+      - "type"

--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -154,7 +154,7 @@ plugin_dir = plugin
 #http_max_header_size = 8192
 
 # The size of the thread pool used exclusively for serving the HTTP interface.
-#http_thread_pool_size = 16
+#http_thread_pool_size = 64
 
 ################
 # HTTPS settings
@@ -680,7 +680,7 @@ mongodb_max_connections = 1000
 # For some cluster-related REST requests, the node must query all other nodes in the cluster. This is the maximum number
 # of threads available for this. Increase it, if '/cluster/*' requests take long to complete.
 # Should be http_thread_pool_size * average_cluster_size if you have a high number of concurrent users.
-proxied_requests_thread_pool_size = 32
+#proxied_requests_thread_pool_size = 64
 
 # The server is writing processing status information to the database on a regular basis. This setting controls how
 # often the data is written to the database.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->


## Description
<!--- Describe your changes in detail -->

The default value for `http_thread_pool_size` is 16, which is pretty low.

16 concurrent requests to `api/cluster/metrics/multiple` on a node will exhaust resources because each request triggers (among others) a subsequent request to the node itself.

As a quick fix, this PR sets the default pool size to 64. This can only really serve as a band-aid to avoid users running into that situation easily because it moves the breaking point to ~64 concurrent requests. We are currently investigating a more sustainable solution.

We are also increasing the default value for `proxied_requests_thread_pool_size` from 32 to 64. The previous advisory of setting it to `http_thread_pool_size * average_cluster_size` has been removed from the example `graylog.conf` though, because that feels a bit excessive.

We also add previously missing (prometheus) metrics for the proxied requests thread pool:
- `gl_http_proxied_requests_executor{type="running"}`
- `gl_http_proxied_requests_executor{type="duration"}`
- `gl_http_proxied_requests_executor{type="idle"}`
- `gl_http_proxied_requests_executor_total{type="completed"}`
- `gl_http_proxied_requests_executor_total{type="submitted"}`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Closes https://github.com/Graylog2/graylog-plugin-enterprise/issues/4325

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Before the change:
```
ab -c16 -n1600 -p <(echo '{"metrics":["org.graylog2.throughput.input.1-sec-rate"]}') -T application/json -H 'X-Requested-By: ab' -A admin:admin http://127.0.0.1:9000/api/cluster/metrics/multiple
...
Concurrency Level:      16
Time taken for tests:   100.178 seconds
Complete requests:      1600
Failed requests:        123
...
```

After the change:
```
ab -c16 -n1600 -p <(echo '{"metrics":["org.graylog2.throughput.input.1-sec-rate"]}') -T application/json -H 'X-Requested-By: ab' -A admin:admin http://127.0.0.1:9000/api/cluster/metrics/multiple
...
Concurrency Level:      16
Time taken for tests:   7.233 seconds
Complete requests:      1600
Failed requests:        0
...
```