### PR TITLE
Remove ineffective settings for output buffer processor thread pool

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -114,9 +114,11 @@ The following Java Code API changes have been made in 5.0.
 
 ## Configuration File Changes
 
-| Option                                        | Action       | Description                                                     |
-|-----------------------------------------------|--------------|-----------------------------------------------------------------|
-| `mongodb_threads_allowed_to_block_multiplier` | **removed**  | Configuring this is not supported by the official MongoDB driver anymore. |
+| Option                                         | Action       | Description                                                               |
+|------------------------------------------------|--------------|---------------------------------------------------------------------------|
+| `mongodb_threads_allowed_to_block_multiplier`  | **removed**  | Configuring this is not supported by the official MongoDB driver anymore. |
+| `outputbuffer_processor_threads_max_pool_size` | **removed**  | This setting has been removed because it was not effective.               |
+| `outputbuffer_processor_keep_alive_time`       | **removed**  | This setting has been removed because it was not effective.               |
 
 ## Behaviour Changes
 

--- a/changelog/unreleased/pr-13971.toml
+++ b/changelog/unreleased/pr-13971.toml
@@ -1,0 +1,11 @@
+type = "removed"
+message = "Remove ineffective settings for output buffer processor thread pool."
+
+pulls = ["13971"]
+
+details.user = """
+Removed the following obsolete settings because they did not have the suggested effect:
+
+- `outputbuffer_processor_threads_max_pool_size`
+- `outputbuffer_processor_keep_alive_time`
+"""

--- a/graylog2-server/src/main/java/org/graylog2/Configuration.java
+++ b/graylog2-server/src/main/java/org/graylog2/Configuration.java
@@ -78,14 +78,8 @@ public class Configuration extends BaseConfiguration {
     @Parameter(value = "outputbuffer_processors", required = true, validators = PositiveIntegerValidator.class)
     private int outputBufferProcessors = 3;
 
-    @Parameter(value = "outputbuffer_processor_threads_max_pool_size", required = true, validators = PositiveIntegerValidator.class)
-    private int outputBufferProcessorThreadsMaxPoolSize = 30;
-
     @Parameter(value = "outputbuffer_processor_threads_core_pool_size", required = true, validators = PositiveIntegerValidator.class)
     private int outputBufferProcessorThreadsCorePoolSize = 3;
-
-    @Parameter(value = "outputbuffer_processor_keep_alive_time", validators = PositiveIntegerValidator.class)
-    private int outputBufferProcessorKeepAliveTime = 5000;
 
     @Parameter(value = "node_id_file", validators = NodeIdFileValidator.class)
     private String nodeIdFile = "/etc/graylog/server/node-id";
@@ -283,14 +277,6 @@ public class Configuration extends BaseConfiguration {
 
     public int getOutputBufferProcessorThreadsCorePoolSize() {
         return outputBufferProcessorThreadsCorePoolSize;
-    }
-
-    public int getOutputBufferProcessorThreadsMaxPoolSize() {
-        return outputBufferProcessorThreadsMaxPoolSize;
-    }
-
-    public int getOutputBufferProcessorKeepAliveTime() {
-        return outputBufferProcessorKeepAliveTime;
     }
 
     public boolean isCloud() {

--- a/graylog2-server/src/main/java/org/graylog2/buffers/processors/OutputBufferProcessor.java
+++ b/graylog2-server/src/main/java/org/graylog2/buffers/processors/OutputBufferProcessor.java
@@ -40,10 +40,9 @@ import javax.inject.Inject;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 import static com.codahale.metrics.MetricRegistry.name;
@@ -80,9 +79,7 @@ public class OutputBufferProcessor implements WorkHandler<MessageEvent> {
 
         final String nameFormat = "outputbuffer-processor-executor-%d";
         final int corePoolSize = configuration.getOutputBufferProcessorThreadsCorePoolSize();
-        final int maxPoolSize = configuration.getOutputBufferProcessorThreadsMaxPoolSize();
-        final int keepAliveTime = configuration.getOutputBufferProcessorKeepAliveTime();
-        this.executor = executorService(metricRegistry, nameFormat, corePoolSize, maxPoolSize, keepAliveTime);
+        this.executor = executorService(metricRegistry, nameFormat, corePoolSize);
 
         this.incomingMessages = metricRegistry.meter(INCOMING_MESSAGES_METRICNAME);
         this.outputThroughput = metricRegistry.counter(GlobalMetricNames.OUTPUT_THROUGHPUT);
@@ -90,11 +87,10 @@ public class OutputBufferProcessor implements WorkHandler<MessageEvent> {
     }
 
     private ExecutorService executorService(final MetricRegistry metricRegistry, final String nameFormat,
-                                            final int corePoolSize, final int maxPoolSize, final int keepAliveTime) {
+                                            final int corePoolSize) {
         final ThreadFactory threadFactory = new ThreadFactoryBuilder().setNameFormat(nameFormat).build();
         return new InstrumentedExecutorService(
-                new ThreadPoolExecutor(corePoolSize, maxPoolSize, keepAliveTime, TimeUnit.MILLISECONDS,
-                        new LinkedBlockingQueue<Runnable>(), threadFactory),
+                Executors.newFixedThreadPool(corePoolSize, threadFactory),
                 metricRegistry,
                 name(this.getClass(), "executor-service"));
     }

--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -463,21 +463,9 @@ output_fault_penalty_seconds = 30
 processbuffer_processors = 5
 outputbuffer_processors = 3
 
-# The following settings (outputbuffer_processor_*) configure the thread pools backing each output buffer processor.
-# See https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/ThreadPoolExecutor.html for technical details
-
-# When the number of threads is greater than the core (see outputbuffer_processor_threads_core_pool_size),
-# this is the maximum time in milliseconds that excess idle threads will wait for new tasks before terminating.
-# Default: 5000
-#outputbuffer_processor_keep_alive_time = 5000
-
-# The number of threads to keep in the pool, even if they are idle, unless allowCoreThreadTimeOut is set
+# The size of the thread pool in the output buffer processor.
 # Default: 3
 #outputbuffer_processor_threads_core_pool_size = 3
-
-# The maximum number of threads to allow in the pool
-# Default: 30
-#outputbuffer_processor_threads_max_pool_size = 30
 
 # UDP receive buffer size for all message inputs (e. g. SyslogUDPInput).
 #udp_recvbuffer_sizes = 1048576


### PR DESCRIPTION
The output buffer processor is using a `ThreadPoolExecutor` with
a practically unbounded queue (with `Integer.MAX_VALUE` capacity).
For this combination, the docs for the `ThreadPoolExecutor` state
the following:

> Using an unbounded queue (for example a LinkedBlockingQueue
> without a predefined capacity) will cause new tasks to wait
> in the queue when all corePoolSize threads are busy. Thus,
> no more than corePoolSize threads will ever be created.
> (And the value of the maximumPoolSize therefore doesn't
> have any effect.)

This PR removes the following obsolete settings:

- `outputbuffer_processor_threads_max_pool_size`
- `outputbuffer_processor_keep_alive_time` 
