### PR TITLE
Add support for a bundled JVM in bin/graylogctl

### DIFF
--- a/bin/graylogctl
+++ b/bin/graylogctl
@@ -46,12 +46,19 @@ done
 
 # take variables from environment if set
 GRAYLOGCTL_DIR=${GRAYLOGCTL_DIR:=$(dirname "$GRAYLOGCTL")}
+GRAYLOG_JVM_DIR="$(dirname "$GRAYLOGCTL_DIR")/jvm"
 GRAYLOG_SERVER_JAR=${GRAYLOG_SERVER_JAR:=graylog.jar}
 GRAYLOG_CONF=${GRAYLOG_CONF:=/etc/graylog/server/server.conf}
 GRAYLOG_PID=${GRAYLOG_PID:=/tmp/graylog.pid}
 LOG_FILE=${LOG_FILE:=log/graylog-server.log}
 LOG4J=${LOG4J:=}
 DEFAULT_JAVA_OPTS="-Dlog4j2.formatMsgNoLookups=true -Djdk.tls.acknowledgeCloseNotify=true -Xms1g -Xmx1g -XX:+UseG1GC -server -XX:-OmitStackTraceInFastThrow"
+
+if [ -z "$JAVA_HOME" ] && [ -d "$GRAYLOG_JVM_DIR" ]; then
+	echo "Using bundled JVM in $GRAYLOG_JVM_DIR"
+	export JAVA_HOME="$GRAYLOG_JVM_DIR"
+	JAVA_CMD="$GRAYLOG_JVM_DIR/bin/java"
+fi
 
 JAVA_OPTS="${JAVA_OPTS:="$DEFAULT_JAVA_OPTS"}"
 

--- a/changelog/unreleased/pr-13980.toml
+++ b/changelog/unreleased/pr-13980.toml
@@ -1,0 +1,4 @@
+type = "add"
+message = "Update `bin/graylogctl` to support a bundled JVM."
+
+pulls = ["13980"]


### PR DESCRIPTION
This change let's `graylogctl` use a bundled JVM when no `JAVA_HOME` is defined and a bundled JVM is present.