### PR TITLE
Always generate metrics for filters aggregation.

### DIFF
--- a/full-backend-tests/src/test/java/org/graylog/plugins/views/aggregations/SearchWithAggregationsSupportingMissingBucketsIT.java
+++ b/full-backend-tests/src/test/java/org/graylog/plugins/views/aggregations/SearchWithAggregationsSupportingMissingBucketsIT.java
@@ -163,6 +163,21 @@ public class SearchWithAggregationsSupportingMissingBucketsIT {
     }
 
     @ContainerMatrixTest
+    void testRowAndColumnPivotHasProperMissingBucket() {
+        final Pivot pivot = Pivot.builder()
+                .rollup(false)
+                .series(Count.builder().build(), Average.builder().field("age").build())
+                .rowGroups(Values.builder().field("firstName").limit(1).build())
+                .columnGroups(Values.builder().field("lastName").limit(1).build())
+                .build();
+        final ValidatableResponse validatableResponse = execute(pivot);
+
+        validatableResponse
+                .rootPath(PIVOT_RESULTS_PATH)
+                .body(".rows.find{ it.key == ['" + MISSING_BUCKET_NAME + "'] }.values.value", hasItems(1, 60.0f));
+    }
+
+    @ContainerMatrixTest
     void testMissingBucketIsNotPresentIfItHasZeroValues() {
         final Pivot pivot = Pivot.builder()
                 .rollup(true)

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/ESPivot.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/ESPivot.java
@@ -87,10 +87,8 @@ public class ESPivot implements ESSearchTypeHandler<Pivot> {
         final AggregationBuilder rootAggregation = createdAggregations.root();
         final AggregationBuilder leafAggregation = createdAggregations.leaf();
         final List<AggregationBuilder> metrics = createdAggregations.metrics();
-        if (!pivot.rowGroups().isEmpty() && (pivot.columnGroups().isEmpty() || pivot.rollup())) {
-            seriesStream(pivot, queryContext, "metrics")
-                    .forEach(aggregation -> metrics.forEach(metric -> metric.subAggregation(aggregation)));
-        }
+        seriesStream(pivot, queryContext, "metrics")
+                .forEach(aggregation -> metrics.forEach(metric -> metric.subAggregation(aggregation)));
 
         if (!pivot.columnGroups().isEmpty()) {
             final BucketSpecHandler.CreatedAggregations<AggregationBuilder> columnsAggregation = createPivots(BucketSpecHandler.Direction.Column, query, pivot, pivot.columnGroups(), queryContext);
@@ -259,16 +257,14 @@ public class ESPivot implements ESSearchTypeHandler<Pivot> {
         pivot.series().forEach(seriesSpec -> {
             final ESPivotSeriesSpecHandler<? extends SeriesSpec, ? extends Aggregation> seriesHandler = this.seriesHandlers.get(seriesSpec.type());
             final Aggregation series = seriesHandler.extractAggregationFromResult(pivot, seriesSpec, aggregation, queryContext);
-            if (series != null) {
-                seriesHandler.handleResult(pivot, seriesSpec, searchResult, series, this, queryContext)
-                        .map(value -> {
-                            columnKeys.addLast(value.id());
-                            final PivotResult.Value v = PivotResult.Value.create(columnKeys, value.value(), rollup, source);
-                            columnKeys.removeLast();
-                            return v;
-                        })
-                        .forEach(rowBuilder::addValue);
-            }
+            seriesHandler.handleResult(pivot, seriesSpec, searchResult, series, this, queryContext)
+                    .map(value -> {
+                        columnKeys.addLast(value.id());
+                        final PivotResult.Value v = PivotResult.Value.create(columnKeys, value.value(), rollup, source);
+                        columnKeys.removeLast();
+                        return v;
+                    })
+                    .forEach(rowBuilder::addValue);
         });
     }
 

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/OSPivot.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/OSPivot.java
@@ -87,10 +87,8 @@ public class OSPivot implements OSSearchTypeHandler<Pivot> {
         final AggregationBuilder rootAggregation = createdAggregations.root();
         final AggregationBuilder leafAggregation = createdAggregations.leaf();
         final List<AggregationBuilder> metricsAggregations = createdAggregations.metrics();
-        if (!pivot.rowGroups().isEmpty() && (pivot.columnGroups().isEmpty() || pivot.rollup())) {
-            seriesStream(pivot, queryContext, "metrics")
-                    .forEach(aggregation -> metricsAggregations.forEach(metricsAggregation -> metricsAggregation.subAggregation(aggregation)));
-        }
+        seriesStream(pivot, queryContext, "metrics")
+                .forEach(aggregation -> metricsAggregations.forEach(metricsAggregation -> metricsAggregation.subAggregation(aggregation)));
 
         if (!pivot.columnGroups().isEmpty()) {
             final BucketSpecHandler.CreatedAggregations<AggregationBuilder> createdColumnsAggregations = createPivots(BucketSpecHandler.Direction.Column, query, pivot, pivot.columnGroups(), queryContext);
@@ -257,16 +255,14 @@ public class OSPivot implements OSSearchTypeHandler<Pivot> {
         pivot.series().forEach(seriesSpec -> {
             final OSPivotSeriesSpecHandler<? extends SeriesSpec, ? extends Aggregation> seriesHandler = seriesHandlers.get(seriesSpec.type());
             final Aggregation series = seriesHandler.extractAggregationFromResult(pivot, seriesSpec, aggregation, queryContext);
-            if (series != null) {
-                seriesHandler.handleResult(pivot, seriesSpec, searchResult, series, this, queryContext)
-                        .map(value -> {
-                            columnKeys.addLast(value.id());
-                            final PivotResult.Value v = PivotResult.Value.create(columnKeys, value.value(), rollup, source);
-                            columnKeys.removeLast();
-                            return v;
-                        })
-                        .forEach(rowBuilder::addValue);
-            }
+            seriesHandler.handleResult(pivot, seriesSpec, searchResult, series, this, queryContext)
+                    .map(value -> {
+                        columnKeys.addLast(value.id());
+                        final PivotResult.Value v = PivotResult.Value.create(columnKeys, value.value(), rollup, source);
+                        columnKeys.removeLast();
+                        return v;
+                    })
+                    .forEach(rowBuilder::addValue);
         });
     }
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is changing the `pivot` search type so that it always generates series for the metrics aggregations returned by the bucket handler. This is necessary e.g. for the `values` bucketing, which uses a `filters` aggregation. For this, we need to generate metrics in the filters aggregation itself, so metrics are generated for the "other" bucket and not only for the buckets produced by the (scripted/multi) terms aggregation nested into it.

This change is fixing the issue described in #13981, as it generates the required metrics in the "other" bucket, so extraction does not fail anymore.

This only affects the generation of metrics. Extracting and including them is still affected by the `rollup` setting.

Fixes #13981.

/nocl

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.