### PR TITLE
Reduce the bulk indexing request size for 429 errors too (backport to 4.3 #13113)

### DIFF
--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/MessagesAdapterES6.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/MessagesAdapterES6.java
@@ -170,7 +170,10 @@ public class MessagesAdapterES6 implements MessagesAdapter {
             final BulkResult result = bulkIndexChunk(chunk);
 
             if (result.getResponseCode() == 413) {
-                throw new ChunkedBulkIndexer.EntityTooLargeException(indexedSuccessfully, indexingErrorsFrom(failedItems, messageList));
+                throw new ChunkedBulkIndexer.EntityTooLargeException(indexedSuccessfully);
+            }
+            if (result.getResponseCode() == 429) {
+                throw new ChunkedBulkIndexer.TooManyRequestsException(indexedSuccessfully);
             }
 
             // Checking `result.isSucceeded()` is always `false` if at least one item fails. Instead, we are checking the response code to

--- a/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/MessagesBatchES6IT.java
+++ b/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/MessagesBatchES6IT.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.storage.elasticsearch6;
+
+import com.codahale.metrics.MetricRegistry;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.searchbox.core.Count;
+import io.searchbox.core.CountResult;
+import org.graylog.storage.elasticsearch6.jest.JestUtils;
+import org.graylog.storage.elasticsearch6.testing.ElasticsearchInstanceES6;
+import org.graylog.testing.elasticsearch.SearchServerInstance;
+import org.graylog.testing.elasticsearch.TestableSearchServerInstance;
+import org.graylog2.indexer.messages.ChunkedBulkIndexer;
+import org.graylog2.indexer.messages.MessagesAdapter;
+import org.graylog2.indexer.messages.MessagesBatchIT;
+import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
+import org.junit.Ignore;
+import org.junit.Rule;
+
+import static org.graylog.storage.elasticsearch6.testing.TestUtils.jestClient;
+
+@Ignore("This does not run on ES6 yet. It will just die with OOM")
+public class MessagesBatchES6IT extends MessagesBatchIT {
+    @Rule
+    public final TestableSearchServerInstance elasticsearch = ElasticsearchInstanceES6.create("256m");
+
+    private final ObjectMapper objectMapper = new ObjectMapperProvider().get();
+
+    @Override
+    protected SearchServerInstance elasticsearch() {
+        return this.elasticsearch;
+    }
+
+    @Override
+    protected MessagesAdapter createMessagesAdapter(MetricRegistry metricRegistry) {
+        return new MessagesAdapterES6(jestClient(elasticsearch), true, metricRegistry, new ChunkedBulkIndexer(), objectMapper);
+    }
+
+    @Override
+    protected long messageCount(String indexName) {
+        final Count count = new Count.Builder().addIndex(indexName).build();
+
+        final CountResult result = JestUtils.execute(jestClient(elasticsearch), count, () -> "Unable to count documents");
+        return result.getCount().longValue();
+    }
+}

--- a/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/testing/ElasticsearchInstanceES6.java
+++ b/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/testing/ElasticsearchInstanceES6.java
@@ -41,8 +41,8 @@ public class ElasticsearchInstanceES6 extends TestableSearchServerInstance {
     private final JestClient jestClient;
     private final FixtureImporter fixtureImporter;
 
-    public ElasticsearchInstanceES6(String image, SearchVersion version, Network network) {
-        super(image, version, network);
+    public ElasticsearchInstanceES6(String image, SearchVersion version, Network network, String heapSize) {
+        super(image, version, network, heapSize);
         this.jestClient = jestClientFrom();
         this.client = new ClientES6(jestClient);
         this.fixtureImporter = new FixtureImporterES6(jestClient);
@@ -68,19 +68,19 @@ public class ElasticsearchInstanceES6 extends TestableSearchServerInstance {
     }
 
     public static TestableSearchServerInstance create() {
-        return create(Network.newNetwork());
+        return create(SearchServer.ES6.getSearchVersion(), Network.newNetwork(), "2g");
     }
 
-    public static TestableSearchServerInstance create(Network network) {
-        return create(SearchServer.ES6.getSearchVersion(), network);
+    public static TestableSearchServerInstance create(String heapSize) {
+        return create(SearchServer.ES6.getSearchVersion(), Network.newNetwork(), heapSize);
     }
 
-    public static TestableSearchServerInstance create(SearchVersion version, Network network) {
+    private static TestableSearchServerInstance create(SearchVersion version, Network network, String heapSize) {
         final String image = imageNameFrom(version);
 
         LOG.debug("Creating instance {}", image);
 
-        return new ElasticsearchInstanceES6(image, version, network);
+        return new ElasticsearchInstanceES6(image, version, network, heapSize);
     }
 
     protected static String imageNameFrom(SearchVersion version) {

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/MessagesAdapterES7.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/MessagesAdapterES7.java
@@ -175,7 +175,10 @@ public class MessagesAdapterES7 implements MessagesAdapter {
         } catch (ElasticsearchException e) {
             for (ElasticsearchException cause : e.guessRootCauses()) {
                 if (cause.status().equals(RestStatus.REQUEST_ENTITY_TOO_LARGE)) {
-                    throw new ChunkedBulkIndexer.EntityTooLargeException(indexedSuccessfully, indexingErrorsFrom(chunk));
+                    throw new ChunkedBulkIndexer.EntityTooLargeException(indexedSuccessfully);
+                }
+                if (cause.status().equals(RestStatus.TOO_MANY_REQUESTS)) {
+                    throw new ChunkedBulkIndexer.TooManyRequestsException(indexedSuccessfully);
                 }
             }
             throw new org.graylog2.indexer.ElasticsearchException(e);

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/MessagesBatchES7IT.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/MessagesBatchES7IT.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.storage.elasticsearch7;
+
+import com.codahale.metrics.MetricRegistry;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
+import org.graylog.shaded.elasticsearch7.org.elasticsearch.client.core.CountRequest;
+import org.graylog.shaded.elasticsearch7.org.elasticsearch.client.core.CountResponse;
+import org.graylog.storage.elasticsearch7.testing.ElasticsearchInstanceES7;
+import org.graylog.testing.elasticsearch.SearchServerInstance;
+import org.graylog2.indexer.messages.ChunkedBulkIndexer;
+import org.graylog2.indexer.messages.MessagesAdapter;
+import org.graylog2.indexer.messages.MessagesBatchIT;
+import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
+import org.junit.Rule;
+
+public class MessagesBatchES7IT extends MessagesBatchIT {
+    @Rule
+    public final ElasticsearchInstanceES7 elasticsearch = ElasticsearchInstanceES7.create("256m");
+
+    private final ObjectMapper objectMapper = new ObjectMapperProvider().get();
+
+    @Override
+    protected SearchServerInstance elasticsearch() {
+        return this.elasticsearch;
+    }
+
+
+    @Override
+    protected MessagesAdapter createMessagesAdapter(MetricRegistry metricRegistry) {
+        return new MessagesAdapterES7(this.elasticsearch.elasticsearchClient(), metricRegistry, new ChunkedBulkIndexer(), objectMapper);
+    }
+
+    @Override
+    protected long messageCount(String indexName) {
+        this.elasticsearch.elasticsearchClient().execute((c, requestOptions) -> c.indices().refresh(new RefreshRequest(), requestOptions));
+
+        final CountRequest countRequest = new CountRequest(indexName);
+        final CountResponse result = this.elasticsearch.elasticsearchClient().execute((c, requestOptions) -> c.count(countRequest, requestOptions));
+
+        return result.getCount();
+    }
+}

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/testing/OpensearchInstance.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/testing/OpensearchInstance.java
@@ -53,7 +53,7 @@ public class OpensearchInstance extends TestableSearchServerInstance {
     private final FixtureImporter fixtureImporter;
 
     protected OpensearchInstance(String image, SearchVersion version, Network network) {
-        super(image, version, network);
+        super(image, version, network, "2g");
         this.restHighLevelClient = buildRestClient();
         this.elasticsearchClient = new ElasticsearchClient(this.restHighLevelClient, false, new ObjectMapperProvider().get());
         this.client = new ClientES7(this.elasticsearchClient);

--- a/graylog2-server/src/test/java/org/graylog/testing/elasticsearch/TestableSearchServerInstance.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/elasticsearch/TestableSearchServerInstance.java
@@ -17,12 +17,14 @@
 package org.graylog.testing.elasticsearch;
 
 import com.google.common.io.Resources;
+import org.graylog2.shared.utilities.StringUtils;
 import org.graylog2.storage.SearchVersion;
 import org.junit.rules.ExternalResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
 import org.testcontainers.utility.DockerImageName;
@@ -49,6 +51,7 @@ public abstract class TestableSearchServerInstance extends ExternalResource impl
     private static final String NETWORK_ALIAS = "elasticsearch";
 
     private final SearchVersion version;
+    private String heapSize;
     protected final GenericContainer<?> container;
 
     @Override
@@ -57,8 +60,9 @@ public abstract class TestableSearchServerInstance extends ExternalResource impl
     @Override
     public abstract FixtureImporter fixtureImporter();
 
-    protected TestableSearchServerInstance(String image, SearchVersion version, Network network) {
+    protected TestableSearchServerInstance(String image, SearchVersion version, Network network, String heapSize) {
         this.version = version;
+        this.heapSize = heapSize;
         this.container = createContainer(image, version, network);
     }
 
@@ -67,6 +71,9 @@ public abstract class TestableSearchServerInstance extends ExternalResource impl
         if (!containersByVersion.containsKey(version)) {
             GenericContainer<?> container = buildContainer(image, network);
             container.start();
+            if (LOG.isDebugEnabled()) {
+                container.followOutput(new Slf4jLogConsumer(LOG));
+            }
             containersByVersion.put(version, container);
         }
         return containersByVersion.get(version);
@@ -77,13 +84,17 @@ public abstract class TestableSearchServerInstance extends ExternalResource impl
         return new ElasticsearchContainer(DockerImageName.parse(image).asCompatibleSubstituteFor("docker.elastic.co/elasticsearch/elasticsearch"))
                 // Avoids reuse warning on Jenkins (we don't want reuse in our CI environment)
                 .withReuse(isNull(System.getenv("BUILD_ID")))
-                .withEnv("ES_JAVA_OPTS", "-Xms2g -Xmx2g -Dlog4j2.formatMsgNoLookups=true")
+                .withEnv("ES_JAVA_OPTS", getEsJavaOpts())
                 .withEnv("discovery.type", "single-node")
                 .withEnv("action.auto_create_index", "false")
                 .withEnv("cluster.info.update.interval", "10s")
                 .withNetwork(network)
                 .withNetworkAliases(NETWORK_ALIAS)
                 .waitingFor(Wait.forHttp("/").forPort(ES_PORT));
+    }
+
+    private String getEsJavaOpts() {
+        return StringUtils.f("-Xms%s -Xmx%s -Dlog4j2.formatMsgNoLookups=true", heapSize, heapSize);
     }
 
     @Override

--- a/graylog2-server/src/test/java/org/graylog2/indexer/messages/MessagesBatchIT.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/messages/MessagesBatchIT.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.indexer.messages;
+
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.collect.Maps;
+import joptsimple.internal.Strings;
+import org.graylog.failure.FailureSubmissionService;
+import org.graylog.testing.elasticsearch.ElasticsearchBaseTest;
+import org.graylog2.indexer.IndexSet;
+import org.graylog2.plugin.Message;
+import org.graylog2.system.processing.ProcessingStatusRecorder;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+public abstract class MessagesBatchIT extends ElasticsearchBaseTest {
+    private static final String INDEX_NAME = "messages_it_deflector";
+
+    protected static final IndexSet indexSet = new MessagesTestIndexSet();
+    protected Messages messages;
+
+    protected abstract MessagesAdapter createMessagesAdapter(MetricRegistry metricRegistry);
+
+    @Mock
+    private FailureSubmissionService failureSubmissionService;
+
+    @Before
+    public void setUp() throws Exception {
+        client().deleteIndices(INDEX_NAME);
+        client().createIndex(INDEX_NAME);
+        client().waitForGreenStatus(INDEX_NAME);
+        final MetricRegistry metricRegistry = new MetricRegistry();
+        messages = new Messages(mock(TrafficAccounting.class), createMessagesAdapter(metricRegistry), mock(ProcessingStatusRecorder.class),
+                failureSubmissionService);
+    }
+
+    @After
+    public void tearDown() {
+        client().cleanUp();
+    }
+
+    @Test
+    public void testIfLargeBatchesGetSplitUpOnCircuitBreakerExceptions() throws Exception {
+        // This test assumes that ES is running with only 256MB heap size.
+        // This will trigger the circuit breaker when we are trying to index large batches
+        final int MESSAGECOUNT = 50;
+        // Each Message is about 1 MB
+        final List<Map.Entry<IndexSet, Message>> largeMessageBatch = createMessageBatch(1024 * 1024, MESSAGECOUNT);
+        final List<String> failedItems = this.messages.bulkIndex(largeMessageBatch);
+
+        client().refreshNode(); // wait for ES to finish indexing
+
+        assertThat(failedItems).isEmpty();
+        assertThat(messageCount(INDEX_NAME)).isEqualTo(MESSAGECOUNT);
+    }
+
+    protected abstract long messageCount(String indexName);
+
+    private DateTime now() {
+        return DateTime.now(DateTimeZone.UTC);
+    }
+
+    private ArrayList<Map.Entry<IndexSet, Message>> createMessageBatch(int size, int count) {
+        final ArrayList<Map.Entry<IndexSet, Message>> messageList = new ArrayList<>();
+
+        final String message = Strings.repeat('A', size);
+        for (int i = 0; i < count; i++) {
+            messageList.add(Maps.immutableEntry(indexSet, new Message(i + message, "source", now())));
+        }
+        return messageList;
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/indexer/messages/MessagesIT.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/messages/MessagesIT.java
@@ -25,13 +25,7 @@ import joptsimple.internal.Strings;
 import org.graylog.failure.FailureSubmissionService;
 import org.graylog.testing.elasticsearch.ElasticsearchBaseTest;
 import org.graylog2.indexer.IndexSet;
-import org.graylog2.indexer.TestIndexSet;
-import org.graylog2.indexer.indexset.IndexSetConfig;
 import org.graylog2.indexer.results.ResultMessage;
-import org.graylog2.indexer.retention.strategies.DeletionRetentionStrategy;
-import org.graylog2.indexer.retention.strategies.DeletionRetentionStrategyConfig;
-import org.graylog2.indexer.rotation.strategies.MessageCountRotationStrategy;
-import org.graylog2.indexer.rotation.strategies.MessageCountRotationStrategyConfig;
 import org.graylog2.plugin.Message;
 import org.graylog2.system.processing.ProcessingStatusRecorder;
 import org.joda.time.DateTime;
@@ -41,8 +35,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -67,24 +59,7 @@ public abstract class MessagesIT extends ElasticsearchBaseTest {
 
     protected Messages messages;
 
-    private static final IndexSetConfig indexSetConfig = IndexSetConfig.builder()
-            .id("index-set-1")
-            .title("Index set 1")
-            .description("For testing")
-            .indexPrefix("messages_it")
-            .creationDate(ZonedDateTime.now(ZoneOffset.UTC))
-            .shards(1)
-            .replicas(0)
-            .rotationStrategyClass(MessageCountRotationStrategy.class.getCanonicalName())
-            .rotationStrategy(MessageCountRotationStrategyConfig.createDefault())
-            .retentionStrategyClass(DeletionRetentionStrategy.class.getCanonicalName())
-            .retentionStrategy(DeletionRetentionStrategyConfig.createDefault())
-            .indexAnalyzer("standard")
-            .indexTemplateName("template-1")
-            .indexOptimizationMaxNumSegments(1)
-            .indexOptimizationDisabled(false)
-            .build();
-    private static final IndexSet indexSet = new TestIndexSet(indexSetConfig);
+    protected static final IndexSet indexSet = new MessagesTestIndexSet();
 
     protected abstract MessagesAdapter createMessagesAdapter(MetricRegistry metricRegistry);
 

--- a/graylog2-server/src/test/java/org/graylog2/indexer/messages/MessagesTestIndexSet.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/messages/MessagesTestIndexSet.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.indexer.messages;
+
+import org.graylog2.indexer.TestIndexSet;
+import org.graylog2.indexer.indexset.IndexSetConfig;
+import org.graylog2.indexer.retention.strategies.DeletionRetentionStrategy;
+import org.graylog2.indexer.retention.strategies.DeletionRetentionStrategyConfig;
+import org.graylog2.indexer.rotation.strategies.MessageCountRotationStrategy;
+import org.graylog2.indexer.rotation.strategies.MessageCountRotationStrategyConfig;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+
+public class MessagesTestIndexSet extends TestIndexSet {
+    public MessagesTestIndexSet() {
+        super(IndexSetConfig.builder()
+                .id("index-set-1")
+                .title("Index set 1")
+                .description("For testing")
+                .indexPrefix("messages_it")
+                .creationDate(ZonedDateTime.now(ZoneOffset.UTC))
+                .shards(1)
+                .replicas(0)
+                .rotationStrategyClass(MessageCountRotationStrategy.class.getCanonicalName())
+                .rotationStrategy(MessageCountRotationStrategyConfig.createDefault())
+                .retentionStrategyClass(DeletionRetentionStrategy.class.getCanonicalName())
+                .retentionStrategy(DeletionRetentionStrategyConfig.createDefault())
+                .indexAnalyzer("standard")
+                .indexTemplateName("template-1")
+                .indexOptimizationMaxNumSegments(1)
+                .indexOptimizationDisabled(false)
+                .build());
+    }
+}


### PR DESCRIPTION
An elastic cluster might not have enough memory available to
accept a full bulk index request. It can reject it with
a HTTP/1.1 429 Too Many Requests exception.

We could handle this the same way we do with Request entity too large
errors. See https://github.com/Graylog2/graylog2-server/pull/7071

/nocl because of old backport pre-cl check

**Note: backport to 4.3 from #13113**
fixes #13997 