### PR TITLE
Fix toast errors on data adapter HTTP JSONPath when editing the title

### DIFF
--- a/changelog/unreleased/issue-13998.toml
+++ b/changelog/unreleased/issue-13998.toml
@@ -1,0 +1,12 @@
+type = "fixed"
+message = "Fix appearing toast errors when creating HTTP JSONPath data adapter and start editing the title."
+
+pulls = ["14004"]
+
+details.user = """
+When a user creates a new adapter and starts to edit the title,
+errors were displayed immediately.
+
+This happened because of the missing URL, now a default URL is used,
+so the new adapter is not immediately invalid.
+"""

--- a/graylog2-server/src/main/java/org/graylog2/lookup/adapters/HTTPJSONPathDataAdapter.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/adapters/HTTPJSONPathDataAdapter.java
@@ -284,7 +284,7 @@ public class HTTPJSONPathDataAdapter extends LookupDataAdapter {
         public Config defaultConfiguration() {
             return Config.builder()
                     .type(NAME)
-                    .url("")
+                    .url("https://example.com/api/lookup?key=${key}")
                     .singleValueJSONPath("$.value")
                     .userAgent("Graylog Lookup - https://www.graylog.org/")
                     .headers(Collections.emptyMap())

--- a/graylog2-server/src/main/java/org/graylog2/lookup/adapters/HTTPJSONPathDataAdapter.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/adapters/HTTPJSONPathDataAdapter.java
@@ -284,7 +284,7 @@ public class HTTPJSONPathDataAdapter extends LookupDataAdapter {
         public Config defaultConfiguration() {
             return Config.builder()
                     .type(NAME)
-                    .url("https://example.com/api/lookup?key=${key}")
+                    .url("https://example.invalid/api/lookup?key=${key}")
                     .singleValueJSONPath("$.value")
                     .userAgent("Graylog Lookup - https://www.graylog.org/")
                     .headers(Collections.emptyMap())

--- a/graylog2-web-interface/src/components/lookup-tables/DataAdapterForm.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/DataAdapterForm.jsx
@@ -310,7 +310,9 @@ class DataAdapterForm extends React.Component {
 
     return (
       <>
-        {this._renderTitle(title, pluginDisplayName, create)}
+        <p>
+          {this._renderTitle(title, pluginDisplayName, create)}
+        </p>
         <Row>
           <Col lg={formRowWidth}>
             <form className="form form-horizontal" onSubmit={this._save}>

--- a/graylog2-web-interface/src/components/lookup-tables/adapters/HTTPJSONPathAdapterDocumentation.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/adapters/HTTPJSONPathAdapterDocumentation.jsx
@@ -135,8 +135,8 @@ end`;
           <p style={{ marginBottom: 10, padding: 0 }}>
             Single value: <code>Jane Doe</code><br />
             Multi value:
-            <pre>{noMultiResult}</pre>
           </p>
+          <pre>{noMultiResult}</pre>
         </Col>
       </Row>
       <Row>
@@ -152,8 +152,8 @@ end`;
           <p style={{ marginBottom: 10, padding: 0 }}>
             Single value: <code>Jane Doe</code><br />
             Multi value:
-            <pre>{mapResult}</pre>
           </p>
+          <pre>{mapResult}</pre>
         </Col>
       </Row>
       <Row>
@@ -169,8 +169,8 @@ end`;
           <p style={{ marginBottom: 10, padding: 0 }}>
             Single value: <code>jane@example.com</code><br />
             Multi value:
-            <pre>{listResult}</pre>
           </p>
+          <pre>{listResult}</pre>
         </Col>
       </Row>
       <Row>
@@ -186,8 +186,8 @@ end`;
           <p style={{ marginBottom: 10, padding: 0 }}>
             Single value: <code>Jane Doe</code><br />
             Multi value:
-            <pre>{smallMapResult}</pre>
           </p>
+          <pre>{smallMapResult}</pre>
         </Col>
       </Row>
 


### PR DESCRIPTION
Fix mainly toast error notifications when editing the HTTP JSONPath data adapter without valid lookup url.

Fix: https://github.com/Graylog2/graylog2-server/issues/13998

## Screenshots (if appropriate):

Fix also one warning:

![Screenshot 2022-11-18 at 16 30 09](https://user-images.githubusercontent.com/92227/202750622-70963a29-acaf-4f4b-a590-812e2d871efa.png)

And introduce spacing between the title and the form:

Before:

![Screenshot 2022-11-18 at 17 03 53](https://user-images.githubusercontent.com/92227/202750698-17f9007e-79ab-48d5-a538-a4348ee52341.png)

After:

![Screenshot 2022-11-18 at 17 14 49](https://user-images.githubusercontent.com/92227/202750863-f9f14465-ae6b-49ba-b874-e2a2637ae8e1.png)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

