### PR TITLE
Only allocate the maximum needed size for one UDP packet

### DIFF
--- a/changelog/unreleased/issue-13306.toml
+++ b/changelog/unreleased/issue-13306.toml
@@ -1,0 +1,11 @@
+type = "fixed"
+message = "Fix performance regression on UDP inputs with newer Java versions"
+
+issues = ["13306"]
+pulls = ["14005"]
+
+contributors = ["@giangi"]
+
+details.user = """
+UDP inputs became slow when running Graylog with a Java version > 8.
+"""

--- a/graylog2-server/src/main/java/org/graylog2/inputs/transports/UdpTransport.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/transports/UdpTransport.java
@@ -88,7 +88,7 @@ public class UdpTransport extends NettyTransport {
         return new Bootstrap()
                 .group(eventLoopGroup)
                 .channelFactory(new DatagramChannelFactory(transportType))
-                .option(ChannelOption.RCVBUF_ALLOCATOR, new FixedRecvByteBufAllocator(getRecvBufferSize()))
+                .option(ChannelOption.RCVBUF_ALLOCATOR, new FixedRecvByteBufAllocator(65535)) // Maximum possible UDP packet size
                 .option(ChannelOption.SO_RCVBUF, getRecvBufferSize())
                 .option(UnixChannelOption.SO_REUSEPORT, true)
                 .handler(getChannelInitializer(getChannelHandlers(input)))


### PR DESCRIPTION
Don't allocate the size of the entire UDP socket buffer for each packet!

This has been wrong for a long time [1], but only came up as a regression when using Java > 9.

On newer Java versions Netty does not use direct buffers via "Unsafe" to allocate memory. It falls back to ByteBuffer.allocateDirect which has inferior performance[2].

This behavior could be restored by adding these JVM options:
```
-Dio.netty.tryReflectionSetAccessible=true
--add-opens=java.base/java.nio=ALL-UNNAMED
--add-opens=java.base/sun.nio.ch=ALL-UNNAMED
```
But since fixing the receive buffer size to 64k gives us the same performance boost [3], we can avoid using these hacks, and not having to rely on Unsafe is also a good idea.

Refs
 https://github.com/netty/netty/pull/7650

 https://github.com/netty/netty/blame/e8df52e442629214e0355528c00e873e213f0139/common/src/main/java/io/netty/util/internal/PlatformDependent0.java#L979-L980

Fixes #13306

[1] https://github.com/Graylog2/graylog2-server/pull/1146
[2] In my test case I only received about `300 msg/sec`.
[3] With this change, I was able to receive ~ `35000 msg/sec` (utilizing only one netty thread)