### PR TITLE
replaced latest aggregation in tests with max

### DIFF
--- a/full-backend-tests/src/test/java/org/graylog/plugins/views/ScriptingApiResourceIT.java
+++ b/full-backend-tests/src/test/java/org/graylog/plugins/views/ScriptingApiResourceIT.java
@@ -300,7 +300,7 @@ public class ScriptingApiResourceIT {
                               "field": "facility"
                             },
                             {
-                              "function": "latest",
+                              "function": "max",
                               "field": "level"
                             }
                           ]
@@ -311,8 +311,8 @@ public class ScriptingApiResourceIT {
                 .log().ifStatusCodeMatches(not(200))
                 .statusCode(200);
 
-        validateRow(validatableResponse, "another-test", 2, 3);
-        validateRow(validatableResponse, "test", 1, 1);
+        validateRow(validatableResponse, "another-test", 2, 3.0f);
+        validateRow(validatableResponse, "test", 1, 1.0f);
     }
 
     @ContainerMatrixTest
@@ -395,7 +395,7 @@ public class ScriptingApiResourceIT {
                               "field": "http_method"
                             },
                              {
-                              "function": "latest",
+                              "function": "max",
                               "field": "level"
                             }
                           ]
@@ -406,8 +406,8 @@ public class ScriptingApiResourceIT {
                 .log().ifStatusCodeMatches(not(200))
                 .statusCode(200);
 
-        validateRow(validatableResponse, "another-test", 2, "POST", 3);
-        validateRow(validatableResponse, "test", 1, "-", 1);
+        validateRow(validatableResponse, "another-test", 2, "POST", 3.0f);
+        validateRow(validatableResponse, "test", 1, "-", 1.0f);
     }
 
     @ContainerMatrixTest


### PR DESCRIPTION
The latest aggregation depends on messages indexed in specific order, which may cause flaky tests.

/nocl

## Description
Replaced latest with max, which is not order dependent.

## How Has This Been Tested?
Adapted existing tests


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

