### PR TITLE
Only allocate the maximum needed size for one UDP packet (#14005)

### DIFF
--- a/changelog/unreleased/issue-13306.toml
+++ b/changelog/unreleased/issue-13306.toml
@@ -1,0 +1,11 @@
+type = "fixed"
+message = "Fix performance regression on UDP inputs with newer Java versions"
+
+issues = ["13306"]
+pulls = ["14005"]
+
+contributors = ["@giangi"]
+
+details.user = """
+UDP inputs became slow when running Graylog with a Java version > 8.
+"""

--- a/graylog2-server/src/main/java/org/graylog2/inputs/transports/UdpTransport.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/transports/UdpTransport.java
@@ -88,7 +88,7 @@ public class UdpTransport extends NettyTransport {
         return new Bootstrap()
                 .group(eventLoopGroup)
                 .channelFactory(new DatagramChannelFactory(transportType))
-                .option(ChannelOption.RCVBUF_ALLOCATOR, new FixedRecvByteBufAllocator(getRecvBufferSize()))
+                .option(ChannelOption.RCVBUF_ALLOCATOR, new FixedRecvByteBufAllocator(65535)) // Maximum possible UDP packet size
                 .option(ChannelOption.SO_RCVBUF, getRecvBufferSize())
                 .option(UnixChannelOption.SO_REUSEPORT, true)
                 .handler(getChannelInitializer(getChannelHandlers(input)))

--- a/graylog2-server/src/test/java/org/graylog2/inputs/transports/UdpTransportTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/inputs/transports/UdpTransportTest.java
@@ -26,7 +26,6 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandler;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
-import io.netty.channel.FixedRecvByteBufAllocator;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.logging.LogLevel;
 import io.netty.handler.logging.LoggingHandler;
@@ -146,7 +145,7 @@ public class UdpTransportTest {
     }
 
     @Test
-    public void transportTruncatesDataLargerRecvBufferSizeOnLinux() throws Exception {
+    public void transportCanRecvLargeUDPPacketsOnLinux() throws Exception {
         assumeTrue("Skipping test intended for Linux systems", SystemUtils.IS_OS_LINUX);
 
         final CountingChannelUpstreamHandler handler = new CountingChannelUpstreamHandler();
@@ -154,11 +153,12 @@ public class UdpTransportTest {
         await().atMost(5, TimeUnit.SECONDS).until(() -> transport.getLocalAddress() != null);
         final InetSocketAddress localAddress = (InetSocketAddress) transport.getLocalAddress();
 
-        sendUdpDatagram(BIND_ADDRESS, localAddress.getPort(), 2 * RECV_BUFFER_SIZE);
+        final int maxUDPSize = 65507; // Maximum theoretical size of a UDP payload over IPv4
+        sendUdpDatagram(BIND_ADDRESS, localAddress.getPort(), maxUDPSize);
         await().atMost(5, TimeUnit.SECONDS).until(() -> !handler.getBytesWritten().isEmpty());
         transport.stop();
 
-        assertThat(handler.getBytesWritten()).containsExactly(RECV_BUFFER_SIZE);
+        assertThat(handler.getBytesWritten()).containsExactly(maxUDPSize);
     }
 
     @Test
@@ -177,13 +177,6 @@ public class UdpTransportTest {
         UdpTransport udpTransport = new UdpTransport(config, eventLoopGroupFactory, nettyTransportConfiguration, throughputCounter, new LocalMetricRegistry());
 
         assertThat(udpTransport.getBootstrap(mock(MessageInput.class)).config().options().get(ChannelOption.SO_RCVBUF)).isEqualTo(recvBufferSize);
-    }
-
-    @Test
-    public void receiveBufferSizePredictorIsUsingDefaultSize() {
-        FixedRecvByteBufAllocator recvByteBufAllocator =
-                (FixedRecvByteBufAllocator) udpTransport.getBootstrap(mock(MessageInput.class)).config().options().get(ChannelOption.RCVBUF_ALLOCATOR);
-        assertThat(recvByteBufAllocator.newHandle().guess()).isEqualTo(RECV_BUFFER_SIZE);
     }
 
     @Test


### PR DESCRIPTION
Don't allocate the size of the entire UDP socket buffer for each packet!

This has been wrong for a long time, but only came up as a regression when using Java > 9.

On newer Java versions Netty does not use direct buffers via "Unsafe" to allocate memory. It falls back to ByteBuffer.allocateDirect which has inferior performance.

This behavior could be restored by adding these JVM options:
```
-Dio.netty.tryReflectionSetAccessible=true
--add-opens=java.base/java.nio=ALL-UNNAMED
--add-opens=java.base/sun.nio.ch=ALL-UNNAMED
```
But since fixing the receive buffer size to 64k gives us the same performance boost, we can avoid using these hacks, and not having to rely on Unsafe is also a good idea.

Refs
 https://github.com/netty/netty/pull/7650

 https://github.com/netty/netty/blame/e8df52e442629214e0355528c00e873e213f0139/common/src/main/java/io/netty/util/internal/PlatformDependent0.java#L979-L980

Fixes #13306

(cherry picked from commit e73ecfbb5d1cdc1f85967e6ee7dd2fe31d373c5f)
