### PR TITLE
Do not implement link for `LinkContainer` children, when child is disabled.

### DIFF
--- a/graylog2-web-interface/src/components/common/LinkContainer.test.jsx
+++ b/graylog2-web-interface/src/components/common/LinkContainer.test.jsx
@@ -15,7 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { render, waitFor } from 'wrappedTestingLibrary';
+import { render, waitFor, screen } from 'wrappedTestingLibrary';
 import { fireEvent } from '@testing-library/react';
 
 import history from 'util/History';
@@ -27,30 +27,27 @@ jest.mock('util/History');
 
 describe('LinkContainer', () => {
   it('should use component passed in children', async () => {
-    const { findByText } = render((
+    render(
       <LinkContainer to="/">
         <Button bsStyle="info">All Alerts</Button>
-      </LinkContainer>
-    ));
+      </LinkContainer>,
+    );
 
-    const button = await findByText('All Alerts');
-
-    fireEvent.click(button);
+    fireEvent.click(await screen.findByText('All Alerts'));
 
     expect(history.push).toHaveBeenCalledWith('/');
   });
 
   it('should call onClick', async () => {
     const onClick = jest.fn();
-    const { findByText } = render((
+
+    render(
       <LinkContainer to="/" onClick={onClick}>
         <Button bsStyle="info">All Alerts</Button>
-      </LinkContainer>
-    ));
+      </LinkContainer>,
+    );
 
-    const button = await findByText('All Alerts');
-
-    fireEvent.click(button);
+    fireEvent.click(await findByText('All Alerts'));
 
     expect(onClick).toHaveBeenCalled();
   });
@@ -63,36 +60,33 @@ describe('LinkContainer', () => {
       </LinkContainer>
     ));
 
-    const button = await findByText('All Alerts');
-
-    fireEvent.click(button);
+    fireEvent.click(await findByText('All Alerts'));
 
     expect(onClick).toHaveBeenCalled();
   });
 
   it('should not call onClick of children for ctrl+click', async () => {
     const onClick = jest.fn();
-    const { findByText } = render((
+
+    render(
       <LinkContainer to="/">
         <Button bsStyle="info" onClick={onClick}>All Alerts</Button>
-      </LinkContainer>
-    ));
+      </LinkContainer>,
+    );
 
-    const button = await findByText('All Alerts');
-
-    fireEvent.click(button, { ctrlKey: true });
+    fireEvent.click(await screen.findByText('All Alerts'), { ctrlKey: true });
 
     expect(onClick).not.toHaveBeenCalled();
   });
 
   it('should add target URL as href to children', async () => {
-    const { findByText } = render((
+    render(
       <LinkContainer to="/alerts">
         <Button bsStyle="info" onClick={jest.fn()}>Alerts</Button>
-      </LinkContainer>
-    ));
+      </LinkContainer>,
+    );
 
-    const button = await findByText('Alerts');
+    const button = await screen.findByText('Alerts');
 
     expect(button.href).toEqual('http://localhost/alerts');
   });
@@ -100,18 +94,17 @@ describe('LinkContainer', () => {
   it('should stop event in generated `onClick`', async () => {
     const onClick = jest.fn();
     const childOnClick = jest.fn();
-    const { findByText } = render((
+
+    render(
       // eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions
       <div onClick={onClick}>
         <LinkContainer to="/">
           <Button bsStyle="info" onClick={childOnClick}>All Alerts</Button>
         </LinkContainer>
-      </div>
-    ));
+      </div>,
+    );
 
-    const button = await findByText('All Alerts');
-
-    fireEvent.click(button);
+    fireEvent.click(await screen.findByText('All Alerts'));
 
     await waitFor(() => expect(childOnClick).toHaveBeenCalled());
 

--- a/graylog2-web-interface/src/components/common/LinkContainer.test.tsx
+++ b/graylog2-web-interface/src/components/common/LinkContainer.test.tsx
@@ -47,7 +47,7 @@ describe('LinkContainer', () => {
       </LinkContainer>,
     );
 
-    fireEvent.click(await findByText('All Alerts'));
+    fireEvent.click(await screen.findByText('All Alerts'));
 
     expect(onClick).toHaveBeenCalled();
   });

--- a/graylog2-web-interface/src/components/common/LinkContainer.test.tsx
+++ b/graylog2-web-interface/src/components/common/LinkContainer.test.tsx
@@ -26,6 +26,14 @@ import { LinkContainer } from './router';
 jest.mock('util/History');
 
 describe('LinkContainer', () => {
+  const hasHref = (element: HTMLElement | HTMLAnchorElement): element is HTMLAnchorElement => {
+    return 'href' in element;
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('should use component passed in children', async () => {
     render(
       <LinkContainer to="/">
@@ -88,7 +96,7 @@ describe('LinkContainer', () => {
 
     const button = await screen.findByText('Alerts');
 
-    expect(button.href).toEqual('http://localhost/alerts');
+    expect(hasHref(button) ? button.href : null).toEqual('http://localhost/alerts');
   });
 
   it('should stop event in generated `onClick`', async () => {
@@ -109,5 +117,29 @@ describe('LinkContainer', () => {
     await waitFor(() => expect(childOnClick).toHaveBeenCalled());
 
     expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it('should not redirect onclick, when children is disabled', async () => {
+    render(
+      <LinkContainer to="/">
+        <Button bsStyle="info" disabled>All Alerts</Button>
+      </LinkContainer>,
+    );
+
+    fireEvent.click(await screen.findByText('All Alerts'));
+
+    expect(history.push).not.toHaveBeenCalled();
+  });
+
+  it('should add target URL as href to children, when children is disabled', async () => {
+    render(
+      <LinkContainer to="/alerts">
+        <Button bsStyle="info" onClick={jest.fn()} disabled>Alerts</Button>
+      </LinkContainer>,
+    );
+
+    const button = await screen.findByText('Alerts');
+
+    expect(hasHref(button) ? button.href : null).toBeNull();
   });
 });

--- a/graylog2-web-interface/src/components/common/router.tsx
+++ b/graylog2-web-interface/src/components/common/router.tsx
@@ -83,7 +83,7 @@ const LinkContainer = ({ children, onClick, to: toProp, relativeActive, ...rest 
     if (!disabled) {
       history.push(to);
     }
-  }, [childrenOnClick, onClick, to]);
+  }, [childrenOnClick, disabled, onClick, to]);
 
   return React.cloneElement(React.Children.only(children), {
     ...rest,

--- a/graylog2-web-interface/src/components/common/router.tsx
+++ b/graylog2-web-interface/src/components/common/router.tsx
@@ -42,11 +42,11 @@ type ChildrenProps = {
   onClick: (e?: any) => void,
   className: string,
   href: string,
+  disabled: boolean,
 };
 type Props = {
   children: React.ReactElement<ChildrenProps, React.ComponentType>,
   onClick?: () => unknown,
-  disabled?: boolean,
   to: string | { pathname: string },
   // if set the child component will receive the active class
   // when the part of the URL path matches the `to` prop.
@@ -59,7 +59,7 @@ const isModifiedEvent = (e: React.MouseEvent) => !!(e.metaKey || e.altKey || e.c
 
 const LinkContainer = ({ children, onClick, to: toProp, relativeActive, ...rest }: Props) => {
   const { pathname } = useLocation();
-  const { props: { onClick: childrenOnClick, className }, type: { displayName } } = React.Children.only(children);
+  const { props: { onClick: childrenOnClick, className, disabled }, type: { displayName } } = React.Children.only(children);
   const to = (typeof toProp === 'object' && 'pathname' in toProp) ? toProp.pathname : toProp;
   const childrenClassName = useMemo(() => _setActiveClassName(pathname, to, className, displayName, relativeActive),
     [pathname, to, className, displayName, relativeActive],
@@ -80,10 +80,18 @@ const LinkContainer = ({ children, onClick, to: toProp, relativeActive, ...rest 
       onClick();
     }
 
-    history.push(to);
+    if (!disabled) {
+      history.push(to);
+    }
   }, [childrenOnClick, onClick, to]);
 
-  return React.cloneElement(React.Children.only(children), { ...rest, className: childrenClassName, onClick: _onClick, href: to });
+  return React.cloneElement(React.Children.only(children), {
+    ...rest,
+    className: childrenClassName,
+    onClick: _onClick,
+    disabled: !!disabled,
+    href: disabled ? undefined : to,
+  });
 };
 
 LinkContainer.defaultProps = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

When wrapping a `Button` or `MenuItem` with `LinkContainer`, the `LinkContainer` defines an href for the child. Previously it was still possible to click on the link, even when the child (e.g. the `Button`) is disabled. 

With this PR we no longer deine the `href` for the children, if it is disabled.

/nocl

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

