### PR TITLE
Remove duplicate HttpHandler filter logic

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/inputs/transports/HttpTransport.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/transports/HttpTransport.java
@@ -108,11 +108,8 @@ public class HttpTransport extends AbstractTcpTransport {
         handlers.put("decompressor", HttpContentDecompressor::new);
         handlers.put("encoder", HttpResponseEncoder::new);
         handlers.put("aggregator", () -> new HttpObjectAggregator(maxChunkSize));
-
-        if (!enableBulkReceiving) {
-            handlers.put("http-handler", () -> new HttpHandler(enableCors));
-        } else {
-            handlers.put("http-bulk-handler", () -> new HttpHandler(enableCors));
+        handlers.put("http-handler", () -> new HttpHandler(enableCors));
+        if (enableBulkReceiving) {
             handlers.put("http-bulk-newline-decoder",
                     () -> new LenientDelimiterBasedFrameDecoder(maxChunkSize, Delimiters.lineDelimiter()));
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Removes duplicate logic that adds the same `HttpHandler` definition both when the `Enable Bulk Receiving` option is enabled and disabled. Although a different name was used for both instances, adding the same handler in two places is unnecessary.

/nocl

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Cleaner more concise code.

Noticed this as I was looking into https://github.com/Graylog2/graylog2-server/issues/13959. Although this has no affect on the issue, I wanted to clean it up.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manual testing when the `Enable Bulk Receiving` option is enabled and disabled and verifying that bulk messages are correctly when enabled, and not when disabled.

See the original PR that added this feature for info on testing it: https://github.com/Graylog2/graylog2-server/pull/11529

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

