### PR TITLE
No sorting on latest aggregation

### DIFF
--- a/changelog/unreleased/issue-12908.toml
+++ b/changelog/unreleased/issue-12908.toml
@@ -1,0 +1,5 @@
+type = "fixed" # One of: a(dded), c(hanged), d(eprecated), r(emoved), f(ixed), s(ecurity)
+message = "Fixes sorting exception on aggregations by removing 'latest' metrics from the list of possible sorts."
+
+issues = ["12908"]
+pulls = ["14027"]

--- a/graylog2-web-interface/src/views/components/aggregationwizard/sort/SortConfiguration.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/sort/SortConfiguration.tsx
@@ -61,6 +61,7 @@ const Sort = React.memo(({ index }: Props) => {
   const hasGroupings = otherSorts.find((s) => s.type === 'groupBy');
 
   const metricsOptions: Array<OptionValue> = hasGroupings ? [] : metrics.map(formatSeries)
+    .filter((metric) => !(metric.label.startsWith('latest(')))
     .map(({ field, label }) => ({
       type: 'metric',
       field,

--- a/graylog2-web-interface/src/views/components/aggregationwizard/sort/SortConfiguration.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/sort/SortConfiguration.tsx
@@ -60,8 +60,9 @@ const Sort = React.memo(({ index }: Props) => {
   const hasMetrics = otherSorts.find((s) => s.type === 'metric');
   const hasGroupings = otherSorts.find((s) => s.type === 'groupBy');
 
-  const metricsOptions: Array<OptionValue> = hasGroupings ? [] : metrics.map(formatSeries)
-    .filter((metric) => !(metric.label.startsWith('latest(')))
+  const metricsOptions: Array<OptionValue> = hasGroupings ? [] : metrics
+    .filter((metric) => metric.function !== 'latest')
+    .map(formatSeries)
     .map(({ field, label }) => ({
       type: 'metric',
       field,


### PR DESCRIPTION
## Description
Fixes #12908 by removing "latest" metrics from the list of possible sorts.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

