### PR TITLE
Allow non-word-characters in lookup tables key field

### DIFF
--- a/changelog/unreleased/issue-13973.toml
+++ b/changelog/unreleased/issue-13973.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Allow non-word-characters in lookup tables key field"
+
+issues = ["13973"]
+pulls = ["14029"]

--- a/graylog2-web-interface/src/components/lookup-tables/LookupTableView.test.tsx
+++ b/graylog2-web-interface/src/components/lookup-tables/LookupTableView.test.tsx
@@ -16,6 +16,7 @@
  */
 import * as React from 'react';
 import { render, screen } from 'wrappedTestingLibrary';
+import { mount } from 'wrappedEnzyme';
 
 import {
   createLookupTable,
@@ -36,6 +37,14 @@ const renderedLUT = (scope: string) => {
   const dataAdapter = createLookupTableAdapter();
 
   return render(<LookupTableView table={table} cache={cache} dataAdapter={dataAdapter} />);
+};
+
+const mountLUT = (scope: string) => {
+  const table = createLookupTable(1, { _scope: scope });
+  const cache = createLookupTableCache();
+  const dataAdapter = createLookupTableAdapter();
+
+  return mount(<LookupTableView table={table} cache={cache} dataAdapter={dataAdapter} />);
 };
 
 describe('LookupTableView', () => {
@@ -65,5 +74,18 @@ describe('LookupTableView', () => {
     renderedLUT('ILLUMINATE');
 
     expect(screen.queryByRole('button', { name: /edit/i })).not.toBeInTheDocument();
+  });
+
+  it('should allow non-word-characters in lookup tables key field', () => {
+    const nonWordCharactersKey = '177.228.126.200';
+
+    const wrapper = mountLUT('DEFAULT');
+
+    wrapper.find('input[name="lookupkey"]').simulate('change', { target: { name: 'lookupkey', value: nonWordCharactersKey } });
+
+    expect(wrapper.find('input[name="lookupkey"]').length).toBe(1);
+    expect(wrapper.find('input[name="lookupkey"]').prop('value')).toBe(nonWordCharactersKey);
+
+    expect(wrapper.find('button[name="lookupbutton"]').prop('disabled')).toBe(false);
   });
 });

--- a/graylog2-web-interface/src/components/lookup-tables/LookupTableView.tsx
+++ b/graylog2-web-interface/src/components/lookup-tables/LookupTableView.tsx
@@ -48,8 +48,7 @@ const LookupTableView = ({ table, cache, dataAdapter }: Props) => {
     const newValue = event.target.name === 'purgekey' ? { ...purgeKey } : { ...lookupKey };
 
     newValue.valid = event.target.value
-                  && event.target.value.replace(/\s/g, '').length > 0
-                  && !event.target.value.match(/[\W]/g);
+                  && event.target.value.replace(/\s/g, '').length > 0;
 
     newValue.value = event.target.value.toLowerCase();
 

--- a/graylog2-web-interface/src/components/lookup-tables/LookupTableView.tsx
+++ b/graylog2-web-interface/src/components/lookup-tables/LookupTableView.tsx
@@ -157,7 +157,7 @@ const LookupTableView = ({ table, cache, dataAdapter }: Props) => {
                    onChange={handleInputOnChange}
                    help="Key to look up a value for."
                    value={lookupKey.value} />
-            <Button type="submit" bsStyle="success" disabled={!lookupKey.valid}>Look up</Button>
+            <Button type="submit" name="lookupbutton" bsStyle="success" disabled={!lookupKey.valid}>Look up</Button>
           </fieldset>
         </form>
         {lookupResult && (


### PR DESCRIPTION
## Description
Before we were only allowing word-characters in lookup tables key field, in this PR we fixed that.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#13973

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

