### PR TITLE
make schema response part more readable and easier to process

### DIFF
--- a/full-backend-tests/src/test/java/org/graylog/plugins/views/ScriptingApiResourceIT.java
+++ b/full-backend-tests/src/test/java/org/graylog/plugins/views/ScriptingApiResourceIT.java
@@ -168,8 +168,8 @@ public class ScriptingApiResourceIT {
                 .log().ifStatusCodeMatches(not(200))
                 .statusCode(200);
 
-        validateSchema(validatableResponse, "Grouping", "string", "facility");
-        validateSchema(validatableResponse, "Metric : count", "numeric", "facility");
+        validateSchema(validatableResponse, "grouping: facility", "string", "facility");
+        validateSchema(validatableResponse, "metric: count(facility)", "numeric", "facility");
     }
 
     @ContainerMatrixTest
@@ -230,9 +230,7 @@ public class ScriptingApiResourceIT {
 
         String expected = """
                 ┌────────────────────────┬───────────────────────┐
-                │Grouping                │Metric : count         │
-                │facility                │facility               │
-                │string                  │numeric                │
+                │grouping: facility      │metric: count(facility)│
                 ├────────────────────────┼───────────────────────┤
                 │another-test            │2                      │
                 │test                    │1                      │
@@ -256,9 +254,7 @@ public class ScriptingApiResourceIT {
 
         String expected = """
                 ┌────────────────────────┬───────────────────────┐
-                │Grouping                │Metric : count         │
-                │facility                │facility               │
-                │string                  │numeric                │
+                │grouping: facility      │metric: count(facility)│
                 ├────────────────────────┼───────────────────────┤
                 │another-test            │2                      │
                 │test                    │1                      │

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/scriptingapi/ScriptingApiResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/scriptingapi/ScriptingApiResource.java
@@ -133,8 +133,6 @@ public class ScriptingApiResource extends RestResource implements PluginRestReso
         at.getContext().setWidth(response.schema().size() * 25);
         at.addRule();
         at.addRow(response.schema().stream().map(ResponseSchemaEntry::name).collect(Collectors.toList()));
-        at.addRow(response.schema().stream().map(f -> f.field() != null ? f.field() : "").collect(Collectors.toList()));
-        at.addRow(response.schema().stream().map(f -> f.type() != null ? f.type() : "").collect(Collectors.toList()));
         at.addRule();
         response.datarows().forEach(at::addRow);
         at.addRule();

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/scriptingapi/mapping/SearchTypeResultToTabularResponseMapper.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/scriptingapi/mapping/SearchTypeResultToTabularResponseMapper.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableList;
 import org.graylog.plugins.views.search.rest.scriptingapi.request.Metric;
 import org.graylog.plugins.views.search.rest.scriptingapi.request.SearchRequestSpec;
 import org.graylog.plugins.views.search.rest.scriptingapi.response.Metadata;
+import org.graylog.plugins.views.search.rest.scriptingapi.response.ResponseEntryDataType;
 import org.graylog.plugins.views.search.rest.scriptingapi.response.ResponseSchemaEntry;
 import org.graylog.plugins.views.search.rest.scriptingapi.response.TabularResponse;
 import org.graylog.plugins.views.search.searchtypes.pivot.PivotResult;
@@ -38,9 +39,9 @@ public class SearchTypeResultToTabularResponseMapper {
         final int numMetrics = searchRequestSpec.metrics().size();
         final int numColumns = numGroupings + numMetrics;
         List<ResponseSchemaEntry> schema = new ArrayList<>(numColumns);
-        searchRequestSpec.groupings().forEach(gr -> schema.add(new ResponseSchemaEntry("Grouping", "string", gr.fieldName())));
-        searchRequestSpec.metrics().forEach(metric -> schema.add(new ResponseSchemaEntry("Metric : " + metric.functionName(),
-                Latest.NAME.equals(metric.functionName()) ? "string" : "numeric", metric.fieldName())));
+        searchRequestSpec.groupings().forEach(gr -> schema.add(ResponseSchemaEntry.groupBy(gr.fieldName())));
+        searchRequestSpec.metrics().forEach(metric -> schema.add(ResponseSchemaEntry.metric(metric.functionName(),
+                Latest.NAME.equals(metric.functionName()) ? ResponseEntryDataType.STRING : ResponseEntryDataType.NUMERIC, metric.fieldName())));
 
         final AbsoluteRange effectiveTimerange = pivotResult.effectiveTimerange();
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/scriptingapi/response/ResponseEntryDataType.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/scriptingapi/response/ResponseEntryDataType.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.views.search.rest.scriptingapi.response;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.util.Locale;
+
+public enum ResponseEntryDataType {
+    STRING,
+    NUMERIC;
+
+    @JsonValue
+    @Override
+    public String toString() {
+        return name().toLowerCase(Locale.ROOT);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/scriptingapi/response/ResponseEntryType.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/scriptingapi/response/ResponseEntryType.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.views.search.rest.scriptingapi.response;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.util.Locale;
+
+public enum ResponseEntryType {
+    GROUPING,
+    METRIC;
+
+    @JsonValue
+    @Override
+    public String toString() {
+        return name().toLowerCase(Locale.ROOT);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/scriptingapi/response/ResponseSchemaEntry.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/scriptingapi/response/ResponseSchemaEntry.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Locale;
+import java.util.Objects;
 import java.util.Optional;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -30,10 +31,13 @@ public record ResponseSchemaEntry(
         @JsonProperty("field") String fieldName) {
 
     public static ResponseSchemaEntry groupBy(String fieldName) {
+        Objects.requireNonNull(fieldName);
         return new ResponseSchemaEntry(ResponseEntryType.GROUPING, ResponseEntryDataType.STRING, null, fieldName);
     }
 
     public static ResponseSchemaEntry metric(String functionName, ResponseEntryDataType dataType, String fieldName) {
+        Objects.requireNonNull(functionName);
+        Objects.requireNonNull(dataType);
         return new ResponseSchemaEntry(ResponseEntryType.METRIC, dataType, functionName, fieldName);
     }
 

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/scriptingapi/response/ResponseSchemaEntryTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/scriptingapi/response/ResponseSchemaEntryTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.views.search.rest.scriptingapi.response;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class ResponseSchemaEntryTest {
+
+    @Test
+    void name() {
+        Assertions.assertThat(ResponseSchemaEntry.groupBy("http_method").name()).isEqualTo("grouping: http_method");
+
+        Assertions.assertThat(ResponseSchemaEntry.metric("max", ResponseEntryDataType.STRING, "took_ms").name())
+                .isEqualTo("metric: max(took_ms)");
+
+        Assertions.assertThat(ResponseSchemaEntry.metric("count", ResponseEntryDataType.STRING, null).name())
+                .isEqualTo("metric: count()");
+    }
+}


### PR DESCRIPTION
Slightly adapted the schema structure of the response. The name has now more human-readable format, there is a field providing the column type information (grouping or metric).

## How Has This Been Tested?
Existing tests + added unit tests

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/4102775/203316798-d3ea612b-db13-41fc-b6d1-14a49d5b6cfc.png)
![image](https://user-images.githubusercontent.com/4102775/203316907-3ccc6f0e-b686-4296-870c-e3d2e19d669c.png)

/nocl

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

