### PR TITLE
Allow specifying multiple identical series in aggregation.

### DIFF
--- a/full-backend-tests/src/test/java/org/graylog/plugins/views/ScriptingApiResourceIT.java
+++ b/full-backend-tests/src/test/java/org/graylog/plugins/views/ScriptingApiResourceIT.java
@@ -337,7 +337,9 @@ public class ScriptingApiResourceIT {
                         """)
                 .post("/search/aggregate")
                 .then()
-                .statusCode(404); // TODO! We should handle the duplicated metric better
+                .statusCode(200);
+        validateRow(validatableResponse, "another-test", 2, 2);
+        validateRow(validatableResponse, "test", 1, 1);
     }
 
     @ContainerMatrixTest

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/ESGeneratedQueryContext.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/ESGeneratedQueryContext.java
@@ -104,7 +104,7 @@ public class ESGeneratedQueryContext implements GeneratedQueryContext {
     }
 
     public String seriesName(SeriesSpec seriesSpec, Pivot pivot) {
-        return pivot.id() + "-series-" + seriesSpec.literal();
+        return pivot.id() + "-series-" + seriesSpec.id();
     }
 
     public Optional<String> fieldType(Set<String> streamIds, String field) {

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/AggTypes.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/AggTypes.java
@@ -22,14 +22,15 @@ import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.H
 import org.jooq.lambda.tuple.Tuple;
 import org.jooq.lambda.tuple.Tuple2;
 
-import java.util.IdentityHashMap;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * This solely exists to hide the nasty type signature of the aggregation type map from the rest of the code.
  * It's just ugly and in the way.
  */
 public class AggTypes {
-    final IdentityHashMap<PivotSpec, Tuple2<String, Class<? extends Aggregation>>> aggTypeMap = new IdentityHashMap<>();
+    final Map<PivotSpec, Tuple2<String, Class<? extends Aggregation>>> aggTypeMap = new HashMap<>();
 
     public void record(PivotSpec pivotSpec, String name, Class<? extends Aggregation> aggClass) {
         aggTypeMap.put(pivotSpec, Tuple.tuple(name, aggClass));

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/ESPivot.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/ESPivot.java
@@ -17,7 +17,6 @@
 package org.graylog.storage.elasticsearch7.views.searchtypes.pivot;
 
 import com.google.common.collect.ImmutableList;
-import one.util.streamex.EntryStream;
 import org.graylog.plugins.views.search.Query;
 import org.graylog.plugins.views.search.SearchJob;
 import org.graylog.plugins.views.search.SearchType;
@@ -170,8 +169,10 @@ public class ESPivot implements ESSearchTypeHandler<Pivot> {
 
 
     private Stream<AggregationBuilder> seriesStream(Pivot pivot, ESGeneratedQueryContext queryContext, String reason) {
-        return EntryStream.of(pivot.series())
-                .mapKeyValue((integer, seriesSpec) -> {
+        return pivot.series()
+                .stream()
+                .distinct()
+                .map((seriesSpec) -> {
                     final String seriesName = queryContext.seriesName(seriesSpec, pivot);
                     LOG.debug("Adding {} series '{}' with name '{}'", reason, seriesSpec.type(), seriesName);
                     final ESPivotSeriesSpecHandler<? extends SeriesSpec, ? extends Aggregation> esPivotSeriesSpecHandler = seriesHandlers.get(seriesSpec.type());

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/OSGeneratedQueryContext.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/OSGeneratedQueryContext.java
@@ -103,7 +103,7 @@ public class OSGeneratedQueryContext implements GeneratedQueryContext {
     }
 
     public String seriesName(SeriesSpec seriesSpec, Pivot pivot) {
-        return pivot.id() + "-series-" + seriesSpec.literal();
+        return pivot.id() + "-series-" + seriesSpec.id();
     }
 
     public Optional<String> fieldType(Set<String> streamIds, String field) {

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/AggTypes.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/AggTypes.java
@@ -22,14 +22,15 @@ import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.HasAggr
 import org.jooq.lambda.tuple.Tuple;
 import org.jooq.lambda.tuple.Tuple2;
 
-import java.util.IdentityHashMap;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * This solely exists to hide the nasty type signature of the aggregation type map from the rest of the code.
  * It's just ugly and in the way.
  */
 public class AggTypes {
-    final IdentityHashMap<PivotSpec, Tuple2<String, Class<? extends Aggregation>>> aggTypeMap = new IdentityHashMap<>();
+    final Map<PivotSpec, Tuple2<String, Class<? extends Aggregation>>> aggTypeMap = new HashMap<>();
 
     public void record(PivotSpec pivotSpec, String name, Class<? extends Aggregation> aggClass) {
         aggTypeMap.put(pivotSpec, Tuple.tuple(name, aggClass));

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/OSPivot.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/OSPivot.java
@@ -17,7 +17,6 @@
 package org.graylog.storage.opensearch2.views.searchtypes.pivot;
 
 import com.google.common.collect.ImmutableList;
-import one.util.streamex.EntryStream;
 import org.graylog.plugins.views.search.Query;
 import org.graylog.plugins.views.search.SearchJob;
 import org.graylog.plugins.views.search.SearchType;
@@ -169,8 +168,10 @@ public class OSPivot implements OSSearchTypeHandler<Pivot> {
     }
 
     private Stream<AggregationBuilder> seriesStream(Pivot pivot, OSGeneratedQueryContext queryContext, String reason) {
-        return EntryStream.of(pivot.series())
-                .mapKeyValue((integer, seriesSpec) -> {
+        return pivot.series()
+                .stream()
+                .distinct()
+                .map((seriesSpec) -> {
                     final String seriesName = queryContext.seriesName(seriesSpec, pivot);
                     LOG.debug("Adding {} series '{}' with name '{}'", reason, seriesSpec.type(), seriesName);
                     final OSPivotSeriesSpecHandler<? extends SeriesSpec, ? extends Aggregation> esPivotSeriesSpecHandler = seriesHandlers.get(seriesSpec.type());


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Prior to this PR, when a user specifies multiple series with identical functions/fields, search query generation would fail because multiple aggregations with the same id are generated.

This change is now making sure that only _distinct_ elements of the series list are generating aggregations. Due to identical series resulting in identical aggregation names, one aggregation can be used by multiple series handlers to extract values. This effectively results in a deduplication of series aggregations.

/nocl

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.