### PR TITLE
Add email attribute to LDAP config

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/security/authservice/backend/LDAPAuthServiceBackend.java
+++ b/graylog2-server/src/main/java/org/graylog/security/authservice/backend/LDAPAuthServiceBackend.java
@@ -129,6 +129,7 @@ public class LDAPAuthServiceBackend implements AuthServiceBackend {
                 .userUniqueIdAttribute(config.userUniqueIdAttribute())
                 .userNameAttribute(config.userNameAttribute())
                 .userFullNameAttribute(config.userFullNameAttribute())
+                .emailAttributes(config.emailAttributes())
                 .build();
 
         return ldapConnector.searchUserByPrincipal(connection, searchConfig, authCredentials.username());

--- a/graylog2-server/src/main/java/org/graylog/security/authservice/backend/LDAPAuthServiceBackendConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/security/authservice/backend/LDAPAuthServiceBackendConfig.java
@@ -51,6 +51,7 @@ public abstract class LDAPAuthServiceBackendConfig implements AuthServiceBackend
     private static final String FIELD_USER_UNIQUE_ID_ATTRIBUTE = "user_unique_id_attribute";
     private static final String FIELD_USER_NAME_ATTRIBUTE = "user_name_attribute";
     private static final String FIELD_USER_FULL_NAME_ATTRIBUTE = "user_full_name_attribute";
+    private static final String FIELD_EMAIL_ATTRIBUTES = "email_attributes";
 
     @JsonProperty(FIELD_SERVERS)
     public abstract ImmutableList<HostAndPort> servers();
@@ -81,6 +82,9 @@ public abstract class LDAPAuthServiceBackendConfig implements AuthServiceBackend
 
     @JsonProperty(FIELD_USER_FULL_NAME_ATTRIBUTE)
     public abstract String userFullNameAttribute();
+
+    @JsonProperty(FIELD_EMAIL_ATTRIBUTES)
+    public abstract ImmutableList<String> emailAttributes();
 
     @Override
     public void validate(ValidationResult result) {
@@ -138,7 +142,8 @@ public abstract class LDAPAuthServiceBackendConfig implements AuthServiceBackend
                     .verifyCertificates(true)
                     .systemUserDn("")
                     .systemUserPassword(EncryptedValue.createUnset())
-                    .userUniqueIdAttribute("entryUUID");
+                    .userUniqueIdAttribute("entryUUID")
+                    .emailAttributes(ImmutableList.of("mail", "fc822Mailbox"));
         }
 
         @JsonProperty(FIELD_SERVERS)
@@ -170,6 +175,9 @@ public abstract class LDAPAuthServiceBackendConfig implements AuthServiceBackend
 
         @JsonProperty(FIELD_USER_FULL_NAME_ATTRIBUTE)
         public abstract Builder userFullNameAttribute(String userFullNameAttribute);
+
+        @JsonProperty(FIELD_EMAIL_ATTRIBUTES)
+        public abstract Builder emailAttributes(List<String> emailAttributes);
 
         public abstract LDAPAuthServiceBackendConfig build();
     }

--- a/graylog2-server/src/main/java/org/graylog/security/authservice/ldap/UnboundLDAPConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/security/authservice/ldap/UnboundLDAPConfig.java
@@ -19,6 +19,8 @@ package org.graylog.security.authservice.ldap;
 
 import com.google.auto.value.AutoValue;
 
+import java.util.List;
+
 @AutoValue
 public abstract class UnboundLDAPConfig {
     public abstract String userSearchBase();
@@ -30,6 +32,8 @@ public abstract class UnboundLDAPConfig {
     public abstract String userNameAttribute();
 
     public abstract String userFullNameAttribute();
+
+    public abstract List<String> emailAttributes();
 
     public abstract Builder toBuilder();
 
@@ -52,6 +56,8 @@ public abstract class UnboundLDAPConfig {
         public abstract Builder userNameAttribute(String userNameAttribute);
 
         public abstract Builder userFullNameAttribute(String userFullNameAttribute);
+
+        public abstract Builder emailAttributes(List<String> emailAttributes);
 
         public abstract UnboundLDAPConfig build();
     }

--- a/graylog2-server/src/main/java/org/graylog/security/authservice/ldap/UnboundLDAPConnector.java
+++ b/graylog2-server/src/main/java/org/graylog/security/authservice/ldap/UnboundLDAPConnector.java
@@ -196,8 +196,7 @@ public class UnboundLDAPConnector {
         final ImmutableSet<String> allAttributes = ImmutableSet.<String>builder()
                 .add("userPrincipalName") // TODO: This is ActiveDirectory specific - Do we need this here?
                 .add("userAccountControl")
-                .add("mail")
-                .add("rfc822Mailbox")
+                .addAll(config.emailAttributes())
                 .add(config.userUniqueIdAttribute())
                 .add(config.userNameAttribute())
                 .add(config.userFullNameAttribute())
@@ -288,12 +287,15 @@ public class UnboundLDAPConnector {
 
     public LDAPUser createLDAPUser(UnboundLDAPConfig config, LDAPEntry ldapEntry) {
         final String username = ldapEntry.nonBlankAttribute(config.userNameAttribute());
+        final String emailValue = config.emailAttributes().stream()
+                .filter(attr -> ldapEntry.firstAttributeValue(attr).isPresent())
+                .findFirst().orElse("unknown@unknown.invalid");
         return LDAPUser.builder()
                 .base64UniqueId(ldapEntry.base64UniqueId())
                 .accountIsEnabled(findAccountIsEnabled(ldapEntry))
                 .username(username)
                 .fullName(ldapEntry.firstAttributeValue(config.userFullNameAttribute()).orElse(username))
-                .email(ldapEntry.firstAttributeValue("mail").orElse(ldapEntry.firstAttributeValue("rfc822Mailbox").orElse("unknown@unknown.invalid")))
+                .email(emailValue)
                 .entry(ldapEntry)
                 .build();
     }


### PR DESCRIPTION
Fixes #11131 

Currently we use hard-coded attribute names for LDAP email and fail if those are not found.
Provide ability to configure this, defaulting to the current attributes.
