### PR TITLE
Metrics that require additional configuration can be used from now on

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/scriptingapi/mapping/AggregationSpecToPivotMapper.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/scriptingapi/mapping/AggregationSpecToPivotMapper.java
@@ -72,9 +72,9 @@ public class AggregationSpecToPivotMapper implements Function<SearchRequestSpec,
                 .filter(sortable -> sortable.sort() != null)
                 .map(sortable -> {
                     if (sortable instanceof Metric) {
-                        return SeriesSort.create(sortable.sortColumnName(), sortable.sort());
+                        return SeriesSort.create(sortable.columnName(), sortable.sort());
                     }
-                    return PivotSort.create(sortable.sortColumnName(), sortable.sort());
+                    return PivotSort.create(sortable.columnName(), sortable.sort());
                 })
                 .collect(Collectors.toList());
     }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/scriptingapi/mapping/MetricToSeriesSpecMapper.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/scriptingapi/mapping/MetricToSeriesSpecMapper.java
@@ -17,6 +17,7 @@
 package org.graylog.plugins.views.search.rest.scriptingapi.mapping;
 
 import org.graylog.plugins.views.search.rest.scriptingapi.request.Metric;
+import org.graylog.plugins.views.search.rest.scriptingapi.request.PercentileConfiguration;
 import org.graylog.plugins.views.search.rest.scriptingapi.validation.MetricValidator;
 import org.graylog.plugins.views.search.searchtypes.pivot.SeriesSpec;
 import org.graylog.plugins.views.search.searchtypes.pivot.series.Average;
@@ -54,7 +55,10 @@ public class MetricToSeriesSpecMapper implements Function<Metric, SeriesSpec> {
             case Latest.NAME -> Latest.builder().field(metric.fieldName()).build();
             case Max.NAME -> Max.builder().field(metric.fieldName()).build();
             case Min.NAME -> Min.builder().field(metric.fieldName()).build();
-            case Percentile.NAME -> Percentile.builder().field(metric.fieldName()).build();
+            case Percentile.NAME -> Percentile.builder()
+                    .field(metric.fieldName())
+                    .percentile(((PercentileConfiguration) metric.configuration()).percentile())
+                    .build();
             case StdDev.NAME -> StdDev.builder().field(metric.fieldName()).build();
             case Sum.NAME -> Sum.builder().field(metric.fieldName()).build();
             case SumOfSquares.NAME -> SumOfSquares.builder().field(metric.fieldName()).build();

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/scriptingapi/mapping/QueryParamsToFullRequestSpecificationMapper.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/scriptingapi/mapping/QueryParamsToFullRequestSpecificationMapper.java
@@ -50,6 +50,9 @@ public class QueryParamsToFullRequestSpecificationMapper {
         if (!metrics.stream().allMatch(m -> m.contains(":") || "count".equals(m))) {
             throw new IllegalArgumentException("All metrics need to be defined as \"function\":\"field_name\"");
         }
+        if (metrics.stream().anyMatch(m -> m.startsWith("percentile:"))) {
+            throw new IllegalArgumentException("Percentile metric cannot be used in simplified query format. Please use POST request instead, specifying configuration for percentile metric");
+        }
 
         return new SearchRequestSpec(
                 query,

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/scriptingapi/mapping/SearchTypeResultToTabularResponseMapper.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/scriptingapi/mapping/SearchTypeResultToTabularResponseMapper.java
@@ -59,7 +59,7 @@ public class SearchTypeResultToTabularResponseMapper {
                                     final ImmutableList<PivotResult.Value> values = pivRow.values();
                                     for (Metric metric : searchRequestSpec.metrics()) {
                                         row.add(values.stream()
-                                                .filter(value -> value.key().contains(metric.sortColumnName()))
+                                                .filter(value -> value.key().contains(metric.columnName()))
                                                 .findFirst()
                                                 .map(PivotResult.Value::value)
                                                 .orElse("-")

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/scriptingapi/request/MetricConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/scriptingapi/request/MetricConfiguration.java
@@ -16,11 +16,11 @@
  */
 package org.graylog.plugins.views.search.rest.scriptingapi.request;
 
-import org.graylog.plugins.views.search.searchtypes.pivot.SortSpec;
+import java.util.Optional;
 
-public interface Sortable {
+public interface MetricConfiguration {
 
-    SortSpec.Direction sort();
-
-    String columnName();
+    default Optional<String> columnName(final Metric metric) {
+        return Optional.empty();
+    }
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/scriptingapi/request/PercentileConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/scriptingapi/request/PercentileConfiguration.java
@@ -16,11 +16,19 @@
  */
 package org.graylog.plugins.views.search.rest.scriptingapi.request;
 
-import org.graylog.plugins.views.search.searchtypes.pivot.SortSpec;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.graylog.plugins.views.search.searchtypes.pivot.series.Percentile;
 
-public interface Sortable {
+import java.util.Optional;
 
-    SortSpec.Direction sort();
+public record PercentileConfiguration(@JsonProperty("percentile") Double percentile) implements MetricConfiguration {
 
-    String columnName();
+    @Override
+    public Optional<String> columnName(final Metric metric) {
+        return Optional.of(Percentile.builder()
+                .field(metric.fieldName())
+                .percentile(percentile())
+                .build()
+                .literal());
+    }
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/scriptingapi/validation/MetricValidator.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/scriptingapi/validation/MetricValidator.java
@@ -24,11 +24,13 @@ import org.graylog.plugins.views.search.searchtypes.pivot.series.Count;
 import javax.inject.Inject;
 import javax.validation.ValidationException;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 
 public class MetricValidator {
 
     private final Collection<String> availableMetricTypes;
+    private final Collection<String> UNSORTABLE_METRICS = List.of("latest", "percentile");
 
     @Inject
     public MetricValidator(final Map<String, SeriesDescription> availableFunctions) {
@@ -44,6 +46,9 @@ public class MetricValidator {
         }
         if (!hasFieldIfFunctionNeedsIt(metric)) {
             throw new ValidationException(metric.functionName() + " metric requires field name to be provided after a colon, i.e. " + metric.functionName() + ":http_status_code");
+        }
+        if (metric.sort() != null && UNSORTABLE_METRICS.contains(metric.functionName())) {
+            throw new ValidationException(metric.functionName() + " metric cannot be used to sort aggregations");
         }
     }
 

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/scriptingapi/mapping/MetricToSeriesSpecMapperTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/scriptingapi/mapping/MetricToSeriesSpecMapperTest.java
@@ -46,12 +46,12 @@ class MetricToSeriesSpecMapperTest {
     @Test
     void throwsExceptionWhenValidatorThrowsException() {
         doThrow(ValidationException.class).when(metricValidator).validate(any());
-        assertThrows(ValidationException.class, () -> toTest.apply(new Metric("http_method", "unknown", null)));
+        assertThrows(ValidationException.class, () -> toTest.apply(new Metric("http_method", "unknown")));
     }
 
     @Test
     void constructsProperSeriesSpec() {
-        final Metric metric = new Metric("took_ms", "avg", null);
+        final Metric metric = new Metric("took_ms", "avg");
         final SeriesSpec result = toTest.apply(metric);
         assertThat(result)
                 .isNotNull()

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/scriptingapi/mapping/QueryParamsToFullRequestSpecificationMapperTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/scriptingapi/mapping/QueryParamsToFullRequestSpecificationMapperTest.java
@@ -89,7 +89,7 @@ class QueryParamsToFullRequestSpecificationMapperTest {
                         Set.of(),
                         DEFAULT_TIMERANGE,
                         List.of(new Grouping("http_method")),
-                        List.of(new Metric(null, "count", null))
+                        List.of(new Metric(null, "count"))
                 )
         );
 
@@ -104,7 +104,7 @@ class QueryParamsToFullRequestSpecificationMapperTest {
                         Set.of(),
                         DEFAULT_TIMERANGE,
                         List.of(new Grouping("http_method")),
-                        List.of(new Metric(null, "count", null))
+                List.of(new Metric(null, "count"))
                 )
         );
     }
@@ -123,7 +123,7 @@ class QueryParamsToFullRequestSpecificationMapperTest {
                         Set.of("000000000000000000000001"),
                         KeywordRange.create("last 1 day", "UTC"),
                         List.of(new Grouping("http_method"), new Grouping("controller")),
-                        List.of(new Metric("took_ms", "avg", null))
+                List.of(new Metric("took_ms", "avg"))
                 )
         );
     }

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/scriptingapi/request/MetricTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/scriptingapi/request/MetricTest.java
@@ -27,12 +27,12 @@ class MetricTest {
         Metric count = Metric.fromStringRepresentation("count");
         assertThat(count)
                 .isNotNull()
-                .isEqualTo(new Metric(null, "count", null));
+                .isEqualTo(new Metric(null, "count"));
 
         count = Metric.fromStringRepresentation("count:");
         assertThat(count)
                 .isNotNull()
-                .isEqualTo(new Metric(null, "count", null));
+                .isEqualTo(new Metric(null, "count"));
     }
 
     @Test
@@ -40,12 +40,12 @@ class MetricTest {
         Metric count = Metric.fromStringRepresentation("count:stars");
         assertThat(count)
                 .isNotNull()
-                .isEqualTo(new Metric("stars", "count", null));
+                .isEqualTo(new Metric("stars", "count"));
 
         count = Metric.fromStringRepresentation("avg:salary");
         assertThat(count)
                 .isNotNull()
-                .isEqualTo(new Metric("salary", "avg", null));
+                .isEqualTo(new Metric("salary", "avg"));
     }
 
 }

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/scriptingapi/validation/MetricValidatiorTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/scriptingapi/validation/MetricValidatiorTest.java
@@ -18,6 +18,7 @@ package org.graylog.plugins.views.search.rest.scriptingapi.validation;
 
 import org.graylog.plugins.views.search.rest.SeriesDescription;
 import org.graylog.plugins.views.search.rest.scriptingapi.request.Metric;
+import org.graylog.plugins.views.search.rest.scriptingapi.request.PercentileConfiguration;
 import org.graylog.plugins.views.search.searchtypes.pivot.SortSpec;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -48,21 +49,27 @@ class MetricValidatiorTest {
 
     @Test
     void throwsExceptionOnMetricWithNoFunctionName() {
-        assertThrows(ValidationException.class, () -> toTest.validate(new Metric("field", null, SortSpec.Direction.Ascending)));
+        assertThrows(ValidationException.class, () -> toTest.validate(new Metric("field", null, SortSpec.Direction.Ascending, null)));
     }
 
     @Test
     void throwsExceptionOnMetricWithIllegalFunctionName() {
-        assertThrows(ValidationException.class, () -> toTest.validate(new Metric("field", "bum", SortSpec.Direction.Ascending)));
+        assertThrows(ValidationException.class, () -> toTest.validate(new Metric("field", "bum", SortSpec.Direction.Ascending, null)));
     }
 
     @Test
     void throwsExceptionOnMetricMissingFieldName() {
         //check count metric is fine with no field
-        toTest.validate(new Metric(null, "count", SortSpec.Direction.Ascending));
+        toTest.validate(new Metric(null, "count", SortSpec.Direction.Ascending, null));
         //check other metrics throw exception on missing field
-        assertThrows(ValidationException.class, () -> toTest.validate(new Metric("", "avg", SortSpec.Direction.Ascending)));
-        assertThrows(ValidationException.class, () -> toTest.validate(new Metric(null, "avg", SortSpec.Direction.Ascending)));
+        assertThrows(ValidationException.class, () -> toTest.validate(new Metric("", "avg", SortSpec.Direction.Ascending, null)));
+        assertThrows(ValidationException.class, () -> toTest.validate(new Metric(null, "avg", SortSpec.Direction.Ascending, null)));
+    }
+
+    @Test
+    void throwsExceptionWhenTryingToSortOnUnsortableMetrics() {
+        assertThrows(ValidationException.class, () -> toTest.validate(new Metric("source", "latest", SortSpec.Direction.Ascending, null)));
+        assertThrows(ValidationException.class, () -> toTest.validate(new Metric("source", "percentile", SortSpec.Direction.Descending, new PercentileConfiguration(25.0d))));
     }
 
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Metrics that require additional configuration can be used from now on
/nocl

## Motivation and Context
Currently we have one metric (percentile), that needs more configuration required than just function_name and field_name.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

