### PR TITLE
Ensure Guice binder creation for the JobResourceHandler interface

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/shared/bindings/RestApiBindings.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/bindings/RestApiBindings.java
@@ -17,7 +17,7 @@
 package org.graylog2.shared.bindings;
 
 import com.google.inject.multibindings.Multibinder;
-import org.graylog2.plugin.inject.Graylog2Module;
+import org.graylog2.plugin.PluginModule;
 import org.graylog2.rest.resources.RestResourcesModule;
 import org.graylog2.shared.rest.resources.RestResourcesSharedModule;
 import org.graylog2.shared.security.ShiroSecurityBinding;
@@ -27,7 +27,7 @@ import org.graylog2.web.resources.WebResourcesModule;
 
 import javax.ws.rs.container.DynamicFeature;
 
-public class RestApiBindings extends Graylog2Module {
+public class RestApiBindings extends PluginModule {
     @Override
     protected void configure() {
         bindDynamicFeatures();
@@ -37,8 +37,11 @@ public class RestApiBindings extends Graylog2Module {
         jerseyExceptionMapperBinder();
         jerseyAdditionalComponentsBinder();
 
+        // Ensure that we create the binder. We might not have any plugin that registers a JobResourceHandler.
+        jobResourceHandlerBinder();
+
         bind(IndexHtmlGenerator.class).toProvider(IndexHtmlGeneratorProvider.class);
-        
+
         // Install all resource modules
         install(new WebResourcesModule());
         install(new RestResourcesModule());


### PR DESCRIPTION
We don't bind any JobResourceHandler classes in Graylog Open, so we have to make sure we create the binding.

This PR changes the RestApiBindings to extend PluginModule instead of Graylog2Module to get access to the `jobResourceHandlerBinder()` method.

Fixes a Jersey injection error when navigating to "System/Overview" in a pure-open Graylog instance.

/nocl

*Notice:* This needs a backport to the 5.0 branch.