### PR TITLE
Fix indexer connectivity check by catching the correct exception type

### DIFF
--- a/changelog/unreleased/pr-14063.toml
+++ b/changelog/unreleased/pr-14063.toml
@@ -1,4 +1,4 @@
 type = "fixed"
-message = "Fix connectivity check when Elasticsearch is not available."
+message = "Fix connectivity check when Elasticsearch/OpenSearch is not available."
 
 pulls = ["14063"]

--- a/changelog/unreleased/pr-14063.toml
+++ b/changelog/unreleased/pr-14063.toml
@@ -1,4 +1,4 @@
 type = "fixed"
-message = "Fix connectivity check when Elasticsearch is not available.."
+message = "Fix connectivity check when Elasticsearch is not available."
 
 pulls = ["14063"]

--- a/changelog/unreleased/pr-14063.toml
+++ b/changelog/unreleased/pr-14063.toml
@@ -1,0 +1,4 @@
+type = "fixed"
+message = "Fix connectivity check when Elasticsearch is not available.."
+
+pulls = ["14063"]

--- a/changelog/unreleased/pr-14067.toml
+++ b/changelog/unreleased/pr-14067.toml
@@ -1,0 +1,4 @@
+type = "fixed"
+message = "Fix potential duplicates in outputs during node restarts."
+
+pulls = ["14067"]

--- a/changelog/unreleased/pr-14067.toml
+++ b/changelog/unreleased/pr-14067.toml
@@ -1,4 +1,0 @@
-type = "fixed"
-message = "Fix potential duplicates in outputs during node restarts."
-
-pulls = ["14067"]

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/ClusterAdapterES7.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/ClusterAdapterES7.java
@@ -168,7 +168,7 @@ public class ClusterAdapterES7 implements ClusterAdapter {
         try {
             final ClusterHealthResponse result = client.execute((c, requestOptions) -> c.cluster().health(request, requestOptions));
             return result.getNumberOfDataNodes() > 0;
-        } catch (ElasticsearchException e) {
+        } catch (org.graylog.shaded.elasticsearch7.org.elasticsearch.ElasticsearchException e) {
             if (LOG.isDebugEnabled()) {
                 LOG.error(e.getMessage(), e);
             }

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/ClusterAdapterOS2.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/ClusterAdapterOS2.java
@@ -169,7 +169,7 @@ public class ClusterAdapterOS2 implements ClusterAdapter {
         try {
             final ClusterHealthResponse result = client.execute((c, requestOptions) -> c.cluster().health(request, requestOptions));
             return result.getNumberOfDataNodes() > 0;
-        } catch (ElasticsearchException e) {
+        } catch (OpenSearchException e) {
             if (LOG.isDebugEnabled()) {
                 LOG.error(e.getMessage(), e);
             }


### PR DESCRIPTION
The connectivity check for ES [Edit: *and OpenSearch*] was handling the wrong exception so that all calls to `#isConnected` would result in an exception when the ES cluster was not reachable. ~~This only affected Elasticsearch, not OpenSearch.~~

This PR fixes that by catching the correct exception type.

To see the effect, sever the connection to ES while the server is running.

Before the change, the server log will be filled with a lot messages from the `IndexFieldTypePollerPeriodical` like these: 

```
2022-11-25 17:23:26,792 ERROR: org.graylog2.indexer.fieldtypes.IndexFieldTypePollerPeriodical - Uncaught exception in Periodical
org.graylog.shaded.elasticsearch7.org.elasticsearch.ElasticsearchException: An error occurred: 
	at org.graylog.storage.elasticsearch7.ElasticsearchClient.exceptionFrom(ElasticsearchClient.java:155) ~[classes/:?]
	at org.graylog.storage.elasticsearch7.ElasticsearchClient.execute(ElasticsearchClient.java:112) ~[classes/:?]
	at org.graylog.storage.elasticsearch7.ElasticsearchClient.execute(ElasticsearchClient.java:105) ~[classes/:?]
	at org.graylog.storage.elasticsearch7.ClusterAdapterES7.isConnected(ClusterAdapterES7.java:169) ~[classes/:?]
	at org.graylog2.indexer.cluster.Cluster.isConnected(Cluster.java:115) ~[classes/:?]
	at org.graylog2.indexer.fieldtypes.IndexFieldTypePollerPeriodical.doRun(IndexFieldTypePollerPeriodical.java:106) ~[classes/:?]
	at org.graylog2.plugin.periodical.Periodical.run(Periodical.java:94) [classes/:?]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539) [?:?]
	at java.util.concurrent.FutureTask.runAndReset$$$capture(FutureTask.java:305) [?:?]
	at java.util.concurrent.FutureTask.runAndReset(FutureTask.java) [?:?]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305) [?:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) [?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) [?:?]
	at java.lang.Thread.run(Thread.java:833) [?:?]
Caused by: org.graylog.shaded.elasticsearch7.org.apache.http.ConnectionClosedException: Connection is closed
	at org.graylog.shaded.elasticsearch7.org.elasticsearch.client.RestClient.extractAndWrapCause(RestClient.java:839) ~[elasticsearch7-7.9.1-0.jar:?]
	at org.graylog.shaded.elasticsearch7.org.elasticsearch.client.RestClient.performRequest(RestClient.java:259) ~[elasticsearch7-7.9.1-0.jar:?]
	at org.graylog.shaded.elasticsearch7.org.elasticsearch.client.RestClient.performRequest(RestClient.java:246) ~[elasticsearch7-7.9.1-0.jar:?]
	at org.graylog.shaded.elasticsearch7.org.elasticsearch.client.RestHighLevelClient.internalPerformRequest(RestHighLevelClient.java:1613) ~[elasticsearch7-7.9.1-0.jar:?]
	at org.graylog.shaded.elasticsearch7.org.elasticsearch.client.RestHighLevelClient.performRequest(RestHighLevelClient.java:1583) ~[elasticsearch7-7.9.1-0.jar:?]
	at org.graylog.shaded.elasticsearch7.org.elasticsearch.client.RestHighLevelClient.performRequestAndParseEntity(RestHighLevelClient.java:1553) ~[elasticsearch7-7.9.1-0.jar:?]
	at org.graylog.shaded.elasticsearch7.org.elasticsearch.client.ClusterClient.health(ClusterClient.java:130) ~[elasticsearch7-7.9.1-0.jar:?]
	at org.graylog.storage.elasticsearch7.ClusterAdapterES7.lambda$isConnected$11(ClusterAdapterES7.java:169) ~[classes/:?]
	at org.graylog.storage.elasticsearch7.ElasticsearchClient.execute(ElasticsearchClient.java:110) ~[classes/:?]
	... 12 more
Caused by: org.graylog.shaded.elasticsearch7.org.apache.http.ConnectionClosedException: Connection is closed
	at org.graylog.shaded.elasticsearch7.org.apache.http.nio.protocol.HttpAsyncRequestExecutor.endOfInput(HttpAsyncRequestExecutor.java:356) ~[elasticsearch7-7.9.1-0.jar:?]
	at org.graylog.shaded.elasticsearch7.org.apache.http.impl.nio.DefaultNHttpClientConnection.consumeInput(DefaultNHttpClientConnection.java:261) ~[elasticsearch7-7.9.1-0.jar:?]
	at org.graylog.shaded.elasticsearch7.org.apache.http.impl.nio.client.InternalIODispatch.onInputReady(InternalIODispatch.java:81) ~[elasticsearch7-7.9.1-0.jar:?]
	at org.graylog.shaded.elasticsearch7.org.apache.http.impl.nio.client.InternalIODispatch.onInputReady(InternalIODispatch.java:39) ~[elasticsearch7-7.9.1-0.jar:?]
	at org.graylog.shaded.elasticsearch7.org.apache.http.impl.nio.reactor.AbstractIODispatch.inputReady(AbstractIODispatch.java:114) ~[elasticsearch7-7.9.1-0.jar:?]
	at org.graylog.shaded.elasticsearch7.org.apache.http.impl.nio.reactor.BaseIOReactor.readable(BaseIOReactor.java:162) ~[elasticsearch7-7.9.1-0.jar:?]
	at org.graylog.shaded.elasticsearch7.org.apache.http.impl.nio.reactor.AbstractIOReactor.processEvent(AbstractIOReactor.java:337) ~[elasticsearch7-7.9.1-0.jar:?]
	at org.graylog.shaded.elasticsearch7.org.apache.http.impl.nio.reactor.AbstractIOReactor.processEvents(AbstractIOReactor.java:315) ~[elasticsearch7-7.9.1-0.jar:?]
	at org.graylog.shaded.elasticsearch7.org.apache.http.impl.nio.reactor.AbstractIOReactor.execute(AbstractIOReactor.java:276) ~[elasticsearch7-7.9.1-0.jar:?]
	at org.graylog.shaded.elasticsearch7.org.apache.http.impl.nio.reactor.BaseIOReactor.execute(BaseIOReactor.java:104) ~[elasticsearch7-7.9.1-0.jar:?]
	at org.graylog.shaded.elasticsearch7.org.apache.http.impl.nio.reactor.AbstractMultiworkerIOReactor$Worker.run(AbstractMultiworkerIOReactor.java:591) ~[elasticsearch7-7.9.1-0.jar:?]
	... 1 more
```

After the change, for the `IndexFieldTypePollerPeriodical`, there will be just a single line logged:
```
2022-11-25 17:27:45,425 INFO : org.graylog2.indexer.fieldtypes.IndexFieldTypePollerPeriodical - Cluster not connected yet, delaying index field type initialization until it is reachable.

```

Graylog Version: `5.1.0-SNAPSHOT`