### PR TITLE
Flush remaining messages to the indexer during shutdown

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/outputs/BlockingBatchedESOutput.java
+++ b/graylog2-server/src/main/java/org/graylog2/outputs/BlockingBatchedESOutput.java
@@ -22,6 +22,7 @@ import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
 import com.google.common.collect.Maps;
 import org.graylog2.indexer.IndexSet;
+import org.graylog2.indexer.cluster.Cluster;
 import org.graylog2.indexer.messages.Messages;
 import org.graylog2.plugin.Message;
 import org.graylog2.shared.journal.Journal;
@@ -33,6 +34,11 @@ import javax.inject.Inject;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -48,6 +54,8 @@ public class BlockingBatchedESOutput extends ElasticSearchOutput {
     private final Meter bufferFlushes;
     private final Meter bufferFlushFailures;
     private final Meter bufferFlushesRequested;
+    private final Cluster cluster;
+    private final int shutdownTimeoutMs;
 
     private volatile List<Map.Entry<IndexSet, Message>> buffer;
 
@@ -60,7 +68,8 @@ public class BlockingBatchedESOutput extends ElasticSearchOutput {
                                    Messages messages,
                                    org.graylog2.Configuration serverConfiguration,
                                    Journal journal,
-                                   MessageQueueAcknowledger acknowledger) {
+                                   MessageQueueAcknowledger acknowledger,
+                                   Cluster cluster) {
         super(metricRegistry, messages, journal, acknowledger);
         this.maxBufferSize = serverConfiguration.getOutputBatchSize();
         outputFlushInterval = serverConfiguration.getOutputFlushInterval();
@@ -69,6 +78,8 @@ public class BlockingBatchedESOutput extends ElasticSearchOutput {
         this.bufferFlushes = metricRegistry.meter(name(this.getClass(), "bufferFlushes"));
         this.bufferFlushFailures = metricRegistry.meter(name(this.getClass(), "bufferFlushFailures"));
         this.bufferFlushesRequested = metricRegistry.meter(name(this.getClass(), "bufferFlushesRequested"));
+        this.cluster = cluster;
+        this.shutdownTimeoutMs = serverConfiguration.getShutdownTimeout();
 
         buffer = new ArrayList<>(maxBufferSize);
 
@@ -129,8 +140,13 @@ public class BlockingBatchedESOutput extends ElasticSearchOutput {
         // if we shouldn't flush at all based on the last flush time, no need to synchronize on this.
         if (lastFlushTime.get() != 0 &&
                 outputFlushInterval > NANOSECONDS.toSeconds(System.nanoTime() - lastFlushTime.get())) {
-                    return;
-                }
+            return;
+        }
+
+        forceFlush();
+    }
+
+    private void forceFlush() {
         // flip buffer quickly and initiate flush
         final List<Map.Entry<IndexSet, Message>> flushBatch;
         synchronized (this) {
@@ -141,6 +157,26 @@ public class BlockingBatchedESOutput extends ElasticSearchOutput {
             bufferFlushesRequested.mark();
             flush(flushBatch);
         }
+    }
+
+    @Override
+    public void stop() {
+        if (cluster.isConnected() && cluster.isDeflectorHealthy()) {
+            // Try to flush current batch. Time-limited to avoid blocking shutdown too long.
+            final ExecutorService executorService = Executors.newSingleThreadExecutor();
+            try {
+                executorService.submit(this::forceFlush).get(shutdownTimeoutMs, TimeUnit.MILLISECONDS);
+            } catch (InterruptedException e) {
+                // OK, we are shutting down anyway
+            } catch (ExecutionException e) {
+                log.warn("Flushing current batch to indexer while stopping failed with message: {}.", e.getMessage());
+            } catch (TimeoutException e) {
+                log.warn("Timed out flushing current batch to indexer while stopping.");
+            } finally {
+                executorService.shutdownNow();
+            }
+        }
+        super.stop();
     }
 
     public interface Factory extends ElasticSearchOutput.Factory {

--- a/graylog2-server/src/test/java/org/graylog2/outputs/BlockingBatchedESOutputTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/outputs/BlockingBatchedESOutputTest.java
@@ -21,32 +21,36 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
 import org.graylog2.Configuration;
 import org.graylog2.indexer.IndexSet;
+import org.graylog2.indexer.cluster.Cluster;
 import org.graylog2.indexer.messages.Messages;
 import org.graylog2.plugin.Message;
 import org.graylog2.plugin.Tools;
 import org.graylog2.shared.journal.NoopJournal;
 import org.graylog2.shared.messageq.MessageQueueAcknowledger;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
+@ExtendWith(MockitoExtension.class)
 public class BlockingBatchedESOutputTest {
-    @Rule
-    public final MockitoRule mockitoRule = MockitoJUnit.rule();
 
-    private MetricRegistry metricRegistry;
-    private NoopJournal journal;
     private Configuration config;
 
     @Mock
@@ -55,45 +59,94 @@ public class BlockingBatchedESOutputTest {
     @Mock
     private MessageQueueAcknowledger acknowledger;
 
-    @Before
+    @Mock
+    private Cluster cluster;
+
+    private BlockingBatchedESOutput output;
+
+    @BeforeEach
     public void setUp() throws Exception {
-        this.metricRegistry = new MetricRegistry();
-        this.journal = new NoopJournal();
+        MetricRegistry metricRegistry = new MetricRegistry();
+        NoopJournal journal = new NoopJournal();
         this.config = new Configuration() {
             @Override
             public int getOutputBatchSize() {
                 return 3;
             }
+
+            @Override
+            public int getShutdownTimeout() {
+                return 10;
+            }
         };
+
+        output = new BlockingBatchedESOutput(metricRegistry, messages, config, journal, acknowledger, cluster);
     }
 
     @Test
     public void write() throws Exception {
-        final BlockingBatchedESOutput output = new BlockingBatchedESOutput(metricRegistry, messages, config, journal, acknowledger);
-
-        final List<Map.Entry<IndexSet, Message>> messageList = buildMessages(config.getOutputBatchSize());
-
-        for (Map.Entry<IndexSet, Message> entry : messageList) {
-            output.writeMessageEntry(entry);
-        }
+        final List<Map.Entry<IndexSet, Message>> messageList = sendMessages(output, config.getOutputBatchSize());
 
         verify(messages, times(1)).bulkIndex(eq(messageList));
     }
 
     @Test
     public void forceFlushIfTimedOut() throws Exception {
-        final BlockingBatchedESOutput output = new BlockingBatchedESOutput(metricRegistry, messages, config, journal, acknowledger);
-
-        final List<Map.Entry<IndexSet, Message>> messageList = buildMessages(config.getOutputBatchSize() - 1);
-
-        for (Map.Entry<IndexSet, Message> entry : messageList) {
-            output.writeMessageEntry(entry);
-        }
+        final List<Map.Entry<IndexSet, Message>> messageList = sendMessages(output, config.getOutputBatchSize() - 1);
 
         // Should flush the buffer even though the batch size is not reached yet
         output.forceFlushIfTimedout();
 
         verify(messages, times(1)).bulkIndex(eq(messageList));
+    }
+
+    @Test
+    public void stop_withHealthyCluster() throws Exception {
+        when(cluster.isConnected()).thenReturn(true);
+        when(cluster.isDeflectorHealthy()).thenReturn(true);
+
+        final List<Map.Entry<IndexSet, Message>> messageList = sendMessages(output, config.getOutputBatchSize() - 1);
+
+        output.stop();
+
+        verify(messages, times(1)).bulkIndex(eq(messageList));
+    }
+
+    @Test
+    @Timeout(1)
+    public void stop_withDisconnectedCluster() throws Exception {
+        when(cluster.isConnected()).thenReturn(false);
+
+        sendMessages(output, config.getOutputBatchSize() - 1);
+        output.stop();
+
+        verifyNoInteractions(messages);
+    }
+
+    @Test
+    @Timeout(1)
+    public void stop_withIndexingBlocked() throws Exception {
+        when(cluster.isConnected()).thenReturn(true);
+        when(cluster.isDeflectorHealthy()).thenReturn(true);
+
+        final AtomicBoolean blocked = new AtomicBoolean(false);
+        final AtomicBoolean completed = new AtomicBoolean(false);
+
+        when(messages.bulkIndex(any())).thenAnswer(invocation -> {
+            blocked.set(true);
+            new CountDownLatch(1).await();
+            completed.set(true);
+            return null;
+        });
+
+        final List<Map.Entry<IndexSet, Message>> messageList = sendMessages(output, config.getOutputBatchSize() - 1);
+
+        output.stop();
+
+        verify(messages, times(1)).bulkIndex(eq(messageList));
+
+        assertThat(blocked).isTrue();
+        assertThat(completed).isFalse();
     }
 
     private List<Map.Entry<IndexSet, Message>> buildMessages(final int count) {
@@ -104,4 +157,15 @@ public class BlockingBatchedESOutputTest {
 
         return builder.build();
     }
+
+    private List<Map.Entry<IndexSet, Message>> sendMessages(BlockingBatchedESOutput output, int count) throws Exception {
+        final List<Map.Entry<IndexSet, Message>> messageList = buildMessages(count);
+
+        for (Map.Entry<IndexSet, Message> entry : messageList) {
+            output.writeMessageEntry(entry);
+        }
+
+        return messageList;
+    }
+
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds an extra step during the shutdown routine of a node to flush out messages to the indexer.
We try to make sure that a blocked indexer is not inhibiting shutdown. Therefore the flush is attempted from a separate thread which we interrupt after a timeout.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When a node shuts down, it may still have messages waiting to be flushed out in the `BlockingBatchedESOutput` singleton.
The `BatchedElasticSearchOutputFlushThread` periodical will be stopped at some point, so the messages will never be written to the index and in turn not be committed to the journal. However, if other outputs are configured, the messages will have been flushed to those outputs already. When the node restarts, these unflushed messages will be reread from the journal and duplicated in outputs other than the ES output.

To reproduce this
1. Temporarily configure `output_flush_interval = 60` in `graylog.conf`
2. Assign a STDOUT output to the "All messages" stream.
3. Send in some messages and observe them being printed to STDOUT
4. Restart the node
5. Observer the messages being printed to STDOUT again
6. Search for the messages and observe them being stored only once

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
See the steps to reproduce above.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

