### PR TITLE
Revert "Use `esbuild` to transpile frontend assets. (#13886)"

### DIFF
--- a/graylog2-web-interface/package.json
+++ b/graylog2-web-interface/package.json
@@ -144,7 +144,6 @@
     "css-loader": "^6.5.1",
     "enzyme": "3.11.0",
     "enzyme-adapter-react-16": "^1.15.2",
-    "esbuild-loader": "^2.20.0",
     "eslint-config-graylog": "file:packages/eslint-config-graylog",
     "estraverse-fb": "^1.3.1",
     "express": "^4.16.4",

--- a/graylog2-web-interface/packages/graylog-web-plugin/src/PluginManifest.js
+++ b/graylog2-web-interface/packages/graylog-web-plugin/src/PluginManifest.js
@@ -14,20 +14,11 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
+const create = (metadata, exports) => {
+  return {
+    metadata: metadata,
+    exports: exports,
+  };
+};
 
-class PluginManifest {
-  constructor(metadata, exports) {
-    this._metadata = metadata;
-    this._exports = exports;
-  }
-
-  get metadata() {
-    return this._metadata;
-  }
-
-  get exports() {
-    return this._exports;
-  }
-}
-
-module.exports = PluginManifest;
+module.exports = create;

--- a/graylog2-web-interface/webpack.config.js
+++ b/graylog2-web-interface/webpack.config.js
@@ -21,7 +21,7 @@ const webpack = require('webpack');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const merge = require('webpack-merge');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
-const { ESBuildMinifyPlugin } = require('esbuild-loader');
+const TerserPlugin = require('terser-webpack-plugin');
 
 const UniqueChunkIdPlugin = require('./webpack/UniqueChunkIdPlugin');
 
@@ -91,13 +91,26 @@ const webpackConfig = {
       {
         test: /\.[jt]s(x)?$/,
         use: {
-          loader: 'esbuild-loader',
+          loader: 'babel-loader',
           options: {
-            loader: 'tsx',
-            target: 'chrome105,edge105,firefox91,safari15'.split(','),
+            cacheDirectory: 'target/web/cache',
+            // eslint-disable-next-line global-require
+            presets: [require('babel-preset-graylog')],
           },
         },
-        exclude: /node_modules\/(?!graylog-web-plugin)|\.node_cache/,
+        include: /node_modules\/graylog-web-plugin/,
+      },
+      {
+        test: /\.[jt]s(x)?$/,
+        use: {
+          loader: 'babel-loader',
+          options: {
+            cacheDirectory: 'target/web/cache',
+            // eslint-disable-next-line global-require
+            presets: [require('babel-preset-graylog')],
+          },
+        },
+        exclude: /node_modules|\.node_cache/,
       },
       {
         test: /\.(svg)(\?.+)?$/,
@@ -248,8 +261,15 @@ if (TARGET.startsWith('build')) {
     mode: 'production',
     optimization: {
       moduleIds: 'deterministic',
-      minimizer: [new ESBuildMinifyPlugin({
-        target: 'es2015',
+      minimizer: [new TerserPlugin({
+        terserOptions: {
+          compress: {
+            warnings: false,
+          },
+          mangle: {
+            reserved: ['$super', '$', 'exports', 'require'],
+          },
+        },
       })],
     },
     plugins: [


### PR DESCRIPTION
This reverts commit 3e7dd9329aafff4e6a78ebffcf1810897293ecff.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

After merging #13886, we discovered two regressions:

  - The production build does not work due to an exception being thrown:

```
plugin.org.graylog.plugins.threatintel.ThreatIntelPlugin.971cbda67668c6ebb98f.js:1 Uncaught TypeError: Cannot convert undefined or null to object
    at hasOwnProperty (<anonymous>)
    at bn (plugin.org.graylog.plugins.threatintel.ThreatIntelPlugin.971cbda67668c6ebb98f.js:1:363)
    at J.build (FetchProvider.ts:189:9)
    at z._validateSession (SessionStore.ts:107:10)
    at z.validate (SessionStore.ts:83:28)
    at r.n (vendor.de83b0a6424b4ec14331.js:2:911149)
    at r.emit (vendor.de83b0a6424b4ec14331.js:2:56458)
    at Function.trigger (vendor.de83b0a6424b4ec14331.js:2:912030)
    at vendor.de83b0a6424b4ec14331.js:2:912135
    at E.<computed> (task.js:61:7)
    at L (task.js:35:5)
    at MessagePort.V (task.js:46:3)
```

  - Looking up plugin entities does not work anymore (reported by @mnin)

Therefore, the PR is reverted and will be recreated with a fix for these issues.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.