### PR TITLE
Use `esbuild` to transpile frontend assets. (Take II)

### DIFF
--- a/graylog2-web-interface/package.json
+++ b/graylog2-web-interface/package.json
@@ -144,6 +144,7 @@
     "css-loader": "^6.5.1",
     "enzyme": "3.11.0",
     "enzyme-adapter-react-16": "^1.15.2",
+    "esbuild-loader": "^2.20.0",
     "eslint-config-graylog": "file:packages/eslint-config-graylog",
     "estraverse-fb": "^1.3.1",
     "express": "^4.16.4",

--- a/graylog2-web-interface/packages/graylog-web-plugin/src/PluginManifest.js
+++ b/graylog2-web-interface/packages/graylog-web-plugin/src/PluginManifest.js
@@ -14,11 +14,20 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-const create = (metadata, exports) => {
-  return {
-    metadata: metadata,
-    exports: exports,
-  };
-};
 
-module.exports = create;
+class PluginManifest {
+  constructor(metadata, exports) {
+    this._metadata = metadata;
+    this._exports = exports;
+  }
+
+  get metadata() {
+    return this._metadata;
+  }
+
+  get exports() {
+    return this._exports;
+  }
+}
+
+module.exports = PluginManifest;

--- a/graylog2-web-interface/src/components/authentication/BackendCreate/ServiceSelect.test.tsx
+++ b/graylog2-web-interface/src/components/authentication/BackendCreate/ServiceSelect.test.tsx
@@ -18,7 +18,7 @@ import * as React from 'react';
 import { render, waitFor, fireEvent } from 'wrappedTestingLibrary';
 import selectEvent from 'react-select-event';
 
-import {} from 'components/authentication/bindings'; // Bind all authentication plugins
+import 'components/authentication/bindings'; // Bind all authentication plugins
 import history from 'util/History';
 import Routes from 'routing/Routes';
 

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventDefinitionFormContainer.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventDefinitionFormContainer.jsx
@@ -32,9 +32,9 @@ import { EventNotificationsActions, EventNotificationsStore } from 'stores/event
 import EventDefinitionForm from './EventDefinitionForm';
 
 // Import built-in plugins
-import {} from 'components/event-definitions/event-definition-types';
+import 'components/event-definitions/event-definition-types';
 
-import {} from 'components/event-notifications/event-notification-types';
+import 'components/event-notifications/event-notification-types';
 
 class EventDefinitionFormContainer extends React.Component {
   static propTypes = {

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventDefinitionSummary.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventDefinitionSummary.jsx
@@ -20,15 +20,15 @@ import lodash from 'lodash';
 import { PluginStore } from 'graylog-web-plugin/plugin';
 import moment from 'moment';
 
-import {} from 'moment-duration-format';
+import 'moment-duration-format';
 import { defaultCompare as naturalSort } from 'logic/DefaultCompare';
 import { Alert, Col, Row } from 'components/bootstrap';
 import { isPermitted } from 'util/PermissionsMixin';
 import EventDefinitionPriorityEnum from 'logic/alerts/EventDefinitionPriorityEnum';
 
 // Import built-in plugins
-import {} from 'components/event-definitions/event-definition-types';
-import {} from 'components/event-notifications/event-notification-types';
+import 'components/event-definitions/event-definition-types';
+import 'components/event-notifications/event-notification-types';
 
 import EventDefinitionValidationSummary from './EventDefinitionValidationSummary';
 import styles from './EventDefinitionSummary.css';

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/FieldsForm.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/FieldsForm.jsx
@@ -26,7 +26,7 @@ import FieldForm from './FieldForm';
 import FieldsList from './FieldsList';
 
 // Import built-in Field Value Providers
-import {} from './field-value-providers';
+import './field-value-providers';
 
 import commonStyles from '../common/commonStyles.css';
 

--- a/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitionDescription.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitionDescription.jsx
@@ -17,7 +17,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment';
-import {} from 'moment-duration-format';
+import 'moment-duration-format';
 import lodash from 'lodash';
 import styled, { css } from 'styled-components';
 

--- a/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitionsContainer.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitionsContainer.jsx
@@ -22,7 +22,7 @@ import withPaginationQueryParameter from 'components/common/withPaginationQueryP
 import connect from 'stores/connect';
 import { EventDefinitionsActions, EventDefinitionsStore } from 'stores/event-definitions/EventDefinitionsStore';
 
-import {} from 'components/event-definitions/event-definition-types';
+import 'components/event-definitions/event-definition-types';
 
 import EventDefinitions, { PAGE_SIZES } from './EventDefinitions';
 

--- a/graylog2-web-interface/src/components/event-notifications/event-notification-form/EventNotificationFormContainer.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-form/EventNotificationFormContainer.jsx
@@ -27,7 +27,7 @@ import EventNotificationForm from './EventNotificationForm';
 
 // Import built-in Event Notification Types
 
-import {} from '../event-notification-types';
+import '../event-notification-types';
 
 const initialValidation = {
   errors: {},

--- a/graylog2-web-interface/src/components/event-notifications/event-notifications/EventNotificationsContainer.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notifications/EventNotificationsContainer.jsx
@@ -25,7 +25,7 @@ import withPaginationQueryParameter from 'components/common/withPaginationQueryP
 import EventNotifications, { PAGE_SIZES } from './EventNotifications';
 // Import built-in Event Notification Types
 
-import {} from '../event-notification-types';
+import '../event-notification-types';
 
 const fetchData = ({ page, pageSize, query }) => {
   return EventNotificationsActions.listPaginated({

--- a/graylog2-web-interface/src/components/events/events/EventsContainer.jsx
+++ b/graylog2-web-interface/src/components/events/events/EventsContainer.jsx
@@ -28,7 +28,7 @@ import withPaginationQueryParameter from 'components/common/withPaginationQueryP
 
 import Events, { PAGE_SIZES } from './Events';
 
-import {} from 'components/event-definitions/event-definition-types';
+import 'components/event-definitions/event-definition-types';
 
 const LOCAL_STORAGE_ITEM = 'events-last-search';
 

--- a/graylog2-web-interface/src/components/indices/rotation/TimeBasedRotationStrategySummary.jsx
+++ b/graylog2-web-interface/src/components/indices/rotation/TimeBasedRotationStrategySummary.jsx
@@ -17,7 +17,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import moment from 'moment';
-import {} from 'moment-duration-format';
+import 'moment-duration-format';
 
 class TimeBasedRotationStrategySummary extends React.Component {
   static propTypes = {

--- a/graylog2-web-interface/src/components/lookup-tables/adapters/index.js
+++ b/graylog2-web-interface/src/components/lookup-tables/adapters/index.js
@@ -16,7 +16,7 @@
  */
 import { PluginManifest, PluginStore } from 'graylog-web-plugin/plugin';
 
-import {} from 'components/maps/adapter';
+import 'components/maps/adapter';
 import CSVFileAdapterFieldSet from './CSVFileAdapterFieldSet';
 import CSVFileAdapterSummary from './CSVFileAdapterSummary';
 import CSVFileAdapterDocumentation from './CSVFileAdapterDocumentation';

--- a/graylog2-web-interface/src/components/lookup-tables/index.js
+++ b/graylog2-web-interface/src/components/lookup-tables/index.js
@@ -14,8 +14,8 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import {} from './adapters';
-import {} from './caches';
+import './adapters';
+import './caches';
 
 export { default as LookupTablesOverview } from './LookupTablesOverview';
 export { default as LUTTableEntry } from './LUTTableEntry';

--- a/graylog2-web-interface/src/components/nodes/JournalDetails.jsx
+++ b/graylog2-web-interface/src/components/nodes/JournalDetails.jsx
@@ -21,7 +21,7 @@ import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import numeral from 'numeral';
 import moment from 'moment';
-import {} from 'moment-duration-format';
+import 'moment-duration-format';
 import styled from 'styled-components';
 
 import { Link } from 'components/common/router';

--- a/graylog2-web-interface/src/pages/AuthenticationBackendCreatePage.tsx
+++ b/graylog2-web-interface/src/pages/AuthenticationBackendCreatePage.tsx
@@ -17,7 +17,7 @@
 import * as React from 'react';
 
 import withParams from 'routing/withParams';
-import {} from 'components/authentication/bindings'; // Bind all authentication plugins
+import 'components/authentication/bindings'; // Bind all authentication plugins
 import { getAuthServicePlugin } from 'util/AuthenticationService';
 
 type Props = {

--- a/graylog2-web-interface/src/pages/AuthenticationBackendDetailsPage.tsx
+++ b/graylog2-web-interface/src/pages/AuthenticationBackendDetailsPage.tsx
@@ -20,7 +20,7 @@ import { useState, useEffect } from 'react';
 import AuthenticationPageNavigation from 'components/authentication/AuthenticationPageNavigation';
 import withParams from 'routing/withParams';
 import { LinkContainer } from 'components/common/router';
-import {} from 'components/authentication/bindings'; // Bind all authentication plugins
+import 'components/authentication/bindings'; // Bind all authentication plugins
 import DocsHelper from 'util/DocsHelper';
 import StringUtils from 'util/StringUtils';
 import AuthenticationDomain from 'domainActions/authentication/AuthenticationDomain';

--- a/graylog2-web-interface/src/pages/AuthenticationBackendEditPage.tsx
+++ b/graylog2-web-interface/src/pages/AuthenticationBackendEditPage.tsx
@@ -20,7 +20,7 @@ import { useState, useEffect } from 'react';
 import withParams from 'routing/withParams';
 import type { Location } from 'routing/withLocation';
 import withLocation from 'routing/withLocation';
-import {} from 'components/authentication/bindings'; // Bind all authentication plugins
+import 'components/authentication/bindings'; // Bind all authentication plugins
 import { getAuthServicePlugin } from 'util/AuthenticationService';
 import { Spinner } from 'components/common';
 import AuthenticationDomain from 'domainActions/authentication/AuthenticationDomain';

--- a/graylog2-web-interface/src/pages/AuthenticationCreatePage.tsx
+++ b/graylog2-web-interface/src/pages/AuthenticationCreatePage.tsx
@@ -16,7 +16,7 @@
  */
 import * as React from 'react';
 
-import {} from 'components/authentication/bindings'; // Bind all authentication plugins
+import 'components/authentication/bindings'; // Bind all authentication plugins
 import AuthenticationPageNavigation from 'components/authentication/AuthenticationPageNavigation';
 import GettingStarted from 'components/authentication/BackendCreate/GettingStarted';
 import { DocumentTitle, PageHeader } from 'components/common';

--- a/graylog2-web-interface/src/pages/AuthenticationOverviewPage.tsx
+++ b/graylog2-web-interface/src/pages/AuthenticationOverviewPage.tsx
@@ -17,7 +17,7 @@
 import * as React from 'react';
 
 import { AuthenticationActions } from 'stores/authentication/AuthenticationStore';
-import {} from 'components/authentication/bindings'; // Bind all authentication plugins
+import 'components/authentication/bindings'; // Bind all authentication plugins
 import { Alert, Row, Col } from 'components/bootstrap';
 import { DocumentTitle, PageHeader, Icon } from 'components/common';
 import DocsHelper from 'util/DocsHelper';

--- a/graylog2-web-interface/src/pages/AuthenticationPage.tsx
+++ b/graylog2-web-interface/src/pages/AuthenticationPage.tsx
@@ -16,7 +16,7 @@
  */
 import * as React from 'react';
 import { useEffect } from 'react';
-import {} from 'components/authentication/bindings'; // Bind all authentication plugins
+import 'components/authentication/bindings'; // Bind all authentication plugins
 
 import AuthenticationPageNavigation from 'components/authentication/AuthenticationPageNavigation';
 import DocsHelper from 'util/DocsHelper';

--- a/graylog2-web-interface/src/pages/ShowEventNotificationPage.jsx
+++ b/graylog2-web-interface/src/pages/ShowEventNotificationPage.jsx
@@ -30,7 +30,7 @@ import withParams from 'routing/withParams';
 import EventNotificationDetails from 'components/event-notifications/event-notification-details/EventNotificationDetails';
 import EventNotificationActionLinks from 'components/event-notifications/event-notification-details/EventNotificationActionLinks';
 import { EventNotificationsActions } from 'stores/event-notifications/EventNotificationsStore';
-import {} from 'components/event-notifications/event-notification-types';
+import 'components/event-notifications/event-notification-types';
 import EventsPageNavigation from 'components/events/EventsPageNavigation';
 
 const ShowEventDefinitionPage = ({ params: { notificationId } }) => {

--- a/graylog2-web-interface/src/util/ISODurationUtils.js
+++ b/graylog2-web-interface/src/util/ISODurationUtils.js
@@ -15,7 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import moment from 'moment';
-import {} from 'moment-duration-format';
+import 'moment-duration-format';
 
 const ISODurationUtils = {
   isValidDuration(duration, validator) {

--- a/graylog2-web-interface/webpack.config.js
+++ b/graylog2-web-interface/webpack.config.js
@@ -97,19 +97,7 @@ const webpackConfig = {
             target: 'es2015',
           },
         },
-        include: /node_modules\/graylog-web-plugin/,
-      },
-      {
-        test: /\.[jt]s(x)?$/,
-        use: {
-          loader: 'babel-loader',
-          options: {
-            cacheDirectory: 'target/web/cache',
-            // eslint-disable-next-line global-require
-            presets: [require('babel-preset-graylog')],
-          },
-        },
-        exclude: /node_modules|\.node_cache/,
+        exclude: /node_modules\/(?!graylog-web-plugin)|\.node_cache/,
       },
       {
         test: /\.(svg)(\?.+)?$/,

--- a/graylog2-web-interface/webpack.config.js
+++ b/graylog2-web-interface/webpack.config.js
@@ -94,7 +94,7 @@ const webpackConfig = {
           loader: 'esbuild-loader',
           options: {
             loader: 'tsx',
-            target: 'es2015',
+            target: 'chrome105,edge105,firefox91,safari15'.split(','),
           },
         },
         exclude: /node_modules\/(?!graylog-web-plugin)|\.node_cache/,

--- a/graylog2-web-interface/webpack.config.js
+++ b/graylog2-web-interface/webpack.config.js
@@ -75,6 +75,8 @@ const chunksSortMode = (c1, c2) => {
   return 0;
 };
 
+const target = 'chrome105,edge105,firefox91,safari15'.split(',');
+
 const webpackConfig = {
   name: 'app',
   dependencies: ['vendor'],
@@ -94,7 +96,7 @@ const webpackConfig = {
           loader: 'esbuild-loader',
           options: {
             loader: 'tsx',
-            target: 'chrome105,edge105,firefox91,safari15'.split(','),
+            target,
           },
         },
         exclude: /node_modules\/(?!graylog-web-plugin)|\.node_cache/,
@@ -249,7 +251,7 @@ if (TARGET.startsWith('build')) {
     optimization: {
       moduleIds: 'deterministic',
       minimizer: [new ESBuildMinifyPlugin({
-        target: 'es2015',
+        target,
       })],
     },
     plugins: [

--- a/graylog2-web-interface/webpack.config.js
+++ b/graylog2-web-interface/webpack.config.js
@@ -21,7 +21,7 @@ const webpack = require('webpack');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const merge = require('webpack-merge');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
-const TerserPlugin = require('terser-webpack-plugin');
+const { ESBuildMinifyPlugin } = require('esbuild-loader');
 
 const UniqueChunkIdPlugin = require('./webpack/UniqueChunkIdPlugin');
 
@@ -91,11 +91,10 @@ const webpackConfig = {
       {
         test: /\.[jt]s(x)?$/,
         use: {
-          loader: 'babel-loader',
+          loader: 'esbuild-loader',
           options: {
-            cacheDirectory: 'target/web/cache',
-            // eslint-disable-next-line global-require
-            presets: [require('babel-preset-graylog')],
+            loader: 'tsx',
+            target: 'es2015',
           },
         },
         include: /node_modules\/graylog-web-plugin/,
@@ -261,15 +260,8 @@ if (TARGET.startsWith('build')) {
     mode: 'production',
     optimization: {
       moduleIds: 'deterministic',
-      minimizer: [new TerserPlugin({
-        terserOptions: {
-          compress: {
-            warnings: false,
-          },
-          mangle: {
-            reserved: ['$super', '$', 'exports', 'require'],
-          },
-        },
+      minimizer: [new ESBuildMinifyPlugin({
+        target: 'es2015',
       })],
     },
     plugins: [


### PR DESCRIPTION
**Note:** This is a reissue of #13886, which contained issues, as explained in #14068. This PR is fixing them, by a) fixing up imports for side-effects and b) using the same, consistent target specification for minification.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is implementing `esbuild-loader` so we can make use of the improved performance of `esbuild` during bundling.

### Before:
```
yarn build  192.80s user 3.71s system 296% cpu 1:06.38 total
```

### After:
```
yarn build  38.77s user 1.81s system 156% cpu 25.961 total
```

The `target` specification is what `browserslist` generates for the `defaults` setting right now as a start. There is no direct integration for it in `esbuild-loader` yet, but writing one is a simple task for a follow-up PR.

Another follow-up could be removing `babel-loader` etc. if we decide that we do not need it anymore.

/nocl

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.