### PR TITLE
Fix public notifications for open core.

### DIFF
--- a/graylog2-web-interface/src/components/common/PublicNotifications.test.tsx
+++ b/graylog2-web-interface/src/components/common/PublicNotifications.test.tsx
@@ -134,4 +134,14 @@ describe('PublicNotifications', () => {
 
     expect(alerts.length).toBe(1);
   });
+
+  it('should render from AppConfig when no plugins are configured', () => {
+    asMock(usePluginEntities).mockImplementation(() => ([]));
+
+    render(<PublicNotifications readFromConfig />);
+
+    const alerts = screen.getAllByRole('alert');
+
+    expect(alerts.length).toBe(1);
+  });
 });

--- a/graylog2-web-interface/src/components/common/PublicNotifications.tsx
+++ b/graylog2-web-interface/src/components/common/PublicNotifications.tsx
@@ -80,7 +80,7 @@ const PublicNotifications = ({ readFromConfig }: Props) => {
   }
 
   const publicNotifications = Object.keys(allNotification).map((notificationId) => {
-    if (dismissedNotifications.has(notificationId)) {
+    if (dismissedNotifications?.has(notificationId)) {
       return null;
     }
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

When the enterprise plugin is not installed, the list of public notifications can be `undefined`. In this case an exception is thrown when the `PublicNotifications` component is rendered.

This PR is making access of notifications more lenient by using optional chaining.

/nocl

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.