### PR TITLE
Change bulk indexing retry failure log level to warn

### DIFF
--- a/changelog/unreleased/issue-14086.toml
+++ b/changelog/unreleased/issue-14086.toml
@@ -1,0 +1,15 @@
+type = "c"
+message = "Changed bulk indexing retry failure log-level from error to warning."
+
+issues = ["14086"]
+pulls = ["14088"]
+
+details.user = """
+The log-level for Opeansearch bulk indexing retry attempts has been changed from `ERROR` to `WARN`.
+
+While bulk indexing retries might indicate an issue with the Opensearch backend, it also might be a temporary condition
+that would resolve on its own (for example, temporary high memory pressure). Warn is a better log-level for such a case.
+
+Example message:
+> WARN Caught exception during bulk indexing: [specific error], retrying (attempt #1).
+"""

--- a/graylog2-server/src/main/java/org/graylog2/indexer/messages/Messages.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/messages/Messages.java
@@ -84,7 +84,7 @@ public class Messages {
                     @Override
                     public <V> void onRetry(Attempt<V> attempt) {
                         if (attempt.hasException()) {
-                            LOG.error("Caught exception during bulk indexing: {}, retrying (attempt #{}).", attempt.getExceptionCause(), attempt.getAttemptNumber());
+                            LOG.warn("Caught exception during bulk indexing: {}, retrying (attempt #{}).", attempt.getExceptionCause(), attempt.getAttemptNumber());
                         } else if (attempt.getAttemptNumber() > 1) {
                             LOG.info("Bulk indexing finally successful (attempt #{}).", attempt.getAttemptNumber());
                         }


### PR DESCRIPTION
Reduce the log level for bulk indexing retry attempts from `error` to `warning`, since they sometimes indicate a temporary condition, which will resolve with time.

Closes #14086

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

