### PR TITLE
Issue 14086 change log: Fix Opensearch typo, mention both indexers

### DIFF
--- a/changelog/unreleased/issue-14086.toml
+++ b/changelog/unreleased/issue-14086.toml
@@ -5,7 +5,7 @@ issues = ["14086"]
 pulls = ["14088"]
 
 details.user = """
-The log-level for Opensearch/Elasticsearch bulk indexing retry attempts has been changed from `ERROR` to `WARN`.
+The log-level for OpenSearch/Elasticsearch bulk indexing retry attempts has been changed from `ERROR` to `WARN`.
 
 While bulk indexing retries might indicate an issue with the Opensearch backend, it also might be a temporary condition
 that would resolve on its own (for example, temporary high memory pressure). Warn is a better log-level for such a case.

--- a/changelog/unreleased/issue-14086.toml
+++ b/changelog/unreleased/issue-14086.toml
@@ -5,7 +5,7 @@ issues = ["14086"]
 pulls = ["14088"]
 
 details.user = """
-The log-level for Opeansearch bulk indexing retry attempts has been changed from `ERROR` to `WARN`.
+The log-level for Opensearch/Elasticsearch bulk indexing retry attempts has been changed from `ERROR` to `WARN`.
 
 While bulk indexing retries might indicate an issue with the Opensearch backend, it also might be a temporary condition
 that would resolve on its own (for example, temporary high memory pressure). Warn is a better log-level for such a case.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix Opensearch word typo and mention both Opensearch/Elasticsearch in change log introduced in https://github.com/Graylog2/graylog2-server/pull/14088.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
See initial discussion: https://github.com/Graylog2/graylog2-server/pull/14088#discussion_r1035653494
