### PR TITLE
Change bulk indexing retry failure log level to warn (5.0)

### DIFF
--- a/changelog/unreleased/issue-14086.toml
+++ b/changelog/unreleased/issue-14086.toml
@@ -1,0 +1,15 @@
+type = "c"
+message = "Changed bulk indexing retry failure log-level from error to warning."
+
+issues = ["14086"]
+pulls = ["14088"]
+
+details.user = """
+The log-level for Opeansearch bulk indexing retry attempts has been changed from `ERROR` to `WARN`.
+
+While bulk indexing retries might indicate an issue with the Opensearch backend, it also might be a temporary condition
+that would resolve on its own (for example, temporary high memory pressure). Warn is a better log-level for such a case.
+
+Example message:
+> WARN Caught exception during bulk indexing: [specific error], retrying (attempt #1).
+"""

--- a/changelog/unreleased/issue-14086.toml
+++ b/changelog/unreleased/issue-14086.toml
@@ -5,7 +5,7 @@ issues = ["14086"]
 pulls = ["14088"]
 
 details.user = """
-The log-level for Opeansearch bulk indexing retry attempts has been changed from `ERROR` to `WARN`.
+The log-level for OpenSearch/Elasticsearch bulk indexing retry attempts has been changed from `ERROR` to `WARN`.
 
 While bulk indexing retries might indicate an issue with the Opensearch backend, it also might be a temporary condition
 that would resolve on its own (for example, temporary high memory pressure). Warn is a better log-level for such a case.

--- a/graylog2-server/src/main/java/org/graylog2/indexer/messages/Messages.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/messages/Messages.java
@@ -84,7 +84,7 @@ public class Messages {
                     @Override
                     public <V> void onRetry(Attempt<V> attempt) {
                         if (attempt.hasException()) {
-                            LOG.error("Caught exception during bulk indexing: {}, retrying (attempt #{}).", attempt.getExceptionCause(), attempt.getAttemptNumber());
+                            LOG.warn("Caught exception during bulk indexing: {}, retrying (attempt #{}).", attempt.getExceptionCause(), attempt.getAttemptNumber());
                         } else if (attempt.getAttemptNumber() > 1) {
                             LOG.info("Bulk indexing finally successful (attempt #{}).", attempt.getAttemptNumber());
                         }


### PR DESCRIPTION
Backport https://github.com/Graylog2/graylog2-server/pull/14088, #14092 to `5.0`.