### PR TITLE
Messages endpoint gives field type information in schema

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/scriptingapi/ScriptingApiResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/scriptingapi/ScriptingApiResource.java
@@ -102,7 +102,7 @@ public class ScriptingApiResource extends RestResource implements PluginRestReso
             postAuditEvent(searchJob);
 
             //Step 3: take complex response and try to map it to simpler, tabular form
-            return messagesTabularResponseCreator.mapToResponse(messagesRequestSpec, searchJob);
+            return messagesTabularResponseCreator.mapToResponse(messagesRequestSpec, searchJob, searchUser);
 
         } catch (IllegalArgumentException | ValidationException | AggregationFailedException ex) {
             throw new BadRequestException(ex.getMessage(), ex);

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/scriptingapi/request/AggregationRequestSpec.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/scriptingapi/request/AggregationRequestSpec.java
@@ -52,7 +52,6 @@ public record AggregationRequestSpec(@JsonProperty("query") String queryString,
         return metrics().stream().anyMatch(m -> m.sort() != null);
     }
 
-    @Override
     @JsonIgnore
     public List<ResponseSchemaEntry> getSchema() {
         final Stream<ResponseSchemaEntry> groupings = groupings().stream()

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/scriptingapi/request/MessagesRequestSpec.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/scriptingapi/request/MessagesRequestSpec.java
@@ -19,10 +19,12 @@ package org.graylog.plugins.views.search.rest.scriptingapi.request;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Strings;
+import org.graylog.plugins.views.search.rest.scriptingapi.response.ResponseEntryDataType;
 import org.graylog.plugins.views.search.rest.scriptingapi.response.ResponseSchemaEntry;
 import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -60,12 +62,14 @@ public record MessagesRequestSpec(@JsonProperty("query") String queryString,
 
     }
 
-    @Override
     @JsonIgnore
-    public List<ResponseSchemaEntry> getSchema() {
+    public List<ResponseSchemaEntry> getSchema(final Map<String, String> fieldTypes) {
         return fields()
                 .stream()
-                .map(ResponseSchemaEntry::field)
+                .map(field -> {
+                    final String type = fieldTypes.getOrDefault(field, null);
+                    return ResponseSchemaEntry.field(field, ResponseEntryDataType.fromSearchEngineType(type));
+                })
                 .collect(Collectors.toList());
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/scriptingapi/request/SearchRequestSpec.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/scriptingapi/request/SearchRequestSpec.java
@@ -16,12 +16,9 @@
  */
 package org.graylog.plugins.views.search.rest.scriptingapi.request;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import org.graylog.plugins.views.search.rest.scriptingapi.response.ResponseSchemaEntry;
 import org.graylog2.plugin.indexer.searches.timeranges.RelativeRange;
 import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
 
-import java.util.List;
 import java.util.Set;
 
 public interface SearchRequestSpec {
@@ -36,6 +33,4 @@ public interface SearchRequestSpec {
 
     TimeRange timerange();
 
-    @JsonIgnore
-    List<ResponseSchemaEntry> getSchema();
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/scriptingapi/response/ResponseEntryDataType.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/scriptingapi/response/ResponseEntryDataType.java
@@ -17,13 +17,37 @@
 package org.graylog.plugins.views.search.rest.scriptingapi.response;
 
 import com.fasterxml.jackson.annotation.JsonValue;
+import org.apache.commons.lang.StringUtils;
 
+import java.util.Arrays;
 import java.util.Locale;
+import java.util.Set;
 
 public enum ResponseEntryDataType {
-    STRING,
-    NUMERIC,
-    UNKNOWN;//TODO: may be temporary
+    STRING(Set.of("keyword", "text")),
+    NUMERIC(Set.of("long", "integer", "short", "byte", "double", "float", "half_float", "scaled_float")),
+    DATE(Set.of("date")),
+    BOOLEAN(Set.of("boolean")),
+    BINARY(Set.of("binary")),
+    IP(Set.of("ip")),
+    GEO(Set.of("geo_point", "geo_shape")),
+    UNKNOWN(Set.of());
+
+    private final Set<String> correspondingSearchEngineTypes;
+
+    ResponseEntryDataType(Set<String> correspondingSearchEngineTypes) {
+        this.correspondingSearchEngineTypes = correspondingSearchEngineTypes;
+    }
+
+    public static ResponseEntryDataType fromSearchEngineType(final String type) {
+        if (StringUtils.isBlank(type)) {
+            return UNKNOWN;
+        }
+        return Arrays.stream(ResponseEntryDataType.values())
+                .filter(dataType -> dataType.correspondingSearchEngineTypes.contains(type))
+                .findFirst()
+                .orElse(UNKNOWN);
+    }
 
     @JsonValue
     @Override

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/scriptingapi/response/ResponseSchemaEntry.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/scriptingapi/response/ResponseSchemaEntry.java
@@ -42,9 +42,8 @@ public record ResponseSchemaEntry(
         return new ResponseSchemaEntry(ResponseEntryType.METRIC, dataType, functionName, fieldName);
     }
 
-    //TODO : do we want to examine ES/OS mapping and fetch exact type for a field?
-    public static ResponseSchemaEntry field(String fieldName) {
-        return new ResponseSchemaEntry(ResponseEntryType.FIELD, ResponseEntryDataType.UNKNOWN, null, fieldName);
+    public static ResponseSchemaEntry field(String fieldName, ResponseEntryDataType dataType) {
+        return new ResponseSchemaEntry(ResponseEntryType.FIELD, dataType, null, fieldName);
     }
 
     /**

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/scriptingapi/request/MessagesRequestSpecTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/scriptingapi/request/MessagesRequestSpecTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.views.search.rest.scriptingapi.request;
+
+import org.graylog.plugins.views.search.rest.scriptingapi.response.ResponseEntryDataType;
+import org.graylog.plugins.views.search.rest.scriptingapi.response.ResponseSchemaEntry;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MessagesRequestSpecTest {
+
+    @Test
+    void testSchemaCreation() {
+        final Map<String, String> fieldTypes = Map.of(
+                "age", "long",
+                "salary", "double",
+                "position", "keyword"
+        );
+
+        final List<String> specifiedFields = List.of("age", "salary", "position", "nvmd");
+        final List<ResponseSchemaEntry> schema = new MessagesRequestSpec("", Set.of(), null, 0, 1, specifiedFields)
+                .getSchema(fieldTypes);
+
+        assertThat(schema).containsAll(
+                Set.of(
+                        ResponseSchemaEntry.field("age", ResponseEntryDataType.NUMERIC),
+                        ResponseSchemaEntry.field("salary", ResponseEntryDataType.NUMERIC),
+                        ResponseSchemaEntry.field("position", ResponseEntryDataType.STRING),
+                        ResponseSchemaEntry.field("nvmd", ResponseEntryDataType.UNKNOWN)
+                )
+        );
+
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/scriptingapi/response/ResponseEntryDataTypeTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/scriptingapi/response/ResponseEntryDataTypeTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.views.search.rest.scriptingapi.response;
+
+import org.junit.jupiter.api.Test;
+
+import static org.graylog.plugins.views.search.rest.scriptingapi.response.ResponseEntryDataType.DATE;
+import static org.graylog.plugins.views.search.rest.scriptingapi.response.ResponseEntryDataType.GEO;
+import static org.graylog.plugins.views.search.rest.scriptingapi.response.ResponseEntryDataType.NUMERIC;
+import static org.graylog.plugins.views.search.rest.scriptingapi.response.ResponseEntryDataType.STRING;
+import static org.graylog.plugins.views.search.rest.scriptingapi.response.ResponseEntryDataType.UNKNOWN;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ResponseEntryDataTypeTest {
+
+    @Test
+    void unknownTypeOnBlankEsType() {
+        assertEquals(UNKNOWN, ResponseEntryDataType.fromSearchEngineType(null));
+        assertEquals(UNKNOWN, ResponseEntryDataType.fromSearchEngineType(""));
+    }
+
+    @Test
+    void unknownTypeOnWrongEsType() {
+        assertEquals(UNKNOWN, ResponseEntryDataType.fromSearchEngineType("hamburger"));
+    }
+
+    @Test
+    void properTypeOnProperEsType() {
+        assertEquals(NUMERIC, ResponseEntryDataType.fromSearchEngineType("float"));
+        assertEquals(NUMERIC, ResponseEntryDataType.fromSearchEngineType("long"));
+        assertEquals(STRING, ResponseEntryDataType.fromSearchEngineType("text"));
+        assertEquals(STRING, ResponseEntryDataType.fromSearchEngineType("keyword"));
+        assertEquals(DATE, ResponseEntryDataType.fromSearchEngineType("date"));
+    }
+
+    @Test
+    void lowercaseToString() {
+        assertEquals("geo", GEO.toString());
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Messages endpoint gives field type information in schema
/nocl

## Motivation and Context
Fields have more rich typing than groupings (field names - always strings) and metrics (either string or numeric).
We need to use our "field types lookup" to provide this information in order to create proper schema part of the response.

## How Has This Been Tested?
Unit tests have been added.
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

