### PR TITLE
Support more than 10 shutdown hooks in graceful shutdown service

### DIFF
--- a/changelog/unreleased/pr-14097.toml
+++ b/changelog/unreleased/pr-14097.toml
@@ -1,0 +1,4 @@
+type = "fixed"
+message = "Prevent RejectedExecutionException during shutdown with a large number of outputs."
+
+pulls = ["14097"]

--- a/graylog2-server/src/main/java/org/graylog2/system/shutdown/GracefulShutdownService.java
+++ b/graylog2-server/src/main/java/org/graylog2/system/shutdown/GracefulShutdownService.java
@@ -27,7 +27,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -126,10 +126,10 @@ public class GracefulShutdownService extends AbstractIdleService {
     }
 
     private ExecutorService executorService(final int maxThreads) {
-        return new ThreadPoolExecutor(0,
+        return new ThreadPoolExecutor(maxThreads,
                 maxThreads,
                 60L, TimeUnit.SECONDS,
-                new SynchronousQueue<>(),
+                new LinkedBlockingQueue<>(),
                 new ThreadFactoryBuilder()
                         .setNameFormat("graceful-shutdown-service-%d")
                         .setUncaughtExceptionHandler((t, e) -> LOG.error("Uncaught exception in <{}>", t, e))

--- a/graylog2-server/src/test/java/org/graylog2/system/shutdown/GracefulShutdownServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/system/shutdown/GracefulShutdownServiceTest.java
@@ -16,9 +16,12 @@
  */
 package org.graylog2.system.shutdown;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -29,7 +32,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class GracefulShutdownServiceTest {
     private GracefulShutdownService shutdownService;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         this.shutdownService = new GracefulShutdownService();
         shutdownService.startAsync().awaitRunning();
@@ -123,7 +126,7 @@ public class GracefulShutdownServiceTest {
     }
 
     @Test
-    public void failRegisterAndUnregisterDuringShutdown() throws Exception {
+    public void failRegisterAndUnregisterDuringShutdown() {
         final GracefulShutdownHook hook = () -> {};
 
         shutdownService.register(hook);
@@ -137,5 +140,43 @@ public class GracefulShutdownServiceTest {
         assertThatThrownBy(() -> shutdownService.unregister(hook), "unregister during shutdown should not work")
                 .hasMessageContaining("unregister")
                 .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    @Timeout(1)
+    public void registerMany() throws Exception {
+
+        final int numberOfHooks = 20;
+        final AtomicInteger hooksStarted = new AtomicInteger(0);
+        final AtomicInteger hooksFinished = new AtomicInteger(0);
+        final AtomicInteger maxConcurrency = new AtomicInteger(0);
+
+        final CountDownLatch countDownLatch = new CountDownLatch(1);
+
+        for (int i = 0; i < numberOfHooks; i++) {
+            shutdownService.register(() -> {
+                hooksStarted.incrementAndGet();
+                countDownLatch.await();
+                maxConcurrency.getAndAccumulate(hooksStarted.get() - hooksFinished.get(), Math::max);
+                hooksFinished.incrementAndGet();
+            });
+        }
+
+        shutdownService.stopAsync();
+
+        // Wait until 10 hooks are being actively executed.
+        // This should not lead to other hooks being skipped, which was a bug.
+        Awaitility.await()
+                .pollInterval(10, TimeUnit.MILLISECONDS)
+                .atMost(100, TimeUnit.MILLISECONDS)
+                .until(() -> hooksStarted.get() >= 10);
+
+        countDownLatch.countDown();
+
+        shutdownService.awaitTerminated(200, TimeUnit.MILLISECONDS);
+
+        assertThat(hooksStarted.get()).isEqualTo(numberOfHooks);
+        assertThat(hooksFinished.get()).isEqualTo(numberOfHooks);
+        assertThat(maxConcurrency.get()).isEqualTo(10);
     }
 }


### PR DESCRIPTION
The GracefulShutdownService used a SynchronousQueue with a fixed capacity. If all threads were busy, the executor would reject additional tasks.

We fix this by using an unbounded blocking queue for the executor. We still limit the number of concurrently run hooks but allow additional hooks to be queued for execution.

To reproduce the problem, assign > 10 outputs to an active stream and then shut down the server. Before aplpying the fix, you should see a `RejectedExecutionException` in the server log. After applying the fix, shutdown should proceed as planned.