### PR TITLE
Trigger refetching fields on search refresh.

### DIFF
--- a/changelog/unreleased/pr-14171.toml
+++ b/changelog/unreleased/pr-14171.toml
@@ -1,0 +1,4 @@
+type = "fixed"
+message = "Triggering field types refetching upon search refresh."
+
+pulls = ["14171"]

--- a/graylog2-web-interface/src/pages/ShowMessagePage.test.tsx
+++ b/graylog2-web-interface/src/pages/ShowMessagePage.test.tsx
@@ -73,7 +73,7 @@ const SimpleShowMessagePage = ({ index, messageId }: SimpleShowMessagePageProps)
 describe('ShowMessagePage', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    asMock(useFieldTypes).mockReturnValue({ data: [] });
+    asMock(useFieldTypes).mockReturnValue({ data: [], refetch: () => {} });
   });
 
   it('triggers a node list refresh on mount', async () => {

--- a/graylog2-web-interface/src/views/components/contexts/DefaultFieldTypesProvider.test.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/DefaultFieldTypesProvider.test.tsx
@@ -30,6 +30,8 @@ import DefaultFieldTypesProvider from './DefaultFieldTypesProvider';
 jest.mock('views/logic/queries/useCurrentQuery');
 jest.mock('views/logic/fieldtypes/useFieldTypes', () => jest.fn());
 
+const refetch = () => {};
+
 describe('DefaultFieldTypesProvider', () => {
   const renderSUT = () => {
     const consume = jest.fn();
@@ -47,7 +49,7 @@ describe('DefaultFieldTypesProvider', () => {
 
   it('provides no field types with empty store', () => {
     asMock(useCurrentQuery).mockReturnValue(Query.builder().id('foobar').build());
-    asMock(useFieldTypes).mockReturnValue({ data: undefined });
+    asMock(useFieldTypes).mockReturnValue({ data: undefined, refetch });
 
     const consume = renderSUT();
 
@@ -61,8 +63,8 @@ describe('DefaultFieldTypesProvider', () => {
       .build());
 
     asMock(useFieldTypes).mockImplementation((streams) => (streams.length === 0
-      ? { data: simpleFields().toArray() }
-      : { data: simpleQueryFields('foo').get('foo').toArray() }));
+      ? { data: simpleFields().toArray(), refetch }
+      : { data: simpleQueryFields('foo').get('foo').toArray(), refetch }));
 
     const consume = renderSUT();
 

--- a/graylog2-web-interface/src/views/components/contexts/DefaultFieldTypesProvider.test.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/DefaultFieldTypesProvider.test.tsx
@@ -15,7 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { render } from 'wrappedTestingLibrary';
+import { render, waitFor } from 'wrappedTestingLibrary';
 import * as Immutable from 'immutable';
 
 import asMock from 'helpers/mocking/AsMock';
@@ -23,6 +23,7 @@ import { simpleFields, simpleQueryFields } from 'fixtures/fields';
 import useCurrentQuery from 'views/logic/queries/useCurrentQuery';
 import Query, { filtersForQuery } from 'views/logic/queries/Query';
 import useFieldTypes from 'views/logic/fieldtypes/useFieldTypes';
+import SearchActions from 'views/actions/SearchActions';
 
 import FieldTypesContext from './FieldTypesContext';
 import DefaultFieldTypesProvider from './DefaultFieldTypesProvider';
@@ -71,5 +72,22 @@ describe('DefaultFieldTypesProvider', () => {
     const fieldTypes = { all: simpleFields(), queryFields: simpleQueryFields('queryId') };
 
     expect(consume).toHaveBeenCalledWith(fieldTypes);
+  });
+
+  it('refetches field types upon search refresh', async () => {
+    asMock(useCurrentQuery).mockReturnValue(Query.builder().id('foobar').build());
+    const refetchMock = jest.fn();
+
+    asMock(useFieldTypes).mockImplementation((streams) => (streams.length === 0
+      ? { data: simpleFields().toArray(), refetch: refetchMock }
+      : { data: simpleQueryFields('foo').get('foo').toArray(), refetch: refetchMock }));
+
+    renderSUT();
+
+    SearchActions.refresh();
+
+    await waitFor(() => {
+      expect(refetchMock).toHaveBeenCalledTimes(2);
+    });
   });
 });

--- a/graylog2-web-interface/src/views/components/contexts/DefaultFieldTypesProvider.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/DefaultFieldTypesProvider.tsx
@@ -23,9 +23,9 @@ import useFieldTypes from 'views/logic/fieldtypes/useFieldTypes';
 import { filtersToStreamSet } from 'views/logic/queries/Query';
 import type { RelativeTimeRange } from 'views/logic/queries/Query';
 import useCurrentQuery from 'views/logic/queries/useCurrentQuery';
+import SearchActions from 'views/actions/SearchActions';
 
 import FieldTypesContext from './FieldTypesContext';
-import SearchActions from 'views/actions/SearchActions';
 
 const defaultId = '';
 const defaultTimeRange: RelativeTimeRange = { type: 'relative', from: 300 };

--- a/graylog2-web-interface/src/views/components/contexts/DefaultFieldTypesProvider.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/DefaultFieldTypesProvider.tsx
@@ -15,7 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import * as Immutable from 'immutable';
 import PropTypes from 'prop-types';
 
@@ -25,6 +25,7 @@ import type { RelativeTimeRange } from 'views/logic/queries/Query';
 import useCurrentQuery from 'views/logic/queries/useCurrentQuery';
 
 import FieldTypesContext from './FieldTypesContext';
+import SearchActions from 'views/actions/SearchActions';
 
 const defaultId = '';
 const defaultTimeRange: RelativeTimeRange = { type: 'relative', from: 300 };
@@ -32,11 +33,18 @@ const defaultTimeRange: RelativeTimeRange = { type: 'relative', from: 300 };
 const DefaultFieldTypesProvider = ({ children }: { children: React.ReactElement }) => {
   const currentQuery = useCurrentQuery();
   const currentStreams = useMemo(() => filtersToStreamSet(currentQuery?.filter).toArray(), [currentQuery?.filter]);
-  const { data: currentFieldTypes } = useFieldTypes(currentStreams, currentQuery?.timerange || defaultTimeRange);
-  const { data: allFieldTypes } = useFieldTypes([], currentQuery?.timerange || defaultTimeRange);
+  const { data: currentFieldTypes, refetch: refreshCurrentTypes } = useFieldTypes(currentStreams, currentQuery?.timerange || defaultTimeRange);
+  const { data: allFieldTypes, refetch: refreshAllTypes } = useFieldTypes([], currentQuery?.timerange || defaultTimeRange);
   const queryFields = useMemo(() => Immutable.Map({ [currentQuery?.id || defaultId]: Immutable.List(currentFieldTypes) }), [currentFieldTypes, currentQuery?.id]);
   const all = useMemo(() => Immutable.List(allFieldTypes ?? []), [allFieldTypes]);
   const fieldTypes = useMemo(() => ({ all, queryFields }), [all, queryFields]);
+
+  useEffect(() => {
+    return SearchActions.refresh.listen(() => {
+      refreshCurrentTypes();
+      refreshAllTypes();
+    });
+  }, [refreshAllTypes, refreshCurrentTypes]);
 
   return (
     <FieldTypesContext.Provider value={fieldTypes}>

--- a/graylog2-web-interface/src/views/logic/fieldtypes/useFieldTypes.ts
+++ b/graylog2-web-interface/src/views/logic/fieldtypes/useFieldTypes.ts
@@ -24,6 +24,7 @@ import type { FieldTypeMappingJSON } from 'views/logic/fieldtypes/FieldTypeMappi
 import FieldTypeMapping from 'views/logic/fieldtypes/FieldTypeMapping';
 import { adjustFormat, toUTCFromTz } from 'util/DateTime';
 import useUserDateTime from 'hooks/useUserDateTime';
+import { singleton } from 'logic/singleton';
 
 const fieldTypesUrl = qualifyUrl('/views/fields');
 
@@ -50,7 +51,9 @@ const createFieldTypeRequest = (streams: Array<string>, timerange: TimeRange): F
   return request;
 };
 
-const fetchAllFieldTypes = (streams: Array<string>, timerange: TimeRange): Promise<Array<FieldTypeMapping>> => fetch('POST', fieldTypesUrl, createFieldTypeRequest(streams, timerange))
+const fetchAllFieldTypes = (streams: Array<string>, timerange: TimeRange): Promise<Array<FieldTypeMapping>> => fetch(
+  'POST', fieldTypesUrl, createFieldTypeRequest(streams, timerange),
+)
   .then(_deserializeFieldTypes);
 
 const normalizeTimeRange = (timerange: TimeRange, userTz: string): TimeRange => {
@@ -66,7 +69,7 @@ const normalizeTimeRange = (timerange: TimeRange, userTz: string): TimeRange => 
   }
 };
 
-const useFieldTypes = (streams: Array<string>, timerange: TimeRange): { data: FieldTypeMapping[] } => {
+const useFieldTypes = (streams: Array<string>, timerange: TimeRange): { data: FieldTypeMapping[], refetch: () => void } => {
   const { userTimezone } = useUserDateTime();
   const _timerange = useMemo(() => normalizeTimeRange(timerange, userTimezone), [timerange, userTimezone]);
 
@@ -77,4 +80,4 @@ const useFieldTypes = (streams: Array<string>, timerange: TimeRange): { data: Fi
   );
 };
 
-export default useFieldTypes;
+export default singleton('hooks.useFieldTypes', () => useFieldTypes);


### PR DESCRIPTION
**Note:** This needs a backport to `4.3` and `5.0`.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This change is reimplementing a missing refetching of field types when the search is refreshed. This helps users to synchronize the field types they see in the UI while new fields are being ingested.

Refs #13279.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.