### PR TITLE
Sorting of messages in Scripting API

### DIFF
--- a/full-backend-tests/src/test/java/org/graylog/plugins/views/ScriptingApiResourceIT.java
+++ b/full-backend-tests/src/test/java/org/graylog/plugins/views/ScriptingApiResourceIT.java
@@ -638,6 +638,52 @@ public class ScriptingApiResourceIT {
     }
 
     @ContainerMatrixTest
+    void testMessagesWithSorting() {
+        ValidatableResponse validatableResponse = given()
+                .spec(requestSpec)
+                .when()
+                .body("""
+                        {
+                          "fields": ["source", "facility", "level"],
+                          "sort": "level",
+                          "sort_order" : "Descending"
+                        }
+                        """)
+                .post("/search/messages")
+                .then()
+                .log().ifStatusCodeMatches(not(200))
+                .statusCode(200);
+
+        List<List<Object>> rows = validatableResponse.extract().body().jsonPath().getList("datarows");
+        Assertions.assertEquals(rows.size(), 3);
+        assertThat(rows.get(0)).contains(3);
+        assertThat(rows.get(1)).contains(2);
+        assertThat(rows.get(2)).contains(1);
+
+        validatableResponse = given()
+                .spec(requestSpec)
+                .when()
+                .body("""
+                        {
+                          "fields": ["source", "facility", "level"],
+                          "sort": "facility",
+                          "sort_order" : "Ascending"
+                        }
+                        """)
+                .post("/search/messages")
+                .then()
+                .log().ifStatusCodeMatches(not(200))
+                .statusCode(200);
+
+        rows = validatableResponse.extract().body().jsonPath().getList("datarows");
+        Assertions.assertEquals(rows.size(), 3);
+        assertThat(rows.get(0)).contains("another-test");
+        assertThat(rows.get(1)).contains("another-test");
+        assertThat(rows.get(2)).contains("test");
+
+    }
+
+    @ContainerMatrixTest
     void testMessagesGetRequestAscii() {
         final List<String> response = given()
                 .spec(requestSpec)

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/scriptingapi/ScriptingApiResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/scriptingapi/ScriptingApiResource.java
@@ -35,6 +35,7 @@ import org.graylog.plugins.views.search.rest.scriptingapi.mapping.SearchRequestS
 import org.graylog.plugins.views.search.rest.scriptingapi.request.AggregationRequestSpec;
 import org.graylog.plugins.views.search.rest.scriptingapi.request.MessagesRequestSpec;
 import org.graylog.plugins.views.search.rest.scriptingapi.response.TabularResponse;
+import org.graylog.plugins.views.search.searchtypes.pivot.SortSpec;
 import org.graylog2.audit.jersey.NoAuditEvent;
 import org.graylog2.plugin.rest.PluginRestResource;
 import org.graylog2.shared.rest.resources.RestResource;
@@ -119,6 +120,8 @@ public class ScriptingApiResource extends RestResource implements PluginRestReso
                                         @ApiParam(name = "streams") @QueryParam("streams") Set<String> streams,
                                         @ApiParam(name = "timerange") @QueryParam("timerange") String timerangeKeyword,
                                         @ApiParam(name = "fields") @QueryParam("fields") List<String> fields,
+                                        @ApiParam(name = "sort") @QueryParam("sort") String sort,
+                                        @ApiParam(name = "sort") @QueryParam("sortOrder") SortSpec.Direction sortOrder,
                                         @ApiParam(name = "from") @QueryParam("from") int from,
                                         @ApiParam(name = "size") @QueryParam("size") int size,
                                         @Context SearchUser searchUser) {
@@ -128,6 +131,8 @@ public class ScriptingApiResource extends RestResource implements PluginRestReso
                     splitByComma(streams),
                     timerangeKeyword,
                     splitByComma(fields),
+                    sort,
+                    sortOrder,
                     from,
                     size);
             return executeQuery(messagesRequestSpec, searchUser);

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/scriptingapi/mapping/QueryParamsToFullRequestSpecificationMapper.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/scriptingapi/mapping/QueryParamsToFullRequestSpecificationMapper.java
@@ -22,6 +22,7 @@ import org.graylog.plugins.views.search.rest.scriptingapi.request.AggregationReq
 import org.graylog.plugins.views.search.rest.scriptingapi.request.Grouping;
 import org.graylog.plugins.views.search.rest.scriptingapi.request.MessagesRequestSpec;
 import org.graylog.plugins.views.search.rest.scriptingapi.request.Metric;
+import org.graylog.plugins.views.search.searchtypes.pivot.SortSpec;
 
 import javax.inject.Inject;
 import java.util.List;
@@ -42,12 +43,16 @@ public class QueryParamsToFullRequestSpecificationMapper {
                                                                            final Set<String> streams,
                                                                            final String timerangeKeyword,
                                                                            final List<String> fields,
+                                                                           final String sort,
+                                                                           final SortSpec.Direction sortOrder,
                                                                            final int from,
                                                                            final int size) {
 
         return new MessagesRequestSpec(query,
                 streams,
                 timerangeParser.parseTimeRange(timerangeKeyword),
+                sort,
+                sortOrder,
                 from,
                 size,
                 fields);

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/scriptingapi/request/MessagesRequestSpec.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/scriptingapi/request/MessagesRequestSpec.java
@@ -21,6 +21,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Strings;
 import org.graylog.plugins.views.search.rest.scriptingapi.response.ResponseEntryDataType;
 import org.graylog.plugins.views.search.rest.scriptingapi.response.ResponseSchemaEntry;
+import org.graylog.plugins.views.search.searchtypes.pivot.SortSpec;
+import org.graylog2.plugin.Message;
 import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
 
 import java.util.List;
@@ -31,18 +33,28 @@ import java.util.stream.Collectors;
 public record MessagesRequestSpec(@JsonProperty("query") String queryString,
                                   @JsonProperty("streams") Set<String> streams,
                                   @JsonProperty("timerange") TimeRange timerange,
+                                  @JsonProperty("sort") String sort,
+                                  @JsonProperty("sort_order") SortSpec.Direction sortOrder,
                                   @JsonProperty("from") int from,
                                   @JsonProperty("size") int size,
                                   @JsonProperty("fields") List<String> fields) implements SearchRequestSpec {
 
 
     public static final List<String> DEFAULT_FIELDS = List.of("source", "timestamp");
+    public static final String DEFAULT_SORT = Message.FIELD_TIMESTAMP;
+    public static final SortSpec.Direction DEFAULT_SORT_ORDER = SortSpec.Direction.Descending;
     public static final int DEFAULT_SIZE = 10;
     public static final int DEFAULT_FROM = 0;
 
     public MessagesRequestSpec {
         if (Strings.isNullOrEmpty(queryString)) {
             queryString = DEFAULT_QUERY_STRING;
+        }
+        if (Strings.isNullOrEmpty(sort)) {
+            sort = DEFAULT_SORT;
+        }
+        if (sortOrder == null) {
+            sortOrder = DEFAULT_SORT_ORDER;
         }
         if (timerange == null) {
             timerange = DEFAULT_TIMERANGE;

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/SortSpec.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/SortSpec.java
@@ -17,9 +17,11 @@
 package org.graylog.plugins.views.search.searchtypes.pivot;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import org.apache.commons.lang3.StringUtils;
+import org.graylog.plugins.views.search.searchtypes.Sort;
 
 import java.util.Locale;
 
@@ -30,8 +32,15 @@ import java.util.Locale;
         visible = true)
 public interface SortSpec {
     enum Direction {
-        Ascending,
-        Descending;
+        Ascending(Sort.Order.ASC),
+        Descending(Sort.Order.DESC);
+
+        @JsonIgnore
+        private Sort.Order sortOrder;
+
+        Direction(Sort.Order sortOrder) {
+            this.sortOrder = sortOrder;
+        }
 
         @JsonCreator
         public static Direction deserialize(String value) {
@@ -44,6 +53,11 @@ public interface SortSpec {
                 case "ascending", "asc" -> Ascending;
                 default -> throw new IllegalArgumentException("Failed to parse sort direction:" + value);
             };
+        }
+
+        @JsonIgnore
+        public Sort.Order toSortOrder() {
+            return this.sortOrder;
         }
     }
 

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/scriptingapi/mapping/QueryParamsToFullRequestSpecificationMapperTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/scriptingapi/mapping/QueryParamsToFullRequestSpecificationMapperTest.java
@@ -19,6 +19,7 @@ package org.graylog.plugins.views.search.rest.scriptingapi.mapping;
 import org.graylog.plugins.views.search.rest.scriptingapi.parsing.TimerangeParser;
 import org.graylog.plugins.views.search.rest.scriptingapi.request.AggregationRequestSpec;
 import org.graylog.plugins.views.search.rest.scriptingapi.request.Grouping;
+import org.graylog.plugins.views.search.rest.scriptingapi.request.MessagesRequestSpec;
 import org.graylog.plugins.views.search.rest.scriptingapi.request.Metric;
 import org.graylog2.plugin.indexer.searches.timeranges.KeywordRange;
 import org.junit.jupiter.api.BeforeEach;
@@ -32,6 +33,9 @@ import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.graylog.plugins.views.search.rest.scriptingapi.request.AggregationRequestSpec.DEFAULT_TIMERANGE;
+import static org.graylog.plugins.views.search.rest.scriptingapi.request.MessagesRequestSpec.DEFAULT_FIELDS;
+import static org.graylog.plugins.views.search.rest.scriptingapi.request.MessagesRequestSpec.DEFAULT_SORT;
+import static org.graylog.plugins.views.search.rest.scriptingapi.request.MessagesRequestSpec.DEFAULT_SORT_ORDER;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.doReturn;
 
@@ -105,6 +109,21 @@ class QueryParamsToFullRequestSpecificationMapperTest {
                         DEFAULT_TIMERANGE,
                         List.of(new Grouping("http_method")),
                         List.of(new Metric("count", null))
+
+                )
+        );
+
+        final MessagesRequestSpec messagesRequestSpec = toTest.simpleQueryParamsToFullRequestSpecification(null, null, null, null, null, null, 0, 10);
+        assertThat(messagesRequestSpec).isEqualTo(new MessagesRequestSpec(
+                        "*",
+                        Set.of(),
+                        DEFAULT_TIMERANGE,
+                        DEFAULT_SORT,
+                        DEFAULT_SORT_ORDER,
+                        0,
+                        10,
+                        DEFAULT_FIELDS
+
 
                 )
         );

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/scriptingapi/request/MessagesRequestSpecTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/scriptingapi/request/MessagesRequestSpecTest.java
@@ -37,7 +37,7 @@ class MessagesRequestSpecTest {
         );
 
         final List<String> specifiedFields = List.of("age", "salary", "position", "nvmd");
-        final List<ResponseSchemaEntry> schema = new MessagesRequestSpec("", Set.of(), null, 0, 1, specifiedFields)
+        final List<ResponseSchemaEntry> schema = new MessagesRequestSpec("", Set.of(), null, "age", null, 0, 1, specifiedFields)
                 .getSchema(fieldTypes);
 
         assertThat(schema).containsAll(

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/scriptingapi/validation/MetricValidatorTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/scriptingapi/validation/MetricValidatorTest.java
@@ -28,7 +28,7 @@ import java.util.Map;
 
 import static org.junit.Assert.assertThrows;
 
-class MetricValidatiorTest {
+class MetricValidatorTest {
 
     private MetricValidator toTest;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Messages endpoint of Scripting API was missing sorting functionality. It has been added.
If no sorting provided, or raw "timestamp" sorting is used, the sorting will automatically switch to "timestamp + gl2_message_id" approach, introduced by @mpfz0r 

/nocl

## How Has This Been Tested?
With new tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

