### PR TITLE
Start global JSON path input on leader node only

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -4,3 +4,9 @@ Upgrading to Graylog 5.1.x
 ## New Functionality
 
 ## Breaking Changes
+
+## Behaviour Changes
+
+The `JSON path value from HTTP API` input will now only run on the leader node,
+if the `Global` option has been selected in the input configuration.
+Previously, the input was started on all nodes in the cluster.

--- a/changelog/unreleased/issue-14074.toml
+++ b/changelog/unreleased/issue-14074.toml
@@ -1,0 +1,4 @@
+type = "changed"
+message = "Start `JSON path value from HTTP API` input on leader node only, if `Global` option was selected in input configuration."
+
+issues = ["14074"]

--- a/graylog2-server/src/main/java/org/graylog2/inputs/misc/jsonpath/JsonPathInput.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/misc/jsonpath/JsonPathInput.java
@@ -68,4 +68,9 @@ public class JsonPathInput extends MessageInput {
             super(transport.getConfig(), codec.getConfig());
         }
     }
+
+    @Override
+    public boolean onlyOnePerCluster() {
+        return true;
+    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The `JSON path value from HTTP API` input will now only run on the leader node,
if the `Global` option has been selected in the input configuration.
Previously, the input was started on all nodes in the cluster.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #14074 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Smoke test in a two-node cluster

