### PR TITLE
Query suggestions use filter instead of must, should speed up responses

### DIFF
--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/QuerySuggestionsES7.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/QuerySuggestionsES7.java
@@ -58,8 +58,8 @@ public class QuerySuggestionsES7 implements QuerySuggestionsService {
         final Set<String> affectedIndices = indexLookup.indexNamesForStreamsInTimeRange(req.streams(), req.timerange());
         final TermSuggestionBuilder suggestionBuilder = SuggestBuilders.termSuggestion(req.field()).text(req.input()).size(req.size());
         final BoolQueryBuilder query = QueryBuilders.boolQuery()
-                .must(QueryBuilders.termsQuery(Message.FIELD_STREAMS, req.streams()))
-                .must(QueryBuilders.prefixQuery(req.field(), req.input()));
+                .filter(QueryBuilders.termsQuery(Message.FIELD_STREAMS, req.streams()))
+                .filter(QueryBuilders.prefixQuery(req.field(), req.input()));
         final SearchSourceBuilder search = new SearchSourceBuilder()
                 .query(query)
                 .size(0)

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/QuerySuggestionsOS2.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/QuerySuggestionsOS2.java
@@ -58,8 +58,8 @@ public class QuerySuggestionsOS2 implements QuerySuggestionsService {
         final Set<String> affectedIndices = indexLookup.indexNamesForStreamsInTimeRange(req.streams(), req.timerange());
         final TermSuggestionBuilder suggestionBuilder = SuggestBuilders.termSuggestion(req.field()).text(req.input()).size(req.size());
         final BoolQueryBuilder query = QueryBuilders.boolQuery()
-                .must(QueryBuilders.termsQuery(Message.FIELD_STREAMS, req.streams()))
-                .must(QueryBuilders.prefixQuery(req.field(), req.input()));
+                .filter(QueryBuilders.termsQuery(Message.FIELD_STREAMS, req.streams()))
+                .filter(QueryBuilders.prefixQuery(req.field(), req.input()));
         final SearchSourceBuilder search = new SearchSourceBuilder()
                 .query(query)
                 .size(0)


### PR DESCRIPTION
Filter should be in theory faster than must clause, we don't care about scoring as we are running an aggregation anyway.

## How Has This Been Tested?
Existing set of integration tests

/nocl

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

