### PR TITLE
Use PKCS5 instead of ISO10126 padding for secrets encryption (4.3 backport)

### DIFF
--- a/changelog/unreleased/issue-14153.toml
+++ b/changelog/unreleased/issue-14153.toml
@@ -1,0 +1,8 @@
+type = "fixed"
+message = "Improve JVM security provider compatibility by switching to a widely supported cipher transformation"
+
+issues = ["14153"]
+pulls = ["14193"]
+
+contributors = [""]
+

--- a/graylog2-server/src/test/java/org/graylog2/security/AESToolsTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/security/AESToolsTest.java
@@ -39,13 +39,38 @@ public class AESToolsTest {
     }
 
     @Test
-    public void testDecryptStaticCipherText() {
-        // The cipherText was encrypted using an AES/CBC/ISO10126Padding transformation.
+    public void testDecryptStaticISO10126PaddedCipherText() {
+        // The cipherText was encrypted using the legacy AES/CBC/ISO10126Padding transformation.
         // If this test fails, we changed the transformation. If the change was intentional, this test must
         // be updated, and we need to create a migration to re-encrypt all existing secrets in the database.
         // Otherwise, existing secrets cannot be decrypted anymore!
         final String cipherText = "374219db59516b706234a60dd9a7e1e2";
         final String salt = "53569ac046df1097";
+
+        final String decrypt = AESTools.decrypt(cipherText, "1234567890123456", salt);
+        Assert.assertEquals("I am secret", decrypt);
+    }
+    @Test
+    public void testDecryptStaticISO10126PaddedLongCipherText() {
+        // The cipherText was encrypted using the legacy AES/CBC/ISO10126Padding transformation.
+        // If this test fails, we changed the transformation. If the change was intentional, this test must
+        // be updated, and we need to create a migration to re-encrypt all existing secrets in the database.
+        // Otherwise, existing secrets cannot be decrypted anymore!
+        final String cipherText = "d8d9ade5456543950e7ff7441b7157ed71564f5b7d656098a8ec87c074ed2d333a797711e06817135ef6d7cfce0a2eb6";
+        final String salt = "17c4bd3761b530f7";
+
+        final String decrypt = AESTools.decrypt(cipherText, "1234567890123456", salt);
+        Assert.assertEquals("I am a very very very long secret", decrypt);
+    }
+
+    @Test
+    public void testDecryptStaticPKCS5PaddedCipherText() {
+        // The cipherText was encrypted using an AES/CBC/PKCS5Padding transformation.
+        // If this test fails, we changed the transformation. If the change was intentional, this test must
+        // be updated, and we need to create a migration to re-encrypt all existing secrets in the database.
+        // Otherwise, existing secrets cannot be decrypted anymore!
+        final String cipherText = "f0b3e951a4b4537e1466a9cd9621eabb";
+        final String salt = "612ac41505dc0120";
 
         final String decrypt = AESTools.decrypt(cipherText, "1234567890123456", salt);
         Assert.assertEquals("I am secret", decrypt);


### PR DESCRIPTION
If Graylog is run in an FIPS environment there is no crypto provider available that supports "AES/CBC/ISO10126Padding". This is likely because this padding standard was withdrawn from ISO in 2007.
It is considered bad practice to leave a subliminal channel in the padding.

We tried to workaround this by explicitly using BouncyCastle for the encryption/decryption.

This however creates problems with Oracle Java, because we strip the signature off the bouncy castle jar while repackaging it into our Uber-Jar.
In contrast to OpenJDK, Oracle Java does not allow the use of unsigned Security Providers.

Solution:

Change our secret encryption to using PKCS5Padding instead. There is a FIPS compatible provider "SunPKCS11-NSS-FIPS" available which supports "AES/CBC/PKCS5Padding".

For backwards compatibility, we decrypt the ISO10126Padded keys without stripping the padding, and do that manually.

Fixes #14153

Refs #13525

use explicit type to simplify backport

Also try legacy decoding when catching a ProviderException

This seems to happen with FIPS enabled OpenJDK 17

Try decrypting legacy keys on any Exception

improve wording on comments

improve changelog
