### PR TITLE
Disable GracefulShutdownService test which is flaky on Jenkins

### DIFF
--- a/graylog2-server/src/test/java/org/graylog2/system/shutdown/GracefulShutdownServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/system/shutdown/GracefulShutdownServiceTest.java
@@ -18,9 +18,9 @@ package org.graylog2.system.shutdown;
 
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -143,7 +143,7 @@ public class GracefulShutdownServiceTest {
                 .isInstanceOf(IllegalStateException.class);
     }
 
-    @Disabled("Disabled because it is flaky on Jenkins. Could maybe be fixed by adjusting timeouts.")
+    @DisabledIfEnvironmentVariable(named = "CI", matches = "true", disabledReason = "Flaky on Jenkins")
     @Test
     @Timeout(1)
     public void registerMany() throws Exception {

--- a/graylog2-server/src/test/java/org/graylog2/system/shutdown/GracefulShutdownServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/system/shutdown/GracefulShutdownServiceTest.java
@@ -18,6 +18,7 @@ package org.graylog2.system.shutdown;
 
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
@@ -142,6 +143,7 @@ public class GracefulShutdownServiceTest {
                 .isInstanceOf(IllegalStateException.class);
     }
 
+    @Disabled("Disabled because it is flaky on Jenkins. Could maybe be fixed by adjusting timeouts.")
     @Test
     @Timeout(1)
     public void registerMany() throws Exception {


### PR DESCRIPTION
It's not a critical test so I think it's OK to disable it.
Could probably be fixed by adjusting the timeouts but that would potentially increase test runtime even more and is also guesswork.

/nocl