### PR TITLE
Support providing custom commands for query input component.

### DIFF
--- a/changelog/unreleased/pr-14239.toml
+++ b/changelog/unreleased/pr-14239.toml
@@ -1,0 +1,17 @@
+type = "added"
+message = "Providing plugin API to supply custom query input commands."
+
+pulls = ["14239"]
+
+details.user = """
+A new frontend plugin API is provided that allows plugins to contribute custom commands to the query input. It allows to
+provide two different entities:
+
+  - a command definition (`views.queryInput.commands`) specifying a usage scope, name, mac/windows key bindings as well
+    as a function that is being executed, which gets an `Editor` instance as well as a `CustomCommandContext` object
+  - a context provider (`views.queryInput.commandContextProviders`) which allows a plugin to extend the `CustomCommandContext`
+    object which is supplied
+
+Part of the context is the `usage`, which specifies the scope the query input is currently running in. It can be one of
+`'search_query' | 'widget_query' | 'global_override_query'` currently.
+"""

--- a/graylog2-web-interface/src/views/components/DashboardSearchBar.tsx
+++ b/graylog2-web-interface/src/views/components/DashboardSearchBar.tsx
@@ -54,7 +54,7 @@ import {
   SearchButtonAndQuery,
   SearchInputAndValidationContainer,
 } from 'views/components/searchbar/SearchBarLayout';
-import usePluggableCommands from 'views/components/searchbar/queryinput/usePluggableCommands';
+import PluggableCommands from 'views/components/searchbar/queryinput/PluggableCommands';
 
 import TimeRangeInput from './searchbar/TimeRangeInput';
 import type { DashboardFormValues } from './DashboardSearchBarForm';
@@ -117,8 +117,6 @@ const DashboardSearchBar = () => {
   const { parameters } = useParameters();
   const initialValues = useInitialFormValues(timerange, queryString);
 
-  const customCommands = usePluggableCommands('global_override_query');
-
   if (!config) {
     return <Spinner />;
   }
@@ -160,18 +158,22 @@ const DashboardSearchBar = () => {
                             {({ field: { name, value, onChange }, meta: { error } }) => (
                               <FormWarningsContext.Consumer>
                                 {({ warnings }) => (
-                                  <QueryInput value={value}
-                                              timeRange={values?.timerange}
-                                              placeholder="Apply filter to all widgets"
-                                              name={name}
-                                              onChange={onChange}
-                                              disableExecution={disableSearchSubmit}
-                                              error={error}
-                                              isValidating={isValidating}
-                                              validate={validateForm}
-                                              warning={warnings.queryString}
-                                              onExecute={handleSubmit as () => void}
-                                              commands={customCommands} />
+                                  <PluggableCommands usage="global_override_query">
+                                    {(customCommands) => (
+                                      <QueryInput value={value}
+                                                  timeRange={values?.timerange}
+                                                  placeholder="Apply filter to all widgets"
+                                                  name={name}
+                                                  onChange={onChange}
+                                                  disableExecution={disableSearchSubmit}
+                                                  error={error}
+                                                  isValidating={isValidating}
+                                                  validate={validateForm}
+                                                  warning={warnings.queryString}
+                                                  onExecute={handleSubmit as () => void}
+                                                  commands={customCommands} />
+                                    )}
+                                  </PluggableCommands>
                                 )}
                               </FormWarningsContext.Consumer>
                             )}

--- a/graylog2-web-interface/src/views/components/DashboardSearchBar.tsx
+++ b/graylog2-web-interface/src/views/components/DashboardSearchBar.tsx
@@ -54,6 +54,7 @@ import {
   SearchButtonAndQuery,
   SearchInputAndValidationContainer,
 } from 'views/components/searchbar/SearchBarLayout';
+import usePluggableCommands from 'views/components/searchbar/queryinput/usePluggableCommands';
 
 import TimeRangeInput from './searchbar/TimeRangeInput';
 import type { DashboardFormValues } from './DashboardSearchBarForm';
@@ -116,6 +117,8 @@ const DashboardSearchBar = () => {
   const { parameters } = useParameters();
   const initialValues = useInitialFormValues(timerange, queryString);
 
+  const customCommands = usePluggableCommands('global_override_query');
+
   if (!config) {
     return <Spinner />;
   }
@@ -167,7 +170,8 @@ const DashboardSearchBar = () => {
                                               isValidating={isValidating}
                                               validate={validateForm}
                                               warning={warnings.queryString}
-                                              onExecute={handleSubmit as () => void} />
+                                              onExecute={handleSubmit as () => void}
+                                              commands={customCommands} />
                                 )}
                               </FormWarningsContext.Consumer>
                             )}

--- a/graylog2-web-interface/src/views/components/SearchBar.tsx
+++ b/graylog2-web-interface/src/views/components/SearchBar.tsx
@@ -61,7 +61,7 @@ import {
   SearchButtonAndQuery,
   SearchInputAndValidationContainer,
 } from 'views/components/searchbar/SearchBarLayout';
-import usePluggableCommands from 'views/components/searchbar/queryinput/usePluggableCommands';
+import PluggableCommands from 'views/components/searchbar/queryinput/PluggableCommands';
 
 import SearchBarForm from './searchbar/SearchBarForm';
 
@@ -140,7 +140,6 @@ const SearchBar = ({
   const pluggableSearchBarControls = usePluginEntities('views.components.searchBar');
   const initialValues = useInitialFormValues({ queryFilters, currentQuery });
   const _onSubmit = useCallback((values: SearchBarFormValues) => onSubmit(values, pluggableSearchBarControls, currentQuery), [currentQuery, onSubmit, pluggableSearchBarControls]);
-  const customCommands = usePluggableCommands('search_query');
 
   if (!currentQuery || !config) {
     return <Spinner />;
@@ -198,19 +197,23 @@ const SearchBar = ({
                               {({ field: { name, value, onChange }, meta: { error } }) => (
                                 <FormWarningsContext.Consumer>
                                   {({ warnings }) => (
-                                    <QueryInput value={value}
-                                                timeRange={values.timerange}
-                                                streams={values.streams}
-                                                name={name}
-                                                onChange={onChange}
-                                                placeholder='Type your search query here and press enter. E.g.: ("not found" AND http) OR http_response_code:[400 TO 404]'
-                                                error={error}
-                                                isValidating={isValidating}
-                                                warning={warnings.queryString}
-                                                disableExecution={disableSearchSubmit}
-                                                validate={validateForm}
-                                                onExecute={handleSubmit as () => void}
-                                                commands={customCommands} />
+                                    <PluggableCommands usage="search_query">
+                                      {(customCommands) => (
+                                        <QueryInput value={value}
+                                                    timeRange={values.timerange}
+                                                    streams={values.streams}
+                                                    name={name}
+                                                    onChange={onChange}
+                                                    placeholder='Type your search query here and press enter. E.g.: ("not found" AND http) OR http_response_code:[400 TO 404]'
+                                                    error={error}
+                                                    isValidating={isValidating}
+                                                    warning={warnings.queryString}
+                                                    disableExecution={disableSearchSubmit}
+                                                    validate={validateForm}
+                                                    onExecute={handleSubmit as () => void}
+                                                    commands={customCommands} />
+                                      )}
+                                    </PluggableCommands>
                                   )}
                                 </FormWarningsContext.Consumer>
                               )}

--- a/graylog2-web-interface/src/views/components/SearchBar.tsx
+++ b/graylog2-web-interface/src/views/components/SearchBar.tsx
@@ -61,6 +61,7 @@ import {
   SearchButtonAndQuery,
   SearchInputAndValidationContainer,
 } from 'views/components/searchbar/SearchBarLayout';
+import usePluggableCommands from 'views/components/searchbar/queryinput/usePluggableCommands';
 
 import SearchBarForm from './searchbar/SearchBarForm';
 
@@ -139,6 +140,7 @@ const SearchBar = ({
   const pluggableSearchBarControls = usePluginEntities('views.components.searchBar');
   const initialValues = useInitialFormValues({ queryFilters, currentQuery });
   const _onSubmit = useCallback((values: SearchBarFormValues) => onSubmit(values, pluggableSearchBarControls, currentQuery), [currentQuery, onSubmit, pluggableSearchBarControls]);
+  const customCommands = usePluggableCommands('search_query');
 
   if (!currentQuery || !config) {
     return <Spinner />;
@@ -207,7 +209,8 @@ const SearchBar = ({
                                                 warning={warnings.queryString}
                                                 disableExecution={disableSearchSubmit}
                                                 validate={validateForm}
-                                                onExecute={handleSubmit as () => void} />
+                                                onExecute={handleSubmit as () => void}
+                                                commands={customCommands} />
                                   )}
                                 </FormWarningsContext.Consumer>
                               )}

--- a/graylog2-web-interface/src/views/components/WidgetQueryControls.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetQueryControls.tsx
@@ -56,7 +56,7 @@ import {
   TimeRangeRow,
   SearchQueryRow,
 } from 'views/components/searchbar/SearchBarLayout';
-import usePluggableCommands from 'views/components/searchbar/queryinput/usePluggableCommands';
+import PluggableCommands from 'views/components/searchbar/queryinput/PluggableCommands';
 
 import TimeRangeOverrideInfo from './searchbar/WidgetTimeRangeOverride';
 import TimeRangeInput from './searchbar/TimeRangeInput';
@@ -166,7 +166,6 @@ const WidgetQueryControls = ({ availableStreams, globalOverride }: Props) => {
   const validate = (values) => _validateQueryString(values, globalOverride, pluggableSearchBarControls, userTimezone);
   const initialValues = useInitialFormValues(widget);
   const _onSubmit = useCallback((values) => onSubmit(values, pluggableSearchBarControls, widget), [pluggableSearchBarControls, widget]);
-  const customCommands = usePluggableCommands('widget_query');
 
   useBindApplySearchControlsChanges(formRef);
 
@@ -217,19 +216,23 @@ const WidgetQueryControls = ({ availableStreams, globalOverride }: Props) => {
                     {({ field: { name, value, onChange }, meta: { error } }) => (
                       <FormWarningsContext.Consumer>
                         {({ warnings }) => (
-                          <QueryInput value={value}
-                                      timeRange={!isEmpty(globalOverride?.timerange) ? globalOverride.timerange : values?.timerange}
-                                      streams={values?.streams}
-                                      placeholder={'Type your search query here and press enter. E.g.: ("not found" AND http) OR http_response_code:[400 TO 404]'}
-                                      error={error}
-                                      disableExecution={disableSearchSubmit}
-                                      isValidating={isValidatingQuery}
-                                      warning={warnings.queryString}
-                                      validate={validateForm}
-                                      name={name}
-                                      onChange={onChange}
-                                      onExecute={handleSubmit as () => void}
-                                      commands={customCommands} />
+                          <PluggableCommands usage="widget_query">
+                            {(customCommands) => (
+                              <QueryInput value={value}
+                                          timeRange={!isEmpty(globalOverride?.timerange) ? globalOverride.timerange : values?.timerange}
+                                          streams={values?.streams}
+                                          placeholder={'Type your search query here and press enter. E.g.: ("not found" AND http) OR http_response_code:[400 TO 404]'}
+                                          error={error}
+                                          disableExecution={disableSearchSubmit}
+                                          isValidating={isValidatingQuery}
+                                          warning={warnings.queryString}
+                                          validate={validateForm}
+                                          name={name}
+                                          onChange={onChange}
+                                          onExecute={handleSubmit as () => void}
+                                          commands={customCommands} />
+                            )}
+                          </PluggableCommands>
                         )}
                       </FormWarningsContext.Consumer>
                     )}

--- a/graylog2-web-interface/src/views/components/WidgetQueryControls.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetQueryControls.tsx
@@ -56,6 +56,7 @@ import {
   TimeRangeRow,
   SearchQueryRow,
 } from 'views/components/searchbar/SearchBarLayout';
+import usePluggableCommands from 'views/components/searchbar/queryinput/usePluggableCommands';
 
 import TimeRangeOverrideInfo from './searchbar/WidgetTimeRangeOverride';
 import TimeRangeInput from './searchbar/TimeRangeInput';
@@ -165,6 +166,7 @@ const WidgetQueryControls = ({ availableStreams, globalOverride }: Props) => {
   const validate = (values) => _validateQueryString(values, globalOverride, pluggableSearchBarControls, userTimezone);
   const initialValues = useInitialFormValues(widget);
   const _onSubmit = useCallback((values) => onSubmit(values, pluggableSearchBarControls, widget), [pluggableSearchBarControls, widget]);
+  const customCommands = usePluggableCommands('widget_query');
 
   useBindApplySearchControlsChanges(formRef);
 
@@ -226,7 +228,8 @@ const WidgetQueryControls = ({ availableStreams, globalOverride }: Props) => {
                                       validate={validateForm}
                                       name={name}
                                       onChange={onChange}
-                                      onExecute={handleSubmit as () => void} />
+                                      onExecute={handleSubmit as () => void}
+                                      commands={customCommands} />
                         )}
                       </FormWarningsContext.Consumer>
                     )}

--- a/graylog2-web-interface/src/views/components/searchbar/queryinput/BasicQueryInput.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/queryinput/BasicQueryInput.tsx
@@ -52,7 +52,7 @@ const isDisabledInput = (props: Props): props is DisabledInputProps => props.dis
 
 const getMarkers = (errors: QueryValidationState | undefined, warnings: QueryValidationState | undefined) => {
   const markerClassName = 'ace_marker';
-  const createMarkers = (explanations = [], className = '') => explanations.map(({
+  const createMarkers = (explanations: QueryValidationState['explanations'] = [], className: string = '') => explanations.map(({
     beginLine,
     beginColumn,
     endLine,
@@ -74,7 +74,7 @@ const getMarkers = (errors: QueryValidationState | undefined, warnings: QueryVal
 
 // Basic query input component which is being implemented by the `QueryInput` component.
 // This is just a very basic query input which can be implemented for example to display a read only query.
-const BasicQueryInput = forwardRef<StyledAceEditor, Props>((props, ref) => {
+const BasicQueryInput = forwardRef<{ editor: Editor }, Props>((props, ref) => {
   const {
     className,
     disabled,

--- a/graylog2-web-interface/src/views/components/searchbar/queryinput/PluggableCommands.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/queryinput/PluggableCommands.test.tsx
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 import * as React from 'react';
 import { render } from 'wrappedTestingLibrary';
 import type { PluginExports } from 'graylog-web-plugin/plugin';

--- a/graylog2-web-interface/src/views/components/searchbar/queryinput/PluggableCommands.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/queryinput/PluggableCommands.test.tsx
@@ -1,0 +1,77 @@
+import * as React from 'react';
+import { render } from 'wrappedTestingLibrary';
+import type { PluginExports } from 'graylog-web-plugin/plugin';
+import { PluginManifest, PluginStore } from 'graylog-web-plugin/plugin';
+
+import PluggableCommands from './PluggableCommands';
+
+describe('PluggableCommands', () => {
+  const plugin: PluginExports = {
+    'views.queryInput.commands': [{
+      name: 'Testcommand',
+      bindKey: {
+        mac: 'Ctrl+Enter',
+        win: 'Ctrl+Enter',
+      },
+      usages: ['search_query'],
+      exec: (editor, context) => ({ editor, context }),
+    }],
+    'views.queryInput.commandContextProviders': [{
+      key: 'foo',
+      provider: () => 42,
+    }],
+  };
+
+  const manifest = new PluginManifest({}, plugin);
+
+  beforeEach(() => {
+    PluginStore.register(manifest);
+  });
+
+  afterEach(() => {
+    PluginStore.unregister(manifest);
+  });
+
+  it('retrieves commands from plugins for current scope', () => {
+    render((
+      <PluggableCommands usage="search_query">
+        {(commands) => {
+          expect(commands.length).not.toBe(0);
+
+          return null;
+        }}
+      </PluggableCommands>
+    ));
+  });
+
+  it('ignores commands from plugins for other scopes', () => {
+    render((
+      <PluggableCommands usage="global_override_query">
+        {(commands) => {
+          expect(commands.length).toBe(0);
+
+          return null;
+        }}
+      </PluggableCommands>
+    ));
+  });
+
+  it('extends context with values from providers', () => {
+    render((
+      <PluggableCommands usage="search_query">
+        {(commands) => {
+          const [command] = commands;
+          const inputEditor = {};
+
+          // @ts-ignore
+          const { editor, context } = command.exec(inputEditor);
+
+          expect(editor).toBe(inputEditor);
+          expect(context).toStrictEqual({ usage: 'search_query', foo: 42 });
+
+          return null;
+        }}
+      </PluggableCommands>
+    ));
+  });
+});

--- a/graylog2-web-interface/src/views/components/searchbar/queryinput/PluggableCommands.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/queryinput/PluggableCommands.tsx
@@ -1,0 +1,18 @@
+import { useMemo } from 'react';
+
+import usePluggableCommands from 'views/components/searchbar/queryinput/usePluggableCommands';
+import type { Command } from 'views/components/searchbar/queryinput/ace-types';
+import type { Usage } from 'views/components/searchbar/queryinput/types';
+
+type Props = {
+  children: (commands: Array<Command>) => React.ReactElement,
+  usage: Usage,
+}
+
+const PluggableCommands = ({ children, usage }: Props) => {
+  const customCommands = usePluggableCommands(usage);
+
+  return useMemo(() => children(customCommands), [children, customCommands]);
+};
+
+export default PluggableCommands;

--- a/graylog2-web-interface/src/views/components/searchbar/queryinput/PluggableCommands.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/queryinput/PluggableCommands.tsx
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 import { useMemo } from 'react';
 
 import usePluggableCommands from 'views/components/searchbar/queryinput/usePluggableCommands';

--- a/graylog2-web-interface/src/views/components/searchbar/queryinput/QueryInput.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/queryinput/QueryInput.test.tsx
@@ -15,7 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { render, screen } from 'wrappedTestingLibrary';
+import { render, screen, waitFor } from 'wrappedTestingLibrary';
 import userEvent from '@testing-library/user-event';
 
 import QueryValidationActions from 'views/actions/QueryValidationActions';
@@ -131,6 +131,30 @@ describe('QueryInput', () => {
       expect(QueryValidationActions.displayValidationErrors).toHaveBeenCalledTimes(1);
 
       expect(onExecute).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('supports custom commands', () => {
+    it('adds custom commands to ace', async () => {
+      const exec = jest.fn();
+      const commands = [{
+        name: 'TestCommand',
+        bindKey: {
+          mac: 'Ctrl+Enter',
+          win: 'Ctrl+Enter',
+        },
+        exec,
+      }];
+
+      render(<SimpleQueryInput commands={commands} />);
+
+      const queryInput = getQueryInput();
+      queryInput.focus();
+      userEvent.type(queryInput, '{ctrl}{enter}');
+
+      await waitFor(() => {
+        expect(exec).toHaveBeenCalled();
+      });
     });
   });
 });

--- a/graylog2-web-interface/src/views/components/searchbar/queryinput/QueryInput.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/queryinput/QueryInput.tsx
@@ -118,7 +118,7 @@ const _onLoadEditor = (editor, isInitialTokenizerUpdate: React.MutableRefObject<
 // This is necessary for configuration options which rely on external data.
 // Unfortunately it is not possible to configure for example the command once
 // with the `onLoad` or `commands` prop, because the reference for the related function will be outdated.
-const _updateEditorConfiguration = (node, completer, onExecute) => {
+const _updateEditorConfiguration = (node: { editor: Editor; }, completer: AutoCompleter, onExecute: (editor: Editor) => void) => {
   const editor = node && node.editor;
 
   if (editor) {
@@ -201,7 +201,7 @@ const QueryInput = ({
     isValidating,
     validate,
   }), [onExecuteProp, value, error, disableExecution, isValidating, validate]);
-  const updateEditorConfiguration = useCallback((node) => _updateEditorConfiguration(node, completer, onExecute), [onExecute, completer]);
+  const updateEditorConfiguration = useCallback((node: { editor: Editor }) => _updateEditorConfiguration(node, completer, onExecute), [onExecute, completer]);
   const _onChange = useCallback((newQuery) => {
     onChange({ target: { value: newQuery, name } });
 

--- a/graylog2-web-interface/src/views/components/searchbar/queryinput/QueryInput.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/queryinput/QueryInput.tsx
@@ -30,7 +30,7 @@ import { isNoTimeRangeOverride } from 'views/typeGuards/timeRange';
 import usePluginEntities from 'hooks/usePluginEntities';
 import useUserDateTime from 'hooks/useUserDateTime';
 
-import type { AutoCompleter, Editor } from './ace-types';
+import type { AutoCompleter, Editor, Command } from './ace-types';
 import type { BaseProps } from './BasicQueryInput';
 import BasicQueryInput from './BasicQueryInput';
 
@@ -93,7 +93,7 @@ const handleExecution = ({
 
 // This function takes care of all editor configuration options, which do not rely on external data.
 // It will only run once, on mount, which is important for e.g. the event listeners.
-const _onLoadEditor = (editor, isInitialTokenizerUpdate: React.MutableRefObject<boolean>) => {
+const _onLoadEditor = (editor: Editor, isInitialTokenizerUpdate: React.MutableRefObject<boolean>) => {
   if (editor) {
     editor.commands.removeCommands(['find', 'indent', 'outdent']);
 
@@ -118,15 +118,11 @@ const _onLoadEditor = (editor, isInitialTokenizerUpdate: React.MutableRefObject<
 // This is necessary for configuration options which rely on external data.
 // Unfortunately it is not possible to configure for example the command once
 // with the `onLoad` or `commands` prop, because the reference for the related function will be outdated.
-const _updateEditorConfiguration = (node: { editor: Editor; }, completer: AutoCompleter, onExecute: (editor: Editor) => void) => {
+const _updateEditorConfiguration = (node: { editor: Editor; }, completer: AutoCompleter, commands: Array<Command>) => {
   const editor = node && node.editor;
 
   if (editor) {
-    editor.commands.addCommand({
-      name: 'Execute',
-      bindKey: { win: 'Enter', mac: 'Enter' },
-      exec: onExecute,
-    });
+    commands.forEach((command) => editor.commands.addCommand(command));
 
     editor.completers = [completer];
   }
@@ -148,6 +144,7 @@ const useCompleter = ({ streams, timeRange, completerFactory, userTimezone }: Pi
 };
 
 type Props = BaseProps & {
+  commands?: Array<Command>,
   completerFactory?: (
     completers: Array<Completer>,
     timeRange: TimeRange | NoTimeRangeOverride | undefined,
@@ -168,6 +165,7 @@ type Props = BaseProps & {
 
 const QueryInput = ({
   className,
+  commands,
   completerFactory = defaultCompleterFactory,
   disableExecution,
   error,
@@ -201,8 +199,13 @@ const QueryInput = ({
     isValidating,
     validate,
   }), [onExecuteProp, value, error, disableExecution, isValidating, validate]);
-  const updateEditorConfiguration = useCallback((node: { editor: Editor }) => _updateEditorConfiguration(node, completer, onExecute), [onExecute, completer]);
-  const _onChange = useCallback((newQuery) => {
+  const _commands = useMemo(() => [...commands, {
+    name: 'Execute',
+    bindKey: { win: 'Enter', mac: 'Enter' },
+    exec: onExecute,
+  }], [commands, onExecute]);
+  const updateEditorConfiguration = useCallback((node: { editor: Editor }) => _updateEditorConfiguration(node, completer, _commands), [_commands, completer]);
+  const _onChange = useCallback((newQuery: string) => {
     onChange({ target: { value: newQuery, name } });
 
     return Promise.resolve(newQuery);
@@ -251,6 +254,7 @@ QueryInput.propTypes = {
 
 QueryInput.defaultProps = {
   className: '',
+  commands: [],
   completerFactory: defaultCompleterFactory,
   disableExecution: false,
   error: undefined,

--- a/graylog2-web-interface/src/views/components/searchbar/queryinput/StyledAceEditor.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/queryinput/StyledAceEditor.tsx
@@ -15,17 +15,23 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import styled, { css } from 'styled-components';
+import type { DefaultTheme } from 'styled-components';
 
 import { INPUT_BORDER_RADIUS } from 'theme/constants';
 
 import AceEditor from './ace';
 
-const StyledAceEditor = styled(AceEditor).attrs(({ aceTheme, theme, $height }) => ({
+type Props = {
+  $height: number,
+  aceTheme: string,
+  theme: DefaultTheme,
+};
+const StyledAceEditor = styled(AceEditor).attrs(({ aceTheme, theme, $height }: Props) => ({
   // NOTE: After setting the prop we need to swap them back so AceEditor uses the proper styles
   theme: aceTheme, /* stylelint-disable-line */
   $scTheme: theme,
   $height,
-}))(({ $scTheme, $height, disabled, value }) => css`
+}))<{ disabled: boolean }>(({ $scTheme, $height, disabled, value }) => css`
   &.ace-queryinput {
     ${$height ? `height: ${$height}px !important` : ''};
     min-height: 34px;

--- a/graylog2-web-interface/src/views/components/searchbar/queryinput/ace-types.ts
+++ b/graylog2-web-interface/src/views/components/searchbar/queryinput/ace-types.ts
@@ -77,6 +77,8 @@ export type Editor = {
   session: Session,
   renderer: Renderer,
   setFontSize: (newFontSize: number) => void,
+  getValue: () => string,
+  setValue: (newValue: string) => void,
 };
 
 export type CompletionResult = {

--- a/graylog2-web-interface/src/views/components/searchbar/queryinput/ace-types.ts
+++ b/graylog2-web-interface/src/views/components/searchbar/queryinput/ace-types.ts
@@ -20,10 +20,23 @@ export type Token = {
   value: string,
 };
 
+type EventName = 'tokenizerUpdate';
+
+type Tokenizer = {
+  bgTokenizer: {
+    currentLine: number,
+    lines: Array<Array<Line>>,
+  }
+};
+type EventCallback = {
+  tokenizerUpdate: (input: string, tokenizer: Tokenizer) => void,
+};
+
 export type Session = {
   getTokens: (no: number) => Array<Token>,
   getTokenAt: (no: number, idx: number) => Token | undefined | null,
   getValue: () => string,
+  on: <T extends EventName>(event: T, cb: EventCallback[T]) => void,
 };
 
 export type Renderer = {
@@ -60,6 +73,7 @@ export type Editor = {
   completer: Completer,
   // eslint-disable-next-line @typescript-eslint/no-use-before-define
   completers: Array<AutoCompleter>,
+  execCommand: (command: string) => void,
   session: Session,
   renderer: Renderer,
   setFontSize: (newFontSize: number) => void,
@@ -89,5 +103,5 @@ export type Line = {
 
 export interface AutoCompleter {
   getCompletions(editor: Editor, session: Session, position: Position, prefix: string, callback: ResultsCallback): void;
-  shouldShowCompletions(currentLine, lines): boolean;
+  shouldShowCompletions(currentLine: number, lines: Array<Array<Line>>): boolean;
 }

--- a/graylog2-web-interface/src/views/components/searchbar/queryinput/types.ts
+++ b/graylog2-web-interface/src/views/components/searchbar/queryinput/types.ts
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 import type { Editor } from 'views/components/searchbar/queryinput/ace-types';
 
 export type Usage = 'search_query' | 'widget_query' | 'global_override_query';

--- a/graylog2-web-interface/src/views/components/searchbar/queryinput/types.ts
+++ b/graylog2-web-interface/src/views/components/searchbar/queryinput/types.ts
@@ -1,0 +1,19 @@
+import type { Editor } from 'views/components/searchbar/queryinput/ace-types';
+
+export type Usage = 'search_query' | 'widget_query' | 'global_override_query';
+
+export interface CustomCommandContext {
+  usage: Usage;
+}
+
+export type CustomCommandExec = (editor: Editor, context: CustomCommandContext) => void;
+
+export type CustomCommand = {
+  usages: Array<Usage>,
+  name: string,
+  bindKey: {
+    mac: string,
+    win: string,
+  },
+  exec: CustomCommandExec,
+}

--- a/graylog2-web-interface/src/views/components/searchbar/queryinput/usePluggableCommands.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/queryinput/usePluggableCommands.tsx
@@ -1,0 +1,27 @@
+import { useMemo } from 'react';
+
+import type { Usage, CustomCommandContext } from 'views/components/searchbar/queryinput/types';
+import type { Command, Editor } from 'views/components/searchbar/queryinput/ace-types';
+import usePluginEntities from 'hooks/usePluginEntities';
+
+const useCommandsContext = (usage: Usage): CustomCommandContext => {
+  const contextProviders = usePluginEntities('views.queryInput.commandContextProviders');
+
+  const context = useMemo(() => Object.fromEntries(contextProviders.map(({ key, provider }) => [key, provider()])), [contextProviders]);
+
+  return { ...context, usage };
+};
+
+const usePluggableCommands = (usage: Usage): Array<Command> => {
+  const pluggableCommands = usePluginEntities('views.queryInput.commands');
+  const commandsForUsage = useMemo(() => pluggableCommands.filter(({ usages = [] }) => usages.includes(usage)), [pluggableCommands, usage]);
+  const context = useCommandsContext(usage);
+
+  return useMemo(() => commandsForUsage.map(({ name, bindKey, exec: commandExec }) => ({
+    name,
+    bindKey,
+    exec: (editor: Editor) => commandExec(editor, context),
+  })), [commandsForUsage, context]);
+};
+
+export default usePluggableCommands;

--- a/graylog2-web-interface/src/views/components/searchbar/queryinput/usePluggableCommands.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/queryinput/usePluggableCommands.tsx
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 import { useMemo } from 'react';
 
 import type { Usage, CustomCommandContext } from 'views/components/searchbar/queryinput/types';

--- a/graylog2-web-interface/src/views/components/searchbar/queryinput/usePluggableCommands.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/queryinput/usePluggableCommands.tsx
@@ -7,7 +7,7 @@ import usePluginEntities from 'hooks/usePluginEntities';
 const useCommandsContext = (usage: Usage): CustomCommandContext => {
   const contextProviders = usePluginEntities('views.queryInput.commandContextProviders');
 
-  const context = useMemo(() => Object.fromEntries(contextProviders.map(({ key, provider }) => [key, provider()])), [contextProviders]);
+  const context = Object.fromEntries(contextProviders.map(({ key, provider }) => [key, provider()]));
 
   return { ...context, usage };
 };

--- a/graylog2-web-interface/src/views/types.ts
+++ b/graylog2-web-interface/src/views/types.ts
@@ -46,6 +46,7 @@ import type WidgetPosition from 'views/logic/widgets/WidgetPosition';
 import type MessagesWidgetConfig from 'views/logic/widgets/MessagesWidgetConfig';
 import type { QueryValidationState } from 'views/components/searchbar/queryvalidation/types';
 import type Query from 'views/logic/queries/Query';
+import type { CustomCommand, CustomCommandContext } from 'views/components/searchbar/queryinput/types';
 
 export type BackendWidgetPosition = {
   id: string,
@@ -283,6 +284,11 @@ export type SaveViewControls = {
   onDashboardDuplication?: (view: View, userPermissions: Immutable.List<string>) => Promise<View>,
 }
 
+export type CustomCommandContextProvider<T extends keyof CustomCommandContext> = {
+  key: T,
+  provider: () => CustomCommandContext[T],
+}
+
 declare module 'graylog-web-plugin/plugin' {
   export interface PluginExports {
     creators?: Array<Creator>;
@@ -314,6 +320,8 @@ declare module 'graylog-web-plugin/plugin' {
     'views.overrides.widgetEdit'?: Array<React.ComponentType<OverrideProps>>;
     'views.widgets.actions'?: Array<WidgetActionType>;
     'views.requires.provided'?: Array<string>;
+    'views.queryInput.commands'?: Array<CustomCommand>;
+    'views.queryInput.commandContextProviders'?: Array<CustomCommandContextProvider<any>>,
     visualizationTypes?: Array<VisualizationType<any>>;
   }
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR  is adding a new frontend plugin API that allows plugins to contribute custom commands to the query input. It allows to provide two different entities:

  - a command definition (`views.queryInput.commands`) specifying a usage scope, name, mac/windows key bindings as well as a function that is being executed, which gets an `Editor` instance as well as a `CustomCommandContext` object
  - a context provider (`views.queryInput.commandContextProviders`) which allows a plugin to extend the `CustomCommandContext` object which is supplied

Part of the context is the `usage`, which specifies the scope the query input is currently running in. It can be one of `'search_query' | 'widget_query' | 'global_override_query'` currently. This `usage` scope can be specified when binding the command to list the scopes the command should be used in. It is then valuable as part of the context to do scope-specific logic when running the command.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.