### PR TITLE
Sort streams case-insensitive in API.

### DIFF
--- a/changelog/unreleased/pr-14262.toml
+++ b/changelog/unreleased/pr-14262.toml
@@ -1,0 +1,4 @@
+type = "changed"
+message = "Sorting streams case-insensitive in API."
+
+pulls = ["14262"]

--- a/full-backend-tests/src/test/java/org/graylog2/streams/StreamsIT.java
+++ b/full-backend-tests/src/test/java/org/graylog2/streams/StreamsIT.java
@@ -91,7 +91,7 @@ public class StreamsIT {
                 .body("streams*.title", equalTo(List.of("sorttest: aaaaa", "sorttest: ZZZZZZ", "sorttest: 12345")));
         paginatedByFieldWithOrder("sorttest", "disabled", "desc")
                 .assertThat()
-                .body("streams*.title", equalTo(List.of("sorttest: 12345", "sorttest: ZZZZZZ", "sorttest: aaaaa")));
+                .body("streams*.title", equalTo(List.of("sorttest: ZZZZZZ", "sorttest: 12345", "sorttest: aaaaa")));
     }
 
     private ValidatableResponse paginatedByFieldWithOrder(String query, String field, String order) {

--- a/full-backend-tests/src/test/java/org/graylog2/streams/StreamsIT.java
+++ b/full-backend-tests/src/test/java/org/graylog2/streams/StreamsIT.java
@@ -54,8 +54,8 @@ public class StreamsIT {
         api.streams().createStream("New Stream 3", newIndexSetId2);
 
         api.streams().createStream("sorttest: aaaaa", defaultIndexSetId);
-        api.streams().createStream("sorttest: ZZZZZZ", defaultIndexSetId);
-        api.streams().createStream("sorttest: 12345", defaultIndexSetId);
+        api.streams().createStream("sorttest: ZZZZZZ", defaultIndexSetId, false);
+        api.streams().createStream("sorttest: 12345", defaultIndexSetId, false);
     }
 
     @ContainerMatrixTest
@@ -82,6 +82,16 @@ public class StreamsIT {
         paginatedByFieldWithOrder("sorttest", "title", "desc")
                 .assertThat()
                 .body("streams*.title", equalTo(List.of("sorttest: ZZZZZZ", "sorttest: aaaaa", "sorttest: 12345")));
+    }
+
+    @ContainerMatrixTest
+    void sortByStatus() {
+        paginatedByFieldWithOrder("sorttest", "status", "asc")
+                .assertThat()
+                .body("streams*.title", equalTo(List.of("sorttest: aaaaa", "sorttest: ZZZZZZ", "sorttest: 12345")));
+        paginatedByFieldWithOrder("sorttest", "status", "desc")
+                .assertThat()
+                .body("streams*.title", equalTo(List.of("sorttest: 12345", "sorttest: ZZZZZZ", "sorttest: aaaaa")));
     }
 
     private ValidatableResponse paginatedByFieldWithOrder(String query, String field, String order) {

--- a/full-backend-tests/src/test/java/org/graylog2/streams/StreamsIT.java
+++ b/full-backend-tests/src/test/java/org/graylog2/streams/StreamsIT.java
@@ -86,10 +86,10 @@ public class StreamsIT {
 
     @ContainerMatrixTest
     void sortByStatus() {
-        paginatedByFieldWithOrder("sorttest", "status", "asc")
+        paginatedByFieldWithOrder("sorttest", "disabled", "asc")
                 .assertThat()
                 .body("streams*.title", equalTo(List.of("sorttest: aaaaa", "sorttest: ZZZZZZ", "sorttest: 12345")));
-        paginatedByFieldWithOrder("sorttest", "status", "desc")
+        paginatedByFieldWithOrder("sorttest", "disabled", "desc")
                 .assertThat()
                 .body("streams*.title", equalTo(List.of("sorttest: 12345", "sorttest: ZZZZZZ", "sorttest: aaaaa")));
     }

--- a/graylog2-server/src/main/java/org/graylog2/streams/PaginatedStreamService.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/PaginatedStreamService.java
@@ -68,13 +68,14 @@ public class PaginatedStreamService extends PaginatedDbService<StreamDTO> {
                             List.of(Aggregates.match(doc("$expr", doc("$eq", List.of("$_id", "$$index_set_id"))))),
                             "index_set"
                     ))
-                    .add(Aggregates.set(new Field<>("index_set_title", doc("$first", "$index_set.title"))));
+                    .add(Aggregates.set(new Field<>("index_set_title", doc("$first", "$index_set.title"))))
+                    .add(Aggregates.unset("index_set"));
         }
 
         if (isStringField(sortField)) {
             pipelineBuilder.add(Aggregates.set(new Field<>("lower" + sortField, doc("$toLower", "$" + sortField))))
                     .add(Aggregates.sort(getSortBuilder(order, "lower" + sortField)))
-                    .add(Aggregates.project(Projections.exclude("index_set", "lower" + sortField)));
+                    .add(Aggregates.unset("lower" + sortField));
         } else {
             pipelineBuilder.add(Aggregates.sort(getSortBuilder(order, sortField)));
         }

--- a/graylog2-server/src/main/java/org/graylog2/streams/PaginatedStreamService.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/PaginatedStreamService.java
@@ -21,7 +21,6 @@ import com.mongodb.client.AggregateIterable;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.model.Aggregates;
 import com.mongodb.client.model.Field;
-import com.mongodb.client.model.Projections;
 import com.mongodb.client.model.Variable;
 import org.bson.Document;
 import org.bson.conversions.Bson;

--- a/graylog2-server/src/test/java/org/graylog/testing/completebackend/apis/Streams.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/completebackend/apis/Streams.java
@@ -43,6 +43,10 @@ public final class Streams implements GraylogRestApi {
                                @JsonProperty("index_set_id") String indexSetId) {}
 
     public String createStream(String title, String indexSetId, StreamRule... streamRules) {
+        return createStream(title, indexSetId, true, streamRules);
+    }
+
+    public String createStream(String title, String indexSetId, boolean started, StreamRule... streamRules) {
         final CreateStreamRequest body = new CreateStreamRequest(title, List.of(streamRules), indexSetId);
         final String streamId = given()
                 .spec(this.requestSpecification)
@@ -55,13 +59,15 @@ public final class Streams implements GraylogRestApi {
                 .assertThat().body("stream_id", notNullValue())
                 .extract().body().jsonPath().getString("stream_id");
 
-        given()
-                .spec(this.requestSpecification)
-                .when()
-                .post("/streams/" + streamId + "/resume")
-                .then()
-                .log().ifError()
-                .statusCode(204);
+        if (started) {
+            given()
+                    .spec(this.requestSpecification)
+                    .when()
+                    .post("/streams/" + streamId + "/resume")
+                    .then()
+                    .log().ifError()
+                    .statusCode(204);
+        }
 
         return streamId;
     }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Prior to this PR, sorting streams by title/description/... sorted them lexicographically, but case-sensitive. This is most probably not what users are expecting.

This change is now adding functionality which is lower-casing the sort field before applying the sort to it.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.