### PR TITLE
Added test to aggregate messages by streams

### DIFF
--- a/full-backend-tests/src/test/java/org/graylog/plugins/views/ScriptingApiResourceIT.java
+++ b/full-backend-tests/src/test/java/org/graylog/plugins/views/ScriptingApiResourceIT.java
@@ -145,7 +145,9 @@ public class ScriptingApiResourceIT {
                 .log().ifStatusCodeMatches(not(200))
                 .statusCode(200);
 
-        validatableResponse.assertThat().body("datarows", Matchers.hasSize(3));
+        validatableResponse.log().ifValidationFails()
+                .assertThat().body("datarows", Matchers.hasSize(3));
+
         validateRow(validatableResponse, DEFAULT_STREAM, 3);
         validateRow(validatableResponse, stream2Id, 2);
         validateRow(validatableResponse, stream1Id, 1);


### PR DESCRIPTION
Some of the scripting api integration tests are flaky. The assumption is that there may be a problem/async/timing issue between stream and stream rule creation and message ingestion. In the moment the message is ingested, the stream could be not fully initialized yet. 

This test verifies that all messages are routed to correct streams by aggregating by stream ID. 

/nocl

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

