### PR TITLE
Adding logarithmic scale for X/Y charts.

### DIFF
--- a/changelog/unreleased/pr-14269.toml
+++ b/changelog/unreleased/pr-14269.toml
@@ -1,0 +1,4 @@
+type = "added"
+message = "Added the option to toggle between a linear and a logarithmic axis for area/bar/line/scatter charts."
+
+pulls = ["14269"]

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/ViewsBindings.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/ViewsBindings.java
@@ -108,6 +108,7 @@ import org.graylog.plugins.views.search.views.widgets.aggregation.DataTableVisua
 import org.graylog.plugins.views.search.views.widgets.aggregation.HeatmapVisualizationConfigDTO;
 import org.graylog.plugins.views.search.views.widgets.aggregation.LineVisualizationConfigDTO;
 import org.graylog.plugins.views.search.views.widgets.aggregation.NumberVisualizationConfigDTO;
+import org.graylog.plugins.views.search.views.widgets.aggregation.ScatterVisualizationConfigDTO;
 import org.graylog.plugins.views.search.views.widgets.aggregation.TimeHistogramConfigDTO;
 import org.graylog.plugins.views.search.views.widgets.aggregation.TimeUnitIntervalDTO;
 import org.graylog.plugins.views.search.views.widgets.aggregation.ValueConfigDTO;
@@ -278,6 +279,7 @@ public class ViewsBindings extends ViewsModule {
         registerJacksonSubtype(AreaVisualizationConfigDTO.class);
         registerJacksonSubtype(HeatmapVisualizationConfigDTO.class);
         registerJacksonSubtype(DataTableVisualizationConfigDTO.class);
+        registerJacksonSubtype(ScatterVisualizationConfigDTO.class);
     }
 
     private void registerParameterSubtypes() {

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/widgets/aggregation/AreaVisualizationConfigDTO.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/widgets/aggregation/AreaVisualizationConfigDTO.java
@@ -25,24 +25,31 @@ import com.google.auto.value.AutoValue;
 @AutoValue
 @JsonTypeName(AreaVisualizationConfigDTO.NAME)
 @JsonDeserialize(builder = AreaVisualizationConfigDTO.Builder.class)
-public abstract class AreaVisualizationConfigDTO implements VisualizationConfigDTO {
+public abstract class AreaVisualizationConfigDTO implements VisualizationConfigDTO, XYVisualizationConfig {
     public static final String NAME = "area";
     private static final String FIELD_INTERPOLATION = "interpolation";
 
     @JsonProperty(FIELD_INTERPOLATION)
     public abstract Interpolation interpolation();
 
+    @JsonProperty(FIELD_AXIS_TYPE)
+    public abstract AxisType axisType();
+
     @AutoValue.Builder
     public abstract static class Builder {
         @JsonProperty(FIELD_INTERPOLATION)
         public abstract Builder interpolation(Interpolation interpolation);
+
+        @JsonProperty(FIELD_AXIS_TYPE)
+        public abstract Builder axisType(AxisType axisType);
 
         public abstract AreaVisualizationConfigDTO build();
 
         @JsonCreator
         public static Builder builder() {
             return new AutoValue_AreaVisualizationConfigDTO.Builder()
-                    .interpolation(Interpolation.defaultValue());
+                    .interpolation(Interpolation.defaultValue())
+                    .axisType(DEFAULT_AXIS_TYPE);
         }
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/widgets/aggregation/BarVisualizationConfigDTO.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/widgets/aggregation/BarVisualizationConfigDTO.java
@@ -25,7 +25,7 @@ import com.google.auto.value.AutoValue;
 @AutoValue
 @JsonTypeName(BarVisualizationConfigDTO.NAME)
 @JsonDeserialize(builder = BarVisualizationConfigDTO.Builder.class)
-public abstract class BarVisualizationConfigDTO implements VisualizationConfigDTO {
+public abstract class BarVisualizationConfigDTO implements VisualizationConfigDTO, XYVisualizationConfig {
     public static final String NAME = "bar";
     private static final String FIELD_BAR_MODE = "barmode";
 
@@ -39,17 +39,24 @@ public abstract class BarVisualizationConfigDTO implements VisualizationConfigDT
     @JsonProperty
     public abstract BarMode barmode();
 
+    @JsonProperty(FIELD_AXIS_TYPE)
+    public abstract AxisType axisType();
+
     @AutoValue.Builder
     public abstract static class Builder {
 
         @JsonProperty(FIELD_BAR_MODE)
         public abstract Builder barmode(BarMode barMode);
 
+        @JsonProperty(FIELD_AXIS_TYPE)
+        public abstract Builder axisType(AxisType axisType);
+
         public abstract BarVisualizationConfigDTO build();
 
         @JsonCreator
         public static Builder builder() {
-            return new AutoValue_BarVisualizationConfigDTO.Builder();
+            return new AutoValue_BarVisualizationConfigDTO.Builder()
+                    .axisType(DEFAULT_AXIS_TYPE);
         }
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/widgets/aggregation/LineVisualizationConfigDTO.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/widgets/aggregation/LineVisualizationConfigDTO.java
@@ -25,24 +25,31 @@ import com.google.auto.value.AutoValue;
 @AutoValue
 @JsonTypeName(LineVisualizationConfigDTO.NAME)
 @JsonDeserialize(builder = LineVisualizationConfigDTO.Builder.class)
-public abstract class LineVisualizationConfigDTO implements VisualizationConfigDTO {
+public abstract class LineVisualizationConfigDTO implements VisualizationConfigDTO, XYVisualizationConfig {
     public static final String NAME = "line";
     private static final String FIELD_INTERPOLATION = "interpolation";
 
     @JsonProperty(FIELD_INTERPOLATION)
     public abstract Interpolation interpolation();
 
+    @JsonProperty(FIELD_AXIS_TYPE)
+    public abstract AxisType axisType();
+
     @AutoValue.Builder
     public abstract static class Builder {
         @JsonProperty(FIELD_INTERPOLATION)
         public abstract Builder interpolation(Interpolation interpolation);
+
+        @JsonProperty(FIELD_AXIS_TYPE)
+        public abstract Builder axisType(AxisType axisType);
 
         public abstract LineVisualizationConfigDTO build();
 
         @JsonCreator
         public static Builder builder() {
             return new AutoValue_LineVisualizationConfigDTO.Builder()
-                    .interpolation(Interpolation.defaultValue());
+                    .interpolation(Interpolation.defaultValue())
+                    .axisType(DEFAULT_AXIS_TYPE);
         }
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/widgets/aggregation/ScatterVisualizationConfigDTO.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/widgets/aggregation/ScatterVisualizationConfigDTO.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog.plugins.views.search.views.widgets.aggregation;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/widgets/aggregation/ScatterVisualizationConfigDTO.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/widgets/aggregation/ScatterVisualizationConfigDTO.java
@@ -1,0 +1,32 @@
+package org.graylog.plugins.views.search.views.widgets.aggregation;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.auto.value.AutoValue;
+
+@AutoValue
+@JsonTypeName(ScatterVisualizationConfigDTO.NAME)
+@JsonDeserialize(builder = ScatterVisualizationConfigDTO.Builder.class)
+public abstract class ScatterVisualizationConfigDTO implements VisualizationConfigDTO, XYVisualizationConfig{
+    public static final String NAME = "scatter";
+
+    @JsonProperty(FIELD_AXIS_TYPE)
+    public abstract XYVisualizationConfig.AxisType axisType();
+
+    @AutoValue.Builder
+    public abstract static class Builder {
+        @JsonProperty(FIELD_AXIS_TYPE)
+        public abstract Builder axisType(AxisType axisType);
+
+        public abstract ScatterVisualizationConfigDTO build();
+
+        @JsonCreator
+        public static Builder builder() {
+            return new AutoValue_ScatterVisualizationConfigDTO.Builder()
+                    .axisType(DEFAULT_AXIS_TYPE);
+        }
+
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/widgets/aggregation/XYVisualizationConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/widgets/aggregation/XYVisualizationConfig.java
@@ -16,13 +16,28 @@
  */
 package org.graylog.plugins.views.search.views.widgets.aggregation;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
 public interface XYVisualizationConfig {
     String FIELD_AXIS_TYPE = "axis_type";
     AxisType DEFAULT_AXIS_TYPE = AxisType.LINEAR;
 
     enum AxisType {
-        LINEAR,
-        LOGARITHMIC
+        LINEAR("linear"),
+        LOGARITHMIC("logarithmic");
+
+        private final String value;
+
+        @JsonValue
+        public String value() {
+            return this.value;
+        }
+
+        @JsonCreator
+        AxisType(String value) {
+            this.value = value;
+        }
     }
 
     AxisType axisType();

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/widgets/aggregation/XYVisualizationConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/widgets/aggregation/XYVisualizationConfig.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog.plugins.views.search.views.widgets.aggregation;
 
 public interface XYVisualizationConfig {

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/widgets/aggregation/XYVisualizationConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/widgets/aggregation/XYVisualizationConfig.java
@@ -1,0 +1,13 @@
+package org.graylog.plugins.views.search.views.widgets.aggregation;
+
+public interface XYVisualizationConfig {
+    String FIELD_AXIS_TYPE = "axis_type";
+    AxisType DEFAULT_AXIS_TYPE = AxisType.LINEAR;
+
+    enum AxisType {
+        LINEAR,
+        LOGARITHMIC
+    }
+
+    AxisType axisType();
+}

--- a/graylog2-web-interface/src/views/Constants.ts
+++ b/graylog2-web-interface/src/views/Constants.ts
@@ -18,6 +18,7 @@ import chroma from 'chroma-js';
 
 import type { TimeRange, RelativeTimeRangeWithEnd, RelativeTimeRange } from 'views/logic/queries/Query';
 import { StaticColor } from 'views/logic/views/formatting/highlighting/HighlightingColor';
+import type { ArrayElement } from 'views/types';
 
 export type SearchBarFormValues = {
   timerange: TimeRange,
@@ -50,6 +51,8 @@ export const DEFAULT_CUSTOM_HIGHLIGHT_RANGE = chroma.scale(['lightyellow', 'ligh
   .colors(40);
 
 export const DEFAULT_INTERPOLATION = 'linear';
+export const interpolationTypes = ['linear', 'step-after', 'spline'] as const;
+export type InterpolationType = ArrayElement<typeof interpolationTypes>;
 
 export const TimeUnits = {
   seconds: 'Seconds',

--- a/graylog2-web-interface/src/views/Constants.ts
+++ b/graylog2-web-interface/src/views/Constants.ts
@@ -49,6 +49,8 @@ export const DEFAULT_CUSTOM_HIGHLIGHT_RANGE = chroma.scale(['lightyellow', 'ligh
   .mode('lch')
   .colors(40);
 
+export const DEFAULT_INTERPOLATION = 'linear';
+
 export const TimeUnits = {
   seconds: 'Seconds',
   minutes: 'Minutes',

--- a/graylog2-web-interface/src/views/bindings.tsx
+++ b/graylog2-web-interface/src/views/bindings.tsx
@@ -85,6 +85,8 @@ import CopyValueToClipboard from 'views/logic/valueactions/CopyValueToClipboard'
 import CopyFieldToClipboard from 'views/logic/fieldactions/CopyFieldToClipboard';
 import DataTableVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/DataTableVisualizationConfig';
 import ViewHeader from 'views/components/views/ViewHeader';
+import ScatterVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/ScatterVisualizationConfig';
+import ScatterVisualization from 'views/components/visualizations/scatter/ScatterVisualization';
 
 import type { ActionHandlerArguments } from './components/actions/ActionHandler';
 import NumberVisualizationConfig from './logic/aggregationbuilder/visualizations/NumberVisualizationConfig';
@@ -106,6 +108,7 @@ VisualizationConfig.registerSubtype(LineVisualization.type, LineVisualizationCon
 VisualizationConfig.registerSubtype(AreaVisualization.type, AreaVisualizationConfig);
 VisualizationConfig.registerSubtype(HeatmapVisualization.type, HeatmapVisualizationConfig);
 VisualizationConfig.registerSubtype(DataTable.type, DataTableVisualizationConfig);
+VisualizationConfig.registerSubtype(ScatterVisualization.type, ScatterVisualizationConfig);
 
 Parameter.registerSubtype(ValueParameter.type, ValueParameter);
 Parameter.registerSubtype(LookupTableParameter.type, LookupTableParameter);

--- a/graylog2-web-interface/src/views/components/MigrateFieldCharts.tsx
+++ b/graylog2-web-interface/src/views/components/MigrateFieldCharts.tsx
@@ -126,7 +126,7 @@ const createVisualizationConfig = (legacyInterpolation: LegacyInterpolation, vis
   }
 };
 
-const _updateExistingWidgetPos = (existingPositions, rowOffset) => {
+const _updateExistingWidgetPos = (existingPositions: { [key: string]: WidgetPosition; }, rowOffset: number) => {
   const updatedWidgetPos = { ...existingPositions };
 
   Object.keys(updatedWidgetPos).forEach((widgetId) => {
@@ -138,7 +138,7 @@ const _updateExistingWidgetPos = (existingPositions, rowOffset) => {
   return updatedWidgetPos;
 };
 
-const _migrateWidgets = (legacyCharts) => {
+const _migrateWidgets = (legacyCharts: Array<LegacyFieldChart>) => {
   return new Promise((resolve) => {
     const { defaultHeight } = widgetDefinition(AggregationWidget.type);
     const currentView = CurrentViewStateStore.getInitialState();
@@ -205,7 +205,7 @@ const _onMigrate = (legacyCharts: Array<LegacyFieldChart>, setMigrating: (migrat
   });
 };
 
-const _onCancel = (setMigrationFinished) => {
+const _onCancel = (setMigrationFinished: (finished: boolean) => void) => {
   Store.set(FIELD_CHARTS_MIGRATED_KEY, 'discarded');
   setMigrationFinished(true);
 };

--- a/graylog2-web-interface/src/views/components/MigrateFieldCharts.tsx
+++ b/graylog2-web-interface/src/views/components/MigrateFieldCharts.tsx
@@ -26,7 +26,6 @@ import Store from 'logic/local-storage/Store';
 import { widgetDefinition } from 'views/logic/Widgets';
 import AggregationWidget from 'views/logic/aggregationbuilder/AggregationWidget';
 import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
-import type { PivotConfigType } from 'views/logic/aggregationbuilder/Pivot';
 import Pivot from 'views/logic/aggregationbuilder/Pivot';
 import Series from 'views/logic/aggregationbuilder/Series';
 import WidgetPosition from 'views/logic/widgets/WidgetPosition';
@@ -151,7 +150,7 @@ const _migrateWidgets = (legacyCharts: Array<LegacyFieldChart>) => {
       const series = new Series(mapSeries(chart.valuetype, field));
       // Because all field charts show the results for the defined timerange,
       // the new row pivot always contains the timestamp field.
-      const rowPivotConfig = { interval: { type: 'timeunit', ...mapTime(chart.interval) } } as PivotConfigType;
+      const rowPivotConfig = { interval: { type: 'timeunit', ...mapTime(chart.interval) } };
       const rowPivot = new Pivot(TIMESTAMP_FIELD, 'time', rowPivotConfig);
       const visualization = mapVisualization(chart.renderer);
       const visualizationConfig = createVisualizationConfig(chart.interpolation, visualization);

--- a/graylog2-web-interface/src/views/components/MigrateFieldCharts.tsx
+++ b/graylog2-web-interface/src/views/components/MigrateFieldCharts.tsx
@@ -186,7 +186,7 @@ const _migrateWidgets = (legacyCharts: Array<LegacyFieldChart>) => {
       .widgetPositions({ ...existingWidgetPos, ...newWidgetPositions })
       .build();
 
-    return resolve({ newViewState, currentQueryId: currentView.activeQuery });
+    resolve({ newViewState, currentQueryId: currentView.activeQuery });
   });
 };
 

--- a/graylog2-web-interface/src/views/components/MigrateFieldCharts.tsx
+++ b/graylog2-web-interface/src/views/components/MigrateFieldCharts.tsx
@@ -118,9 +118,9 @@ const createVisualizationConfig = (legacyInterpolation: LegacyInterpolation, vis
 
   switch (visualization) {
     case 'line':
-      return new LineVisualizationConfig(interpolation);
+      return LineVisualizationConfig.create(interpolation);
     case 'area':
-      return new AreaVisualizationConfig(interpolation);
+      return AreaVisualizationConfig.create(interpolation);
     default:
       return undefined;
   }

--- a/graylog2-web-interface/src/views/components/__tests__/MigrateFieldCharts.test.tsx
+++ b/graylog2-web-interface/src/views/components/__tests__/MigrateFieldCharts.test.tsx
@@ -197,7 +197,7 @@ describe('MigrateFieldCharts', () => {
     });
 
     it('create area visualization config, if field chart visualization is area', async () => {
-      const expVisualizationConfg = new AreaVisualizationConfig('linear');
+      const expVisualizationConfg = AreaVisualizationConfig.create('linear');
 
       Store.get.mockImplementation(mockStoreGet({ renderer: 'area' }));
       renderAndMigrate();

--- a/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.corevisualizations.test.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.corevisualizations.test.tsx
@@ -142,6 +142,7 @@ describe('AggregationWizard/Core Visualizations', () => {
     await selectOption('Select visualization type', 'Line Chart');
 
     await selectOption('Select Interpolation', 'spline');
+
     await expectSubmitButtonNotToBeDisabled();
 
     userEvent.click(await submitButton());

--- a/graylog2-web-interface/src/views/components/visualizations/GenericPlot.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/GenericPlot.tsx
@@ -90,6 +90,10 @@ const nonInteractiveLayout = {
   hovermode: false,
 };
 
+const style = { height: '100%', width: '100%' };
+
+const config = { displayModeBar: false, doubleClick: false as const, responsive: true };
+
 class GenericPlot extends React.Component<GenericPlotProps, State> {
   static propTypes = {
     chartData: PropTypes.array.isRequired,
@@ -198,10 +202,6 @@ class GenericPlot extends React.Component<GenericPlotProps, State> {
       },
     };
     const plotLayout = merge({}, defaultLayout, layout);
-
-    const style = { height: '100%', width: '100%' };
-
-    const config = { displayModeBar: false, doubleClick: false as const, responsive: true };
 
     const { legendConfig } = this.state;
 

--- a/graylog2-web-interface/src/views/components/visualizations/__tests__/XYPlot.test.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/__tests__/XYPlot.test.tsx
@@ -110,7 +110,7 @@ describe('XYPlot', () => {
     const genericPlot = wrapper.find('GenericPlot');
 
     expect(genericPlot).toHaveProp('layout', {
-      yaxis: { fixedrange: true, rangemode: 'tozero', tickformat: ',~r' },
+      yaxis: { fixedrange: true, rangemode: 'tozero', tickformat: ',~r', type: 'linear' },
       xaxis: { fixedrange: true },
       showlegend: false,
       hovermode: 'x',

--- a/graylog2-web-interface/src/views/components/visualizations/area/AreaVisualization.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/area/AreaVisualization.tsx
@@ -75,6 +75,7 @@ const AreaVisualization = makeVisualization(({
 
   return (
     <XYPlot config={config}
+            axisType={visualizationConfig.axisType}
             plotLayout={layout}
             effectiveTimerange={effectiveTimerange}
             getChartColor={getChartColor}

--- a/graylog2-web-interface/src/views/components/visualizations/area/bindings.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/area/bindings.tsx
@@ -18,12 +18,15 @@ import type { VisualizationType } from 'views/types';
 import AreaVisualization from 'views/components/visualizations/area/AreaVisualization';
 import AreaVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/AreaVisualizationConfig';
 import { hasAtLeastOneMetric } from 'views/components/visualizations/validations';
+import type { InterpolationType } from 'views/Constants';
+import { DEFAULT_INTERPOLATION, interpolationTypes } from 'views/Constants';
+import type { AxisType } from 'views/logic/aggregationbuilder/visualizations/XYVisualization';
+import { axisTypes, DEFAULT_AXIS_TYPE } from 'views/logic/aggregationbuilder/visualizations/XYVisualization';
 
 type AreaVisualizationConfigFormValues = {
-  interpolation: 'linear' | 'step-after' | 'spline';
+  interpolation: InterpolationType;
+  axisType: AxisType,
 };
-
-const DEFAULT_INTERPOLATION = 'linear';
 
 const validate = hasAtLeastOneMetric('Area chart');
 
@@ -32,14 +35,20 @@ const areaChart: VisualizationType<typeof AreaVisualization.type, AreaVisualizat
   displayName: 'Area Chart',
   component: AreaVisualization,
   config: {
-    createConfig: () => ({ interpolation: DEFAULT_INTERPOLATION }),
-    fromConfig: (config: AreaVisualizationConfig) => ({ interpolation: config?.interpolation }),
-    toConfig: (formValues: AreaVisualizationConfigFormValues) => AreaVisualizationConfig.create(formValues.interpolation),
+    createConfig: () => ({ interpolation: DEFAULT_INTERPOLATION, axisType: DEFAULT_AXIS_TYPE }),
+    fromConfig: (config: AreaVisualizationConfig) => ({ interpolation: config?.interpolation, axisType: config?.axisType }),
+    toConfig: (formValues: AreaVisualizationConfigFormValues) => AreaVisualizationConfig.create(formValues.interpolation, formValues.axisType),
     fields: [{
       name: 'interpolation',
       title: 'Interpolation',
       type: 'select',
-      options: ['linear', 'step-after', 'spline'],
+      options: interpolationTypes,
+      required: true,
+    }, {
+      name: 'axisType',
+      title: 'Axis Type',
+      type: 'select',
+      options: axisTypes,
       required: true,
     }],
   },

--- a/graylog2-web-interface/src/views/components/visualizations/bar/BarVisualization.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/bar/BarVisualization.tsx
@@ -23,7 +23,7 @@ import type { VisualizationComponentProps } from 'views/components/aggregationbu
 import { makeVisualization, retrieveChartData } from 'views/components/aggregationbuilder/AggregationBuilder';
 import type { Shapes } from 'views/logic/searchtypes/events/EventHandler';
 import { DateType } from 'views/logic/aggregationbuilder/Pivot';
-import type BarVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/BarVisualizationConfig';
+import BarVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/BarVisualizationConfig';
 import useChartData from 'views/components/visualizations/useChartData';
 import useEvents from 'views/components/visualizations/useEvents';
 
@@ -88,7 +88,7 @@ const BarVisualization = makeVisualization(({
   effectiveTimerange,
   height,
 }: VisualizationComponentProps) => {
-  const visualizationConfig = config.visualizationConfig as BarVisualizationConfig;
+  const visualizationConfig = (config.visualizationConfig ?? BarVisualizationConfig.empty()) as BarVisualizationConfig;
   const _layout: Layout = {};
 
   if (visualizationConfig && visualizationConfig.barmode) {
@@ -115,6 +115,7 @@ const BarVisualization = makeVisualization(({
 
   return (
     <XYPlot config={config}
+            axisType={visualizationConfig.axisType}
             chartData={defineSingleDateBarWidth(chartDataResult, config, effectiveTimerange?.from, effectiveTimerange?.to)}
             effectiveTimerange={effectiveTimerange}
             getChartColor={getChartColor}

--- a/graylog2-web-interface/src/views/components/visualizations/bar/bindings.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/bar/bindings.tsx
@@ -18,14 +18,15 @@ import * as React from 'react';
 
 import type { VisualizationType } from 'views/types';
 import BarVisualization from 'views/components/visualizations/bar/BarVisualization';
-import BarVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/BarVisualizationConfig';
+import BarVisualizationConfig, { DEFAULT_BARMODE } from 'views/logic/aggregationbuilder/visualizations/BarVisualizationConfig';
 import { hasAtLeastOneMetric } from 'views/components/visualizations/validations';
+import type { AxisType } from 'views/logic/aggregationbuilder/visualizations/XYVisualization';
+import { axisTypes, DEFAULT_AXIS_TYPE } from 'views/logic/aggregationbuilder/visualizations/XYVisualization';
 
 type BarVisualizationConfigFormValues = {
   barmode: 'group' | 'stack' | 'relative' | 'overlay',
+  axisType: AxisType,
 };
-
-const DEFAULT_BARMODE = 'group';
 
 const validate = hasAtLeastOneMetric('Bar chart');
 
@@ -34,9 +35,9 @@ const barChart: VisualizationType<typeof BarVisualization.type, BarVisualization
   displayName: 'Bar Chart',
   component: BarVisualization,
   config: {
-    createConfig: () => ({ barmode: DEFAULT_BARMODE }),
-    fromConfig: (config: BarVisualizationConfig | undefined) => ({ barmode: config?.barmode ?? DEFAULT_BARMODE }),
-    toConfig: (formValues: BarVisualizationConfigFormValues) => BarVisualizationConfig.create(formValues.barmode),
+    createConfig: () => ({ barmode: DEFAULT_BARMODE, axisType: DEFAULT_AXIS_TYPE }),
+    fromConfig: (config: BarVisualizationConfig | undefined) => ({ barmode: config?.barmode ?? DEFAULT_BARMODE, axisType: config?.axisType ?? DEFAULT_AXIS_TYPE }),
+    toConfig: (formValues: BarVisualizationConfigFormValues) => BarVisualizationConfig.create(formValues.barmode, formValues.axisType),
     fields: [{
       name: 'barmode',
       title: 'Mode',
@@ -75,6 +76,12 @@ const barChart: VisualizationType<typeof BarVisualization.type, BarVisualization
           </ul>
         );
       },
+    }, {
+      name: 'axisType',
+      title: 'Axis Type',
+      type: 'select',
+      options: axisTypes,
+      required: true,
     }],
   },
   capabilities: ['event-annotations'],

--- a/graylog2-web-interface/src/views/components/visualizations/line/LineVisualization.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/line/LineVisualization.tsx
@@ -22,9 +22,9 @@ import type { VisualizationComponentProps } from 'views/components/aggregationbu
 import { makeVisualization, retrieveChartData } from 'views/components/aggregationbuilder/AggregationBuilder';
 import LineVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/LineVisualizationConfig';
 import toPlotly from 'views/logic/aggregationbuilder/visualizations/Interpolation';
-import type { Shapes } from 'views/logic/searchtypes/events/EventHandler';
 import useChartData from 'views/components/visualizations/useChartData';
 import useEvents from 'views/components/visualizations/useEvents';
+import { DEFAULT_AXIS_TYPE } from 'views/logic/aggregationbuilder/visualizations/XYVisualization';
 
 import type { ChartDefinition } from '../ChartData';
 import XYPlot from '../XYPlot';
@@ -50,7 +50,7 @@ const LineVisualization = makeVisualization(({
   height,
 }: VisualizationComponentProps) => {
   const visualizationConfig = (config.visualizationConfig ?? LineVisualizationConfig.empty()) as LineVisualizationConfig;
-  const { interpolation = 'linear' } = visualizationConfig;
+  const { interpolation = 'linear', axisType = DEFAULT_AXIS_TYPE } = visualizationConfig;
   const chartGenerator = useCallback((type, name, labels, values): ChartDefinition => ({
     type,
     name,
@@ -69,7 +69,12 @@ const LineVisualization = makeVisualization(({
   const { eventChartData, shapes } = useEvents(config, data.events);
 
   const chartDataResult = eventChartData ? [..._chartDataResult, eventChartData] : _chartDataResult;
-  const layout: { shapes?: Shapes } = shapes ? { shapes } : {};
+  const defaultLayout = {
+    yaxis: {
+      type: axisType,
+    },
+  };
+  const layout = shapes ? { ...defaultLayout, shapes } : defaultLayout;
 
   return (
     <XYPlot config={config}

--- a/graylog2-web-interface/src/views/components/visualizations/line/LineVisualization.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/line/LineVisualization.tsx
@@ -69,16 +69,12 @@ const LineVisualization = makeVisualization(({
   const { eventChartData, shapes } = useEvents(config, data.events);
 
   const chartDataResult = eventChartData ? [..._chartDataResult, eventChartData] : _chartDataResult;
-  const defaultLayout = {
-    yaxis: {
-      type: axisType,
-    },
-  };
-  const layout = shapes ? { ...defaultLayout, shapes } : defaultLayout;
+  const layout = shapes ? { shapes } : {};
 
   return (
     <XYPlot config={config}
             plotLayout={layout}
+            axisType={axisType}
             effectiveTimerange={effectiveTimerange}
             getChartColor={getChartColor}
             height={height}

--- a/graylog2-web-interface/src/views/components/visualizations/line/bindings.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/line/bindings.tsx
@@ -14,20 +14,18 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import type { VisualizationType } from 'views/types';
+import type { VisualizationType, ArrayElement } from 'views/types';
 import LineVisualization from 'views/components/visualizations/line/LineVisualization';
 import LineVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/LineVisualizationConfig';
 import { hasAtLeastOneMetric } from 'views/components/visualizations/validations';
-
-type ArrayElement<ArrayType extends readonly unknown[]> =
-  ArrayType extends readonly (infer ElementType)[] ? ElementType : never;
+import type { AxisType } from 'views/logic/aggregationbuilder/visualizations/XYVisualization';
+import { DEFAULT_AXIS_TYPE, axisTypes } from 'views/logic/aggregationbuilder/visualizations/XYVisualization';
 
 const interpolationTypes = ['linear', 'step-after', 'spline'] as const;
-const axisTypes = ['linear', 'logarithmic'] as const;
 
 type LineVisualizationConfigFormValues = {
   interpolation: ArrayElement<typeof interpolationTypes>;
-  axisType: ArrayElement<typeof axisTypes>;
+  axisType: AxisType;
 };
 
 const validate = hasAtLeastOneMetric('Line chart');
@@ -38,8 +36,11 @@ const lineChart: VisualizationType<typeof LineVisualization.type, LineVisualizat
   component: LineVisualization,
   config: {
     createConfig: () => ({ interpolation: LineVisualizationConfig.DEFAULT_INTERPOLATION }),
-    fromConfig: (config: LineVisualizationConfig | undefined) => ({ interpolation: config?.interpolation ?? LineVisualizationConfig.DEFAULT_INTERPOLATION }),
-    toConfig: (formValues: LineVisualizationConfigFormValues) => LineVisualizationConfig.create(formValues.interpolation),
+    fromConfig: (config: LineVisualizationConfig | undefined) => ({
+      interpolation: config?.interpolation ?? LineVisualizationConfig.DEFAULT_INTERPOLATION,
+      axisType: config?.axisType ?? DEFAULT_AXIS_TYPE,
+    }),
+    toConfig: (formValues: LineVisualizationConfigFormValues) => LineVisualizationConfig.create(formValues.interpolation, formValues.axisType),
     fields: [{
       name: 'interpolation',
       title: 'Interpolation',

--- a/graylog2-web-interface/src/views/components/visualizations/line/bindings.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/line/bindings.tsx
@@ -35,7 +35,7 @@ const lineChart: VisualizationType<typeof LineVisualization.type, LineVisualizat
   displayName: 'Line Chart',
   component: LineVisualization,
   config: {
-    createConfig: () => ({ interpolation: DEFAULT_INTERPOLATION }),
+    createConfig: () => ({ interpolation: DEFAULT_INTERPOLATION, axisType: DEFAULT_AXIS_TYPE }),
     fromConfig: (config: LineVisualizationConfig | undefined) => ({
       interpolation: config?.interpolation ?? DEFAULT_INTERPOLATION,
       axisType: config?.axisType ?? DEFAULT_AXIS_TYPE,

--- a/graylog2-web-interface/src/views/components/visualizations/line/bindings.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/line/bindings.tsx
@@ -14,17 +14,17 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import type { VisualizationType, ArrayElement } from 'views/types';
+import type { VisualizationType } from 'views/types';
 import LineVisualization from 'views/components/visualizations/line/LineVisualization';
 import LineVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/LineVisualizationConfig';
 import { hasAtLeastOneMetric } from 'views/components/visualizations/validations';
 import type { AxisType } from 'views/logic/aggregationbuilder/visualizations/XYVisualization';
 import { DEFAULT_AXIS_TYPE, axisTypes } from 'views/logic/aggregationbuilder/visualizations/XYVisualization';
-
-const interpolationTypes = ['linear', 'step-after', 'spline'] as const;
+import type { InterpolationType } from 'views/Constants';
+import { DEFAULT_INTERPOLATION, interpolationTypes } from 'views/Constants';
 
 type LineVisualizationConfigFormValues = {
-  interpolation: ArrayElement<typeof interpolationTypes>;
+  interpolation: InterpolationType;
   axisType: AxisType;
 };
 
@@ -35,9 +35,9 @@ const lineChart: VisualizationType<typeof LineVisualization.type, LineVisualizat
   displayName: 'Line Chart',
   component: LineVisualization,
   config: {
-    createConfig: () => ({ interpolation: LineVisualizationConfig.DEFAULT_INTERPOLATION }),
+    createConfig: () => ({ interpolation: DEFAULT_INTERPOLATION }),
     fromConfig: (config: LineVisualizationConfig | undefined) => ({
-      interpolation: config?.interpolation ?? LineVisualizationConfig.DEFAULT_INTERPOLATION,
+      interpolation: config?.interpolation ?? DEFAULT_INTERPOLATION,
       axisType: config?.axisType ?? DEFAULT_AXIS_TYPE,
     }),
     toConfig: (formValues: LineVisualizationConfigFormValues) => LineVisualizationConfig.create(formValues.interpolation, formValues.axisType),

--- a/graylog2-web-interface/src/views/components/visualizations/line/bindings.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/line/bindings.tsx
@@ -19,8 +19,15 @@ import LineVisualization from 'views/components/visualizations/line/LineVisualiz
 import LineVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/LineVisualizationConfig';
 import { hasAtLeastOneMetric } from 'views/components/visualizations/validations';
 
+type ArrayElement<ArrayType extends readonly unknown[]> =
+  ArrayType extends readonly (infer ElementType)[] ? ElementType : never;
+
+const interpolationTypes = ['linear', 'step-after', 'spline'] as const;
+const axisTypes = ['linear', 'logarithmic'] as const;
+
 type LineVisualizationConfigFormValues = {
-  interpolation: 'linear' | 'step-after' | 'spline';
+  interpolation: ArrayElement<typeof interpolationTypes>;
+  axisType: ArrayElement<typeof axisTypes>;
 };
 
 const validate = hasAtLeastOneMetric('Line chart');
@@ -37,7 +44,13 @@ const lineChart: VisualizationType<typeof LineVisualization.type, LineVisualizat
       name: 'interpolation',
       title: 'Interpolation',
       type: 'select',
-      options: ['linear', 'step-after', 'spline'],
+      options: interpolationTypes,
+      required: true,
+    }, {
+      name: 'axisType',
+      title: 'Axis Type',
+      type: 'select',
+      options: axisTypes,
       required: true,
     }],
   },

--- a/graylog2-web-interface/src/views/components/visualizations/scatter/ScatterVisualization.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/scatter/ScatterVisualization.tsx
@@ -24,7 +24,6 @@ import type { VisualizationComponentProps } from 'views/components/aggregationbu
 import { makeVisualization, retrieveChartData } from 'views/components/aggregationbuilder/AggregationBuilder';
 import useChartData from 'views/components/visualizations/useChartData';
 import useEvents from 'views/components/visualizations/useEvents';
-import type LineVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/LineVisualizationConfig';
 import ScatterVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/ScatterVisualizationConfig';
 
 import XYPlot from '../XYPlot';

--- a/graylog2-web-interface/src/views/components/visualizations/scatter/ScatterVisualization.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/scatter/ScatterVisualization.tsx
@@ -24,6 +24,8 @@ import type { VisualizationComponentProps } from 'views/components/aggregationbu
 import { makeVisualization, retrieveChartData } from 'views/components/aggregationbuilder/AggregationBuilder';
 import useChartData from 'views/components/visualizations/useChartData';
 import useEvents from 'views/components/visualizations/useEvents';
+import type LineVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/LineVisualizationConfig';
+import ScatterVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/ScatterVisualizationConfig';
 
 import XYPlot from '../XYPlot';
 
@@ -37,6 +39,7 @@ const ScatterVisualization = makeVisualization(({
   effectiveTimerange,
   height,
 }: VisualizationComponentProps) => {
+  const visualizationConfig = (config.visualizationConfig ?? ScatterVisualizationConfig.empty()) as ScatterVisualizationConfig;
   const rows = useMemo(() => retrieveChartData(data), [data]);
   const _chartDataResult = useChartData(rows, {
     widgetConfig: config,
@@ -50,6 +53,7 @@ const ScatterVisualization = makeVisualization(({
 
   return (
     <XYPlot config={config}
+            axisType={visualizationConfig.axisType}
             chartData={chartDataResult}
             setChartColor={setChartColor}
             plotLayout={layout}

--- a/graylog2-web-interface/src/views/components/visualizations/scatter/bindings.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/scatter/bindings.tsx
@@ -17,13 +17,32 @@
 import type { VisualizationType } from 'views/types';
 import ScatterVisualization from 'views/components/visualizations/scatter/ScatterVisualization';
 import { hasAtLeastOneMetric } from 'views/components/visualizations/validations';
+import type { AxisType } from 'views/logic/aggregationbuilder/visualizations/XYVisualization';
+import { DEFAULT_AXIS_TYPE, axisTypes } from 'views/logic/aggregationbuilder/visualizations/XYVisualization';
+import ScatterVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/ScatterVisualizationConfig';
+
+type ScatterVisualizationConfigFormValues = {
+  axisType: AxisType,
+};
 
 const validate = hasAtLeastOneMetric('Scatter plot');
 
-const scatterChart: VisualizationType<typeof ScatterVisualization.type> = {
+const scatterChart: VisualizationType<typeof ScatterVisualization.type, ScatterVisualizationConfig, ScatterVisualizationConfigFormValues> = {
   type: ScatterVisualization.type,
   displayName: 'Scatter Plot',
   component: ScatterVisualization,
+  config: {
+    createConfig: () => ({ axisType: DEFAULT_AXIS_TYPE }),
+    fromConfig: (config) => ({ axisType: config?.axisType ?? DEFAULT_AXIS_TYPE }),
+    toConfig: (formValues) => ScatterVisualizationConfig.create(formValues.axisType),
+    fields: [{
+      name: 'axisType',
+      title: 'Axis Type',
+      type: 'select',
+      options: axisTypes,
+      required: true,
+    }],
+  },
   capabilities: ['event-annotations'],
   validate,
 };

--- a/graylog2-web-interface/src/views/logic/aggregationbuilder/visualizations/AreaVisualizationConfig.ts
+++ b/graylog2-web-interface/src/views/logic/aggregationbuilder/visualizations/AreaVisualizationConfig.ts
@@ -15,29 +15,38 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as Immutable from 'immutable';
-import type { $PropertyType } from 'utility-types';
+
+import type { AxisType, XYVisualization } from 'views/logic/aggregationbuilder/visualizations/XYVisualization';
+import { DEFAULT_AXIS_TYPE } from 'views/logic/aggregationbuilder/visualizations/XYVisualization';
+import { DEFAULT_INTERPOLATION } from 'views/Constants';
 
 import VisualizationConfig from './VisualizationConfig';
 import type { InterpolationMode } from './Interpolation';
 
 type InternalState = {
   interpolation: InterpolationMode,
+  axisType: AxisType,
 };
 
 export type AreaVisualizationConfigJSON = {
   interpolation: InterpolationMode,
+  axis_type?: AxisType,
 };
 
-export default class AreaVisualizationConfig extends VisualizationConfig {
+export default class AreaVisualizationConfig extends VisualizationConfig implements XYVisualization {
   private readonly _value: InternalState;
 
-  constructor(interpolation: $PropertyType<InternalState, 'interpolation'>) {
+  constructor(interpolation: InternalState['interpolation'], axisType: InternalState['axisType']) {
     super();
-    this._value = { interpolation };
+    this._value = { interpolation, axisType };
   }
 
   get interpolation() {
     return this._value.interpolation;
+  }
+
+  get axisType() {
+    return this._value.axisType;
   }
 
   toBuilder() {
@@ -45,24 +54,28 @@ export default class AreaVisualizationConfig extends VisualizationConfig {
     return new Builder(Immutable.Map(this._value));
   }
 
-  static create(interpolation: $PropertyType<InternalState, 'interpolation'>) {
-    return new AreaVisualizationConfig(interpolation);
+  static create(interpolation: InternalState['interpolation'], axisType: InternalState['axisType']) {
+    return new AreaVisualizationConfig(interpolation, axisType);
   }
 
   static empty() {
-    return new AreaVisualizationConfig('linear');
+    return new AreaVisualizationConfig('linear', DEFAULT_AXIS_TYPE);
   }
 
   toJSON() {
-    const { interpolation } = this._value;
+    const { interpolation, axisType } = this._value;
 
-    return { interpolation };
+    return {
+      interpolation,
+      axis_type: axisType,
+    };
   }
 
-  static fromJSON(_type: string, value: AreaVisualizationConfigJSON = { interpolation: 'linear' }) {
-    const { interpolation = 'linear' } = value;
-
-    return AreaVisualizationConfig.create(interpolation);
+  static fromJSON(_type: string, value: AreaVisualizationConfigJSON) {
+    return AreaVisualizationConfig.create(
+      value?.interpolation ?? DEFAULT_INTERPOLATION,
+      value?.axis_type ?? DEFAULT_AXIS_TYPE,
+    );
   }
 }
 
@@ -75,13 +88,13 @@ class Builder {
     this.value = value;
   }
 
-  interpolation(value: $PropertyType<InternalState, 'interpolation'>) {
+  interpolation(value: InternalState['interpolation']) {
     return new Builder(this.value.set('interpolation', value));
   }
 
   build() {
-    const { interpolation } = this.value.toObject();
+    const { interpolation, axisType } = this.value.toObject();
 
-    return new AreaVisualizationConfig(interpolation);
+    return new AreaVisualizationConfig(interpolation, axisType);
   }
 }

--- a/graylog2-web-interface/src/views/logic/aggregationbuilder/visualizations/AreaVisualizationConfig.ts
+++ b/graylog2-web-interface/src/views/logic/aggregationbuilder/visualizations/AreaVisualizationConfig.ts
@@ -36,7 +36,7 @@ export type AreaVisualizationConfigJSON = {
 export default class AreaVisualizationConfig extends VisualizationConfig implements XYVisualization {
   private readonly _value: InternalState;
 
-  constructor(interpolation: InternalState['interpolation'], axisType: InternalState['axisType']) {
+  constructor(interpolation: InternalState['interpolation'], axisType: InternalState['axisType'] = DEFAULT_AXIS_TYPE) {
     super();
     this._value = { interpolation, axisType };
   }
@@ -54,12 +54,12 @@ export default class AreaVisualizationConfig extends VisualizationConfig impleme
     return new Builder(Immutable.Map(this._value));
   }
 
-  static create(interpolation: InternalState['interpolation'], axisType: InternalState['axisType']) {
+  static create(interpolation: InternalState['interpolation'], axisType: InternalState['axisType'] = DEFAULT_AXIS_TYPE) {
     return new AreaVisualizationConfig(interpolation, axisType);
   }
 
   static empty() {
-    return new AreaVisualizationConfig('linear', DEFAULT_AXIS_TYPE);
+    return AreaVisualizationConfig.create(DEFAULT_INTERPOLATION);
   }
 
   toJSON() {

--- a/graylog2-web-interface/src/views/logic/aggregationbuilder/visualizations/BarVisualizationConfig.ts
+++ b/graylog2-web-interface/src/views/logic/aggregationbuilder/visualizations/BarVisualizationConfig.ts
@@ -15,8 +15,11 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import type { XYVisualization, AxisType } from 'views/logic/aggregationbuilder/visualizations/XYVisualization';
+import { DEFAULT_AXIS_TYPE } from 'views/logic/aggregationbuilder/visualizations/XYVisualization';
 
 import VisualizationConfig from './VisualizationConfig';
+
+export const DEFAULT_BARMODE = 'group';
 
 export type BarMode = 'stack' | 'group' | 'overlay' | 'relative';
 
@@ -59,6 +62,10 @@ export default class BarVisualizationConfig extends VisualizationConfig implemen
 
   static create(barmode: BarMode, axisType: AxisType) {
     return new BarVisualizationConfig(barmode, axisType);
+  }
+
+  static empty() {
+    return BarVisualizationConfig.create(DEFAULT_BARMODE, DEFAULT_AXIS_TYPE);
   }
 
   toJSON() {

--- a/graylog2-web-interface/src/views/logic/aggregationbuilder/visualizations/BarVisualizationConfig.ts
+++ b/graylog2-web-interface/src/views/logic/aggregationbuilder/visualizations/BarVisualizationConfig.ts
@@ -60,12 +60,12 @@ export default class BarVisualizationConfig extends VisualizationConfig implemen
     return new Builder({ barmode, axisType });
   }
 
-  static create(barmode: BarMode, axisType: AxisType) {
+  static create(barmode: BarMode, axisType: AxisType = DEFAULT_AXIS_TYPE) {
     return new BarVisualizationConfig(barmode, axisType);
   }
 
   static empty() {
-    return BarVisualizationConfig.create(DEFAULT_BARMODE, DEFAULT_AXIS_TYPE);
+    return BarVisualizationConfig.create(DEFAULT_BARMODE);
   }
 
   toJSON() {

--- a/graylog2-web-interface/src/views/logic/aggregationbuilder/visualizations/BarVisualizationConfig.ts
+++ b/graylog2-web-interface/src/views/logic/aggregationbuilder/visualizations/BarVisualizationConfig.ts
@@ -14,7 +14,7 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import * as Immutable from 'immutable';
+import type { XYVisualization, AxisType } from 'views/logic/aggregationbuilder/visualizations/XYVisualization';
 
 import VisualizationConfig from './VisualizationConfig';
 
@@ -22,18 +22,28 @@ export type BarMode = 'stack' | 'group' | 'overlay' | 'relative';
 
 export type BarVisualizationConfigType = {
   barmode: BarMode,
+  axisType: AxisType,
 };
 
-export default class BarVisualizationConfig extends VisualizationConfig {
+export type BarVisualizationConfigJson = {
+  barmode: BarMode,
+  axis_type: AxisType,
+};
+
+export default class BarVisualizationConfig extends VisualizationConfig implements XYVisualization {
   _value: BarVisualizationConfigType;
 
-  constructor(barmode: BarMode) {
+  constructor(barmode: BarMode, axisType: AxisType) {
     super();
-    this._value = { barmode };
+    this._value = { barmode, axisType };
   }
 
   get barmode() {
     return this._value.barmode;
+  }
+
+  get axisType() {
+    return this._value.axisType;
   }
 
   get opacity() {
@@ -41,47 +51,55 @@ export default class BarVisualizationConfig extends VisualizationConfig {
   }
 
   toBuilder() {
-    const { barmode } = this._value;
+    const { barmode, axisType } = this._value;
 
     // eslint-disable-next-line @typescript-eslint/no-use-before-define
-    return new Builder(Immutable.Map({ barmode }));
+    return new Builder({ barmode, axisType });
   }
 
-  static create(barmode: BarMode) {
-    return new BarVisualizationConfig(barmode);
+  static create(barmode: BarMode, axisType: AxisType) {
+    return new BarVisualizationConfig(barmode, axisType);
   }
 
   toJSON() {
-    const { barmode } = this._value;
+    const { barmode, axisType } = this._value;
 
     return {
       barmode,
+      axis_type: axisType,
     };
   }
 
-  static fromJSON(_type: string, value: BarVisualizationConfigType) {
-    const { barmode } = value;
+  static fromJSON(_type: string, value: BarVisualizationConfigJson) {
+    const { barmode, axis_type } = value;
 
-    return BarVisualizationConfig.create(barmode);
+    return BarVisualizationConfig.create(barmode, axis_type);
   }
 }
 
-type InternalBuilderState = Immutable.Map<string, any>;
+type InternalBuilderState = {
+  barmode: BarMode,
+  axisType: AxisType,
+};
 
 class Builder {
-  value: InternalBuilderState;
+  private readonly value: InternalBuilderState;
 
-  constructor(value: InternalBuilderState = Immutable.Map()) {
-    this.value = value;
+  constructor(value: InternalBuilderState) {
+    this.value = Object.freeze({ ...value });
   }
 
   barmode(value: BarMode) {
-    return new Builder(this.value.set('barmode', value));
+    return new Builder({ ...this.value, barmode: value });
+  }
+
+  axisType(value: AxisType) {
+    return new Builder({ ...this.value, axisType: value });
   }
 
   build() {
-    const { barmode } = this.value.toObject();
+    const { barmode, axisType } = this.value;
 
-    return new BarVisualizationConfig(barmode);
+    return new BarVisualizationConfig(barmode, axisType);
   }
 }

--- a/graylog2-web-interface/src/views/logic/aggregationbuilder/visualizations/LineVisualizationConfig.ts
+++ b/graylog2-web-interface/src/views/logic/aggregationbuilder/visualizations/LineVisualizationConfig.ts
@@ -15,13 +15,10 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as Immutable from 'immutable';
+import { DEFAULT_INTERPOLATION } from 'src/views/Constants';
 
-import type {
-  XYVisualization,
-  AxisType,
-  AxisTypeJSON,
-} from 'views/logic/aggregationbuilder/visualizations/XYVisualization';
-import { DEFAULT_AXIS_TYPE, parseAxisType } from 'views/logic/aggregationbuilder/visualizations/XYVisualization';
+import type { XYVisualization, AxisType } from 'views/logic/aggregationbuilder/visualizations/XYVisualization';
+import { DEFAULT_AXIS_TYPE } from 'views/logic/aggregationbuilder/visualizations/XYVisualization';
 
 import VisualizationConfig from './VisualizationConfig';
 import type { InterpolationMode } from './Interpolation';
@@ -33,15 +30,13 @@ type InternalState = {
 
 export type LineVisualizationConfigJSON = {
   interpolation: InterpolationMode,
-  axis_type?: AxisTypeJSON,
+  axis_type?: AxisType,
 };
 
 export default class LineVisualizationConfig extends VisualizationConfig implements XYVisualization {
   private readonly _value: InternalState;
 
-  static readonly DEFAULT_INTERPOLATION: InterpolationMode = 'linear';
-
-  constructor(interpolation: InternalState['interpolation'], axisType: InternalState['axisType']) {
+  constructor(interpolation: InternalState['interpolation'], axisType: InternalState['axisType'] = DEFAULT_AXIS_TYPE) {
     super();
     this._value = { interpolation, axisType };
   }
@@ -64,19 +59,22 @@ export default class LineVisualizationConfig extends VisualizationConfig impleme
   }
 
   static empty() {
-    return new LineVisualizationConfig(this.DEFAULT_INTERPOLATION, DEFAULT_AXIS_TYPE);
+    return new LineVisualizationConfig(DEFAULT_INTERPOLATION, DEFAULT_AXIS_TYPE);
   }
 
   toJSON() {
-    const { interpolation } = this._value;
+    const { interpolation, axisType } = this._value;
 
-    return { interpolation };
+    return {
+      interpolation,
+      axis_type: axisType,
+    };
   }
 
   static fromJSON(_type: string, value: LineVisualizationConfigJSON) {
     return LineVisualizationConfig.create(
-      value?.interpolation ?? this.DEFAULT_INTERPOLATION,
-      parseAxisType(value?.axis_type),
+      value?.interpolation ?? DEFAULT_INTERPOLATION,
+      value?.axis_type ?? DEFAULT_AXIS_TYPE,
     );
   }
 }
@@ -92,6 +90,10 @@ class Builder {
 
   interpolation(value: InternalState['interpolation']) {
     return new Builder(this.value.set('interpolation', value));
+  }
+
+  axisType(value: InternalState['axisType']) {
+    return new Builder((this.value.set('axisType', value)));
   }
 
   build() {

--- a/graylog2-web-interface/src/views/logic/aggregationbuilder/visualizations/LineVisualizationConfig.ts
+++ b/graylog2-web-interface/src/views/logic/aggregationbuilder/visualizations/LineVisualizationConfig.ts
@@ -15,31 +15,43 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as Immutable from 'immutable';
-import type { $PropertyType } from 'utility-types';
+
+import type {
+  XYVisualization,
+  AxisType,
+  AxisTypeJSON,
+} from 'views/logic/aggregationbuilder/visualizations/XYVisualization';
+import { DEFAULT_AXIS_TYPE, parseAxisType } from 'views/logic/aggregationbuilder/visualizations/XYVisualization';
 
 import VisualizationConfig from './VisualizationConfig';
 import type { InterpolationMode } from './Interpolation';
 
 type InternalState = {
   interpolation: InterpolationMode,
+  axisType: AxisType,
 };
 
 export type LineVisualizationConfigJSON = {
   interpolation: InterpolationMode,
+  axis_type?: AxisTypeJSON,
 };
 
-export default class LineVisualizationConfig extends VisualizationConfig {
+export default class LineVisualizationConfig extends VisualizationConfig implements XYVisualization {
   private readonly _value: InternalState;
 
   static readonly DEFAULT_INTERPOLATION: InterpolationMode = 'linear';
 
-  constructor(interpolation: $PropertyType<InternalState, 'interpolation'>) {
+  constructor(interpolation: InternalState['interpolation'], axisType: InternalState['axisType']) {
     super();
-    this._value = { interpolation };
+    this._value = { interpolation, axisType };
   }
 
   get interpolation() {
     return this._value.interpolation;
+  }
+
+  get axisType() {
+    return this._value.axisType;
   }
 
   toBuilder() {
@@ -47,12 +59,12 @@ export default class LineVisualizationConfig extends VisualizationConfig {
     return new Builder(Immutable.Map(this._value));
   }
 
-  static create(interpolation: $PropertyType<InternalState, 'interpolation'>) {
-    return new LineVisualizationConfig(interpolation);
+  static create(interpolation: InternalState['interpolation'], axisType: InternalState['axisType']) {
+    return new LineVisualizationConfig(interpolation, axisType);
   }
 
   static empty() {
-    return new LineVisualizationConfig(this.DEFAULT_INTERPOLATION);
+    return new LineVisualizationConfig(this.DEFAULT_INTERPOLATION, DEFAULT_AXIS_TYPE);
   }
 
   toJSON() {
@@ -62,7 +74,10 @@ export default class LineVisualizationConfig extends VisualizationConfig {
   }
 
   static fromJSON(_type: string, value: LineVisualizationConfigJSON) {
-    return LineVisualizationConfig.create(value?.interpolation ?? this.DEFAULT_INTERPOLATION);
+    return LineVisualizationConfig.create(
+      value?.interpolation ?? this.DEFAULT_INTERPOLATION,
+      parseAxisType(value?.axis_type),
+    );
   }
 }
 
@@ -75,13 +90,13 @@ class Builder {
     this.value = value;
   }
 
-  interpolation(value: $PropertyType<InternalState, 'interpolation'>) {
+  interpolation(value: InternalState['interpolation']) {
     return new Builder(this.value.set('interpolation', value));
   }
 
   build() {
-    const { interpolation } = this.value.toObject();
+    const { interpolation, axisType } = this.value.toObject();
 
-    return new LineVisualizationConfig(interpolation);
+    return new LineVisualizationConfig(interpolation, axisType);
   }
 }

--- a/graylog2-web-interface/src/views/logic/aggregationbuilder/visualizations/LineVisualizationConfig.ts
+++ b/graylog2-web-interface/src/views/logic/aggregationbuilder/visualizations/LineVisualizationConfig.ts
@@ -54,7 +54,7 @@ export default class LineVisualizationConfig extends VisualizationConfig impleme
     return new Builder(Immutable.Map(this._value));
   }
 
-  static create(interpolation: InternalState['interpolation'], axisType: InternalState['axisType']) {
+  static create(interpolation: InternalState['interpolation'], axisType: InternalState['axisType'] = DEFAULT_AXIS_TYPE) {
     return new LineVisualizationConfig(interpolation, axisType);
   }
 

--- a/graylog2-web-interface/src/views/logic/aggregationbuilder/visualizations/LineVisualizationConfig.ts
+++ b/graylog2-web-interface/src/views/logic/aggregationbuilder/visualizations/LineVisualizationConfig.ts
@@ -15,8 +15,8 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as Immutable from 'immutable';
-import { DEFAULT_INTERPOLATION } from 'src/views/Constants';
 
+import { DEFAULT_INTERPOLATION } from 'views/Constants';
 import type { XYVisualization, AxisType } from 'views/logic/aggregationbuilder/visualizations/XYVisualization';
 import { DEFAULT_AXIS_TYPE } from 'views/logic/aggregationbuilder/visualizations/XYVisualization';
 

--- a/graylog2-web-interface/src/views/logic/aggregationbuilder/visualizations/ScatterVisualizationConfig.ts
+++ b/graylog2-web-interface/src/views/logic/aggregationbuilder/visualizations/ScatterVisualizationConfig.ts
@@ -1,0 +1,74 @@
+import * as Immutable from 'immutable';
+
+import type { AxisType, XYVisualization } from 'views/logic/aggregationbuilder/visualizations/XYVisualization';
+import VisualizationConfig from 'views/logic/aggregationbuilder/visualizations/VisualizationConfig';
+import { DEFAULT_AXIS_TYPE } from 'views/logic/aggregationbuilder/visualizations/XYVisualization';
+import LineVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/LineVisualizationConfig';
+
+type InternalState = {
+  axisType: AxisType,
+};
+
+export type ScatterVisualizationConfigJson = {
+  axis_type?: AxisType,
+};
+
+export default class ScatterVisualizationConfig extends VisualizationConfig implements XYVisualization {
+  private readonly _value: InternalState;
+
+  constructor(axisType: InternalState['axisType'] = DEFAULT_AXIS_TYPE) {
+    super();
+    this._value = { axisType };
+  }
+
+  get axisType() {
+    return this._value.axisType;
+  }
+
+  toBuilder() {
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
+    return new Builder(Immutable.Map(this._value));
+  }
+
+  static create(axisType: InternalState['axisType']) {
+    return new ScatterVisualizationConfig(axisType);
+  }
+
+  static empty() {
+    return new ScatterVisualizationConfig(DEFAULT_AXIS_TYPE);
+  }
+
+  toJSON() {
+    const { axisType } = this._value;
+
+    return {
+      axis_type: axisType,
+    };
+  }
+
+  static fromJSON(_type: string, value: ScatterVisualizationConfigJson) {
+    return ScatterVisualizationConfig.create(
+      value?.axis_type ?? DEFAULT_AXIS_TYPE,
+    );
+  }
+}
+
+type BuilderState = Immutable.Map<string, any>;
+
+class Builder {
+  value: BuilderState;
+
+  constructor(value: BuilderState = Immutable.Map()) {
+    this.value = value;
+  }
+
+  axisType(value: InternalState['axisType']) {
+    return new Builder((this.value.set('axisType', value)));
+  }
+
+  build() {
+    const { interpolation, axisType } = this.value.toObject();
+
+    return new LineVisualizationConfig(interpolation, axisType);
+  }
+}

--- a/graylog2-web-interface/src/views/logic/aggregationbuilder/visualizations/ScatterVisualizationConfig.ts
+++ b/graylog2-web-interface/src/views/logic/aggregationbuilder/visualizations/ScatterVisualizationConfig.ts
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 import * as Immutable from 'immutable';
 
 import type { AxisType, XYVisualization } from 'views/logic/aggregationbuilder/visualizations/XYVisualization';

--- a/graylog2-web-interface/src/views/logic/aggregationbuilder/visualizations/XYVisualization.ts
+++ b/graylog2-web-interface/src/views/logic/aggregationbuilder/visualizations/XYVisualization.ts
@@ -1,0 +1,21 @@
+import assertUnreachable from 'logic/assertUnreachable';
+
+export type AxisType = 'linear' | 'logarithmic';
+
+export interface XYVisualization {
+  axisType: AxisType;
+}
+
+export type AxisTypeJSON = 'LINEAR' | 'LOGARITHMIC';
+
+export const DEFAULT_AXIS_TYPE: AxisType = 'linear';
+
+export const parseAxisType = (axisType: AxisTypeJSON | null | undefined) => {
+  switch (axisType) {
+    case 'LINEAR': return 'linear';
+    case 'LOGARITHMIC': return 'logarithmic';
+    case null:
+    case undefined: return DEFAULT_AXIS_TYPE;
+    default: return assertUnreachable(axisType, 'Unable to parse axis type: ');
+  }
+};

--- a/graylog2-web-interface/src/views/logic/aggregationbuilder/visualizations/XYVisualization.ts
+++ b/graylog2-web-interface/src/views/logic/aggregationbuilder/visualizations/XYVisualization.ts
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 import type { ArrayElement } from 'views/types';
 
 export const axisTypes = ['linear', 'logarithmic'] as const;

--- a/graylog2-web-interface/src/views/logic/aggregationbuilder/visualizations/XYVisualization.ts
+++ b/graylog2-web-interface/src/views/logic/aggregationbuilder/visualizations/XYVisualization.ts
@@ -1,21 +1,11 @@
-import assertUnreachable from 'logic/assertUnreachable';
+import type { ArrayElement } from 'views/types';
 
-export type AxisType = 'linear' | 'logarithmic';
+export const axisTypes = ['linear', 'logarithmic'] as const;
+
+export type AxisType = ArrayElement<typeof axisTypes>;
 
 export interface XYVisualization {
   axisType: AxisType;
 }
 
-export type AxisTypeJSON = 'LINEAR' | 'LOGARITHMIC';
-
 export const DEFAULT_AXIS_TYPE: AxisType = 'linear';
-
-export const parseAxisType = (axisType: AxisTypeJSON | null | undefined) => {
-  switch (axisType) {
-    case 'LINEAR': return 'linear';
-    case 'LOGARITHMIC': return 'logarithmic';
-    case null:
-    case undefined: return DEFAULT_AXIS_TYPE;
-    default: return assertUnreachable(axisType, 'Unable to parse axis type: ');
-  }
-};

--- a/graylog2-web-interface/src/views/types.ts
+++ b/graylog2-web-interface/src/views/types.ts
@@ -48,6 +48,9 @@ import type { QueryValidationState } from 'views/components/searchbar/queryvalid
 import type Query from 'views/logic/queries/Query';
 import type { CustomCommand, CustomCommandContext } from 'views/components/searchbar/queryinput/types';
 
+export type ArrayElement<ArrayType extends readonly unknown[]> =
+  ArrayType extends readonly (infer ElementType)[] ? ElementType : never;
+
 export type BackendWidgetPosition = {
   id: string,
   col: number,


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is adding the option to switch the Y Axis of an X/Y-Chart (currently Area, Bar, Line & Scatter charts) to a logarithmic scale. The default is still a linear scale though.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/41929/208689022-47b7cb3b-eeca-4379-8b44-0e98b5b4bc91.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.