### PR TITLE
Fix unit test to avoid issues with day boundary or DST

### DIFF
--- a/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
@@ -1258,10 +1258,12 @@ public class FunctionsSnippetsTest extends BaseParserTest {
     @Test
     public void dateConversion() {
         final Rule rule = parser.parseRule(ruleForTest(), true);
-        final Message message = evaluateRule(rule);
+        Message message = new Message("test", "source", DateTime.parse("2010-01-01T10:00:00Z"));
+        evaluateRule(rule, message);
 
         Long utcHour = (Long) message.getField("utcHour");
         Long manilaHour = (Long) message.getField("manilaHour");
-        assertThat(manilaHour).isEqualTo(utcHour + 8);
+        assertThat(utcHour).isEqualTo(10);
+        assertThat(manilaHour).isEqualTo(18);
     }
 }


### PR DESCRIPTION
Unit test for date conversion should not use `now()`, as this may cause problems depending on when the test is executed.

/nocl