### PR TITLE
Avoid vanishing grouping direction when dragged.

### DIFF
--- a/changelog/unreleased/pr-14277.toml
+++ b/changelog/unreleased/pr-14277.toml
@@ -1,0 +1,4 @@
+type = "fixed"
+message = "Avoid vanishing grouping direction when dragged."
+
+pulls = ["14277"]

--- a/graylog2-web-interface/src/views/components/aggregationwizard/grouping/configuration/Direction.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/grouping/configuration/Direction.tsx
@@ -41,7 +41,7 @@ const Direction = ({ index }: Props) => (
              labelClassName="col-sm-3"
              wrapperClassName="col-sm-9">
         <DirectionOptions>
-          <Input defaultChecked={value === 'row'}
+          <Input checked={value === 'row'}
                  formGroupClassName=""
                  id={name}
                  label="Row"
@@ -49,7 +49,7 @@ const Direction = ({ index }: Props) => (
                  onChange={onChange}
                  type="radio"
                  value="row" />
-          <Input defaultChecked={value === 'column'}
+          <Input checked={value === 'column'}
                  formGroupClassName=""
                  id={name}
                  label="Column"


### PR DESCRIPTION
**Note:** This needs to be backported to `4.3` and `5.0`.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is using the `checked` instead of the `defaultChecked` prop for the radio input of the grouping directions.

This avoids the phenomenon that the radio input is becoming unchecked when a grouping is dragged, although the state stays consistent.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.