### PR TITLE
Remove not needed usage of `UserDateTimeProvider` in tests.

### DIFF
--- a/graylog2-web-interface/src/views/components/visualizations/__tests__/XYPlot.test.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/__tests__/XYPlot.test.tsx
@@ -31,7 +31,6 @@ import Query from 'views/logic/queries/Query';
 import { QueriesActions } from 'views/stores/QueriesStore';
 import { SearchActions } from 'views/stores/SearchStore';
 import { ALL_MESSAGES_TIMERANGE } from 'views/Constants';
-import UserDateTimeProvider from 'contexts/UserDateTimeProvider';
 
 jest.mock('views/stores/CurrentViewStateStore', () => ({
   CurrentViewStateStore: MockStore(
@@ -75,15 +74,13 @@ describe('XYPlot', () => {
     onZoom?: $PropertyType<XYPlotProps, 'onZoom'>,
   };
 
-  const SimpleXYPlot = ({ tz = 'UTC', ...props }: SimpleXYPlotProps) => (
-    <UserDateTimeProvider tz={tz}>
-      <XYPlot chartData={chartData}
-              config={config}
-              getChartColor={getChartColor}
-              setChartColor={setChartColor}
-              currentQuery={currentQuery}
-              {...props} />
-    </UserDateTimeProvider>
+  const SimpleXYPlot = (props: SimpleXYPlotProps) => (
+    <XYPlot chartData={chartData}
+            config={config}
+            getChartColor={getChartColor}
+            setChartColor={setChartColor}
+            currentQuery={currentQuery}
+            {...props} />
   );
 
   SimpleXYPlot.defaultProps = {
@@ -129,7 +126,7 @@ describe('XYPlot', () => {
     const genericPlot = wrapper.find('GenericPlot');
 
     expect(genericPlot).toHaveProp('layout', expect.objectContaining({
-      xaxis: { range: ['2018-10-11T22:04:21.723-04:00', '2018-10-12T06:04:21.723-04:00'], type: 'date' },
+      xaxis: { range: ['2018-10-12T04:04:21.723+02:00', '2018-10-12T12:04:21.723+02:00'], type: 'date' },
     }));
 
     genericPlot.get(0).props.onZoom('2018-10-12T04:04:21.723Z', '2018-10-12T08:04:21.723Z');
@@ -153,7 +150,7 @@ describe('XYPlot', () => {
     const genericPlot = wrapper.find('GenericPlot');
 
     expect(genericPlot).toHaveProp('layout', expect.objectContaining({
-      xaxis: { range: ['2018-10-12T02:04:21.723+00:00', '2018-10-12T10:04:21.723+00:00'], type: 'date' },
+      xaxis: { range: ['2018-10-12T04:04:21.723+02:00', '2018-10-12T12:04:21.723+02:00'], type: 'date' },
     }));
   });
 

--- a/graylog2-web-interface/src/views/components/visualizations/area/__tests__/AreaVisualization.test.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/area/__tests__/AreaVisualization.test.tsx
@@ -24,7 +24,6 @@ import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationW
 import Pivot from 'views/logic/aggregationbuilder/Pivot';
 import Series from 'views/logic/aggregationbuilder/Series';
 import MockQuery from 'views/logic/queries/Query';
-import UserDateTimeProvider from 'contexts/UserDateTimeProvider';
 
 import { effectiveTimerange, simpleChartData } from './AreaVisualization.fixtures';
 
@@ -42,12 +41,6 @@ jest.mock('util/AppConfig', () => ({
   gl2ServerUrl: jest.fn(() => undefined),
 }));
 
-const SUT = (props: React.ComponentProps<typeof AreaVisualization>) => (
-  <UserDateTimeProvider tz="Canada/Saskatchewan">
-    <AreaVisualization {...props} />
-  </UserDateTimeProvider>
-);
-
 describe('AreaVisualization', () => {
   it('generates correct props for plot component', () => {
     const config = AggregationWidgetConfig.builder()
@@ -57,19 +50,19 @@ describe('AreaVisualization', () => {
       .series([Series.forFunction('avg(nf_bytes)'), Series.forFunction('sum(nf_pkts)')])
       .build();
 
-    const wrapper = mount(<SUT config={config}
-                               data={simpleChartData}
-                               effectiveTimerange={effectiveTimerange}
-                               fields={Immutable.List()}
-                               height={1024}
-                               onChange={() => {}}
-                               toggleEdit={() => {}}
-                               width={800} />);
+    const wrapper = mount(<AreaVisualization config={config}
+                                             data={simpleChartData}
+                                             effectiveTimerange={effectiveTimerange}
+                                             fields={Immutable.List()}
+                                             height={1024}
+                                             onChange={() => {}}
+                                             toggleEdit={() => {}}
+                                             width={800} />);
 
     const genericPlot = wrapper.find('GenericPlot');
 
     expect(genericPlot).toHaveProp('layout', expect.objectContaining({
-      xaxis: { range: ['2019-11-28T09:21:00.486-06:00', '2019-11-28T09:25:57.000-06:00'], type: 'date' },
+      xaxis: { range: ['2019-11-28T16:21:00.486+01:00', '2019-11-28T16:25:57.000+01:00'], type: 'date' },
       legend: { y: -0.14 },
     }));
 
@@ -78,11 +71,11 @@ describe('AreaVisualization', () => {
         type: 'scatter',
         name: 'avg(nf_bytes)',
         x: [
-          '2019-11-28T09:21:00.000-06:00',
-          '2019-11-28T09:22:00.000-06:00',
-          '2019-11-28T09:23:00.000-06:00',
-          '2019-11-28T09:24:00.000-06:00',
-          '2019-11-28T09:25:00.000-06:00',
+          '2019-11-28T16:21:00.000+01:00',
+          '2019-11-28T16:22:00.000+01:00',
+          '2019-11-28T16:23:00.000+01:00',
+          '2019-11-28T16:24:00.000+01:00',
+          '2019-11-28T16:25:00.000+01:00',
         ],
         y: [24558.239393939395, 3660.5666666666666, 49989.69, 2475.225, 10034.822222222223],
         fill: 'tozeroy',
@@ -92,11 +85,11 @@ describe('AreaVisualization', () => {
         type: 'scatter',
         name: 'sum(nf_pkts)',
         x: [
-          '2019-11-28T09:21:00.000-06:00',
-          '2019-11-28T09:22:00.000-06:00',
-          '2019-11-28T09:23:00.000-06:00',
-          '2019-11-28T09:24:00.000-06:00',
-          '2019-11-28T09:25:00.000-06:00',
+          '2019-11-28T16:21:00.000+01:00',
+          '2019-11-28T16:22:00.000+01:00',
+          '2019-11-28T16:23:00.000+01:00',
+          '2019-11-28T16:24:00.000+01:00',
+          '2019-11-28T16:25:00.000+01:00',
         ],
         y: [14967, 1239, 20776, 1285, 4377],
         fill: 'tozeroy',

--- a/graylog2-web-interface/src/views/components/visualizations/heatmap/__tests__/HeatmapVisualization.test.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/heatmap/__tests__/HeatmapVisualization.test.tsx
@@ -24,19 +24,12 @@ import Series from 'views/logic/aggregationbuilder/Series';
 import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
 import type { AbsoluteTimeRange } from 'views/logic/queries/Query';
 import HeatmapVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/HeatmapVisualizationConfig';
-import UserDateTimeProvider from 'contexts/UserDateTimeProvider';
 
 import * as fixtures from './HeatmapVisualization.fixtures';
 
 import HeatmapVisualization from '../HeatmapVisualization';
 
 jest.mock('../../GenericPlot', () => mockComponent('GenericPlot'));
-
-const SUT = (props: React.ComponentProps<typeof HeatmapVisualization>) => (
-  <UserDateTimeProvider tz="Europe/Berlin">
-    <HeatmapVisualization {...props} />
-  </UserDateTimeProvider>
-);
 
 describe('HeatmapVisualization', () => {
   it('generates correct props for plot component', () => {
@@ -65,14 +58,14 @@ describe('HeatmapVisualization', () => {
       },
     ];
 
-    const wrapper = mount(<SUT data={fixtures.validData}
-                               config={config}
-                               effectiveTimerange={effectiveTimerange}
-                               fields={Immutable.List()}
-                               height={1024}
-                               onChange={() => {}}
-                               toggleEdit={() => {}}
-                               width={800} />);
+    const wrapper = mount(<HeatmapVisualization data={fixtures.validData}
+                                                config={config}
+                                                effectiveTimerange={effectiveTimerange}
+                                                fields={Immutable.List()}
+                                                height={1024}
+                                                onChange={() => {}}
+                                                toggleEdit={() => {}}
+                                                width={800} />);
     const genericPlot = wrapper.find('GenericPlot');
 
     expect(genericPlot).toHaveProp('layout', plotLayout);
@@ -110,14 +103,14 @@ describe('HeatmapVisualization', () => {
       },
     ];
 
-    const wrapper = mount(<SUT data={{ chart: [] }}
-                               config={config}
-                               effectiveTimerange={effectiveTimerange}
-                               fields={Immutable.List()}
-                               height={1024}
-                               onChange={() => {}}
-                               toggleEdit={() => {}}
-                               width={800} />);
+    const wrapper = mount(<HeatmapVisualization data={{ chart: [] }}
+                                                config={config}
+                                                effectiveTimerange={effectiveTimerange}
+                                                fields={Immutable.List()}
+                                                height={1024}
+                                                onChange={() => {}}
+                                                toggleEdit={() => {}}
+                                                width={800} />);
     const genericPlot = wrapper.find('GenericPlot');
 
     expect(genericPlot).toHaveProp('layout', plotLayout);

--- a/graylog2-web-interface/src/views/components/visualizations/worldmap/__tests__/WorldMapVisualization.test.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/worldmap/__tests__/WorldMapVisualization.test.tsx
@@ -25,7 +25,6 @@ import Series from 'views/logic/aggregationbuilder/Series';
 import RenderCompletionCallback from 'views/components/widgets/RenderCompletionCallback';
 import type { AbsoluteTimeRange } from 'views/logic/queries/Query';
 import type { Rows } from 'views/logic/searchtypes/pivot/PivotHandler';
-import UserDateTimeProvider from 'contexts/UserDateTimeProvider';
 
 import WorldMapVisualization from '../WorldMapVisualization';
 
@@ -35,12 +34,6 @@ type MapVisualizationProps = HTMLAttributes & {
   onChange: (viewPort: Viewport) => void;
   onRenderComplete: () => void;
 };
-
-const SUT = (props: React.ComponentProps<typeof WorldMapVisualization>) => (
-  <UserDateTimeProvider tz="Europe/Berlin">
-    <WorldMapVisualization {...props} />
-  </UserDateTimeProvider>
-);
 
 describe('WorldMapVisualization', () => {
   const config = AggregationWidgetConfig.builder().visualization(WorldMapVisualization.type).build();
@@ -52,15 +45,15 @@ describe('WorldMapVisualization', () => {
 
   it('does not call onChange when not editing', () => {
     const onChange = jest.fn();
-    const wrapper = mount(<SUT config={config}
-                               data={{ chart: [] }}
-                               editing={false}
-                               effectiveTimerange={effectiveTimerange}
-                               fields={Immutable.List()}
-                               onChange={onChange}
-                               toggleEdit={() => {}}
-                               height={1024}
-                               width={800} />);
+    const wrapper = mount(<WorldMapVisualization config={config}
+                                                 data={{ chart: [] }}
+                                                 editing={false}
+                                                 effectiveTimerange={effectiveTimerange}
+                                                 fields={Immutable.List()}
+                                                 onChange={onChange}
+                                                 toggleEdit={() => {}}
+                                                 height={1024}
+                                                 width={800} />);
     const mapVisualization = wrapper.find('map-visualization');
 
     const { onChange: _onChange } = mapVisualization.at(0).props() as MapVisualizationProps;
@@ -74,15 +67,15 @@ describe('WorldMapVisualization', () => {
 
   it('does call onChange when editing', () => {
     const onChange = jest.fn();
-    const wrapper = mount(<SUT config={config}
-                               data={{ chart: [] }}
-                               editing
-                               effectiveTimerange={effectiveTimerange}
-                               fields={Immutable.List()}
-                               onChange={onChange}
-                               toggleEdit={() => {}}
-                               height={1024}
-                               width={800} />);
+    const wrapper = mount(<WorldMapVisualization config={config}
+                                                 data={{ chart: [] }}
+                                                 editing
+                                                 effectiveTimerange={effectiveTimerange}
+                                                 fields={Immutable.List()}
+                                                 onChange={onChange}
+                                                 toggleEdit={() => {}}
+                                                 height={1024}
+                                                 width={800} />);
     const mapVisualization = wrapper.find('map-visualization');
 
     const { onChange: _onChange } = mapVisualization.at(0).props() as MapVisualizationProps;
@@ -102,15 +95,15 @@ describe('WorldMapVisualization', () => {
     const renderCompletionCallback = jest.fn();
     const wrapper = mount((
       <RenderCompletionCallback.Provider value={renderCompletionCallback}>
-        <SUT config={config}
-             data={{ chart: [] }}
-             editing
-             effectiveTimerange={effectiveTimerange}
-             fields={Immutable.List()}
-             onChange={() => {}}
-             toggleEdit={() => {}}
-             height={1024}
-             width={800} />
+        <WorldMapVisualization config={config}
+                               data={{ chart: [] }}
+                               editing
+                               effectiveTimerange={effectiveTimerange}
+                               fields={Immutable.List()}
+                               onChange={() => {}}
+                               toggleEdit={() => {}}
+                               height={1024}
+                               width={800} />
       </RenderCompletionCallback.Provider>
     ));
 
@@ -144,15 +137,15 @@ describe('WorldMapVisualization', () => {
       values: { '37.751,-97.822': 25, '35.69,139.69': 6 },
     }];
     const wrapper = mount((
-      <SUT config={configWithMetric}
-           data={data}
-           editing
-           effectiveTimerange={effectiveTimerange}
-           fields={Immutable.List()}
-           onChange={() => {}}
-           toggleEdit={() => {}}
-           height={1024}
-           width={800} />
+      <WorldMapVisualization config={configWithMetric}
+                             data={data}
+                             editing
+                             effectiveTimerange={effectiveTimerange}
+                             fields={Immutable.List()}
+                             onChange={() => {}}
+                             toggleEdit={() => {}}
+                             height={1024}
+                             width={800} />
     ));
     const mapVisualization = wrapper.find('map-visualization');
 
@@ -173,15 +166,15 @@ describe('WorldMapVisualization', () => {
       values: { '37.751,-97.822': null, '35.69,139.69': null },
     }];
     const wrapper = mount((
-      <SUT config={configWithoutMetric}
-           data={data}
-           editing
-           effectiveTimerange={effectiveTimerange}
-           fields={Immutable.List()}
-           onChange={() => {}}
-           toggleEdit={() => {}}
-           height={1024}
-           width={800} />
+      <WorldMapVisualization config={configWithoutMetric}
+                             data={data}
+                             editing
+                             effectiveTimerange={effectiveTimerange}
+                             fields={Immutable.List()}
+                             onChange={() => {}}
+                             toggleEdit={() => {}}
+                             height={1024}
+                             width={800} />
     ));
     const mapVisualization = wrapper.find('map-visualization');
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Since we included the `UserDateTimeProvider` in the `WrappingContainer`, which we render for every test, we do not have to render the `UserDateTimeProvider` in test manually anymore.

/nocl