### PR TITLE
Fix overflow of more actions dropdown in streams overview.

### DIFF
--- a/graylog2-web-interface/src/components/bootstrap/DropdownButton.jsx
+++ b/graylog2-web-interface/src/components/bootstrap/DropdownButton.jsx
@@ -20,6 +20,9 @@ import styled, { css } from 'styled-components';
 
 import menuItemStyles from './styles/menuItem';
 
+/**
+ * This is the default dropdown button component. If you need to display the dropdown in a portal, please use the `OverlayDropdownButton`.
+ */
 const DropdownButton = styled(BootstrapDropdownButton)(({ theme }) => css`
   ${theme.components.button}
   & ~ {

--- a/graylog2-web-interface/src/components/common/OverlayDropdown.tsx
+++ b/graylog2-web-interface/src/components/common/OverlayDropdown.tsx
@@ -14,7 +14,7 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import React, { useState } from 'react';
+import React, { useState, useRef } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { Overlay, Transition } from 'react-overlays';
@@ -61,12 +61,13 @@ type Props = {
   onToggle: () => void,
   placement?: Placement,
   show: boolean,
-  toggle: React.ReactNode,
+  toggleChild?: React.ReactNode,
+  renderToggle?: (payload: { onToggle: () => void, toggleTarget: React.Ref<HTMLElement> }) => React.ReactNode,
 }
 
-const OverlayDropdown = ({ children, menuContainer, onToggle, placement, show, toggle }: Props) => {
+const OverlayDropdown = ({ children, menuContainer, onToggle, placement, show, toggleChild, renderToggle }: Props) => {
   const [currentPlacement, setCurrentPlacement] = useState<Placement>(placement);
-  const toggleTarget = React.createRef<HTMLSpanElement>();
+  const toggleTarget = useRef<HTMLElement>();
 
   const handleOverlayEntering = (dropdownElem) => {
     const dropdownOffsetLeft = dropdownElem.offsetLeft;
@@ -82,11 +83,13 @@ const OverlayDropdown = ({ children, menuContainer, onToggle, placement, show, t
 
   return (
     <>
-      <ToggleDropdown onClick={onToggle}
-                      ref={toggleTarget}
-                      role="presentation">
-        {toggle}
-      </ToggleDropdown>
+      {typeof renderToggle === 'function' ? renderToggle({ onToggle, toggleTarget }) : (
+        <ToggleDropdown onClick={onToggle}
+                        ref={toggleTarget}
+                        role="presentation">
+          {toggleChild}
+        </ToggleDropdown>
+      )}
       {show && (
         <Overlay show={show}
                  container={menuContainer}
@@ -115,12 +118,14 @@ OverlayDropdown.propTypes = {
   onToggle: PropTypes.func.isRequired,
   placement: PropTypes.string,
   show: PropTypes.bool.isRequired,
-  toggle: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
+  toggleChild: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
 };
 
 OverlayDropdown.defaultProps = {
   menuContainer: document.body,
   placement: 'bottom',
+  renderToggle: () => 'Toggle',
+  toggleChild: 'Toggle',
 };
 
 export default OverlayDropdown;

--- a/graylog2-web-interface/src/components/common/OverlayDropdown.tsx
+++ b/graylog2-web-interface/src/components/common/OverlayDropdown.tsx
@@ -124,7 +124,7 @@ OverlayDropdown.propTypes = {
 OverlayDropdown.defaultProps = {
   menuContainer: document.body,
   placement: 'bottom',
-  renderToggle: () => 'Toggle',
+  renderToggle: undefined,
   toggleChild: 'Toggle',
 };
 

--- a/graylog2-web-interface/src/components/common/OverlayDropdown.tsx
+++ b/graylog2-web-interface/src/components/common/OverlayDropdown.tsx
@@ -19,7 +19,7 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { Overlay, Transition } from 'react-overlays';
 
-import { DropdownMenu } from 'components/common';
+import { DropdownMenu } from 'components/common/index';
 
 const ToggleDropdown = styled.span`
   cursor: pointer;
@@ -71,7 +71,7 @@ const OverlayDropdown = ({ children, menuContainer, onToggle, placement, show, t
       <ToggleDropdown onClick={onToggle}
                       ref={toggleTarget}
                       role="presentation">
-        {toggle}<span className="caret" />
+        {toggle}
       </ToggleDropdown>
       {show && (
         <Overlay show={show}

--- a/graylog2-web-interface/src/components/common/OverlayDropdown.tsx
+++ b/graylog2-web-interface/src/components/common/OverlayDropdown.tsx
@@ -21,6 +21,8 @@ import { Overlay, Transition } from 'react-overlays';
 
 import { DropdownMenu } from 'components/common/index';
 
+type Placement = 'top' | 'right' | 'bottom' | 'left';
+
 const ToggleDropdown = styled.span`
   cursor: pointer;
 
@@ -40,8 +42,7 @@ const oppositePlacement = {
 
 type _FilterProps = {
   children: React.ReactElement,
-  // eslint-disable-next-line react/require-default-props
-  style?: {}
+  style?: CSSStyleDeclaration
 };
 
 const FilterProps = ({ children, style }: _FilterProps) => (
@@ -50,8 +51,21 @@ const FilterProps = ({ children, style }: _FilterProps) => (
   </>
 );
 
-const OverlayDropdown = ({ children, menuContainer, onToggle, placement, show, toggle }) => {
-  const [currentPlacement, setCurrentPlacement] = useState(placement);
+FilterProps.defaultProps = {
+  style: {},
+};
+
+type Props = {
+  children: React.ReactNode,
+  menuContainer?: HTMLElement,
+  onToggle: () => void,
+  placement?: Placement,
+  show: boolean,
+  toggle: React.ReactNode,
+}
+
+const OverlayDropdown = ({ children, menuContainer, onToggle, placement, show, toggle }: Props) => {
+  const [currentPlacement, setCurrentPlacement] = useState<Placement>(placement);
   const toggleTarget = React.createRef<HTMLSpanElement>();
 
   const handleOverlayEntering = (dropdownElem) => {
@@ -62,7 +76,7 @@ const OverlayDropdown = ({ children, menuContainer, onToggle, placement, show, t
     const trimmedDropdown = (overflowLeft && currentPlacement === 'left') || (overflowRight && currentPlacement === 'right');
 
     if (trimmedDropdown) {
-      setCurrentPlacement(oppositePlacement[currentPlacement]);
+      setCurrentPlacement(oppositePlacement[currentPlacement] as Placement);
     }
   };
 

--- a/graylog2-web-interface/src/components/common/OverlayDropdownButton.tsx
+++ b/graylog2-web-interface/src/components/common/OverlayDropdownButton.tsx
@@ -19,7 +19,6 @@ import { useState } from 'react';
 
 import Button from 'components/bootstrap/Button';
 import OverlayDropdown from 'components/common/OverlayDropdown';
-import Icon from 'components/common/Icon';
 
 type Props = {
   children: React.ReactNode,
@@ -38,12 +37,15 @@ const OverlayDropdownButton = ({ children, title, bsSize, disabled }: Props) => 
   return (
     <OverlayDropdown show={show}
                      renderToggle={({ onToggle, toggleTarget }) => (
-                       <Button bsSize={bsSize}
-                               ref={toggleTarget}
-                               disabled={disabled}
-                               onClick={onToggle}>
-                         {title} <span className="caret" />
-                       </Button>
+                       <div className={`dropdown btn-group ${show ? 'open' : ''}`}>
+                         <Button bsSize={bsSize}
+                                 className="dropdown-toggle"
+                                 ref={toggleTarget}
+                                 disabled={disabled}
+                                 onClick={onToggle}>
+                           {title} <span className="caret" />
+                         </Button>
+                       </div>
                      )}
                      placement="bottom"
                      onToggle={() => setShowDropdown((cur) => !cur)}>

--- a/graylog2-web-interface/src/components/common/OverlayDropdownButton.tsx
+++ b/graylog2-web-interface/src/components/common/OverlayDropdownButton.tsx
@@ -28,8 +28,7 @@ type Props = {
 };
 
 /**
- * Component used to display a simple alert message for a search that returned no matching results.
- * Usage should include utilizing the `children` props to supply the user with a descriptive message.
+ * This component is an alternative to the `DropdownButton` component and displays the dropdown in a portal.
  */
 const OverlayDropdownButton = ({ children, title, bsSize, disabled }: Props) => {
   const [show, setShowDropdown] = useState(false);

--- a/graylog2-web-interface/src/components/common/OverlayDropdownButton.tsx
+++ b/graylog2-web-interface/src/components/common/OverlayDropdownButton.tsx
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import { useState } from 'react';
+
+import Button from 'components/bootstrap/Button';
+import OverlayDropdown from 'components/common/OverlayDropdown';
+import Icon from 'components/common/Icon';
+
+type Props = {
+  children: React.ReactNode,
+  title: string,
+  bsSize?: string
+  disabled?: boolean
+};
+
+/**
+ * Component used to display a simple alert message for a search that returned no matching results.
+ * Usage should include utilizing the `children` props to supply the user with a descriptive message.
+ */
+const OverlayDropdownButton = ({ children, title, bsSize, disabled }: Props) => {
+  const [show, setShowDropdown] = useState(false);
+
+  return (
+    <OverlayDropdown show={show}
+                     renderToggle={({ onToggle, toggleTarget }) => (
+                       <Button bsSize={bsSize}
+                               ref={toggleTarget}
+                               disabled={disabled}
+                               onClick={onToggle}>
+                         {title} <span className="caret" />
+                       </Button>
+                     )}
+                     placement="bottom"
+                     onToggle={() => setShowDropdown((cur) => !cur)}>
+      {children}
+    </OverlayDropdown>
+  );
+};
+
+OverlayDropdownButton.defaultProps = {
+  bsSize: undefined,
+  disabled: false,
+};
+
+export default OverlayDropdownButton;

--- a/graylog2-web-interface/src/components/streams/StreamsOverview/StreamActions.tsx
+++ b/graylog2-web-interface/src/components/streams/StreamsOverview/StreamActions.tsx
@@ -18,7 +18,7 @@ import * as React from 'react';
 import { useState, useCallback } from 'react';
 
 import { ShareButton, IfPermitted, HoverForHelp } from 'components/common';
-import { ButtonToolbar, DropdownButton, MenuItem } from 'components/bootstrap';
+import { ButtonToolbar, MenuItem } from 'components/bootstrap';
 import type { Stream, StreamRule, StreamRuleType } from 'stores/streams/StreamsStore';
 import StreamsStore from 'stores/streams/StreamsStore';
 import { LinkContainer } from 'components/common/router';
@@ -31,6 +31,7 @@ import EntityShareModal from 'components/permissions/EntityShareModal';
 import { StreamRulesStore } from 'stores/streams/StreamRulesStore';
 import useCurrentUser from 'hooks/useCurrentUser';
 import type { IndexSet } from 'stores/indices/IndexSetsStore';
+import OverlayDropdownButton from 'components/common/OverlayDropdownButton';
 
 import StreamModal from '../StreamModal';
 
@@ -123,11 +124,9 @@ const StreamActions = ({
                    entityType="stream"
                    onClick={toggleEntityShareModal}
                    bsSize="xsmall" />
-      <DropdownButton title="More Actions"
-                      pullRight
-                      bsSize="xsmall"
-                      id={`more-actions-dropdown-${stream.id}`}
-                      disabled={isNotEditable}>
+      <OverlayDropdownButton title="More Actions"
+                             bsSize="xsmall"
+                             disabled={isNotEditable}>
         <IfPermitted permissions={[`streams:changestate:${stream.id}`, `streams:edit:${stream.id}`]} anyPermissions>
           <MenuItem bsStyle="success"
                     onSelect={onToggleStreamStatus}
@@ -189,7 +188,7 @@ const StreamActions = ({
             Delete this stream {isDefaultStream && <DefaultStreamHelp />}
           </MenuItem>
         </IfPermitted>
-      </DropdownButton>
+      </OverlayDropdownButton>
       {showUpdateModal && (
         <StreamModal title="Editing Stream"
                      onSubmit={onUpdate}

--- a/graylog2-web-interface/src/views/components/actions/Action.tsx
+++ b/graylog2-web-interface/src/views/components/actions/Action.tsx
@@ -18,10 +18,9 @@ import * as React from 'react';
 import { useCallback, useState } from 'react';
 
 import type { ActionHandlerArguments } from 'views/components/actions/ActionHandler';
+import OverlayDropdown from 'components/common/OverlayDropdown';
 
 import ActionDropdown from './ActionDropdown';
-
-import OverlayDropdown from '../OverlayDropdown';
 
 type Props = {
   children: React.ReactNode,
@@ -37,7 +36,7 @@ const Action = ({ type, handlerArgs, menuContainer, element: Element, children }
 
   const _onMenuToggle = useCallback(() => setOpen(!open), [open]);
   const overflowingComponentsValues: Array<React.ReactNode> = Object.values(overflowingComponents);
-  const element = <Element active={open} />;
+  const element = <><Element active={open} /><span className="caret" /></>;
 
   return (
     <>

--- a/graylog2-web-interface/src/views/components/actions/Action.tsx
+++ b/graylog2-web-interface/src/views/components/actions/Action.tsx
@@ -41,7 +41,7 @@ const Action = ({ type, handlerArgs, menuContainer, element: Element, children }
   return (
     <>
       <OverlayDropdown show={open}
-                       toggle={element}
+                       toggleChild={element}
                        placement="right"
                        onToggle={_onMenuToggle}
                        menuContainer={menuContainer}>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The new layout for the streams overview scroll horizontally when there is not enough space. This resulted in a problem with the more actions dropdown, under some circumstances

![image](https://user-images.githubusercontent.com/46300478/209165792-2b3ada0f-3dda-424a-ba75-c791ba291941.png)

With this PR we are using a portal for the dropdown to fix the overflow problem
![image](https://user-images.githubusercontent.com/46300478/209165910-f7a73730-9b30-496b-997b-482182a32b85.png)

/nocl