### PR TITLE
Escape Event content in HTML email notifications (#14286) (5.0)

### DIFF
--- a/changelog/unreleased/issue-11183.toml
+++ b/changelog/unreleased/issue-11183.toml
@@ -1,0 +1,8 @@
+type = "fixed"
+message = "Properly escape event content for HTML email notifications"
+
+issues = ["11183"]
+pulls = ["14286"]
+
+contributors = ["zhu"]
+

--- a/graylog2-server/src/main/java/org/graylog/events/notifications/types/EmailSender.java
+++ b/graylog2-server/src/main/java/org/graylog/events/notifications/types/EmailSender.java
@@ -39,6 +39,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 import java.util.ArrayList;
 import java.util.Map;
 import java.util.Set;
@@ -54,6 +55,7 @@ public class EmailSender {
     private final NodeId nodeId;
     private final ObjectMapperProvider objectMapperProvider;
     private final Engine templateEngine;
+    private final Engine htmlTemplateEngine;
     private final EmailFactory emailFactory;
 
     @Inject
@@ -62,12 +64,14 @@ public class EmailSender {
                        NodeId nodeId,
                        ObjectMapperProvider objectMapperProvider,
                        Engine templateEngine,
+                       @Named("HtmlSafe") Engine htmlTemplateEngine,
                        EmailFactory emailFactory) {
         this.emailRecipientsFactory = requireNonNull(emailRecipientsFactory, "emailRecipientsFactory");
         this.notificationService = requireNonNull(notificationService, "notificationService");
         this.nodeId = requireNonNull(nodeId, "nodeId");
         this.objectMapperProvider = requireNonNull(objectMapperProvider, "objectMapperProvider)");
         this.templateEngine = requireNonNull(templateEngine, "templateEngine");
+        this.htmlTemplateEngine = requireNonNull(htmlTemplateEngine, "htmlTemplateEngine");
         this.emailFactory = requireNonNull(emailFactory, "emailFactory");
     }
 
@@ -92,12 +96,12 @@ public class EmailSender {
             template = config.bodyTemplate();
         }
 
-        return this.templateEngine.transform(template, model);
+        return templateEngine.transform(template, model);
     }
 
     @VisibleForTesting
     private String buildHtmlBody(EmailEventNotificationConfig config, Map<String, Object> model) {
-        return this.templateEngine.transform(config.htmlBodyTemplate(), model);
+        return htmlTemplateEngine.transform(config.htmlBodyTemplate(), model);
     }
 
     private Map<String, Object> getModel(EventNotificationContext ctx, ImmutableList<MessageSummary> backlog, DateTimeZone timeZone) {

--- a/graylog2-server/src/main/java/org/graylog2/bindings/ServerBindings.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/ServerBindings.java
@@ -21,6 +21,7 @@ import com.google.inject.Scopes;
 import com.google.inject.assistedinject.FactoryModuleBuilder;
 import com.google.inject.multibindings.Multibinder;
 import com.google.inject.multibindings.OptionalBinder;
+import com.google.inject.name.Names;
 import org.apache.shiro.mgt.DefaultSecurityManager;
 import org.glassfish.grizzly.http.server.ErrorPageGenerator;
 import org.graylog.scheduler.capabilities.ServerNodeCapabilitiesModule;
@@ -31,6 +32,7 @@ import org.graylog2.alerts.FormattedEmailAlertSender;
 import org.graylog2.bindings.providers.ClusterEventBusProvider;
 import org.graylog2.bindings.providers.DefaultSecurityManagerProvider;
 import org.graylog2.bindings.providers.DefaultStreamProvider;
+import org.graylog2.bindings.providers.HtmlSafeJmteEngineProvider;
 import org.graylog2.bindings.providers.SystemJobFactoryProvider;
 import org.graylog2.bindings.providers.SystemJobManagerProvider;
 import org.graylog2.cluster.ClusterConfigServiceImpl;
@@ -175,6 +177,7 @@ public class ServerBindings extends Graylog2Module {
         bind(ClusterConfigService.class).to(ClusterConfigServiceImpl.class).asEagerSingleton();
         bind(GrokPatternRegistry.class).in(Scopes.SINGLETON);
         bind(Engine.class).toInstance(Engine.createEngine());
+        bind(Engine.class).annotatedWith(Names.named("HtmlSafe")).toProvider(HtmlSafeJmteEngineProvider.class).asEagerSingleton();
         bind(ErrorPageGenerator.class).to(GraylogErrorPageGenerator.class).asEagerSingleton();
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/bindings/providers/HtmlSafeJmteEngineProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/providers/HtmlSafeJmteEngineProvider.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.bindings.providers;
+
+import com.floreysoft.jmte.Engine;
+import com.floreysoft.jmte.Renderer;
+import com.google.common.html.HtmlEscapers;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+import javax.inject.Singleton;
+import java.util.Locale;
+import java.util.Map;
+
+
+@Singleton
+public class HtmlSafeJmteEngineProvider implements Provider<Engine> {
+    private final Engine engine;
+
+    @Inject
+    public HtmlSafeJmteEngineProvider() {
+      engine = Engine.createEngine();
+      engine.registerRenderer(String.class, new HtmlSafeRenderer());
+    }
+
+    @Override
+    public Engine get() {
+      return engine;
+    }
+
+    private static class HtmlSafeRenderer implements Renderer<String> {
+      @Override
+      public String render(String value, Locale locale, Map<String,Object> model) {
+          return HtmlEscapers.htmlEscaper().escape(value);
+      }
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog/events/notifications/types/EmailSenderTest.java
+++ b/graylog2-server/src/test/java/org/graylog/events/notifications/types/EmailSenderTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.events.notifications.types;
+
+import com.floreysoft.jmte.Engine;
+import org.apache.commons.mail.EmailException;
+import org.apache.commons.mail.HtmlEmail;
+import org.graylog2.alerts.EmailRecipients;
+import org.graylog2.bindings.providers.HtmlSafeJmteEngineProvider;
+import org.graylog2.notifications.NotificationService;
+import org.graylog2.plugin.system.NodeId;
+import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
+import org.graylog2.shared.email.EmailFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Map;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class EmailSenderTest {
+    @Mock
+    private EmailRecipients.Factory emailRecpientsFactory;
+    @Mock
+    private NotificationService notificationService;
+    @Mock
+    private NodeId nodeId;
+    @Mock
+    private ObjectMapperProvider objectMapperProvider;
+    @Mock
+    private EmailFactory emailFactory;
+    @Mock
+    private HtmlEmail htmlEmail;
+
+    private EmailSender emailSender;
+
+    @BeforeEach
+    void setUp() throws EmailException {
+        when(emailFactory.htmlEmail()).thenReturn(htmlEmail);
+
+        emailSender = new EmailSender(emailRecpientsFactory, notificationService, nodeId, objectMapperProvider,
+                new Engine(), new HtmlSafeJmteEngineProvider().get(), emailFactory);
+    }
+
+    @Test
+    void testEmailHtmlEscaping() throws EmailException {
+        Map<String, Object> model = Map.of(
+                "event_definition_title", "<<Test Event Title>>",
+                "event", Map.of("message", "Event Message & Whatnot")
+        );
+        final EmailEventNotificationConfig config = EmailEventNotificationConfig.builder()
+                .htmlBodyTemplate(
+                    "Message:              ${event.message}\n" +
+                    "Title:                ${event_definition_title}\n"
+                )
+                .build();
+
+        emailSender.createEmailWithBody(config, model);
+
+        final ArgumentCaptor<String> plainCaptor = ArgumentCaptor.forClass(String.class);
+        final ArgumentCaptor<String> htmlCaptor = ArgumentCaptor.forClass(String.class);
+        verify(htmlEmail).setTextMsg(plainCaptor.capture());
+        verify(htmlEmail).setHtmlMsg(htmlCaptor.capture());
+
+        assertThat(plainCaptor.getValue()).matches(Pattern.compile(".*Title:\\s+<<Test Event Title>>.*", Pattern.DOTALL));
+        assertThat(plainCaptor.getValue()).matches(Pattern.compile(".*Message:\\s+Event Message & Whatnot.*", Pattern.DOTALL));
+
+        assertThat(htmlCaptor.getValue()).matches(Pattern.compile(".*Title:\\s+&lt;&lt;Test Event Title&gt;&gt;.*", Pattern.DOTALL));
+        assertThat(htmlCaptor.getValue()).matches(Pattern.compile(".*Message:\\s+Event Message &amp; Whatnot.*", Pattern.DOTALL));
+    }
+}


### PR DESCRIPTION
* replace Jmte Engine instance with JmteEngineProvider

plugins can add NamedRenderer to engine
add HtmlSafeRenderer to engine by default

* Add EmailJmteEngineProvider, always escape values

* Apply html escape to new event notification emails

The legacy email notification was plaintext only
and does not need to be escaped.

Also simplify escaping a bit and don't escape the email Subject.

* Add EmailSenderTest

* add changelog

* remove unneded multibinder

* revert test notification title change

* keep singleton binding for regular template engine

Co-authored-by: 朱穆穆 <mumu.zhu@feat.com>
(cherry picked from commit 29a4c31682274c252b7a95a355b2361966611471)
