### PR TITLE
Showing widget placeholders allowing inline widget creation.

### DIFF
--- a/changelog/unreleased/pr-14331.toml
+++ b/changelog/unreleased/pr-14331.toml
@@ -1,0 +1,4 @@
+type = "added"
+message = "Adding inline widget creation in empty slots on grid."
+
+pulls = ["14331"]

--- a/graylog2-web-interface/src/components/common/ReactGridContainer.tsx
+++ b/graylog2-web-interface/src/components/common/ReactGridContainer.tsx
@@ -158,6 +158,18 @@ const computeLayout = (positions: WidgetPositions = {}) => {
 
 type Layout = { i: string, x: number, y: number, h: number, w: number }[];
 
+const removeGaps = (_layout: Layout) => {
+  const gapIndices = [];
+
+  _layout.forEach((item, idx) => {
+    if (item.i.startsWith('gap')) {
+      gapIndices.push(idx);
+    }
+  });
+
+  gapIndices.reverse().forEach((idx) => _layout.splice(idx, 1));
+};
+
 /**
  * Component that renders a draggable and resizable grid. You can control
  * the grid elements' positioning, as well as if they should be resizable
@@ -200,7 +212,9 @@ const ReactGridContainer = ({
       // Do not allow dragging from elements inside a `.actions` css class. This is
       // meant to avoid calling `onDragStop` callbacks when clicking on an action button.
                                    draggableCancel=".actions"
+                                   onDragStart={removeGaps}
                                    onDragStop={onLayoutChange}
+                                   onResizeStart={removeGaps}
                                    onResizeStop={onLayoutChange}
       // While CSS transform improves the paint performance,
       // it currently results in bug when using `react-sticky-el` inside a grid item.

--- a/graylog2-web-interface/src/components/common/ReactGridContainer.tsx
+++ b/graylog2-web-interface/src/components/common/ReactGridContainer.tsx
@@ -139,7 +139,7 @@ type Props = {
   locked?: boolean,
   measureBeforeMount?: boolean,
   onPositionsChange: (newPositions: Array<WidgetPositionJSON>) => void,
-  onSyncLayout: (newPositions: Array<WidgetPositionJSON>) => void,
+  onSyncLayout?: (newPositions: Array<WidgetPositionJSON>) => void,
   positions: { [widgetId: string]: WidgetPosition },
   rowHeight?: number,
   theme: DefaultTheme,
@@ -330,6 +330,7 @@ ReactGridContainer.defaultProps = {
   rowHeight: ROW_HEIGHT,
   draggableHandle: undefined,
   width: undefined,
+  onSyncLayout: () => {},
 };
 
 export default withTheme(ReactGridContainer);

--- a/graylog2-web-interface/src/components/common/ReactGridContainer.tsx
+++ b/graylog2-web-interface/src/components/common/ReactGridContainer.tsx
@@ -107,15 +107,17 @@ type Position = {
 const _onLayoutChange = (newLayout: Layout, onPositionsChange: (newPositions: Position[]) => void) => {
   const newPositions: Position[] = [];
 
-  newLayout.forEach((widget) => {
-    newPositions.push({
-      id: widget.i,
-      col: widget.x + 1,
-      row: widget.y + 1,
-      height: widget.h,
-      width: widget.w,
+  newLayout
+    .filter(({ i }) => !i.startsWith('gap'))
+    .forEach((widget) => {
+      newPositions.push({
+        id: widget.i,
+        col: widget.x + 1,
+        row: widget.y + 1,
+        height: widget.h,
+        width: widget.w,
+      });
     });
-  });
 
   onPositionsChange(newPositions);
 };
@@ -136,6 +138,7 @@ type Props = {
   locked?: boolean,
   measureBeforeMount?: boolean,
   onPositionsChange: (newPositions: Array<WidgetPositionJSON>) => void,
+  onSyncLayout: (newPositions: Array<WidgetPositionJSON>) => void,
   positions: { [widgetId: string]: WidgetPosition },
   rowHeight?: number,
   theme: DefaultTheme,
@@ -185,6 +188,7 @@ const ReactGridContainer = ({
   locked,
   measureBeforeMount,
   onPositionsChange,
+  onSyncLayout: _onSyncLayout,
   positions,
   rowHeight,
   theme,
@@ -192,6 +196,7 @@ const ReactGridContainer = ({
 }: Props) => {
   const cellMargin = theme.spacings.px.xs;
   const onLayoutChange = useCallback((layout: Layout) => _onLayoutChange(layout, onPositionsChange), [onPositionsChange]);
+  const onSyncLayout = useCallback((layout: Layout) => _onLayoutChange(layout, _onSyncLayout), [_onSyncLayout]);
   const gridClass = _gridClass(locked, isResizable, draggableHandle, className);
   const layout = useMemo(() => computeLayout(positions), [positions]);
 
@@ -216,6 +221,7 @@ const ReactGridContainer = ({
                                    onDragStop={onLayoutChange}
                                    onResizeStart={removeGaps}
                                    onResizeStop={onLayoutChange}
+                                   onLayoutChange={onSyncLayout}
       // While CSS transform improves the paint performance,
       // it currently results in bug when using `react-sticky-el` inside a grid item.
                                    useCSSTransforms={false}

--- a/graylog2-web-interface/src/components/common/ReactGridContainer.tsx
+++ b/graylog2-web-interface/src/components/common/ReactGridContainer.tsx
@@ -20,6 +20,7 @@ import PropTypes from 'prop-types';
 import type { DefaultTheme } from 'styled-components';
 import styled, { css, withTheme } from 'styled-components';
 import { Responsive, WidthProvider } from 'react-grid-layout';
+import type { ItemCallback } from 'react-grid-layout';
 
 import { themePropTypes } from 'theme';
 import 'react-grid-layout/css/styles.css';
@@ -104,7 +105,7 @@ type Position = {
   width: number
 };
 
-const _onLayoutChange = (newLayout: Layout, onPositionsChange: (newPositions: Position[]) => void) => {
+const _onLayoutChange = (newLayout: Layout, callback: (newPositions: Position[]) => void) => {
   const newPositions: Position[] = [];
 
   newLayout
@@ -119,7 +120,7 @@ const _onLayoutChange = (newLayout: Layout, onPositionsChange: (newPositions: Po
       });
     });
 
-  onPositionsChange(newPositions);
+  return callback(newPositions);
 };
 
 type Props = {
@@ -195,7 +196,7 @@ const ReactGridContainer = ({
   width,
 }: Props) => {
   const cellMargin = theme.spacings.px.xs;
-  const onLayoutChange = useCallback((layout: Layout) => _onLayoutChange(layout, onPositionsChange), [onPositionsChange]);
+  const onLayoutChange = useCallback<ItemCallback>((layout) => _onLayoutChange(layout, onPositionsChange), [onPositionsChange]);
   const onSyncLayout = useCallback((layout: Layout) => _onLayoutChange(layout, _onSyncLayout), [_onSyncLayout]);
   const gridClass = _gridClass(locked, isResizable, draggableHandle, className);
   const layout = useMemo(() => computeLayout(positions), [positions]);

--- a/graylog2-web-interface/src/components/common/ReactGridContainer.tsx
+++ b/graylog2-web-interface/src/components/common/ReactGridContainer.tsx
@@ -15,7 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import type { DefaultTheme } from 'styled-components';
 import styled, { css, withTheme } from 'styled-components';
@@ -26,6 +26,7 @@ import 'react-grid-layout/css/styles.css';
 import 'react-resizable/css/styles.css';
 import type { WidgetPositionJSON } from 'views/logic/widgets/WidgetPosition';
 import type WidgetPosition from 'views/logic/widgets/WidgetPosition';
+import type { WidgetPositions } from 'views/types';
 
 const WidthAdjustedReactGridLayout = WidthProvider(Responsive);
 
@@ -81,7 +82,7 @@ const BREAKPOINTS = {
   xs: COLUMN_WIDTH * COLUMNS.xs,
 };
 
-const _gridClass = (locked, isResizable, draggableHandle, propsClassName) => {
+const _gridClass = (locked: boolean, isResizable: boolean, draggableHandle: string, propsClassName: string) => {
   const className = `${propsClassName}`;
 
   if (locked || !isResizable) {
@@ -95,8 +96,16 @@ const _gridClass = (locked, isResizable, draggableHandle, propsClassName) => {
   return `${className} unlocked`;
 };
 
-const _onLayoutChange = (newLayout, onPositionsChange) => {
-  const newPositions = [];
+type Position = {
+  id: string,
+  col: number,
+  row: number,
+  height: number,
+  width: number
+};
+
+const _onLayoutChange = (newLayout: Layout, onPositionsChange: (newPositions: Position[]) => void) => {
+  const newPositions: Position[] = [];
 
   newLayout.forEach((widget) => {
     newPositions.push({
@@ -133,7 +142,7 @@ type Props = {
   width?: number,
 }
 
-const computeLayout = (positions = {}) => {
+const computeLayout = (positions: WidgetPositions = {}) => {
   return Object.keys(positions).map((id) => {
     const { col, row, height, width } = positions[id];
 
@@ -146,6 +155,8 @@ const computeLayout = (positions = {}) => {
     };
   });
 };
+
+type Layout = { i: string, x: number, y: number, h: number, w: number }[];
 
 /**
  * Component that renders a draggable and resizable grid. You can control
@@ -168,9 +179,9 @@ const ReactGridContainer = ({
   width,
 }: Props) => {
   const cellMargin = theme.spacings.px.xs;
-  const onLayoutChange = useCallback((layout) => _onLayoutChange(layout, onPositionsChange), [onPositionsChange]);
+  const onLayoutChange = useCallback((layout: Layout) => _onLayoutChange(layout, onPositionsChange), [onPositionsChange]);
   const gridClass = _gridClass(locked, isResizable, draggableHandle, className);
-  const layout = computeLayout(positions);
+  const layout = useMemo(() => computeLayout(positions), [positions]);
 
   // We need to use a className and draggableHandle to avoid re-rendering all graphs on lock/unlock. See:
   // https://github.com/STRML/react-grid-layout/issues/371

--- a/graylog2-web-interface/src/views/bindings.tsx
+++ b/graylog2-web-interface/src/views/bindings.tsx
@@ -87,6 +87,7 @@ import DataTableVisualizationConfig from 'views/logic/aggregationbuilder/visuali
 import ViewHeader from 'views/components/views/ViewHeader';
 import ScatterVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/ScatterVisualizationConfig';
 import ScatterVisualization from 'views/components/visualizations/scatter/ScatterVisualization';
+import Icon from 'components/common/Icon';
 
 import type { ActionHandlerArguments } from './components/actions/ActionHandler';
 import NumberVisualizationConfig from './logic/aggregationbuilder/visualizations/NumberVisualizationConfig';
@@ -327,12 +328,15 @@ const exports: PluginExports = {
   widgetCreators: [{
     title: 'Message Count',
     func: CreateMessageCount,
+    icon: () => <Icon name="hashtag" />,
   }, {
     title: 'Message Table',
     func: CreateMessagesWidget,
+    icon: () => <Icon name="list" />,
   }, {
     title: 'Custom Aggregation',
     func: CreateCustomAggregation,
+    icon: () => <Icon name="chart-column" />,
   }],
   creators: [
     {

--- a/graylog2-web-interface/src/views/bindings.tsx
+++ b/graylog2-web-interface/src/views/bindings.tsx
@@ -49,11 +49,11 @@ import ExcludeFromQueryHandler from 'views/logic/valueactions/ExcludeFromQueryHa
 import { isFunction } from 'views/logic/aggregationbuilder/Series';
 import EditMessageList from 'views/components/widgets/EditMessageList';
 import { DashboardsPage, ShowViewPage, NewSearchPage, NewDashboardPage, StreamSearchPage } from 'views/pages';
-import AddMessageCountActionHandler from 'views/logic/fieldactions/AddMessageCountActionHandler';
-import AddMessageTableActionHandler from 'views/logic/fieldactions/AddMessageTableActionHandler';
+import AddMessageCountActionHandler, { CreateMessageCount } from 'views/logic/fieldactions/AddMessageCountActionHandler';
+import AddMessageTableActionHandler, { CreateMessagesWidget } from 'views/logic/fieldactions/AddMessageTableActionHandler';
 import RemoveFromTableActionHandler from 'views/logic/fieldactions/RemoveFromTableActionHandler';
 import RemoveFromAllTablesActionHandler from 'views/logic/fieldactions/RemoveFromAllTablesActionHandler';
-import CreateCustomAggregation from 'views/logic/creatoractions/CreateCustomAggregation';
+import AddCustomAggregation, { CreateCustomAggregation } from 'views/logic/creatoractions/AddCustomAggregation';
 import SelectExtractorType from 'views/logic/valueactions/SelectExtractorType';
 import VisualizationConfig from 'views/logic/aggregationbuilder/visualizations/VisualizationConfig';
 import WorldMapVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/WorldMapVisualizationConfig';
@@ -324,6 +324,16 @@ const exports: PluginExports = {
     },
   ], ['create-extractor']),
   visualizationTypes: visualizationBindings,
+  widgetCreators: [{
+    title: 'Message Count',
+    func: CreateMessageCount,
+  }, {
+    title: 'Message Table',
+    func: CreateMessagesWidget,
+  }, {
+    title: 'Custom Aggregation',
+    func: CreateCustomAggregation,
+  }],
   creators: [
     {
       type: 'preset',
@@ -338,7 +348,7 @@ const exports: PluginExports = {
     {
       type: 'generic',
       title: 'Aggregation',
-      func: CreateCustomAggregation,
+      func: AddCustomAggregation,
     },
   ],
   'views.completers': [

--- a/graylog2-web-interface/src/views/components/CreateNewWidgetModal.tsx
+++ b/graylog2-web-interface/src/views/components/CreateNewWidgetModal.tsx
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 import * as React from 'react';
 import { useMemo } from 'react';
 import styled, { css } from 'styled-components';

--- a/graylog2-web-interface/src/views/components/CreateNewWidgetModal.tsx
+++ b/graylog2-web-interface/src/views/components/CreateNewWidgetModal.tsx
@@ -45,8 +45,10 @@ const CreateWidgetButton = styled(Button)`
   padding: 10px;
   width: 8rem;
   white-space: normal;
-  background: transparent !important;
-  border-radius: 4px !important;
+  && {
+    background: transparent;
+    border-radius: 4px;
+  }
 `;
 
 const HugeIcon = styled.div(({ theme }) => css`

--- a/graylog2-web-interface/src/views/components/CreateNewWidgetModal.tsx
+++ b/graylog2-web-interface/src/views/components/CreateNewWidgetModal.tsx
@@ -32,7 +32,8 @@ const modalTitle = 'Create new widget';
 const WidgetList = styled.div`
   display: flex;
   flex-wrap: wrap;
-  justify-content: space-evenly;
+  justify-content: center;
+  gap: 12px;
 `;
 
 const CreateWidgetButton = styled(Button)`
@@ -44,6 +45,8 @@ const CreateWidgetButton = styled(Button)`
   padding: 10px;
   width: 8rem;
   white-space: normal;
+  background: transparent !important;
+  border-radius: 4px !important;
 `;
 
 const HugeIcon = styled.div(({ theme }) => css`
@@ -69,13 +72,14 @@ const CreateNewWidgetModal = ({ onCancel, position }: Props) => {
     };
 
     return (
-      <CreateWidgetButton type="button" onClick={onClick}><HugeIcon><WidgetIcon /></HugeIcon>{title}</CreateWidgetButton>
+      <CreateWidgetButton type="button" title={`Create ${title} Widget`} onClick={onClick}>
+        <HugeIcon><WidgetIcon /></HugeIcon>{title}
+      </CreateWidgetButton>
     );
   }), [creators, position, view]);
 
   return (
-    <Modal title={modalTitle}
-           onHide={onCancel}
+    <Modal onHide={onCancel}
            show>
       <Modal.Header closeButton>
         <Modal.Title>{modalTitle}</Modal.Title>

--- a/graylog2-web-interface/src/views/components/CreateNewWidgetModal.tsx
+++ b/graylog2-web-interface/src/views/components/CreateNewWidgetModal.tsx
@@ -1,0 +1,57 @@
+import * as React from 'react';
+import { useMemo } from 'react';
+
+import { Modal, Button } from 'components/bootstrap';
+import type WidgetPosition from 'views/logic/widgets/WidgetPosition';
+import usePluginEntities from 'hooks/usePluginEntities';
+import { WidgetActions } from 'views/stores/WidgetStore';
+import generateId from 'logic/generateId';
+import { CurrentViewStateActions } from 'views/stores/CurrentViewStateStore';
+import { useStore } from 'stores/connect';
+import { ViewStore } from 'views/stores/ViewStore';
+
+const modalTitle = 'Create new widget';
+
+type Props = {
+  onCancel: () => void,
+  position: WidgetPosition,
+}
+
+const CreateNewWidgetModal = ({ onCancel, position }: Props) => {
+  const creators = usePluginEntities('widgetCreators');
+  const view = useStore(ViewStore, (store) => store?.view);
+
+  const widgetButtons = useMemo(() => creators.map(({ title, func }) => {
+    const onClick = async () => {
+      const newId = generateId();
+      await CurrentViewStateActions.updateWidgetPosition(newId, position);
+      const newWidget = func({ view }).toBuilder().id(newId).build();
+
+      return WidgetActions.create(newWidget);
+    };
+
+    return (
+      <Button type="button" onClick={onClick}>{title}</Button>
+    );
+  }), [creators, position, view]);
+
+  return (
+    <Modal title={modalTitle}
+           onHide={onCancel}
+           show>
+      <Modal.Header closeButton>
+        <Modal.Title>{modalTitle}</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        {widgetButtons}
+      </Modal.Body>
+      <Modal.Footer>
+        <Button type="button" onClick={onCancel}>
+          Cancel
+        </Button>
+      </Modal.Footer>
+    </Modal>
+  );
+};
+
+export default CreateNewWidgetModal;

--- a/graylog2-web-interface/src/views/components/CreateNewWidgetModal.tsx
+++ b/graylog2-web-interface/src/views/components/CreateNewWidgetModal.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { useMemo } from 'react';
+import styled, { css } from 'styled-components';
 
 import { Modal, Button } from 'components/bootstrap';
 import type WidgetPosition from 'views/logic/widgets/WidgetPosition';
@@ -12,6 +13,27 @@ import { ViewStore } from 'views/stores/ViewStore';
 
 const modalTitle = 'Create new widget';
 
+const WidgetList = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-evenly;
+`;
+
+const CreateWidgetButton = styled(Button)`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;  
+  text-align: center;
+  padding: 10px;
+  width: 8rem;
+  white-space: normal;
+`;
+
+const HugeIcon = styled.div(({ theme }) => css`
+  font-size: ${theme.fonts.size.huge};
+`);
+
 type Props = {
   onCancel: () => void,
   position: WidgetPosition,
@@ -21,7 +43,7 @@ const CreateNewWidgetModal = ({ onCancel, position }: Props) => {
   const creators = usePluginEntities('widgetCreators');
   const view = useStore(ViewStore, (store) => store?.view);
 
-  const widgetButtons = useMemo(() => creators.map(({ title, func }) => {
+  const widgetButtons = useMemo(() => creators.map(({ title, func, icon: WidgetIcon }) => {
     const onClick = async () => {
       const newId = generateId();
       await CurrentViewStateActions.updateWidgetPosition(newId, position);
@@ -31,7 +53,7 @@ const CreateNewWidgetModal = ({ onCancel, position }: Props) => {
     };
 
     return (
-      <Button type="button" onClick={onClick}>{title}</Button>
+      <CreateWidgetButton type="button" onClick={onClick}><HugeIcon><WidgetIcon /></HugeIcon>{title}</CreateWidgetButton>
     );
   }), [creators, position, view]);
 
@@ -43,7 +65,9 @@ const CreateNewWidgetModal = ({ onCancel, position }: Props) => {
         <Modal.Title>{modalTitle}</Modal.Title>
       </Modal.Header>
       <Modal.Body>
-        {widgetButtons}
+        <WidgetList>
+          {widgetButtons}
+        </WidgetList>
       </Modal.Body>
       <Modal.Footer>
         <Button type="button" onClick={onCancel}>

--- a/graylog2-web-interface/src/views/components/GridGaps.test.ts
+++ b/graylog2-web-interface/src/views/components/GridGaps.test.ts
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 import findGaps from './GridGaps';
 
 describe('GridGaps', () => {

--- a/graylog2-web-interface/src/views/components/GridGaps.test.ts
+++ b/graylog2-web-interface/src/views/components/GridGaps.test.ts
@@ -201,4 +201,44 @@ describe('GridGaps', () => {
       });
     });
   });
+
+  it('avoid overflowing into next row', () => {
+    const items = [
+      {
+        start: {
+          x: 11,
+          y: 1,
+        },
+        end: {
+          x: 13,
+          y: 7,
+        },
+      },
+      {
+        start: {
+          x: 7,
+          y: 1,
+        },
+        end: {
+          x: 11,
+          y: 7,
+        },
+      },
+      {
+        start: {
+          x: 1,
+          y: 1,
+        },
+        end: {
+          x: 4,
+          y: 7,
+        },
+      },
+    ];
+
+    expect(findGaps(items)).toEqual([{
+      start: { x: 4, y: 1 },
+      end: { x: 7, y: 7 },
+    }]);
+  });
 });

--- a/graylog2-web-interface/src/views/components/GridGaps.test.ts
+++ b/graylog2-web-interface/src/views/components/GridGaps.test.ts
@@ -257,4 +257,171 @@ describe('GridGaps', () => {
       end: { x: 7, y: 7 },
     }]);
   });
+
+  it('avoid occupying empty row(s)', () => {
+    const items = [
+      {
+        start: {
+          x: 1,
+          y: 1,
+        },
+        end: {
+          x: 4,
+          y: 4,
+        },
+      },
+      {
+        start: {
+          x: 1,
+          y: 10,
+        },
+        end: {
+          x: 13,
+          y: 15,
+        },
+      },
+    ];
+
+    expect(findGaps(items)).toEqual([{
+      start: { x: 4, y: 1 },
+      end: { x: 13, y: 4 },
+    }]);
+  });
+
+  it('should not generate gaps for overlapping widgets', () => {
+    const items = [
+      {
+        start: {
+          x: 1,
+          y: 1,
+        },
+        end: {
+          x: 5,
+          y: 5,
+        },
+      },
+      {
+        start: {
+          x: 1,
+          y: 1,
+        },
+        end: {
+          x: Infinity,
+          y: 3,
+        },
+      },
+    ];
+
+    expect(findGaps(items)).toEqual([]);
+  });
+
+  it('should not overlap initial placeholders with other widgets', () => {
+    const items = [{
+      start: {
+        x: 5,
+        y: 1,
+      },
+      end: {
+        x: 13,
+        y: 5,
+      },
+    },
+
+    {
+      start: {
+        x: 1,
+        y: 5,
+      },
+      end: {
+        x: 13,
+        y: 7,
+      },
+    },
+    {
+      start: {
+        x: 5,
+        y: 7,
+      },
+      end: {
+        x: 13,
+        y: 11,
+      },
+    },
+    ];
+
+    expect(findGaps(items)).toEqual([{
+      start: {
+        x: 1,
+        y: 1,
+      },
+      end: {
+        x: 5,
+        y: 5,
+      },
+    }, {
+      start: {
+        x: 1,
+        y: 7,
+      },
+      end: {
+        x: 5,
+        y: 11,
+      },
+    }]);
+  });
+
+  it('should not overlap final placeholders with other widgets', () => {
+    const items = [
+      {
+        start: {
+          x: 1,
+          y: 1,
+        },
+        end: {
+          x: 5,
+          y: 5,
+        },
+      },
+      {
+        start: {
+          x: 1,
+          y: 5,
+        },
+        end: {
+          x: 13,
+          y: 7,
+        },
+      },
+      {
+        start: {
+          x: 1,
+          y: 7,
+        },
+        end: {
+          x: 5,
+          y: 11,
+        },
+      },
+    ];
+
+    expect(findGaps(items)).toEqual([{
+      start: {
+        x: 5,
+        y: 1,
+      },
+      end: {
+        x: 13,
+        y: 5,
+      },
+    }, {
+      start: {
+        x: 5,
+        y: 7,
+      },
+      end: {
+        x: 13,
+        y: 11,
+      },
+    }]);
+  });
 });

--- a/graylog2-web-interface/src/views/components/GridGaps.test.ts
+++ b/graylog2-web-interface/src/views/components/GridGaps.test.ts
@@ -1,4 +1,4 @@
-import { findGaps } from './GridGaps';
+import findGaps from './GridGaps';
 
 describe('GridGaps', () => {
   it('finds single gap between two items', () => {

--- a/graylog2-web-interface/src/views/components/GridGaps.test.ts
+++ b/graylog2-web-interface/src/views/components/GridGaps.test.ts
@@ -13,10 +13,10 @@ describe('GridGaps', () => {
       },
     ];
 
-    expect(findGaps(items)).toEqual([{
+    expect(findGaps(items)).toContainEqual({
       start: { x: 1, y: 0 },
       end: { x: 3, y: 1 },
-    }]);
+    });
   });
 
   it('does not find gaps for two items below each other occupying max width', () => {
@@ -68,7 +68,7 @@ describe('GridGaps', () => {
       },
     ];
 
-    expect(findGaps(items)).toEqual([
+    expect(findGaps(items)).toContainEqual(
       {
         start: {
           x: 4,
@@ -78,22 +78,50 @@ describe('GridGaps', () => {
           x: 7,
           y: 5,
         },
-      },
-    ]);
+      });
   });
 
   it('finds initial gap', () => {
     const items = [
       {
-        start: { x: 3, y: 0 },
-        end: { x: 3, y: 1 },
+        start: { x: 3, y: 1 },
+        end: { x: 12, y: 2 },
+      },
+    ];
+
+    expect(findGaps(items)).toContainEqual({
+      start: { x: 1, y: 1 },
+      end: { x: 3, y: 2 },
+    });
+  });
+
+  it('calculates initial gap correctly', () => {
+    const items = [
+      {
+        start: {
+          x: 5,
+          y: 1,
+        },
+        end: {
+          x: 13,
+          y: 5,
+        },
+      },
+      {
+        start: {
+          x: 1,
+          y: 6,
+        },
+        end: {
+          x: 13,
+          y: 11,
+        },
       },
     ];
 
     expect(findGaps(items)).toEqual([{
-      start: { x: 0, y: 0 },
-      end: { x: 2, y: 1 },
-    },
-    ]);
+      start: { x: 1, y: 1 },
+      end: { x: 5, y: 5 },
+    }]);
   });
 });

--- a/graylog2-web-interface/src/views/components/GridGaps.test.ts
+++ b/graylog2-web-interface/src/views/components/GridGaps.test.ts
@@ -9,14 +9,76 @@ describe('GridGaps', () => {
       },
       {
         start: { x: 3, y: 0 },
-        end: { x: 3, y: 1 },
+        end: { x: 4, y: 1 },
       },
     ];
 
     expect(findGaps(items)).toEqual([{
-      start: { x: 2, y: 0 },
-      end: { x: 2, y: 1 },
-    },
+      start: { x: 1, y: 0 },
+      end: { x: 3, y: 1 },
+    }]);
+  });
+
+  it('does not find gaps for two items below each other occupying max width', () => {
+    const items = [
+      {
+        start: { x: 1, y: 1 },
+        end: { x: Infinity, y: 3 },
+      },
+      {
+        start: { x: 1, y: 4 },
+        end: { x: Infinity, y: 10 },
+      },
+    ];
+
+    expect(findGaps(items)).toEqual([]);
+  });
+
+  it('finds gaps between two widgets separated by multiple units', () => {
+    const items = [
+      {
+        start: {
+          x: 1,
+          y: 1,
+        },
+        end: {
+          x: 4,
+          y: 5,
+        },
+      },
+      {
+        start: {
+          x: 7,
+          y: 1,
+        },
+        end: {
+          x: 12,
+          y: 5,
+        },
+      },
+      {
+        start: {
+          x: 1,
+          y: 5,
+        },
+        end: {
+          x: Infinity,
+          y: 11,
+        },
+      },
+    ];
+
+    expect(findGaps(items)).toEqual([
+      {
+        start: {
+          x: 4,
+          y: 1,
+        },
+        end: {
+          x: 7,
+          y: 5,
+        },
+      },
     ]);
   });
 

--- a/graylog2-web-interface/src/views/components/GridGaps.test.ts
+++ b/graylog2-web-interface/src/views/components/GridGaps.test.ts
@@ -1,0 +1,37 @@
+import { findGaps } from './GridGaps';
+
+describe('GridGaps', () => {
+  it('finds single gap between two items', () => {
+    const items = [
+      {
+        start: { x: 0, y: 0 },
+        end: { x: 1, y: 1 },
+      },
+      {
+        start: { x: 3, y: 0 },
+        end: { x: 3, y: 1 },
+      },
+    ];
+
+    expect(findGaps(items)).toEqual([{
+      start: { x: 2, y: 0 },
+      end: { x: 2, y: 1 },
+    },
+    ]);
+  });
+
+  it('finds initial gap', () => {
+    const items = [
+      {
+        start: { x: 3, y: 0 },
+        end: { x: 3, y: 1 },
+      },
+    ];
+
+    expect(findGaps(items)).toEqual([{
+      start: { x: 0, y: 0 },
+      end: { x: 2, y: 1 },
+    },
+    ]);
+  });
+});

--- a/graylog2-web-interface/src/views/components/GridGaps.test.ts
+++ b/graylog2-web-interface/src/views/components/GridGaps.test.ts
@@ -26,7 +26,7 @@ describe('GridGaps', () => {
         end: { x: Infinity, y: 3 },
       },
       {
-        start: { x: 1, y: 4 },
+        start: { x: 1, y: 3 },
         end: { x: Infinity, y: 10 },
       },
     ];
@@ -110,7 +110,7 @@ describe('GridGaps', () => {
       {
         start: {
           x: 1,
-          y: 6,
+          y: 5,
         },
         end: {
           x: 13,
@@ -123,5 +123,82 @@ describe('GridGaps', () => {
       start: { x: 1, y: 1 },
       end: { x: 5, y: 5 },
     }]);
+  });
+
+  describe('calculates overlapping gaps correctly', () => {
+    const items = [
+      {
+        start: {
+          x: 5,
+          y: 2,
+        },
+        end: {
+          x: 9,
+          y: 6,
+        },
+      },
+      {
+        start: {
+          x: 4,
+          y: 6,
+        },
+        end: {
+          x: 8,
+          y: 10,
+        },
+      },
+    ];
+
+    it('leading gaps', () => {
+      const result = findGaps(items);
+
+      expect(result).toContainEqual({
+        start: {
+          x: 1,
+          y: 2,
+        },
+        end: {
+          x: 5,
+          y: 6,
+        },
+      });
+
+      expect(result).toContainEqual({
+        start: {
+          x: 1,
+          y: 6,
+        },
+        end: {
+          x: 4,
+          y: 10,
+        },
+      });
+    });
+
+    it('trailing gaps', () => {
+      const result = findGaps(items);
+
+      expect(result).toContainEqual({
+        start: {
+          x: 9,
+          y: 2,
+        },
+        end: {
+          x: 13,
+          y: 6,
+        },
+      });
+
+      expect(result).toContainEqual({
+        start: {
+          x: 8,
+          y: 6,
+        },
+        end: {
+          x: 13,
+          y: 10,
+        },
+      });
+    });
   });
 });

--- a/graylog2-web-interface/src/views/components/GridGaps.ts
+++ b/graylog2-web-interface/src/views/components/GridGaps.ts
@@ -9,14 +9,14 @@ const range = (start: number, end: number): Array<number> => [
   ...Array((end + 1) - start).keys(),
 ].map((i) => i + start);
 
-const itemsInRow = (items: Item[], row: number): Item[] => items.filter(({ start, end }) => start.y <= row && end.y >= row);
+const itemsInRow = (items: Item[], row: number): Item[] => items.filter(({ start, end }) => start.y <= row && end.y > row);
 
 function isRightToItem(item: Item, i: Item) {
   return item.start.x <= i.start.x;
 }
 
 const neighborsToRight = (item: Item, rowItems: { [row: string]: Item[] }) => {
-  const rows = range(item.start.y, item.end.y);
+  const rows = range(item.start.y, item.end.y - 1);
   const neighbors = rows.flatMap((row) => rowItems[row].filter((i) => i !== item).filter((i) => isRightToItem(item, i))[0])
     .filter((i) => i !== undefined);
 
@@ -43,16 +43,16 @@ const findInitialGaps = (rows: Array<number>, rowItems: RowItems, minWidth: numb
   .filter(([, startX]) => startX > minWidth)
   .reduce((gaps, [row, startX]) => {
     if (gaps.length === 0) {
-      return [{ start: { x: minWidth, y: row }, end: { x: startX, y: row } }] as Item[];
+      return [{ start: { x: minWidth, y: row }, end: { x: startX, y: row + 1 } }] as Item[];
     }
 
     const [gap, ...rest] = gaps.reverse();
 
     if (gap.end.x !== startX) {
-      return [...rest, gap, { start: { x: minWidth, y: row }, end: { x: startX, y: row } }];
+      return [...rest, gap, { start: { x: minWidth, y: row }, end: { x: startX, y: row + 1 } }];
     }
 
-    return [...rest, { start: gap.start, end: { x: startX, y: row } }];
+    return [...rest, { start: gap.start, end: { x: startX, y: row + 1 } }];
   }, [] as Item[]);
 
 const findFinalGaps = (rows: Array<number>, rowItems: RowItems, maxWidth: number) => rows
@@ -80,7 +80,7 @@ export const findGaps = (_items: Item[], minWidth: number = 1, maxWidth: number 
   const items = _items.map((item) => normalizeInfinity(item, maxWidth));
   console.log({ items });
   const minY = Math.min(...items.map(({ start: { y } }) => y));
-  const maxY = Math.max(...items.map(({ end: { y } }) => y));
+  const maxY = Math.max(...items.map(({ end: { y } }) => y - 1));
 
   const rows = range(minY, maxY);
 

--- a/graylog2-web-interface/src/views/components/GridGaps.ts
+++ b/graylog2-web-interface/src/views/components/GridGaps.ts
@@ -78,7 +78,6 @@ export const findGaps = (_items: Item[], minWidth: number = 1, maxWidth: number 
   }
 
   const items = _items.map((item) => normalizeInfinity(item, maxWidth));
-  console.log({ items });
   const minY = Math.min(...items.map(({ start: { y } }) => y));
   const maxY = Math.max(...items.map(({ end: { y } }) => y - 1));
 

--- a/graylog2-web-interface/src/views/components/GridGaps.ts
+++ b/graylog2-web-interface/src/views/components/GridGaps.ts
@@ -28,10 +28,6 @@ const gapBetween = (item: Item, neighbor: Item): Item => ({
   end: { x: neighbor.start.x, y: Math.min(item.end.y, neighbor.end.y) },
 });
 
-const isFirstItemInRow = (items: Item[], item: Item) => {
-
-};
-
 const normalizeInfinity = ({ start, end }: Item, maxWidth: number): Item => ({
   start,
   end: {
@@ -40,14 +36,49 @@ const normalizeInfinity = ({ start, end }: Item, maxWidth: number): Item => ({
   },
 });
 
-export const findGaps = (_items: Item[], maxWidth: number = 12): Item[] => {
+type RowItems = { [row: string]: Item[] };
+
+const findInitialGaps = (rows: Array<number>, rowItems: RowItems, minWidth: number) => rows
+  .map((row) => [row, Math.min(...rowItems[row].map((item) => item.start.x))])
+  .filter(([, startX]) => startX > minWidth)
+  .reduce((gaps, [row, startX]) => {
+    if (gaps.length === 0) {
+      return [{ start: { x: minWidth, y: row }, end: { x: startX, y: row } }] as Item[];
+    }
+
+    const [gap, ...rest] = gaps.reverse();
+
+    if (gap.end.x !== startX) {
+      return [...rest, gap, { start: { x: minWidth, y: row }, end: { x: startX, y: row } }];
+    }
+
+    return [...rest, { start: gap.start, end: { x: startX, y: row } }];
+  }, [] as Item[]);
+
+const findFinalGaps = (rows: Array<number>, rowItems: RowItems, maxWidth: number) => rows
+  .map((row) => [row, Math.max(...rowItems[row].map((item) => item.end.x))])
+  .filter(([, endX]) => endX < maxWidth)
+  .reduce((gaps, [row, endX]) => {
+    if (gaps.length === 0) {
+      return [{ start: { x: endX, y: row }, end: { x: maxWidth + 1, y: row + 1 } }] as Item[];
+    }
+
+    const [gap, ...rest] = gaps.reverse();
+
+    if (gap.start.x !== endX) {
+      return [...rest, gap, { start: { x: endX, y: row }, end: { x: maxWidth + 1, y: row + 1 } }];
+    }
+
+    return [...rest, { start: gap.start, end: { x: maxWidth + 1, y: row + 1 } }];
+  }, [] as Item[]);
+
+export const findGaps = (_items: Item[], minWidth: number = 1, maxWidth: number = 12): Item[] => {
   if (_items.length === 0) {
     return [];
   }
 
   const items = _items.map((item) => normalizeInfinity(item, maxWidth));
-  const minX = Math.min(...items.map(({ start: { x } }) => x));
-  const maxX = Math.max(...items.map(({ end: { x } }) => x));
+  console.log({ items });
   const minY = Math.min(...items.map(({ start: { y } }) => y));
   const maxY = Math.max(...items.map(({ end: { y } }) => y));
 
@@ -55,7 +86,12 @@ export const findGaps = (_items: Item[], maxWidth: number = 12): Item[] => {
 
   const rowItems = Object.fromEntries(rows.map((row) => [row, itemsInRow(items, row)]));
 
-  const initialGaps = items.filter((item) => isFirstItemInRow(items, item));
+  const initialGaps = findInitialGaps(rows, rowItems, minWidth);
+
+  const finalGaps = findFinalGaps(rows, rowItems, maxWidth);
+
+  console.log({ initialGaps, finalGaps });
+
   const gaps = items.flatMap((item) => {
     const neighbors = neighborsToRight(item, rowItems);
 
@@ -63,5 +99,5 @@ export const findGaps = (_items: Item[], maxWidth: number = 12): Item[] => {
       .map((neighbor) => gapBetween(item, neighbor));
   });
 
-  return uniq(gaps);
+  return uniq([...gaps, ...initialGaps, ...finalGaps]);
 };

--- a/graylog2-web-interface/src/views/components/GridGaps.ts
+++ b/graylog2-web-interface/src/views/components/GridGaps.ts
@@ -60,19 +60,19 @@ const findFinalGaps = (rows: Array<number>, rowItems: RowItems, maxWidth: number
   .filter(([, endX]) => endX < maxWidth)
   .reduce((gaps, [row, endX]) => {
     if (gaps.length === 0) {
-      return [{ start: { x: endX, y: row }, end: { x: maxWidth + 1, y: row + 1 } }] as Item[];
+      return [{ start: { x: endX, y: row }, end: { x: maxWidth, y: row + 1 } }] as Item[];
     }
 
     const [gap, ...rest] = gaps.reverse();
 
     if (gap.start.x !== endX) {
-      return [...rest, gap, { start: { x: endX, y: row }, end: { x: maxWidth + 1, y: row + 1 } }];
+      return [...rest, gap, { start: { x: endX, y: row }, end: { x: maxWidth, y: row + 1 } }];
     }
 
-    return [...rest, { start: gap.start, end: { x: maxWidth + 1, y: row + 1 } }];
+    return [...rest, { start: gap.start, end: { x: maxWidth, y: row + 1 } }];
   }, [] as Item[]);
 
-export const findGaps = (_items: Item[], minWidth: number = 1, maxWidth: number = 12): Item[] => {
+export const findGaps = (_items: Item[], minWidth: number = 1, maxWidth: number = 13): Item[] => {
   if (_items.length === 0) {
     return [];
   }

--- a/graylog2-web-interface/src/views/components/GridGaps.ts
+++ b/graylog2-web-interface/src/views/components/GridGaps.ts
@@ -102,15 +102,16 @@ const itemsOverlap = (items: Item[]) => {
 
   const spaces = [];
 
-  for (let row = minY; row <= maxY; row++) {
+  for (let row = minY; row <= maxY; row += 1) {
     spaces[row] = [];
   }
 
+  // eslint-disable-next-line no-restricted-syntax
   for (const item of items) {
     const { start, end } = item;
 
-    for (let { x } = start; x < end.x; x++) {
-      for (let { y } = start; y < end.y; y++) {
+    for (let { x } = start; x < end.x; x += 1) {
+      for (let { y } = start; y < end.y; y += 1) {
         if (spaces[y][x] !== undefined) {
           return true;
         }
@@ -125,16 +126,12 @@ const itemsOverlap = (items: Item[]) => {
 
 const findGaps = (_items: Item[], minWidth: number = 1, maxWidth: number = 13): Item[] => {
   if (_items.length === 0) {
-    console.log('no items');
-
     return [];
   }
 
   const items = _items.map((item) => normalizeInfinity(item, maxWidth));
 
   if (itemsOverlap(items)) {
-    console.log('items overlapping');
-
     return [];
   }
 
@@ -156,10 +153,7 @@ const findGaps = (_items: Item[], minWidth: number = 1, maxWidth: number = 13): 
       .map((neighbor) => gapBetween(item, neighbor));
   });
 
-  const result = uniq([...gaps, ...initialGaps, ...finalGaps]);
-  console.log('Returning ', { result });
-
-  return result;
+  return uniq([...gaps, ...initialGaps, ...finalGaps]);
 };
 
 export default findGaps;

--- a/graylog2-web-interface/src/views/components/GridGaps.ts
+++ b/graylog2-web-interface/src/views/components/GridGaps.ts
@@ -15,9 +15,11 @@ function isRightToItem(item: Item, i: Item) {
   return item.start.x <= i.start.x;
 }
 
+const sortByStartXAsc = (item1: Item, item2: Item) => item1.start.x - item2.start.x;
+
 const neighborsToRight = (item: Item, rowItems: { [row: string]: Item[] }) => {
   const rows = range(item.start.y, item.end.y - 1);
-  const neighbors = rows.flatMap((row) => rowItems[row].filter((i) => i !== item).filter((i) => isRightToItem(item, i))[0])
+  const neighbors = rows.flatMap((row) => rowItems[row].filter((i) => i !== item).filter((i) => isRightToItem(item, i)).sort(sortByStartXAsc)[0])
     .filter((i) => i !== undefined);
 
   return uniq(neighbors);

--- a/graylog2-web-interface/src/views/components/GridGaps.ts
+++ b/graylog2-web-interface/src/views/components/GridGaps.ts
@@ -1,0 +1,58 @@
+import uniq from 'lodash/uniq';
+
+type Item = {
+  start: { x: number, y: number },
+  end: { x: number, y: number },
+};
+
+const range = (start: number, end: number): Array<number> => [
+  ...Array((end + 1) - start).keys(),
+].map((i) => i + start);
+
+const itemsInRow = (items: Item[], row: number): Item[] => items.filter(({ start, end }) => start.y <= row && end.y >= row);
+
+function isRightToItem(item: Item, i: Item) {
+  return item.start.x <= i.start.x;
+}
+
+const neighborsToRight = (item: Item, rowItems: Item[][]) => {
+  const rows = range(item.start.y, item.end.y);
+  const neighbors = rows.flatMap((row) => rowItems[row].filter((i) => i !== item).filter((i) => isRightToItem(item, i))[0])
+    .filter((i) => i !== undefined);
+
+  return uniq(neighbors);
+};
+
+const gapBetween = (item: Item, neighbor: Item): Item => ({
+  start: { x: item.end.x + 1, y: Math.min(item.start.y, neighbor.start.y) },
+  end: { x: neighbor.start.x - 1, y: Math.min(item.end.y, neighbor.end.y) },
+});
+
+const isFirstItemInRow = (items: Item[], item: Item) => {
+
+};
+
+export const findGaps = (items: Item[]): Item[] => {
+  if (items.length === 0) {
+    return [];
+  }
+
+  const minX = Math.min(...items.map(({ start: { x } }) => x));
+  const maxX = Math.max(...items.map(({ end: { x } }) => x));
+  const minY = Math.min(...items.map(({ start: { y } }) => y));
+  const maxY = Math.max(...items.map(({ end: { y } }) => y));
+
+  const rows = range(minY, maxY);
+
+  const rowItems = rows.map((row) => itemsInRow(items, row));
+
+  const initialGaps = items.filter((item) => isFirstItemInRow(items, item));
+  const gaps = items.flatMap((item) => {
+    const neighbors = neighborsToRight(item, rowItems);
+
+    return neighbors.filter((neighbor) => neighbor.start.x > item.end.x)
+      .map((neighbor) => gapBetween(item, neighbor));
+  });
+
+  return uniq(gaps);
+};

--- a/graylog2-web-interface/src/views/components/GridGaps.ts
+++ b/graylog2-web-interface/src/views/components/GridGaps.ts
@@ -90,8 +90,6 @@ export const findGaps = (_items: Item[], minWidth: number = 1, maxWidth: number 
 
   const finalGaps = findFinalGaps(rows, rowItems, maxWidth);
 
-  console.log({ initialGaps, finalGaps });
-
   const gaps = items.flatMap((item) => {
     const neighbors = neighborsToRight(item, rowItems);
 

--- a/graylog2-web-interface/src/views/components/GridGaps.ts
+++ b/graylog2-web-interface/src/views/components/GridGaps.ts
@@ -72,7 +72,7 @@ const findFinalGaps = (rows: Array<number>, rowItems: RowItems, maxWidth: number
     return [...rest, { start: gap.start, end: { x: maxWidth, y: row + 1 } }];
   }, [] as Item[]);
 
-export const findGaps = (_items: Item[], minWidth: number = 1, maxWidth: number = 13): Item[] => {
+const findGaps = (_items: Item[], minWidth: number = 1, maxWidth: number = 13): Item[] => {
   if (_items.length === 0) {
     return [];
   }
@@ -98,3 +98,5 @@ export const findGaps = (_items: Item[], minWidth: number = 1, maxWidth: number 
 
   return uniq([...gaps, ...initialGaps, ...finalGaps]);
 };
+
+export default findGaps;

--- a/graylog2-web-interface/src/views/components/GridGaps.ts
+++ b/graylog2-web-interface/src/views/components/GridGaps.ts
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 import uniq from 'lodash/uniq';
 
 type Item = {

--- a/graylog2-web-interface/src/views/components/NewWidgetPlaceholder.test.tsx
+++ b/graylog2-web-interface/src/views/components/NewWidgetPlaceholder.test.tsx
@@ -1,0 +1,53 @@
+import * as React from 'react';
+import { render, screen } from 'wrappedTestingLibrary';
+import userEvent from '@testing-library/user-event';
+
+import WidgetPosition from 'views/logic/widgets/WidgetPosition';
+
+import NewWidgetPlaceholder from './NewWidgetPlaceholder';
+
+describe('NewWidgetPlaceholder', () => {
+  const widgetPosition = WidgetPosition.builder()
+    .col(3)
+    .row(3)
+    .height(4)
+    .width(8)
+    .build();
+
+  it('shows helpful text when rendered', async () => {
+    render(<NewWidgetPlaceholder position={widgetPosition} component={() => <></>} />);
+    await screen.findByText('Create a new widget here');
+  });
+
+  it('renders custom component when clicked', async () => {
+    const component = () => <>Hey there!</>;
+    render(<NewWidgetPlaceholder position={widgetPosition} component={component} />);
+    const text = await screen.findByText('Create a new widget here');
+    userEvent.click(text);
+
+    await screen.findByText('Hey there!');
+  });
+
+  it('passes position to custom component', async () => {
+    const component = jest.fn(() => <>Hey there!</>);
+    render(<NewWidgetPlaceholder position={widgetPosition} component={component} />);
+    const text = await screen.findByText('Create a new widget here');
+    userEvent.click(text);
+
+    await screen.findByText('Hey there!');
+
+    expect(component).toHaveBeenCalledWith(expect.objectContaining({ position: widgetPosition }), expect.anything());
+  });
+
+  it('unmounts custom component after calling `onCancel`', async () => {
+    const component = ({ onCancel }) => <button onClick={onCancel}>Close</button>;
+    render(<NewWidgetPlaceholder position={widgetPosition} component={component} />);
+    const text = await screen.findByText('Create a new widget here');
+    userEvent.click(text);
+
+    const close = await screen.findByRole('button', { name: 'Close' });
+    userEvent.click(close);
+
+    expect(screen.queryByRole('button', { name: 'Close' })).not.toBeInTheDocument();
+  });
+});

--- a/graylog2-web-interface/src/views/components/NewWidgetPlaceholder.test.tsx
+++ b/graylog2-web-interface/src/views/components/NewWidgetPlaceholder.test.tsx
@@ -31,7 +31,7 @@ describe('NewWidgetPlaceholder', () => {
     .build();
 
   it('shows helpful text when rendered', async () => {
-    render(<NewWidgetPlaceholder position={widgetPosition} component={() => <></>} />);
+    render(<NewWidgetPlaceholder position={widgetPosition} component={() => null} />);
     await screen.findByText('Create a new widget here');
   });
 
@@ -56,7 +56,7 @@ describe('NewWidgetPlaceholder', () => {
   });
 
   it('unmounts custom component after calling `onCancel`', async () => {
-    const component = ({ onCancel }) => <button onClick={onCancel}>Close</button>;
+    const component = ({ onCancel }) => <button type="button" onClick={onCancel}>Close</button>;
     render(<NewWidgetPlaceholder position={widgetPosition} component={component} />);
     const text = await screen.findByText('Create a new widget here');
     userEvent.click(text);

--- a/graylog2-web-interface/src/views/components/NewWidgetPlaceholder.test.tsx
+++ b/graylog2-web-interface/src/views/components/NewWidgetPlaceholder.test.tsx
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 import * as React from 'react';
 import { render, screen } from 'wrappedTestingLibrary';
 import userEvent from '@testing-library/user-event';

--- a/graylog2-web-interface/src/views/components/NewWidgetPlaceholder.tsx
+++ b/graylog2-web-interface/src/views/components/NewWidgetPlaceholder.tsx
@@ -5,6 +5,13 @@ import type WidgetPosition from 'views/logic/widgets/WidgetPosition';
 import AddMessageCountActionHandler from 'views/logic/fieldactions/AddMessageCountActionHandler';
 import { CurrentViewStateActions } from 'views/stores/CurrentViewStateStore';
 import { Icon } from 'components/common';
+import Series from 'views/logic/aggregationbuilder/Series';
+import SeriesConfig from 'views/logic/aggregationbuilder/SeriesConfig';
+import { WidgetActions } from 'views/stores/WidgetStore';
+import AggregationWidget from 'views/logic/aggregationbuilder/AggregationWidget';
+import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
+import NumberVisualization from 'views/components/visualizations/number/NumberVisualization';
+import generateId from 'logic/generateId';
 
 const PlaceholderBox = styled.div(({ theme }) => css`
   opacity: 0;
@@ -12,18 +19,22 @@ const PlaceholderBox = styled.div(({ theme }) => css`
   
   height: 100%;
   display: flex;
+  flex-direction: column;
   justify-content: center;
   align-items: center;  
   
   background-color: ${theme.colors.global.contentBackground};
-  border: 1px dashed ${theme.colors.variant.lighter.default};
+  color: ${theme.colors.gray[30]};
   margin-bottom: ${theme.spacings.xs};
-  border-radius: 4px;
-  font-size: ${theme.fonts.size.huge};
   
   :hover {
     opacity: 1;
   }
+`);
+
+const HugeIcon = styled(Icon)(({ theme }) => css`
+  font-size: ${theme.fonts.size.huge};
+  margin-bottom: 10px;
 `);
 
 type Props = {
@@ -38,15 +49,27 @@ const NewWidgetPlaceholder = React.forwardRef<HTMLDivElement, Props>(({ style, p
   };
 
   const onClick = async () => {
-    const newWidget = await AddMessageCountActionHandler({});
+    const newId = generateId();
+    await CurrentViewStateActions.updateWidgetPosition(newId, position);
+    const series = Series.forFunction('count()')
+      .toBuilder()
+      .config(new SeriesConfig('Message Count'))
+      .build();
 
-    return CurrentViewStateActions.updateWidgetPosition(newWidget.id, position);
+    return WidgetActions.create(AggregationWidget.builder()
+      .id(newId)
+      .config(AggregationWidgetConfig.builder()
+        .series([series])
+        .visualization(NumberVisualization.type)
+        .build())
+      .build());
   };
 
   return (
     <div style={containerStyle} ref={ref}>
       <PlaceholderBox onClick={onClick}>
-        <Icon name="circle-plus" />
+        <HugeIcon name="circle-plus" />
+        Create a new widget here
       </PlaceholderBox>
     </div>
   );

--- a/graylog2-web-interface/src/views/components/NewWidgetPlaceholder.tsx
+++ b/graylog2-web-interface/src/views/components/NewWidgetPlaceholder.tsx
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 import * as React from 'react';
 import { useCallback, useState } from 'react';
 import styled, { css } from 'styled-components';

--- a/graylog2-web-interface/src/views/components/NewWidgetPlaceholder.tsx
+++ b/graylog2-web-interface/src/views/components/NewWidgetPlaceholder.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import styled, { css } from 'styled-components';
 
 import type WidgetPosition from 'views/logic/widgets/WidgetPosition';
-import AddMessageCountActionHandler from 'views/logic/fieldactions/AddMessageCountActionHandler';
 import { CurrentViewStateActions } from 'views/stores/CurrentViewStateStore';
 import { Icon } from 'components/common';
 import Series from 'views/logic/aggregationbuilder/Series';

--- a/graylog2-web-interface/src/views/components/NewWidgetPlaceholder.tsx
+++ b/graylog2-web-interface/src/views/components/NewWidgetPlaceholder.tsx
@@ -1,0 +1,59 @@
+import * as React from 'react';
+import styled, { css } from 'styled-components';
+
+import type WidgetPosition from 'views/logic/widgets/WidgetPosition';
+import AddMessageCountActionHandler from 'views/logic/fieldactions/AddMessageCountActionHandler';
+import { CurrentViewStateActions } from 'views/stores/CurrentViewStateStore';
+import { Icon } from 'components/common';
+
+const PlaceholderBox = styled.div(({ theme }) => css`
+  opacity: 0;
+  transition: visibility 0s, opacity 0.2s linear;
+  
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;  
+  
+  background-color: ${theme.colors.global.contentBackground};
+  border: 1px dashed ${theme.colors.variant.lighter.default};
+  margin-bottom: ${theme.spacings.xs};
+  border-radius: 4px;
+  font-size: ${theme.fonts.size.huge};
+  
+  :hover {
+    opacity: 1;
+  }
+`);
+
+type Props = {
+  style?: React.CSSProperties,
+  position: WidgetPosition,
+}
+
+const NewWidgetPlaceholder = React.forwardRef<HTMLDivElement, Props>(({ style, position }, ref) => {
+  const containerStyle = {
+    ...style,
+    transition: 'none',
+  };
+
+  const onClick = async () => {
+    const newWidget = await AddMessageCountActionHandler({});
+
+    return CurrentViewStateActions.updateWidgetPosition(newWidget.id, position);
+  };
+
+  return (
+    <div style={containerStyle} ref={ref}>
+      <PlaceholderBox onClick={onClick}>
+        <Icon name="circle-plus" />
+      </PlaceholderBox>
+    </div>
+  );
+});
+
+NewWidgetPlaceholder.defaultProps = {
+  style: {},
+};
+
+export default NewWidgetPlaceholder;

--- a/graylog2-web-interface/src/views/components/NewWidgetPlaceholder.tsx
+++ b/graylog2-web-interface/src/views/components/NewWidgetPlaceholder.tsx
@@ -21,6 +21,8 @@ const PlaceholderBox = styled.div(({ theme }) => css`
   flex-direction: column;
   justify-content: center;
   align-items: center;  
+  text-align: center;
+  padding: 10px;
   
   background-color: ${theme.colors.global.contentBackground};
   color: ${theme.colors.gray[30]};

--- a/graylog2-web-interface/src/views/components/NewWidgetPlaceholder.tsx
+++ b/graylog2-web-interface/src/views/components/NewWidgetPlaceholder.tsx
@@ -40,6 +40,8 @@ const PlaceholderBox = styled.div(({ theme }) => css`
   :hover {
     opacity: 1;
   }
+
+  cursor: pointer;
 `);
 
 const HugeIcon = styled(Icon)(({ theme }) => css`

--- a/graylog2-web-interface/src/views/components/WidgetGrid.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetGrid.tsx
@@ -167,7 +167,7 @@ const renderGaps = (widgets: { id: string, type: string}[], positions: WidgetPos
   const _positions = { ...positions };
 
   const gapsItems = gaps.map((gap) => {
-    const id = generateId();
+    const id = `gap-${generateId()}`;
 
     const gapPosition = WidgetPosition.builder()
       .col(gap.start.x)

--- a/graylog2-web-interface/src/views/components/WidgetGrid.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetGrid.tsx
@@ -165,7 +165,6 @@ const renderGaps = (widgets: { id: string, type: string}[], positions: WidgetPos
     .map((p) => ({ start: { x: p.col, y: p.row }, end: { x: p.col + p.width, y: p.row + p.height } }));
   const gaps = findGaps(items);
   const _positions = { ...positions };
-  console.log({ gaps });
 
   const gapsItems = gaps.map((gap) => {
     const id = generateId();

--- a/graylog2-web-interface/src/views/components/WidgetGrid.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetGrid.tsx
@@ -61,7 +61,7 @@ const StyledReactGridContainer = styled(ReactGridContainer)(({ $hasFocusedWidget
   transition: none;
 `);
 
-const _defaultDimensions = (type) => {
+const _defaultDimensions = (type: string) => {
   const widgetDef = widgetDefinition(type);
 
   return new WidgetPosition(1, 1, widgetDef.defaultHeight, widgetDef.defaultWidth);
@@ -94,11 +94,11 @@ const WidgetGridItem = ({
   );
 };
 
-const generatePositions = (widgets: Array<{ id: string, type: string }>, positions: { [widgetId: string]: WidgetPosition }) => widgets
-  .map<[string, WidgetPosition]>(({ id, type }) => [id, positions[id] ?? _defaultDimensions(type)])
-  .reduce((prev, [id, position]) => ({ ...prev, [id]: position }), {});
+const generatePositions = (widgets: Array<{ id: string, type: string }>, positions: { [widgetId: string]: WidgetPosition }) => Object.fromEntries(
+  widgets.map<[string, WidgetPosition]>(({ id, type }) => [id, positions[id] ?? _defaultDimensions(type)]),
+);
 
-const mapWidgetPositions = (states: StoreState<typeof ViewStatesStore>) => states.map((state) => state.widgetPositions).reduce((prev, cur) => ({ ...prev, ...cur }), {});
+const mapWidgetPositions = (states: StoreState<typeof ViewStatesStore>) => Object.fromEntries(states.toArray().flatMap((state) => Object.entries(state.widgetPositions)));
 const mapWidgets = (state: StoreState<typeof WidgetStore>) => state.map(({ id, type }) => ({ id, type })).toArray();
 
 const useWidgetPositions = (): WidgetPositions => {

--- a/graylog2-web-interface/src/views/components/WidgetGrid.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetGrid.tsx
@@ -34,7 +34,7 @@ import type { StoreState } from 'stores/StoreTypes';
 import { ViewStatesStore } from 'views/stores/ViewStatesStore';
 import ElementDimensions from 'components/common/ElementDimensions';
 import useActiveQueryId from 'views/hooks/useActiveQueryId';
-import { findGaps } from 'views/components/GridGaps';
+import findGaps from 'views/components/GridGaps';
 import generateId from 'logic/generateId';
 import NewWidgetPlaceholder from 'views/components/NewWidgetPlaceholder';
 import CreateNewWidgetModal from 'views/components/CreateNewWidgetModal';

--- a/graylog2-web-interface/src/views/components/WidgetGrid.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetGrid.tsx
@@ -220,6 +220,8 @@ const WidgetGrid = () => {
     }
 
     return [widgetItems, positions];
+    // We need to include lastUpdate explicitly to be able to force recalculation
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [fields, focusedWidget, isInteractive, lastUpdate, positions, widgets]);
 
   // Measuring the width is required to update the widget grid

--- a/graylog2-web-interface/src/views/components/WidgetGrid.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetGrid.tsx
@@ -36,7 +36,7 @@ import ElementDimensions from 'components/common/ElementDimensions';
 import useActiveQueryId from 'views/hooks/useActiveQueryId';
 import { findGaps } from 'views/components/GridGaps';
 import generateId from 'logic/generateId';
-import { Icon } from 'components/common';
+import NewWidgetPlaceholder from 'views/components/NewWidgetPlaceholder';
 
 import WidgetContainer from './WidgetContainer';
 import WidgetComponent from './WidgetComponent';
@@ -159,45 +159,6 @@ const onPositionsChange = (newPositions: Array<BackendWidgetPosition>) => {
   CurrentViewStateActions.widgetPositions(widgetPositions);
 };
 
-const PlaceholderBox = styled.div(({ theme }) => css`
-  opacity: 0;
-  transition: visibility 0s, opacity 0.2s linear;
-  
-  height: 100%;
-  display: flex;
-  justify-content: center;
-  align-items: center;  
-  
-  background-color: ${theme.colors.global.contentBackground};
-  border: 1px dashed ${theme.colors.variant.lighter.default};
-  margin-bottom: ${theme.spacings.xs};
-  border-radius: 4px;
-  font-size: ${theme.fonts.size.huge};
-  
-  :hover {
-    opacity: 1;
-  }
-`);
-
-type WidgetPlaceholderProps = {
-  style: React.CSSProperties,
-}
-
-const WidgetPlaceholder = React.forwardRef<HTMLDivElement, WidgetPlaceholderProps>(({ style }, ref) => {
-  const containerStyle = {
-    ...style,
-    transition: 'none',
-  };
-
-  return (
-    <div style={containerStyle} ref={ref}>
-      <PlaceholderBox>
-        <Icon name="circle-plus" />
-      </PlaceholderBox>
-    </div>
-  );
-});
-
 const WidgetGrid = () => {
   const isInteractive = useContext(InteractiveContext);
   const { focusedWidget } = useContext(WidgetFocusContext);
@@ -227,6 +188,7 @@ const WidgetGrid = () => {
       );
     }).filter((x) => (x !== null));
     const items = widgets.map((widget) => positions[widget.id])
+      .filter((position) => !!position)
       .map((p) => ({ start: { x: p.col, y: p.row }, end: { x: p.col + p.width, y: p.row + p.height } }));
     const gaps = findGaps(items);
     const _positions = { ...positions };
@@ -234,15 +196,17 @@ const WidgetGrid = () => {
     const gapItems = gaps.map((gap) => {
       const id = generateId();
 
-      _positions[id] = WidgetPosition.builder()
+      const gapPosition = WidgetPosition.builder()
         .col(gap.start.x)
         .row(gap.start.y)
         .height(gap.end.y - gap.start.y)
         .width(gap.end.x - gap.start.x)
         .build();
 
+      _positions[id] = gapPosition;
+
       return (
-        <WidgetPlaceholder key={id} />
+        <NewWidgetPlaceholder key={id} position={gapPosition} />
       );
     });
 

--- a/graylog2-web-interface/src/views/components/WidgetGrid.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetGrid.tsx
@@ -37,6 +37,7 @@ import useActiveQueryId from 'views/hooks/useActiveQueryId';
 import { findGaps } from 'views/components/GridGaps';
 import generateId from 'logic/generateId';
 import NewWidgetPlaceholder from 'views/components/NewWidgetPlaceholder';
+import CreateNewWidgetModal from 'views/components/CreateNewWidgetModal';
 
 import WidgetContainer from './WidgetContainer';
 import WidgetComponent from './WidgetComponent';
@@ -179,7 +180,7 @@ const renderGaps = (widgets: { id: string, type: string}[], positions: WidgetPos
     _positions[id] = gapPosition;
 
     return (
-      <NewWidgetPlaceholder key={id} position={gapPosition} />
+      <NewWidgetPlaceholder key={id} position={gapPosition} component={CreateNewWidgetModal} />
     );
   });
 

--- a/graylog2-web-interface/src/views/components/WidgetGrid.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetGrid.tsx
@@ -210,10 +210,14 @@ const WidgetGrid = () => {
         </WidgetContainer>
       ));
 
-    const [gapItems, _positions] = renderGaps(widgets, positions);
+    if (isInteractive) {
+      const [gapItems, _positions] = renderGaps(widgets, positions);
 
-    return [[...widgetItems, ...gapItems], _positions];
-  }, [fields, focusedWidget, positions, widgets]);
+      return [[...widgetItems, ...gapItems], _positions];
+    }
+
+    return [widgetItems, positions];
+  }, [fields, focusedWidget, isInteractive, positions, widgets]);
 
   // Measuring the width is required to update the widget grid
   // when its content height results in a scrollbar

--- a/graylog2-web-interface/src/views/components/WidgetGrid.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetGrid.tsx
@@ -236,7 +236,4 @@ const WidgetGrid = () => {
 };
 
 WidgetGrid.displayName = 'WidgetGrid';
-
-const MemoizedWidgetGrid = React.memo(WidgetGrid);
-
-export default MemoizedWidgetGrid;
+export default WidgetGrid;

--- a/graylog2-web-interface/src/views/components/sidebar/create/AddWidgetButton.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/create/AddWidgetButton.tsx
@@ -53,7 +53,7 @@ export type CreatorProps = {
   view: View,
 };
 type CreatorType = 'preset' | 'generic';
-type CreatorFunction = (CreatorProps) => React.ReactNode | undefined | null | void;
+type CreatorFunction = (creatorProps: CreatorProps) => React.ReactNode | undefined | null | void;
 
 type FunctionalCreator = {
   func: CreatorFunction,

--- a/graylog2-web-interface/src/views/components/sidebar/create/AddWidgetButton.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/create/AddWidgetButton.tsx
@@ -75,7 +75,7 @@ type ComponentCreator = {
 
 export type Creator = ComponentCreator | FunctionalCreator;
 
-const isCreatorFunc = (creator: Creator): creator is FunctionalCreator => ('func' in creator);
+export const isCreatorFunc = (creator: Creator): creator is FunctionalCreator => ('func' in creator);
 
 class AddWidgetButton extends React.Component<Props, State> {
   constructor(props: Props) {

--- a/graylog2-web-interface/src/views/logic/creatoractions/AddCustomAggregation.ts
+++ b/graylog2-web-interface/src/views/logic/creatoractions/AddCustomAggregation.ts
@@ -22,16 +22,15 @@ import DataTable from 'views/components/datatable/DataTable';
 import type { CreatorProps } from 'views/components/sidebar/create/AddWidgetButton';
 import { DEFAULT_TIMERANGE } from 'views/Constants';
 
-export default function CreateCustomAggregation({ view }: CreatorProps) {
-  const newWidget = AggregationWidget.builder()
-    .newId()
-    .timerange(view.type === View.Type.Dashboard ? DEFAULT_TIMERANGE : undefined)
-    .config(AggregationWidgetConfig.builder()
-      .rowPivots([])
-      .series([])
-      .visualization(DataTable.type)
-      .build())
-    .build();
+export const CreateCustomAggregation = ({ view }: CreatorProps) => AggregationWidget.builder()
+  .newId()
+  .timerange(view.type === View.Type.Dashboard ? DEFAULT_TIMERANGE : undefined)
+  .config(AggregationWidgetConfig.builder()
+    .rowPivots([])
+    .series([])
+    .visualization(DataTable.type)
+    .build())
+  .build();
 
-  return WidgetActions.create(newWidget);
-}
+const AddCustomAggregation = (props: CreatorProps) => WidgetActions.create(CreateCustomAggregation(props));
+export default AddCustomAggregation;

--- a/graylog2-web-interface/src/views/logic/fieldactions/AddMessageCountActionHandler.ts
+++ b/graylog2-web-interface/src/views/logic/fieldactions/AddMessageCountActionHandler.ts
@@ -20,9 +20,8 @@ import AggregationWidget from 'views/logic/aggregationbuilder/AggregationWidget'
 import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
 import Series from 'views/logic/aggregationbuilder/Series';
 import SeriesConfig from 'views/logic/aggregationbuilder/SeriesConfig';
-import type { ActionHandler } from 'views/components/actions/ActionHandler';
 
-const AddMessageCountActionHandler: ActionHandler<{}> = async () => {
+const AddMessageCountActionHandler = async () => {
   const series = Series.forFunction('count()')
     .toBuilder()
     .config(new SeriesConfig('Message Count'))

--- a/graylog2-web-interface/src/views/logic/fieldactions/AddMessageCountActionHandler.ts
+++ b/graylog2-web-interface/src/views/logic/fieldactions/AddMessageCountActionHandler.ts
@@ -21,19 +21,21 @@ import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationW
 import Series from 'views/logic/aggregationbuilder/Series';
 import SeriesConfig from 'views/logic/aggregationbuilder/SeriesConfig';
 
-const AddMessageCountActionHandler = async () => {
+export const CreateMessageCount = () => {
   const series = Series.forFunction('count()')
     .toBuilder()
     .config(new SeriesConfig('Message Count'))
     .build();
 
-  WidgetActions.create(AggregationWidget.builder()
+  return AggregationWidget.builder()
     .newId()
     .config(AggregationWidgetConfig.builder()
       .series([series])
       .visualization(NumberVisualization.type)
       .build())
-    .build());
+    .build();
 };
+
+const AddMessageCountActionHandler = async () => WidgetActions.create(CreateMessageCount());
 
 export default AddMessageCountActionHandler;

--- a/graylog2-web-interface/src/views/logic/fieldactions/AddMessageTableActionHandler.ts
+++ b/graylog2-web-interface/src/views/logic/fieldactions/AddMessageTableActionHandler.ts
@@ -20,14 +20,14 @@ import { DEFAULT_MESSAGE_FIELDS } from 'views/Constants';
 import MessagesWidget from '../widgets/MessagesWidget';
 import MessagesWidgetConfig from '../widgets/MessagesWidgetConfig';
 
-export default () => WidgetActions.create(
-  MessagesWidget.builder()
-    .newId()
-    .config(
-      MessagesWidgetConfig.builder()
-        .fields(DEFAULT_MESSAGE_FIELDS)
-        .showMessageRow(true)
-        .showSummary(true)
-        .build(),
-    ).build(),
-);
+export const CreateMessagesWidget = () => MessagesWidget.builder()
+  .newId()
+  .config(
+    MessagesWidgetConfig.builder()
+      .fields(DEFAULT_MESSAGE_FIELDS)
+      .showMessageRow(true)
+      .showSummary(true)
+      .build(),
+  ).build();
+
+export default () => WidgetActions.create(CreateMessagesWidget());

--- a/graylog2-web-interface/src/views/stores/CurrentViewStateStore.ts
+++ b/graylog2-web-interface/src/views/stores/CurrentViewStateStore.ts
@@ -127,7 +127,6 @@ export const CurrentViewStateStore = singletonStore(
 
     widgetPositions(newPositions) {
       const newActiveState = this._activeState().toBuilder().widgetPositions(newPositions).build();
-      console.log({ newPositions, newActiveState });
       const promise = ViewStatesActions.update(this.activeQuery, newActiveState);
 
       CurrentViewStateActions.widgetPositions.promise(promise);

--- a/graylog2-web-interface/src/views/stores/CurrentViewStateStore.ts
+++ b/graylog2-web-interface/src/views/stores/CurrentViewStateStore.ts
@@ -127,6 +127,7 @@ export const CurrentViewStateStore = singletonStore(
 
     widgetPositions(newPositions) {
       const newActiveState = this._activeState().toBuilder().widgetPositions(newPositions).build();
+      console.log({ newPositions, newActiveState });
       const promise = ViewStatesActions.update(this.activeQuery, newActiveState);
 
       CurrentViewStateActions.widgetPositions.promise(promise);

--- a/graylog2-web-interface/src/views/stores/ViewStore.ts
+++ b/graylog2-web-interface/src/views/stores/ViewStore.ts
@@ -53,6 +53,7 @@ type ViewActionsType = RefluxActions<{
   properties: (properties: Properties) => Promise<void>,
   search: (search: Search) => Promise<View>,
   selectQuery: (queryId: string) => Promise<string>,
+  setDirty: (isDirty: boolean) => Promise<View>,
   state: (state: ViewStateMap) => Promise<View>,
   update: (view: View) => Promise<ViewStoreState>,
 }>;
@@ -67,7 +68,7 @@ export const ViewActions: ViewActionsType = singletonActions(
     search: { asyncResult: true },
     selectQuery: { asyncResult: true },
     state: { asyncResult: true },
-    setNew: { asyncResult: true },
+    setDirty: { asyncResult: true },
     update: { asyncResult: true },
   }),
 );
@@ -218,6 +219,15 @@ export const ViewStore: ViewStoreType = singletonStore(
       const promise = Promise.resolve(this.view);
 
       ViewActions.selectQuery.promise(promise);
+
+      return promise;
+    },
+    setDirty(isDirty) {
+      this.dirty = isDirty;
+      this._trigger();
+      const promise = Promise.resolve(this.view);
+
+      ViewActions.setDirty.promise(promise);
 
       return promise;
     },

--- a/graylog2-web-interface/src/views/types.ts
+++ b/graylog2-web-interface/src/views/types.ts
@@ -292,6 +292,14 @@ export type CustomCommandContextProvider<T extends keyof CustomCommandContext> =
   provider: () => CustomCommandContext[T],
 }
 
+export interface WidgetCreatorArgs {
+  view: View;
+}
+export interface WidgetCreator {
+  title: string;
+  func: (args: WidgetCreatorArgs) => Widget;
+}
+
 declare module 'graylog-web-plugin/plugin' {
   export interface PluginExports {
     creators?: Array<Creator>;
@@ -327,6 +335,7 @@ declare module 'graylog-web-plugin/plugin' {
     'views.queryInput.commands'?: Array<CustomCommand>;
     'views.queryInput.commandContextProviders'?: Array<CustomCommandContextProvider<any>>,
     visualizationTypes?: Array<VisualizationType<any>>;
+    widgetCreators?: Array<WidgetCreator>;
   }
 }
 export interface ViewActions {

--- a/graylog2-web-interface/src/views/types.ts
+++ b/graylog2-web-interface/src/views/types.ts
@@ -298,6 +298,7 @@ export interface WidgetCreatorArgs {
 export interface WidgetCreator {
   title: string;
   func: (args: WidgetCreatorArgs) => Widget;
+  icon: React.ComponentType<{}>,
 }
 
 declare module 'graylog-web-plugin/plugin' {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is adding a feature that adds widget placeholders in empty slots on the widget grid, allowing the user to create widgets in these spots. This removes the need for the user to create a widget and then move it to the desired spot.

/jenkins-pr-deps Graylog2/graylog-plugin-enterprise#4510

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![inline-widget-creation](https://user-images.githubusercontent.com/41929/210065939-0342a2c3-5412-4500-a185-f17eb0e31a62.gif)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.