### PR TITLE
Sorting of indices inside an index set is based on their numbers, descending

### DIFF
--- a/changelog/unreleased/issue-14280.toml
+++ b/changelog/unreleased/issue-14280.toml
@@ -2,4 +2,4 @@ type = "fixed" # One of: a(dded), c(hanged), d(eprecated), r(emoved), f(ixed), s
 message = "Sorting of indices inside an index set is based on their numbers, descending."
 
 issues = ["14280"]
-pulls = [""]
+pulls = ["14339"]

--- a/changelog/unreleased/issue-14280.toml
+++ b/changelog/unreleased/issue-14280.toml
@@ -1,0 +1,5 @@
+type = "fixed" # One of: a(dded), c(hanged), d(eprecated), r(emoved), f(ixed), s(ecurity)
+message = "Sorting of indices inside an index set is based on their numbers, descending."
+
+issues = ["14280"]
+pulls = [""]

--- a/graylog2-server/src/main/java/org/graylog2/indexer/indices/util/NumberBasedIndexNameComparator.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indices/util/NumberBasedIndexNameComparator.java
@@ -18,6 +18,10 @@ package org.graylog2.indexer.indices.util;
 
 import java.util.Comparator;
 
+/**
+ * Compares Strings in format [index_prefix][separator][number], i.e. graylog_12.
+ * Tries to compare by index_prefix first (ascending), if prefixes are the same, uses number to compare(descending).
+ */
 public class NumberBasedIndexNameComparator implements Comparator<String> {
 
     private final String separator;
@@ -30,6 +34,7 @@ public class NumberBasedIndexNameComparator implements Comparator<String> {
     public int compare(String indexName1, String indexName2) {
         int separatorPosition = indexName1.lastIndexOf(separator);
         int index1Number;
+        final String indexPrefix1 = separatorPosition != -1 ? indexName1.substring(0, separatorPosition) : indexName1;
         try {
             index1Number = Integer.parseInt(indexName1.substring(separatorPosition + 1));
         } catch (Exception e) {
@@ -38,11 +43,18 @@ public class NumberBasedIndexNameComparator implements Comparator<String> {
 
         separatorPosition = indexName2.lastIndexOf(separator);
         int index2Number;
+        final String indexPrefix2 = separatorPosition != -1 ? indexName2.substring(0, separatorPosition) : indexName2;
         try {
             index2Number = Integer.parseInt(indexName2.substring(separatorPosition + 1));
         } catch (NumberFormatException e) {
             index2Number = Integer.MIN_VALUE; //wrongly formatted index names go last
         }
-        return -Integer.compare(index1Number, index2Number);
+
+        final int prefixComparisonResult = indexPrefix1.compareTo(indexPrefix2);
+        if (prefixComparisonResult == 0) {
+            return -Integer.compare(index1Number, index2Number);
+        } else {
+            return prefixComparisonResult;
+        }
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/indices/util/NumberBasedIndexNameComparator.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indices/util/NumberBasedIndexNameComparator.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.indexer.indices.util;
+
+import java.util.Comparator;
+
+public class NumberBasedIndexNameComparator implements Comparator<String> {
+
+    private final String separator;
+
+    public NumberBasedIndexNameComparator(final String separator) {
+        this.separator = separator;
+    }
+
+    @Override
+    public int compare(String indexName1, String indexName2) {
+        int separatorPosition = indexName1.lastIndexOf(separator);
+        int index1Number;
+        try {
+            index1Number = Integer.parseInt(indexName1.substring(separatorPosition + 1));
+        } catch (Exception e) {
+            index1Number = Integer.MIN_VALUE; //wrongly formatted index names go last
+        }
+
+        separatorPosition = indexName2.lastIndexOf(separator);
+        int index2Number;
+        try {
+            index2Number = Integer.parseInt(indexName2.substring(separatorPosition + 1));
+        } catch (NumberFormatException e) {
+            index2Number = Integer.MIN_VALUE; //wrongly formatted index names go last
+        }
+        return -Integer.compare(index1Number, index2Number);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/rest/models/system/indexer/responses/IndexInfo.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/system/indexer/responses/IndexInfo.java
@@ -28,6 +28,10 @@ import java.util.List;
 @AutoValue
 @WithBeanGetter
 public abstract class IndexInfo {
+
+    @JsonProperty
+    public abstract String indexName();
+
     @JsonProperty
     public abstract IndexStats primaryShards();
 
@@ -41,10 +45,11 @@ public abstract class IndexInfo {
     public abstract boolean isReopened();
 
     @JsonCreator
-    public static IndexInfo create(@JsonProperty("primary_shards") IndexStats primaryShards,
+    public static IndexInfo create(@JsonProperty("index_name") String indexName,
+                                   @JsonProperty("primary_shards") IndexStats primaryShards,
                                    @JsonProperty("all_shards") IndexStats allShards,
                                    @JsonProperty("routing") List<ShardRouting> routing,
                                    @JsonProperty("is_reopened") boolean isReopened) {
-        return new AutoValue_IndexInfo(primaryShards, allShards, routing, isReopened);
+        return new AutoValue_IndexInfo(indexName, primaryShards, allShards, routing, isReopened);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/models/system/indexer/responses/IndexSummary.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/system/indexer/responses/IndexSummary.java
@@ -28,6 +28,10 @@ import javax.annotation.Nullable;
 @WithBeanGetter
 @JsonAutoDetect
 public abstract class IndexSummary {
+
+    @JsonProperty("index_name")
+    public abstract String indexName();
+
     @JsonProperty("size")
     @Nullable
     public abstract IndexSizeSummary size();
@@ -46,11 +50,12 @@ public abstract class IndexSummary {
     public abstract boolean isReopened();
 
     @JsonCreator
-    public static IndexSummary create(@JsonProperty("size") @Nullable IndexSizeSummary size,
+    public static IndexSummary create(@JsonProperty("index_name") String indexName,
+                                      @JsonProperty("size") @Nullable IndexSizeSummary size,
                                       @JsonProperty("range") @Nullable IndexRangeSummary range,
                                       @JsonProperty("is_deflector") boolean isDeflector,
                                       @JsonProperty("is_closed") boolean isClosed,
                                       @JsonProperty("is_reopened") boolean isReopened) {
-        return new AutoValue_IndexSummary(size, range, isDeflector, isClosed, isReopened);
+        return new AutoValue_IndexSummary(indexName, size, range, isDeflector, isClosed, isReopened);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/models/system/indexer/responses/IndexerOverview.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/system/indexer/responses/IndexerOverview.java
@@ -24,7 +24,7 @@ import org.graylog.autovalue.WithBeanGetter;
 import org.graylog2.rest.models.count.responses.MessageCountResponse;
 import org.graylog2.rest.models.system.deflector.responses.DeflectorSummary;
 
-import java.util.Map;
+import java.util.List;
 
 @AutoValue
 @WithBeanGetter
@@ -40,13 +40,13 @@ public abstract class IndexerOverview {
     public abstract MessageCountResponse messageCountResponse();
 
     @JsonProperty("indices")
-    public abstract Map<String, IndexSummary> indices();
+    public abstract List<IndexSummary> indices();
 
     @JsonCreator
     public static IndexerOverview create(@JsonProperty("deflector_summary") DeflectorSummary deflectorSummary,
                                          @JsonProperty("indexer_cluster") IndexerClusterOverview indexerCluster,
                                          @JsonProperty("counts") MessageCountResponse messageCountResponse,
-                                         @JsonProperty("indices") Map<String, IndexSummary> indices) {
+                                         @JsonProperty("indices") List<IndexSummary> indices) {
         return new AutoValue_IndexerOverview(deflectorSummary, indexerCluster, messageCountResponse, indices);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/models/system/indexer/responses/OpenIndicesInfo.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/system/indexer/responses/OpenIndicesInfo.java
@@ -22,17 +22,17 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 import org.graylog.autovalue.WithBeanGetter;
 
-import java.util.Map;
+import java.util.List;
 
 @JsonAutoDetect
 @AutoValue
 @WithBeanGetter
 public abstract class OpenIndicesInfo {
     @JsonProperty
-    public abstract Map<String, IndexInfo> indices();
+    public abstract List<IndexInfo> indices();
 
     @JsonCreator
-    public static OpenIndicesInfo create(@JsonProperty("indices") Map<String, IndexInfo> indices) {
+    public static OpenIndicesInfo create(@JsonProperty("indices") List<IndexInfo> indices) {
         return new AutoValue_OpenIndicesInfo(indices);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndicesResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndicesResource.java
@@ -61,7 +61,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import java.util.Collection;
 import java.util.Comparator;
-import java.util.LinkedHashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -307,7 +307,7 @@ public class IndicesResource extends RestResource {
     }
 
     private OpenIndicesInfo getOpenIndicesInfo(Set<IndexStatistics> indicesStatistics) {
-        final Map<String, IndexInfo> indexInfos = new LinkedHashMap<>();
+        final List<IndexInfo> indexInfos = new LinkedList<>();
         final Set<String> indices = indicesStatistics.stream()
                 .map(IndexStatistics::index)
                 .collect(Collectors.toSet());
@@ -319,12 +319,13 @@ public class IndicesResource extends RestResource {
 
         for (IndexStatistics indexStatistics : sortedIndexStatistics) {
             final IndexInfo indexInfo = IndexInfo.create(
+                    indexStatistics.index(),
                     indexStatistics.primaryShards(),
                     indexStatistics.allShards(),
                     fillShardRoutings(indexStatistics.routing()),
                     areReopened.get(indexStatistics.index()));
 
-            indexInfos.put(indexStatistics.index(), indexInfo);
+            indexInfos.add(indexInfo);
         }
 
         return OpenIndicesInfo.create(indexInfos);
@@ -341,6 +342,7 @@ public class IndicesResource extends RestResource {
 
     private IndexInfo toIndexInfo(final IndexStatistics indexStatistics) {
         return IndexInfo.create(
+                indexStatistics.index(),
                 indexStatistics.primaryShards(),
                 indexStatistics.allShards(),
                 fillShardRoutings(indexStatistics.routing()),
@@ -355,6 +357,7 @@ public class IndicesResource extends RestResource {
         final ImmutableMap.Builder<String, IndexInfo> indexInfos = ImmutableMap.builder();
         for (IndexStatistics indexStats : indexStatistics) {
             final IndexInfo indexInfo = IndexInfo.create(
+                    indexStats.index(),
                     indexStats.primaryShards(),
                     indexStats.allShards(),
                     fillShardRoutings(indexStats.routing()),

--- a/graylog2-server/src/test/java/org/graylog2/indexer/indices/util/NumberBasedIndexNameComparatorTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/indices/util/NumberBasedIndexNameComparatorTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.indexer.indices.util;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class NumberBasedIndexNameComparatorTest {
+
+    private NumberBasedIndexNameComparator comparator;
+
+    @BeforeEach
+    void setUp() {
+        comparator = new NumberBasedIndexNameComparator("_");
+    }
+
+    @Test
+    void comparesDescByNumberAfterLastSeparatorOccurrence() {
+        assertEquals(-1, comparator.compare("lalala_5", "lalala_3"));
+        assertEquals(1, comparator.compare("lalala_3", "lalala_5"));
+
+        assertEquals(-1, comparator.compare("lalala_1_5", "lalala_3"));
+        assertEquals(-1, comparator.compare("lalala_1_5", "lalala_0"));
+    }
+
+    @Test
+    void indexNameWithNoSeparatorGoesLast() {
+        assertEquals(1, comparator.compare("lalala", "lalala_3"));
+        assertEquals(-1, comparator.compare("lalala_3", "lalala"));
+        assertEquals(1, comparator.compare("lalala", "lalala_42"));
+        assertEquals(-1, comparator.compare("lalala_42", "lalala"));
+    }
+
+    @Test
+    void isImmuneToWrongNumbersWhichGoLast() {
+        assertEquals(1, comparator.compare("lalala_1!1", "lalala_3"));
+        assertEquals(-1, comparator.compare("lalala_3", "lalala_1!1"));
+    }
+
+    @Test
+    void isImmuneToMissingNumbersWhichGoLast() {
+        assertEquals(1, comparator.compare("lalala_", "lalala_3"));
+        assertEquals(-1, comparator.compare("lalala_3", "lalala_"));
+    }
+
+}

--- a/graylog2-server/src/test/java/org/graylog2/indexer/indices/util/NumberBasedIndexNameComparatorTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/indices/util/NumberBasedIndexNameComparatorTest.java
@@ -19,7 +19,7 @@ package org.graylog2.indexer.indices.util;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class NumberBasedIndexNameComparatorTest {
 
@@ -31,32 +31,40 @@ class NumberBasedIndexNameComparatorTest {
     }
 
     @Test
-    void comparesDescByNumberAfterLastSeparatorOccurrence() {
-        assertEquals(-1, comparator.compare("lalala_5", "lalala_3"));
-        assertEquals(1, comparator.compare("lalala_3", "lalala_5"));
+    void indexPrefixIsMoreImportantThanNumberWhileSorting() {
+        assertTrue(comparator.compare("abc_5", "bcd_3") < 0);
+        assertTrue(comparator.compare("abc", "bcd_3") < 0);
+        assertTrue(comparator.compare("zzz_1", "aaa") > 0);
+        assertTrue(comparator.compare("zzz", "aaa") > 0);
+    }
 
-        assertEquals(-1, comparator.compare("lalala_1_5", "lalala_3"));
-        assertEquals(-1, comparator.compare("lalala_1_5", "lalala_0"));
+    @Test
+    void comparesDescByNumberAfterLastSeparatorOccurrence() {
+        assertTrue(comparator.compare("lalala_5", "lalala_3") < 0);
+        assertTrue(comparator.compare("lalala_3", "lalala_5") > 0);
+
+        assertTrue(comparator.compare("lalala_1_5", "lalala_1_3") < 0);
+        assertTrue(comparator.compare("lalala_1_5", "lalala_1_0") < 0);
     }
 
     @Test
     void indexNameWithNoSeparatorGoesLast() {
-        assertEquals(1, comparator.compare("lalala", "lalala_3"));
-        assertEquals(-1, comparator.compare("lalala_3", "lalala"));
-        assertEquals(1, comparator.compare("lalala", "lalala_42"));
-        assertEquals(-1, comparator.compare("lalala_42", "lalala"));
+        assertTrue(comparator.compare("lalala", "lalala_3") > 0);
+        assertTrue(comparator.compare("lalala_3", "lalala") < 0);
+        assertTrue(comparator.compare("lalala", "lalala_42") > 0);
+        assertTrue(comparator.compare("lalala_42", "lalala") < 0);
     }
 
     @Test
     void isImmuneToWrongNumbersWhichGoLast() {
-        assertEquals(1, comparator.compare("lalala_1!1", "lalala_3"));
-        assertEquals(-1, comparator.compare("lalala_3", "lalala_1!1"));
+        assertTrue(comparator.compare("lalala_1!1", "lalala_3") > 0);
+        assertTrue(comparator.compare("lalala_3", "lalala_1!1") < 0);
     }
 
     @Test
     void isImmuneToMissingNumbersWhichGoLast() {
-        assertEquals(1, comparator.compare("lalala_", "lalala_3"));
-        assertEquals(-1, comparator.compare("lalala_3", "lalala_"));
+        assertTrue(comparator.compare("lalala_", "lalala_3") > 0);
+        assertTrue(comparator.compare("lalala_3", "lalala_") < 0);
     }
 
 }

--- a/graylog2-web-interface/src/components/indices/IndicesOverview.jsx
+++ b/graylog2-web-interface/src/components/indices/IndicesOverview.jsx
@@ -22,9 +22,10 @@ import { ClosedIndexDetails, IndexDetails, IndexSummary } from 'components/indic
 
 const Index = ({ index, indexDetails, indexSetId }) => {
   const indexRange = index && index.range ? index.range : null;
+  const details = indexDetails.find(({ index_name }) => index_name === index.index_name);
 
   return (
-    <Row key={`index-summary-${index.index_name}`} className="content index-description">
+    <Row className="content index-description">
       <Col md={12}>
         <IndexSummary index={index}
                       name={index.index_name}
@@ -32,7 +33,7 @@ const Index = ({ index, indexDetails, indexSetId }) => {
                       indexRange={indexRange}
                       isDeflector={index.is_deflector}>
           <span>
-            <IndexDetails index={indexDetails[index.index_name]}
+            <IndexDetails index={details}
                           indexName={index.index_name}
                           indexRange={indexRange}
                           indexSetId={indexSetId}
@@ -48,7 +49,7 @@ const ClosedIndex = ({ index }) => {
   const indexRange = index.range;
 
   return (
-    <Row key={`index-summary-${index.index_name}`} className="content index-description">
+    <Row className="content index-description">
       <Col md={12}>
         <IndexSummary index={index} name={index.index_name} indexRange={indexRange} isDeflector={index.is_deflector}>
           <span>
@@ -63,15 +64,15 @@ const ClosedIndex = ({ index }) => {
 const IndicesOverview = ({ indexDetails, indices, indexSetId }) => (
   <span>
     {indices.map((index) => (!index.is_closed
-      ? <Index index={index} indexDetails={indexDetails} indexSetId={indexSetId} />
-      : <ClosedIndex index={index} />),
+      ? <Index index={index} indexDetails={indexDetails} indexSetId={indexSetId} key={`index-summary-${index.index_name}`} />
+      : <ClosedIndex index={index} key={`index-summary-${index.index_name}`} />),
     )}
   </span>
 );
 
 IndicesOverview.propTypes = {
-  indexDetails: PropTypes.object.isRequired,
-  indices: PropTypes.object.isRequired,
+  indexDetails: PropTypes.array.isRequired,
+  indices: PropTypes.array.isRequired,
   indexSetId: PropTypes.string.isRequired,
 };
 

--- a/graylog2-web-interface/src/components/indices/IndicesOverview.jsx
+++ b/graylog2-web-interface/src/components/indices/IndicesOverview.jsx
@@ -17,72 +17,62 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import { defaultCompare as naturalSort } from 'logic/DefaultCompare';
 import { Col, Row } from 'components/bootstrap';
 import { ClosedIndexDetails, IndexDetails, IndexSummary } from 'components/indices';
 
-class IndicesOverview extends React.Component {
-  static propTypes = {
-    closedIndices: PropTypes.array.isRequired,
-    deflector: PropTypes.object.isRequired,
-    indexDetails: PropTypes.object.isRequired,
-    indices: PropTypes.object.isRequired,
-    indexSetId: PropTypes.string.isRequired,
-  };
+const Index = ({ index, indexDetails, indexSetId }) => {
+  const indexRange = index && index.range ? index.range : null;
 
-  _formatIndex = (indexName, index) => {
-    const indexSummary = this.props.indices[indexName];
-    const indexRange = indexSummary && indexSummary.range ? indexSummary.range : null;
+  return (
+    <Row key={`index-summary-${index.index_name}`} className="content index-description">
+      <Col md={12}>
+        <IndexSummary index={index}
+                      name={index.index_name}
+                      count={index.size}
+                      indexRange={indexRange}
+                      isDeflector={index.is_deflector}>
+          <span>
+            <IndexDetails index={indexDetails[index.index_name]}
+                          indexName={index.index_name}
+                          indexRange={indexRange}
+                          indexSetId={indexSetId}
+                          isDeflector={index.is_deflector} />
+          </span>
+        </IndexSummary>
+      </Col>
+    </Row>
+  );
+};
 
-    return (
-      <Row key={`index-summary-${indexName}`} className="content index-description">
-        <Col md={12}>
-          <IndexSummary index={index}
-                        name={indexName}
-                        count={indexSummary.size}
-                        indexRange={indexRange}
-                        isDeflector={indexSummary.is_deflector}>
-            <span>
-              <IndexDetails index={this.props.indexDetails[indexName]}
-                            indexName={indexName}
-                            indexRange={indexRange}
-                            indexSetId={this.props.indexSetId}
-                            isDeflector={indexSummary.is_deflector} />
-            </span>
-          </IndexSummary>
-        </Col>
-      </Row>
-    );
-  };
+const ClosedIndex = ({ index }) => {
+  const indexRange = index.range;
 
-  _formatClosedIndex = (indexName, index) => {
-    const indexRange = index.range;
+  return (
+    <Row key={`index-summary-${index.index_name}`} className="content index-description">
+      <Col md={12}>
+        <IndexSummary index={index} name={index.index_name} indexRange={indexRange} isDeflector={index.is_deflector}>
+          <span>
+            <ClosedIndexDetails indexName={index.index_name} indexRange={indexRange} />
+          </span>
+        </IndexSummary>
+      </Col>
+    </Row>
+  );
+};
 
-    return (
-      <Row key={`index-summary-${indexName}`} className="content index-description">
-        <Col md={12}>
-          <IndexSummary index={index} name={indexName} indexRange={indexRange} isDeflector={index.is_deflector}>
-            <span>
-              <ClosedIndexDetails indexName={indexName} indexRange={indexRange} />
-            </span>
-          </IndexSummary>
-        </Col>
-      </Row>
-    );
-  };
+const IndicesOverview = ({ indexDetails, indices, indexSetId }) => (
+  <span>
+    {indices.map((index) => (!index.is_closed
+      ? <Index index={index} indexDetails={indexDetails} indexSetId={indexSetId} />
+      : <ClosedIndex index={index} />),
+    )}
+  </span>
+);
 
-  render() {
-    const indices = Object.keys(this.props.indices).map((indexName) => {
-      return !this.props.indices[indexName].is_closed
-        ? this._formatIndex(indexName, this.props.indices[indexName]) : this._formatClosedIndex(indexName, this.props.indices[indexName]);
-    });
-
-    return (
-      <span>
-        {indices.sort((index1, index2) => naturalSort(index2.key, index1.key))}
-      </span>
-    );
-  }
-}
+IndicesOverview.propTypes = {
+  indexDetails: PropTypes.object.isRequired,
+  indices: PropTypes.object.isRequired,
+  indexSetId: PropTypes.string.isRequired,
+};
 
 export default IndicesOverview;

--- a/graylog2-web-interface/src/components/indices/IndicesOverview.tsx
+++ b/graylog2-web-interface/src/components/indices/IndicesOverview.tsx
@@ -19,8 +19,9 @@ import React from 'react';
 
 import { Col, Row } from 'components/bootstrap';
 import { ClosedIndexDetails, IndexDetails, IndexSummary } from 'components/indices';
+import type { IndexInfo } from 'stores/indices/IndicesStore';
 
-const Index = ({ index, indexDetails, indexSetId }) => {
+const Index = ({ index, indexDetails, indexSetId }: { index: IndexSummary, indexDetails: Array<IndexInfo>, indexSetId: string }) => {
   const indexRange = index && index.range ? index.range : null;
   const details = indexDetails.find(({ index_name }) => index_name === index.index_name);
 
@@ -45,7 +46,7 @@ const Index = ({ index, indexDetails, indexSetId }) => {
   );
 };
 
-const ClosedIndex = ({ index }) => {
+const ClosedIndex = ({ index }: { index: IndexSummary }) => {
   const indexRange = index.range;
 
   return (
@@ -61,7 +62,13 @@ const ClosedIndex = ({ index }) => {
   );
 };
 
-const IndicesOverview = ({ indexDetails, indices, indexSetId }) => (
+type Props = {
+  indexDetails: Array<IndexInfo>,
+  indices: Array<IndexSummary>
+  indexSetId: string,
+}
+
+const IndicesOverview = ({ indexDetails, indices, indexSetId }: Props) => (
   <span>
     {indices.map((index) => (!index.is_closed
       ? <Index index={index} indexDetails={indexDetails} indexSetId={indexSetId} key={`index-summary-${index.index_name}`} />

--- a/graylog2-web-interface/src/pages/IndexSetPage.tsx
+++ b/graylog2-web-interface/src/pages/IndexSetPage.tsx
@@ -124,9 +124,9 @@ class IndexSetPage extends React.Component<Props, State> {
   }
 
   _totalIndexCount = () => {
-    const { indexerOverview: { indices } } = this.props;
+    const { indexerOverview: { indices = [] } } = this.props;
 
-    return indices ? Object.keys(indices).length : null;
+    return indices.length;
   };
 
   _isLoading = () => {

--- a/graylog2-web-interface/src/stores/indexers/IndexerOverviewStore.ts
+++ b/graylog2-web-interface/src/stores/indexers/IndexerOverviewStore.ts
@@ -69,9 +69,7 @@ export type IndexerOverview = {
   counts: {
     [key: string]: number,
   },
-  indices: {
-    [key: string]: IndexSummary,
-  },
+  indices: Array<IndexSummary>,
 };
 
 export const IndexerOverviewStore = singletonStore(

--- a/graylog2-web-interface/src/stores/indices/IndicesStore.ts
+++ b/graylog2-web-interface/src/stores/indices/IndicesStore.ts
@@ -79,10 +79,10 @@ export type Indices = Array<IndexInfo>
 
 type IndicesListResponse = {
   all: {
-    indices: IndexInfo,
+    indices: Indices,
   },
   closed: {
-    indices: IndexInfo,
+    indices: Indices,
   },
 };
 
@@ -150,7 +150,7 @@ export const IndicesStore = singletonStore(
     multiple() {
       const indexNames = Object.keys(this.registrations);
 
-      if (indexNames.length <= 0) {
+      if (!indexNames.length) {
         return;
       }
 

--- a/graylog2-web-interface/src/stores/indices/IndicesStore.ts
+++ b/graylog2-web-interface/src/stores/indices/IndicesStore.ts
@@ -38,6 +38,7 @@ export type IndexShardRouting = {
 };
 
 export type IndexInfo = {
+  index_name: string,
   primary_shards: {
     flush: IndexTimeAndTotalStats,
     get: IndexTimeAndTotalStats,

--- a/graylog2-web-interface/src/stores/indices/IndicesStore.ts
+++ b/graylog2-web-interface/src/stores/indices/IndicesStore.ts
@@ -74,9 +74,8 @@ export type IndexInfo = {
   reopened: boolean,
 };
 
-export type Indices = {
-  [key: string]: IndexInfo,
-};
+export type Indices = Array<IndexInfo>
+
 type IndicesListResponse = {
   all: {
     indices: IndexInfo,
@@ -157,7 +156,7 @@ export const IndicesStore = singletonStore(
       const urlList = qualifyUrl(ApiRoutes.IndicesApiController.multiple().url);
       const request = { indices: indexNames };
       const promise = fetch('POST', urlList, request).then((response: Indices) => {
-        this.indices = { ...this.indices, ...response };
+        this.indices = [...this.indices, ...response];
         this.trigger({ indices: this.indices, closedIndices: this.closedIndices });
 
         return { indices: this.indices, closedIndices: this.closedIndices };


### PR DESCRIPTION
## Description
Fixes #14280. See the issue for details.
For the indices list we are now using an array instead of an object to preserve the sorting.

## Motivation and Context
See  #14280.

## How Has This Been Tested?
Unit tests have been added.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

/jenkins-pr-deps https://github.com/Graylog2/graylog-plugin-enterprise/pull/4539
