### PR TITLE
 Start global JSON path input on leader node only (#14186) 4.3 backport

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -86,3 +86,7 @@ We now persist the desired input state: manually stopped inputs remain stopped, 
 - Introducing new archive config parameter retentionTime in days. 
   Archives exceeding the specified retentionTime are automatically deleted. 
   By default the behavior is unchanged: archives are retained indefinitely. 
+
+- The `JSON path value from HTTP API` input will now only run on the leader node,
+  if the `Global` option has been selected in the input configuration.
+  Previously, the input was started on all nodes in the cluster.

--- a/changelog/unreleased/issue-14074.toml
+++ b/changelog/unreleased/issue-14074.toml
@@ -1,0 +1,4 @@
+type = "changed"
+message = "Start `JSON path value from HTTP API` input on leader node only, if `Global` option was selected in input configuration."
+
+issues = ["14074"]

--- a/graylog2-server/src/main/java/org/graylog2/inputs/misc/jsonpath/JsonPathInput.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/misc/jsonpath/JsonPathInput.java
@@ -68,4 +68,9 @@ public class JsonPathInput extends MessageInput {
             super(transport.getConfig(), codec.getConfig());
         }
     }
+
+    @Override
+    public boolean onlyOnePerCluster() {
+        return true;
+    }
 }


### PR DESCRIPTION
4.3 backport for #14186 PR / #14074 issue.
