### PR TITLE
Start global JSON path input on leader node only (#14186) 5.0 backport

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -149,6 +149,9 @@ cannot handle multiple log sources with different encodings.
 - The permissions for which options are populated in the System dropdown menu were updated to more closely match the page that they link to. See [graylog2-server#13188](https://github.com/Graylog2/graylog2-server/pull/13188) for details.
 The Page permissions remain unchanged but this could affect the workflow for users with legacy permissions.
 - Newly created aggregation widgets will now have rollup disabled by default. Existing widgets are unchanged.
+- The `JSON path value from HTTP API` input will now only run on the leader node,
+  if the `Global` option has been selected in the input configuration.
+  Previously, the input was started on all nodes in the cluster.
 
 ### Changed archived default path
 On new Graylog installations, the default archiving configuration will now 

--- a/changelog/unreleased/issue-14074.toml
+++ b/changelog/unreleased/issue-14074.toml
@@ -1,0 +1,4 @@
+type = "changed"
+message = "Start `JSON path value from HTTP API` input on leader node only, if `Global` option was selected in input configuration."
+
+issues = ["14074"]

--- a/graylog2-server/src/main/java/org/graylog2/inputs/misc/jsonpath/JsonPathInput.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/misc/jsonpath/JsonPathInput.java
@@ -68,4 +68,9 @@ public class JsonPathInput extends MessageInput {
             super(transport.getConfig(), codec.getConfig());
         }
     }
+
+    @Override
+    public boolean onlyOnePerCluster() {
+        return true;
+    }
 }


### PR DESCRIPTION
5.0 backport for #14186 PR / #14074 issue.
