### PR TITLE
Concatenate query strings of queries/search types properly when exporting. (`4.3`)

### DIFF
--- a/changelog/unreleased/issue-14268.toml
+++ b/changelog/unreleased/issue-14268.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Fix concatenation of query strings in export."
+
+issues = ["14268"]
+pulls = ["14284"]

--- a/changelog/unreleased/issue-14268.toml
+++ b/changelog/unreleased/issue-14268.toml
@@ -2,4 +2,4 @@ type = "fixed"
 message = "Fix concatenation of query strings in export."
 
 issues = ["14268"]
-pulls = ["14284"]
+pulls = ["14350"]

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/elasticsearch/ElasticsearchQueryString.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/elasticsearch/ElasticsearchQueryString.java
@@ -66,15 +66,11 @@ public abstract class ElasticsearchQueryString implements BackendQuery {
         final String thisQueryString = Strings.nullToEmpty(this.queryString()).trim();
         final String otherQueryString = Strings.nullToEmpty(other.queryString()).trim();
 
-        final StringBuilder finalStringBuilder = new StringBuilder(thisQueryString);
         if (!thisQueryString.isEmpty() && !otherQueryString.isEmpty()) {
-            finalStringBuilder.append(" AND ");
-        }
-        if (!otherQueryString.isEmpty()) {
-            finalStringBuilder.append(otherQueryString);
+            return ElasticsearchQueryString.of("(" + thisQueryString + ") AND (" + otherQueryString + ")");
         }
 
-        return new AutoValue_ElasticsearchQueryString(NAME, finalStringBuilder.toString());
+        return this.queryString().isEmpty() ? other : this;
     }
 
     @Override

--- a/graylog2-server/src/test/java/org/graylog/events/processor/aggregation/AggregationEventProcessorTest.java
+++ b/graylog2-server/src/test/java/org/graylog/events/processor/aggregation/AggregationEventProcessorTest.java
@@ -494,7 +494,7 @@ public class AggregationEventProcessorTest {
         );
         sourceMessagesWithAggregation(groupByFields, 1);
 
-        String expectedQueryString = "aQueryString AND group_field_one:\"one\" AND group_field_two:\"two\"";
+        String expectedQueryString = "(aQueryString) AND ((group_field_one:\"one\") AND (group_field_two:\"two\"))";
         verify(moreSearch).scrollQuery(eq(expectedQueryString), any(), any(), any(), eq(1), any());
     }
 
@@ -506,7 +506,7 @@ public class AggregationEventProcessorTest {
         );
         sourceMessagesWithAggregation(groupByFields, 1);
 
-        String expectedQueryString = "aQueryString AND group_field_one:\"\\\" \\\" \\* \\& \\? \\- \\\\\" AND group_field_two:\"\\/ \\/ \\~ \\| \\[\\]\\{\\}\"";
+        String expectedQueryString = "(aQueryString) AND ((group_field_one:\"\\\" \\\" \\* \\& \\? \\- \\\\\") AND (group_field_two:\"\\/ \\/ \\~ \\| \\[\\]\\{\\}\"))";
         verify(moreSearch).scrollQuery(eq(expectedQueryString), any(), any(), any(), eq(1), any());
     }
 
@@ -517,7 +517,7 @@ public class AggregationEventProcessorTest {
         );
         sourceMessagesWithAggregation(groupByFields, 5);
 
-        String expectedQueryString = "aQueryString AND group_field_one:\"group_value_one\"";
+        String expectedQueryString = "(aQueryString) AND (group_field_one:\"group_value_one\")";
         verify(moreSearch).scrollQuery(eq(expectedQueryString), any(), any(), any(), eq(5), any());
     }
 

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/elasticsearch/ElasticsearchQueryStringTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/elasticsearch/ElasticsearchQueryStringTest.java
@@ -44,7 +44,7 @@ class ElasticsearchQueryStringTest {
 
     @Test
     void concatenatingTwoNonEmptyStringsReturnsAppendedQueryString() {
-        assertThat(create("nf_bytes>200").concatenate(create("_exists_:nf_version")).queryString()).isEqualTo("nf_bytes>200 AND _exists_:nf_version");
+        assertThat(create("nf_bytes>200").concatenate(create("_exists_:nf_version")).queryString()).isEqualTo("(nf_bytes>200) AND (_exists_:nf_version)");
     }
 
     @ParameterizedTest

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/engine/ValidationRequestTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/engine/ValidationRequestTest.java
@@ -48,7 +48,7 @@ class ValidationRequestTest {
                 .build()
                 .getCombinedQueryWithFilter();
 
-        assertThat(q).isEqualTo("foo:bar AND lorem:ipsum");
+        assertThat(q).isEqualTo("(foo:bar) AND (lorem:ipsum)");
     }
 
     private ValidationRequest.Builder builder() throws InvalidRangeParametersException {


### PR DESCRIPTION
**Note:** This is a backport of #14284 to `4.3`.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is fixing an issue related to exporting a search type. When both the search type and the query contain query strings, they are being concatenated, by simply combining them with an AND. For simple query strings this works, but it changes the logic for more complicated ones (e.g. when query string1 is foo OR bar and the second is also foo OR bar, the resulting query string foo OR bar AND foo bar has a different meaning, due to the stronger binding of the logical AND.

With this PR, concatenating two query strings wraps them in braces too, so foo OR bar concatenated to itself ends up as (foo OR bar) AND (foo or BAR), which returns the same, correct results.

Fixes #14268.

/jenkins-pr-deps Graylog2/graylog-plugin-enterprise#4514

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.