### PR TITLE
Saved searches can be sorted by 3 additional fields

### DIFF
--- a/changelog/unreleased/issue-14140.toml
+++ b/changelog/unreleased/issue-14140.toml
@@ -2,4 +2,4 @@ type = "fixed" # One of: a(dded), c(hanged), d(eprecated), r(emoved), f(ixed), s
 message = "Saved searches can be now sorted by 3 additional fields: owner, description and summary."
 
 issues = ["14140"]
-pulls = [""]
+pulls = ["14355"]

--- a/changelog/unreleased/issue-14140.toml
+++ b/changelog/unreleased/issue-14140.toml
@@ -1,0 +1,5 @@
+type = "fixed" # One of: a(dded), c(hanged), d(eprecated), r(emoved), f(ixed), s(ecurity)
+message = "Saved searches can be now sorted by 3 additional fields: owner, description and summary."
+
+issues = ["14140"]
+pulls = [""]

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/savedsearch/SavedSearchService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/savedsearch/SavedSearchService.java
@@ -27,6 +27,10 @@ import org.mongojack.JacksonDBCollection;
 import javax.inject.Inject;
 import java.util.stream.Stream;
 
+/**
+ * @deprecated Needed only by migrations.
+ */
+@Deprecated
 public class SavedSearchService {
     private static final String COLLECTION_NAME = "saved_searches";
     private final JacksonDBCollection<SavedSearch, ObjectId> db;

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/ViewDTO.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/ViewDTO.java
@@ -64,7 +64,7 @@ public abstract class ViewDTO implements ContentPackable<ViewEntity.Builder>, Vi
     public static final String FIELD_CREATED_AT = "created_at";
     public static final String FIELD_OWNER = "owner";
 
-    public static final ImmutableSet<String> SORT_FIELDS = ImmutableSet.of(FIELD_ID, FIELD_TITLE, FIELD_CREATED_AT);
+    public static final ImmutableSet<String> SORT_FIELDS = ImmutableSet.of(FIELD_ID, FIELD_TITLE, FIELD_CREATED_AT, FIELD_OWNER, FIELD_DESCRIPTION, FIELD_SUMMARY);
 
     @Override
     @ObjectId

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/ViewService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/ViewService.java
@@ -16,6 +16,7 @@
  */
 package org.graylog.plugins.views.search.views;
 
+import com.mongodb.BasicDBObject;
 import com.mongodb.DuplicateKeyException;
 import org.bson.types.ObjectId;
 import org.graylog.security.entities.EntityOwnershipService;
@@ -62,6 +63,11 @@ public class ViewService extends PaginatedDbService<ViewDTO> {
         this.viewRequirementsFactory = viewRequirementsFactory;
         this.entityOwnerShipService = entityOwnerShipService;
         this.viewSummaryService = viewSummaryService;
+        for (String sortField : ViewDTO.SORT_FIELDS) {
+            if (!sortField.equals(ViewDTO.FIELD_ID)) { //id has index by default
+                this.db.createIndex(new BasicDBObject(sortField, 1), new BasicDBObject("unique", false));
+            }
+        }
     }
 
     private PaginatedList<ViewDTO> searchPaginated(DBQuery.Query query,

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/views/ViewServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/views/ViewServiceTest.java
@@ -208,11 +208,9 @@ public class ViewServiceTest {
 
         assertThat(result)
                 .hasSize(3)
-                .extracting("owner")
-                .containsExactly(
-                        Optional.of("roderick"),
-                        Optional.of("gotfryd"),
-                        Optional.of("franz"));
+                .extracting(ViewDTO::owner)
+                .extracting(Optional::get)
+                .containsExactly("roderick", "gotfryd", "franz");
 
         assertThat(result.grandTotal()).hasValue(5L);
 
@@ -227,11 +225,9 @@ public class ViewServiceTest {
 
         assertThat(result)
                 .hasSize(3)
-                .extracting("owner")
-                .containsExactly(
-                        Optional.of("abelard"),
-                        Optional.of("baldwin"),
-                        Optional.of("franz"));
+                .extracting(ViewDTO::owner)
+                .extracting(Optional::get)
+                .containsExactly("abelard", "baldwin", "franz");
 
         assertThat(result.grandTotal()).hasValue(5L);
     }


### PR DESCRIPTION
## Description
Saved searches can be sorted by 3 additional fields: owner, description and summary.
Proper indexes prepared in Mongo DB for sortable fields.
Fixes #14140.

## Motivation and Context
See #14140.

## How Has This Been Tested?
Manually and with additional integration test.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

