### PR TITLE
Update to freemarker 2.3.31 and use a more secure default configuration

### DIFF
--- a/changelog/unreleased/pr-14354.toml
+++ b/changelog/unreleased/pr-14354.toml
@@ -1,0 +1,4 @@
+type = "s"
+message = "Update to freemarker 2.3.31 and use a more secure default configuration."
+
+pulls = ["14354"]

--- a/graylog2-server/src/main/java/org/graylog2/bindings/ServerBindings.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/ServerBindings.java
@@ -32,6 +32,7 @@ import org.graylog2.bindings.providers.ClusterEventBusProvider;
 import org.graylog2.bindings.providers.DefaultSecurityManagerProvider;
 import org.graylog2.bindings.providers.DefaultStreamProvider;
 import org.graylog2.bindings.providers.HtmlSafeJmteEngineProvider;
+import org.graylog2.bindings.providers.SecureFreemarkerConfigProvider;
 import org.graylog2.bindings.providers.SystemJobFactoryProvider;
 import org.graylog2.bindings.providers.SystemJobManagerProvider;
 import org.graylog2.cluster.ClusterConfigServiceImpl;
@@ -137,6 +138,7 @@ public class ServerBindings extends Graylog2Module {
 
     private void bindProviders() {
         bind(ClusterEventBus.class).toProvider(ClusterEventBusProvider.class).asEagerSingleton();
+        bind(freemarker.template.Configuration.class).toProvider(SecureFreemarkerConfigProvider.class);
     }
 
     private void bindFactoryModules() {

--- a/graylog2-server/src/main/java/org/graylog2/bindings/providers/SecureFreemarkerConfigProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/providers/SecureFreemarkerConfigProvider.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.bindings.providers;
+
+import freemarker.core.TemplateClassResolver;
+import freemarker.template.Configuration;
+import freemarker.template.SimpleObjectWrapper;
+import freemarker.template.Version;
+
+import javax.inject.Provider;
+import javax.inject.Singleton;
+
+/**
+ * Provide a freemarker configuration with sane security defaults.
+ * For Reference see <a href="https://freemarker.apache.org/docs/app_faq.html#faq_template_uploading_security">
+ * Freemarker Uploading Security Guide
+ * </a>
+ */
+@Singleton
+public class SecureFreemarkerConfigProvider implements Provider<Configuration> {
+    public static final Version VERSION = Configuration.VERSION_2_3_31;
+
+    @Override
+    public Configuration get() {
+        final Configuration configuration = new Configuration(VERSION);
+
+        configuration.setNewBuiltinClassResolver(TemplateClassResolver.ALLOWS_NOTHING_RESOLVER);
+        final SimpleObjectWrapper simpleObjectWrapper = new SimpleObjectWrapper(VERSION);
+        simpleObjectWrapper.setDOMNodeSupport(false);
+        configuration.setObjectWrapper(simpleObjectWrapper);
+
+        return configuration;
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog/plugins/sidecar/collectors/ConfigurationServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/sidecar/collectors/ConfigurationServiceTest.java
@@ -23,8 +23,10 @@ import org.graylog.plugins.sidecar.rest.models.NodeDetails;
 import org.graylog.plugins.sidecar.rest.models.Sidecar;
 import org.graylog.plugins.sidecar.services.ConfigurationService;
 import org.graylog.plugins.sidecar.services.ConfigurationVariableService;
+import org.graylog.plugins.sidecar.template.RenderTemplateException;
 import org.graylog.testing.mongodb.MongoDBInstance;
 import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
+import org.graylog2.bindings.providers.SecureFreemarkerConfigProvider;
 import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
 import org.junit.Before;
 import org.junit.Rule;
@@ -34,6 +36,7 @@ import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.when;
 
 public class ConfigurationServiceTest {
@@ -70,7 +73,7 @@ public class ConfigurationServiceTest {
         when(sidecar.nodeDetails()).thenReturn(nodeDetails);
 
         this.configurationVariableService = new ConfigurationVariableService(mongodb.mongoConnection(), mongoJackObjectMapperProvider);
-        this.configurationService = new ConfigurationService(mongodb.mongoConnection(), mongoJackObjectMapperProvider, configurationVariableService);
+        this.configurationService = new ConfigurationService(mongodb.mongoConnection(), mongoJackObjectMapperProvider, configurationVariableService, new SecureFreemarkerConfigProvider());
     }
 
     @Test
@@ -83,6 +86,17 @@ public class ConfigurationServiceTest {
 
         Configuration configWithNewline = buildTestConfig(TEMPLATE_RENDERED);
         assertEquals(configWithNewline, result);
+    }
+
+    @Test
+    public void testTemplateRenderUsingForbiddenFeatures() throws Exception {
+        final String TEMPLATE = "<#assign ex=\"freemarker.template.utility.Execute\"?new()> ${ex(\"date\")}\n nodename: ${sidecar.nodeName}\n";
+
+        assertThrows("Template should not allow insecure features", RenderTemplateException.class, () -> {
+            configuration = buildTestConfig(TEMPLATE);
+            this.configurationService.save(configuration);
+            this.configurationService.renderConfigurationForCollector(sidecar, configuration);
+        });
     }
 
     @Test

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/SidecarCollectorConfigurationFacadeTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/SidecarCollectorConfigurationFacadeTest.java
@@ -22,6 +22,7 @@ import org.graylog.plugins.sidecar.services.ConfigurationVariableService;
 import org.graylog.testing.mongodb.MongoDBFixtures;
 import org.graylog.testing.mongodb.MongoDBInstance;
 import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
+import org.graylog2.bindings.providers.SecureFreemarkerConfigProvider;
 import org.graylog2.contentpacks.EntityDescriptorIds;
 import org.graylog2.contentpacks.model.ModelId;
 import org.graylog2.contentpacks.model.ModelTypes;
@@ -50,7 +51,8 @@ public class SidecarCollectorConfigurationFacadeTest {
     public void setUp() throws Exception {
         final MongoJackObjectMapperProvider mapperProvider = new MongoJackObjectMapperProvider(objectMapper);
         final ConfigurationService configurationService = new ConfigurationService(mongodb.mongoConnection(),
-                mapperProvider, new ConfigurationVariableService(mongodb.mongoConnection(), mapperProvider));
+                mapperProvider, new ConfigurationVariableService(mongodb.mongoConnection(), mapperProvider),
+                new SecureFreemarkerConfigProvider());
 
         facade = new SidecarCollectorConfigurationFacade(objectMapper, configurationService);
     }

--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
         <commons-validator.version>1.6</commons-validator.version>
         <commons-io.version>2.6</commons-io.version>
         <disruptor.version>3.4.2</disruptor.version>
-        <freemarker.version>2.3.29</freemarker.version>
+        <freemarker.version>2.3.31</freemarker.version>
         <gelfclient.version>1.5.0</gelfclient.version>
         <geoip2.version>2.12.0</geoip2.version>
         <grok.version>0.1.9-graylog-2</grok.version>


### PR DESCRIPTION
- https://freemarker.apache.org/docs/versions_2_3_30.html
- https://freemarker.apache.org/docs/versions_2_3_31.html

Co-authored-by: Marco Pfatschbacher <marco@graylog.com>

(cherry picked from commit 69bde48cfea6348283aacced6feda38f883353ac)