### PR TITLE
Trim whitespace characters on stream names

### DIFF
--- a/changelog/unreleased/issue-12857.toml
+++ b/changelog/unreleased/issue-12857.toml
@@ -1,0 +1,4 @@
+type = "fixed"
+message = "Trim whitespace characters on stream names."
+
+pulls = ["14359"]

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/StreamResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/StreamResource.java
@@ -113,6 +113,13 @@ import static org.graylog2.shared.rest.documentation.generator.Generator.CLOUD_V
 @Api(value = "Streams", description = "Manage streams", tags = {CLOUD_VISIBLE})
 @Path("/streams")
 public class StreamResource extends RestResource {
+    protected static final Map<String, SearchQueryField> SEARCH_FIELD_MAPPING = Map.of(
+            "id", SearchQueryField.create(StreamDTO.FIELD_ID, SearchQueryField.Type.OBJECT_ID),
+            StreamDTO.FIELD_TITLE, SearchQueryField.create(StreamDTO.FIELD_TITLE),
+            StreamDTO.FIELD_DESCRIPTION, SearchQueryField.create(StreamDTO.FIELD_DESCRIPTION),
+            StreamDTO.FIELD_CREATED_AT, SearchQueryField.create(StreamDTO.FIELD_CREATED_AT),
+            "status", SearchQueryField.create(StreamDTO.FIELD_DISABLED)
+    );
     private static final String DEFAULT_SORT_FIELD = StreamDTO.FIELD_TITLE;
     private static final String DEFAULT_SORT_DIRECTION = "asc";
     private static final List<EntityAttribute> attributes = List.of(
@@ -124,19 +131,9 @@ public class StreamResource extends RestResource {
                     FilterOption.create("running", "Running")
             )).build()
     );
-
     private static final EntityDefaults settings = EntityDefaults.builder()
             .sort(Sorting.create(DEFAULT_SORT_FIELD, Sorting.Direction.valueOf(DEFAULT_SORT_DIRECTION.toUpperCase(Locale.ROOT))))
             .build();
-
-    protected static final Map<String, SearchQueryField> SEARCH_FIELD_MAPPING = Map.of(
-            "id", SearchQueryField.create(StreamDTO.FIELD_ID, SearchQueryField.Type.OBJECT_ID),
-            StreamDTO.FIELD_TITLE, SearchQueryField.create(StreamDTO.FIELD_TITLE),
-            StreamDTO.FIELD_DESCRIPTION, SearchQueryField.create(StreamDTO.FIELD_DESCRIPTION),
-            StreamDTO.FIELD_CREATED_AT, SearchQueryField.create(StreamDTO.FIELD_CREATED_AT),
-            "status", SearchQueryField.create(StreamDTO.FIELD_DISABLED)
-    );
-
     private final PaginatedStreamService paginatedStreamService;
     private final StreamService streamService;
     private final StreamRuleService streamRuleService;
@@ -250,7 +247,7 @@ public class StreamResource extends RestResource {
     @Timed
     @ApiOperation(value = "Get a list of all enabled streams")
     @Produces(MediaType.APPLICATION_JSON)
-    public StreamListResponse getEnabled() throws NotFoundException {
+    public StreamListResponse getEnabled() {
         final List<Stream> streams = streamService.loadAllEnabled()
                 .stream()
                 .filter(stream -> isPermitted(RestPermissions.STREAMS_READ, stream.getId()))
@@ -296,7 +293,7 @@ public class StreamResource extends RestResource {
         final Stream stream = streamService.load(streamId);
 
         if (!Strings.isNullOrEmpty(cr.title())) {
-            stream.setTitle(cr.title());
+            stream.setTitle(cr.title().strip());
         }
 
         if (!Strings.isNullOrEmpty(cr.description())) {
@@ -460,14 +457,14 @@ public class StreamResource extends RestResource {
                 .collect(Collectors.toSet());
 
         final Map<String, Object> streamData = Map.of(
-            StreamImpl.FIELD_TITLE, cr.title(),
-            StreamImpl.FIELD_DESCRIPTION, cr.description(),
-            StreamImpl.FIELD_CREATOR_USER_ID, creatorUser,
-            StreamImpl.FIELD_CREATED_AT, Tools.nowUTC(),
-            StreamImpl.FIELD_MATCHING_TYPE, sourceStream.getMatchingType().toString(),
-            StreamImpl.FIELD_REMOVE_MATCHES_FROM_DEFAULT_STREAM, cr.removeMatchesFromDefaultStream(),
-            StreamImpl.FIELD_DISABLED, true,
-            StreamImpl.FIELD_INDEX_SET_ID, cr.indexSetId()
+                StreamImpl.FIELD_TITLE, cr.title().strip(),
+                StreamImpl.FIELD_DESCRIPTION, cr.description(),
+                StreamImpl.FIELD_CREATOR_USER_ID, creatorUser,
+                StreamImpl.FIELD_CREATED_AT, Tools.nowUTC(),
+                StreamImpl.FIELD_MATCHING_TYPE, sourceStream.getMatchingType().toString(),
+                StreamImpl.FIELD_REMOVE_MATCHES_FROM_DEFAULT_STREAM, cr.removeMatchesFromDefaultStream(),
+                StreamImpl.FIELD_DISABLED, true,
+                StreamImpl.FIELD_INDEX_SET_ID, cr.indexSetId()
         );
 
         final Stream stream = streamService.create(streamData);

--- a/graylog2-server/src/main/java/org/graylog2/streams/StreamServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/StreamServiceImpl.java
@@ -135,7 +135,7 @@ public class StreamServiceImpl extends PersistedServiceImpl implements StreamSer
     @Override
     public Stream create(CreateStreamRequest cr, String userId) {
         Map<String, Object> streamData = Maps.newHashMap();
-        streamData.put(StreamImpl.FIELD_TITLE, cr.title());
+        streamData.put(StreamImpl.FIELD_TITLE, cr.title().strip());
         streamData.put(StreamImpl.FIELD_DESCRIPTION, cr.description());
         streamData.put(StreamImpl.FIELD_CREATOR_USER_ID, userId);
         streamData.put(StreamImpl.FIELD_CREATED_AT, Tools.nowUTC());


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Leading and trailing whitespaces are removed on stream names while saving, creating or cloning a stream.

fixes #12857 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

