### PR TITLE
remove single-quotes from jvm.memory metric names

### DIFF
--- a/changelog/unreleased/pr-14370.toml
+++ b/changelog/unreleased/pr-14370.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Remove single-quotes from jvm.memory metric names"
+
+issues = ["graylog-plugin-enterprise#4394"]
+pulls = ["14370"]

--- a/graylog2-server/src/main/java/org/graylog2/shared/metrics/CustomMemoryUsageGaugeSet.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/metrics/CustomMemoryUsageGaugeSet.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog2.shared.metrics;
 
 import com.codahale.metrics.Metric;

--- a/graylog2-server/src/main/java/org/graylog2/shared/metrics/CustomMemoryUsageGaugeSet.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/metrics/CustomMemoryUsageGaugeSet.java
@@ -1,0 +1,16 @@
+package org.graylog2.shared.metrics;
+
+import com.codahale.metrics.Metric;
+import com.codahale.metrics.MetricSet;
+import com.codahale.metrics.jvm.MemoryUsageGaugeSet;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class CustomMemoryUsageGaugeSet implements MetricSet {
+    @Override
+    public Map<String, Metric> getMetrics() {
+        return new MemoryUsageGaugeSet().getMetrics().entrySet().stream()
+                .collect(Collectors.toMap(e -> e.getKey().replace("'", ""), Map.Entry::getValue));
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/shared/metrics/MetricRegistryFactory.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/metrics/MetricRegistryFactory.java
@@ -20,7 +20,6 @@ import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.jvm.BufferPoolMetricSet;
 import com.codahale.metrics.jvm.ClassLoadingGaugeSet;
 import com.codahale.metrics.jvm.GarbageCollectorMetricSet;
-import com.codahale.metrics.jvm.MemoryUsageGaugeSet;
 import com.codahale.metrics.jvm.ThreadStatesGaugeSet;
 
 import javax.inject.Singleton;
@@ -35,7 +34,7 @@ public class MetricRegistryFactory {
         metricRegistry.register("jvm.buffers", new BufferPoolMetricSet(ManagementFactory.getPlatformMBeanServer()));
         metricRegistry.register("jvm.cl", new ClassLoadingGaugeSet());
         metricRegistry.register("jvm.gc", new GarbageCollectorMetricSet());
-        metricRegistry.register("jvm.memory", new MemoryUsageGaugeSet());
+        metricRegistry.register("jvm.memory", new CustomMemoryUsageGaugeSet());
         metricRegistry.register("jvm.threads", new ThreadStatesGaugeSet());
         return metricRegistry;
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Single quotes are removed from all jvm.memory.* metric names because they make it difficult to design a match_pattern for 
Prometheus Exporter Custom Mappings. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fixes Graylog2/graylog-plugin-enterprise#4394

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

