### PR TITLE
Separate concerns in `PaginatedList` to simplify state management.

### DIFF
--- a/graylog2-web-interface/src/components/common/PaginatedList.test.tsx
+++ b/graylog2-web-interface/src/components/common/PaginatedList.test.tsx
@@ -33,14 +33,25 @@ jest.mock('react-router-dom', () => ({
 
 describe('PaginatedList', () => {
   it('should display Pagination', () => {
-    const { getByText } = render(<PaginatedList totalItems={100} onChange={() => {}}><div>The list</div></PaginatedList>);
+    const { getByText } = render(
+      <PaginatedList totalItems={100}
+                     onChange={() => {}}>
+        <div>The list</div>
+      </PaginatedList>,
+    );
 
     expect(getByText('The list')).not.toBeNull();
     expect(getByText('1')).not.toBeNull();
   });
 
   it('should not dived by 0 if pageSize is 0 Pagination', () => {
-    const { getByText } = render(<PaginatedList totalItems={100} pageSize={0} onChange={() => {}}><div>The list</div></PaginatedList>);
+    const { getByText } = render(
+      <PaginatedList totalItems={100}
+                     pageSize={0}
+                     onChange={() => {}}>
+        <div>The list</div>
+      </PaginatedList>,
+    );
 
     expect(getByText('The list')).not.toBeNull();
   });
@@ -59,7 +70,12 @@ describe('PaginatedList', () => {
 
   it('should reset current page on page size change', () => {
     const onChangeStub = jest.fn();
-    const { getByLabelText } = render(<PaginatedList totalItems={200} onChange={onChangeStub} activePage={3}><div>The list</div></PaginatedList>);
+    const { getByLabelText } = render(
+      <PaginatedList totalItems={200}
+                     onChange={onChangeStub}
+                     activePage={3}>
+        <div>The list</div>
+      </PaginatedList>);
 
     const pageSizeInput = getByLabelText('Show');
 
@@ -68,19 +84,57 @@ describe('PaginatedList', () => {
     expect(onChangeStub).toHaveBeenCalledWith(1, 100);
   });
 
-  it('should set <page> query parameter as active page', async () => {
-    const currentPage = 4;
+  describe('with state based on URL query params', () => {
+    it('should set <page> query parameter as active page', async () => {
+      const currentPage = 4;
 
-    asMock(useLocation).mockReturnValue({
-      search: `?page=${currentPage}`,
-    } as Location<{ search: string }>);
+      asMock(useLocation).mockReturnValue({
+        search: `?page=${currentPage}`,
+      } as Location<{ search: string }>);
 
-    const { findByTestId } = render(<PaginatedList totalItems={200} onChange={() => {}} activePage={3}><div>The list</div></PaginatedList>);
+      const { findByTestId } = render(
+        <PaginatedList totalItems={200}
+                       onChange={() => {}}
+                       activePage={3}>
+          <div>The list</div>
+        </PaginatedList>);
 
-    const graylogPagination = await findByTestId('graylog-pagination');
-    const activePageElement = graylogPagination.getElementsByClassName('active');
+      const graylogPagination = await findByTestId('graylog-pagination');
+      const activePageElement = graylogPagination.getElementsByClassName('active');
 
-    expect(activePageElement).not.toBeNull();
-    expect(activePageElement[0].textContent).toContain(`${currentPage}`);
+      expect(activePageElement).not.toBeNull();
+      expect(activePageElement[0].textContent).toContain(`${currentPage}`);
+    });
+  });
+
+  describe('with internal state', () => {
+    it('should update active page, when prop changes', async () => {
+      const { findByTestId, rerender } = render(
+        <PaginatedList totalItems={200}
+                       onChange={() => {}}
+                       activePage={3}
+                       useQueryParameter={false}>
+          <div>The list</div>
+        </PaginatedList>);
+
+      const graylogPagination = await findByTestId('graylog-pagination');
+      const activePageElement = graylogPagination.getElementsByClassName('active');
+
+      expect(activePageElement[0].textContent).toContain('3');
+
+      rerender(
+        <PaginatedList totalItems={200}
+                       onChange={() => {}}
+                       activePage={1}
+                       useQueryParameter={false}>
+          <div>The list</div>
+        </PaginatedList>,
+      );
+
+      await findByTestId('graylog-pagination');
+      const newActivePageElement = graylogPagination.getElementsByClassName('active');
+
+      expect(newActivePageElement[0].textContent).toContain('1');
+    });
   });
 });

--- a/graylog2-web-interface/src/components/common/PaginatedList.tsx
+++ b/graylog2-web-interface/src/components/common/PaginatedList.tsx
@@ -17,69 +17,41 @@
 import * as React from 'react';
 
 import IfInteractive from 'views/components/dashboard/IfInteractive';
-import usePaginationQueryParameter from 'hooks/usePaginationQueryParameter';
+import usePaginationQueryParameter, { DEFAULT_PAGE_SIZES } from 'hooks/usePaginationQueryParameter';
 
 import Pagination from './Pagination';
 import PageSizeSelect from './PageSizeSelect';
 
-const DEFAULT_PAGE_SIZES = [10, 20, 50, 100];
 export const INITIAL_PAGE = 1;
 
 type Props = {
-  activePage?: number,
   children: React.ReactNode,
   className?: string,
   hideFirstAndLastPageLinks?: boolean
   hidePreviousAndNextPageLinks?: boolean
   onChange?: (currentPage: number, pageSize: number) => void,
   pageSizes?: Array<number>,
-  pageSize?: number,
   showPageSizeSelect?: boolean,
   totalItems: number,
-  useQueryParameter?: boolean,
 };
 
-/**
- * Wrapper component around an element that renders pagination
- * controls and provides a callback when the page or page size change.
- * You still need to fetch or filter the data yourself to ensure that
- * the selected page is displayed on screen.
- */
-const PaginatedList = ({
-  activePage,
+const ListBase = ({
   children,
   className,
+  currentPage,
+  currentPageSize,
   hideFirstAndLastPageLinks,
   hidePreviousAndNextPageLinks,
   onChange,
-  pageSize: propPageSize,
   pageSizes,
+  setPagination,
   showPageSizeSelect,
   totalItems,
-  useQueryParameter,
-}: Props) => {
-  const { page, setPage, pageSize: queryParamPageSize, setPageSize } = usePaginationQueryParameter(pageSizes, propPageSize);
-
-  const [{ currentPage, currentPageSize }, setPagination] = React.useState({
-    currentPage: useQueryParameter ? page : Math.max(activePage, INITIAL_PAGE),
-    currentPageSize: (useQueryParameter && showPageSizeSelect) ? queryParamPageSize : propPageSize,
-  });
-
-  const executeOnChageCB = React.useCallback(() => {
-    if (currentPage !== page || currentPageSize !== queryParamPageSize) {
-      setPagination({
-        currentPage: Math.max(page, INITIAL_PAGE),
-        currentPageSize: queryParamPageSize,
-      });
-
-      if (onChange) onChange(Math.max(page, INITIAL_PAGE), queryParamPageSize);
-    }
-  }, [page, queryParamPageSize, currentPage, currentPageSize, onChange]);
-
-  React.useEffect(() => {
-    if (useQueryParameter) executeOnChageCB();
-  }, [useQueryParameter, executeOnChageCB]);
-
+}: Required<Props> & {
+  currentPageSize: number,
+  currentPage: number;
+  setPagination: (newPagination: { page: number, pageSize: number }) => void
+}) => {
   const numberPages = React.useMemo(() => (
     currentPageSize > 0 ? Math.ceil(totalItems / currentPageSize) : 0
   ), [currentPageSize, totalItems]);
@@ -87,17 +59,15 @@ const PaginatedList = ({
   const _onChangePageSize = React.useCallback((event: React.ChangeEvent<HTMLOptionElement>) => {
     event.preventDefault();
     const newPageSize = Number(event.target.value);
-    setPagination({ currentPage: INITIAL_PAGE, currentPageSize: newPageSize });
 
-    if (useQueryParameter) setPageSize(newPageSize);
+    setPagination({ page: INITIAL_PAGE, pageSize: newPageSize });
     if (onChange) onChange(INITIAL_PAGE, newPageSize);
-  }, [onChange, setPageSize, useQueryParameter]);
+  }, [onChange, setPagination]);
 
   const _onChangePage = React.useCallback((pageNum: number) => {
-    setPagination({ currentPage: pageNum, currentPageSize });
-    if (useQueryParameter) setPage(pageNum);
+    setPagination({ page: pageNum, pageSize: currentPageSize });
     if (onChange) onChange(pageNum, currentPageSize);
-  }, [useQueryParameter, setPage, onChange, currentPageSize]);
+  }, [setPagination, currentPageSize, onChange]);
 
   React.useEffect(() => {
     if (numberPages > 0 && currentPage > numberPages) _onChangePage(numberPages);
@@ -121,6 +91,81 @@ const PaginatedList = ({
         </div>
       </IfInteractive>
     </>
+  );
+};
+
+const ListBasedOnQueryParams = ({
+  pageSizes,
+  ...props
+}: Required<Props> & { pageSize: number }) => {
+  const { page: currentPage, pageSize: currentPageSize, setPagination } = usePaginationQueryParameter(pageSizes, props.pageSize); // should we be able to provide the active page here?
+
+  return <ListBase {...props} currentPage={currentPage} currentPageSize={currentPageSize} setPagination={setPagination} pageSizes={pageSizes} />;
+};
+
+const ListWithOwnState = ({
+  activePage,
+  pageSize: propPageSize,
+  ...props
+}: Required<Props> & { activePage: number, pageSize: number }) => {
+  const [{ page: currentPage, pageSize: currentPageSize }, setPagination] = React.useState({
+    page: Math.max(activePage, INITIAL_PAGE),
+    pageSize: propPageSize,
+  });
+
+  return <ListBase {...props} currentPage={currentPage} currentPageSize={currentPageSize} setPagination={setPagination} />;
+};
+
+/**
+ * Wrapper component around an element that renders pagination
+ * controls and provides a callback when the page or page size change.
+ * You still need to fetch or filter the data yourself to ensure that
+ * the selected page is displayed on screen.
+ */
+const PaginatedList = ({
+  activePage,
+  children,
+  className,
+  hideFirstAndLastPageLinks,
+  hidePreviousAndNextPageLinks,
+  onChange,
+  pageSize,
+  pageSizes,
+  showPageSizeSelect,
+  totalItems,
+  useQueryParameter,
+}: Props & {
+  activePage?: number,
+  pageSize?: number,
+  useQueryParameter?: boolean,
+}) => {
+  if (useQueryParameter) {
+    return (
+      <ListBasedOnQueryParams className={className}
+                              hideFirstAndLastPageLinks={hideFirstAndLastPageLinks}
+                              hidePreviousAndNextPageLinks={hidePreviousAndNextPageLinks}
+                              onChange={onChange}
+                              pageSizes={pageSizes}
+                              pageSize={pageSize}
+                              showPageSizeSelect={showPageSizeSelect}
+                              totalItems={totalItems}>
+        {children}
+      </ListBasedOnQueryParams>
+    );
+  }
+
+  return (
+    <ListWithOwnState className={className}
+                      hideFirstAndLastPageLinks={hideFirstAndLastPageLinks}
+                      hidePreviousAndNextPageLinks={hidePreviousAndNextPageLinks}
+                      onChange={onChange}
+                      pageSizes={pageSizes}
+                      pageSize={pageSize}
+                      showPageSizeSelect={showPageSizeSelect}
+                      totalItems={totalItems}
+                      activePage={activePage}>
+      {children}
+    </ListWithOwnState>
   );
 };
 

--- a/graylog2-web-interface/src/components/common/PaginatedList.tsx
+++ b/graylog2-web-interface/src/components/common/PaginatedList.tsx
@@ -98,7 +98,7 @@ const ListBasedOnQueryParams = ({
   pageSizes,
   ...props
 }: Required<Props> & { pageSize: number }) => {
-  const { page: currentPage, pageSize: currentPageSize, setPagination } = usePaginationQueryParameter(pageSizes, props.pageSize); // should we be able to provide the active page here?
+  const { page: currentPage, pageSize: currentPageSize, setPagination } = usePaginationQueryParameter(pageSizes, props.pageSize);
 
   return <ListBase {...props} currentPage={currentPage} currentPageSize={currentPageSize} setPagination={setPagination} pageSizes={pageSizes} />;
 };

--- a/graylog2-web-interface/src/components/common/PaginatedList.tsx
+++ b/graylog2-web-interface/src/components/common/PaginatedList.tsx
@@ -115,8 +115,6 @@ const ListWithOwnState = ({
   });
 
   useEffect(() => {
-    console.log({ activePage, currentPage });
-
     if (activePage > 0 && activePage !== currentPage) {
       setPagination((cur) => ({ ...cur, page: activePage }));
     }

--- a/graylog2-web-interface/src/components/common/PaginatedList.tsx
+++ b/graylog2-web-interface/src/components/common/PaginatedList.tsx
@@ -15,6 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
+import { useEffect, useMemo, useCallback } from 'react';
 
 import IfInteractive from 'views/components/dashboard/IfInteractive';
 import usePaginationQueryParameter, { DEFAULT_PAGE_SIZES } from 'hooks/usePaginationQueryParameter';
@@ -52,11 +53,11 @@ const ListBase = ({
   currentPage: number;
   setPagination: (newPagination: { page: number, pageSize: number }) => void
 }) => {
-  const numberPages = React.useMemo(() => (
+  const numberPages = useMemo(() => (
     currentPageSize > 0 ? Math.ceil(totalItems / currentPageSize) : 0
   ), [currentPageSize, totalItems]);
 
-  const _onChangePageSize = React.useCallback((event: React.ChangeEvent<HTMLOptionElement>) => {
+  const _onChangePageSize = useCallback((event: React.ChangeEvent<HTMLOptionElement>) => {
     event.preventDefault();
     const newPageSize = Number(event.target.value);
 
@@ -64,12 +65,12 @@ const ListBase = ({
     if (onChange) onChange(INITIAL_PAGE, newPageSize);
   }, [onChange, setPagination]);
 
-  const _onChangePage = React.useCallback((pageNum: number) => {
+  const _onChangePage = useCallback((pageNum: number) => {
     setPagination({ page: pageNum, pageSize: currentPageSize });
     if (onChange) onChange(pageNum, currentPageSize);
   }, [setPagination, currentPageSize, onChange]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (numberPages > 0 && currentPage > numberPages) _onChangePage(numberPages);
   }, [currentPage, numberPages, _onChangePage]);
 
@@ -113,7 +114,20 @@ const ListWithOwnState = ({
     pageSize: propPageSize,
   });
 
-  return <ListBase {...props} currentPage={currentPage} currentPageSize={currentPageSize} setPagination={setPagination} />;
+  useEffect(() => {
+    console.log({ activePage, currentPage });
+
+    if (activePage > 0 && activePage !== currentPage) {
+      setPagination((cur) => ({ ...cur, page: activePage }));
+    }
+  }, [activePage, currentPage]);
+
+  return (
+    <ListBase {...props}
+              currentPage={currentPage}
+              currentPageSize={currentPageSize}
+              setPagination={setPagination} />
+  );
 };
 
 /**

--- a/graylog2-web-interface/src/components/pipelines/ProcessingTimelineComponent.tsx
+++ b/graylog2-web-interface/src/components/pipelines/ProcessingTimelineComponent.tsx
@@ -104,7 +104,7 @@ const _loadPipelines = (pagination, setLoading, setPaginatedPipelines) => {
 const ProcessingTimelineComponent = () => {
   const currentUser = useCurrentUser();
   const { connections } = useStore(PipelineConnectionsStore);
-  const { page, pageSize: perPage, resetPage, setPage } = usePaginationQueryParameter();
+  const { page, pageSize: perPage, resetPage, setPagination } = usePaginationQueryParameter();
   const [query, setQuery] = useState('');
   const [streams, setStreams] = useState<Stream[] | undefined>();
   const [paginatedPipelines, setPaginatedPipelines] = useState<PaginatedPipelines|undefined>();
@@ -172,7 +172,7 @@ const ProcessingTimelineComponent = () => {
       if (window.confirm(`Do you really want to delete pipeline "${pipeline.title}"? This action cannot be undone.`)) {
         PipelinesActions.delete(pipeline.id).then(() => {
           _loadPipelines({ page, perPage, query }, setLoading, setPaginatedPipelines);
-          setPage(Math.max(DEFAULT_PAGINATION.page, page - 1));
+          setPagination({ page: Math.max(DEFAULT_PAGINATION.page, page - 1) });
         });
       }
     };

--- a/graylog2-web-interface/src/components/pipelines/ProcessingTimelineComponent.tsx
+++ b/graylog2-web-interface/src/components/pipelines/ProcessingTimelineComponent.tsx
@@ -61,7 +61,9 @@ const PipelineStage = styled.div<{ $idle?: boolean }>(({ $idle, theme }) => css`
   padding: 20px;
   text-align: center;
   width: 120px;
-  background-color: ${$idle ? theme.utils.colorLevel(theme.colors.global.contentBackground, 10) : theme.colors.global.contentBackground};
+  background-color: ${$idle
+    ? theme.utils.colorLevel(theme.colors.global.contentBackground, 10)
+    : theme.colors.global.contentBackground};
 `);
 
 const PipelineNameTD = styled.td`

--- a/graylog2-web-interface/src/components/streams/StreamsOverview/StreamsOverview.tsx
+++ b/graylog2-web-interface/src/components/streams/StreamsOverview/StreamsOverview.tsx
@@ -119,7 +119,7 @@ const StreamsOverview = ({ indexSets }: Props) => {
 
   const onSearch = useCallback((newQuery: string) => {
     paginationQueryParameter.resetPage();
-    setSearchParams((cur) => ({ ...cur, query: newQuery }));
+    setSearchParams((cur) => ({ ...cur, query: newQuery, page: 1 }));
   }, [paginationQueryParameter]);
 
   const onReset = useCallback(() => {

--- a/graylog2-web-interface/src/hooks/usePaginationQueryParameter.test.tsx
+++ b/graylog2-web-interface/src/hooks/usePaginationQueryParameter.test.tsx
@@ -53,30 +53,30 @@ describe('usePaginationQueryParameter custom hook', () => {
     expect(pageSize).toEqual(DEFAULT_PAGE_SIZES[0]);
   });
 
-  it('should set <page> query parameter with the value sent in setPage', () => {
+  it('should set <page> query parameter with the value sent in setPagination', () => {
     const { result } = renderHook(() => usePaginationQueryParameter(DEFAULT_PAGE_SIZES));
 
-    const { page, setPage } = result.current;
+    const { page, setPagination } = result.current;
 
     expect(page).toEqual(DEFAULT_PAGE);
 
     const nextPage = 4;
 
-    act(() => setPage(nextPage));
+    act(() => setPagination({ page: nextPage }));
 
     expect(mockHistoryReplace).toHaveBeenCalledWith(`?page=${nextPage}`);
   });
 
-  it('should set <pageSize> query parameter with the value sent in setPageSize and initilize the <page> query parameter', () => {
+  it('should set <pageSize> query parameter with the value sent in setPagination and initialize the <page> query parameter', () => {
     const { result } = renderHook(() => usePaginationQueryParameter(DEFAULT_PAGE_SIZES));
 
-    const { pageSize, setPageSize } = result.current;
+    const { pageSize, setPagination } = result.current;
 
     expect(pageSize).toEqual(DEFAULT_PAGE_SIZES[0]);
 
     const nextPageSize = DEFAULT_PAGE_SIZES[1];
 
-    act(() => setPageSize(nextPageSize));
+    act(() => setPagination({ pageSize: nextPageSize }));
 
     expect(mockHistoryReplace).toHaveBeenCalledWith(`?page=${DEFAULT_PAGE}&pageSize=${nextPageSize}`);
   });

--- a/graylog2-web-interface/src/hooks/usePaginationQueryParameter.test.tsx
+++ b/graylog2-web-interface/src/hooks/usePaginationQueryParameter.test.tsx
@@ -64,7 +64,7 @@ describe('usePaginationQueryParameter custom hook', () => {
 
     act(() => setPagination({ page: nextPage }));
 
-    expect(mockHistoryReplace).toHaveBeenCalledWith(`?page=${nextPage}`);
+    expect(mockHistoryReplace).toHaveBeenCalledWith(`?page=${nextPage}&pageSize=10`);
   });
 
   it('should set <pageSize> query parameter with the value sent in setPagination and initialize the <page> query parameter', () => {

--- a/graylog2-web-interface/src/hooks/usePaginationQueryParameter.ts
+++ b/graylog2-web-interface/src/hooks/usePaginationQueryParameter.ts
@@ -40,7 +40,7 @@ const usePaginationQueryParameter = (PAGE_SIZES: number[] = DEFAULT_PAGE_SIZES, 
   const pageSizeQueryParameterAsNumber = Number(pageSizeQueryParameter);
   const pageSize = (Number.isInteger(pageSizeQueryParameterAsNumber) && PAGE_SIZES?.includes(pageSizeQueryParameterAsNumber)) ? pageSizeQueryParameterAsNumber : defaultPageSize;
 
-  const setPagination = ({ page: newPage = page, pageSize: newPageSize = page }: { page?: number, pageSize?: number }) => {
+  const setPagination = ({ page: newPage = page, pageSize: newPageSize = pageSize }: { page?: number, pageSize?: number }) => {
     const uri = new URI(query).setSearch({ page: String(newPage), pageSize: String(newPageSize) });
     history.replace(uri.toString());
   };

--- a/graylog2-web-interface/src/hooks/usePaginationQueryParameter.ts
+++ b/graylog2-web-interface/src/hooks/usePaginationQueryParameter.ts
@@ -24,39 +24,32 @@ export const DEFAULT_PAGE_SIZES = [10, 20, 50, 100];
 
 export type PaginationQueryParameterResult = {
   page: number;
-  setPage: (newPage: number) => void;
   resetPage: () => void;
   pageSize: number;
-  setPageSize: (newPageSize: number) => void;
+  setPagination: (payload: { page?: number, pageSize?: number }) => void;
 };
 
-const usePaginationQueryParameter = (PAGE_SIZES: number[] = DEFAULT_PAGE_SIZES, defaultPageSize: number = PAGE_SIZES[0]): PaginationQueryParameterResult => {
+const usePaginationQueryParameter = (PAGE_SIZES: number[] = DEFAULT_PAGE_SIZES, defaultPageSize: number = DEFAULT_PAGE_SIZES[0]): PaginationQueryParameterResult => {
   const { page: pageQueryParameter, pageSize: pageSizeQueryParameter } = useQuery();
   const history = useHistory();
   const { search, pathname } = useLocation();
   const query = pathname + search;
-
-  const setPage = (newPage: number) => {
-    const uri = new URI(query).setSearch('page', String(newPage));
-    history.replace(uri.toString());
-  };
-
-  const resetPage = () => {
-    setPage(DEFAULT_PAGE);
-  };
-
-  const setPageSize = (newPageSize: number) => {
-    const uri = new URI(query).setSearch({ page: String(DEFAULT_PAGE), pageSize: String(newPageSize) });
-    history.replace(uri.toString());
-  };
-
   const pageQueryParameterAsNumber = Number(pageQueryParameter);
   const page = (Number.isInteger(pageQueryParameterAsNumber) && pageQueryParameterAsNumber > 0) ? pageQueryParameterAsNumber : DEFAULT_PAGE;
 
   const pageSizeQueryParameterAsNumber = Number(pageSizeQueryParameter);
   const pageSize = (Number.isInteger(pageSizeQueryParameterAsNumber) && PAGE_SIZES?.includes(pageSizeQueryParameterAsNumber)) ? pageSizeQueryParameterAsNumber : defaultPageSize;
 
-  return { page, setPage, resetPage, pageSize, setPageSize };
+  const setPagination = ({ page: newPage = page, pageSize: newPageSize = page }: { page?: number, pageSize?: number }) => {
+    const uri = new URI(query).setSearch({ page: String(newPage), pageSize: String(newPageSize) });
+    history.replace(uri.toString());
+  };
+
+  const resetPage = () => {
+    setPagination({ page: DEFAULT_PAGE, pageSize: Number(pageSizeQueryParameter) });
+  };
+
+  return { page, resetPage, pageSize, setPagination };
 };
 
 export default usePaginationQueryParameter;

--- a/graylog2-web-interface/src/pages/RulesPage.tsx
+++ b/graylog2-web-interface/src/pages/RulesPage.tsx
@@ -56,7 +56,7 @@ const _loadRuleMetricData = (setMetricsConfig) => {
 };
 
 const RulesPage = () => {
-  const { page, pageSize: perPage, resetPage, setPage } = usePaginationQueryParameter();
+  const { page, pageSize: perPage, resetPage, setPagination } = usePaginationQueryParameter();
   const [query, setQuery] = useState('');
   const [isDataLoading, setIsDataLoading] = useState<boolean>(false);
   const [openMetricsConfig, toggleMetricsConfig] = useState<boolean>(false);
@@ -89,7 +89,7 @@ const RulesPage = () => {
             return;
           }
 
-          setPage(Math.max(DEFAULT_PAGINATION.page, page - 1));
+          setPagination({ page: Math.max(DEFAULT_PAGINATION.page, page - 1) });
         });
       }
     };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

With this PR we are simplifying the state management in the `PaginatedList` component. The component can maintain the state for the active page and page size in two different ways:
1. It can have its own react state
2. Or It can use the URL query params to maintain the state

Before this PR the component contained all necessary logic for both use cases. Even when the state was based on the URL query params it still maintained its own state. This resulted in a comparable complex state management.

The `PaginatedList` component now contains the stateless `ListBase` component which receives the active page and page size. 
In case 1 we render a wrapper component which maintains a state for the active page and page size and passes it to the `ListBase` component.
In case 2 we render a wrapper component which extracts the page and page size from the URL and passes it to the `ListBase` component

With this approach the change in https://github.com/Graylog2/graylog2-server/pull/14141 is no longer necessary.

One thought I had while working on the state management, in case 1 we currently often maintain two states, one outside of the `PaginatedList` and one which is part of the component. In my opinion we can remove the internal `PaginatedList` state to simplify the sate management even more.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

/nocl