### PR TITLE
Fix grouping in aggregation builder for fields which only exist in event streams.

### DIFF
--- a/changelog/unreleased/issue-14404.toml
+++ b/changelog/unreleased/issue-14404.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Fix grouping in aggregation builder for fields which only exist in event streams."
+
+issues = ["14387"]
+pulls = ["14404"]

--- a/changelog/unreleased/issue-14404.toml
+++ b/changelog/unreleased/issue-14404.toml
@@ -1,5 +1,5 @@
 type = "fixed"
-message = "Fix grouping in aggregation builder for fields which only exist in event streams."
+message = "Fix grouping in aggregation builder for fields which only exist in the All Events, All System Events or Processing and Indexing Failures stream."
 
 issues = ["14387"]
 pulls = ["14404"]

--- a/graylog2-web-interface/src/views/components/WidgetComponent.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetComponent.tsx
@@ -17,13 +17,11 @@
 import * as React from 'react';
 import { useMemo } from 'react';
 import PropTypes from 'prop-types';
-import type * as Immutable from 'immutable';
 
 import type { BackendWidgetPosition } from 'views/types';
 import { AdditionalContext } from 'views/logic/ActionContext';
 import WidgetContext from 'views/components/contexts/WidgetContext';
 import type WidgetPosition from 'views/logic/widgets/WidgetPosition';
-import type TFieldTypeMapping from 'views/logic/fieldtypes/FieldTypeMapping';
 import ExportSettingsContextProvider from 'views/components/ExportSettingsContextProvider';
 import View from 'views/logic/views/View';
 import { useStore } from 'stores/connect';
@@ -41,7 +39,6 @@ import WidgetFieldTypesContextProvider from './contexts/WidgetFieldTypesContextP
 
 type Props = {
   editing: boolean,
-  fields: Immutable.List<TFieldTypeMapping>,
   onPositionsChange: (position: BackendWidgetPosition) => void,
   position: WidgetPosition,
   widgetId: string,
@@ -52,7 +49,6 @@ const useTitle = (widget: WidgetType) => useStore(TitlesStore, (titles) => title
 
 const WidgetComponent = ({
   editing,
-  fields,
   onPositionsChange = () => undefined,
   position,
   widgetId,
@@ -71,7 +67,6 @@ const WidgetComponent = ({
           <ExportSettingsContextProvider>
             <WidgetFieldTypesIfDashboard>
               <Widget editing={editing}
-                      fields={fields}
                       id={widget.id}
                       onPositionsChange={onPositionsChange}
                       position={position}
@@ -87,7 +82,6 @@ const WidgetComponent = ({
 
 WidgetComponent.propTypes = {
   editing: PropTypes.bool.isRequired,
-  fields: PropTypes.object.isRequired,
   onPositionsChange: PropTypes.func,
   position: PropTypes.shape(Position).isRequired,
 };

--- a/graylog2-web-interface/src/views/components/WidgetGrid.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetGrid.tsx
@@ -24,16 +24,13 @@ import { widgetDefinition } from 'views/logic/Widgets';
 import WidgetPosition from 'views/logic/widgets/WidgetPosition';
 import type { FocusContextState } from 'views/components/contexts/WidgetFocusContext';
 import WidgetFocusContext from 'views/components/contexts/WidgetFocusContext';
-import type { FieldTypeMappingsList } from 'views/logic/fieldtypes/types';
 import { useStore } from 'stores/connect';
 import { WidgetStore } from 'views/stores/WidgetStore';
 import { CurrentViewStateActions } from 'views/stores/CurrentViewStateStore';
-import FieldTypesContext from 'views/components/contexts/FieldTypesContext';
 import InteractiveContext from 'views/components/contexts/InteractiveContext';
 import type { StoreState } from 'stores/StoreTypes';
 import { ViewStatesStore } from 'views/stores/ViewStatesStore';
 import ElementDimensions from 'components/common/ElementDimensions';
-import useActiveQueryId from 'views/hooks/useActiveQueryId';
 import findGaps from 'views/components/GridGaps';
 import generateId from 'logic/generateId';
 import NewWidgetPlaceholder from 'views/components/NewWidgetPlaceholder';
@@ -74,7 +71,6 @@ const _defaultDimensions = (type: string) => {
 };
 
 type WidgetsProps = {
-  fields: FieldTypeMappingsList,
   widgetId: string,
   focusedWidget: FocusContextState | undefined,
   onPositionsChange: (position: BackendWidgetPosition) => void,
@@ -82,7 +78,6 @@ type WidgetsProps = {
 };
 
 const WidgetGridItem = ({
-  fields,
   onPositionsChange,
   positions,
   widgetId,
@@ -93,7 +88,6 @@ const WidgetGridItem = ({
 
   return (
     <WidgetComponent editing={editing}
-                     fields={fields}
                      onPositionsChange={onPositionsChange}
                      position={widgetPosition}
                      widgetId={widgetId} />
@@ -144,13 +138,6 @@ const Grid = ({ children, locked, onPositionsChange, onSyncLayout, positions, wi
 
 Grid.defaultProps = {
   onSyncLayout: () => {},
-};
-
-const useQueryFieldTypes = () => {
-  const fieldTypes = useContext(FieldTypesContext);
-  const queryId = useActiveQueryId();
-
-  return useMemo(() => fieldTypes.queryFields.get(queryId, fieldTypes.all), [fieldTypes.all, fieldTypes.queryFields, queryId]);
 };
 
 const MAXIMUM_GRID_SIZE = 12;
@@ -226,15 +213,12 @@ const WidgetGrid = () => {
     }
   }, [positions]);
 
-  const fields = useQueryFieldTypes();
-
   const [children, newPositions] = useMemo(() => {
     const widgetItems = widgets
       .filter((widget) => !!positions[widget.id])
       .map(({ id: widgetId }) => (
         <WidgetContainer key={widgetId} isFocused={focusedWidget?.id === widgetId && focusedWidget?.focusing}>
-          <WidgetGridItem fields={fields}
-                          positions={positions}
+          <WidgetGridItem positions={positions}
                           widgetId={widgetId}
                           focusedWidget={focusedWidget}
                           onPositionsChange={onPositionChange} />
@@ -250,7 +234,7 @@ const WidgetGrid = () => {
     return [widgetItems, positions];
     // We need to include lastUpdate explicitly to be able to force recalculation
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [fields, focusedWidget, isInteractive, lastUpdate, positions, widgets]);
+  }, [focusedWidget, isInteractive, lastUpdate, positions, widgets]);
 
   // Measuring the width is required to update the widget grid
   // when its content height results in a scrollbar

--- a/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.groupBy.test.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.groupBy.test.tsx
@@ -147,10 +147,9 @@ describe('AggregationWizard', () => {
     await selectField('status_code');
     await submitWidgetConfigForm();
 
-    const pivot = Pivot.create('status_code', 'values');
+    const pivot = Pivot.create(['status_code'], 'values');
     const updatedConfig = widgetConfig
       .toBuilder()
-      .rowLimit(15)
       .rowPivots([pivot])
       .build();
 
@@ -161,10 +160,9 @@ describe('AggregationWizard', () => {
 
   it('should not throw an error when field in config no longer exists in field types list.', async () => {
     const onChange = jest.fn();
-    const pivot = Pivot.create('status_code', 'values');
+    const pivot = Pivot.create(['status_code'], 'values');
     const initialConfig = widgetConfig
       .toBuilder()
-      .rowLimit(15)
       .rowPivots([pivot])
       .build();
 

--- a/graylog2-web-interface/src/views/components/aggregationwizard/grouping/configuration/FieldComponent.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/grouping/configuration/FieldComponent.tsx
@@ -19,7 +19,7 @@ import { useContext, useCallback } from 'react';
 import { useFormikContext } from 'formik';
 
 import FieldTypesContext from 'views/components/contexts/FieldTypesContext';
-import type { WidgetConfigFormValues, GroupByFormValues } from 'views/components/aggregationwizard/WidgetConfigForm';
+import type { GroupByFormValues, WidgetConfigFormValues } from 'views/components/aggregationwizard/WidgetConfigForm';
 import Input from 'components/bootstrap/Input';
 import SelectedFieldsList from 'views/components/aggregationwizard/grouping/configuration/SelectedFieldsList';
 import type { GroupByError } from 'views/components/aggregationwizard/grouping/GroupingElement';
@@ -50,7 +50,6 @@ const FieldComponent = ({ groupingIndex }: Props) => {
   const { setFieldValue, values, errors } = useFormikContext<WidgetConfigFormValues>();
   const grouping = values.groupBy.groupings[groupingIndex];
   const activeQueryId = useActiveQueryId();
-
   const createSelectPlaceholder = placeholder(grouping);
 
   const onAddField = useCallback((fieldName: string) => {

--- a/graylog2-web-interface/src/views/components/widgets/Widget.aggregations.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/Widget.aggregations.test.tsx
@@ -149,7 +149,6 @@ describe('Aggregation Widget', () => {
           <WidgetContext.Provider value={propsWidget}>
             <Widget widget={propsWidget}
                     id="widgetId"
-                    fields={Immutable.List([])}
                     onPositionsChange={() => {}}
                     title="Widget Title"
                     position={new WidgetPosition(1, 1, 1, 1)}

--- a/graylog2-web-interface/src/views/components/widgets/Widget.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/Widget.test.tsx
@@ -35,6 +35,7 @@ import type { ViewStoreState } from 'views/stores/ViewStore';
 import type { TitlesMap } from 'views/stores/TitleTypes';
 import useWidgetResults from 'views/components/useWidgetResults';
 import type SearchError from 'views/logic/SearchError';
+import type FieldTypeMapping from 'views/logic/fieldtypes/FieldTypeMapping';
 
 import Widget from './Widget';
 import type { Props as WidgetComponentProps } from './Widget';
@@ -42,6 +43,7 @@ import type { Props as WidgetComponentProps } from './Widget';
 import WidgetContext from '../contexts/WidgetContext';
 import type { WidgetFocusContextType } from '../contexts/WidgetFocusContext';
 import WidgetFocusContext from '../contexts/WidgetFocusContext';
+import FieldTypesContext from '../contexts/FieldTypesContext';
 
 jest.mock('../searchbar/queryinput/QueryInput', () => mockComponent('QueryInput'));
 jest.mock('./WidgetHeader', () => 'widget-header');
@@ -98,6 +100,11 @@ describe('<Widget />', () => {
     dirty: false,
   };
 
+  const fieldTypes = {
+    all: Immutable.List<FieldTypeMapping>(),
+    queryFields: Immutable.Map<string, Immutable.List<FieldTypeMapping>>(),
+  };
+
   beforeEach(() => {
     ViewStore.getInitialState = jest.fn(() => viewStoreState);
   });
@@ -119,17 +126,19 @@ describe('<Widget />', () => {
     unsetWidgetEditing = () => {},
     ...props
   }: DummyWidgetProps) => (
-    // eslint-disable-next-line react/jsx-no-constructed-context-values
-    <WidgetFocusContext.Provider value={{ focusedWidget, setWidgetFocusing, setWidgetEditing, unsetWidgetFocusing, unsetWidgetEditing }}>
-      <WidgetContext.Provider value={propsWidget}>
-        <Widget widget={propsWidget}
-                id="widgetId"
-                onPositionsChange={() => {}}
-                title="Widget Title"
-                position={new WidgetPosition(1, 1, 1, 1)}
-                {...props} />
-      </WidgetContext.Provider>
-    </WidgetFocusContext.Provider>
+    <FieldTypesContext.Provider value={fieldTypes}>
+      {/* eslint-disable-next-line react/jsx-no-constructed-context-values */}
+      <WidgetFocusContext.Provider value={{ focusedWidget, setWidgetFocusing, setWidgetEditing, unsetWidgetFocusing, unsetWidgetEditing }}>
+        <WidgetContext.Provider value={propsWidget}>
+          <Widget widget={propsWidget}
+                  id="widgetId"
+                  onPositionsChange={() => {}}
+                  title="Widget Title"
+                  position={new WidgetPosition(1, 1, 1, 1)}
+                  {...props} />
+        </WidgetContext.Provider>
+      </WidgetFocusContext.Provider>
+    </FieldTypesContext.Provider>
   );
 
   const getWidgetUpdateButton = () => screen.getByRole('button', { name: /update widget/i });
@@ -189,7 +198,6 @@ describe('<Widget />', () => {
     const UnknownWidget = (props) => (
       <DummyWidget widget={unknownWidget}
                    id="widgetId"
-                   fields={[]}
                    onPositionsChange={() => {}}
                    onSizeChange={() => {}}
                    title="Widget Title"
@@ -212,17 +220,18 @@ describe('<Widget />', () => {
       .config({})
       .build();
     const UnknownWidget = (props) => (
-      <WidgetContext.Provider value={unknownWidget}>
-        <Widget widget={unknownWidget}
-                editing
-                id="widgetId"
-                fields={[]}
-                onPositionsChange={() => {}}
-                onSizeChange={() => {}}
-                title="Widget Title"
-                position={new WidgetPosition(1, 1, 1, 1)}
-                {...props} />
-      </WidgetContext.Provider>
+      <FieldTypesContext.Provider value={fieldTypes}>
+        <WidgetContext.Provider value={unknownWidget}>
+          <Widget widget={unknownWidget}
+                  editing
+                  id="widgetId"
+                  onPositionsChange={() => {}}
+                  onSizeChange={() => {}}
+                  title="Widget Title"
+                  position={new WidgetPosition(1, 1, 1, 1)}
+                  {...props} />
+        </WidgetContext.Provider>
+      </FieldTypesContext.Provider>
     );
 
     render(

--- a/graylog2-web-interface/src/views/components/widgets/Widget.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/Widget.test.tsx
@@ -124,7 +124,6 @@ describe('<Widget />', () => {
       <WidgetContext.Provider value={propsWidget}>
         <Widget widget={propsWidget}
                 id="widgetId"
-                fields={Immutable.List([])}
                 onPositionsChange={() => {}}
                 title="Widget Title"
                 position={new WidgetPosition(1, 1, 1, 1)}

--- a/graylog2-web-interface/src/views/components/widgets/Widget.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/Widget.tsx
@@ -16,10 +16,10 @@
  */
 import * as React from 'react';
 import { useCallback, useContext, useMemo, useState } from 'react';
-import type * as Immutable from 'immutable';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
+import useActiveQueryId from 'views/hooks/useActiveQueryId';
 import type { BackendWidgetPosition, WidgetResults } from 'views/types';
 import { useStore } from 'stores/connect';
 import { widgetDefinition } from 'views/logic/Widgets';
@@ -28,7 +28,6 @@ import { WidgetActions } from 'views/stores/WidgetStore';
 import { TitlesActions } from 'views/stores/TitlesStore';
 import { ViewStore } from 'views/stores/ViewStore';
 import { RefreshActions } from 'views/stores/RefreshStore';
-import type FieldTypeMapping from 'views/logic/fieldtypes/FieldTypeMapping';
 import WidgetModel from 'views/logic/widgets/Widget';
 import type WidgetPosition from 'views/logic/widgets/WidgetPosition';
 import type { Rows } from 'views/logic/searchtypes/pivot/PivotHandler';
@@ -39,6 +38,7 @@ import IfDashboard from 'views/components/dashboard/IfDashboard';
 import type WidgetConfig from 'views/logic/widgets/WidgetConfig';
 import type { FieldTypeMappingsList } from 'views/logic/fieldtypes/types';
 import useWidgetResults from 'views/components/useWidgetResults';
+import FieldTypesContext from 'views/components/contexts/FieldTypesContext';
 
 import WidgetFrame from './WidgetFrame';
 import WidgetHeader from './WidgetHeader';
@@ -55,7 +55,6 @@ export type Props = {
   id: string,
   widget: WidgetModel,
   editing: boolean,
-  fields: Immutable.List<FieldTypeMapping>,
   title: string,
   position: WidgetPosition,
   onPositionsChange: (position: BackendWidgetPosition) => void,
@@ -79,17 +78,25 @@ const _hasOwnEditSubmitButton = (type) => {
   return widgetDefinition(type).hasEditSubmitButton;
 };
 
+const useQueryFieldTypes = () => {
+  const fieldTypes = useContext(FieldTypesContext);
+  const queryId = useActiveQueryId();
+
+  return useMemo(() => fieldTypes.queryFields.get(queryId, fieldTypes.all), [fieldTypes.all, fieldTypes.queryFields, queryId]);
+};
+
 const WidgetFooter = styled.div`
   width: 100%;
   display: flex;
   justify-content: flex-end;
 `;
 
-type VisualizationProps = Pick<Props, 'title' | 'id' | 'widget' | 'fields' | 'editing'> & {
+type VisualizationProps = Pick<Props, 'title' | 'id' | 'widget' | 'editing'> & {
   queryId: string,
   setLoadingState: (loading: boolean) => void,
   onToggleEdit: () => void,
   onWidgetConfigChange: (newWidgetConfig: WidgetConfig) => Promise<Widgets>,
+  fields: FieldTypeMappingsList,
 };
 
 const Visualization = ({ title, id, widget, fields, queryId, editing, setLoadingState, onToggleEdit, onWidgetConfigChange }: VisualizationProps) => {
@@ -154,7 +161,8 @@ const EditWrapper = ({ children, config, editing, fields, id, onToggleEdit, onCa
   ) : children;
 };
 
-const Widget = ({ id, editing, widget, fields, title, position, onPositionsChange }: Props) => {
+const Widget = ({ id, editing, widget, title, position, onPositionsChange }: Props) => {
+  const fields = useQueryFieldTypes();
   const [loading, setLoading] = useState(false);
   const [oldWidget, setOldWidget] = useState(editing ? widget : undefined);
   const { focusedWidget, setWidgetEditing, unsetWidgetEditing } = useContext(WidgetFocusContext);
@@ -233,7 +241,6 @@ const Widget = ({ id, editing, widget, fields, title, position, onPositionsChang
 
 Widget.propTypes = {
   editing: PropTypes.bool,
-  fields: PropTypes.any.isRequired,
   id: PropTypes.string.isRequired,
   onPositionsChange: PropTypes.func.isRequired,
   title: PropTypes.string.isRequired,


### PR DESCRIPTION
_Please note, this PR requires a backport for 4.2, 4.3 and 5.0._

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

As described in #14404 an error can occur when creating a grouping for a field which only exists in the following streams: `All Events`, `All System Events` or `Processing and Indexing Failures`.

The error occurred because the field type only exists in the fields list of the current query, but the code implemented in the list for all field types, where the field type is not part of. That the field is not part of this list is correct, please have a look at https://github.com/Graylog2/graylog2-server/pull/11405 for more information.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

