### PR TITLE
Update the node_id field on Notification.addNode()

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/events/processor/systemnotification/SystemNotificationRenderService.java
+++ b/graylog2-server/src/main/java/org/graylog/events/processor/systemnotification/SystemNotificationRenderService.java
@@ -35,6 +35,7 @@ import java.util.Locale;
 import java.util.Map;
 
 import static org.apache.commons.lang.CharEncoding.UTF_8;
+import static org.graylog2.shared.utilities.StringUtils.f;
 
 public class SystemNotificationRenderService {
     public enum Format {HTML, PLAINTEXT}
@@ -70,7 +71,7 @@ public class SystemNotificationRenderService {
 
     public RenderResponse render(Notification.Type type, Format format, Map<String, Object> values) {
         Notification notification = notificationService.getByType(type)
-                .orElseThrow(() -> new IllegalArgumentException("Event type is not currently active"));
+                .orElseThrow(() -> new IllegalArgumentException(f("Event type <%s> is not currently active", type)));
         return render(notification, format, values);
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/notifications/NotificationImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/notifications/NotificationImpl.java
@@ -150,6 +150,7 @@ public class NotificationImpl extends PersistedImpl implements Notification {
 
     @Override
     public Notification addNode(String nodeId) {
+        node_id = nodeId;
         fields.put(FIELD_NODE_ID, nodeId);
         return this;  //To change body of created methods use File | Settings | File Templates.
     }


### PR DESCRIPTION
Otherwise Notification.getNodeId() is returning nil

Improve SystemNotificationRenderService render exception message.

I stumbled over these while testing with an `An input has failed to start` notification.

Relates to #14399

/nocl
