### PR TITLE
PageListResponse receives fields for attributes and defaults

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/models/tools/responses/PageListResponse.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/tools/responses/PageListResponse.java
@@ -22,6 +22,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 import org.graylog.autovalue.WithBeanGetter;
 import org.graylog2.database.PaginatedList;
+import org.graylog2.rest.resources.entities.EntityAttribute;
+import org.graylog2.rest.resources.entities.EntityDefaults;
 
 import javax.annotation.Nullable;
 import java.util.List;
@@ -52,6 +54,12 @@ public abstract class PageListResponse<T> {
     @JsonProperty("elements")
     public abstract List<T> elements();
 
+    @JsonProperty
+    public abstract List<EntityAttribute> attributes();
+
+    @JsonProperty
+    public abstract EntityDefaults defaults();
+
     @JsonCreator
     public static <T> PageListResponse<T> create(
             @JsonProperty("query") @Nullable String query,
@@ -59,16 +67,20 @@ public abstract class PageListResponse<T> {
             @JsonProperty("total") long total,
             @JsonProperty("sort") @Nullable String sort,
             @JsonProperty("order") @Nullable String order,
-            @JsonProperty("elements") List<T> elements) {
-        return new AutoValue_PageListResponse<>(query, paginationInfo, total, sort, order, elements);
+            @JsonProperty("elements") List<T> elements,
+            @JsonProperty("attributes") List<EntityAttribute> attributes,
+            @JsonProperty("defaults") EntityDefaults defaults) {
+        return new AutoValue_PageListResponse<>(query, paginationInfo, total, sort, order, elements, attributes, defaults);
     }
 
     public static <T> PageListResponse<T> create(
             @Nullable String query,
             final PaginatedList<T> paginatedList,
             @Nullable String sort,
-            @Nullable String order) {
-        return new AutoValue_PageListResponse<>(query, paginatedList.pagination(), paginatedList.pagination().total(), sort, order, paginatedList);
+            @Nullable String order,
+            List<EntityAttribute> attributes,
+            EntityDefaults defaults) {
+        return new AutoValue_PageListResponse<>(query, paginatedList.pagination(), paginatedList.pagination().total(), sort, order, paginatedList, attributes, defaults);
     }
 
 }

--- a/graylog2-server/src/test/java/org/graylog2/rest/models/tools/responses/PageListResponseTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/rest/models/tools/responses/PageListResponseTest.java
@@ -18,9 +18,15 @@ package org.graylog2.rest.models.tools.responses;
 
 import com.google.common.collect.ImmutableList;
 import org.graylog2.database.PaginatedList;
+import org.graylog2.rest.resources.entities.EntityAttribute;
+import org.graylog2.rest.resources.entities.EntityDefaults;
+import org.graylog2.rest.resources.entities.Sorting;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class PageListResponseTest {
@@ -31,7 +37,9 @@ class PageListResponseTest {
                 new PaginatedList<>(
                         ImmutableList.of("1", "2"),
                         500, 1, 5),
-                "whatever", "asc");
+                "whatever", "asc",
+                List.of(EntityAttribute.builder().title("some_attr").id("some_id").build()),
+                EntityDefaults.builder().sort(Sorting.create("some_id", Sorting.Direction.ASC)).build());
 
         assertThat(pageListResponse.total()).isEqualTo(500);
         assertThat(pageListResponse.paginationInfo().page()).isEqualTo(1);
@@ -40,6 +48,8 @@ class PageListResponseTest {
         assertThat(pageListResponse.sort()).isEqualTo("whatever");
         assertThat(pageListResponse.order()).isEqualTo("asc");
         assertTrue(pageListResponse.elements().containsAll(ImmutableList.of("1", "2")));
+        assertEquals(pageListResponse.attributes(), List.of(EntityAttribute.builder().title("some_attr").id("some_id").build()));
+        assertEquals(pageListResponse.defaults(), EntityDefaults.builder().sort(Sorting.create("some_id", Sorting.Direction.ASC)).build());
     }
 
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
PageListResponse receives fields for attributes and defaults.
It is a first step to make it a reusable type of response for all entities migrated to new entity list approach.

/jenkins-pr-deps Graylog2/graylog-plugin-enterprise#4556
/nocl

## Motivation and Context
So far moving to new entity list approach was achieved by creating new type of response in the BE. Those types of responses were almost identical. It's time to unify the code, this is the first step in this process.

## How Has This Been Tested?
Unit tests have been modified and run.
Tested manually on SearchFiltersUsage (see corresponding enterprise PR).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

