### PR TITLE
Reduce logging and add metric for stream warning

### DIFF
--- a/changelog/unreleased/pr-14409.toml
+++ b/changelog/unreleased/pr-14409.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Reduce logging and add metric for [Couldn't remove default stream] warning."
+
+issues = ["graylog-plugin-enterprise#3481"]
+pulls = ["14409"]

--- a/changelog/unreleased/pr-14409.toml
+++ b/changelog/unreleased/pr-14409.toml
@@ -1,5 +1,5 @@
 type = "fixed"
-message = "Reduce logging and add metric for [Couldn't remove default stream] warning."
+message = "Reduce logging and add metric for \"Couldn't remove default stream\" warning."
 
 issues = ["graylog-plugin-enterprise#3481"]
 pulls = ["14409"]

--- a/graylog2-server/src/main/java/org/graylog2/streams/StreamRouterEngine.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/StreamRouterEngine.java
@@ -229,12 +229,12 @@ public class StreamRouterEngine {
                         LOG.trace("Successfully removed default stream <{}> from message <{}>", defaultStream.getId(), message.getId());
                     }
                 } else {
+                    // A previously executed message processor (or Illuminate) has likely already removed the
+                    // default stream from the message. Now, the message has matched a stream in the Graylog
+                    // MessageFilterChain during stream matching, which is also set to remove the default stream.
+                    // This is generally not a problem.
                     cannotRemoveDefaultMeter.inc();
                     if (LOG.isTraceEnabled()) {
-                        // A previously executed message processor (or Illuminate) has likely already removed the
-                        // default stream from the message. Now, the message has matched a stream in the Graylog
-                        // MessageFilterChain during stream matching, which is also set to remove the default stream.
-                        // This is generally not a problem.
                         LOG.trace("Couldn't remove default stream <{}> from message <{}>", defaultStream.getId(), message.getId());
                     }
                 }

--- a/graylog2-server/src/main/java/org/graylog2/streams/StreamRouterEngine.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/StreamRouterEngine.java
@@ -16,7 +16,7 @@
  */
 package org.graylog2.streams;
 
-import com.codahale.metrics.Meter;
+import com.codahale.metrics.Counter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
 import com.google.common.collect.ImmutableList;
@@ -68,7 +68,7 @@ public class StreamRouterEngine {
     private final Provider<Stream> defaultStreamProvider;
 
     private final List<Rule> rulesList;
-    private final Meter cannotRemoveDefaultMeter;
+    private final Counter cannotRemoveDefaultMeter;
 
     public interface Factory {
         StreamRouterEngine create(List<Stream> streams, ExecutorService executorService);
@@ -88,7 +88,7 @@ public class StreamRouterEngine {
         this.streamProcessingTimeout = streamFaultManager.getStreamProcessingTimeout();
         this.fingerprint = new StreamListFingerprint(streams).getFingerprint();
         this.defaultStreamProvider = defaultStreamProvider;
-        this.cannotRemoveDefaultMeter = metricRegistry.meter(name(this.getClass(), METER_NAME_CANNOT_REMOVE_DEFAULT));
+        this.cannotRemoveDefaultMeter = metricRegistry.counter(name(this.getClass(), METER_NAME_CANNOT_REMOVE_DEFAULT));
 
         final List<Rule> alwaysMatchRules = Lists.newArrayList();
         final List<Rule> presenceRules = Lists.newArrayList();
@@ -229,7 +229,7 @@ public class StreamRouterEngine {
                         LOG.trace("Successfully removed default stream <{}> from message <{}>", defaultStream.getId(), message.getId());
                     }
                 } else {
-                    cannotRemoveDefaultMeter.mark();
+                    cannotRemoveDefaultMeter.inc();
                     if (LOG.isTraceEnabled()) {
                         // A previously executed message processor (or Illuminate) has likely already removed the
                         // default stream from the message. Now, the message has matched a stream in the Graylog

--- a/graylog2-server/src/main/java/org/graylog2/streams/StreamRouterEngine.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/StreamRouterEngine.java
@@ -231,8 +231,8 @@ public class StreamRouterEngine {
                 } else {
                     // A previously executed message processor (or Illuminate) has likely already removed the
                     // default stream from the message. Now, the message has matched a stream in the Graylog
-                    // MessageFilterChain during stream matching, which is also set to remove the default stream.
-                    // This is generally not a problem.
+                    // MessageFilterChain, and the matching stream is also set to remove the default stream.
+                    // This is usually from user-defined stream rules, and is generally not a problem.
                     cannotRemoveDefaultMeter.inc();
                     if (LOG.isTraceEnabled()) {
                         LOG.trace("Couldn't remove default stream <{}> from message <{}>", defaultStream.getId(), message.getId());

--- a/graylog2-server/src/main/java/org/graylog2/streams/StreamRouterEngine.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/StreamRouterEngine.java
@@ -16,6 +16,8 @@
  */
 package org.graylog2.streams;
 
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
@@ -45,6 +47,8 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 
+import static com.codahale.metrics.MetricRegistry.name;
+
 /**
  * Stream routing engine to select matching streams for a message.
  *
@@ -52,6 +56,7 @@ import java.util.concurrent.TimeUnit;
  */
 public class StreamRouterEngine {
     private static final Logger LOG = LoggerFactory.getLogger(StreamRouterEngine.class);
+    private static final String METER_NAME_CANNOT_REMOVE_DEFAULT = "cannotRemoveDefault";
 
     private final EnumSet<StreamRuleType> ruleTypesNotNeedingFieldPresence = EnumSet.of(StreamRuleType.PRESENCE, StreamRuleType.EXACT, StreamRuleType.REGEX, StreamRuleType.ALWAYS_MATCH, StreamRuleType.CONTAINS, StreamRuleType.MATCH_INPUT);
     private final List<Stream> streams;
@@ -63,6 +68,7 @@ public class StreamRouterEngine {
     private final Provider<Stream> defaultStreamProvider;
 
     private final List<Rule> rulesList;
+    private final Meter cannotRemoveDefaultMeter;
 
     public interface Factory {
         StreamRouterEngine create(List<Stream> streams, ExecutorService executorService);
@@ -73,7 +79,8 @@ public class StreamRouterEngine {
                               @Assisted ExecutorService executorService,
                               StreamFaultManager streamFaultManager,
                               StreamMetrics streamMetrics,
-                              @DefaultStream Provider<Stream> defaultStreamProvider) {
+                              @DefaultStream Provider<Stream> defaultStreamProvider,
+                              MetricRegistry metricRegistry) {
         this.streams = streams;
         this.streamFaultManager = streamFaultManager;
         this.streamMetrics = streamMetrics;
@@ -81,6 +88,7 @@ public class StreamRouterEngine {
         this.streamProcessingTimeout = streamFaultManager.getStreamProcessingTimeout();
         this.fingerprint = new StreamListFingerprint(streams).getFingerprint();
         this.defaultStreamProvider = defaultStreamProvider;
+        this.cannotRemoveDefaultMeter = metricRegistry.meter(name(this.getClass(), METER_NAME_CANNOT_REMOVE_DEFAULT));
 
         final List<Rule> alwaysMatchRules = Lists.newArrayList();
         final List<Rule> presenceRules = Lists.newArrayList();
@@ -221,8 +229,13 @@ public class StreamRouterEngine {
                         LOG.trace("Successfully removed default stream <{}> from message <{}>", defaultStream.getId(), message.getId());
                     }
                 } else {
-                    if (LOG.isWarnEnabled()) {
-                        LOG.warn("Couldn't remove default stream <{}> from message <{}>", defaultStream.getId(), message.getId());
+                    cannotRemoveDefaultMeter.mark();
+                    if (LOG.isTraceEnabled()) {
+                        // A previously executed message processor (or Illuminate) has likely already removed the
+                        // default stream from the message. Now, the message has matched a stream in the Graylog
+                        // MessageFilterChain during stream matching, which is also set to remove the default stream.
+                        // This is generally not a problem.
+                        LOG.trace("Couldn't remove default stream <{}> from message <{}>", defaultStream.getId(), message.getId());
                     }
                 }
             }

--- a/graylog2-server/src/main/resources/prometheus-exporter.yml
+++ b/graylog2-server/src/main/resources/prometheus-exporter.yml
@@ -24,7 +24,7 @@ metric_mappings:
       - "stream_rule"
 
   - metric_name: "stream_router_cannot_remove_default"
-    match_pattern: "org.graylog2.streams.StreamRouterEngine.cannotRemoveDefaultStream"
+    match_pattern: "org.graylog2.streams.StreamRouterEngine.cannotRemoveDefault"
 
   - metric_name: "enterprise_forwarder_journal_written_bytes"
     match_pattern: "org.graylog.enterprise.integrations.outputs.forwarder.buffer.ForwarderJournallingMessageHandler.*.writtenBytes"

--- a/graylog2-server/src/main/resources/prometheus-exporter.yml
+++ b/graylog2-server/src/main/resources/prometheus-exporter.yml
@@ -23,6 +23,9 @@ metric_mappings:
       - "stream"
       - "stream_rule"
 
+  - metric_name: "stream_router_cannot_remove_default"
+    match_pattern: "org.graylog2.streams.StreamRouterEngine.cannotRemoveDefaultStream"
+
   - metric_name: "enterprise_forwarder_journal_written_bytes"
     match_pattern: "org.graylog.enterprise.integrations.outputs.forwarder.buffer.ForwarderJournallingMessageHandler.*.writtenBytes"
     wildcard_extract_labels:

--- a/graylog2-server/src/test/java/org/graylog2/streams/StreamRouterEngineTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/streams/StreamRouterEngineTest.java
@@ -71,7 +71,8 @@ public class StreamRouterEngineTest {
 
     @SuppressForbidden("Executors#newSingleThreadExecutor() is okay for tests")
     private StreamRouterEngine newEngine(List<Stream> streams) {
-        return new StreamRouterEngine(streams, Executors.newSingleThreadExecutor(), streamFaultManager, streamMetrics, defaultStreamProvider);
+        return new StreamRouterEngine(streams, Executors.newSingleThreadExecutor(), streamFaultManager, streamMetrics,
+                defaultStreamProvider, new MetricRegistry());
     }
 
     @Test


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Implements the following:
1) Reduce logging level for warning from `warn` to `trace`, to not show the warning unless `trace` logging is explicitly enabled:
> Couldn't remove default stream [stream-id] from message [message-id]

2) Add a metric, so that the condition can be monitored, if desired:

### Graylog metric (counter)
`counter org.graylog2.streams.StreamRouterEngine.cannotRemoveDefault`

![image](https://user-images.githubusercontent.com/3423655/211674484-e839842f-a321-42eb-b8cd-565698062843.png)

### Prometheus metric
`stream_router_cannot_remove_default`

![image](https://user-images.githubusercontent.com/3423655/211665495-4ce4c42f-a738-40bc-a461-92fe50f4d683.png)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/Graylog2/graylog-plugin-enterprise/issues/3481

This warning is logged when a previously executed message processor (or Illuminate) has already removed the default stream from the message (Illuminate does this by default for all messages currently). Once the message exits the first processor, it then enters the Graylog MessageFilterChain and is offered up for matching on all streams. If any stream (including an Illuminate stream) has a stream rule defined that matches the message, then the warning would trigger. This could result in a high volume of server log messages (one per message), which can cause increased disk IO and potentially other contention issues.

## Workaround

One workaround is to uncheck the `Remove matches from 'Default Stream' option for any stream that is matching messages that have completed Illuminate processing. Or, remove the matching stream rule (which could be present on any Illuminate or non-Illuminate stream).

Another workaround is to turn down the logging level in the affected class with this API command:
```
curl -I -X PUT http://<the-api-token>:token@localhost:9000/api/system/loggers/org.graylog2.streams.StreamRouterEngine/level/error \
-H 'X-Requested-By: graylog-api-user' -v 
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manual testing to make sure the warning no longer shows unless trace is enabled. Manual testing also verified that the metric is working in Graylog > Nodes > Metrics and in Prometheus when the export is set up. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

