### PR TITLE
Set default grace_period to 5mn in Event Definition

### DIFF
--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventDefinitionFormContainer.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventDefinitionFormContainer.jsx
@@ -181,7 +181,7 @@ EventDefinitionFormContainer.defaultProps = {
     field_spec: {},
     key_spec: [],
     notification_settings: {
-      grace_period_ms: 600000,
+      grace_period_ms: 300000,
       // Defaults to system setting for notification backlog size
       backlog_size: null,
     },


### PR DESCRIPTION
Set the default `grace_period` in Event definition's notification setting to `5mn`.

/nocl
fix Graylog2/graylog-plugin-enterprise#3741

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

