### PR TITLE
Remove not needed button styling in `GlobalThemeStyles`.

### DIFF
--- a/graylog2-web-interface/src/theme/GlobalThemeStyles.js
+++ b/graylog2-web-interface/src/theme/GlobalThemeStyles.js
@@ -488,10 +488,6 @@ const GlobalThemeStyles = createGlobalStyle(({ theme }) => css`
     width: 110px;
   }
 
-  .btn {
-    border-radius: 0;
-  }
-
   .btn-text {
     font-family: ${theme.fonts.family.body};
     font-size: ${theme.fonts.size.small};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

The button border radius is now part of the `bootstrap-config.json` and no longer required in the `GlobalThemeStyles`.

/nocl