### PR TITLE
Store the time when an index gets closed (rotated)

### DIFF
--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/IndicesAdapterES7.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/IndicesAdapterES7.java
@@ -42,6 +42,8 @@ import org.graylog.shaded.elasticsearch7.org.elasticsearch.client.GetAliasesResp
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.client.indices.CloseIndexRequest;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.client.indices.CreateIndexRequest;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.client.indices.DeleteAliasRequest;
+import org.graylog.shaded.elasticsearch7.org.elasticsearch.client.indices.GetMappingsRequest;
+import org.graylog.shaded.elasticsearch7.org.elasticsearch.client.indices.GetMappingsResponse;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.client.indices.IndexTemplatesExistRequest;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.client.indices.PutIndexTemplateRequest;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.client.indices.PutMappingRequest;
@@ -171,6 +173,35 @@ public class IndicesAdapterES7 implements IndicesAdapter {
     }
 
     @Override
+    public void updateIndexMetaData(@Nonnull String index, @Nonnull Map<String, Object> metadata, boolean mergeExisting) {
+        Map<String, Object> metaUpdate = new HashMap<>();
+        if (mergeExisting) {
+            final Map<String, Object> oldMetaData = getIndexMetaData(index);
+            metaUpdate.putAll(oldMetaData);
+        }
+        metaUpdate.putAll(metadata);
+        updateIndexMapping(index, "ignored", Map.of("_meta", metaUpdate));
+    }
+
+    @Override
+    public Map<String, Object> getIndexMetaData(@Nonnull String index) {
+        final GetMappingsRequest request = new GetMappingsRequest()
+                .indices(index)
+                .indicesOptions(IndicesOptions.fromOptions(true, true, true, false));
+
+        final GetMappingsResponse result = client.execute((c, requestOptions) -> c.indices().getMapping(request, requestOptions),
+                "Couldn't read mapping of index " + index);
+
+        final Object metaData = result.mappings().get(index).sourceAsMap().get("_meta");
+        //noinspection rawtypes
+        if (metaData instanceof Map map) {
+            //noinspection unchecked
+            return map;
+        }
+        return Map.of();
+    }
+
+    @Override
     public boolean ensureIndexTemplate(String templateName, Map<String, Object> template) {
         final PutIndexTemplateRequest request = new PutIndexTemplateRequest(templateName)
                 .source(template);
@@ -201,6 +232,13 @@ public class IndicesAdapterES7 implements IndicesAdapter {
 
         return creationDate
                 .map(Long::valueOf)
+                .map(instant -> new DateTime(instant, DateTimeZone.UTC));
+    }
+
+    @Override
+    public Optional<DateTime> indexClosingDate(String index) {
+        final Map<String, Object> indexMetaData = getIndexMetaData(index);
+        return Optional.ofNullable(indexMetaData.get("closing_date")).filter(Long.class::isInstance).map(Long.class::cast)
                 .map(instant -> new DateTime(instant, DateTimeZone.UTC));
     }
 

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/testing/ClientES7.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/testing/ClientES7.java
@@ -41,8 +41,11 @@ import org.graylog.shaded.elasticsearch7.org.elasticsearch.client.indices.Create
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.client.indices.GetIndexRequest;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.client.indices.GetIndexTemplatesRequest;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.client.indices.GetIndexTemplatesResponse;
+import org.graylog.shaded.elasticsearch7.org.elasticsearch.client.indices.GetMappingsRequest;
+import org.graylog.shaded.elasticsearch7.org.elasticsearch.client.indices.GetMappingsResponse;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.client.indices.IndexTemplateMetadata;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.client.indices.PutIndexTemplateRequest;
+import org.graylog.shaded.elasticsearch7.org.elasticsearch.client.indices.PutMappingRequest;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.cluster.health.ClusterHealthStatus;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.common.settings.Settings;
 import org.graylog.storage.elasticsearch7.ElasticsearchClient;
@@ -130,10 +133,10 @@ public class ClientES7 implements Client {
 
     @Override
     public String fieldType(String testIndexName, String field) {
-        return getMapping(testIndexName).get(field);
+        return getFieldMappings(testIndexName).get(field);
     }
 
-    private Map<String, String> getMapping(String index) {
+    private Map<String, String> getFieldMappings(String index) {
         final Request request = new Request("GET", "/" + index + "/_mapping");
         final JsonNode response = client.execute((c, requestOptions) -> {
             request.setOptions(requestOptions);
@@ -280,6 +283,25 @@ public class ClientES7 implements Client {
 
         client.execute((c, requestOptions) -> c.indices().putSettings(request, requestOptions),
                 "Unable to set index block for " + index);
+    }
+
+    @Override
+    public void updateMapping(String index, Map<String, Object> mapping) {
+        final PutMappingRequest request = new PutMappingRequest(index)
+                .source(mapping);
+
+        client.execute((c, requestOptions) -> c.indices().putMapping(request, requestOptions),
+                "Unable to update index mapping " + index);
+    }
+
+    @Override
+    public Map<String, Object> getMapping(String index) {
+        final GetMappingsRequest request = new GetMappingsRequest().indices(index);
+
+        final GetMappingsResponse result = client.execute((c, requestOptions) -> c.indices().getMapping(request, requestOptions),
+                "Couldn't read mapping of index " + index);
+
+        return result.mappings().get(index).sourceAsMap();
     }
 
     private void waitForResult(Callable<Boolean> task) {

--- a/graylog2-server/src/main/java/org/graylog2/indexer/SetIndexReadOnlyJob.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/SetIndexReadOnlyJob.java
@@ -20,6 +20,7 @@ import com.google.inject.assistedinject.Assisted;
 import com.google.inject.assistedinject.AssistedInject;
 import org.graylog2.indexer.indices.Indices;
 import org.graylog2.indexer.indices.jobs.OptimizeIndexJob;
+import org.graylog2.plugin.Tools;
 import org.graylog2.shared.system.activities.Activity;
 import org.graylog2.shared.system.activities.ActivityWriter;
 import org.graylog2.system.jobs.SystemJob;
@@ -83,6 +84,9 @@ public class SetIndexReadOnlyJob extends SystemJob {
 
         log.info("Setting old index <{}> to read-only.", index);
         indices.setReadOnly(index);
+
+        // record time index was "closed"
+        indices.setClosingDate(index, Tools.nowUTC());
 
         activityWriter.write(new Activity("Flushed and set <" + index + "> to read-only.", SetIndexReadOnlyJob.class));
 

--- a/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
@@ -357,6 +357,14 @@ public class Indices {
         return indicesAdapter.indexCreationDate(index);
     }
 
+    public void setClosingDate(String index, DateTime closingDate) {
+        indicesAdapter.updateIndexMetaData(index, Map.of("closing_date", closingDate.getMillis()), true);
+    }
+
+    public Optional<DateTime> indexClosingDate(String index) {
+       return indicesAdapter.indexClosingDate(index);
+    }
+
     public IndexRangeStats indexRangeStatsOfIndex(String index) {
         return indicesAdapter.indexRangeStatsOfIndex(index);
     }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/indices/IndicesAdapter.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indices/IndicesAdapter.java
@@ -49,11 +49,22 @@ public interface IndicesAdapter {
      */
     void updateIndexMapping(@Nonnull String indexName, @Nonnull String mappingType, @Nonnull Map<String, Object> mapping);
 
+    /**
+     * Updates the metadata field (_meta) of an index mapping
+     * @param indexName existing index name
+     * @param metaData  the new metadata
+     * @param mergeExisting merge or overwrite existing metadata
+     */
+    void updateIndexMetaData(@Nonnull String indexName, @Nonnull Map<String, Object> metaData, boolean mergeExisting);
+    Map<String, Object> getIndexMetaData(@Nonnull String indexName);
+
     boolean ensureIndexTemplate(String templateName, Map<String, Object> template);
 
     boolean indexTemplateExists(String templateName);
 
     Optional<DateTime> indexCreationDate(String index);
+
+    Optional<DateTime> indexClosingDate(String index);
 
     void openIndex(String index);
 

--- a/graylog2-server/src/test/java/org/graylog/testing/elasticsearch/Client.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/elasticsearch/Client.java
@@ -67,4 +67,7 @@ public interface Client {
     void resetIndexBlock(String index);
 
     void setIndexBlock(String index);
+
+    void updateMapping(String index, Map<String, Object> mapping);
+    Map<String, Object> getMapping(String index);
 }


### PR DESCRIPTION
For the new index rotation and retention strategy feature, we need to know when an index was created and when it was closed.

While the creation date is already available, the "closing" date is not.

A good place to store this information is the _meta field of each index:
 https://www.elastic.co/guide/en/elasticsearch/reference/7.10/mapping-meta-field.html#mapping-meta-field

```
A mapping type can have custom meta data associated with it. These are
not used at all by Elasticsearch, but can be used to store
application-specific metadata.
```
