### PR TITLE
Entity list preferences resource, part 1: inmemory storage and retrieval

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/bindings/PersistenceServicesBindings.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/PersistenceServicesBindings.java
@@ -30,6 +30,8 @@ import org.graylog2.inputs.persistence.InputStatusService;
 import org.graylog2.inputs.persistence.MongoInputStatusService;
 import org.graylog2.notifications.NotificationService;
 import org.graylog2.notifications.NotificationServiceImpl;
+import org.graylog2.rest.resources.entities.preferences.service.EntityListPreferencesService;
+import org.graylog2.rest.resources.entities.preferences.service.InMemoryEntityListPreferencesService;
 import org.graylog2.security.AccessTokenService;
 import org.graylog2.security.AccessTokenServiceImpl;
 import org.graylog2.security.MongoDBSessionService;
@@ -62,5 +64,6 @@ public class PersistenceServicesBindings extends AbstractModule {
         bind(AccessTokenService.class).to(AccessTokenServiceImpl.class);
         bind(MongoDBSessionService.class).to(MongoDBSessionServiceImpl.class);
         bind(InputStatusService.class).to(MongoInputStatusService.class).asEagerSingleton();
+        bind(EntityListPreferencesService.class).to(InMemoryEntityListPreferencesService.class);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/RestResourcesModule.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/RestResourcesModule.java
@@ -30,6 +30,7 @@ import org.graylog2.rest.resources.cluster.ClusterSystemPluginResource;
 import org.graylog2.rest.resources.cluster.ClusterSystemProcessingResource;
 import org.graylog2.rest.resources.cluster.ClusterSystemResource;
 import org.graylog2.rest.resources.cluster.ClusterSystemShutdownResource;
+import org.graylog2.rest.resources.entities.preferences.EntityListPreferencesResource;
 import org.graylog2.rest.resources.messages.MessageResource;
 import org.graylog2.rest.resources.roles.RolesResource;
 import org.graylog2.rest.resources.search.AbsoluteSearchResource;
@@ -123,6 +124,7 @@ public class RestResourcesModule extends Graylog2Module {
         addSystemRestResource(SystemShutdownResource.class);
         addSystemRestResource(TrafficResource.class);
         addSystemRestResource(SearchVersionResource.class);
+        addSystemRestResource(EntityListPreferencesResource.class);
     }
 
     private void addAuthResources() {

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/entities/preferences/EntityListPreferencesResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/entities/preferences/EntityListPreferencesResource.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.rest.resources.entities.preferences;
+
+import com.codahale.metrics.annotation.Timed;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import org.apache.shiro.authz.annotation.RequiresAuthentication;
+import org.graylog.security.UserContext;
+import org.graylog2.audit.jersey.NoAuditEvent;
+import org.graylog2.database.NotFoundException;
+import org.graylog2.plugin.database.ValidationException;
+import org.graylog2.rest.resources.entities.preferences.model.EntityListPreferences;
+import org.graylog2.rest.resources.entities.preferences.model.StoredEntityListPreferences;
+import org.graylog2.rest.resources.entities.preferences.service.EntityListPreferencesService;
+
+import javax.inject.Inject;
+import javax.validation.constraints.NotEmpty;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import static org.graylog2.shared.rest.documentation.generator.Generator.CLOUD_VISIBLE;
+
+@RequiresAuthentication
+@Api(value = "EntityLists", description = "Entity Lists Preferences", tags = {CLOUD_VISIBLE})
+@Path("/entitylists/preferences")
+public class EntityListPreferencesResource {
+
+    private final EntityListPreferencesService entityListPreferencesService;
+
+    @Inject
+    public EntityListPreferencesResource(final EntityListPreferencesService entityListPreferencesService) {
+        this.entityListPreferencesService = entityListPreferencesService;
+    }
+
+    @POST
+    @Path("/{entity_list_id}")
+    @Timed
+    @ApiOperation(value = "Create or update user preferences for certain entity list")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @NoAuditEvent("Storage details have not yet been decided") //TODO
+    public Response create(@ApiParam(name = "JSON body", required = true) EntityListPreferences entityListPreferences,
+                           @ApiParam(name = "entity_list_id", required = true) @PathParam("entity_list_id") @NotEmpty String entityListId,
+                           @Context UserContext userContext) throws ValidationException {
+
+        final String currentUserId = userContext.getUserId();
+        final StoredEntityListPreferences storedPreferences = new StoredEntityListPreferences(currentUserId, entityListId, entityListPreferences);
+        entityListPreferencesService.save(storedPreferences);
+        return Response.ok().build();
+    }
+
+    @GET
+    @Path("/{entity_list_id}")
+    @Timed
+    @ApiOperation(value = "Get preferences for user's entity list", response = EntityListPreferences.class)
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiResponses(value = {
+            @ApiResponse(code = 404, message = "Preferences not found.")
+    })
+    public EntityListPreferences get(@ApiParam(name = "entity_list_id", required = true) @PathParam("entity_list_id") @NotEmpty String entityListId,
+                                     @Context UserContext userContext) throws NotFoundException {
+
+        final String currentUserId = userContext.getUserId();
+        final StoredEntityListPreferences entityListPreferences = entityListPreferencesService.get(currentUserId, entityListId);
+        if (entityListPreferences == null) {
+            throw new NotFoundException("Preferences not found for user " + userContext.getUser().getName() + " and entity list id " + entityListId);
+        }
+        return entityListPreferences.preferences();
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/entities/preferences/EntityListPreferencesResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/entities/preferences/EntityListPreferencesResource.java
@@ -29,6 +29,7 @@ import org.graylog2.database.NotFoundException;
 import org.graylog2.plugin.database.ValidationException;
 import org.graylog2.rest.resources.entities.preferences.model.EntityListPreferences;
 import org.graylog2.rest.resources.entities.preferences.model.StoredEntityListPreferences;
+import org.graylog2.rest.resources.entities.preferences.model.StoredEntityListPreferencesId;
 import org.graylog2.rest.resources.entities.preferences.service.EntityListPreferencesService;
 
 import javax.inject.Inject;
@@ -68,7 +69,11 @@ public class EntityListPreferencesResource {
                            @Context UserContext userContext) throws ValidationException {
 
         final String currentUserId = userContext.getUserId();
-        final StoredEntityListPreferences storedPreferences = new StoredEntityListPreferences(currentUserId, entityListId, entityListPreferences);
+        final StoredEntityListPreferencesId complexId = StoredEntityListPreferencesId.builder()
+                .userId(currentUserId)
+                .entityListId(entityListId)
+                .build();
+        final StoredEntityListPreferences storedPreferences = new StoredEntityListPreferences(complexId, entityListPreferences);
         entityListPreferencesService.save(storedPreferences);
         return Response.ok().build();
     }
@@ -85,7 +90,11 @@ public class EntityListPreferencesResource {
                                      @Context UserContext userContext) throws NotFoundException {
 
         final String currentUserId = userContext.getUserId();
-        final StoredEntityListPreferences entityListPreferences = entityListPreferencesService.get(currentUserId, entityListId);
+        final StoredEntityListPreferencesId complexId = StoredEntityListPreferencesId.builder()
+                .userId(currentUserId)
+                .entityListId(entityListId)
+                .build();
+        final StoredEntityListPreferences entityListPreferences = entityListPreferencesService.get(complexId);
         if (entityListPreferences == null) {
             throw new NotFoundException("Preferences not found for user " + userContext.getUser().getName() + " and entity list id " + entityListId);
         }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/entities/preferences/model/EntityListPreferences.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/entities/preferences/model/EntityListPreferences.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.rest.resources.entities.preferences.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public record EntityListPreferences(@JsonProperty("displayed_attributes") List<String> displayedAttributes,
+                                    @JsonProperty("sort") String sort,
+                                    @JsonProperty("order") String order,
+                                    @JsonProperty("query") String query,
+                                    @JsonProperty("per_page") int perPage
+
+) {
+}

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/entities/preferences/model/StoredEntityListPreferences.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/entities/preferences/model/StoredEntityListPreferences.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.rest.resources.entities.preferences.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+
+public record StoredEntityListPreferences(@JsonProperty("user_id") String userId,
+                                          @JsonProperty("entity_list_id") String entityListId,
+                                          @JsonUnwrapped EntityListPreferences preferences) {
+}

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/entities/preferences/model/StoredEntityListPreferences.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/entities/preferences/model/StoredEntityListPreferences.java
@@ -16,10 +16,8 @@
  */
 package org.graylog2.rest.resources.entities.preferences.model;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
 
-public record StoredEntityListPreferences(@JsonProperty("user_id") String userId,
-                                          @JsonProperty("entity_list_id") String entityListId,
+public record StoredEntityListPreferences(@JsonUnwrapped StoredEntityListPreferencesId preferencesId,
                                           @JsonUnwrapped EntityListPreferences preferences) {
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/entities/preferences/model/StoredEntityListPreferencesId.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/entities/preferences/model/StoredEntityListPreferencesId.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.rest.resources.entities.preferences.model;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import com.google.auto.value.AutoValue;
+
+@AutoValue
+@JsonAutoDetect
+@JsonDeserialize(builder = StoredEntityListPreferencesId.Builder.class)
+public abstract class StoredEntityListPreferencesId {
+
+    @JsonProperty("user_id")
+    public abstract String userId();
+
+    @JsonProperty("entity_list_id")
+    public abstract String entityListId();
+
+    @JsonCreator
+    public static Builder builder() {
+        return new AutoValue_StoredEntityListPreferencesId.Builder();
+    }
+
+    @AutoValue.Builder
+    @JsonPOJOBuilder(withPrefix = "")
+    public abstract static class Builder {
+
+        @JsonProperty("user_id")
+        public abstract Builder userId(final String userId);
+
+        @JsonProperty("entity_list_id")
+        public abstract Builder entityListId(final String entityListId);
+
+        public abstract StoredEntityListPreferencesId build();
+
+        @JsonCreator
+        public static Builder create() {
+            return builder();
+        }
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/entities/preferences/service/EntityListPreferencesService.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/entities/preferences/service/EntityListPreferencesService.java
@@ -17,10 +17,11 @@
 package org.graylog2.rest.resources.entities.preferences.service;
 
 import org.graylog2.rest.resources.entities.preferences.model.StoredEntityListPreferences;
+import org.graylog2.rest.resources.entities.preferences.model.StoredEntityListPreferencesId;
 
 public interface EntityListPreferencesService {
 
-    StoredEntityListPreferences get(String userId, String entityListId);
+    StoredEntityListPreferences get(final StoredEntityListPreferencesId preferencesId);
 
-    void save(StoredEntityListPreferences preferences);
+    void save(final StoredEntityListPreferences preferences);
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/entities/preferences/service/EntityListPreferencesService.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/entities/preferences/service/EntityListPreferencesService.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.rest.resources.entities.preferences.service;
+
+import org.graylog2.rest.resources.entities.preferences.model.StoredEntityListPreferences;
+
+public interface EntityListPreferencesService {
+
+    StoredEntityListPreferences get(String userId, String entityListId);
+
+    void save(StoredEntityListPreferences preferences);
+}

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/entities/preferences/service/InMemoryEntityListPreferencesService.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/entities/preferences/service/InMemoryEntityListPreferencesService.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.rest.resources.entities.preferences.service;
+
+import org.graylog2.rest.resources.entities.preferences.model.StoredEntityListPreferences;
+
+import java.util.HashMap;
+import java.util.Map;
+
+//TODO: to be replaced by MongoDB storage in a new collection, or session storage, or maybe even combination of both...no decision made yet
+public class InMemoryEntityListPreferencesService implements EntityListPreferencesService {
+
+    private static final Map<String, Map<String, StoredEntityListPreferences>> INMEMORY_STORAGE = new HashMap<>();
+
+    @Override
+    public StoredEntityListPreferences get(final String userId, final String entityListId) {
+        final Map<String, StoredEntityListPreferences> userPreferences = INMEMORY_STORAGE.getOrDefault(userId, Map.of());
+        return userPreferences.get(entityListId);
+    }
+
+    @Override
+    public void save(final StoredEntityListPreferences preferences) {
+        final Map<String, StoredEntityListPreferences> userPreferences = INMEMORY_STORAGE.getOrDefault(preferences.userId(), new HashMap<>());
+        userPreferences.put(preferences.entityListId(), preferences);
+        INMEMORY_STORAGE.put(preferences.userId(), userPreferences);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/entities/preferences/service/InMemoryEntityListPreferencesService.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/entities/preferences/service/InMemoryEntityListPreferencesService.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 //TODO: to be replaced by MongoDB storage in a new collection, or session storage, or maybe even combination of both...no decision made yet
+//TODO: when replacing with proper, permanent storage, consider replacing "sort" String with enum
 public class InMemoryEntityListPreferencesService implements EntityListPreferencesService {
 
     private static final Map<String, Map<String, StoredEntityListPreferences>> INMEMORY_STORAGE = new HashMap<>();

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/entities/preferences/service/InMemoryEntityListPreferencesService.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/entities/preferences/service/InMemoryEntityListPreferencesService.java
@@ -17,6 +17,7 @@
 package org.graylog2.rest.resources.entities.preferences.service;
 
 import org.graylog2.rest.resources.entities.preferences.model.StoredEntityListPreferences;
+import org.graylog2.rest.resources.entities.preferences.model.StoredEntityListPreferencesId;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -27,15 +28,17 @@ public class InMemoryEntityListPreferencesService implements EntityListPreferenc
     private static final Map<String, Map<String, StoredEntityListPreferences>> INMEMORY_STORAGE = new HashMap<>();
 
     @Override
-    public StoredEntityListPreferences get(final String userId, final String entityListId) {
-        final Map<String, StoredEntityListPreferences> userPreferences = INMEMORY_STORAGE.getOrDefault(userId, Map.of());
-        return userPreferences.get(entityListId);
+    public StoredEntityListPreferences get(final StoredEntityListPreferencesId preferencesId) {
+        final Map<String, StoredEntityListPreferences> userPreferences = INMEMORY_STORAGE.getOrDefault(preferencesId.userId(), Map.of());
+        return userPreferences.get(preferencesId.entityListId());
     }
 
     @Override
     public void save(final StoredEntityListPreferences preferences) {
-        final Map<String, StoredEntityListPreferences> userPreferences = INMEMORY_STORAGE.getOrDefault(preferences.userId(), new HashMap<>());
-        userPreferences.put(preferences.entityListId(), preferences);
-        INMEMORY_STORAGE.put(preferences.userId(), userPreferences);
+        final String userId = preferences.preferencesId().userId();
+        final String entityListId = preferences.preferencesId().entityListId();
+        final Map<String, StoredEntityListPreferences> userPreferences = INMEMORY_STORAGE.getOrDefault(userId, new HashMap<>());
+        userPreferences.put(entityListId, preferences);
+        INMEMORY_STORAGE.put(userId, userPreferences);
     }
 }


### PR DESCRIPTION
## Description
Entity list preferences resource, so that FE can save preferences per user/entity list type pair.
The decisions about exact storage method have not been made yet - resource uses in-memory storage for now.
The decisions about exact schema of preferences have not been made yet - EntityListPreferences class will be almost for sure a subject of change in the future.
/nocl

## Motivation and Context
Provide alpha version of resource for the FE to allow FE development in the preferences area and provide some first feedback for decision making process.

## Screenshots (if appropriate):
![Screenshot 2023-01-18 at 12-56-06 Graylog REST API browser](https://user-images.githubusercontent.com/100699120/213165446-bff63ba4-11f3-4ecb-9456-5282be47f500.png)

![Screenshot 2023-01-18 at 12-55-26 Graylog REST API browser](https://user-images.githubusercontent.com/100699120/213165457-9403941d-0d4a-403b-a010-74fd27f21edd.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

