### PR TITLE
Add TimeBasedSizeOptimizingRotationAndRetentionTest

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/scheduler/clock/JobSchedulerClock.java
+++ b/graylog2-server/src/main/java/org/graylog/scheduler/clock/JobSchedulerClock.java
@@ -19,6 +19,9 @@ package org.graylog.scheduler.clock;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -33,11 +36,25 @@ public interface JobSchedulerClock {
     DateTime nowUTC();
 
     /**
+     * Returns the current java.time.Instant.
+     *
+     * @return current time as {@link Instant}
+     */
+    Instant instantNow();
+
+    /**
      * Returns the current time for the give time zone.
      *
      * @return current time
      */
     DateTime now(DateTimeZone zone);
+
+    /**
+     * Returns the current time for the give time zone.
+     *
+     * @return current time
+     */
+    ZonedDateTime now(ZoneId zone);
 
     /**
      * Causes the current execution thread to sleep for the given duration.

--- a/graylog2-server/src/main/java/org/graylog/scheduler/clock/JobSchedulerSystemClock.java
+++ b/graylog2-server/src/main/java/org/graylog/scheduler/clock/JobSchedulerSystemClock.java
@@ -20,6 +20,10 @@ import com.google.common.util.concurrent.Uninterruptibles;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.concurrent.TimeUnit;
 
 public class JobSchedulerSystemClock implements JobSchedulerClock {
@@ -37,8 +41,24 @@ public class JobSchedulerSystemClock implements JobSchedulerClock {
      * {@inheritDoc}
      */
     @Override
+    public Instant instantNow() {
+        return now(ZoneOffset.UTC).toInstant();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public DateTime now(DateTimeZone zone) {
         return DateTime.now(zone);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ZonedDateTime now(ZoneId zone) {
+        return ZonedDateTime.now(zone);
     }
 
     /**

--- a/graylog2-server/src/main/java/org/graylog2/indexer/TestIndexSet.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/TestIndexSet.java
@@ -36,7 +36,7 @@ public class TestIndexSet implements IndexSet {
     private static final String SEPARATOR = "_";
     private static final String DEFLECTOR_SUFFIX = "deflector";
 
-    private final IndexSetConfig config;
+    protected final IndexSetConfig config;
     private final Pattern indexPattern;
 
     public TestIndexSet(IndexSetConfig config) {

--- a/graylog2-server/src/main/java/org/graylog2/indexer/retention/strategies/AbstractIndexRetentionStrategy.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/retention/strategies/AbstractIndexRetentionStrategy.java
@@ -79,6 +79,8 @@ public abstract class AbstractIndexRetentionStrategy implements RetentionStrateg
                 .filter(indexName -> !hasCurrentWriteAlias(indexSet, deflectorIndices, indexName))
                 .filter(indexName -> {
                     DateTime closingDate = indices.indexClosingDate(indexName)
+                            // TODO we might encounter older indices that don't have a closing date yet. How do we handle this?
+                            // TODO maybe use the creationDate as a fallback?
                             .orElseThrow(() -> new IllegalStateException(f("Index %s has no closing date - retention failed", indexName)));
                     return closingDate.isBefore(cutoff + 1);
                 })

--- a/graylog2-server/src/main/java/org/graylog2/indexer/retention/strategies/AbstractIndexRetentionStrategy.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/retention/strategies/AbstractIndexRetentionStrategy.java
@@ -16,6 +16,7 @@
  */
 package org.graylog2.indexer.retention.strategies;
 
+import org.graylog.scheduler.clock.JobSchedulerClock;
 import org.graylog2.indexer.IndexSet;
 import org.graylog2.indexer.indices.Indices;
 import org.graylog2.indexer.rotation.strategies.TimeBasedSizeOptimizingStrategyConfig;
@@ -27,7 +28,6 @@ import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashSet;
@@ -46,11 +46,14 @@ public abstract class AbstractIndexRetentionStrategy implements RetentionStrateg
 
     private final Indices indices;
     private final ActivityWriter activityWriter;
+    private JobSchedulerClock clock;
 
     public AbstractIndexRetentionStrategy(Indices indices,
-                                          ActivityWriter activityWriter) {
+                                          ActivityWriter activityWriter,
+                                          JobSchedulerClock clock) {
         this.indices = requireNonNull(indices);
         this.activityWriter = requireNonNull(activityWriter);
+        this.clock = clock;
     }
 
     protected abstract Optional<Integer> getMaxNumberOfIndices(IndexSet indexSet);
@@ -60,8 +63,7 @@ public abstract class AbstractIndexRetentionStrategy implements RetentionStrateg
     public void retain(IndexSet indexSet) {
         if (indexSet.getConfig().rotationStrategy() instanceof TimeBasedSizeOptimizingStrategyConfig smartConfig) {
             retainTimeBased(indexSet, smartConfig);
-        }
-        else {
+        } else {
             retainCountBased(indexSet);
         }
     }
@@ -70,14 +72,15 @@ public abstract class AbstractIndexRetentionStrategy implements RetentionStrateg
         final Map<String, Set<String>> deflectorIndices = indexSet.getAllIndexAliases();
 
         // Account for DST and time zones in determining age
-        final long cutoff = Instant.now().minus(smartConfig.indexLifetimeSoft()).toEpochMilli();
+        final long cutoff = clock.instantNow().minus(smartConfig.indexLifetimeSoft()).toEpochMilli();
         final int removeCount = (int)deflectorIndices.keySet()
                 .stream()
                 .filter(indexName -> !indices.isReopened(indexName))
+                .filter(indexName -> !hasCurrentWriteAlias(indexSet, deflectorIndices, indexName))
                 .filter(indexName -> {
                     DateTime closingDate = indices.indexClosingDate(indexName)
                             .orElseThrow(() -> new IllegalStateException(f("Index %s has no closing date - retention failed", indexName)));
-                    return closingDate.isBefore(cutoff);
+                    return closingDate.isBefore(cutoff + 1);
                 })
                 .count();
 
@@ -124,7 +127,7 @@ public abstract class AbstractIndexRetentionStrategy implements RetentionStrateg
     private void runRetention(IndexSet indexSet, Map<String, Set<String>> deflectorIndices, int removeCount) {
         final Set<String> orderedIndices = Arrays.stream(indexSet.getManagedIndices())
             .filter(indexName -> !indices.isReopened(indexName))
-            .filter(indexName -> !(deflectorIndices.getOrDefault(indexName, Collections.emptySet()).contains(indexSet.getWriteIndexAlias())))
+            .filter(indexName -> !hasCurrentWriteAlias(indexSet, deflectorIndices, indexName))
             .sorted((indexName1, indexName2) -> indexSet.extractIndexNumber(indexName2).orElse(0).compareTo(indexSet.extractIndexNumber(indexName1).orElse(0)))
             .collect(Collectors.toCollection(LinkedHashSet::new));
 
@@ -145,5 +148,9 @@ public abstract class AbstractIndexRetentionStrategy implements RetentionStrateg
         activityWriter.write(new Activity(msg, IndexRetentionThread.class));
 
         retain(orderedIndicesDescending, indexSet);
+    }
+
+    private static boolean hasCurrentWriteAlias(IndexSet indexSet, Map<String, Set<String>> deflectorIndices, String indexName) {
+        return deflectorIndices.getOrDefault(indexName, Collections.emptySet()).contains(indexSet.getWriteIndexAlias());
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/retention/strategies/ClosingRetentionStrategy.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/retention/strategies/ClosingRetentionStrategy.java
@@ -18,6 +18,7 @@ package org.graylog2.indexer.retention.strategies;
 
 import com.google.common.base.Stopwatch;
 import com.google.common.collect.ImmutableMap;
+import org.graylog.scheduler.clock.JobSchedulerClock;
 import org.graylog2.audit.AuditActor;
 import org.graylog2.audit.AuditEventSender;
 import org.graylog2.indexer.IndexSet;
@@ -48,8 +49,9 @@ public class ClosingRetentionStrategy extends AbstractIndexRetentionStrategy {
     public ClosingRetentionStrategy(Indices indices,
                                     ActivityWriter activityWriter,
                                     NodeId nodeId,
-                                    AuditEventSender auditEventSender) {
-        super(indices, activityWriter);
+                                    AuditEventSender auditEventSender,
+                                    JobSchedulerClock clock) {
+        super(indices, activityWriter, clock);
         this.indices = indices;
         this.nodeId = nodeId;
         this.auditEventSender = auditEventSender;

--- a/graylog2-server/src/main/java/org/graylog2/indexer/retention/strategies/DeletionRetentionStrategy.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/retention/strategies/DeletionRetentionStrategy.java
@@ -18,6 +18,7 @@ package org.graylog2.indexer.retention.strategies;
 
 import com.google.common.base.Stopwatch;
 import com.google.common.collect.ImmutableMap;
+import org.graylog.scheduler.clock.JobSchedulerClock;
 import org.graylog2.audit.AuditActor;
 import org.graylog2.audit.AuditEventSender;
 import org.graylog2.indexer.IndexSet;
@@ -48,8 +49,9 @@ public class DeletionRetentionStrategy extends AbstractIndexRetentionStrategy {
     public DeletionRetentionStrategy(Indices indices,
                                      ActivityWriter activityWriter,
                                      NodeId nodeId,
-                                     AuditEventSender auditEventSender) {
-        super(indices, activityWriter);
+                                     AuditEventSender auditEventSender,
+                                     JobSchedulerClock clock) {
+        super(indices, activityWriter, clock);
         this.indices = indices;
         this.nodeId = nodeId;
         this.auditEventSender = auditEventSender;

--- a/graylog2-server/src/main/java/org/graylog2/indexer/retention/strategies/NoopRetentionStrategy.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/retention/strategies/NoopRetentionStrategy.java
@@ -16,6 +16,7 @@
  */
 package org.graylog2.indexer.retention.strategies;
 
+import org.graylog.scheduler.clock.JobSchedulerClock;
 import org.graylog2.indexer.IndexSet;
 import org.graylog2.indexer.indices.Indices;
 import org.graylog2.plugin.indexer.retention.RetentionStrategyConfig;
@@ -32,8 +33,8 @@ public class NoopRetentionStrategy extends AbstractIndexRetentionStrategy {
     public static final String NAME = "none";
 
     @Inject
-    public NoopRetentionStrategy(Indices indices, ActivityWriter activityWriter) {
-        super(indices, activityWriter);
+    public NoopRetentionStrategy(Indices indices, ActivityWriter activityWriter, JobSchedulerClock clock) {
+        super(indices, activityWriter, clock);
     }
 
     @Override

--- a/graylog2-server/src/test/java/org/graylog/events/JobSchedulerTestClock.java
+++ b/graylog2-server/src/test/java/org/graylog/events/JobSchedulerTestClock.java
@@ -45,6 +45,10 @@ public class JobSchedulerTestClock implements JobSchedulerClock {
         this.instant = instant.plus(unit.toMillis(duration));
     }
 
+    public void setTime(DateTime newTime) {
+        this.instant = newTime.toInstant();
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/graylog2-server/src/test/java/org/graylog/events/JobSchedulerTestClock.java
+++ b/graylog2-server/src/test/java/org/graylog/events/JobSchedulerTestClock.java
@@ -21,6 +21,8 @@ import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.Instant;
 
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -55,8 +57,25 @@ public class JobSchedulerTestClock implements JobSchedulerClock {
      * {@inheritDoc}
      */
     @Override
+    public java.time.Instant instantNow() {
+        return java.time.Instant.ofEpochMilli(instant.getMillis());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public DateTime now(DateTimeZone zone) {
         return instant.toDateTime().withZone(zone);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ZonedDateTime now(ZoneId zone) {
+        final java.time.Instant javaInstant = java.time.Instant.ofEpochMilli(instant.getMillis());
+        return javaInstant.atZone(zone);
     }
 
     /**

--- a/graylog2-server/src/test/java/org/graylog2/indexer/retention/strategies/AbstractIndexRetentionStrategyTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/retention/strategies/AbstractIndexRetentionStrategyTest.java
@@ -16,6 +16,7 @@
  */
 package org.graylog2.indexer.retention.strategies;
 
+import org.graylog.scheduler.clock.JobSchedulerSystemClock;
 import org.graylog2.indexer.IndexSet;
 import org.graylog2.indexer.indexset.IndexSetConfig;
 import org.graylog2.indexer.indices.Indices;
@@ -97,7 +98,7 @@ public class AbstractIndexRetentionStrategyTest {
         when(indexSet.extractIndexNumber(anyString())).then(this::extractIndexNumber);
         when(indexSet.getConfig()).thenReturn(indexSetConfigCountBased);
 
-        retentionStrategy = spy(new AbstractIndexRetentionStrategy(indices, activityWriter) {
+        retentionStrategy = spy(new AbstractIndexRetentionStrategy(indices, activityWriter, new JobSchedulerSystemClock()) {
             @Override
             protected Optional<Integer> getMaxNumberOfIndices(IndexSet indexSet) {
                 return null;

--- a/graylog2-server/src/test/java/org/graylog2/indexer/rotation/strategies/TimeBasedSizeOptimizingRotationAndRetentionTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/rotation/strategies/TimeBasedSizeOptimizingRotationAndRetentionTest.java
@@ -1,0 +1,333 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.indexer.rotation.strategies;
+
+import org.graylog.events.JobSchedulerTestClock;
+import org.graylog2.audit.AuditEventSender;
+import org.graylog2.configuration.ElasticsearchConfiguration;
+import org.graylog2.indexer.indexset.IndexSetConfig;
+import org.graylog2.indexer.indices.Indices;
+import org.graylog2.indexer.retention.strategies.DeletionRetentionStrategy;
+import org.graylog2.indexer.retention.strategies.DeletionRetentionStrategyConfig;
+import org.graylog2.plugin.Tools;
+import org.graylog2.plugin.system.NodeId;
+import org.graylog2.shared.system.activities.ActivityWriter;
+import org.joda.time.DateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+import java.time.Period;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.graylog2.shared.utilities.StringUtils.f;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+
+@ExtendWith(MockitoExtension.class)
+class TimeBasedSizeOptimizingRotationAndRetentionTest {
+    private static final Logger LOG = LoggerFactory.getLogger(TimeBasedSizeOptimizingRotationAndRetentionTest.class);
+
+    private TimeBasedSizeOptimizingStrategy timeBasedSizeOptimizingStrategy;
+
+    @Mock
+    private Indices indices;
+
+    @Mock
+    private NodeId nodeId;
+
+    @Mock
+    private AuditEventSender auditEventSender;
+
+    private JobSchedulerTestClock clock;
+
+    private TestIndexSet indexSet;
+    private ElasticsearchConfiguration elasticsearchConfiguration;
+    private TimeBasedSizeOptimizingStrategyConfig rotationStrategyConfig;
+
+    private DeletionRetentionStrategy deletionRetentionStrategy;
+
+    @BeforeEach
+    void setUp() {
+        clock = new JobSchedulerTestClock(Tools.nowUTC());
+
+        elasticsearchConfiguration = new ElasticsearchConfiguration();
+        timeBasedSizeOptimizingStrategy = new TimeBasedSizeOptimizingStrategy(indices, nodeId, auditEventSender, elasticsearchConfiguration, clock);
+        rotationStrategyConfig = TimeBasedSizeOptimizingStrategyConfig.builder()
+                .indexLifetimeSoft(Period.ofDays(4))
+                .indexLifetimeHard(Period.ofDays(6))
+                .build();
+
+        final DeletionRetentionStrategyConfig deletionRetention = DeletionRetentionStrategyConfig.createDefault();
+        deletionRetentionStrategy = new DeletionRetentionStrategy(indices, mock(ActivityWriter.class), nodeId, auditEventSender, clock);
+
+        indexSet = new TestIndexSet(IndexSetConfig.builder()
+                .title("test index")
+                .indexPrefix("test")
+                .shards(elasticsearchConfiguration.getShards())
+                .replicas(elasticsearchConfiguration.getReplicas())
+                .creationDate(clock.now(ZoneOffset.UTC))
+                .indexAnalyzer(elasticsearchConfiguration.getAnalyzer())
+                .indexTemplateName(elasticsearchConfiguration.getDefaultIndexTemplateName())
+                .indexOptimizationMaxNumSegments(elasticsearchConfiguration.getIndexOptimizationMaxNumSegments())
+                .indexOptimizationDisabled(elasticsearchConfiguration.isDisableIndexOptimization())
+                .rotationStrategy(rotationStrategyConfig)
+                .retentionStrategy(deletionRetention)
+                .build());
+
+        lenient().when(indices.indexCreationDate(anyString())).thenAnswer(a -> {
+            final String indexName = a.getArgument(0);
+            final Optional<TestIndex> index = indexSet.findByName(indexName);
+            return index.map(TestIndex::getCreationDate);
+        });
+
+        lenient().when(indices.getStoreSizeInBytes(anyString())).then(a -> {
+            final String indexName = a.getArgument(0);
+            final Optional<TestIndex> index = indexSet.findByName(indexName);
+            return index.map(TestIndex::getSize);
+        });
+
+        lenient().when(indices.indexClosingDate(anyString())).then(a -> {
+            final String indexName = a.getArgument(0);
+            final Optional<TestIndex> index = indexSet.findByName(indexName);
+            return index.map(TestIndex::getClosingDate);
+        });
+
+        lenient().doAnswer(a -> {
+            final String indexName = a.getArgument(0);
+            indexSet.deleteByName(indexName);
+            return null;
+        }).when(indices).delete(anyString());
+    }
+
+    @Test
+    void rotationAndThenRetention() {
+        testRotation();
+        testRetention();
+    }
+
+    void testRotation() {
+        indexSet.addNewIndex(0, TimeBasedSizeOptimizingStrategy.MIN_INDEX_SIZE.toBytes());
+        assertThat(indexSet.getIndicesNames()).isEqualTo(List.of("test_0"));
+
+        // We rotate _after_ 1 day. This is too early
+        clock.plus(12, TimeUnit.HOURS);
+        timeBasedSizeOptimizingStrategy.rotate(indexSet);
+        assertThat(indexSet.getIndicesNames()).isEqualTo(List.of("test_0"));
+
+        // We rotate _after_ 1 day. Now is the time.
+        clock.plus(12, TimeUnit.HOURS);
+        timeBasedSizeOptimizingStrategy.rotate(indexSet);
+        assertThat(indexSet.getIndicesNames()).isEqualTo(List.of("test_0", "test_1"));
+
+        // We can skp the rotation if the index is not big enough.
+        clock.plus(1, TimeUnit.DAYS);
+        timeBasedSizeOptimizingStrategy.rotate(indexSet);
+        assertThat(indexSet.getIndicesNames()).isEqualTo(List.of("test_0", "test_1"));
+
+        // with the minimum required size, this works
+        indexSet.getNewest().setSize(TimeBasedSizeOptimizingStrategy.MIN_INDEX_SIZE.toBytes());
+        clock.plus(1, TimeUnit.DAYS);
+        timeBasedSizeOptimizingStrategy.rotate(indexSet);
+        assertThat(indexSet.getIndicesNames()).isEqualTo(List.of("test_0", "test_1", "test_2"));
+
+        // If an index reaches TimeBasedSizeOptimizingStrategy.MAX_INDEX_SIZE
+        // it can be rotated, even if the rotation period has been reached.
+        indexSet.getNewest().setSize(TimeBasedSizeOptimizingStrategy.MAX_INDEX_SIZE.toBytes());
+        clock.plus(12, TimeUnit.HOURS);
+        timeBasedSizeOptimizingStrategy.rotate(indexSet);
+        assertThat(indexSet.getIndicesNames()).isEqualTo(List.of("test_0", "test_1", "test_2", "test_3"));
+
+        // If an index doesn't reach TimeBasedSizeOptimizingStrategy.MAX_INDEX_SIZE
+        // But exceeds the optimization "leeway" ( indexLifetimeHard - indexLifetimeSoft) (6 - 4) = 2 days
+        // it will also be rotated.
+        indexSet.getNewest().setSize(100);
+        clock.plus(3, TimeUnit.DAYS);
+        timeBasedSizeOptimizingStrategy.rotate(indexSet);
+        assertThat(indexSet.getIndicesNames()).isEqualTo(List.of("test_0", "test_1", "test_2", "test_3", "test_4"));
+    }
+
+    void testRetention() {
+        assertThat(indexSet.getIndicesNames()).isEqualTo(List.of("test_0", "test_1", "test_2", "test_3", "test_4"));
+
+        LOG.info("Existing indices from rotation:\n<{}>",
+                indexSet.getIndices().stream()
+                        .map(i -> f("%s: created: %s closed: %s/(%s ago)\n", i.name, i.creationDate, i.closingDate, getBetween(i))).toList());
+
+        // Retention should happen after indexLifetimeSoft (4 days)
+        deletionRetentionStrategy.retain(indexSet);
+
+        // Only test_0 will be retained
+        assertThat(indexSet.getIndicesNames()).isEqualTo(List.of("test_1", "test_2", "test_3", "test_4"));
+
+        // Moving forward in time will retain more indices
+        clock.plus(12, TimeUnit.HOURS);
+        deletionRetentionStrategy.retain(indexSet);
+        assertThat(indexSet.getIndicesNames()).isEqualTo(List.of("test_2", "test_3", "test_4"));
+
+        clock.plus(1, TimeUnit.DAYS);
+        deletionRetentionStrategy.retain(indexSet);
+        assertThat(indexSet.getIndicesNames()).isEqualTo(List.of("test_3", "test_4"));
+
+        clock.plus(3, TimeUnit.DAYS);
+        deletionRetentionStrategy.retain(indexSet);
+        assertThat(indexSet.getIndicesNames()).isEqualTo(List.of("test_4"));
+
+        // Active index will never be retained
+        clock.plus(10, TimeUnit.DAYS);
+        deletionRetentionStrategy.retain(indexSet);
+        assertThat(indexSet.getIndicesNames()).isEqualTo(List.of("test_4"));
+    }
+
+    private String getBetween(TestIndex i) {
+        if (i.getClosingDate() == null) {
+            return "null";
+        }
+        return org.joda.time.Period.fieldDifference(clock.nowUTC().toLocalDateTime(), i.getClosingDate().toLocalDateTime()).toString();
+    }
+
+    class TestIndexSet extends org.graylog2.indexer.TestIndexSet {
+        private final List<TestIndex> indices;
+
+        public TestIndexSet(IndexSetConfig config) {
+            super(config);
+            this.indices = new ArrayList<>();
+        }
+
+        public List<TestIndex> getIndices() {
+            return indices;
+        }
+
+        public List<String> getIndicesNames() {
+            return indices.stream().map(TestIndex::getName).toList();
+        }
+        public Optional<TestIndex> findByName(String name) {
+            return indices.stream().filter(i -> i.name.equals(name)).findFirst();
+        }
+
+        public void deleteByName(String name) {
+            findByName(name).map(indices::remove);
+        }
+        public void addNewIndex(int count, long size) {
+            indices.add(new TestIndex(buildIndexName(count), clock.nowUTC(), null, size));
+        }
+
+        @Override
+        public Map<String, Set<String>> getAllIndexAliases() {
+            final String newestIndex = getNewestIndex();
+            return indices.stream().map(TestIndex::getName)
+                    .collect(Collectors.toMap(i -> i, i -> i.equals(newestIndex) ? Set.of(config.indexPrefix() + "_deflector") : Set.of()));
+        }
+
+        @Override
+        public String[] getManagedIndices() {
+            return indices.stream().map(TestIndex::getName).toArray(String[]::new);
+        }
+
+        @Override
+        public void cycle() {
+            final TestIndex newest = getNewest();
+            newest.setClosingDate(clock.nowUTC());
+
+            final Integer indexNr = extractIndexNumber(newest.getName()).get();
+            var nextIndexName = buildIndexName(indexNr + 1);
+            indices.add(new TestIndex(nextIndexName, clock.nowUTC(), null, 0));
+        }
+
+        @Override
+        public String getNewestIndex() {
+            return getNewest().getName();
+        }
+
+        public TestIndex getNewest() {
+            return indices.stream().sorted(Comparator.comparing(TestIndex::getCreationDate)).reduce((a, b) -> b).get();
+        }
+
+        @Override
+        public Optional<Integer> extractIndexNumber(final String indexName) {
+            final int beginIndex = config.indexPrefix().length() + 1;
+            if (indexName.length() < beginIndex) {
+                return Optional.empty();
+            }
+
+            final String suffix = indexName.substring(beginIndex);
+            try {
+                return Optional.of(Integer.parseInt(suffix));
+            } catch (NumberFormatException e) {
+                return Optional.empty();
+            }
+        }
+
+        String buildIndexName(final int number) {
+            return config.indexPrefix() + "_" + number;
+        }
+
+    }
+
+    static class TestIndex {
+        private final String name;
+        private final DateTime creationDate;
+        private DateTime closingDate;
+        private long size;
+
+        public TestIndex(String name, DateTime creationDate, @Nullable DateTime closingDate, long size) {
+            this.name = name;
+            this.creationDate = creationDate;
+            this.closingDate = closingDate;
+            this.size = size;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public DateTime getCreationDate() {
+            return creationDate;
+        }
+
+        public DateTime getClosingDate() {
+            return closingDate;
+        }
+
+        public void setClosingDate(DateTime closingDate) {
+            this.closingDate = closingDate;
+        }
+
+        public long getSize() {
+            return size;
+        }
+
+        public void setSize(long size) {
+            this.size = size;
+        }
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/indexer/rotation/strategies/TimeBasedSizeOptimizingRotationAndRetentionTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/rotation/strategies/TimeBasedSizeOptimizingRotationAndRetentionTest.java
@@ -160,9 +160,9 @@ class TimeBasedSizeOptimizingRotationAndRetentionTest {
         timeBasedSizeOptimizingStrategy.rotate(indexSet);
         assertThat(indexSet.getIndicesNames()).isEqualTo(List.of("test_0", "test_1", "test_2"));
 
-        // If an index reaches TimeBasedSizeOptimizingStrategy.MAX_INDEX_SIZE
+        // If an index exceeds TimeBasedSizeOptimizingStrategy.MAX_INDEX_SIZE
         // it can be rotated, even if the rotation period has been reached.
-        indexSet.getNewest().setSize(TimeBasedSizeOptimizingStrategy.MAX_INDEX_SIZE.toBytes());
+        indexSet.getNewest().setSize(TimeBasedSizeOptimizingStrategy.MAX_INDEX_SIZE.toBytes() + 1);
         clock.plus(12, TimeUnit.HOURS);
         timeBasedSizeOptimizingStrategy.rotate(indexSet);
         assertThat(indexSet.getIndicesNames()).isEqualTo(List.of("test_0", "test_1", "test_2", "test_3"));

--- a/graylog2-server/src/test/java/org/graylog2/indexer/rotation/strategies/TimeBasedSizeOptimizingStrategyTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/rotation/strategies/TimeBasedSizeOptimizingStrategyTest.java
@@ -16,6 +16,7 @@
  */
 package org.graylog2.indexer.rotation.strategies;
 
+import org.graylog.scheduler.clock.JobSchedulerSystemClock;
 import org.graylog2.audit.AuditEventSender;
 import org.graylog2.configuration.ElasticsearchConfiguration;
 import org.graylog2.indexer.IndexSet;
@@ -63,7 +64,7 @@ class TimeBasedSizeOptimizingStrategyTest {
 
     @BeforeEach
     void setUp() {
-        timeBasedSizeOptimizingStrategy = new TimeBasedSizeOptimizingStrategy(indices, nodeId, auditEventSender, new ElasticsearchConfiguration());
+        timeBasedSizeOptimizingStrategy = new TimeBasedSizeOptimizingStrategy(indices, nodeId, auditEventSender, new ElasticsearchConfiguration(), new JobSchedulerSystemClock());
 
         timeBasedSizeOptimizingStrategyConfig = TimeBasedSizeOptimizingStrategyConfig.builder().build();
         final IndexSetConfig indexSetConfig = mock(IndexSetConfig.class);


### PR DESCRIPTION
This test creates indices, forwards the clock,
calls the rotations and retentions and asserts that the list of open indices gets modified accordingly.

Use the JobSchedulerClock which can be used forward the time. Extend the JobSchedulerClock to support java.time Instant and ZonedDateTime.

/jenkins-pr-deps https://github.com/Graylog2/graylog-plugin-enterprise/pull/4572

/nocl