### PR TITLE
Make the rotation period and sizes customizable

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchConfiguration.java
@@ -19,6 +19,7 @@ package org.graylog2.configuration;
 import com.github.joschi.jadconfig.Parameter;
 import com.github.joschi.jadconfig.converters.StringListConverter;
 import com.github.joschi.jadconfig.util.Duration;
+import com.github.joschi.jadconfig.util.Size;
 import com.github.joschi.jadconfig.validators.PositiveDurationValidator;
 import com.github.joschi.jadconfig.validators.PositiveIntegerValidator;
 import com.github.joschi.jadconfig.validators.PositiveLongValidator;
@@ -100,6 +101,12 @@ public class ElasticsearchConfiguration {
     // TimeBasedSizeOptimizingStrategy Rotation
     @Parameter(value = "time_size_optimizing_rotation_period")
     private Period timeSizeOptimizingRotationPeriod = Period.days(1);
+
+    @Parameter(value = "time_size_optimizing_rotation_min_size")
+    private Size timeSizeOptimizingRotationMinSize = Size.gigabytes(20);
+
+    @Parameter(value = "time_size_optimizing_rotation_max_size")
+    private Size timeSizeOptimizingRotationMaxSize = Size.gigabytes(50);
 
     @Parameter(value = "elasticsearch_disable_version_check")
     private boolean disableVersionCheck = false;
@@ -209,6 +216,14 @@ public class ElasticsearchConfiguration {
 
     public Period getTimeSizeOptimizingRotationPeriod() {
         return timeSizeOptimizingRotationPeriod;
+    }
+
+    public Size getTimeSizeOptimizingRotationMinSize() {
+        return timeSizeOptimizingRotationMinSize;
+    }
+
+    public Size getTimeSizeOptimizingRotationMaxSize() {
+        return timeSizeOptimizingRotationMaxSize;
     }
 
     public boolean isDisableVersionCheck() {

--- a/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchConfiguration.java
@@ -29,6 +29,7 @@ import org.graylog2.indexer.retention.strategies.DeletionRetentionStrategy;
 import org.graylog2.indexer.rotation.strategies.MessageCountRotationStrategy;
 import org.graylog2.indexer.rotation.strategies.SizeBasedRotationStrategy;
 import org.graylog2.indexer.rotation.strategies.TimeBasedRotationStrategy;
+import org.graylog2.indexer.rotation.strategies.TimeBasedSizeOptimizingStrategy;
 import org.joda.time.Period;
 
 import javax.annotation.Nullable;
@@ -118,7 +119,9 @@ public class ElasticsearchConfiguration {
     private boolean noRetention = false;
 
     @Parameter(value = "enabled_index_rotation_strategies", converter = StringListConverter.class, validators = RotationStrategyValidator.class)
-    private List<String> enabledRotationStrategies = Arrays.asList(TimeBasedRotationStrategy.NAME, MessageCountRotationStrategy.NAME, SizeBasedRotationStrategy.NAME);
+    private List<String> enabledRotationStrategies = Arrays.asList(
+            TimeBasedRotationStrategy.NAME, MessageCountRotationStrategy.NAME,
+            SizeBasedRotationStrategy.NAME, TimeBasedSizeOptimizingStrategy.NAME);
 
     /**
      * Provides a hard upper limit for the retention period of any index set at configuration time.

--- a/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchConfiguration.java
@@ -35,6 +35,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 
+@SuppressWarnings({"FieldMayBeFinal", "FieldCanBeLocal"})
 public class ElasticsearchConfiguration {
     public static final String MAX_INDEX_RETENTION_PERIOD = "max_index_retention_period";
     public static final String DEFAULT_EVENTS_INDEX_PREFIX = "default_events_index_prefix";
@@ -95,6 +96,10 @@ public class ElasticsearchConfiguration {
     // Retention
     @Parameter(value = "elasticsearch_max_number_of_indices", required = true, validator = PositiveIntegerValidator.class)
     private int maxNumberOfIndices = 20;
+
+    // TimeBasedSizeOptimizingStrategy Rotation
+    @Parameter(value = "time_size_optimizing_rotation_period")
+    private Period timeSizeOptimizingRotationPeriod = Period.days(1);
 
     @Parameter(value = "elasticsearch_disable_version_check")
     private boolean disableVersionCheck = false;
@@ -200,6 +205,10 @@ public class ElasticsearchConfiguration {
 
     public int getMaxNumberOfIndices() {
         return maxNumberOfIndices;
+    }
+
+    public Period getTimeSizeOptimizingRotationPeriod() {
+        return timeSizeOptimizingRotationPeriod;
     }
 
     public boolean isDisableVersionCheck() {

--- a/graylog2-server/src/main/java/org/graylog2/indexer/IndexSetValidator.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/IndexSetValidator.java
@@ -104,18 +104,18 @@ public class IndexSetValidator {
 
     @Nullable
     public Violation validateRotation(RotationStrategyConfig rotationStrategyConfig) {
-        if ((rotationStrategyConfig instanceof TimeBasedSizeOptimizingStrategyConfig smartConfig)) {
-            final Period leeway = smartConfig.indexLifetimeHard().minus(smartConfig.indexLifetimeSoft());
+        if ((rotationStrategyConfig instanceof TimeBasedSizeOptimizingStrategyConfig config)) {
+            final Period leeway = config.indexLifetimeHard().minus(config.indexLifetimeSoft());
             if (leeway.toStandardSeconds().getSeconds() < 0) {
-                return Violation.create(f("%s <%s> is shorter than %s <%s>", INDEX_LIFETIME_HARD, smartConfig.indexLifetimeHard(),
-                        INDEX_LIFETIME_SOFT, smartConfig.indexLifetimeSoft()));
+                return Violation.create(f("%s <%s> is shorter than %s <%s>", INDEX_LIFETIME_HARD, config.indexLifetimeHard(),
+                        INDEX_LIFETIME_SOFT, config.indexLifetimeSoft()));
             }
 
             final Period maxRetentionPeriod = elasticsearchConfiguration.getMaxIndexRetentionPeriod();
             if (maxRetentionPeriod != null
-                    && smartConfig.indexLifetimeHard().toStandardSeconds().isGreaterThan(maxRetentionPeriod.toStandardSeconds())) {
+                    && config.indexLifetimeHard().toStandardSeconds().isGreaterThan(maxRetentionPeriod.toStandardSeconds())) {
                 f("Lifetime setting %s <%s> exceeds the configured maximum of %s=%s.",
-                        INDEX_LIFETIME_HARD, smartConfig.indexLifetimeHard(),
+                        INDEX_LIFETIME_HARD, config.indexLifetimeHard(),
                         ElasticsearchConfiguration.MAX_INDEX_RETENTION_PERIOD, maxRetentionPeriod);
             }
         }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/IndexSetValidator.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/IndexSetValidator.java
@@ -20,8 +20,8 @@ import com.google.auto.value.AutoValue;
 import com.google.common.base.Strings;
 import org.graylog2.configuration.ElasticsearchConfiguration;
 import org.graylog2.indexer.indexset.IndexSetConfig;
-import org.graylog2.indexer.rotation.strategies.TimeBasedSizeOptimizingStrategyConfig;
 import org.graylog2.indexer.rotation.strategies.TimeBasedRotationStrategyConfig;
+import org.graylog2.indexer.rotation.strategies.TimeBasedSizeOptimizingStrategyConfig;
 import org.graylog2.plugin.indexer.retention.RetentionStrategyConfig;
 import org.graylog2.plugin.indexer.rotation.RotationStrategyConfig;
 import org.joda.time.DateTime;
@@ -31,9 +31,10 @@ import org.joda.time.Period;
 
 import javax.annotation.Nullable;
 import javax.inject.Inject;
-import java.time.Instant;
 import java.util.Optional;
 
+import static org.graylog2.indexer.rotation.strategies.TimeBasedSizeOptimizingStrategyConfig.INDEX_LIFETIME_HARD;
+import static org.graylog2.indexer.rotation.strategies.TimeBasedSizeOptimizingStrategyConfig.INDEX_LIFETIME_SOFT;
 import static org.graylog2.shared.utilities.StringUtils.f;
 
 public class IndexSetValidator {
@@ -104,31 +105,23 @@ public class IndexSetValidator {
     @Nullable
     public Violation validateRotation(RotationStrategyConfig rotationStrategyConfig) {
         if ((rotationStrategyConfig instanceof TimeBasedSizeOptimizingStrategyConfig smartConfig)) {
-            final java.time.Period leeway = smartConfig.indexLifetimeHard().minus(smartConfig.indexLifetimeSoft());
-            if (leeway.isNegative()) {
-                return Violation.create("Maximum and minimum lifetime periods are reversed or use different units");
+            final Period leeway = smartConfig.indexLifetimeHard().minus(smartConfig.indexLifetimeSoft());
+            if (leeway.toStandardSeconds().getSeconds() < 0) {
+                return Violation.create(f("%s <%s> is shorter than %s <%s>", INDEX_LIFETIME_HARD, smartConfig.indexLifetimeHard(),
+                        INDEX_LIFETIME_SOFT, smartConfig.indexLifetimeSoft()));
             }
 
             final Period maxRetentionPeriod = elasticsearchConfiguration.getMaxIndexRetentionPeriod();
             if (maxRetentionPeriod != null
-                && isGreater(smartConfig.indexLifetimeHard(), jodaToJavaPeriod(maxRetentionPeriod))) {
-                f("Lifetime setting %s exceeds the configured maximum of %s=%s.",
-                        TimeBasedSizeOptimizingStrategyConfig.INDEX_LIFETIME_HARD,
+                    && smartConfig.indexLifetimeHard().toStandardSeconds().isGreaterThan(maxRetentionPeriod.toStandardSeconds())) {
+                f("Lifetime setting %s <%s> exceeds the configured maximum of %s=%s.",
+                        INDEX_LIFETIME_HARD, smartConfig.indexLifetimeHard(),
                         ElasticsearchConfiguration.MAX_INDEX_RETENTION_PERIOD, maxRetentionPeriod);
             }
         }
         return null;
     }
 
-    private static java.time.Period jodaToJavaPeriod (Period jodaPeriod) {
-        return java.time.Period.of(jodaPeriod.getYears(), jodaPeriod.getMonths(), jodaPeriod.getDays());
-    }
-
-    // Note that periods are generally NOT comparable (e.g. is 1 month > 30 days?).
-    private static boolean isGreater(java.time.Period p1, java.time.Period p2) {
-        final Instant NOW = Instant.now();
-        return (NOW.plus(p1).isAfter(NOW.plus(p2)));
-    }
 
     @Nullable
     public Violation validateRetentionPeriod(RotationStrategyConfig rotationStrategyConfig, RetentionStrategyConfig retentionStrategyConfig) {

--- a/graylog2-server/src/main/java/org/graylog2/indexer/retention/strategies/AbstractIndexRetentionStrategy.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/retention/strategies/AbstractIndexRetentionStrategy.java
@@ -72,7 +72,7 @@ public abstract class AbstractIndexRetentionStrategy implements RetentionStrateg
         final Map<String, Set<String>> deflectorIndices = indexSet.getAllIndexAliases();
 
         // Account for DST and time zones in determining age
-        final long cutoff = clock.instantNow().minus(smartConfig.indexLifetimeSoft()).toEpochMilli();
+        final long cutoff = clock.nowUTC().minus(smartConfig.indexLifetimeSoft()).getMillis();
         final int removeCount = (int)deflectorIndices.keySet()
                 .stream()
                 .filter(indexName -> !indices.isReopened(indexName))

--- a/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/AbstractRotationStrategy.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/AbstractRotationStrategy.java
@@ -75,7 +75,7 @@ public abstract class AbstractRotationStrategy implements RotationStrategy {
         }
         LOG.debug("Rotation strategy result: {}", rotate.getDescription());
         if (rotate.shouldRotate()) {
-            LOG.info("Deflector index <{}> (index set <{}>) should be rotated, Pointing deflector to new index now!", indexSetTitle, indexName);
+            LOG.info("Deflector index <{}> (index set <{}>) should be rotated ({}), Pointing deflector to new index now!", indexSetTitle, indexName, rotate.getDescription());
             indexSet.cycle();
             auditEventSender.success(AuditActor.system(nodeId), ES_INDEX_ROTATION_COMPLETE, ImmutableMap.of(
                     "index_name", indexName,

--- a/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/TimeBasedSizeOptimizingStrategy.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/TimeBasedSizeOptimizingStrategy.java
@@ -86,6 +86,10 @@ public class TimeBasedSizeOptimizingStrategy extends AbstractRotationStrategy {
             throw new IllegalStateException(f("Unsupported RotationStrategyConfig type <%s>", indexSet.getConfig().rotationStrategy()));
         }
 
+        if (sizeInBytes == 0) {
+            return createResult(false, "Index is empty");
+        }
+
         if (indexExceedsSizeLimit(sizeInBytes)) {
             return createResult(true,
                     f("Index size <%s> exceeds MAX_INDEX_SIZE <%s>",

--- a/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/TimeBasedSizeOptimizingStrategy.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/TimeBasedSizeOptimizingStrategy.java
@@ -26,7 +26,8 @@ import org.graylog2.plugin.indexer.rotation.RotationStrategyConfig;
 import org.graylog2.plugin.system.NodeId;
 import org.graylog2.shared.utilities.StringUtils;
 import org.joda.time.DateTime;
-import org.joda.time.Days;
+import org.joda.time.Period;
+import org.joda.time.Seconds;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,7 +35,6 @@ import javax.annotation.Nonnull;
 import javax.inject.Inject;
 import java.time.Duration;
 import java.time.Instant;
-import java.time.Period;
 
 import static org.graylog2.shared.utilities.StringUtils.f;
 
@@ -107,15 +107,15 @@ public class TimeBasedSizeOptimizingStrategy extends AbstractRotationStrategy {
     }
 
     private boolean indexExceedsLeeWay(DateTime creationDate, Period leeWay) {
-        final Days leewayDays = Days.days(leeWay.getDays()); // can only be a multiple of Days
-        return timePassedIsBeyondLimit(creationDate, rotationPeriod.plus(leewayDays));
+        final Seconds leewaySeconds = Seconds.seconds(leeWay.toStandardSeconds().getSeconds());
+        return timePassedIsBeyondLimit(creationDate, rotationPeriod.plus(leewaySeconds));
     }
 
     private boolean indexIsOldEnough(DateTime creationDate) {
         return timePassedIsBeyondLimit(creationDate, rotationPeriod);
     }
 
-    private boolean timePassedIsBeyondLimit(DateTime date, org.joda.time.Period limit) {
+    private boolean timePassedIsBeyondLimit(DateTime date, Period limit) {
         final Instant now = clock.instantNow();
         final Duration timePassed = Duration.between(Instant.ofEpochMilli(date.getMillis()), now);
         final Duration limitAsDuration = Duration.ofSeconds(limit.toStandardSeconds().getSeconds());

--- a/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/TimeBasedSizeOptimizingStrategy.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/TimeBasedSizeOptimizingStrategy.java
@@ -86,7 +86,7 @@ public class TimeBasedSizeOptimizingStrategy extends AbstractRotationStrategy {
             throw new IllegalStateException(f("Unsupported RotationStrategyConfig type <%s>", indexSet.getConfig().rotationStrategy()));
         }
 
-        if (sizeInBytes == 0) {
+        if (indices.numberOfMessages(index) == 0) {
             return createResult(false, "Index is empty");
         }
 

--- a/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/TimeBasedSizeOptimizingStrategy.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/TimeBasedSizeOptimizingStrategy.java
@@ -41,10 +41,10 @@ import static org.graylog2.shared.utilities.StringUtils.f;
 public class TimeBasedSizeOptimizingStrategy extends AbstractRotationStrategy {
     private static final Logger LOG = LoggerFactory.getLogger(TimeBasedSizeOptimizingStrategy.class);
     public static final String NAME = "time-size-optimizing";
-    public static final org.joda.time.Period ROTATION_PERIOD = org.joda.time.Period.days(1);
 
     private final Indices indices;
     private final JobSchedulerClock clock;
+    public final org.joda.time.Period rotationPeriod;
 
     // TODO: move this into server.conf or maybe into IndexSetsDefaultConfiguration
     // also see elasticsearch_max_size_per_index
@@ -60,6 +60,7 @@ public class TimeBasedSizeOptimizingStrategy extends AbstractRotationStrategy {
         super(auditEventSender, nodeId, elasticsearchConfiguration);
         this.indices = indices;
         this.clock = clock;
+        this.rotationPeriod = elasticsearchConfiguration.getTimeSizeOptimizingRotationPeriod();
     }
 
     @Override
@@ -107,11 +108,11 @@ public class TimeBasedSizeOptimizingStrategy extends AbstractRotationStrategy {
 
     private boolean indexExceedsLeeWay(DateTime creationDate, Period leeWay) {
         final Days leewayDays = Days.days(leeWay.getDays()); // can only be a multiple of Days
-        return timePassedIsBeyondLimit(creationDate, ROTATION_PERIOD.plus(leewayDays));
+        return timePassedIsBeyondLimit(creationDate, rotationPeriod.plus(leewayDays));
     }
 
     private boolean indexIsOldEnough(DateTime creationDate) {
-        return timePassedIsBeyondLimit(creationDate, ROTATION_PERIOD);
+        return timePassedIsBeyondLimit(creationDate, rotationPeriod);
     }
 
     private boolean timePassedIsBeyondLimit(DateTime date, org.joda.time.Period limit) {

--- a/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/TimeBasedSizeOptimizingStrategyConfig.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/TimeBasedSizeOptimizingStrategyConfig.java
@@ -23,8 +23,8 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
 import org.graylog.autovalue.WithBeanGetter;
 import org.graylog2.plugin.indexer.rotation.RotationStrategyConfig;
+import org.joda.time.Period;
 
-import java.time.Period;
 
 @JsonAutoDetect
 @AutoValue
@@ -34,8 +34,8 @@ public abstract class TimeBasedSizeOptimizingStrategyConfig implements RotationS
     public static final String INDEX_LIFETIME_SOFT = "index_lifetime_soft";
     public static final String INDEX_LIFETIME_HARD = "index_lifetime_hard";
 
-    private static final Period DEFAULT_LIFETIME_SOFT = Period.ofDays(30);
-    private static final Period DEFAULT_LIFETIME_HARD = Period.ofDays(40);
+    private static final Period DEFAULT_LIFETIME_SOFT = Period.days(30);
+    private static final Period DEFAULT_LIFETIME_HARD = Period.days(40);
     @JsonProperty(INDEX_LIFETIME_SOFT)
     public abstract Period indexLifetimeSoft();
 

--- a/graylog2-server/src/test/java/org/graylog2/configuration/ElasticsearchConfigurationTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/configuration/ElasticsearchConfigurationTest.java
@@ -54,7 +54,7 @@ public class ElasticsearchConfigurationTest {
         assertFalse(configuration.isDisableVersionCheck());
         assertNull(configuration.getMaxWriteIndexAge());
         assertTrue(configuration.performRetention());
-        assertEquals(3, configuration.getEnabledRotationStrategies().size());
+        assertEquals(4, configuration.getEnabledRotationStrategies().size());
         assertNull(configuration.getMaxIndexRetentionPeriod());
         assertEquals(Duration.hours(1), configuration.getIndexOptimizationTimeout());
         assertEquals(10, configuration.getIndexOptimizationJobs());

--- a/graylog2-server/src/test/java/org/graylog2/indexer/retention/strategies/AbstractIndexRetentionStrategyTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/retention/strategies/AbstractIndexRetentionStrategyTest.java
@@ -28,6 +28,7 @@ import org.graylog2.shared.system.activities.ActivityWriter;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.Duration;
+import org.joda.time.Period;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -266,8 +267,8 @@ public class AbstractIndexRetentionStrategyTest {
                 1, 0,
                 TimeBasedSizeOptimizingStrategyConfig.class.getCanonicalName(),
                 TimeBasedSizeOptimizingStrategyConfig.builder()
-                        .indexLifetimeSoft(java.time.Period.ofDays(minDays))
-                        .indexLifetimeHard(java.time.Period.ofDays(maxDays))
+                        .indexLifetimeSoft(Period.days(minDays))
+                        .indexLifetimeHard(Period.days(maxDays))
                         .build(),
                 DeletionRetentionStrategy.class.getCanonicalName(),
                 DeletionRetentionStrategyConfig.createDefault(),

--- a/graylog2-server/src/test/java/org/graylog2/indexer/rotation/strategies/TimeBasedSizeOptimizingRotationAndRetentionTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/rotation/strategies/TimeBasedSizeOptimizingRotationAndRetentionTest.java
@@ -27,6 +27,7 @@ import org.graylog2.plugin.Tools;
 import org.graylog2.plugin.system.NodeId;
 import org.graylog2.shared.system.activities.ActivityWriter;
 import org.joda.time.DateTime;
+import org.joda.time.Period;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -36,7 +37,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
-import java.time.Period;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -83,8 +83,8 @@ class TimeBasedSizeOptimizingRotationAndRetentionTest {
         elasticsearchConfiguration = new ElasticsearchConfiguration();
         timeBasedSizeOptimizingStrategy = new TimeBasedSizeOptimizingStrategy(indices, nodeId, auditEventSender, elasticsearchConfiguration, clock);
         rotationStrategyConfig = TimeBasedSizeOptimizingStrategyConfig.builder()
-                .indexLifetimeSoft(Period.ofDays(4))
-                .indexLifetimeHard(Period.ofDays(6))
+                .indexLifetimeSoft(Period.days(4))
+                .indexLifetimeHard(Period.days(6))
                 .build();
 
         final DeletionRetentionStrategyConfig deletionRetention = DeletionRetentionStrategyConfig.createDefault();
@@ -212,7 +212,7 @@ class TimeBasedSizeOptimizingRotationAndRetentionTest {
         if (i.getClosingDate() == null) {
             return "null";
         }
-        return org.joda.time.Period.fieldDifference(clock.nowUTC().toLocalDateTime(), i.getClosingDate().toLocalDateTime()).toString();
+        return Period.fieldDifference(clock.nowUTC().toLocalDateTime(), i.getClosingDate().toLocalDateTime()).toString();
     }
 
     class TestIndexSet extends org.graylog2.indexer.TestIndexSet {

--- a/graylog2-server/src/test/java/org/graylog2/indexer/rotation/strategies/TimeBasedSizeOptimizingRotationAndRetentionTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/rotation/strategies/TimeBasedSizeOptimizingRotationAndRetentionTest.java
@@ -116,6 +116,8 @@ class TimeBasedSizeOptimizingRotationAndRetentionTest {
             return index.map(TestIndex::getSize);
         });
 
+        lenient().when(indices.numberOfMessages(anyString())).thenReturn(10L);
+
         lenient().when(indices.indexClosingDate(anyString())).then(a -> {
             final String indexName = a.getArgument(0);
             final Optional<TestIndex> index = indexSet.findByName(indexName);

--- a/graylog2-server/src/test/java/org/graylog2/indexer/rotation/strategies/TimeBasedSizeOptimizingStrategyTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/rotation/strategies/TimeBasedSizeOptimizingStrategyTest.java
@@ -28,6 +28,7 @@ import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.Days;
 import org.joda.time.Duration;
+import org.joda.time.Period;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -35,7 +36,6 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.time.Period;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -143,7 +143,7 @@ class TimeBasedSizeOptimizingStrategyTest {
     void shouldRotateWhenRightSizedAndOverCustomRotationPeriod(String startDate) {
         setClockTo(startDate);
 
-        final org.joda.time.Period customRotationPeriod = org.joda.time.Period.hours(12);
+        final Period customRotationPeriod = Period.hours(12);
         when(elasticsearchConfiguration.getTimeSizeOptimizingRotationPeriod()).thenReturn(customRotationPeriod);
         timeBasedSizeOptimizingStrategy = new TimeBasedSizeOptimizingStrategy(indices, nodeId, auditEventSender, elasticsearchConfiguration, clock);
 

--- a/graylog2-server/src/test/java/org/graylog2/indexer/rotation/strategies/TimeBasedSizeOptimizingStrategyTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/rotation/strategies/TimeBasedSizeOptimizingStrategyTest.java
@@ -39,6 +39,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
@@ -76,6 +77,8 @@ class TimeBasedSizeOptimizingStrategyTest {
         final IndexSetConfig indexSetConfig = mock(IndexSetConfig.class);
         when(indexSetConfig.rotationStrategy()).thenReturn(timeBasedSizeOptimizingStrategyConfig);
         when(indexSet.getConfig()).thenReturn(indexSetConfig);
+
+        when(indices.numberOfMessages(anyString())).thenReturn(10L);
     }
 
     @ParameterizedTest


### PR DESCRIPTION
While the default should be good enough,
add a new config option:

`time_size_optimizing_rotation_period = 1d`
`time_size_optimizing_rotation_min_size = 20gb`
`time_size_optimizing_rotation_max_size = 50gb`


We also convert `java.time.Period` back to `org.joda.time.Period` since it allows smaller durations
which is helpful for testing and needs less conversions

/nocl
/jenkins-pr-deps https://github.com/Graylog2/graylog-plugin-enterprise/pull/4572

