### PR TITLE
Fix line break in field select options. (Backport of #14418 for 5.0)

### DIFF
--- a/graylog2-web-interface/src/views/components/aggregationwizard/FieldSelect.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/FieldSelect.tsx
@@ -30,18 +30,11 @@ import type FieldTypeMapping from 'views/logic/fieldtypes/FieldTypeMapping';
 import FieldTypeIcon from 'views/components/sidebar/fields/FieldTypeIcon';
 import type FieldType from 'views/logic/fieldtypes/FieldType';
 
-type Props = {
-  ariaLabel?: string,
-  clearable?: boolean,
-  error?: string,
-  id: string,
-  label: string,
-  name: string,
-  onChange: (changeEvent: { target: { name: string, value: string } }) => void,
-  value: string | undefined,
-  selectRef?: React.Ref<React.ComponentType>
-  properties?: Array<Property>,
-}
+const FieldName = styled.span`
+  display: inline-flex;
+  gap: 2px;
+  align-items: center;
+`;
 
 const sortByLabel = ({ label: label1 }: { label: string }, { label: label2 }: { label: string }) => defaultCompare(label1, label2);
 
@@ -64,10 +57,23 @@ type OptionRendererProps = {
 };
 
 const OptionRenderer = ({ label, qualified, type }: OptionRendererProps) => {
-  const children = <><FieldTypeIcon type={type} /> {label}</>;
+  const children = <FieldName><FieldTypeIcon type={type} /> {label}</FieldName>;
 
   return qualified ? <span>{children}</span> : <UnqualifiedOption>{children}</UnqualifiedOption>;
 };
+
+type Props = {
+  ariaLabel?: string,
+  clearable?: boolean,
+  error?: string,
+  id: string,
+  label: string,
+  name: string,
+  onChange: (changeEvent: { target: { name: string, value: string } }) => void,
+  value: string | undefined,
+  selectRef?: React.Ref<React.ComponentType>
+  properties?: Array<Property>,
+}
 
 const FieldSelect = ({ name, id, error, clearable, value, onChange, label, ariaLabel, selectRef, properties }: Props) => {
   const { activeQuery } = useStore(ViewMetadataStore);


### PR DESCRIPTION
_Please note, this is a backport of #14418 for 5.0_

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is fixing a styling problem in the fields select in the aggregations builder.

Before:

<img width="214" alt="image" src="https://user-images.githubusercontent.com/46300478/211776275-c46e21eb-ad1d-42b8-b129-b09d22118710.png">

After:

![image](https://user-images.githubusercontent.com/46300478/211775914-6165b7f4-c5ba-4b6e-8443-6391ffa33b24.png)

The styling / scrolling behaviour is now similar to 4.3.

/nocl
