### PR TITLE
Unify stylelint rule `string-quotes` with ESList by enforcing single quotes.

### DIFF
--- a/graylog2-web-interface/packages/stylelint-config-graylog/index.js
+++ b/graylog2-web-interface/packages/stylelint-config-graylog/index.js
@@ -40,6 +40,7 @@ module.exports = {
     'property-no-vendor-prefix': [true, {
       ignoreProperties: ['grid-rows', 'grid-columns', 'grid-row', 'grid-column'],
     }],
+    'string-quotes': 'single',
     'value-no-vendor-prefix': [true, {
       ignoreValues: ['grid', 'inline-grid'],
     }],

--- a/graylog2-web-interface/src/components/bootstrap/Alert.tsx
+++ b/graylog2-web-interface/src/components/bootstrap/Alert.tsx
@@ -36,7 +36,7 @@ interface Props {
 
 const StyledAlert = styled(BootstrapAlert).attrs(({ bsStyle }: { bsStyle: ColorVariants }) => ({
   bsStyle: null,
-  $bsStyle: bsStyle || "default",
+  $bsStyle: bsStyle || 'default',
 }))(({ $bsStyle, theme }: AlertProps) => {
   const borderColor = theme.colors.variant.lighter[$bsStyle];
   const backgroundColor = theme.colors.variant.lightest[$bsStyle];
@@ -47,7 +47,7 @@ const StyledAlert = styled(BootstrapAlert).attrs(({ bsStyle }: { bsStyle: ColorV
     color: ${theme.utils.contrastingColor(backgroundColor)};
 
     a:not(.btn) {
-      color: ${theme.utils.contrastingColor(backgroundColor, "AA")};
+      color: ${theme.utils.contrastingColor(backgroundColor, 'AA')};
       font-weight: bold;
       text-decoration: underline;
 

--- a/graylog2-web-interface/src/components/bootstrap/FormControl.jsx
+++ b/graylog2-web-interface/src/components/bootstrap/FormControl.jsx
@@ -25,7 +25,7 @@ const FormControl = styled(BootstrapFormControl)(({ theme }) => css`
     border-radius: ${INPUT_BORDER_RADIUS};
   }
 
-  &.form-control:not([type="range"]) {
+  &.form-control:not([type='range']) {
     color: ${theme.colors.input.color};
     background-color: ${theme.colors.input.background};
     border-color: ${theme.colors.input.border};

--- a/graylog2-web-interface/src/components/common/Autocomplete/Autocomplete.tsx
+++ b/graylog2-web-interface/src/components/common/Autocomplete/Autocomplete.tsx
@@ -29,7 +29,7 @@ const StyledLabel = styled.label`
 `;
 
 const HelpText = styled.span`
-  color: ${(props: any) => props.theme.colors.gray["50"]};
+  color: ${(props: any) => props.theme.colors.gray['50']};
 `;
 
 export type AutocompleteOption = {

--- a/graylog2-web-interface/src/components/common/DropdownMenu.tsx
+++ b/graylog2-web-interface/src/components/common/DropdownMenu.tsx
@@ -29,7 +29,7 @@ type Props = {
 const StyledDropdownMenu = styled.ul.attrs(() => ({
   className: 'dropdown-menu' /* stylelint-disable-line property-no-unknown*/
 }))<{ $show: boolean, $zIndex: number }>(({ $show, theme, $zIndex }) => css`
-  display: ${$show ? "block" : "none"};
+  display: ${$show ? 'block' : 'none'};
   min-width: max-content;
   color: ${theme.colors.variant.dark.default};
   background-color: ${theme.colors.variant.lightest.default};

--- a/graylog2-web-interface/src/components/common/DropdownSubmenu.tsx
+++ b/graylog2-web-interface/src/components/common/DropdownSubmenu.tsx
@@ -27,9 +27,8 @@ type Props = {
   title: string,
 };
 
-const Toggle = styled.a.attrs({
-  href: '#' /* stylelint-disable-line property-no-unknown*/
-})(({ theme }) => css`
+/* stylelint-disable-next-line property-no-unknown */
+const Toggle = styled.a.attrs({ href: '#' })(({ theme }) => css`
   &::after {
     display: block;
     content: ' ';

--- a/graylog2-web-interface/src/components/common/DropdownSubmenu.tsx
+++ b/graylog2-web-interface/src/components/common/DropdownSubmenu.tsx
@@ -32,7 +32,7 @@ const Toggle = styled.a.attrs({
 })(({ theme }) => css`
   &::after {
     display: block;
-    content: " ";
+    content: ' ';
     float: right;
     width: 0;
     height: 0;
@@ -50,11 +50,11 @@ const StyledSubmenu = styled(Dropdown)(({ left, theme }: { left: boolean, theme:
 
   > .dropdown-menu {
     top: 0;
-    left: ${left ? "auto" : "100%"};
-    right: ${left ? "98%" : "auto"};
+    left: ${left ? 'auto' : '100%'};
+    right: ${left ? '98%' : 'auto'};
     margin-top: -6px;
-    margin-left: ${left ? "10px" : "-1px"};
-    border-radius: ${left ? "6px 0 6px 6px" : "0 6px 6px 6px"};
+    margin-left: ${left ? '10px' : '-1px'};
+    border-radius: ${left ? '6px 0 6px 6px' : '0 6px 6px 6px'};
   }
 
   &:hover > .dropdown-menu {

--- a/graylog2-web-interface/src/components/common/EntityDataTable/TableHead.tsx
+++ b/graylog2-web-interface/src/components/common/EntityDataTable/TableHead.tsx
@@ -25,7 +25,7 @@ import BulkSelectHead from './BulkSelectHead';
 import type { Column, ColumnRenderer, ColumnRenderers, EntityBase } from './types';
 
 const Th = styled.th<{ $width: number | undefined }>(({ $width }) => css`
-  width: ${$width ? `${$width}px` : "auto"};
+  width: ${$width ? `${$width}px` : 'auto'};
 `);
 
 const TableHeader = <Entity extends EntityBase>({
@@ -61,7 +61,7 @@ const TableHeader = <Entity extends EntityBase>({
 
 const ActionsHead = styled.th<{ $width: number | undefined }>(({ $width }) => css`
   text-align: right;
-  width: ${$width ? `${$width}px` : "auto"};
+  width: ${$width ? `${$width}px` : 'auto'};
 `);
 
 const TableHead = <Entity extends EntityBase>({

--- a/graylog2-web-interface/src/components/common/ExpandableListItem.tsx
+++ b/graylog2-web-interface/src/components/common/ExpandableListItem.tsx
@@ -23,7 +23,7 @@ import { Checkbox } from 'components/bootstrap';
 import Icon from './Icon';
 
 const ItemWrap = styled.li(({ padded }: { padded: boolean }) => css`
-  padding: ${padded ? "10px 5px" : ""};
+  padding: ${padded ? '10px 5px' : ''};
 `);
 
 const Container = styled.div(({ theme }) => css`
@@ -57,16 +57,16 @@ const IconStack = styled.div(({ theme }) => css`
     height: 1em;
     vertical-align: text-top;
 
-    &:hover [class*="fa-"] {
+    &:hover [class*='fa-'] {
       color: ${theme.colors.variant.primary};
       opacity: 1;
     }
   }
 
-  [class*="fa-"]:first-child {
+  [class*='fa-']:first-child {
     opacity: 0;
 
-    ~ [class*="fa-"]:hover {
+    ~ [class*='fa-']:hover {
       color: ${theme.colors.global.contentBackground};
     }
   }

--- a/graylog2-web-interface/src/components/common/HoverForHelp.tsx
+++ b/graylog2-web-interface/src/components/common/HoverForHelp.tsx
@@ -42,8 +42,8 @@ const StyledPopover = styled(Popover)(({ theme }) => css`
 `);
 
 const StyledIcon = styled(Icon)<{ $type: Type, $displayLeftMargin: boolean }>(({ theme, $type, $displayLeftMargin }) => css`
-  color: ${$type === "error" ? theme.colors.variant.danger : "inherit"};
-  margin-left: ${$displayLeftMargin ? "0.3em" : 0};
+  color: ${$type === 'error' ? theme.colors.variant.danger : 'inherit'};
+  margin-left: ${$displayLeftMargin ? '0.3em' : 0};
 `);
 
 const iconName = (type: Type) => {

--- a/graylog2-web-interface/src/components/common/NavItemStateIndicator.tsx
+++ b/graylog2-web-interface/src/components/common/NavItemStateIndicator.tsx
@@ -40,7 +40,7 @@ const Container = styled.div`
   position: relative;
   
   ${indicatorPseudoElement} {
-    content: " ";
+    content: ' ';
     position: absolute;
     border-bottom: 1px solid transparent;
     left: 0;

--- a/graylog2-web-interface/src/components/common/PageHeader.tsx
+++ b/graylog2-web-interface/src/components/common/PageHeader.tsx
@@ -51,7 +51,7 @@ const LifecycleIndicatorContainer = styled.span(({ theme }) => css`
 const TopActions = styled.div<{ $hasMultipleChildren: boolean }>(({ $hasMultipleChildren }) => css`
   display: flex;
   gap: 10px;
-  align-items: ${$hasMultipleChildren ? "center" : "flex-start"};
+  align-items: ${$hasMultipleChildren ? 'center' : 'flex-start'};
 `);
 
 const Actions = styled.div`

--- a/graylog2-web-interface/src/components/common/PublicNotifications.tsx
+++ b/graylog2-web-interface/src/components/common/PublicNotifications.tsx
@@ -41,7 +41,7 @@ const ShortContent = styled.p`
 
 const LongContent = styled.div(({ $visible }: {$visible: boolean}) => css`
   white-space: pre-wrap;
-  display: ${$visible ? "block" : "none"};
+  display: ${$visible ? 'block' : 'none'};
   padding-top: 12px;
 `);
 

--- a/graylog2-web-interface/src/components/common/RangeInput.tsx
+++ b/graylog2-web-interface/src/components/common/RangeInput.tsx
@@ -68,7 +68,7 @@ const Thumb = (props, state) => {
 const StyledTrack = styled.div(({ theme }: { theme: DefaultTheme }) => css`
     top: ${theme.spacings.xxs};
     bottom: 0;
-    background: ${(props: any) => (props.index === 1 ? "#5082bc" : theme.colors.variant.default)};
+    background: ${(props: any) => (props.index === 1 ? '#5082bc' : theme.colors.variant.default)};
     border-radius: 999px;
 `);
 

--- a/graylog2-web-interface/src/components/common/Section/SectionGrid.tsx
+++ b/graylog2-web-interface/src/components/common/Section/SectionGrid.tsx
@@ -18,7 +18,7 @@ import styled, { css } from 'styled-components';
 
 const SectionGrid = styled.div<{ $columns?: string } >(({ $columns, theme }) => css`
   display: grid;
-  grid-template-columns: ${$columns ?? "1fr 1fr"};
+  grid-template-columns: ${$columns ?? '1fr 1fr'};
   grid-column-gap: 40px;
 
   @media (max-width: ${theme.breakpoints.max.md}) {

--- a/graylog2-web-interface/src/components/common/SourceCodeEditor.jsx
+++ b/graylog2-web-interface/src/components/common/SourceCodeEditor.jsx
@@ -36,7 +36,7 @@ import './ace/theme-graylog';
 const SourceCodeContainer = styled.div(({ resizable, theme }) => css`
   .react-resizable-handle {
     z-index: 100; /* Ensure resize handle is over text editor */
-    display: ${resizable ? "block" : "none"};
+    display: ${resizable ? 'block' : 'none'};
   }
 
   ${theme.components.aceEditor}

--- a/graylog2-web-interface/src/components/common/Wizard.tsx
+++ b/graylog2-web-interface/src/components/common/Wizard.tsx
@@ -62,7 +62,7 @@ const StyledNav = styled(Nav)(({ theme }: { theme: DefaultTheme }) => css`
           border-color: ${theme.colors.variant.lighter.default};
           border-style: solid;
           border-width: 0 1px 1px 0;
-          content: "";
+          content: '';
           display: block;
           height: 15px;
           position: absolute;

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/AggregationConditionExpressions/BooleanOperatorSelector.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/AggregationConditionExpressions/BooleanOperatorSelector.jsx
@@ -28,7 +28,7 @@ const OperatorSelector = styled.div(({ theme }) => css`
 
 const BooleanOperatorSelect = styled(({ isFirstElement, ...props }) => <FormGroup {...props} />)`
   width: 100px;
-  margin-left: ${(props) => (props.isFirstElement ? "" : "1em")};
+  margin-left: ${(props) => (props.isFirstElement ? '' : '1em')};
   margin-right: 1em;
 `;
 

--- a/graylog2-web-interface/src/components/events/events/Events.jsx
+++ b/graylog2-web-interface/src/components/events/events/Events.jsx
@@ -55,8 +55,8 @@ const ExpandedTR = styled.tr(({ theme }) => css`
 `);
 
 const EventsTbody = styled.tbody(({ expanded, theme }) => css`
-    border-left: ${expanded ? `3px solid ${theme.colors.variant.light.info}` : ""};
-    border-collapse: ${expanded ? "separate" : "collapse"};
+    border-left: ${expanded ? `3px solid ${theme.colors.variant.light.info}` : ''};
+    border-collapse: ${expanded ? 'separate' : 'collapse'};
 `);
 
 const CollapsibleTr = styled.tr`

--- a/graylog2-web-interface/src/components/login/LoginChrome.tsx
+++ b/graylog2-web-interface/src/components/login/LoginChrome.tsx
@@ -82,7 +82,7 @@ const WelcomeMessage = styled.strong(({ theme }) => css`
 `);
 
 const BrandName = styled.h3(({ theme }) => css`
-  color: ${theme.colors.gray["60"]};
+  color: ${theme.colors.gray['60']};
   font-size: 1.5rem;
   line-height: 2rem;
 `);

--- a/graylog2-web-interface/src/components/navigation/Navigation.styles.jsx
+++ b/graylog2-web-interface/src/components/navigation/Navigation.styles.jsx
@@ -92,7 +92,7 @@ const StyledNavbar = styled(Navbar)(({ theme }) => css`
           content: attr(aria-label);
         }
 
-        [class*="fa-"] {
+        [class*='fa-'] {
           display: none;
         }
       }

--- a/graylog2-web-interface/src/components/navigation/ThemeModeToggle.tsx
+++ b/graylog2-web-interface/src/components/navigation/ThemeModeToggle.tsx
@@ -38,7 +38,7 @@ const ThemeModeToggleWrap = styled.div`
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const ModeIcon = styled(({ currentMode, theme, ...props }) => <Icon {...props} />)`
-  opacity: ${({ currentMode }) => (currentMode ? "1" : "0.5")};
+  opacity: ${({ currentMode }) => (currentMode ? '1' : '0.5')};
   color: ${({ currentMode, theme }) => (currentMode ? theme.colors.brand.primary : theme.colors.variant.darkest.default)};
 `;
 
@@ -91,7 +91,7 @@ const Toggle = styled.label(({ theme }) => css`
 
     &::before {
       transition: transform 75ms ease-in-out;
-      content: "";
+      content: '';
       display: block;
       width: 18px;
       height: 18px;

--- a/graylog2-web-interface/src/components/pipelines/PipelineDetails.tsx
+++ b/graylog2-web-interface/src/components/pipelines/PipelineDetails.tsx
@@ -37,7 +37,7 @@ const PipelineDl = styled.dl`
   }
 
   & > dt::after {
-    content: ":";
+    content: ':';
   }
 
   & > dd {

--- a/graylog2-web-interface/src/components/pipelines/ProcessingTimelineComponent.tsx
+++ b/graylog2-web-interface/src/components/pipelines/ProcessingTimelineComponent.tsx
@@ -54,7 +54,7 @@ const Header = styled.div`
 `;
 
 const PipelineStage = styled.div<{ $idle?: boolean }>(({ $idle, theme }) => css`
-  border: 1px solid ${theme.colors.gray[$idle ? "50px" : "70px"]};
+  border: 1px solid ${theme.colors.gray[$idle ? '50px' : '70px']};
   border-radius: 4px;
   display: inline-block;
   margin-right: 15px;

--- a/graylog2-web-interface/src/components/scratchpad/Scratchpad.tsx
+++ b/graylog2-web-interface/src/components/scratchpad/Scratchpad.tsx
@@ -84,7 +84,7 @@ const StatusMessage = styled.span(({ theme, $visible }: { theme: DefaultTheme, $
   flex: 1;
   color: ${theme.colors.variant.success};
   font-style: italic;
-  opacity: ${$visible ? "1" : "0"};
+  opacity: ${$visible ? '1' : '0'};
   transition: opacity 150ms ease-in-out;
 `);
 

--- a/graylog2-web-interface/src/components/sidecars/administration/CollectorConfigurationModal.tsx
+++ b/graylog2-web-interface/src/components/sidecars/administration/CollectorConfigurationModal.tsx
@@ -59,8 +59,8 @@ const SecondaryText = styled.div`
 `;
 
 const TableRow = styled.tr(({ disabled = false }: {disabled?: boolean}) => css`
-  cursor: ${disabled ? "auto" : "pointer"};
-  background-color: ${disabled ? "#E8E8E8 !important" : "initial"};
+  cursor: ${disabled ? 'auto' : 'pointer'};
+  background-color: ${disabled ? '#E8E8E8 !important' : 'initial'};
   border-bottom: 1px solid lightgray;
   height: 49px;
 `);

--- a/graylog2-web-interface/src/components/sidecars/common/ColorLabel.tsx
+++ b/graylog2-web-interface/src/components/sidecars/common/ColorLabel.tsx
@@ -42,7 +42,7 @@ const ColorLabelWrap = styled.span(({ size, theme }: ColorLabelWrapProps) => {
 
   return css`
     vertical-align: middle;
-    font-size: ${size === "xsmall" ? tiny : fontSize};
+    font-size: ${size === 'xsmall' ? tiny : fontSize};
 `;
 });
 

--- a/graylog2-web-interface/src/components/sidecars/sidecars/SidecarRow.jsx
+++ b/graylog2-web-interface/src/components/sidecars/sidecars/SidecarRow.jsx
@@ -29,15 +29,15 @@ import SidecarStatusEnum from 'logic/sidecar/SidecarStatusEnum';
 import style from './SidecarRow.css';
 
 const SidecarTR = styled.tr(({ inactive, theme }) => css`
-  color: ${inactive ? theme.utils.contrastingColor(theme.colors.table.background, "AA") : "currentColor"};
+  color: ${inactive ? theme.utils.contrastingColor(theme.colors.table.background, 'AA') : 'currentColor'};
   opacity: ${inactive ? 0.9 : 1};
 
   &:nth-of-type(2n+1) {
-    color: ${inactive ? theme.utils.contrastingColor(theme.colors.table.backgroundAlt, "AA") : "currentColor"};
+    color: ${inactive ? theme.utils.contrastingColor(theme.colors.table.backgroundAlt, 'AA') : 'currentColor'};
   }
 
   td:not(:last-child) {
-    font-style: ${inactive ? "italic" : "normal"};
+    font-style: ${inactive ? 'italic' : 'normal'};
   }
 `);
 

--- a/graylog2-web-interface/src/components/simulator/SimulationChanges.jsx
+++ b/graylog2-web-interface/src/components/simulator/SimulationChanges.jsx
@@ -40,7 +40,7 @@ const SimulationChangesWrap = styled.div`
     padding: 3px 9px 1px;
 
     &::after {
-      content: ": ";
+      content: ': ';
     }
 
     &:first-child {

--- a/graylog2-web-interface/src/components/streams/MatchingTypeSwitcher.jsx
+++ b/graylog2-web-interface/src/components/streams/MatchingTypeSwitcher.jsx
@@ -39,7 +39,7 @@ const StreamRuleConnector = styled.div(({ theme }) => css`
     margin-bottom: 0;
   }
 
-  input[type="radio"] {
+  input[type='radio'] {
     margin-top: 2px;
     margin-bottom: 2px;
   }

--- a/graylog2-web-interface/src/components/streams/StreamsOverview/StatusCell.tsx
+++ b/graylog2-web-interface/src/components/streams/StreamsOverview/StatusCell.tsx
@@ -24,7 +24,7 @@ import { StreamsStore } from 'stores/streams/StreamsStore';
 import type { Stream } from 'stores/streams/StreamsStore';
 
 const StatusLabel = styled(Label)(({ $clickable }: { $clickable: boolean }) => css`
-  cursor: ${$clickable ? "pointer" : "default"};
+  cursor: ${$clickable ? 'pointer' : 'default'};
   display: inline-flex;
   justify-content: center;
   gap: 4px;

--- a/graylog2-web-interface/src/components/throughput/GlobalThroughput.jsx
+++ b/graylog2-web-interface/src/components/throughput/GlobalThroughput.jsx
@@ -65,7 +65,7 @@ const ContentWrap = styled.strong`
 const ThroughputData = styled.span(({ dataIn, theme }) => css`
   font-size: ${theme.fonts.size.small};
   line-height: 1;
-  grid-area: ${dataIn ? "1 / 1 / 2 / 2" : "2 / 1 / 3 / 2"};
+  grid-area: ${dataIn ? '1 / 1 / 2 / 2' : '2 / 1 / 3 / 2'};
   display: grid;
   grid-template-columns: 1fr 1.75em;
   grid-template-rows: 1fr 1px;

--- a/graylog2-web-interface/src/theme/GlobalThemeStyles.js
+++ b/graylog2-web-interface/src/theme/GlobalThemeStyles.js
@@ -105,9 +105,9 @@ const GlobalThemeStyles = createGlobalStyle(({ theme }) => css`
   /* Remove boostrap outline */
   a:active,
   select:active,
-  input[type="file"]:active,
-  input[type="radio"]:active,
-  input[type="checkbox"]:active,
+  input[type='file']:active,
+  input[type='radio']:active,
+  input[type='checkbox']:active,
   .btn:active {
     outline: none;
     outline-offset: 0;
@@ -480,7 +480,7 @@ const GlobalThemeStyles = createGlobalStyle(({ theme }) => css`
     display: inline-block;
   }
 
-  .configuration-bundles input[type="file"] {
+  .configuration-bundles input[type='file'] {
     line-height: inherit !important;
   }
 
@@ -629,7 +629,7 @@ const GlobalThemeStyles = createGlobalStyle(({ theme }) => css`
 
   .tag-remove::before,
   .pill-remove::before {
-    content: "×";
+    content: '×';
   }
 
   .save-button-margin {
@@ -668,8 +668,8 @@ const GlobalThemeStyles = createGlobalStyle(({ theme }) => css`
     border-color: ${theme.colors.variant.lighter.default};
   }
 
-  input[type="range"],
-  input[type="range"]:focus {
+  input[type='range'],
+  input[type='range']:focus {
     box-shadow: none;
     height: auto;
   }

--- a/graylog2-web-interface/src/views/components/Search.tsx
+++ b/graylog2-web-interface/src/views/components/Search.tsx
@@ -80,7 +80,7 @@ const SearchArea = styled(PageContentLayout)(() => {
         width: 100%;
 
         /* overflow auto is required to display the message table widget height correctly */
-        overflow: ${focusedWidget?.id ? "auto" : "visible"};
+        overflow: ${focusedWidget?.id ? 'auto' : 'visible'};
       }
     `}
 `;

--- a/graylog2-web-interface/src/views/components/SearchResult.tsx
+++ b/graylog2-web-interface/src/views/components/SearchResult.tsx
@@ -27,8 +27,8 @@ import WidgetFocusContext from 'views/components/contexts/WidgetFocusContext';
 import useIsLoading from 'views/hooks/useIsLoading';
 
 const StyledRow = styled(Row)(({ $hasFocusedWidget }: { $hasFocusedWidget: boolean }) => css`
-  height: ${$hasFocusedWidget ? "100%" : "auto"};
-  overflow: ${$hasFocusedWidget ? "auto" : "visible"};
+  height: ${$hasFocusedWidget ? '100%' : 'auto'};
+  overflow: ${$hasFocusedWidget ? 'auto' : 'visible'};
   position: relative;
 `);
 

--- a/graylog2-web-interface/src/views/components/WidgetGrid.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetGrid.tsx
@@ -63,9 +63,9 @@ const DashboardWrap = styled(ElementDimensions)(({ theme }) => css`
 `);
 
 const StyledReactGridContainer = styled(ReactGridContainer)(({ $hasFocusedWidget }: { $hasFocusedWidget: boolean }) => css`
-  height: ${$hasFocusedWidget ? "100% !important" : "100%"};
-  max-height: ${$hasFocusedWidget ? "100%" : "auto"};
-  overflow: ${$hasFocusedWidget ? "hidden" : "visible"};
+  height: ${$hasFocusedWidget ? '100% !important' : '100%'};
+  max-height: ${$hasFocusedWidget ? '100%' : 'auto'};
+  overflow: ${$hasFocusedWidget ? 'hidden' : 'visible'};
   transition: none;
 `);
 

--- a/graylog2-web-interface/src/views/components/actions/FieldActions.tsx
+++ b/graylog2-web-interface/src/views/components/actions/FieldActions.tsx
@@ -41,8 +41,8 @@ type FieldElementProps = {
 const FieldElement = styled.span.attrs({
   className: 'field-element' /* stylelint-disable-line property-no-unknown*/
 })<FieldElementProps>(({ active, disabled, theme }) => css`
-  color: ${active ? theme.colors.variant.info : "currentColor"};
-  opacity: ${disabled ? "0.3" : "1"};
+  color: ${active ? theme.colors.variant.info : 'currentColor'};
+  opacity: ${disabled ? '0.3' : '1'};
 `);
 
 const FieldActions = ({ children, disabled, element, menuContainer, name, type, queryId }: Props) => {

--- a/graylog2-web-interface/src/views/components/aggregationwizard/ElementConfigurationSection.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/ElementConfigurationSection.tsx
@@ -28,7 +28,7 @@ const Wrapper = styled.div(({ theme }) => css`
     margin-bottom: 0;
   }
 
-  div[class^="col-"] {
+  div[class^='col-'] {
     padding-right: 0;
     padding-left: 0;
   }
@@ -73,17 +73,17 @@ const Header = styled.div(({ theme, $isEmpty }: { theme: DefaultTheme, $isEmpty:
   z-index: 1;
   
   ::before {
-    content: " ";
+    content: ' ';
     top: 50%;
     width: 100%;
-    border-bottom: 1px solid ${$isEmpty ? theme.colors.gray["70"] : theme.utils.contrastingColor(theme.colors.global.contentBackground, "AA")};
+    border-bottom: 1px solid ${$isEmpty ? theme.colors.gray['70'] : theme.utils.contrastingColor(theme.colors.global.contentBackground, 'AA')};
     position: absolute;
   }
 `);
 
 const ElementTitle = styled.div(({ theme, $isEmpty }: { theme: DefaultTheme, $isEmpty: boolean }) => css`
   background-color: ${theme.colors.global.contentBackground};
-  color: ${$isEmpty ? theme.colors.gray["70"] : theme.colors.global.textDefault};
+  color: ${$isEmpty ? theme.colors.gray['70'] : theme.colors.global.textDefault};
   z-index: 1;
   padding-right: 8px;
 `);

--- a/graylog2-web-interface/src/views/components/aggregationwizard/visualization/VisualizationConfiguration.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/visualization/VisualizationConfiguration.tsx
@@ -34,7 +34,7 @@ import VisualizationElement from './VisualizationElement';
 import ElementConfigurationContainer from '../ElementConfigurationContainer';
 
 const EventAnnotationCheckbox = styled(Checkbox)`
-  input[type="checkbox"] {
+  input[type='checkbox'] {
     margin-right: 0;
     right: 0;
   }

--- a/graylog2-web-interface/src/views/components/aggregationwizard/visualization/configurationFields/BooleanField.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/visualization/configurationFields/BooleanField.tsx
@@ -23,7 +23,7 @@ import { Input, HelpBlock } from 'components/bootstrap';
 import type { FieldComponentProps } from '../VisualizationConfigurationOptions';
 
 const StyledField = styled(Field)`
-  &&[type="checkbox"] {
+  &&[type='checkbox'] {
     margin-top: 8px;
   }
 `;

--- a/graylog2-web-interface/src/views/components/datatable/MessagesTable.tsx
+++ b/graylog2-web-interface/src/views/components/datatable/MessagesTable.tsx
@@ -123,7 +123,7 @@ const StyledTable = styled(Table)(({ theme, $stickyHeader, $borderedHeader }: { 
     margin-right: 0;
   }
 
-  tr.message-detail-row div[class*="col-"] {
+  tr.message-detail-row div[class*='col-'] {
     padding-right: 0;
   }
 

--- a/graylog2-web-interface/src/views/components/messagelist/MessageTableEntry.tsx
+++ b/graylog2-web-interface/src/views/components/messagelist/MessageTableEntry.tsx
@@ -78,7 +78,7 @@ const MessageDetailRow = styled.tr`
     margin-right: 0;
   }
 
-  div[class*="col-"] {
+  div[class*='col-'] {
     padding-right: 0;
   }
 `;

--- a/graylog2-web-interface/src/views/components/queries/QueryTitle.tsx
+++ b/graylog2-web-interface/src/views/components/queries/QueryTitle.tsx
@@ -29,7 +29,7 @@ import { duplicateQuery } from 'views/logic/slices/viewSlice';
 import QueryActionDropdown from './QueryActionDropdown';
 
 const TitleWrap = styled.span<{ active: boolean }>(({ active }) => css`
-  padding-right: ${active ? "6px" : "0"};
+  padding-right: ${active ? '6px' : '0'};
 `);
 
 type Props = {

--- a/graylog2-web-interface/src/views/components/searchbar/SearchButton.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/SearchButton.tsx
@@ -35,7 +35,7 @@ const StyledButton = styled(Button)(({ theme, $dirty }: { theme: DefaultTheme, $
   ${$dirty ? css`
     &::after {
       position: absolute;
-      content: "";
+      content: '';
       height: 16px;
       width: 16px;
       top: -5px;

--- a/graylog2-web-interface/src/views/components/searchbar/date-time-picker/RelativeRangeSelect.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/date-time-picker/RelativeRangeSelect.tsx
@@ -63,7 +63,7 @@ const Ago = styled.span(({ theme }) => css`
   font-size: ${theme.fonts.size.large};
 
   ::after {
-    content: "ago";
+    content: 'ago';
   }
 `);
 

--- a/graylog2-web-interface/src/views/components/searchbar/queryvalidation/QueryValidation.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/queryvalidation/QueryValidation.tsx
@@ -47,11 +47,11 @@ const ExplanationTrigger = styled.button<{ $clickable?: boolean }>(({ $clickable
   border: 0;
   display: flex;
   align-items: center;
-  cursor: ${$clickable ? "pointer" : "default"};
+  cursor: ${$clickable ? 'pointer' : 'default'};
 `);
 
 const ErrorIcon = styled(Icon)(({ theme, $status }: { theme: DefaultTheme, $status: string }) => css`
-  color: ${$status === "ERROR" ? theme.colors.variant.danger : theme.colors.variant.warning};
+  color: ${$status === 'ERROR' ? theme.colors.variant.danger : theme.colors.variant.warning};
   font-size: 22px;
 `);
 
@@ -97,7 +97,7 @@ const shakeAnimation = keyframes`
 `;
 
 const StyledPopover = styled(Popover)(({ $shaking }) => css`
-  animation: ${$shaking ? css`${shakeAnimation} 0.82s cubic-bezier(0.36, 0.07, 0.19, 0.97) both` : "none"};
+  animation: ${$shaking ? css`${shakeAnimation} 0.82s cubic-bezier(0.36, 0.07, 0.19, 0.97) both` : 'none'};
 `);
 
 const ExplanationTitle = ({ title }: { title: string }) => (

--- a/graylog2-web-interface/src/views/components/sidebar/ContentColumn.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/ContentColumn.tsx
@@ -29,21 +29,21 @@ type Props = {
 };
 
 export const Container = styled.div<{ sidebarIsPinned: boolean }>(({ theme, sidebarIsPinned }) => css`
-  position: ${sidebarIsPinned ? "relative" : "fixed"};
+  position: ${sidebarIsPinned ? 'relative' : 'fixed'};
   width: 270px;
-  height: ${sidebarIsPinned ? "100%" : "calc(100% - 50px)"}; /* subtract the nav height */
-  top: ${sidebarIsPinned ? 0 : "50px"};
-  left: ${sidebarIsPinned ? 0 : "50px"};
+  height: ${sidebarIsPinned ? '100%' : 'calc(100% - 50px)'}; /* subtract the nav height */
+  top: ${sidebarIsPinned ? 0 : '50px'};
+  left: ${sidebarIsPinned ? 0 : '50px'};
 
   background: ${theme.colors.global.contentBackground};
-  border-right: ${sidebarIsPinned ? "none" : `1px solid ${theme.colors.variant.light.default}`};
-  box-shadow: ${sidebarIsPinned ? `3px 3px 3px ${theme.colors.global.navigationBoxShadow}` : "none"};
+  border-right: ${sidebarIsPinned ? 'none' : `1px solid ${theme.colors.variant.light.default}`};
+  box-shadow: ${sidebarIsPinned ? `3px 3px 3px ${theme.colors.global.navigationBoxShadow}` : 'none'};
 
   z-index: ${sidebarIsPinned ? 1030 : 6};
 
   ${sidebarIsPinned && css`
     ::before {
-      content: "";
+      content: '';
       position: absolute;
       top: 0;
       right: -6px;

--- a/graylog2-web-interface/src/views/components/sidebar/NavItem.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/NavItem.tsx
@@ -59,7 +59,7 @@ const Container = styled.div<ContainerProps>(({ theme: { colors, fonts }, isSele
   ${(isSelected && !sidebarIsPinned) && css`
     ::before,
     ::after {
-      content: "";
+      content: '';
       position: absolute;
       right: -5px;
       height: 15px;

--- a/graylog2-web-interface/src/views/components/sidebar/SidebarNavigation.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/SidebarNavigation.tsx
@@ -30,15 +30,15 @@ type Props = {
 
 const Container = styled.div<{ isOpen: boolean, sidebarIsPinned: boolean }>(({ isOpen, sidebarIsPinned, theme }) => css`
   background: ${theme.colors.global.navigationBackground};
-  color: ${theme.utils.contrastingColor(theme.colors.global.navigationBackground, "AA")};
-  box-shadow: ${(sidebarIsPinned && isOpen) ? "none" : `3px 3px 3px ${theme.colors.global.navigationBoxShadow}`};
+  color: ${theme.utils.contrastingColor(theme.colors.global.navigationBackground, 'AA')};
+  box-shadow: ${(sidebarIsPinned && isOpen) ? 'none' : `3px 3px 3px ${theme.colors.global.navigationBoxShadow}`};
   width: 50px;
   height: 100%;
   position: relative;
   z-index: 1031;
 
   ::before {
-    content: "";
+    content: '';
     position: absolute;
     top: 0;
     right: -6px;

--- a/graylog2-web-interface/src/views/components/sidebar/fields/FieldGroup.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/fields/FieldGroup.tsx
@@ -28,7 +28,7 @@ const FieldGroup = ({ onSelect, selected, group, text, title }: Props) => (
   // eslint-disable-next-line jsx-a11y/anchor-is-valid,jsx-a11y/click-events-have-key-events
   <a onClick={() => onSelect(group)}
      role="button"
-     style={{ fontWeight: selected ? "bold" : "normal" }}
+     style={{ fontWeight: selected ? 'bold' : 'normal' }}
      tabIndex={0}
      title={title}>
     {text}

--- a/graylog2-web-interface/src/views/components/sidebar/highlighting/ColorPreview.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/highlighting/ColorPreview.tsx
@@ -42,7 +42,7 @@ export const GradientColorPreview = styled(ColorPreviewBase)(({ gradient }: { gr
 
   return css`
       border: none;
-      background: linear-gradient(0deg, ${colors.map((color, idx) => `${color} ${idx * (100 / colors.length)}%`).join(", ")});
+      background: linear-gradient(0deg, ${colors.map((color, idx) => `${color} ${idx * (100 / colors.length)}%`).join(', ')});
 `;
 });
 

--- a/graylog2-web-interface/src/views/components/visualizations/PlotLegend.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/PlotLegend.tsx
@@ -43,7 +43,7 @@ const ColorHint = styled.div(({ color }) => `
 const Container = styled.div`
   display: grid;
   grid-template: 4fr auto / 1fr;
-  grid-template-areas: "." ".";
+  grid-template-areas: '.' '.';
   height: 100%;
 `;
 

--- a/graylog2-web-interface/src/views/components/widgets/StickyBottomActions.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/StickyBottomActions.tsx
@@ -42,13 +42,13 @@ const Actions = styled.div<{ $scrolledToBottom: boolean, $alignAtBottom: boolean
   display: flex;
   flex-direction: column;
   flex: 1;
-  justify-content: ${$alignAtBottom ? "flex-end" : "space-between"};
+  justify-content: ${$alignAtBottom ? 'flex-end' : 'space-between'};
   padding-top: 5px;
 
   ::before {
     box-shadow: 1px -2px 3px rgb(0 0 0 / 25%);
-    content: " ";
-    display: ${$scrolledToBottom ? "block" : "none"};
+    content: ' ';
+    display: ${$scrolledToBottom ? 'block' : 'none'};
     height: 3px;
     position: absolute;
     left: 0;


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

There are some cases where ESLint enforced single quotes:
`display: ${$show ? 'block' : 'none'};`

Before this change Stylelint threw an error in this case because it expected double quotes.

/nocl