### PR TITLE
Favorite: use DTO on creation to also submit the type

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/favorites/FavoritesResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/favorites/FavoritesResource.java
@@ -22,11 +22,14 @@ import io.swagger.annotations.ApiParam;
 import org.apache.shiro.authz.annotation.RequiresAuthentication;
 import org.graylog.plugins.views.audit.ViewsAuditEventTypes;
 import org.graylog.plugins.views.search.permissions.SearchUser;
+import org.graylog.plugins.views.search.views.ViewDTO;
 import org.graylog2.audit.jersey.AuditEvent;
 import org.graylog2.rest.models.PaginatedResponse;
 
 import javax.inject.Inject;
+import javax.validation.Valid;
 import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
@@ -62,12 +65,24 @@ public class FavoritesResource {
         return favoritesService.findFavoritesFor(searchUser, type, page, perPage);
     }
 
+    /**
+     *  method will get removed asap in favor of the method that receives a body
+     */
     @PUT
     @Path("/{id}")
     @ApiOperation("Add an item for inclusion on the Start Page for the user")
     @AuditEvent(type = ViewsAuditEventTypes.DYNAMIC_STARTUP_PAGE_ADD_FAVORITE_ITEM)
-    public void addItemToFavorites(@ApiParam(name = "id", required = true) @PathParam("id") @NotEmpty String id, @Context SearchUser searchUser) {
+    @Deprecated
+    public void deprecatedAddItemToFavorites(@ApiParam(name = "id", required = true) @PathParam("id") @NotEmpty String id, @Context SearchUser searchUser) {
         favoritesService.addFavoriteItemFor(id, searchUser);
+    }
+
+    @PUT
+    @ApiOperation("Add an item for inclusion on the Start Page for the user")
+    @AuditEvent(type = ViewsAuditEventTypes.DYNAMIC_STARTUP_PAGE_ADD_FAVORITE_ITEM)
+    @Deprecated
+    public void addItemToFavorites(@ApiParam @NotNull(message = "Favorite is mandatory") FavoriteDTO dto, @Context SearchUser searchUser) {
+        favoritesService.addFavoriteItemFor(dto, searchUser);
     }
 
     @DELETE

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/favorites/FavoritesService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/favorites/FavoritesService.java
@@ -65,9 +65,9 @@ public class FavoritesService extends PaginatedDbService<FavoritesForUserDTO> {
         return PaginatedResponse.create("favorites", new PaginatedList<>(getPage(items, page, perPage), items.size(), page, perPage));
     }
 
-    public void addFavoriteItemFor(final String id, final SearchUser searchUser) {
+    protected void addFavoriteItemFor(final String id, final String type, final SearchUser searchUser) {
         final var favorites = this.findForUser(searchUser);
-        final var item = new FavoriteDTO(id, catalog.getType(id));
+        final var item = new FavoriteDTO(id, type);
         if(favorites.isPresent()) {
             var fi = favorites.get();
             fi.items().add(item);
@@ -76,6 +76,14 @@ public class FavoritesService extends PaginatedDbService<FavoritesForUserDTO> {
             var items = new FavoritesForUserDTO(searchUser.getUser().getId(), List.of(item));
             this.create(items, searchUser);
         }
+    }
+
+    public void addFavoriteItemFor(final FavoriteDTO dto, final SearchUser searchUser) {
+        this.addFavoriteItemFor(dto.id(), dto.type(), searchUser);
+    }
+
+    public void addFavoriteItemFor(final String id, final SearchUser searchUser) {
+        this.addFavoriteItemFor(id, catalog.getType(id), searchUser);
     }
 
     public void removeFavoriteItemFor(final String id, final SearchUser searchUser) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Uses the DTO in the body on a PUT so we can also specify the type on creation.

The old method should be removed (is tagged as deprecated) when the FE implemented usage of the new method.

/nocl
fixes: #14401

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

