### PR TITLE
Decode Security Views correctly for the Last Opened Feature of the StartPage

### DIFF
--- a/graylog2-server/src/test/java/org/graylog/plugins/views/startpage/StartPageServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/startpage/StartPageServiceTest.java
@@ -26,6 +26,7 @@ import org.graylog.plugins.views.search.permissions.SearchUser;
 import org.graylog.plugins.views.search.rest.TestSearchUser;
 import org.graylog.plugins.views.search.rest.TestUser;
 import org.graylog.plugins.views.search.views.ViewDTO;
+import org.graylog.plugins.views.search.views.ViewResolver;
 import org.graylog.plugins.views.startpage.lastOpened.LastOpened;
 import org.graylog.plugins.views.startpage.lastOpened.LastOpenedDTO;
 import org.graylog.plugins.views.startpage.lastOpened.LastOpenedForUserDTO;
@@ -50,7 +51,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
+import java.util.function.BiPredicate;
+import java.util.function.Predicate;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -118,7 +123,28 @@ public class StartPageServiceTest {
         var entityOwnerShipService = new EntityOwnershipService(dbGrantService, grnRegistry);
         var lastOpenedService = new LastOpenedService(mongodb.mongoConnection(), mongoJackObjectMapperProvider, entityOwnerShipService);
         var recentActivityService = new RecentActivityService(mongodb.mongoConnection(), mongoJackObjectMapperProvider, eventbus, grnRegistry, permissionAndRoleResolver);
-        startPageService = new StartPageService(new TestCatalog(), lastOpenedService, recentActivityService, eventbus);
+        var viewResolvers = Map.of("graylog-security-views", (ViewResolver)new ViewResolver() {
+            @Override
+            public Optional<ViewDTO> get(String id) {
+                return Optional.empty();
+            }
+
+            @Override
+            public Set<ViewDTO> getBySearchId(String searchId) {
+                return Set.of();
+            }
+
+            @Override
+            public Set<String> getSearchIds() {
+                return Set.of();
+            }
+
+            @Override
+            public boolean canReadView(String viewId, Predicate<String> permissionTester, BiPredicate<String, String> entityPermissionsTester) {
+                return false;
+            }
+        });
+        startPageService = new StartPageService(new TestCatalog(), lastOpenedService, recentActivityService, viewResolvers, eventbus);
     }
 
     @Test


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The pre-configured Security Views are not part of the regular Entity-Catalog so they need special handling.
<img width="535" alt="Screenshot 2023-01-23 at 15 04 27" src="https://user-images.githubusercontent.com/1190735/214306540-7db1c3f5-2870-49e7-b381-bfa6a5bd1548.png">

/nocl

abandoned for now, see #14549 and also #14548

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

