### PR TITLE
Retention improvements

### DIFF
--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/IndicesAdapterES7.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/IndicesAdapterES7.java
@@ -253,6 +253,7 @@ public class IndicesAdapterES7 implements IndicesAdapter {
     @Override
     public void setReadOnly(String index) {
         // https://www.elastic.co/guide/en/elasticsearch/reference/7.8/indices-update-settings.html
+        // https://www.elastic.co/guide/en/elasticsearch/reference/7.10/index-modules-blocks.html
         final Map<String, Object> settings = ImmutableMap.of(
                 "index", ImmutableMap.of("blocks",
                         ImmutableMap.of(

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/IndicesAdapterOS2.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/IndicesAdapterOS2.java
@@ -253,6 +253,7 @@ public class IndicesAdapterOS2 implements IndicesAdapter {
     @Override
     public void setReadOnly(String index) {
         // https://www.elastic.co/guide/en/elasticsearch/reference/7.8/indices-update-settings.html
+        // https://www.elastic.co/guide/en/elasticsearch/reference/7.10/index-modules-blocks.html
         final Map<String, Object> settings = ImmutableMap.of(
                 "index", ImmutableMap.of("blocks",
                         ImmutableMap.of(

--- a/graylog2-server/src/main/java/org/graylog2/indexer/SetIndexReadOnlyJob.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/SetIndexReadOnlyJob.java
@@ -82,11 +82,12 @@ public class SetIndexReadOnlyJob extends SystemJob {
         log.info("Flushing old index <{}>.", index);
         indices.flush(index);
 
+        // Record the time an index was set read-only.
+        // We call this the "closing date" because it denotes when we stopped writing to it.
+        indices.setClosingDate(index, Tools.nowUTC());
+
         log.info("Setting old index <{}> to read-only.", index);
         indices.setReadOnly(index);
-
-        // record time index was "closed"
-        indices.setClosingDate(index, Tools.nowUTC());
 
         activityWriter.write(new Activity("Flushed and set <" + index + "> to read-only.", SetIndexReadOnlyJob.class));
 


### PR DESCRIPTION
After the index rotation, we asynchronously start the
`SetIndexReadOnlyJob`, which will flush the index, set the index read only and
then set the closing Date.

This means that there is a time frame, where we can have rotated indices
that still haven't received their closing Date.

The retention strategy would falsely assume that it is missing and
fallback to using the creation date.

Avoid this by fetching the `IndicesBlockStatus` and use it to filter
only indices that are read only ("index.blocks.write")

Add a test for the backwards compatible retention without a closing date.


/nocl

/jenkins-pr-deps https://github.com/Graylog2/graylog-plugin-enterprise/pull/4572