### PR TITLE
Fix rotation leeway computation

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchConfiguration.java
@@ -48,6 +48,7 @@ public class ElasticsearchConfiguration {
     public static final String DEFAULT_SYSTEM_EVENTS_INDEX_PREFIX = "default_system_events_index_prefix";
     public static final String TIME_SIZE_OPTIMIZING_ROTATION_MIN_SIZE = "time_size_optimizing_rotation_min_size";
     public static final String TIME_SIZE_OPTIMIZING_ROTATION_MAX_SIZE = "time_size_optimizing_rotation_max_size";
+    public static final String TIME_SIZE_OPTIMIZING_ROTATION_PERIOD = "time_size_optimizing_rotation_period";
 
     @Parameter(value = "elasticsearch_index_prefix", required = true)
     private String defaultIndexPrefix = "graylog";
@@ -106,7 +107,7 @@ public class ElasticsearchConfiguration {
     private int maxNumberOfIndices = 20;
 
     // TimeBasedSizeOptimizingStrategy Rotation
-    @Parameter(value = "time_size_optimizing_rotation_period")
+    @Parameter(value = TIME_SIZE_OPTIMIZING_ROTATION_PERIOD)
     private Period timeSizeOptimizingRotationPeriod = Period.days(1);
 
     @Parameter(value = TIME_SIZE_OPTIMIZING_ROTATION_MIN_SIZE)

--- a/graylog2-server/src/main/java/org/graylog2/indexer/IndexSetValidator.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/IndexSetValidator.java
@@ -36,6 +36,7 @@ import javax.inject.Inject;
 import java.util.Arrays;
 import java.util.Optional;
 
+import static org.graylog2.configuration.ElasticsearchConfiguration.TIME_SIZE_OPTIMIZING_ROTATION_PERIOD;
 import static org.graylog2.indexer.rotation.strategies.TimeBasedSizeOptimizingStrategyConfig.INDEX_LIFETIME_HARD;
 import static org.graylog2.indexer.rotation.strategies.TimeBasedSizeOptimizingStrategyConfig.INDEX_LIFETIME_SOFT;
 import static org.graylog2.shared.utilities.StringUtils.f;
@@ -112,6 +113,10 @@ public class IndexSetValidator {
             if (leeway.toStandardSeconds().getSeconds() < 0) {
                 return Violation.create(f("%s <%s> is shorter than %s <%s>", INDEX_LIFETIME_HARD, config.indexLifetimeHard(),
                         INDEX_LIFETIME_SOFT, config.indexLifetimeSoft()));
+            }
+            if (leeway.toStandardSeconds().isLessThan(elasticsearchConfiguration.getTimeSizeOptimizingRotationPeriod().toStandardSeconds())) {
+                return Violation.create(f("The duration between %s and %s <%s> cannot be shorter than %s <%s>", INDEX_LIFETIME_HARD, INDEX_LIFETIME_SOFT,
+                        leeway, TIME_SIZE_OPTIMIZING_ROTATION_PERIOD, elasticsearchConfiguration.getTimeSizeOptimizingRotationPeriod()));
             }
 
             final Period maxRetentionPeriod = elasticsearchConfiguration.getMaxIndexRetentionPeriod();

--- a/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/TimeBasedSizeOptimizingStrategy.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/TimeBasedSizeOptimizingStrategy.java
@@ -27,7 +27,6 @@ import org.graylog2.plugin.system.NodeId;
 import org.graylog2.shared.utilities.StringUtils;
 import org.joda.time.DateTime;
 import org.joda.time.Period;
-import org.joda.time.Seconds;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -111,8 +110,7 @@ public class TimeBasedSizeOptimizingStrategy extends AbstractRotationStrategy {
     }
 
     private boolean indexExceedsLeeWay(DateTime creationDate, Period leeWay) {
-        final Seconds leewaySeconds = Seconds.seconds(leeWay.toStandardSeconds().getSeconds());
-        return timePassedIsBeyondLimit(creationDate, rotationPeriod.plus(leewaySeconds));
+        return timePassedIsBeyondLimit(creationDate, leeWay);
     }
 
     private boolean indexIsOldEnough(DateTime creationDate) {

--- a/graylog2-server/src/test/java/org/graylog2/indexer/IndexSetValidatorTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/IndexSetValidatorTest.java
@@ -152,6 +152,8 @@ public class IndexSetValidatorTest {
         // no max retention period configured
         assertThat(validator.validate(testIndexSetConfig())).isNotPresent();
 
+        when(elasticsearchConfiguration.getTimeSizeOptimizingRotationPeriod()).thenReturn(Period.days(1));
+
         // max retention period >= effective retention period
         when(elasticsearchConfiguration.getMaxIndexRetentionPeriod()).thenReturn(Period.days(10));
         assertThat(validator.validate(testIndexSetConfig())).isNotPresent();
@@ -186,6 +188,8 @@ public class IndexSetValidatorTest {
 
     @Test
     public void timeBasedSizeOptimizingOnlyWithMultipleOfDays() {
+        when(elasticsearchConfiguration.getTimeSizeOptimizingRotationPeriod()).thenReturn(Period.days(1));
+
         when(indexSetRegistry.iterator()).thenReturn(Collections.emptyIterator());
         final IndexSetConfig sizeOptimizingConfig = testIndexSetConfig().toBuilder()
                 .rotationStrategyClass(TimeBasedSizeOptimizingStrategy.class.getCanonicalName())

--- a/graylog2-server/src/test/java/org/graylog2/indexer/rotation/strategies/TimeBasedSizeOptimizingRotationAndRetentionTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/rotation/strategies/TimeBasedSizeOptimizingRotationAndRetentionTest.java
@@ -188,7 +188,7 @@ class TimeBasedSizeOptimizingRotationAndRetentionTest {
         // but exceeds the optimization "leeway" ( indexLifetimeHard - indexLifetimeSoft) (6 - 4) = 2 days
         // it will also be rotated.
         indexSet.getNewest().setSize(100);
-        clock.plus(3, TimeUnit.DAYS);
+        clock.plus(2, TimeUnit.DAYS);
         timeBasedSizeOptimizingStrategy.rotate(indexSet);
         assertThat(indexSet.getIndicesNames()).isEqualTo(List.of("test_0", "test_1", "test_2", "test_3", "test_4"));
     }
@@ -207,7 +207,7 @@ class TimeBasedSizeOptimizingRotationAndRetentionTest {
         assertThat(indexSet.getIndicesNames()).isEqualTo(List.of("test_1", "test_2", "test_3", "test_4"));
 
         // Moving forward in time will retain more indices
-        clock.plus(12, TimeUnit.HOURS);
+        clock.plus(36, TimeUnit.HOURS);
         deletionRetentionStrategy.retain(indexSet);
         assertThat(indexSet.getIndicesNames()).isEqualTo(List.of("test_2", "test_3", "test_4"));
 


### PR DESCRIPTION
- Add validation for minimum required leeway

 index_liftime_soft == index_liftime_hard would result in a leeway of 0.
 Having a leeway of zero means that we effectivly cannot store any data
 in the index. We cannot meet both requirements: the minimum retention 
 (soft) and the maximum retention (hard) would contradict each other.

- Don't add rotation period to leeway computation

 This was a mistake made earlier, when I was still under the assumption
 that a leeway of zero is a valid possible configuration.

/nocl

/jenkins-pr-deps https://github.com/Graylog2/graylog-plugin-enterprise/pull/4572
