### PR TITLE
Retrieving widgets/positions from `ViewStore` to avoid race condition.

### DIFF
--- a/graylog2-web-interface/src/views/components/WidgetComponent.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetComponent.tsx
@@ -29,10 +29,10 @@ import View from 'views/logic/views/View';
 import { useStore } from 'stores/connect';
 import { TitlesStore } from 'views/stores/TitlesStore';
 import defaultTitle from 'views/components/defaultTitle';
-import { WidgetStore } from 'views/stores/WidgetStore';
 import TitleTypes from 'views/stores/TitleTypes';
 import useViewType from 'views/hooks/useViewType';
 import type WidgetType from 'views/logic/widgets/Widget';
+import { ViewStore } from 'views/stores/ViewStore';
 
 import { Position } from './widgets/WidgetPropTypes';
 import Widget from './widgets/Widget';
@@ -47,7 +47,12 @@ type Props = {
   widgetId: string,
 };
 
-const useWidget = (widgetId: string) => useStore(WidgetStore, (state) => state.get(widgetId));
+const useWidget = (widgetId: string) => useStore(ViewStore, (state) => {
+  const { view } = state;
+  const widgets = view.state.valueSeq().flatMap((s) => s.widgets).toArray();
+
+  return widgets.find((w) => w.id === widgetId);
+});
 const useTitle = (widget: WidgetType) => useStore(TitlesStore, (titles) => titles?.getIn([TitleTypes.Widget, widget.id], defaultTitle(widget)) as string);
 
 const WidgetComponent = ({

--- a/graylog2-web-interface/src/views/components/WidgetGrid.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetGrid.tsx
@@ -26,12 +26,9 @@ import type { FocusContextState } from 'views/components/contexts/WidgetFocusCon
 import WidgetFocusContext from 'views/components/contexts/WidgetFocusContext';
 import type { FieldTypeMappingsList } from 'views/logic/fieldtypes/types';
 import { useStore } from 'stores/connect';
-import { WidgetStore } from 'views/stores/WidgetStore';
 import { CurrentViewStateActions } from 'views/stores/CurrentViewStateStore';
 import FieldTypesContext from 'views/components/contexts/FieldTypesContext';
 import InteractiveContext from 'views/components/contexts/InteractiveContext';
-import type { StoreState } from 'stores/StoreTypes';
-import { ViewStatesStore } from 'views/stores/ViewStatesStore';
 import ElementDimensions from 'components/common/ElementDimensions';
 import useActiveQueryId from 'views/hooks/useActiveQueryId';
 import findGaps from 'views/components/GridGaps';
@@ -39,6 +36,7 @@ import generateId from 'logic/generateId';
 import NewWidgetPlaceholder from 'views/components/NewWidgetPlaceholder';
 import CreateNewWidgetModal from 'views/components/CreateNewWidgetModal';
 import isDeepEqual from 'stores/isDeepEqual';
+import type { ViewStoreState } from 'views/stores/ViewStore';
 import { ViewActions, ViewStore } from 'views/stores/ViewStore';
 
 import WidgetContainer from './WidgetContainer';
@@ -98,20 +96,6 @@ const WidgetGridItem = ({
                      position={widgetPosition}
                      widgetId={widgetId} />
   );
-};
-
-const generatePositions = (widgets: Array<{ id: string, type: string }>, positions: { [widgetId: string]: WidgetPosition }) => Object.fromEntries(
-  widgets.map<[string, WidgetPosition]>(({ id, type }) => [id, positions[id] ?? _defaultDimensions(type)]),
-);
-
-const mapWidgetPositions = (states: StoreState<typeof ViewStatesStore>) => Object.fromEntries(states.toArray().flatMap((state) => Object.entries(state.widgetPositions)));
-const mapWidgets = (state: StoreState<typeof WidgetStore>) => state.map(({ id, type }) => ({ id, type })).toArray();
-
-const useWidgetPositions = (): WidgetPositions => {
-  const initialPositions = useStore(ViewStatesStore, mapWidgetPositions);
-  const widgets = useStore(WidgetStore, mapWidgets);
-
-  return useMemo(() => generatePositions(widgets, initialPositions), [widgets, initialPositions]);
 };
 
 type GridProps = {
@@ -206,14 +190,33 @@ const renderGaps = (widgets: { id: string, type: string}[], positions: WidgetPos
   return [gapsItems, _positions] as const;
 };
 
+const generatePositions = (widgets: Array<{ id: string, type: string }>, positions: { [widgetId: string]: WidgetPosition }) => Object.fromEntries(
+  widgets.map<[string, WidgetPosition]>(({ id, type }) => [id, positions[id] ?? _defaultDimensions(type)]),
+);
+
+const mapWidgetsAndPositions = (store: ViewStoreState) => {
+  const { activeQuery, view } = store;
+  const currentViewState = view.state.get(activeQuery);
+  const { widgets, widgetPositions } = currentViewState;
+  const positions = generatePositions(widgets.toArray(), widgetPositions);
+
+  return {
+    widgets: widgets.map(({ id, type }) => ({ id, type })).toArray().reverse(),
+    positions,
+  };
+};
+
+const useWidgetsAndPositions = () => {
+  return useStore(ViewStore, mapWidgetsAndPositions);
+};
+
 const WidgetGrid = () => {
   const isInteractive = useContext(InteractiveContext);
   const { focusedWidget } = useContext(WidgetFocusContext);
   const [lastUpdate, setLastUpdate] = useState<string>(undefined);
   const preventDoubleUpdate = useRef<BackendWidgetPosition[]>();
 
-  const widgets = useStore(WidgetStore, (state) => state.map(({ id, type }) => ({ id, type })).toArray().reverse());
-  const positions = useWidgetPositions();
+  const { widgets, positions } = useWidgetsAndPositions();
 
   const onPositionsChange = useCallback((newPositions: Array<BackendWidgetPosition>) => {
     preventDoubleUpdate.current = newPositions;


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Prior to this PR, a race condition existed that resulted in wrong widget dimensions being used after switching dashboard tabs.

This change is now extracting widgets and positions directly from the `ViewStore`, to avoid race conditions when the `activeQuery` is changed, but the changed widgets/positions have not been propagated to other stores yet.

Fixes #14478.

/nocl

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.