### PR TITLE
Fix grouping in aggregation builder for fields which only exist in event streams. (`4.3`)

### DIFF
--- a/changelog/unreleased/issue-14404.toml
+++ b/changelog/unreleased/issue-14404.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Fix grouping in aggregation builder for fields which only exist in the All Events, All System Events or Processing and Indexing Failures stream."
+
+issues = ["14387"]
+pulls = ["14404"]

--- a/graylog2-web-interface/src/views/components/WidgetComponent.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetComponent.tsx
@@ -17,13 +17,11 @@
 import * as React from 'react';
 import { useContext, useMemo } from 'react';
 import PropTypes from 'prop-types';
-import type * as Immutable from 'immutable';
 
 import type { BackendWidgetPosition } from 'views/types';
 import { AdditionalContext } from 'views/logic/ActionContext';
 import WidgetContext from 'views/components/contexts/WidgetContext';
 import type WidgetPosition from 'views/logic/widgets/WidgetPosition';
-import type TFieldTypeMapping from 'views/logic/fieldtypes/FieldTypeMapping';
 import ExportSettingsContextProvider from 'views/components/ExportSettingsContextProvider';
 import ViewTypeContext from 'views/components/contexts/ViewTypeContext';
 import View from 'views/logic/views/View';
@@ -40,7 +38,6 @@ import WidgetFieldTypesContextProvider from './contexts/WidgetFieldTypesContextP
 
 type Props = {
   editing: boolean,
-  fields: Immutable.List<TFieldTypeMapping>,
   onPositionsChange: (position: BackendWidgetPosition) => void,
   position: WidgetPosition,
   widgetId: string,
@@ -48,7 +45,6 @@ type Props = {
 
 const WidgetComponent = ({
   editing,
-  fields,
   onPositionsChange = () => undefined,
   position,
   widgetId,
@@ -67,7 +63,6 @@ const WidgetComponent = ({
           <ExportSettingsContextProvider>
             <WidgetFieldTypesIfDashboard>
               <Widget editing={editing}
-                      fields={fields}
                       id={widget.id}
                       onPositionsChange={onPositionsChange}
                       position={position}
@@ -83,7 +78,6 @@ const WidgetComponent = ({
 
 WidgetComponent.propTypes = {
   editing: PropTypes.bool.isRequired,
-  fields: PropTypes.object.isRequired,
   onPositionsChange: PropTypes.func,
   position: PropTypes.shape(Position).isRequired,
 };

--- a/graylog2-web-interface/src/views/components/WidgetGrid.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetGrid.tsx
@@ -24,13 +24,10 @@ import { widgetDefinition } from 'views/logic/Widgets';
 import WidgetPosition from 'views/logic/widgets/WidgetPosition';
 import type { FocusContextState } from 'views/components/contexts/WidgetFocusContext';
 import WidgetFocusContext from 'views/components/contexts/WidgetFocusContext';
-import type { FieldTypeMappingsList } from 'views/logic/fieldtypes/types';
 import { useStore } from 'stores/connect';
 import { WidgetStore } from 'views/stores/WidgetStore';
 import { CurrentViewStateActions } from 'views/stores/CurrentViewStateStore';
-import FieldTypesContext from 'views/components/contexts/FieldTypesContext';
 import InteractiveContext from 'views/components/contexts/InteractiveContext';
-import { ViewMetadataStore } from 'views/stores/ViewMetadataStore';
 import type { StoreState } from 'stores/StoreTypes';
 import { ViewStatesStore } from 'views/stores/ViewStatesStore';
 import ElementDimensions from 'components/common/ElementDimensions';
@@ -68,7 +65,6 @@ const _defaultDimensions = (type) => {
 };
 
 type WidgetsProps = {
-  fields: FieldTypeMappingsList,
   widgetId: string,
   focusedWidget: FocusContextState | undefined,
   onPositionsChange: (position: BackendWidgetPosition) => void,
@@ -76,7 +72,6 @@ type WidgetsProps = {
 };
 
 const WidgetGridItem = ({
-  fields,
   onPositionsChange,
   positions,
   widgetId,
@@ -87,7 +82,6 @@ const WidgetGridItem = ({
 
   return (
     <WidgetComponent editing={editing}
-                     fields={fields}
                      onPositionsChange={onPositionsChange}
                      position={widgetPosition}
                      widgetId={widgetId} />
@@ -134,13 +128,6 @@ const Grid = ({ children, locked, onPositionsChange, positions, width }: GridPro
   );
 };
 
-const useQueryFieldTypes = () => {
-  const fieldTypes = useContext(FieldTypesContext);
-  const queryId = useStore(ViewMetadataStore, (viewMetadataStore) => viewMetadataStore.activeQuery);
-
-  return useMemo(() => fieldTypes.queryFields.get(queryId, fieldTypes.all), [fieldTypes.all, fieldTypes.queryFields, queryId]);
-};
-
 const MAXIMUM_GRID_SIZE = 12;
 
 const convertPosition = ({ col, row, height, width }: BackendWidgetPosition) => new WidgetPosition(col, row, height, width >= MAXIMUM_GRID_SIZE ? Infinity : width);
@@ -164,8 +151,6 @@ const WidgetGrid = () => {
 
   const positions = useWidgetPositions();
 
-  const fields = useQueryFieldTypes();
-
   const children = useMemo(() => widgets.map(({ id: widgetId }) => {
     const position = positions[widgetId];
 
@@ -175,14 +160,13 @@ const WidgetGrid = () => {
 
     return (
       <WidgetContainer key={widgetId} isFocused={focusedWidget?.id === widgetId && focusedWidget?.focusing}>
-        <WidgetGridItem fields={fields}
-                        positions={positions}
+        <WidgetGridItem positions={positions}
                         widgetId={widgetId}
                         focusedWidget={focusedWidget}
                         onPositionsChange={onPositionChange} />
       </WidgetContainer>
     );
-  }).filter((x) => (x !== null)), [fields, focusedWidget, positions, widgets]);
+  }).filter((x) => (x !== null)), [focusedWidget, positions, widgets]);
 
   // Measuring the width is required to update the widget grid
   // when its content height results in a scrollbar

--- a/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.groupBy.test.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.groupBy.test.tsx
@@ -23,7 +23,7 @@ import type { PluginRegistration } from 'graylog-web-plugin/plugin';
 import { PluginStore } from 'graylog-web-plugin/plugin';
 import { applyTimeoutMultiplier } from 'jest-preset-graylog/lib/timeouts';
 
-import { MockStore } from 'helpers/mocking';
+import { asMock } from 'helpers/mocking';
 import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
 import DataTable from 'views/components/datatable/DataTable';
 import FieldType, { FieldTypes } from 'views/logic/fieldtypes/FieldType';
@@ -31,18 +31,19 @@ import FieldTypeMapping from 'views/logic/fieldtypes/FieldTypeMapping';
 import FieldTypesContext from 'views/components/contexts/FieldTypesContext';
 import Pivot from 'views/logic/aggregationbuilder/Pivot';
 import dataTable from 'views/components/datatable/bindings';
+import DataTableVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/DataTableVisualizationConfig';
+import useActiveQueryId from 'views/hooks/useActiveQueryId';
 
 import AggregationWizard from '../AggregationWizard';
 
 const extendedTimeout = applyTimeoutMultiplier(15000);
 
-jest.mock('views/stores/ViewMetadataStore', () => ({
-  ViewMetadataStore: MockStore(['getInitialState', () => ({ activeQuery: 'queryId' })]),
-}));
+jest.mock('views/hooks/useActiveQueryId');
 
 const widgetConfig = AggregationWidgetConfig
   .builder()
   .visualization(DataTable.type)
+  .visualizationConfig(DataTableVisualizationConfig.empty())
   .build();
 
 const fieldType = new FieldType('field_type', ['numeric'], []);
@@ -62,7 +63,7 @@ const addElement = async (key: 'Grouping' | 'Metric' | 'Sort') => {
 };
 
 const selectField = async (fieldName) => {
-  const fieldSelection = await screen.findByLabelText('Field');
+  const fieldSelection = await screen.findByLabelText('Fields');
 
   await act(async () => {
     await selectEvent.openMenu(fieldSelection);
@@ -71,21 +72,30 @@ const selectField = async (fieldName) => {
 };
 
 const submitWidgetConfigForm = async () => {
-  const applyButton = await screen.findByRole('button', { name: 'Update Preview' });
+  const applyButton = await screen.findByRole('button', { name: /update preview/i });
   fireEvent.click(applyButton);
 };
 
 describe('AggregationWizard', () => {
-  const renderSUT = (props = {}) => render(
-    <FieldTypesContext.Provider value={fieldTypes}>
+  type Props = Partial<React.ComponentProps<typeof AggregationWizard>> & {
+    fieldTypesList?: {
+      all: FieldTypeMappingsList
+      queryFields: Map<string, FieldTypeMappingsList>,
+    }
+  }
+
+  const renderSUT = ({ fieldTypesList = fieldTypes, ...props }: Props = {}) => render(
+    <FieldTypesContext.Provider value={fieldTypesList}>
       <AggregationWizard config={widgetConfig}
                          editing
                          id="widget-id"
                          type="AGGREGATION"
+                         onSubmit={() => {}}
+                         onCancel={() => {}}
                          fields={Immutable.List([])}
                          onChange={() => {}}
                          {...props}>
-        <>The Visualization</>
+        <span>The Visualization</span>
       </AggregationWizard>,
     </FieldTypesContext.Provider>,
   );
@@ -93,6 +103,10 @@ describe('AggregationWizard', () => {
   beforeAll(() => PluginStore.register(plugin));
 
   afterAll(() => PluginStore.unregister(plugin));
+
+  beforeEach(() => {
+    asMock(useActiveQueryId).mockReturnValue('queryId');
+  });
 
   it('should require group by function when adding a group by element', async () => {
     renderSUT();
@@ -102,7 +116,7 @@ describe('AggregationWizard', () => {
     await screen.findByText('Field is required.');
   });
 
-  it('should change the config when applied', async () => {
+  it('should add pivot to widget config', async () => {
     const onChange = jest.fn();
     renderSUT({ onChange });
 
@@ -110,7 +124,7 @@ describe('AggregationWizard', () => {
     await selectField('took_ms');
     await submitWidgetConfigForm();
 
-    const pivot = Pivot.create('took_ms', 'values', { limit: 15 });
+    const pivot = Pivot.create(['took_ms'], 'values', { limit: 15 });
     const updatedConfig = widgetConfig
       .toBuilder()
       .rowPivots([pivot])
@@ -121,21 +135,45 @@ describe('AggregationWizard', () => {
     expect(onChange).toHaveBeenCalledWith(updatedConfig);
   });
 
-  it('should handle timestamp field types', async () => {
-    renderSUT();
+  it('should update config, even when field only exists for current query', async () => {
+    const onChange = jest.fn();
+    const queryFieldTypeMapping = new FieldTypeMapping('status_code', fieldType);
+    const queryFields = Immutable.List([queryFieldTypeMapping]);
+    renderSUT({ onChange, fieldTypesList: { all: fields, queryFields: Immutable.Map({ queryId: queryFields }) } });
 
     await addElement('Grouping');
-    await selectField('timestamp');
+    await selectField('status_code');
+    await submitWidgetConfigForm();
 
-    const autoCheckbox = await screen.findByRole('checkbox', { name: 'Auto' });
-    await screen.findByRole('slider', { name: /interval/i });
+    const pivot = Pivot.create(['status_code'], 'values');
+    const updatedConfig = widgetConfig
+      .toBuilder()
+      .rowPivots([pivot])
+      .build();
 
-    await userEvent.click(autoCheckbox);
+    await waitFor(() => expect(onChange).toHaveBeenCalledTimes(1));
 
-    await screen.findByRole('button', { name: /minutes/i });
-  }, extendedTimeout);
+    expect(onChange).toHaveBeenCalledWith(updatedConfig);
+  });
 
-  it('should create group by with multiple groupings', async () => {
+  it('should not throw an error when field in config no longer exists in field types list.', async () => {
+    const onChange = jest.fn();
+    const pivot = Pivot.create(['status_code'], 'values');
+    const initialConfig = widgetConfig
+      .toBuilder()
+      .rowPivots([pivot])
+      .build();
+
+    renderSUT({
+      onChange,
+      fieldTypesList: { all: Immutable.List([]), queryFields: Immutable.Map({ queryId: Immutable.List([]) }) },
+      config: initialConfig,
+    });
+
+    await screen.findByRole('button', { name: /update preview/i });
+  });
+
+  it('should add multiple pivots to widget', async () => {
     const onChange = jest.fn();
     renderSUT({ onChange });
 
@@ -143,7 +181,7 @@ describe('AggregationWizard', () => {
     await selectField('timestamp');
     await addElement('Grouping');
 
-    const fieldSelections = await screen.findAllByLabelText('Field');
+    const fieldSelections = await screen.findAllByLabelText('Fields');
 
     await act(async () => {
       await selectEvent.openMenu(fieldSelections[1]);
@@ -152,8 +190,8 @@ describe('AggregationWizard', () => {
 
     await submitWidgetConfigForm();
 
-    const pivot0 = Pivot.create('timestamp', 'time', { interval: { type: 'auto', scaling: 1 } });
-    const pivot1 = Pivot.create('took_ms', 'values', { limit: 15 });
+    const pivot0 = Pivot.create(['timestamp'], 'time', { interval: { type: 'auto', scaling: 1 } });
+    const pivot1 = Pivot.create(['took_ms'], 'values', { limit: 15 });
     const updatedConfig = widgetConfig
       .toBuilder()
       .rowPivots([pivot0, pivot1])
@@ -164,9 +202,101 @@ describe('AggregationWizard', () => {
     expect(onChange).toHaveBeenCalledWith(updatedConfig);
   }, extendedTimeout);
 
-  it('should display group by with values from config', async () => {
-    const pivot0 = Pivot.create('timestamp', 'time', { interval: { type: 'auto', scaling: 1 } });
-    const pivot1 = Pivot.create('took_ms', 'values', { limit: 15 });
+  it('should add pivot with type "date" to widget when adding time field', async () => {
+    const pivot = Pivot.create(['timestamp'], 'time', { interval: { type: 'timeunit', unit: 'minutes', value: 1 } });
+    const onChange = jest.fn();
+    renderSUT({ onChange });
+
+    await addElement('Grouping');
+    await selectField('timestamp');
+
+    const autoCheckbox = await screen.findByRole('checkbox', { name: 'Auto' });
+    await screen.findByRole('slider', { name: /interval/i });
+
+    await userEvent.click(autoCheckbox);
+
+    await screen.findByRole('button', { name: /minutes/i });
+
+    await submitWidgetConfigForm();
+
+    const updatedConfig = widgetConfig
+      .toBuilder()
+      .rowPivots([pivot])
+      .build();
+
+    await waitFor(() => expect(onChange).toHaveBeenCalledTimes(1));
+
+    expect(onChange).toHaveBeenCalledWith(updatedConfig);
+  }, extendedTimeout);
+
+  it('should add multiple fields to one pivot', async () => {
+    const initialPivot = Pivot.create(['took_ms'], 'values', { limit: 15 });
+    const updatedPivot = Pivot.create(['took_ms', 'http_method'], 'values', { limit: 15 });
+    const config = widgetConfig
+      .toBuilder()
+      .rowPivots([initialPivot])
+      .build();
+
+    const onChange = jest.fn();
+    renderSUT({ onChange, config });
+
+    await screen.findByText('took_ms');
+    await selectField('http_method');
+    await submitWidgetConfigForm();
+
+    const updatedConfig = widgetConfig
+      .toBuilder()
+      .rowPivots([updatedPivot])
+      .build();
+
+    await waitFor(() => expect(onChange).toHaveBeenCalledTimes(1));
+
+    expect(onChange).toHaveBeenCalledWith(updatedConfig);
+  });
+
+  it('should save pivot with type "values" when adding date and values field', async () => {
+    const initialPivot = Pivot.create(['took_ms'], 'values', { limit: 15 });
+    const updatedPivot = Pivot.create(['took_ms', 'timestamp'], 'values', { limit: 15 });
+    const config = widgetConfig
+      .toBuilder()
+      .rowPivots([initialPivot])
+      .build();
+
+    const onChange = jest.fn();
+    renderSUT({ onChange, config });
+
+    await screen.findByText('took_ms');
+    await selectField('timestamp');
+    await submitWidgetConfigForm();
+
+    const updatedConfig = widgetConfig
+      .toBuilder()
+      .rowPivots([updatedPivot])
+      .build();
+
+    await waitFor(() => expect(onChange).toHaveBeenCalledTimes(1));
+
+    expect(onChange).toHaveBeenCalledWith(updatedConfig);
+  });
+
+  it('should display limit field when all fields of a grouping have been removed', async () => {
+    const pivot = Pivot.create(['timestamp'], 'time', { interval: { type: 'timeunit', unit: 'minutes', value: 1 } });
+    const config = widgetConfig
+      .toBuilder()
+      .rowPivots([pivot])
+      .build();
+    renderSUT({ config });
+
+    const deleteFieldButton = await screen.findByRole('button', { name: /remove timestamp field/i });
+
+    userEvent.click(deleteFieldButton);
+
+    await screen.findByLabelText('Limit');
+  }, extendedTimeout);
+
+  it('should display groupings with values from config', async () => {
+    const pivot0 = Pivot.create(['timestamp'], 'time', { interval: { type: 'auto', scaling: 1 } });
+    const pivot1 = Pivot.create(['took_ms'], 'values', { limit: 15 });
     const config = widgetConfig
       .toBuilder()
       .rowPivots([pivot0, pivot1])
@@ -179,7 +309,7 @@ describe('AggregationWizard', () => {
   });
 
   it('should remove all groupings', async () => {
-    const pivot = Pivot.create('took_ms', 'values', { limit: 15 });
+    const pivot = Pivot.create(['took_ms'], 'values', { limit: 15 });
     const config = widgetConfig
       .toBuilder()
       .rowPivots([pivot])
@@ -211,37 +341,12 @@ describe('AggregationWizard', () => {
 
     const configureElementsSection = await screen.findByTestId('configure-elements-section');
 
-    expect(within(configureElementsSection).queryByText('Group By')).toBeInTheDocument();
-  });
-
-  it('should correctly change config', async () => {
-    const pivot0 = Pivot.create('timestamp', 'time', { interval: { type: 'auto', scaling: 1 } });
-    const pivot1 = Pivot.create('took_ms', 'values', { limit: 15 });
-    const config = widgetConfig
-      .toBuilder()
-      .rowPivots([pivot0])
-      .build();
-
-    const onChange = jest.fn();
-    renderSUT({ onChange, config });
-
-    await screen.findByText('timestamp');
-    await selectField('took_ms');
-    await submitWidgetConfigForm();
-
-    const updatedConfig = widgetConfig
-      .toBuilder()
-      .rowPivots([pivot1])
-      .build();
-
-    await waitFor(() => expect(onChange).toHaveBeenCalledTimes(1));
-
-    expect(onChange).toHaveBeenCalledWith(updatedConfig);
+    expect(within(configureElementsSection).getByText('Group By')).toBeInTheDocument();
   });
 
   it('should correctly update sort of groupings', async () => {
-    const pivot0 = Pivot.create('timestamp', 'time', { interval: { type: 'auto', scaling: 1 } });
-    const pivot1 = Pivot.create('took_ms', 'values', { limit: 15 });
+    const pivot0 = Pivot.create(['timestamp'], 'time', { interval: { type: 'auto', scaling: 1 } });
+    const pivot1 = Pivot.create(['took_ms'], 'values', { limit: 15 });
     const config = widgetConfig
       .toBuilder()
       .rowPivots([pivot0, pivot1])
@@ -265,6 +370,39 @@ describe('AggregationWizard', () => {
     const updatedConfig = widgetConfig
       .toBuilder()
       .rowPivots([pivot1, pivot0])
+      .build();
+
+    await waitFor(() => expect(onChange).toHaveBeenCalledTimes(1));
+
+    expect(onChange).toHaveBeenCalledWith(updatedConfig);
+  }, extendedTimeout);
+
+  it('should correctly update sort of grouping fields', async () => {
+    const initialPivot = Pivot.create(['http_method', 'took_ms'], 'values', { limit: 15 });
+    const updatedPivot = Pivot.create(['took_ms', 'http_method'], 'values', { limit: 15 });
+    const config = widgetConfig
+      .toBuilder()
+      .rowPivots([initialPivot])
+      .build();
+
+    const onChange = jest.fn();
+    renderSUT({ onChange, config });
+
+    const groupBySection = await screen.findByTestId('Group By-section');
+
+    const firstItem = within(groupBySection).getByTestId('grouping-0-field-0-drag-handle');
+    fireEvent.keyDown(firstItem, { key: 'Space', keyCode: 32 });
+    await screen.findByText(/You have lifted an item/i);
+    fireEvent.keyDown(firstItem, { key: 'ArrowDown', keyCode: 40 });
+    await screen.findByText(/You have moved the item/i);
+    fireEvent.keyDown(firstItem, { key: 'Space', keyCode: 32 });
+    await screen.findByText(/You have dropped the item/i);
+
+    await submitWidgetConfigForm();
+
+    const updatedConfig = widgetConfig
+      .toBuilder()
+      .rowPivots([updatedPivot])
       .build();
 
     await waitFor(() => expect(onChange).toHaveBeenCalledTimes(1));

--- a/graylog2-web-interface/src/views/components/aggregationwizard/grouping/configuration/FieldComponent.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/grouping/configuration/FieldComponent.tsx
@@ -20,6 +20,8 @@ import { useContext } from 'react';
 
 import FieldTypesContext from 'views/components/contexts/FieldTypesContext';
 import type { WidgetConfigFormValues } from 'views/components/aggregationwizard/WidgetConfigForm';
+import { useStore } from 'stores/connect';
+import { ViewStore } from 'views/stores/ViewStore';
 
 import FieldSelect from '../../FieldSelect';
 
@@ -30,11 +32,13 @@ type Props = {
 
 const FieldComponent = ({ index, fieldType }: Props) => {
   const fieldTypes = useContext(FieldTypesContext);
+  const activeQueryId = useStore(ViewStore, ({ activeQuery: currentQuery }) => currentQuery);
   const { setFieldValue } = useFormikContext<WidgetConfigFormValues>();
+  const queryFieldTypes = fieldTypes.queryFields.get(activeQueryId, fieldTypes.all);
 
   const onChangeField = (e, name, onChange) => {
     const fieldName = e.target.value;
-    const newField = fieldTypes.all.find((field) => field.name === fieldName);
+    const newField = queryFieldTypes.find((field) => field.name === fieldName);
     const newFieldType = newField?.type.type === 'date' ? 'time' : 'values';
 
     if (fieldType !== newFieldType) {

--- a/graylog2-web-interface/src/views/components/aggregationwizard/grouping/configuration/FieldComponent.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/grouping/configuration/FieldComponent.tsx
@@ -21,7 +21,7 @@ import { useContext } from 'react';
 import FieldTypesContext from 'views/components/contexts/FieldTypesContext';
 import type { WidgetConfigFormValues } from 'views/components/aggregationwizard/WidgetConfigForm';
 import { useStore } from 'stores/connect';
-import { ViewStore } from 'views/stores/ViewStore';
+import { ViewMetadataStore } from 'views/stores/ViewMetadataStore';
 
 import FieldSelect from '../../FieldSelect';
 
@@ -32,7 +32,7 @@ type Props = {
 
 const FieldComponent = ({ index, fieldType }: Props) => {
   const fieldTypes = useContext(FieldTypesContext);
-  const activeQueryId = useStore(ViewStore, ({ activeQuery: currentQuery }) => currentQuery);
+  const activeQueryId = useStore(ViewMetadataStore, (viewMetadataStore) => viewMetadataStore.activeQuery);
   const { setFieldValue } = useFormikContext<WidgetConfigFormValues>();
   const queryFieldTypes = fieldTypes.queryFields.get(activeQueryId, fieldTypes.all);
 

--- a/graylog2-web-interface/src/views/components/widgets/Widget.aggregations.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/Widget.aggregations.test.tsx
@@ -149,7 +149,6 @@ describe('Aggregation Widget', () => {
           <WidgetContext.Provider value={propsWidget}>
             <Widget widget={propsWidget}
                     id="widgetId"
-                    fields={Immutable.List([])}
                     onPositionsChange={() => {}}
                     title="Widget Title"
                     position={new WidgetPosition(1, 1, 1, 1)}

--- a/graylog2-web-interface/src/views/components/widgets/Widget.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/Widget.test.tsx
@@ -35,6 +35,7 @@ import type { ViewStoreState } from 'views/stores/ViewStore';
 import type { TitlesMap } from 'views/stores/TitleTypes';
 import useWidgetResults from 'views/components/useWidgetResults';
 import type SearchError from 'views/logic/SearchError';
+import type FieldTypeMapping from 'views/logic/fieldtypes/FieldTypeMapping';
 
 import Widget from './Widget';
 import type { Props as WidgetComponentProps } from './Widget';
@@ -42,6 +43,7 @@ import type { Props as WidgetComponentProps } from './Widget';
 import WidgetContext from '../contexts/WidgetContext';
 import type { WidgetFocusContextType } from '../contexts/WidgetFocusContext';
 import WidgetFocusContext from '../contexts/WidgetFocusContext';
+import FieldTypesContext from '../contexts/FieldTypesContext';
 
 jest.mock('../searchbar/queryinput/QueryInput', () => mockComponent('QueryInput'));
 jest.mock('./WidgetHeader', () => 'widget-header');
@@ -98,6 +100,11 @@ describe('<Widget />', () => {
     dirty: false,
   };
 
+  const fieldTypes = {
+    all: Immutable.List<FieldTypeMapping>(),
+    queryFields: Immutable.Map<string, Immutable.List<FieldTypeMapping>>(),
+  };
+
   beforeEach(() => {
     ViewStore.getInitialState = jest.fn(() => viewStoreState);
   });
@@ -119,18 +126,19 @@ describe('<Widget />', () => {
     unsetWidgetEditing = () => {},
     ...props
   }: DummyWidgetProps) => (
-    // eslint-disable-next-line react/jsx-no-constructed-context-values
-    <WidgetFocusContext.Provider value={{ focusedWidget, setWidgetFocusing, setWidgetEditing, unsetWidgetFocusing, unsetWidgetEditing }}>
-      <WidgetContext.Provider value={propsWidget}>
-        <Widget widget={propsWidget}
-                id="widgetId"
-                fields={Immutable.List([])}
-                onPositionsChange={() => {}}
-                title="Widget Title"
-                position={new WidgetPosition(1, 1, 1, 1)}
-                {...props} />
-      </WidgetContext.Provider>
-    </WidgetFocusContext.Provider>
+    <FieldTypesContext.Provider value={fieldTypes}>
+      {/* eslint-disable-next-line react/jsx-no-constructed-context-values */}
+      <WidgetFocusContext.Provider value={{ focusedWidget, setWidgetFocusing, setWidgetEditing, unsetWidgetFocusing, unsetWidgetEditing }}>
+        <WidgetContext.Provider value={propsWidget}>
+          <Widget widget={propsWidget}
+                  id="widgetId"
+                  onPositionsChange={() => {}}
+                  title="Widget Title"
+                  position={new WidgetPosition(1, 1, 1, 1)}
+                  {...props} />
+        </WidgetContext.Provider>
+      </WidgetFocusContext.Provider>
+    </FieldTypesContext.Provider>
   );
 
   it('should render with empty props', async () => {
@@ -188,7 +196,6 @@ describe('<Widget />', () => {
     const UnknownWidget = (props) => (
       <DummyWidget widget={unknownWidget}
                    id="widgetId"
-                   fields={[]}
                    onPositionsChange={() => {}}
                    onSizeChange={() => {}}
                    title="Widget Title"
@@ -211,17 +218,18 @@ describe('<Widget />', () => {
       .config({})
       .build();
     const UnknownWidget = (props) => (
-      <WidgetContext.Provider value={unknownWidget}>
-        <Widget widget={unknownWidget}
-                editing
-                id="widgetId"
-                fields={[]}
-                onPositionsChange={() => {}}
-                onSizeChange={() => {}}
-                title="Widget Title"
-                position={new WidgetPosition(1, 1, 1, 1)}
-                {...props} />
-      </WidgetContext.Provider>
+      <FieldTypesContext.Provider value={fieldTypes}>
+        <WidgetContext.Provider value={unknownWidget}>
+          <Widget widget={unknownWidget}
+                  editing
+                  id="widgetId"
+                  onPositionsChange={() => {}}
+                  onSizeChange={() => {}}
+                  title="Widget Title"
+                  position={new WidgetPosition(1, 1, 1, 1)}
+                  {...props} />
+        </WidgetContext.Provider>
+      </FieldTypesContext.Provider>
     );
 
     render(

--- a/graylog2-web-interface/src/views/components/widgets/Widget.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/Widget.tsx
@@ -38,6 +38,7 @@ import type WidgetConfig from 'views/logic/widgets/WidgetConfig';
 import type { FieldTypeMappingsList } from 'views/logic/fieldtypes/types';
 import useWidgetResults from 'views/components/useWidgetResults';
 import FieldTypesContext from 'views/components/contexts/FieldTypesContext';
+import { ViewMetadataStore } from 'views/stores/ViewMetadataStore';
 
 import WidgetFrame from './WidgetFrame';
 import WidgetHeader from './WidgetHeader';
@@ -75,9 +76,9 @@ const _editComponentForType = (type) => {
 
 const useQueryFieldTypes = () => {
   const fieldTypes = useContext(FieldTypesContext);
-  const activeQueryId = useStore(ViewStore, ({ activeQuery: currentQuery }) => currentQuery);
+  const queryId = useStore(ViewMetadataStore, (viewMetadataStore) => viewMetadataStore.activeQuery);
 
-  return useMemo(() => fieldTypes.queryFields.get(activeQueryId, fieldTypes.all), [fieldTypes.all, fieldTypes.queryFields, activeQueryId]);
+  return useMemo(() => fieldTypes.queryFields.get(queryId, fieldTypes.all), [fieldTypes.all, fieldTypes.queryFields, queryId]);
 };
 
 const WidgetFooter = styled.div`


### PR DESCRIPTION
_Please note, this is a backport of https://github.com/Graylog2/graylog2-server/pull/14387 for 4.3_

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

As described in #14404 an error can occur when creating a grouping for a field which only exists in the following streams: `All Events`, `All System Events` or `Processing and Indexing Failures`.

The error occurred because the field type only exists in the fields list of the current query, but the code implemented in the list for all field types, where the field type is not part of. That the field is not part of this list is correct, please have a look at https://github.com/Graylog2/graylog2-server/pull/11405 for more information.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

