### PR TITLE
Display entity data table bulk actions as dropdown.

### DIFF
--- a/graylog2-web-interface/src/components/common/EntityDataTable/BulkActions.tsx
+++ b/graylog2-web-interface/src/components/common/EntityDataTable/BulkActions.tsx
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import styled from 'styled-components';
+import { useCallback } from 'react';
+
+import MenuItem from 'components/bootstrap/MenuItem';
+import OverlayDropdownButton from 'components/common/OverlayDropdownButton';
+import StringUtils from 'util/StringUtils';
+
+const Container = styled.div`
+  display: flex;
+  align-items: center;
+`;
+
+const SelectedEntitiesAmount = styled.div`
+  margin-left: 5px;
+`;
+
+type Props = {
+  bulkActions?: (selectedEntities: Array<string>, setSelectedEntities: (streamIds: Array<string>) => void) => React.ReactNode
+  selectedEntities: Array<string>,
+  setSelectedEntities: React.Dispatch<React.SetStateAction<Array<string>>>
+
+};
+
+const BulkActions = ({ selectedEntities, setSelectedEntities, bulkActions }: Props) => {
+  const cancelEntitySelection = useCallback(() => setSelectedEntities([]), [setSelectedEntities]);
+
+  return (
+    <Container>
+      <OverlayDropdownButton title="Bulk actions"
+                             disabled={!selectedEntities?.length}
+                             bsSize="small"
+                             dropdownZIndex={1000}>
+        {bulkActions(selectedEntities, setSelectedEntities)}
+        <MenuItem divider />
+        <MenuItem onClick={cancelEntitySelection}>Cancel selection</MenuItem>
+      </OverlayDropdownButton>
+      {!!selectedEntities.length && (
+        <SelectedEntitiesAmount>
+          {selectedEntities.length} {StringUtils.pluralize(selectedEntities.length, 'item', 'items')} selected
+        </SelectedEntitiesAmount>
+      )}
+    </Container>
+  );
+};
+
+BulkActions.defaultProps = {
+  bulkActions: undefined,
+};
+
+export default BulkActions;

--- a/graylog2-web-interface/src/components/common/EntityDataTable/EntityDataTable.tsx
+++ b/graylog2-web-interface/src/components/common/EntityDataTable/EntityDataTable.tsx
@@ -20,16 +20,16 @@ import { useMemo, useState, useCallback, useRef } from 'react';
 import type * as Immutable from 'immutable';
 import { merge } from 'lodash';
 
-import { Button, Table, ButtonToolbar } from 'components/bootstrap';
+import { Table } from 'components/bootstrap';
 import { isPermitted, isAnyPermitted } from 'util/PermissionsMixin';
 import useCurrentUser from 'hooks/useCurrentUser';
-import StringUtils from 'util/StringUtils';
 import ColumnsVisibilitySelect from 'components/common/EntityDataTable/ColumnsVisibilitySelect';
 import DefaultColumnRenderers from 'components/common/EntityDataTable/DefaultColumnRenderers';
 import { CELL_PADDING, BULK_SELECT_COLUMN_WIDTH } from 'components/common/EntityDataTable/Constants';
 import useColumnsWidths from 'components/common/EntityDataTable/hooks/useColumnsWidths';
 import useElementDimensions from 'hooks/useElementDimensions';
 import type { Sort } from 'stores/PaginationTypes';
+import BulkActions from 'components/common/EntityDataTable/BulkActions';
 
 import TableHead from './TableHead';
 import TableRow from './TableRow';
@@ -53,15 +53,6 @@ const ActionsRow = styled.div`
   justify-content: space-between;
   margin-bottom: 10px;
   min-height: 22px;
-`;
-
-const BulkActionsWrapper = styled.div`
-  display: flex;
-  align-items: center;
-`;
-
-const BulkActions = styled(ButtonToolbar)`
-  margin-left: 5px;
 `;
 
 const filterAccessibleColumns = (
@@ -113,7 +104,7 @@ const useElementsWidths = <Entity extends EntityBase>({
 type Props<Entity extends EntityBase> = {
   /** Currently active sort */
   activeSort?: Sort,
-  /** Supported batch operations */
+  /** Supported bulk actions */
   bulkActions?: (selectedEntities: Array<string>, setSelectedEntities: (streamIds: Array<string>) => void) => React.ReactNode
   /** List of all available columns. */
   columnDefinitions: Array<Column>,
@@ -180,20 +171,14 @@ const EntityDataTable = <Entity extends EntityBase>({
     }));
   }, []);
 
-  const unselectAllItems = useCallback(() => setSelectedEntities([]), []);
-
   return (
     <>
       <ActionsRow>
         <div>
-          {(displayBulkSelectCol && !!selectedEntities?.length) && (
-            <BulkActionsWrapper>
-              {selectedEntities.length} {StringUtils.pluralize(selectedEntities.length, 'item', 'items')} selected
-              <BulkActions>
-                {bulkActions(selectedEntities, setSelectedEntities)}
-                <Button bsSize="xsmall" onClick={unselectAllItems}>Cancel</Button>
-              </BulkActions>
-            </BulkActionsWrapper>
+          {displayBulkSelectCol && (
+            <BulkActions bulkActions={bulkActions}
+                         selectedEntities={selectedEntities}
+                         setSelectedEntities={setSelectedEntities} />
           )}
         </div>
         <div>

--- a/graylog2-web-interface/src/components/streams/StreamsOverview/BulkActions.test.tsx
+++ b/graylog2-web-interface/src/components/streams/StreamsOverview/BulkActions.test.tsx
@@ -18,8 +18,8 @@ import * as React from 'react';
 import { render, screen, within, waitFor } from 'wrappedTestingLibrary';
 import userEvent from '@testing-library/user-event';
 import selectEvent from 'react-select-event';
-import { Streams } from '@graylog/server-api';
 
+import { Streams } from '@graylog/server-api';
 import UserNotification from 'util/UserNotification';
 import BulkActions from 'components/streams/StreamsOverview/BulkActions';
 import { indexSets } from 'fixtures/indexSets';
@@ -39,7 +39,7 @@ jest.mock('@graylog/server-api', () => ({
 
 describe('StreamsOverview BulkActions', () => {
   const assignIndexSet = async () => {
-    userEvent.click(await screen.findByRole('button', { name: /assign index set/i }));
+    userEvent.click(await screen.findByRole('menuitem', { name: /assign index set/i }));
 
     await screen.findByRole('heading', {
       name: /assign index set to 2 streams/i,

--- a/graylog2-web-interface/src/components/streams/StreamsOverview/BulkActions.tsx
+++ b/graylog2-web-interface/src/components/streams/StreamsOverview/BulkActions.tsx
@@ -19,9 +19,9 @@ import { uniq } from 'lodash';
 import { useQueryClient } from '@tanstack/react-query';
 import { useCallback, useState } from 'react';
 import { Formik, Form } from 'formik';
-import { Streams } from '@graylog/server-api';
 
-import { Button, Modal } from 'components/bootstrap';
+import { Streams } from '@graylog/server-api';
+import { Modal } from 'components/bootstrap';
 import StringUtils from 'util/StringUtils';
 import fetch from 'logic/rest/FetchProvider';
 import { qualifyUrl } from 'util/URLUtils';
@@ -31,6 +31,7 @@ import UserNotification from 'util/UserNotification';
 import ModalSubmit from 'components/common/ModalSubmit';
 import IfPermitted from 'components/common/IfPermitted';
 import type { IndexSet } from 'stores/indices/IndexSetsStore';
+import MenuItem from 'components/bootstrap/MenuItem';
 
 import IndexSetSelect from '../IndexSetSelect';
 
@@ -154,9 +155,9 @@ const BulkActions = ({ selectedStreamIds, refetchStreams, setSelectedStreamIds, 
   return (
     <>
       <IfPermitted permissions="indexsets:read">
-        <Button bsSize="xsmall" bsStyle="info" onClick={toggleAssignIndexSetModal}>Assign index set</Button>
+        <MenuItem onClick={toggleAssignIndexSetModal}>Assign index set</MenuItem>
       </IfPermitted>
-      <Button bsSize="xsmall" bsStyle="danger" onClick={onDelete}>Delete</Button>
+      <MenuItem onClick={onDelete}>Delete</MenuItem>
       {showIndexSetModal && (
         <AssignIndexSetModal selectedStreamIds={selectedStreamIds}
                              setSelectedStreamIds={setSelectedStreamIds}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

With this PR we are changing the way we display bulk actions for the entity data table.

Before:
<img width="360" alt="image" src="https://user-images.githubusercontent.com/46300478/215070588-b87e9715-8378-4b39-af9c-ca0a929b8d35.png">

After:
<img width="247" alt="image" src="https://user-images.githubusercontent.com/46300478/215070446-5d2a55c0-ac95-4561-a794-a0d2bd5206f9.png">

The new layout has a few benefits:
- it scales better, there are cases where we might will have over 10 bulk actions
- it looks cleaner, especially with many bulk actions
- it is easier to style the surrounding layout, because the bulk actions button width will not change a lot
- we unify the UI with similar cases in the application
