### PR TITLE
Don't add a LastOpenedEntry for Security Views

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/ViewsResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/ViewsResource.java
@@ -188,13 +188,7 @@ public class ViewsResource extends RestResource implements PluginRestResource {
 
         // Attempt to resolve the view from optional view resolvers before using the default database lookup.
         // The view resolvers must be used first, because the ID may not be a valid hex ID string.
-        ViewDTO view = resolveView(searchUser, id);
-        if (searchUser.canReadView(view)) {
-            startPageService.addLastOpenedFor(view, searchUser);
-            return view;
-        }
-
-        throw viewNotFoundException(id);
+        return resolveView(searchUser, id);
     }
 
     /**
@@ -210,13 +204,24 @@ public class ViewsResource extends RestResource implements PluginRestResource {
         if (decoder.isResolverViewId()) {
             final ViewResolver viewResolver = viewResolvers.get(decoder.getResolverName());
             if (viewResolver != null) {
-                return viewResolver.get(decoder.getViewId())
-                        .orElseThrow(() -> new NotFoundException("Failed to resolve view:" + id));
+                ViewDTO view = viewResolver.get(decoder.getViewId()).orElseThrow(() -> new NotFoundException("Failed to resolve view:" + id));
+                if (searchUser.canReadView(view)) {
+                    return view;
+                } else {
+                    throw viewNotFoundException(id);
+                }
             } else {
                 throw new NotFoundException("Failed to find view resolver: " + decoder.getResolverName());
             }
         } else {
-            return loadViewIncludingFavorite(searchUser, id);
+            ViewDTO view =  loadViewIncludingFavorite(searchUser, id);
+            if (searchUser.canReadView(view)) {
+                // Only register normal views in LastOpened, for ViewResolvers, a more global solution has to be found because of the catalog
+                startPageService.addLastOpenedFor(view, searchUser);
+                return view;
+            } else {
+                throw viewNotFoundException(id);
+            }
         }
     }
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Views resolved by a View Resolver (e.g. Security Views) should not create an entry in Last Opened. 

Because these entities are not really anchored in the Catalog yet, and the way to do it needs discussion.


/nocl

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

