### PR TITLE
Optimum index size should be based on shards

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchConfiguration.java
@@ -46,8 +46,8 @@ public class ElasticsearchConfiguration {
     public static final String MAX_INDEX_RETENTION_PERIOD = "max_index_retention_period";
     public static final String DEFAULT_EVENTS_INDEX_PREFIX = "default_events_index_prefix";
     public static final String DEFAULT_SYSTEM_EVENTS_INDEX_PREFIX = "default_system_events_index_prefix";
-    public static final String TIME_SIZE_OPTIMIZING_ROTATION_MIN_SIZE = "time_size_optimizing_rotation_min_size";
-    public static final String TIME_SIZE_OPTIMIZING_ROTATION_MAX_SIZE = "time_size_optimizing_rotation_max_size";
+    public static final String TIME_SIZE_OPTIMIZING_ROTATION_MIN_SHARD_SIZE = "time_size_optimizing_rotation_min_shard_size";
+    public static final String TIME_SIZE_OPTIMIZING_ROTATION_MAX_SHARD_SIZE = "time_size_optimizing_rotation_max_shard_size";
     public static final String TIME_SIZE_OPTIMIZING_ROTATION_PERIOD = "time_size_optimizing_rotation_period";
 
     @Parameter(value = "elasticsearch_index_prefix", required = true)
@@ -110,11 +110,11 @@ public class ElasticsearchConfiguration {
     @Parameter(value = TIME_SIZE_OPTIMIZING_ROTATION_PERIOD)
     private Period timeSizeOptimizingRotationPeriod = Period.days(1);
 
-    @Parameter(value = TIME_SIZE_OPTIMIZING_ROTATION_MIN_SIZE)
-    private Size timeSizeOptimizingRotationMinSize = Size.gigabytes(20);
+    @Parameter(value = TIME_SIZE_OPTIMIZING_ROTATION_MIN_SHARD_SIZE)
+    private Size timeSizeOptimizingRotationMinShardSize = Size.gigabytes(20);
 
-    @Parameter(value = TIME_SIZE_OPTIMIZING_ROTATION_MAX_SIZE)
-    private Size timeSizeOptimizingRotationMaxSize = Size.gigabytes(50);
+    @Parameter(value = TIME_SIZE_OPTIMIZING_ROTATION_MAX_SHARD_SIZE)
+    private Size timeSizeOptimizingRotationMaxShardSize = Size.gigabytes(50);
 
     @Parameter(value = "elasticsearch_disable_version_check")
     private boolean disableVersionCheck = false;
@@ -228,12 +228,12 @@ public class ElasticsearchConfiguration {
         return timeSizeOptimizingRotationPeriod;
     }
 
-    public Size getTimeSizeOptimizingRotationMinSize() {
-        return timeSizeOptimizingRotationMinSize;
+    public Size getTimeSizeOptimizingRotationMinShardSize() {
+        return timeSizeOptimizingRotationMinShardSize;
     }
 
-    public Size getTimeSizeOptimizingRotationMaxSize() {
-        return timeSizeOptimizingRotationMaxSize;
+    public Size getTimeSizeOptimizingRotationMaxShardSize() {
+        return timeSizeOptimizingRotationMaxShardSize;
     }
 
     public boolean isDisableVersionCheck() {
@@ -263,10 +263,10 @@ public class ElasticsearchConfiguration {
     @ValidatorMethod
     @SuppressWarnings("unused")
     public void validateTimeSizeOptimizingRotation() throws ValidationException {
-        if (getTimeSizeOptimizingRotationMaxSize().compareTo(getTimeSizeOptimizingRotationMinSize()) < 0) {
+        if (getTimeSizeOptimizingRotationMaxShardSize().compareTo(getTimeSizeOptimizingRotationMinShardSize()) < 0) {
             throw new ValidationException(f("\"%s=%s\" cannot be larger than \"%s=%s\"",
-                    TIME_SIZE_OPTIMIZING_ROTATION_MIN_SIZE, getTimeSizeOptimizingRotationMinSize(),
-                    TIME_SIZE_OPTIMIZING_ROTATION_MAX_SIZE, getTimeSizeOptimizingRotationMaxSize())
+                    TIME_SIZE_OPTIMIZING_ROTATION_MIN_SHARD_SIZE, getTimeSizeOptimizingRotationMinShardSize(),
+                    TIME_SIZE_OPTIMIZING_ROTATION_MAX_SHARD_SIZE, getTimeSizeOptimizingRotationMaxShardSize())
             );
         }
     }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/TimeBasedSizeOptimizingStrategy.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/TimeBasedSizeOptimizingStrategy.java
@@ -86,7 +86,6 @@ public class TimeBasedSizeOptimizingStrategy extends AbstractRotationStrategy {
 
         final int shards = indexSet.getConfig().shards();
 
-        //final Size maxIndexSize = getTotalIndexSizeLimit(shards, maxShardSize);
         final long maxIndexSize = maxShardSize.toBytes() * shards;
         if (sizeInBytes > maxIndexSize) {
             return createResult(true,

--- a/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/TimeBasedSizeOptimizingStrategy.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/TimeBasedSizeOptimizingStrategy.java
@@ -24,7 +24,6 @@ import org.graylog2.indexer.IndexSet;
 import org.graylog2.indexer.indices.Indices;
 import org.graylog2.plugin.indexer.rotation.RotationStrategyConfig;
 import org.graylog2.plugin.system.NodeId;
-import org.graylog2.shared.utilities.StringUtils;
 import org.joda.time.DateTime;
 import org.joda.time.Period;
 import org.slf4j.Logger;
@@ -36,6 +35,7 @@ import java.time.Duration;
 import java.time.Instant;
 
 import static org.graylog2.shared.utilities.StringUtils.f;
+import static org.graylog2.shared.utilities.StringUtils.humanReadableByteCount;
 
 public class TimeBasedSizeOptimizingStrategy extends AbstractRotationStrategy {
     private static final Logger LOG = LoggerFactory.getLogger(TimeBasedSizeOptimizingStrategy.class);
@@ -44,8 +44,8 @@ public class TimeBasedSizeOptimizingStrategy extends AbstractRotationStrategy {
     private final JobSchedulerClock clock;
     private final org.joda.time.Period rotationPeriod;
 
-    private final Size maxIndexSize;
-    private final Size minIndexSize;
+    private final Size maxShardSize;
+    private final Size minShardSize;
 
     @Inject
     public TimeBasedSizeOptimizingStrategy(Indices indices,
@@ -56,8 +56,8 @@ public class TimeBasedSizeOptimizingStrategy extends AbstractRotationStrategy {
         super(auditEventSender, nodeId, elasticsearchConfiguration, indices);
         this.clock = clock;
         this.rotationPeriod = elasticsearchConfiguration.getTimeSizeOptimizingRotationPeriod();
-        this.maxIndexSize = elasticsearchConfiguration.getTimeSizeOptimizingRotationMaxSize();
-        this.minIndexSize = elasticsearchConfiguration.getTimeSizeOptimizingRotationMinSize();
+        this.maxShardSize = elasticsearchConfiguration.getTimeSizeOptimizingRotationMaxShardSize();
+        this.minShardSize = elasticsearchConfiguration.getTimeSizeOptimizingRotationMinShardSize();
     }
 
     @Override
@@ -76,10 +76,7 @@ public class TimeBasedSizeOptimizingStrategy extends AbstractRotationStrategy {
         final DateTime creationDate = indices.indexCreationDate(index).orElseThrow(()-> new IllegalStateException("No index creation date"));
         final Long sizeInBytes = indices.getStoreSizeInBytes(index).orElseThrow(() -> new IllegalStateException("No index size"));
 
-        Period leeWay;
-        if (indexSet.getConfig().rotationStrategy() instanceof TimeBasedSizeOptimizingStrategyConfig rotationConfig) {
-            leeWay = rotationConfig.indexLifetimeMax().minus(rotationConfig.indexLifetimeMin());
-        } else {
+        if (!(indexSet.getConfig().rotationStrategy() instanceof TimeBasedSizeOptimizingStrategyConfig config)) {
             throw new IllegalStateException(f("Unsupported RotationStrategyConfig type <%s>", indexSet.getConfig().rotationStrategy()));
         }
 
@@ -87,21 +84,28 @@ public class TimeBasedSizeOptimizingStrategy extends AbstractRotationStrategy {
             return createResult(false, "Index is empty");
         }
 
-        if (indexExceedsSizeLimit(sizeInBytes)) {
+        final int shards = indexSet.getConfig().shards();
+
+        //final Size maxIndexSize = getTotalIndexSizeLimit(shards, maxShardSize);
+        final long maxIndexSize = maxShardSize.toBytes() * shards;
+        if (sizeInBytes > maxIndexSize) {
             return createResult(true,
-                    f("Index size <%s> exceeds MAX_INDEX_SIZE <%s>",
-                            StringUtils.humanReadableByteCount(sizeInBytes), maxIndexSize));
+                    f("Index size <%s> exceeds maximum size <%s>",
+                            humanReadableByteCount(sizeInBytes), humanReadableByteCount(maxIndexSize)));
         }
+
+        Period leeWay = config.indexLifetimeMax().minus(config.indexLifetimeMin());
         if (indexExceedsLeeWay(creationDate, leeWay)) {
             return createResult(true,
                     f("Index creation date <%s> exceeds optimization leeway <%s>",
                             creationDate, leeWay));
         }
 
-        if (indexIsOldEnough(creationDate) && !indexSubceedsSizeLimit(sizeInBytes)) {
+        final long minIndexSize = minShardSize.toBytes() * shards;
+        if (indexIsOldEnough(creationDate) && sizeInBytes >= minIndexSize) {
             return createResult(true,
                     f("Index creation date <%s> has passed rotation period <%s> and has a reasonable size <%s> for rotation",
-                            creationDate, rotationPeriod, StringUtils.humanReadableByteCount(sizeInBytes)));
+                            creationDate, rotationPeriod, humanReadableByteCount(minIndexSize)));
         }
 
         return createResult(false, "No reason to rotate found");
@@ -121,14 +125,6 @@ public class TimeBasedSizeOptimizingStrategy extends AbstractRotationStrategy {
         final Duration limitAsDuration = Duration.ofSeconds(limit.toStandardSeconds().getSeconds());
 
         return timePassed.compareTo(limitAsDuration) >= 0;
-    }
-
-    private boolean indexExceedsSizeLimit(long size) {
-        return size > maxIndexSize.toBytes();
-    }
-
-    private boolean indexSubceedsSizeLimit(long size) {
-        return size < minIndexSize.toBytes();
     }
 
     @Override

--- a/graylog2-server/src/test/java/org/graylog2/indexer/rotation/strategies/TimeBasedSizeOptimizingRotationAndRetentionTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/rotation/strategies/TimeBasedSizeOptimizingRotationAndRetentionTest.java
@@ -153,7 +153,7 @@ class TimeBasedSizeOptimizingRotationAndRetentionTest {
     }
 
     void testRotation() {
-        indexSet.addNewIndex(0, elasticsearchConfiguration.getTimeSizeOptimizingRotationMinSize().toBytes());
+        indexSet.addNewIndex(0, elasticsearchConfiguration.getTimeSizeOptimizingRotationMinShardSize().toBytes());
         assertThat(indexSet.getIndicesNames()).isEqualTo(List.of("test_0"));
 
         // We rotate _after_ 1 day. This is too early
@@ -172,14 +172,14 @@ class TimeBasedSizeOptimizingRotationAndRetentionTest {
         assertThat(indexSet.getIndicesNames()).isEqualTo(List.of("test_0", "test_1"));
 
         // with the minimum required size, this works
-        indexSet.getNewest().setSize(elasticsearchConfiguration.getTimeSizeOptimizingRotationMinSize().toBytes());
+        indexSet.getNewest().setSize(elasticsearchConfiguration.getTimeSizeOptimizingRotationMinShardSize().toBytes());
         clock.plus(1, TimeUnit.DAYS);
         timeBasedSizeOptimizingStrategy.rotate(indexSet);
         assertThat(indexSet.getIndicesNames()).isEqualTo(List.of("test_0", "test_1", "test_2"));
 
         // If an index exceeds its maximum size
         // it can be rotated, even if the rotation period has been reached.
-        indexSet.getNewest().setSize(elasticsearchConfiguration.getTimeSizeOptimizingRotationMaxSize().toBytes() + 1);
+        indexSet.getNewest().setSize(elasticsearchConfiguration.getTimeSizeOptimizingRotationMaxShardSize().toBytes() + 1);
         clock.plus(12, TimeUnit.HOURS);
         timeBasedSizeOptimizingStrategy.rotate(indexSet);
         assertThat(indexSet.getIndicesNames()).isEqualTo(List.of("test_0", "test_1", "test_2", "test_3"));
@@ -240,11 +240,11 @@ class TimeBasedSizeOptimizingRotationAndRetentionTest {
             return indicesBlockStatus;
         });
 
-        indexSet.addNewIndex(0, elasticsearchConfiguration.getTimeSizeOptimizingRotationMinSize().toBytes());
+        indexSet.addNewIndex(0, elasticsearchConfiguration.getTimeSizeOptimizingRotationMinShardSize().toBytes());
         clock.plus(1, TimeUnit.DAYS);
-        indexSet.addNewIndex(1, elasticsearchConfiguration.getTimeSizeOptimizingRotationMinSize().toBytes());
+        indexSet.addNewIndex(1, elasticsearchConfiguration.getTimeSizeOptimizingRotationMinShardSize().toBytes());
         clock.plus(1, TimeUnit.DAYS);
-        indexSet.addNewIndex(2, elasticsearchConfiguration.getTimeSizeOptimizingRotationMinSize().toBytes());
+        indexSet.addNewIndex(2, elasticsearchConfiguration.getTimeSizeOptimizingRotationMinShardSize().toBytes());
 
         assertThat(indexSet.getIndicesNames()).isEqualTo(List.of("test_0", "test_1", "test_2"));
 

--- a/graylog2-server/src/test/java/org/graylog2/indexer/rotation/strategies/TimeBasedSizeOptimizingStrategyTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/rotation/strategies/TimeBasedSizeOptimizingStrategyTest.java
@@ -75,10 +75,13 @@ class TimeBasedSizeOptimizingStrategyTest {
 
         timeBasedSizeOptimizingStrategyConfig = TimeBasedSizeOptimizingStrategyConfig.builder().build();
         final IndexSetConfig indexSetConfig = mock(IndexSetConfig.class);
+        when(indexSetConfig.shards()).thenReturn(1);
+
         when(indexSetConfig.rotationStrategy()).thenReturn(timeBasedSizeOptimizingStrategyConfig);
         when(indexSet.getConfig()).thenReturn(indexSetConfig);
 
         when(indices.numberOfMessages(anyString())).thenReturn(10L);
+
     }
 
     @ParameterizedTest
@@ -88,13 +91,13 @@ class TimeBasedSizeOptimizingStrategyTest {
 
         final DateTime creationDate = clock.nowUTC().minus(Duration.standardMinutes(10));
         when(indices.indexCreationDate("index_0")).thenReturn(Optional.of(creationDate));
-        final Size timeSizeOptimizingRotationMaxSize = elasticsearchConfiguration.getTimeSizeOptimizingRotationMaxSize();
+        final Size timeSizeOptimizingRotationMaxSize = elasticsearchConfiguration.getTimeSizeOptimizingRotationMaxShardSize();
         when(indices.getStoreSizeInBytes("index_0")).thenReturn(Optional.of(timeSizeOptimizingRotationMaxSize.toBytes() + 10));
 
         final TimeBasedSizeOptimizingStrategy.Result result = timeBasedSizeOptimizingStrategy.shouldRotate("index_0", indexSet);
 
         assertThat(result.shouldRotate()).isEqualTo(true);
-        assertThat(result.getDescription()).contains("exceeds MAX_INDEX_SIZE");
+        assertThat(result.getDescription()).contains("exceeds maximum size");
     }
 
     private void setClockTo(String startDate) {
@@ -112,7 +115,7 @@ class TimeBasedSizeOptimizingStrategyTest {
 
         final DateTime creationDate = clock.nowUTC().minus(elasticsearchConfiguration.getTimeSizeOptimizingRotationPeriod());
         when(indices.indexCreationDate("index_0")).thenReturn(Optional.of(creationDate));
-        final Size timeSizeOptimizingRotationMinSize = elasticsearchConfiguration.getTimeSizeOptimizingRotationMinSize();
+        final Size timeSizeOptimizingRotationMinSize = elasticsearchConfiguration.getTimeSizeOptimizingRotationMinShardSize();
         when(indices.getStoreSizeInBytes("index_0")).thenReturn(Optional.of(timeSizeOptimizingRotationMinSize.toBytes() + 10));
 
         final TimeBasedSizeOptimizingStrategy.Result result = timeBasedSizeOptimizingStrategy.shouldRotate("index_0", indexSet);
@@ -152,7 +155,7 @@ class TimeBasedSizeOptimizingStrategyTest {
 
         final DateTime creationDate = clock.nowUTC().minus(customRotationPeriod);
         when(indices.indexCreationDate("index_0")).thenReturn(Optional.of(creationDate));
-        final Size timeSizeOptimizingRotationMinSize = elasticsearchConfiguration.getTimeSizeOptimizingRotationMinSize();
+        final Size timeSizeOptimizingRotationMinSize = elasticsearchConfiguration.getTimeSizeOptimizingRotationMinShardSize();
         when(indices.getStoreSizeInBytes("index_0")).thenReturn(Optional.of(timeSizeOptimizingRotationMinSize.toBytes() + 10));
 
         final TimeBasedSizeOptimizingStrategy.Result result = timeBasedSizeOptimizingStrategy.shouldRotate("index_0", indexSet);


### PR DESCRIPTION
The optimal index size needs to take into account how many shards have been configured.

Thus we change the size definition from per index to per shard:

`time_size_optimizing_rotation_min_size` -> `time_size_optimizing_rotation_min_shard_size`

/jenkins-pr-deps https://github.com/Graylog2/graylog-plugin-enterprise/pull/4572

/nocl