### PR TITLE
Feature/13628 consistent identifier for inputs

### DIFF
--- a/changelog/unreleased/issue-13628.toml
+++ b/changelog/unreleased/issue-13628.toml
@@ -2,3 +2,4 @@ type = "changed" # One of: a(dded), c(hanged), d(eprecated), r(emoved), f(ixed),
 message = "Consistent use of message identifiers in strings. Message id visible in message list."
 
 issues = ["13628"]
+pulls = ["14562"]

--- a/changelog/unreleased/issue-13628.toml
+++ b/changelog/unreleased/issue-13628.toml
@@ -1,0 +1,4 @@
+type = "changed" # One of: a(dded), c(hanged), d(eprecated), r(emoved), f(ixed), s(ecurity)
+message = "Consistent use of message identifiers in strings. Message id visible in message list."
+
+issues = ["13628"]

--- a/graylog2-server/src/main/java/org/graylog2/inputs/Input.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/Input.java
@@ -46,7 +46,7 @@ public interface Input extends Persisted {
     void setDesiredState(IOState.Type desiredState);
 
     default String toIdentifier() {
-        return String.format("[%s/%s/%s]", getType(), getTitle(), getId());
+        return "[" + getType() + "/" + getTitle() + "/" + getId() + "]";
     }
 
 }

--- a/graylog2-server/src/main/java/org/graylog2/inputs/Input.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/Input.java
@@ -45,4 +45,8 @@ public interface Input extends Persisted {
 
     void setDesiredState(IOState.Type desiredState);
 
+    default String toIdentifier() {
+        return String.format("[%s/%s/%s]", getType(), getTitle(), getId());
+    }
+
 }

--- a/graylog2-server/src/main/java/org/graylog2/inputs/InputEventListener.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/InputEventListener.java
@@ -120,14 +120,14 @@ public class InputEventListener {
         try {
             messageInput = inputService.getMessageInput(input);
         } catch (NoSuchInputTypeException e) {
-            LOG.warn("Input {} ({}) is of invalid type {}", input.getTitle(), input.getId(), input.getType(), e);
+            LOG.warn("Input {} is of invalid type {}", input.toIdentifier(), input.getType(), e);
             return;
         }
         if (!inputLauncher.leaderStatusInhibitsLaunch(messageInput)) {
             startMessageInput(messageInput);
         } else {
-            LOG.info("Not launching 'onlyOnePerCluster' input [{}/{}/{}] because this node is not the leader.",
-                    input.getType(), input.getTitle(), input.getId());
+            LOG.info("Not launching 'onlyOnePerCluster' input {} because this node is not the leader.",
+                    input.toIdentifier());
         }
     }
 
@@ -158,7 +158,7 @@ public class InputEventListener {
                 final IOState<MessageInput> inputState = inputRegistry.getInputState(input.getId());
                 if (input.onlyOnePerCluster() && input.isGlobal() && (inputState == null || inputState.canBeStarted())
                         && inputLauncher.shouldStartAutomatically(input)) {
-                    LOG.info("Got leader role. Starting input [{}/{}/{}]", input.getName(), input.getTitle(), input.getId());
+                    LOG.info("Got leader role. Starting input {}", input.toIdentifier());
                     startMessageInput(input);
                 }
             }
@@ -167,7 +167,7 @@ public class InputEventListener {
                     .map(IOState::getStoppable)
                     .filter(input -> input.isGlobal() && input.onlyOnePerCluster())
                     .forEach(input -> {
-                        LOG.info("Lost leader role. Stopping input [{}/{}/{}]", input.getName(), input.getTitle(), input.getId());
+                        LOG.info("Lost leader role. Stopping input {}", input.toIdentifier());
                         inputDeleted(InputDeleted.create(input.getId()));
                     });
         }

--- a/graylog2-server/src/main/java/org/graylog2/inputs/InputStateListener.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/InputStateListener.java
@@ -66,12 +66,12 @@ public class InputStateListener {
                 notificationService.fixed(Notification.Type.NO_INPUT_RUNNING);
                 // fall through
             default:
-                final String msg = "Input [" + input.getName() + "/" + input.getId() + "] is now " + event.newState().toString();
+                final String msg = "Input " + input.toIdentifier() + " is now " + event.newState().toString();
                 activityWriter.write(new Activity(msg, InputStateListener.class));
                 break;
         }
 
-        LOG.debug("Input State of [{}/{}] changed: {} -> {}", input.getTitle(), input.getId(), event.oldState(), event.newState());
-        LOG.info("Input [{}/{}] is now {}", input.getName(), input.getId(), event.newState());
+        LOG.debug("Input State of {} changed: {} -> {}", input.toIdentifier(), event.oldState(), event.newState());
+        LOG.info("Input {} is now {}", input.toIdentifier(), event.newState());
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/inputs/transports/AmqpConsumer.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/transports/AmqpConsumer.java
@@ -153,7 +153,7 @@ public class AmqpConsumer {
 
         if (tls) {
             try {
-                LOG.info("Enabling TLS for AMQP input [{}/{}].", sourceInput.getName(), sourceInput.getId());
+                LOG.info("Enabling TLS for AMQP input {}.", sourceInput.toIdentifier());
                 factory.useSslProtocol();
             } catch (NoSuchAlgorithmException | KeyManagementException e) {
                 throw new IOException("Couldn't enable TLS for AMQP input.", e);

--- a/graylog2-server/src/main/java/org/graylog2/inputs/transports/netty/ExceptionLoggingChannelHandler.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/transports/netty/ExceptionLoggingChannelHandler.java
@@ -40,22 +40,19 @@ public class ExceptionLoggingChannelHandler extends ChannelInboundHandlerAdapter
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
         if (logger.isTraceEnabled() && "Connection reset by peer".equals(cause.getMessage())) {
-            logger.trace("{} in Input [{}/{}] (channel {})",
+            logger.trace("{} in Input {} (channel {})",
                     cause.getMessage(),
-                    input.getName(),
-                    input.getId(),
+                    input.toIdentifier(),
                     ctx.channel());
         } else if (this.keepAliveEnabled && cause instanceof ReadTimeoutException) {
             if (logger.isTraceEnabled()) {
-                logger.trace("KeepAlive Timeout in input [{}/{}] (channel {})",
-                        input.getName(),
-                        input.getId(),
+                logger.trace("KeepAlive Timeout in input {} (channel {})",
+                        input.toIdentifier(),
                         ctx.channel());
             }
         } else {
-            logger.error("Error in Input [{}/{}] (channel {}) (cause {})",
-                    input.getName(),
-                    input.getId(),
+            logger.error("Error in Input {} (channel {}) (cause {})",
+                    input.toIdentifier(),
                     ctx.channel(),
                     cause);
         }

--- a/graylog2-server/src/main/java/org/graylog2/plugin/inputs/MessageInput.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/inputs/MessageInput.java
@@ -375,11 +375,10 @@ public abstract class MessageInput implements Stoppable {
     public void processRawMessage(RawMessage rawMessage) {
         final int payloadLength = rawMessage.getPayload().length;
         if (payloadLength == 0) {
-            LOG.debug("Discarding empty message {} from input [{}/{}] (remote address {}). Turn logger org.graylog2.plugin.journal.RawMessage to TRACE to see originating stack trace.",
-                      rawMessage.getId(),
-                      getTitle(),
-                      getId(),
-                      rawMessage.getRemoteAddress() == null ? "unknown" : rawMessage.getRemoteAddress());
+            LOG.debug("Discarding empty message {} from input {} (remote address {}). Turn logger org.graylog2.plugin.journal.RawMessage to TRACE to see originating stack trace.",
+                    rawMessage.getId(),
+                    toIdentifier(),
+                    rawMessage.getRemoteAddress() == null ? "unknown" : rawMessage.getRemoteAddress());
             emptyMessages.inc();
             return;
         }
@@ -465,5 +464,9 @@ public abstract class MessageInput implements Stoppable {
                 .add("type", getType())
                 .add("nodeId", getNodeId())
                 .toString();
+    }
+
+    public String toIdentifier() {
+        return String.format("[%s/%s/%s]", getName(), getTitle(), getId());
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/plugin/inputs/MessageInput.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/inputs/MessageInput.java
@@ -467,6 +467,6 @@ public abstract class MessageInput implements Stoppable {
     }
 
     public String toIdentifier() {
-        return String.format("[%s/%s/%s]", getName(), getTitle(), getId());
+        return "[" + getName() + "/" + getTitle() + "/" + getId() + "]";
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/plugin/inputs/transports/AbstractTcpTransport.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/inputs/transports/AbstractTcpTransport.java
@@ -262,7 +262,7 @@ public abstract class AbstractTcpTransport extends NettyTransport {
         handlers.put("traffic-counter", () -> throughputCounter);
         handlers.put("connection-counter", () -> connectionCounter);
         if (tlsEnable) {
-            LOG.info("Enabled TLS for input [{}/{}]. key-file=\"{}\" cert-file=\"{}\"", input.getName(), input.getId(), tlsKeyFile, tlsCertFile);
+            LOG.info("Enabled TLS for input {}. key-file=\"{}\" cert-file=\"{}\"", input.toIdentifier(), tlsKeyFile, tlsCertFile);
             handlers.put("tls", getSslHandlerCallable(input));
         }
         handlers.putAll(getCustomChildChannelHandlers(input));
@@ -283,7 +283,7 @@ public abstract class AbstractTcpTransport extends NettyTransport {
             certFile = tlsCertFile;
             keyFile = tlsKeyFile;
         } else {
-            LOG.warn("TLS key file or certificate file does not exist, creating a self-signed certificate for input [{}/{}].", input.getName(), input.getId());
+            LOG.warn("TLS key file or certificate file does not exist, creating a self-signed certificate for input {}.", input.toIdentifier());
 
             final String tmpDir = System.getProperty("java.io.tmpdir");
             checkState(tmpDir != null, "The temporary directory must not be null!");
@@ -304,7 +304,7 @@ public abstract class AbstractTcpTransport extends NettyTransport {
                     keyFile = ssc.privateKey();
                 }
             } catch (GeneralSecurityException e) {
-                final String msg = String.format(Locale.ENGLISH, "Problem creating a self-signed certificate for input [%s/%s].", input.getName(), input.getId());
+                final String msg = String.format(Locale.ENGLISH, "Problem creating a self-signed certificate for input %s.", input.toIdentifier());
                 throw new IllegalStateException(msg, e);
             }
         }
@@ -331,7 +331,7 @@ public abstract class AbstractTcpTransport extends NettyTransport {
     }
 
     private Callable<ChannelHandler> buildSslHandlerCallable(SslProvider tlsProvider, File certFile, File keyFile, String password, ClientAuth clientAuth, File clientAuthCertFile, MessageInput input) {
-        return new Callable<ChannelHandler>() {
+        return new Callable<>() {
             @Override
             public ChannelHandler call() throws Exception {
                 try {
@@ -348,8 +348,8 @@ public abstract class AbstractTcpTransport extends NettyTransport {
                     if (clientAuthCertFile.exists()) {
                         clientAuthCerts = KeyUtil.loadX509Certificates(clientAuthCertFile.toPath());
                     } else {
-                        LOG.warn("Client auth configured, but no authorized certificates / certificate authorities configured for input [{}/{}]",
-                                input.getName(), input.getId());
+                        LOG.warn("Client auth configured, but no authorized certificates / certificate authorities configured for input {}",
+                                input.toIdentifier());
                         clientAuthCerts = null;
                     }
                 } else {

--- a/graylog2-server/src/main/java/org/graylog2/plugin/inputs/util/PacketInformationDumper.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/inputs/util/PacketInformationDumper.java
@@ -35,7 +35,7 @@ public class PacketInformationDumper extends SimpleChannelInboundHandler<ByteBuf
         sourceInputId = sourceInput.getId();
         sourceInputLog = LoggerFactory.getLogger(PacketInformationDumper.class.getCanonicalName() + "." + sourceInputId);
         LOG.debug("Set {} to TRACE for network packet metadata dumps of input {}", sourceInputLog.getName(),
-                sourceInput.getUniqueReadableId());
+                sourceInput.toIdentifier());
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/shared/initializers/InputSetupService.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/initializers/InputSetupService.java
@@ -108,15 +108,15 @@ public class InputSetupService extends AbstractExecutionThreadService {
         for (IOState<MessageInput> state : inputRegistry.getRunningInputs()) {
             MessageInput input = state.getStoppable();
 
-            LOG.info("Attempting to close input <{}> [{}].", input.getUniqueReadableId(), input.getName());
+            LOG.info("Attempting to close input {}.", input.toIdentifier());
 
             Stopwatch s = Stopwatch.createStarted();
             try {
                 input.stop();
 
-                LOG.info("Input <{}> closed. Took [{}ms]", input.getUniqueReadableId(), s.elapsed(TimeUnit.MILLISECONDS));
+                LOG.info("Input {} closed. Took [{}ms]", input.toIdentifier(), s.elapsed(TimeUnit.MILLISECONDS));
             } catch (Exception e) {
-                LOG.error("Unable to stop input <{}> [{}]: " + e.getMessage(), input.getUniqueReadableId(), input.getName());
+                LOG.error("Unable to stop input {}: {}", input.toIdentifier(), e.getMessage());
             } finally {
                 s.stop();
             }

--- a/graylog2-server/src/main/java/org/graylog2/shared/inputs/InputLauncher.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/inputs/InputLauncher.java
@@ -84,13 +84,13 @@ public class InputLauncher {
         executor.submit(new Runnable() {
             @Override
             public void run() {
-                LOG.debug("Starting [{}] input with ID <{}>", input.getClass().getCanonicalName(), input.getId());
+                LOG.debug("Starting [{}] input {}", input.getClass().getCanonicalName(), input.toIdentifier());
                 try {
                     input.checkConfiguration();
                     inputState.setState(IOState.Type.STARTING);
                     input.launch(inputBuffer);
                     inputState.setState(IOState.Type.RUNNING);
-                    String msg = "Completed starting [" + input.getClass().getCanonicalName() + "] input with ID <" + input.getId() + ">";
+                    String msg = "Completed starting [" + input.getClass().getCanonicalName() + "] input " + input.toIdentifier();
                     LOG.debug(msg);
                 } catch (Exception e) {
                     handleLaunchException(e, inputState);
@@ -103,7 +103,7 @@ public class InputLauncher {
 
     protected void handleLaunchException(Throwable e, IOState<MessageInput> inputState) {
         final MessageInput input = inputState.getStoppable();
-        StringBuilder msg = new StringBuilder("The [" + input.getClass().getCanonicalName() + "] input with ID <" + input.getId() + "> misfired. Reason: ");
+        StringBuilder msg = new StringBuilder("The [" + input.getClass().getCanonicalName() + "] input " + input.toIdentifier() + " misfired. Reason: ");
 
         String causeMsg = ExceptionUtils.getRootCauseMessage(e);
 
@@ -120,18 +120,18 @@ public class InputLauncher {
     public void launchAllPersisted() {
         for (MessageInput input : persistedInputs) {
             if (leaderStatusInhibitsLaunch(input)) {
-                LOG.info("Not launching 'onlyOnePerCluster' input [{}/{}/{}] because this node is not the leader.",
-                        input.getName(), input.getTitle(), input.getId());
+                LOG.info("Not launching 'onlyOnePerCluster' input {} because this node is not the leader.",
+                        input.toIdentifier());
                 continue;
             }
             if (shouldStartAutomatically(input)) {
-                LOG.info("Launching input [{}/{}/{}] - desired state is {}",
-                        input.getName(), input.getTitle(), input.getId(), input.getDesiredState());
+                LOG.info("Launching input {} - desired state is {}",
+                        input.toIdentifier(), input.getDesiredState());
                 input.initialize();
                 launch(input);
             } else {
-                LOG.info("Not auto-starting input [{}/{}/{}] - desired state is {}",
-                        input.getName(), input.getTitle(), input.getId(), input.getDesiredState());
+                LOG.info("Not auto-starting input {} - desired state is {}",
+                        input.toIdentifier(), input.getDesiredState());
             }
         }
     }

--- a/graylog2-server/src/main/java/org/graylog2/shared/inputs/InputRegistry.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/inputs/InputRegistry.java
@@ -115,7 +115,7 @@ public class InputRegistry extends HashSet<IOState<MessageInput>> {
             try {
                 input.stop();
             } catch (Exception e) {
-                LOG.warn("Stopping input <{}> failed, removing anyway: {}", input.getId(), e);
+                LOG.warn("Stopping input {} failed, removing anyway: {}", input.toIdentifier(), e);
             }
             inputState.setState(IOState.Type.STOPPED);
         }

--- a/graylog2-web-interface/src/components/inputs/InputListItem.jsx
+++ b/graylog2-web-interface/src/components/inputs/InputListItem.jsx
@@ -74,6 +74,8 @@ const InputListItem = createReactClass({
       <span>
         {this.props.input.name}
         &nbsp;
+        ({this.props.input.id})
+        &nbsp;
         <InputStateBadge input={this.props.input} />
       </span>
     );


### PR DESCRIPTION
Replaces all representations in strings for inputs to a new `toIdentifier()` method which concatenates `{name}/{title}/{id}`
Also displays the input id in the frontend.

part of #13628 

## Description
all occurences of messages in log/message strings were identified and the inconsistent output changed to use the `toIdentifier()` message

## Motivation and Context
messages were representated in various formats, e.g. `{title}/{id}`, `<{id}>`, ...

## Screenshots (if appropriate):
<img width="538" alt="image" src="https://user-images.githubusercontent.com/33032967/215449618-db6c86af-a537-44e8-ab5c-9cfc0f32ad6c.png">

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

