### PR TITLE
Response code changes in bulk removal, as requested by FE

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/events/rest/EventDefinitionsResource.java
+++ b/graylog2-server/src/main/java/org/graylog/events/rest/EventDefinitionsResource.java
@@ -24,8 +24,6 @@ import com.google.common.collect.ImmutableMap;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
 import org.apache.shiro.authz.annotation.RequiresAuthentication;
 import org.apache.shiro.authz.annotation.RequiresPermissions;
 import org.graylog.events.audit.EventsAuditEventTypes;
@@ -232,9 +230,6 @@ public class EventDefinitionsResource extends RestResource implements PluginRest
     @Consumes(MediaType.APPLICATION_JSON)
     @Timed
     @ApiOperation(value = "Delete a bulk of event definitions", response = BulkOperationResponse.class)
-    @ApiResponses(value = {
-            @ApiResponse(code = 400, message = "Could not delete at least one of the event definitions in the bulk.")
-    })
     @NoAuditEvent("Audit events triggered manually")
     public Response bulkDelete(@ApiParam(name = "Entities to remove", required = true) final BulkOperationRequest bulkOperationRequest,
                                @Context UserContext userContext) {
@@ -243,7 +238,7 @@ public class EventDefinitionsResource extends RestResource implements PluginRest
                 userContext,
                 new AuditParams(EventsAuditEventTypes.EVENT_DEFINITION_DELETE, "definitionId", EventDefinitionDto.class));
 
-        return Response.status(response.failures().isEmpty() ? Response.Status.OK : Response.Status.BAD_REQUEST)
+        return Response.status(Response.Status.OK)
                 .entity(response)
                 .build();
     }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/ViewsResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/ViewsResource.java
@@ -23,8 +23,6 @@ import com.google.common.collect.Sets;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
 import org.apache.shiro.authz.annotation.RequiresAuthentication;
 import org.graylog.grn.GRNTypes;
 import org.graylog.plugins.views.audit.ViewsAuditEventTypes;
@@ -386,9 +384,6 @@ public class ViewsResource extends RestResource implements PluginRestResource {
     @Consumes(MediaType.APPLICATION_JSON)
     @Timed
     @ApiOperation(value = "Delete a bulk of views", response = BulkOperationResponse.class)
-    @ApiResponses(value = {
-            @ApiResponse(code = 400, message = "Could not delete at least one of the views in the bulk.")
-    })
     @NoAuditEvent("Audit events triggered manually")
     public Response bulkDelete(@ApiParam(name = "Entities to remove", required = true) final BulkOperationRequest bulkOperationRequest,
                                @Context final SearchUser searchUser) {
@@ -397,7 +392,7 @@ public class ViewsResource extends RestResource implements PluginRestResource {
                 searchUser,
                 new AuditParams(ViewsAuditEventTypes.VIEW_DELETE, "id", ViewDTO.class));
 
-        return Response.status(response.failures().isEmpty() ? Response.Status.OK : Response.Status.BAD_REQUEST)
+        return Response.status(Response.Status.OK)
                 .entity(response)
                 .build();
     }

--- a/graylog2-server/src/main/java/org/graylog2/rest/bulk/SequentialBulkExecutor.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/bulk/SequentialBulkExecutor.java
@@ -30,6 +30,7 @@ import org.graylog2.rest.bulk.model.BulkOperationResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.ws.rs.BadRequestException;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -44,7 +45,7 @@ public class SequentialBulkExecutor<T, C extends HasUser> implements BulkExecuto
 
     private static final Logger LOG = LoggerFactory.getLogger(SequentialBulkExecutor.class);
 
-    static final BulkOperationFailure NO_ENTITY_IDS_FAILURE = new BulkOperationFailure("", "No IDs provided in the request");
+    static final String NO_ENTITY_IDS_ERROR = "No IDs provided in the request";
     private final SingleEntityOperationExecutor<T, C> singleEntityOperationExecutor;
     private final AuditEventSender auditEventSender;
     private final SuccessContextCreator<T> successAuditLogContextCreator;
@@ -81,7 +82,7 @@ public class SequentialBulkExecutor<T, C extends HasUser> implements BulkExecuto
     @Override
     public BulkOperationResponse executeBulkOperation(final BulkOperationRequest bulkOperationRequest, final C userContext, final AuditParams params) {
         if (bulkOperationRequest.entityIds() == null || bulkOperationRequest.entityIds().isEmpty()) {
-            return new BulkOperationResponse(0, List.of(NO_ENTITY_IDS_FAILURE));
+            throw new BadRequestException(NO_ENTITY_IDS_ERROR);
         }
 
         List<BulkOperationFailure> capturedFailures = new LinkedList<>();

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/StreamResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/StreamResource.java
@@ -386,9 +386,6 @@ public class StreamResource extends RestResource {
     @Consumes(MediaType.APPLICATION_JSON)
     @Timed
     @ApiOperation(value = "Delete a bulk of streams", response = BulkOperationResponse.class)
-    @ApiResponses(value = {
-            @ApiResponse(code = 400, message = "Could not delete at least one of the streams in the bulk.")
-    })
     @NoAuditEvent("Audit events triggered manually")
     public Response bulkDelete(@ApiParam(name = "Entities to remove", required = true) final BulkOperationRequest bulkOperationRequest,
                                @Context final UserContext userContext) {
@@ -398,7 +395,7 @@ public class StreamResource extends RestResource {
                 userContext,
                 new AuditParams(AuditEventTypes.STREAM_DELETE, "streamId", Stream.class));
 
-        return Response.status(response.failures().isEmpty() ? Response.Status.OK : Response.Status.BAD_REQUEST)
+        return Response.status(Response.Status.OK)
                 .entity(response)
                 .build();
     }

--- a/graylog2-server/src/test/java/org/graylog2/rest/bulk/SequentialBulkExecutorTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/rest/bulk/SequentialBulkExecutorTest.java
@@ -32,10 +32,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import javax.ws.rs.BadRequestException;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.graylog2.rest.bulk.SequentialBulkExecutor.NO_ENTITY_IDS_FAILURE;
+import static org.graylog2.rest.bulk.SequentialBulkExecutor.NO_ENTITY_IDS_ERROR;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -74,25 +76,17 @@ class SequentialBulkExecutorTest {
     }
 
     @Test
-    void returnsProperFailureMsgOnNullEntityIdsList() {
-        final BulkOperationResponse bulkOperationResponse = toTest.executeBulkOperation(new BulkOperationRequest(null), context, params);
-        assertThat(bulkOperationResponse.successfullyPerformed()).isEqualTo(0);
-        assertThat(bulkOperationResponse.failures()).containsOnly(NO_ENTITY_IDS_FAILURE);
-        verifyNoInteractions(singleEntityOperationExecutor);
-        verifyNoInteractions(auditEventSender);
-        verifyNoInteractions(successAuditLogContextCreator);
-        verifyNoInteractions(failureAuditLogContextCreator);
+    void throwsBadRequestExceptionOnNullEntityIdsList() {
+        assertThrows(BadRequestException.class,
+                () -> toTest.executeBulkOperation(new BulkOperationRequest(null), context, params),
+                NO_ENTITY_IDS_ERROR);
     }
 
     @Test
-    void returnsProperFailureMsgOnEmptyEntityIdsList() {
-        final BulkOperationResponse bulkOperationResponse = toTest.executeBulkOperation(new BulkOperationRequest(List.of()), context, params);
-        assertThat(bulkOperationResponse.successfullyPerformed()).isEqualTo(0);
-        assertThat(bulkOperationResponse.failures()).containsOnly(NO_ENTITY_IDS_FAILURE);
-        verifyNoInteractions(singleEntityOperationExecutor);
-        verifyNoInteractions(auditEventSender);
-        verifyNoInteractions(successAuditLogContextCreator);
-        verifyNoInteractions(failureAuditLogContextCreator);
+    void throwsBadRequestExceptionOnEmptyEntityIdsList() {
+        assertThrows(BadRequestException.class,
+                () -> toTest.executeBulkOperation(new BulkOperationRequest(List.of()), context, params),
+                NO_ENTITY_IDS_ERROR);
     }
 
     @Test


### PR DESCRIPTION
## Description
Response code changes in bulk removal, as requested by FE
/nocl

## Motivation and Context
FE wants 400 response code for general errors related to the whole bulk removal.
FE wants 200 response code even if some/all entities in the bulk were not removed successfully. "Failures" part is used by FE to provide detailed notification if needed.

## How Has This Been Tested?
Manually and with changed unit tests.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

