### PR TITLE
FE: Make use of new API endpoint for stream bulk delete.

### DIFF
--- a/graylog2-web-interface/src/components/streams/StreamsOverview/BulkActions.test.tsx
+++ b/graylog2-web-interface/src/components/streams/StreamsOverview/BulkActions.test.tsx
@@ -110,6 +110,8 @@ describe('StreamsOverview BulkActions', () => {
 
     await deleteStreams();
 
+    expect(window.confirm).toHaveBeenCalledWith('Do you really want to remove 2 streams?');
+
     await waitFor(() => expect(fetch).toHaveBeenCalledWith(
       'POST',
       expect.stringContaining(ApiRoutes.StreamsApiController.bulk_delete().url),
@@ -134,6 +136,8 @@ describe('StreamsOverview BulkActions', () => {
                         indexSets={indexSets} />);
 
     await deleteStreams();
+
+    expect(window.confirm).toHaveBeenCalledWith('Do you really want to remove 2 streams?');
 
     await waitFor(() => expect(fetch).toHaveBeenCalledWith(
       'POST',

--- a/graylog2-web-interface/src/components/streams/StreamsOverview/BulkActions.test.tsx
+++ b/graylog2-web-interface/src/components/streams/StreamsOverview/BulkActions.test.tsx
@@ -77,19 +77,15 @@ describe('StreamsOverview BulkActions', () => {
   });
 
   it('should assign index set', async () => {
-    const refetchStreams = jest.fn();
-
     render(<BulkActions selectedStreamIds={['stream-id-1', 'stream-id-2']}
                         setSelectedStreamIds={() => {}}
-                        indexSets={indexSets}
-                        refetchStreams={refetchStreams} />);
+                        indexSets={indexSets} />);
 
     await assignIndexSet();
 
     await waitFor(() => expect(Streams.assignToIndexSet).toHaveBeenCalledWith('index-set-id-2', ['stream-id-1', 'stream-id-2']));
 
     expect(UserNotification.success).toHaveBeenCalledWith('Index set was assigned to 2 streams successfully.', 'Success');
-    expect(refetchStreams).toHaveBeenCalledTimes(1);
   });
 
   it('should handle errors when assigning index set', async () => {
@@ -97,8 +93,7 @@ describe('StreamsOverview BulkActions', () => {
 
     render(<BulkActions selectedStreamIds={['stream-id-1', 'stream-id-2']}
                         setSelectedStreamIds={() => {}}
-                        indexSets={indexSets}
-                        refetchStreams={() => {}} />);
+                        indexSets={indexSets} />);
 
     await assignIndexSet();
 
@@ -107,13 +102,11 @@ describe('StreamsOverview BulkActions', () => {
 
   it('should delete selected streams', async () => {
     asMock(fetch).mockReturnValue(Promise.resolve({ failures: [] }));
-    const refetchStreams = jest.fn();
     const setSelectedStreamIds = jest.fn();
 
     render(<BulkActions selectedStreamIds={['stream-id-1', 'stream-id-2']}
                         setSelectedStreamIds={setSelectedStreamIds}
-                        indexSets={indexSets}
-                        refetchStreams={refetchStreams} />);
+                        indexSets={indexSets} />);
 
     await deleteStreams();
 
@@ -124,7 +117,6 @@ describe('StreamsOverview BulkActions', () => {
     ));
 
     expect(UserNotification.success).toHaveBeenCalledWith('2 streams were deleted successfully.', 'Success');
-    expect(refetchStreams).toHaveBeenCalledTimes(1);
     expect(setSelectedStreamIds).toHaveBeenCalledWith([]);
   });
 
@@ -135,13 +127,11 @@ describe('StreamsOverview BulkActions', () => {
       ],
     }));
 
-    const refetchStreams = jest.fn();
     const setSelectedStreamIds = jest.fn();
 
     render(<BulkActions selectedStreamIds={['stream-id-1', 'stream-id-2']}
                         setSelectedStreamIds={setSelectedStreamIds}
-                        indexSets={indexSets}
-                        refetchStreams={refetchStreams} />);
+                        indexSets={indexSets} />);
 
     await deleteStreams();
 
@@ -152,7 +142,6 @@ describe('StreamsOverview BulkActions', () => {
     ));
 
     expect(UserNotification.error).toHaveBeenCalledWith('1 out of 2 selected streams could not be deleted.');
-    expect(refetchStreams).toHaveBeenCalledTimes(1);
     expect(setSelectedStreamIds).toHaveBeenCalledWith(['stream-id-1']);
   });
 });

--- a/graylog2-web-interface/src/components/streams/StreamsOverview/BulkActions.tsx
+++ b/graylog2-web-interface/src/components/streams/StreamsOverview/BulkActions.tsx
@@ -17,6 +17,7 @@
 import * as React from 'react';
 import { useCallback, useState } from 'react';
 import { Formik, Form } from 'formik';
+import { useQueryClient } from '@tanstack/react-query';
 
 import { Streams } from '@graylog/server-api';
 import { Button, Modal } from 'components/bootstrap';
@@ -105,14 +106,16 @@ type Props = {
   selectedStreamIds: Array<string>,
   setSelectedStreamIds: (streamIds: Array<string>) => void,
   indexSets: Array<IndexSet>
-  refetchStreams: () => void
 }
 
-const BulkActions = ({ selectedStreamIds, refetchStreams, setSelectedStreamIds, indexSets }: Props) => {
+const BulkActions = ({ selectedStreamIds, setSelectedStreamIds, indexSets }: Props) => {
   const [showIndexSetModal, setShowIndexSetModal] = useState(false);
+  const queryClient = useQueryClient();
 
   const selectedItemsAmount = selectedStreamIds?.length;
   const descriptor = StringUtils.pluralize(selectedItemsAmount, 'stream', 'streams');
+
+  const refetchStreams = useCallback(() => queryClient.invalidateQueries(['streams', 'overview']), [queryClient]);
 
   const onDelete = useCallback(() => {
     // eslint-disable-next-line no-alert
@@ -136,7 +139,13 @@ const BulkActions = ({ selectedStreamIds, refetchStreams, setSelectedStreamIds, 
         refetchStreams();
       });
     }
-  }, [descriptor, refetchStreams, selectedItemsAmount, selectedStreamIds, setSelectedStreamIds]);
+  }, [
+    descriptor,
+    refetchStreams,
+    selectedItemsAmount,
+    selectedStreamIds,
+    setSelectedStreamIds,
+  ]);
 
   const toggleAssignIndexSetModal = useCallback(() => {
     setShowIndexSetModal((cur) => !cur);

--- a/graylog2-web-interface/src/components/streams/StreamsOverview/BulkActions.tsx
+++ b/graylog2-web-interface/src/components/streams/StreamsOverview/BulkActions.tsx
@@ -15,7 +15,6 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { useQueryClient } from '@tanstack/react-query';
 import { useCallback, useState } from 'react';
 import { Formik, Form } from 'formik';
 
@@ -110,7 +109,6 @@ type Props = {
 }
 
 const BulkActions = ({ selectedStreamIds, refetchStreams, setSelectedStreamIds, indexSets }: Props) => {
-  const queryClient = useQueryClient();
   const [showIndexSetModal, setShowIndexSetModal] = useState(false);
 
   const selectedItemsAmount = selectedStreamIds?.length;
@@ -130,14 +128,15 @@ const BulkActions = ({ selectedStreamIds, refetchStreams, setSelectedStreamIds, 
           UserNotification.error(`${notDeletedStreamIds.length} out of ${selectedItemsAmount} selected ${descriptor} could not be deleted.`);
         } else {
           setSelectedStreamIds([]);
+          UserNotification.success(`${selectedItemsAmount} ${descriptor} ${StringUtils.pluralize(selectedItemsAmount, 'was', 'were')} deleted successfully.`, 'Success');
         }
       }).catch((error) => {
         UserNotification.error(`An error occurred while deleting streams. ${error}`);
       }).finally(() => {
-        queryClient.invalidateQueries(['streams', 'overview']);
+        refetchStreams();
       });
     }
-  }, [descriptor, queryClient, selectedItemsAmount, selectedStreamIds, setSelectedStreamIds]);
+  }, [descriptor, refetchStreams, selectedItemsAmount, selectedStreamIds, setSelectedStreamIds]);
 
   const toggleAssignIndexSetModal = useCallback(() => {
     setShowIndexSetModal((cur) => !cur);

--- a/graylog2-web-interface/src/components/streams/StreamsOverview/StreamsOverview.test.tsx
+++ b/graylog2-web-interface/src/components/streams/StreamsOverview/StreamsOverview.test.tsx
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import React from 'react';
+import { render, screen } from 'wrappedTestingLibrary';
+
+import { indexSets } from 'fixtures/indexSets';
+import { asMock } from 'helpers/mocking';
+import useStreams from 'components/streams/hooks/useStreams';
+import { stream } from 'fixtures/streams';
+
+import StreamsOverview from './StreamsOverview';
+
+jest.mock('components/streams/hooks/useStreams');
+
+const attributes = [
+  {
+    id: 'title',
+    title: 'Title',
+    sortable: true,
+  },
+  {
+    id: 'description',
+    title: 'Description',
+    sortable: true,
+  },
+];
+
+const paginatedStreams = ({
+  data: {
+    pagination: {
+      total: 1,
+      page: 1,
+      perPage: 5,
+      count: 1,
+    },
+    elements: [stream],
+    attributes,
+  },
+  refetch: () => {},
+  isFetching: false,
+});
+
+describe('StreamsOverview', () => {
+  it('should render empty', async () => {
+    const emptyPaginatedStreams = ({
+      data: {
+        pagination: {
+          total: 0,
+          page: 1,
+          perPage: 5,
+          count: 0,
+        },
+        elements: [],
+        attributes,
+      },
+      refetch: () => {},
+      isFetching: false,
+    });
+    asMock(useStreams).mockReturnValue(emptyPaginatedStreams);
+
+    render(<StreamsOverview indexSets={indexSets} />);
+
+    await screen.findByText('No streams have been found');
+  });
+
+  it('should render list', async () => {
+    asMock(useStreams).mockReturnValue(paginatedStreams);
+
+    render(<StreamsOverview indexSets={indexSets} />);
+
+    await screen.findByText(stream.title);
+    await screen.findByText(stream.description);
+  });
+});

--- a/graylog2-web-interface/src/components/streams/StreamsOverview/StreamsOverview.tsx
+++ b/graylog2-web-interface/src/components/streams/StreamsOverview/StreamsOverview.tsx
@@ -140,15 +140,14 @@ const StreamsOverview = ({ indexSets }: Props) => {
                    streamRuleTypes={streamRuleTypes} />
   ), [indexSets, streamRuleTypes]);
 
-  const renderBulkActions = (
+  const renderBulkActions = useCallback((
     selectedStreamIds: Array<string>,
     setSelectedStreamIds: (streamIds: Array<string>) => void,
   ) => (
     <BulkActions selectedStreamIds={selectedStreamIds}
                  setSelectedStreamIds={setSelectedStreamIds}
-                 refetchStreams={refetchStreams}
                  indexSets={indexSets} />
-  );
+  ), [indexSets]);
 
   if (!paginatedStreams || !streamRuleTypes) {
     return <Spinner />;

--- a/graylog2-web-interface/src/routing/ApiRoutes.ts
+++ b/graylog2-web-interface/src/routing/ApiRoutes.ts
@@ -236,6 +236,7 @@ const ApiRoutes = {
     index: () => { return { url: '/streams' }; },
     paginated: () => { return { url: '/streams/paginated' }; },
     get: (streamId: string) => { return { url: `/streams/${streamId}` }; },
+    bulk_delete: () => ({ url: '/streams/bulk_delete' }),
     create: () => { return { url: '/streams' }; },
     update: (streamId: string) => { return { url: `/streams/${streamId}` }; },
     cloneStream: (streamId: string) => { return { url: `/streams/${streamId}/clone` }; },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is implementing the new API endpoint for stream bulk delete which we added with https://github.com/Graylog2/graylog2-server/pull/14476.


Fixes https://github.com/Graylog2/graylog2-server/issues/14013

/nocl
