### PR TITLE
fix(sec): upgrade org.apache.shiro:shiro-core to 1.9.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -154,7 +154,7 @@
         <retrofit.version>2.9.0</retrofit.version>
         <scala.version>2.13.4</scala.version>
         <semver4j.version>2.2.0-graylog.1</semver4j.version>
-        <shiro.version>1.5.2</shiro.version>
+        <shiro.version>1.9.1</shiro.version>
         <oshi.version>5.3.7</oshi.version>
         <siv-mode.version>1.4.1</siv-mode.version>
         <slf4j.version>1.7.30</slf4j.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.apache.shiro:shiro-core 1.5.2
- [CVE-2021-41303](https://www.oscs1024.com/hd/CVE-2021-41303)


### What did I do？
Upgrade org.apache.shiro:shiro-core from 1.5.2 to 1.9.1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS