### PR TITLE
Fixing missing offset handling in Legacy Searches (backport to 5.0)

### DIFF
--- a/changelog/unreleased/pr-14575.toml
+++ b/changelog/unreleased/pr-14575.toml
@@ -1,0 +1,4 @@
+type = "f"
+message = "Fixing missing offset handling in Legacy Searches."
+
+pulls = ["14575"]

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/search/AbsoluteSearchResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/search/AbsoluteSearchResource.java
@@ -100,7 +100,7 @@ public class AbsoluteSearchResource extends SearchResource {
 
         final TimeRange timeRange = buildAbsoluteTimeRange(from, to);
 
-        return search(query, limit, filter, decorate, searchUser, fieldList, sorting, timeRange);
+        return search(query, limit, offset, filter, decorate, searchUser, fieldList, sorting, timeRange);
     }
 
     @GET

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/search/KeywordSearchResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/search/KeywordSearchResource.java
@@ -99,7 +99,7 @@ public class KeywordSearchResource extends SearchResource {
 
         final TimeRange timeRange = buildKeywordTimeRange(keyword, timezone);
 
-        return search(query, limit, filter, decorate, searchUser, fieldList, sorting, timeRange);
+        return search(query, limit, offset, filter, decorate, searchUser, fieldList, sorting, timeRange);
     }
 
     @GET

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/search/RelativeSearchResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/search/RelativeSearchResource.java
@@ -100,7 +100,7 @@ public class RelativeSearchResource extends SearchResource {
 
         final TimeRange timeRange = buildRelativeTimeRange(range);
 
-        return search(query, limit, filter, decorate, searchUser, fieldList, sorting, timeRange);
+        return search(query, limit, offset, filter, decorate, searchUser, fieldList, sorting, timeRange);
     }
 
     @GET

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/search/SearchResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/search/SearchResource.java
@@ -90,8 +90,8 @@ public abstract class SearchResource extends RestResource {
         this.searchExecutor = searchExecutor;
     }
 
-    protected SearchResponse search(String query, int limit, String filter, boolean decorate, SearchUser searchUser, List<String> fieldList, Sort sorting, TimeRange timeRange) {
-        final Search search = createSearch(query, limit, filter, fieldList, sorting, timeRange);
+    protected SearchResponse search(String query, int limit, int offset, String filter, boolean decorate, SearchUser searchUser, List<String> fieldList, Sort sorting, TimeRange timeRange) {
+        final Search search = createSearch(query, limit, offset, filter, fieldList, sorting, timeRange);
 
         final Optional<String> streamId = Searches.extractStreamId(filter);
 
@@ -207,8 +207,8 @@ public abstract class SearchResource extends RestResource {
         return Sort.create(parts[0], Sort.Order.valueOf(parts[1].toUpperCase(Locale.ENGLISH)));
     }
 
-    protected Search createSearch(String queryString, int limit, String filter, List<String> fieldList, Sort sorting, TimeRange timeRange) {
-        final SearchType searchType = createMessageList(sorting, limit, fieldList);
+    protected Search createSearch(String queryString, int limit, int offset, String filter, List<String> fieldList, Sort sorting, TimeRange timeRange) {
+        final SearchType searchType = createMessageList(sorting, limit, offset, fieldList);
 
         final Query query = Query.builder()
                 .query(ElasticsearchQueryString.of(queryString))
@@ -223,10 +223,11 @@ public abstract class SearchResource extends RestResource {
                 .build();
     }
 
-    private SearchType createMessageList(Sort sorting, int limit, List<String> fieldList) {
+    private SearchType createMessageList(Sort sorting, int limit, int offset, List<String> fieldList) {
         MessageList.Builder messageListBuilder = MessageList.builder()
                 .sort(Collections.singletonList(sorting));
         messageListBuilder = limit > 0 ? messageListBuilder.limit(limit) : messageListBuilder;
+        messageListBuilder = offset > 0 ? messageListBuilder.offset(offset) : messageListBuilder;
         messageListBuilder = fieldList != null && !fieldList.isEmpty() ? messageListBuilder.fields(fieldList) : messageListBuilder;
         return messageListBuilder.build();
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The offset parameter was not used at all any more. This PR fixes it.

**backport from https://github.com/Graylog2/graylog2-server/pull/14575**

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manual testing via the API browser.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

