### PR TITLE
Preferences removal on user removal

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/bindings/ServerBindings.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/ServerBindings.java
@@ -70,6 +70,7 @@ import org.graylog2.rest.NotFoundExceptionMapper;
 import org.graylog2.rest.QueryParsingExceptionMapper;
 import org.graylog2.rest.ScrollChunkWriter;
 import org.graylog2.rest.ValidationExceptionMapper;
+import org.graylog2.rest.resources.entities.preferences.listeners.EntityListPreferencesCleanerOnUserDeletion;
 import org.graylog2.security.realm.AuthenticatingRealmModule;
 import org.graylog2.security.realm.AuthorizationOnlyRealmModule;
 import org.graylog2.shared.buffers.processors.ProcessBufferProcessor;
@@ -223,6 +224,7 @@ public class ServerBindings extends Graylog2Module {
         bind(ClusterDebugEventListener.class).asEagerSingleton();
         bind(StartPageCleanupListener.class).asEagerSingleton();
         bind(GrantsCleanupListener.class).asEagerSingleton();
+        bind(EntityListPreferencesCleanerOnUserDeletion.class).asEagerSingleton();
     }
 
     private void bindSearchResponseDecorators() {

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/entities/preferences/listeners/EntityListPreferencesCleanerOnUserDeletion.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/entities/preferences/listeners/EntityListPreferencesCleanerOnUserDeletion.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.rest.resources.entities.preferences.listeners;
+
+import com.google.common.eventbus.EventBus;
+import com.google.common.eventbus.Subscribe;
+import org.graylog2.rest.resources.entities.preferences.service.EntityListPreferencesService;
+import org.graylog2.users.events.UserDeletedEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+@Singleton
+public class EntityListPreferencesCleanerOnUserDeletion {
+    private static final Logger LOG = LoggerFactory.getLogger(EntityListPreferencesCleanerOnUserDeletion.class);
+
+    private final EntityListPreferencesService entityListPreferencesService;
+
+    @Inject
+    public EntityListPreferencesCleanerOnUserDeletion(final EventBus eventBus,
+                                                      final EntityListPreferencesService entityListPreferencesService) {
+        this.entityListPreferencesService = entityListPreferencesService;
+        eventBus.register(this);
+    }
+
+    @Subscribe
+    public void handleUserDeletedEvent(final UserDeletedEvent event) {
+        LOG.debug("Removing entity list preferences of user <{}/{}>",
+                event.userName(), event.userId());
+        entityListPreferencesService.deleteAllForUser(event.userId());
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/entities/preferences/model/StoredEntityListPreferencesId.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/entities/preferences/model/StoredEntityListPreferencesId.java
@@ -28,7 +28,9 @@ import com.google.auto.value.AutoValue;
 @JsonDeserialize(builder = StoredEntityListPreferencesId.Builder.class)
 public abstract class StoredEntityListPreferencesId {
 
-    @JsonProperty("user_id")
+    public static final String USER_ID_SUB_FIELD = "user_id";
+
+    @JsonProperty(USER_ID_SUB_FIELD)
     public abstract String userId();
 
     @JsonProperty("entity_list_id")
@@ -43,7 +45,7 @@ public abstract class StoredEntityListPreferencesId {
     @JsonPOJOBuilder(withPrefix = "")
     public abstract static class Builder {
 
-        @JsonProperty("user_id")
+        @JsonProperty(USER_ID_SUB_FIELD)
         public abstract Builder userId(final String userId);
 
         @JsonProperty("entity_list_id")

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/entities/preferences/service/EntityListPreferencesService.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/entities/preferences/service/EntityListPreferencesService.java
@@ -24,4 +24,6 @@ public interface EntityListPreferencesService {
     StoredEntityListPreferences get(final StoredEntityListPreferencesId preferencesId);
 
     boolean save(final StoredEntityListPreferences preferences);
+
+    int deleteAllForUser(final String userId);
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/entities/preferences/service/EntityListPreferencesServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/entities/preferences/service/EntityListPreferencesServiceImpl.java
@@ -16,6 +16,8 @@
  */
 package org.graylog2.rest.resources.entities.preferences.service;
 
+import com.mongodb.BasicDBObject;
+import com.mongodb.DBObject;
 import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
 import org.graylog2.database.MongoConnection;
 import org.graylog2.rest.resources.entities.preferences.model.StoredEntityListPreferences;
@@ -24,6 +26,8 @@ import org.mongojack.JacksonDBCollection;
 import org.mongojack.WriteResult;
 
 import javax.inject.Inject;
+
+import static org.graylog2.rest.resources.entities.preferences.model.StoredEntityListPreferencesId.USER_ID_SUB_FIELD;
 
 public class EntityListPreferencesServiceImpl implements EntityListPreferencesService {
 
@@ -51,5 +55,13 @@ public class EntityListPreferencesServiceImpl implements EntityListPreferencesSe
     public boolean save(final StoredEntityListPreferences preferences) {
         final WriteResult<StoredEntityListPreferences, StoredEntityListPreferencesId> save = db.save(preferences);
         return save.getWriteResult().getN() > 0;
+    }
+
+    @Override
+    public int deleteAllForUser(String userId) {
+        DBObject query = new BasicDBObject();
+        query.put("_id." + USER_ID_SUB_FIELD, userId);
+        final WriteResult<StoredEntityListPreferences, StoredEntityListPreferencesId> result = this.db.remove(query);
+        return result.getN();
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/users/UserManagementServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/users/UserManagementServiceImpl.java
@@ -23,9 +23,10 @@ import org.graylog2.Configuration;
 import org.graylog2.database.MongoConnection;
 import org.graylog2.plugin.database.ValidationException;
 import org.graylog2.plugin.database.users.User;
-import org.graylog2.shared.users.ChangeUserRequest;
+import org.graylog2.rest.resources.entities.preferences.service.EntityListPreferencesService;
 import org.graylog2.security.AccessTokenService;
 import org.graylog2.security.InMemoryRolePermissionResolver;
+import org.graylog2.shared.users.ChangeUserRequest;
 import org.graylog2.shared.users.UserManagementService;
 
 import javax.inject.Inject;
@@ -41,9 +42,10 @@ public class UserManagementServiceImpl extends UserServiceImpl implements UserMa
                                      final InMemoryRolePermissionResolver inMemoryRolePermissionResolver,
                                      final EventBus serverEventBus,
                                      final GRNRegistry grnRegistry,
-                                     final PermissionAndRoleResolver permissionAndRoleResolver) {
+                                     final PermissionAndRoleResolver permissionAndRoleResolver,
+                                     final EntityListPreferencesService entityListPreferencesService) {
         super(mongoConnection, configuration, roleService, accessTokenService, userFactory,
-              inMemoryRolePermissionResolver, serverEventBus, grnRegistry, permissionAndRoleResolver);
+                inMemoryRolePermissionResolver, serverEventBus, grnRegistry, permissionAndRoleResolver, entityListPreferencesService);
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/users/UserManagementServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/users/UserManagementServiceImpl.java
@@ -23,7 +23,6 @@ import org.graylog2.Configuration;
 import org.graylog2.database.MongoConnection;
 import org.graylog2.plugin.database.ValidationException;
 import org.graylog2.plugin.database.users.User;
-import org.graylog2.rest.resources.entities.preferences.service.EntityListPreferencesService;
 import org.graylog2.security.AccessTokenService;
 import org.graylog2.security.InMemoryRolePermissionResolver;
 import org.graylog2.shared.users.ChangeUserRequest;
@@ -42,10 +41,9 @@ public class UserManagementServiceImpl extends UserServiceImpl implements UserMa
                                      final InMemoryRolePermissionResolver inMemoryRolePermissionResolver,
                                      final EventBus serverEventBus,
                                      final GRNRegistry grnRegistry,
-                                     final PermissionAndRoleResolver permissionAndRoleResolver,
-                                     final EntityListPreferencesService entityListPreferencesService) {
+                                     final PermissionAndRoleResolver permissionAndRoleResolver) {
         super(mongoConnection, configuration, roleService, accessTokenService, userFactory,
-                inMemoryRolePermissionResolver, serverEventBus, grnRegistry, permissionAndRoleResolver, entityListPreferencesService);
+                inMemoryRolePermissionResolver, serverEventBus, grnRegistry, permissionAndRoleResolver);
     }
 
     @Override

--- a/graylog2-server/src/test/java/org/graylog2/rest/resources/entities/preferences/listeners/EntityListPreferencesCleanerOnUserDeletionTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/rest/resources/entities/preferences/listeners/EntityListPreferencesCleanerOnUserDeletionTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.rest.resources.entities.preferences.listeners;
+
+import com.google.common.eventbus.AsyncEventBus;
+import com.google.common.util.concurrent.MoreExecutors;
+import org.graylog.testing.mongodb.MongoDBExtension;
+import org.graylog.testing.mongodb.MongoDBTestService;
+import org.graylog.testing.mongodb.MongoJackExtension;
+import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
+import org.graylog2.rest.resources.entities.preferences.model.EntityListPreferences;
+import org.graylog2.rest.resources.entities.preferences.model.StoredEntityListPreferences;
+import org.graylog2.rest.resources.entities.preferences.model.StoredEntityListPreferencesId;
+import org.graylog2.rest.resources.entities.preferences.service.EntityListPreferencesService;
+import org.graylog2.rest.resources.entities.preferences.service.EntityListPreferencesServiceImpl;
+import org.graylog2.users.events.UserDeletedEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MongoDBExtension.class)
+@ExtendWith(MongoJackExtension.class)
+@ExtendWith(MockitoExtension.class)
+class EntityListPreferencesCleanerOnUserDeletionTest {
+    private AsyncEventBus eventBus;
+    private EntityListPreferencesService service;
+    @SuppressWarnings("unused")
+    private EntityListPreferencesCleanerOnUserDeletion listener;
+
+    @BeforeEach
+    void setUp(MongoDBTestService mongodb,
+               MongoJackObjectMapperProvider objectMapperProvider) {
+        this.eventBus = new AsyncEventBus(MoreExecutors.directExecutor());
+        this.service = Mockito.spy(new EntityListPreferencesServiceImpl(mongodb.mongoConnection(), objectMapperProvider));
+        this.listener = new EntityListPreferencesCleanerOnUserDeletion(eventBus, service);
+    }
+
+    @Test
+    void handlesUserDeletedEvent() {
+        final String userId = "5f7b3b42f215bd12c3bfd937";
+
+        //insert some preferences
+        final StoredEntityListPreferencesId preferenceId1 = StoredEntityListPreferencesId.builder()
+                .userId(userId)
+                .entityListId("List 1")
+                .build();
+        service.save(StoredEntityListPreferences.builder()
+                .preferencesId(preferenceId1)
+                .preferences(new EntityListPreferences(List.of(), 42, null))
+                .build());
+
+        final StoredEntityListPreferencesId preferenceId2 = StoredEntityListPreferencesId.builder()
+                .userId(userId)
+                .entityListId("List 2")
+                .build();
+        service.save(StoredEntityListPreferences.builder()
+                .preferencesId(preferenceId2)
+                .preferences(new EntityListPreferences(List.of(), 42, null))
+                .build());
+
+        //verify they are present
+        assertThat(service.get(preferenceId1)).isNotNull();
+        assertThat(service.get(preferenceId2)).isNotNull();
+
+        //post delete event for the user
+        eventBus.post(UserDeletedEvent.create(userId, "deleted"));
+
+        //verify preferences are gone
+        assertThat(service.get(preferenceId1)).isNull();
+        assertThat(service.get(preferenceId2)).isNull();
+
+        //verify they were removed by proper service method
+        verify(service).deleteAllForUser(userId);
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/users/UserServiceImplTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/users/UserServiceImplTest.java
@@ -36,7 +36,6 @@ import org.graylog2.database.MongoConnection;
 import org.graylog2.plugin.cluster.ClusterConfigService;
 import org.graylog2.plugin.database.users.User;
 import org.graylog2.plugin.security.PasswordAlgorithm;
-import org.graylog2.rest.resources.entities.preferences.service.EntityListPreferencesService;
 import org.graylog2.security.AccessTokenService;
 import org.graylog2.security.InMemoryRolePermissionResolver;
 import org.graylog2.security.PasswordAlgorithmFactory;
@@ -63,8 +62,6 @@ import java.util.stream.Collectors;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 public class UserServiceImplTest {
@@ -89,8 +86,6 @@ public class UserServiceImplTest {
     private EventBus serverEventBus;
     @Mock
     private PermissionAndRoleResolver permissionAndRoleResolver;
-    @Mock
-    EntityListPreferencesService entityListPreferencesService;
 
     @Before
     public void setUp() throws Exception {
@@ -99,7 +94,7 @@ public class UserServiceImplTest {
         this.permissions = new Permissions(ImmutableSet.of(new RestPermissions()));
         this.userFactory = new UserImplFactory(configuration, permissions);
         this.userService = new UserServiceImpl(mongoConnection, configuration, roleService, accessTokenService,
-                userFactory, permissionsResolver, serverEventBus, GRNRegistry.createWithBuiltinTypes(), permissionAndRoleResolver, entityListPreferencesService);
+                userFactory, permissionsResolver, serverEventBus, GRNRegistry.createWithBuiltinTypes(), permissionAndRoleResolver);
 
         when(roleService.getAdminRoleObjectId()).thenReturn("deadbeef");
     }
@@ -205,10 +200,6 @@ public class UserServiceImplTest {
         assertThat(userService.delete("user1")).isEqualTo(1);
         assertThat(userService.delete("user-duplicate")).isEqualTo(2);
         assertThat(userService.delete("user-does-not-exist")).isEqualTo(0);
-        verify(entityListPreferencesService).deleteAllForUser("54e3deadbeefdeadbeef0001");//user1
-        verify(entityListPreferencesService).deleteAllForUser("54e3deadbeefdeadbeef0003");//user-duplicate : 1
-        verify(entityListPreferencesService).deleteAllForUser("54e3deadbeefdeadbeef0004");//user-duplicate : 2
-        verifyNoMoreInteractions(entityListPreferencesService);
     }
 
     @Test
@@ -217,9 +208,6 @@ public class UserServiceImplTest {
         assertThat(userService.deleteById("54e3deadbeefdeadbeef0001")).isEqualTo(1);
         assertThat(userService.deleteById("54e3deadbeefdeadbeef0003")).isEqualTo(1);
         assertThat(userService.deleteById("00000eadbeefdeadbee00000")).isEqualTo(0);
-        verify(entityListPreferencesService).deleteAllForUser("54e3deadbeefdeadbeef0001");
-        verify(entityListPreferencesService).deleteAllForUser("54e3deadbeefdeadbeef0003");
-        verifyNoMoreInteractions(entityListPreferencesService);
     }
 
     @Test
@@ -337,7 +325,7 @@ public class UserServiceImplTest {
         final GRNRegistry grnRegistry = GRNRegistry.createWithBuiltinTypes();
         final UserService userService = new UserServiceImpl(mongoConnection, configuration, roleService,
                 accessTokenService, userFactory, permissionResolver,
-                serverEventBus, grnRegistry, permissionAndRoleResolver, entityListPreferencesService);
+                serverEventBus, grnRegistry, permissionAndRoleResolver);
 
         final UserImplFactory factory = new UserImplFactory(new Configuration(), permissions);
         final UserImpl user = factory.create(new HashMap<>());


### PR DESCRIPTION
## Description
Preferences removal on user removal.
/nocl

## Motivation and Context
When user is gone, his/her entity list preferences need to be removed as well.

## How Has This Been Tested?
Manually.
Existing tests have been adapted to test that part as well.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

