### PR TITLE
Enusure URL query param for page size is never NAN.

### DIFF
--- a/graylog2-web-interface/src/hooks/usePaginationQueryParameter.test.ts
+++ b/graylog2-web-interface/src/hooks/usePaginationQueryParameter.test.ts
@@ -123,4 +123,23 @@ describe('usePaginationQueryParameter custom hook', () => {
     expect(pageSize).not.toEqual(currentPageSize);
     expect(pageSize).toEqual(DEFAULT_PAGE_SIZES[0]);
   });
+
+  it('should reset current page', () => {
+    const currentPage = 3;
+    const currentPageSize = 50;
+
+    asMock(useLocation).mockReturnValue({
+      search: `?page=${currentPage}&pageSize=${currentPageSize}`,
+      pathname: 'example.org',
+    } as Location<{ search: string }>);
+
+    const { result } = renderHook(() => usePaginationQueryParameter());
+
+    expect(result.current.page).toEqual(currentPage);
+    expect(result.current.pageSize).toEqual(currentPageSize);
+
+    result.current.resetPage();
+
+    expect(mockHistoryReplace).toHaveBeenCalledWith(`example.org?page=1&pageSize=${currentPageSize}`);
+  });
 });

--- a/graylog2-web-interface/src/hooks/usePaginationQueryParameter.ts
+++ b/graylog2-web-interface/src/hooks/usePaginationQueryParameter.ts
@@ -46,7 +46,7 @@ const usePaginationQueryParameter = (PAGE_SIZES: number[] = DEFAULT_PAGE_SIZES, 
   };
 
   const resetPage = () => {
-    setPagination({ page: DEFAULT_PAGE, pageSize: Number(pageSizeQueryParameter) });
+    setPagination({ page: DEFAULT_PAGE });
   };
 
   return { page, resetPage, pageSize, setPagination };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

It is currently possible (in the development version) that the page size URL query param is `NaN`. If you go to the streams overview and you execute a search, the URL query params look like this `?page=1&pageSize=NaN`. This PR is fixing the behaviour.

/nocl
