### PR TITLE
Sorting can be persisted in Entity List preferences

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/entities/preferences/EntityListPreferencesResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/entities/preferences/EntityListPreferencesResource.java
@@ -103,7 +103,7 @@ public class EntityListPreferencesResource {
                 .build();
         final StoredEntityListPreferences entityListPreferences = entityListPreferencesService.get(complexId);
         if (entityListPreferences == null) {
-            throw new NotFoundException("Preferences not found for user " + userContext.getUser().getName() + " and entity list id " + entityListId);
+            return null;
         }
         return entityListPreferences.preferences();
     }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/entities/preferences/model/SingleFieldSortPreferences.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/entities/preferences/model/SingleFieldSortPreferences.java
@@ -18,9 +18,6 @@ package org.graylog2.rest.resources.entities.preferences.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import java.util.List;
-
-public record EntityListPreferences(@JsonProperty("displayed_attributes") List<String> displayedAttributes,
-                                    @JsonProperty("per_page") int perPage,
-                                    @JsonProperty("sort") SortPreferences sort) {
+public record SingleFieldSortPreferences(@JsonProperty("field") String sortField,
+                                         @JsonProperty("order") SortOrder sortOrder) implements SortPreferences {
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/entities/preferences/model/SortPreferences.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/entities/preferences/model/SortPreferences.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.rest.resources.entities.preferences.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonTypeInfo(use = JsonTypeInfo.Id.DEDUCTION)
+@JsonSubTypes({
+        @JsonSubTypes.Type(value = SingleFieldSortPreferences.class),
+        //in the future, we may want to store multiple-field sort as well
+})
+public interface SortPreferences {
+
+    enum SortOrder {
+        ASC("asc"), DESC("desc");
+
+        private String title;
+
+        SortOrder(String title) {
+            this.title = title;
+        }
+
+        @JsonValue
+        public String getTitle() {
+            return title;
+        }
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/rest/resources/entities/preferences/service/EntityListPreferencesServiceImplTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/rest/resources/entities/preferences/service/EntityListPreferencesServiceImplTest.java
@@ -21,6 +21,7 @@ import org.graylog.testing.mongodb.MongoDBInstance;
 import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
 import org.graylog2.database.MongoConnection;
 import org.graylog2.rest.resources.entities.preferences.model.EntityListPreferences;
+import org.graylog2.rest.resources.entities.preferences.model.SingleFieldSortPreferences;
 import org.graylog2.rest.resources.entities.preferences.model.StoredEntityListPreferences;
 import org.graylog2.rest.resources.entities.preferences.model.StoredEntityListPreferencesId;
 import org.junit.Before;
@@ -29,6 +30,8 @@ import org.junit.Test;
 
 import java.util.List;
 
+import static org.graylog2.rest.resources.entities.preferences.model.SortPreferences.SortOrder.ASC;
+import static org.graylog2.rest.resources.entities.preferences.model.SortPreferences.SortOrder.DESC;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -67,7 +70,7 @@ public class EntityListPreferencesServiceImplTest {
     public void performsSaveAndGetOperationsCorrectly() {
         final StoredEntityListPreferences existingPreference = StoredEntityListPreferences.builder()
                 .preferencesId(existingId)
-                .preferences(new EntityListPreferences(List.of("title", "description"), 42))
+                .preferences(new EntityListPreferences(List.of("title", "description"), 42, new SingleFieldSortPreferences("title", ASC)))
                 .build();
 
         //save
@@ -85,7 +88,7 @@ public class EntityListPreferencesServiceImplTest {
         //update with save
         final StoredEntityListPreferences updatedPreference = StoredEntityListPreferences.builder()
                 .preferencesId(existingId)
-                .preferences(new EntityListPreferences(List.of("title", "description", "owner"), 13))
+                .preferences(new EntityListPreferences(List.of("title", "description", "owner"), 13, new SingleFieldSortPreferences("title", DESC)))
                 .build();
         saved = toTest.save(updatedPreference);
         assertTrue(saved);


### PR DESCRIPTION
## Description
Sorting can be persisted in Entity List preferences.

Two additional micro-changes have been added:
1. Sorting order uses enum (as requested by Tomas).
2. If entity list preference is not present, return 204 (No Content) instead of 404 (Not found).

/nocl

## Motivation and Context
Needed by FE.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

