### PR TITLE
StartPage, cleanup/removal of collection items after entity deletion

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/favorites/FavoritesService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/favorites/FavoritesService.java
@@ -59,6 +59,7 @@ public class FavoritesService extends PaginatedDbService<FavoritesForUserDTO> {
         this.catalog = catalog;
 
         db.createIndex(new BasicDBObject(FavoritesForUserDTO.FIELD_USER_ID, 1));
+        db.createIndex(new BasicDBObject(FavoritesForUserDTO.FIELD_ITEMS + "." + FavoriteDTO.FIELD_ID, 1));
     }
 
     public PaginatedResponse<Favorite> findFavoritesFor(final SearchUser searchUser, final Optional<String> type, final int page, final int perPage) {
@@ -117,7 +118,7 @@ public class FavoritesService extends PaginatedDbService<FavoritesForUserDTO> {
     public void removeFavoriteOnEntityDeletion(final RecentActivityEvent event) {
         // if an entity is deleted, we can no longer see it in the favorites collection
         if (event.activityType().equals(ActivityType.DELETE)) {
-            DBObject query = new BasicDBObject();
+            DBObject query = new BasicDBObject(FavoritesForUserDTO.FIELD_ITEMS + "." + FavoriteDTO.FIELD_ID, new BasicDBObject("$eq", event.grn().entity()));
             final DBObject modifications = new BasicDBObject("$pull", new BasicDBObject(FavoritesForUserDTO.FIELD_ITEMS, new BasicDBObject(FavoriteDTO.FIELD_ID, event.grn().entity())));
             db.updateMulti(query, modifications);
         }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/favorites/FavoritesService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/favorites/FavoritesService.java
@@ -16,10 +16,16 @@
  */
 package org.graylog.plugins.views.favorites;
 
+import com.google.common.eventbus.EventBus;
+import com.google.common.eventbus.Subscribe;
+import com.mongodb.BasicDBObject;
+import com.mongodb.DBObject;
 import com.mongodb.DuplicateKeyException;
 import org.bson.types.ObjectId;
 import org.graylog.grn.GRNTypes;
 import org.graylog.plugins.views.search.permissions.SearchUser;
+import org.graylog.plugins.views.startpage.recentActivities.ActivityType;
+import org.graylog.plugins.views.startpage.recentActivities.RecentActivityEvent;
 import org.graylog.security.entities.EntityOwnershipService;
 import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
 import org.graylog2.database.MongoConnection;
@@ -27,17 +33,14 @@ import org.graylog2.database.PaginatedDbService;
 import org.graylog2.database.PaginatedList;
 import org.graylog2.lookup.Catalog;
 import org.graylog2.rest.models.PaginatedResponse;
+import org.graylog2.users.events.UserDeletedEvent;
 import org.mongojack.DBQuery;
 import org.mongojack.WriteResult;
 
 import javax.inject.Inject;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
-/*
- * TODO: remove entity, if a user is deleted?
- */
 public class FavoritesService extends PaginatedDbService<FavoritesForUserDTO> {
     public static final String COLLECTION_NAME = "favorites";
 
@@ -46,10 +49,12 @@ public class FavoritesService extends PaginatedDbService<FavoritesForUserDTO> {
 
     @Inject
     protected FavoritesService(final MongoConnection mongoConnection,
+                               EventBus eventBus,
                                final MongoJackObjectMapperProvider mapper,
                                final EntityOwnershipService entityOwnerShipService,
                                final Catalog catalog) {
         super(mongoConnection, mapper, FavoritesForUserDTO.class, COLLECTION_NAME);
+        eventBus.register(this);
         this.entityOwnerShipService = entityOwnerShipService;
         this.catalog = catalog;
     }
@@ -104,5 +109,20 @@ public class FavoritesService extends PaginatedDbService<FavoritesForUserDTO> {
         } catch (DuplicateKeyException e) {
             throw new IllegalStateException("Unable to create a Favorites collection, collection with this id already exists : " + favorite.id());
         }
+    }
+
+    @Subscribe
+    public void removeFavoriteOnEntityDeletion(final RecentActivityEvent event) {
+        // if an entity is deleted, we can no longer see it in the lastOpened collection
+        if (event.activityType().equals(ActivityType.DELETE)) {
+            DBObject query = new BasicDBObject();
+            final DBObject modifications = new BasicDBObject("$pull", new BasicDBObject("items", new BasicDBObject("id", event.grn().entity())));
+            db.updateMulti(query, modifications);
+        }
+    }
+
+    @Subscribe
+    public void removeFavoriteEntityOnUserDeletion(final UserDeletedEvent event) {
+        db.remove(DBQuery.is(FavoritesForUserDTO.FIELD_USER_ID, event.userId()));
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/favorites/FavoritesService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/favorites/FavoritesService.java
@@ -97,8 +97,12 @@ public class FavoritesService extends PaginatedDbService<FavoritesForUserDTO> {
         }
     }
 
-    protected Optional<FavoritesForUserDTO> findForUser(final SearchUser searchUser) {
-        return streamQuery(DBQuery.is(FavoritesForUserDTO.FIELD_USER_ID, searchUser.getUser().getId())).findAny();
+    Optional<FavoritesForUserDTO> findForUser(final SearchUser searchUser) {
+        return findForUser(searchUser.getUser().getId());
+    }
+
+    Optional<FavoritesForUserDTO> findForUser(final String userId) {
+        return streamQuery(DBQuery.is(FavoritesForUserDTO.FIELD_USER_ID, userId)).findAny();
     }
 
     public Optional<FavoritesForUserDTO> create(final FavoritesForUserDTO favorite, final SearchUser searchUser) {

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/favorites/FavoritesService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/favorites/FavoritesService.java
@@ -57,6 +57,8 @@ public class FavoritesService extends PaginatedDbService<FavoritesForUserDTO> {
         eventBus.register(this);
         this.entityOwnerShipService = entityOwnerShipService;
         this.catalog = catalog;
+
+        db.createIndex(new BasicDBObject(FavoritesForUserDTO.FIELD_USER_ID, 1));
     }
 
     public PaginatedResponse<Favorite> findFavoritesFor(final SearchUser searchUser, final Optional<String> type, final int page, final int perPage) {
@@ -113,7 +115,7 @@ public class FavoritesService extends PaginatedDbService<FavoritesForUserDTO> {
 
     @Subscribe
     public void removeFavoriteOnEntityDeletion(final RecentActivityEvent event) {
-        // if an entity is deleted, we can no longer see it in the lastOpened collection
+        // if an entity is deleted, we can no longer see it in the favorites collection
         if (event.activityType().equals(ActivityType.DELETE)) {
             DBObject query = new BasicDBObject();
             final DBObject modifications = new BasicDBObject("$pull", new BasicDBObject(FavoritesForUserDTO.FIELD_ITEMS, new BasicDBObject(FavoriteDTO.FIELD_ID, event.grn().entity())));

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/favorites/FavoritesService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/favorites/FavoritesService.java
@@ -116,7 +116,7 @@ public class FavoritesService extends PaginatedDbService<FavoritesForUserDTO> {
         // if an entity is deleted, we can no longer see it in the lastOpened collection
         if (event.activityType().equals(ActivityType.DELETE)) {
             DBObject query = new BasicDBObject();
-            final DBObject modifications = new BasicDBObject("$pull", new BasicDBObject("items", new BasicDBObject("id", event.grn().entity())));
+            final DBObject modifications = new BasicDBObject("$pull", new BasicDBObject(FavoritesForUserDTO.FIELD_ITEMS, new BasicDBObject(FavoriteDTO.FIELD_ID, event.grn().entity())));
             db.updateMulti(query, modifications);
         }
     }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/startpage/lastOpened/LastOpenedService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/startpage/lastOpened/LastOpenedService.java
@@ -52,6 +52,7 @@ public class LastOpenedService extends PaginatedDbService<LastOpenedForUserDTO> 
         eventBus.register(this);
 
         db.createIndex(new BasicDBObject(LastOpenedForUserDTO.FIELD_USER_ID, 1));
+        db.createIndex(new BasicDBObject(LastOpenedForUserDTO.FIELD_ITEMS + "." + LastOpenedDTO.FIELD_ID, 1));
     }
 
     public Optional<LastOpenedForUserDTO> findForUser(final SearchUser searchUser) {
@@ -75,7 +76,7 @@ public class LastOpenedService extends PaginatedDbService<LastOpenedForUserDTO> 
     public void removeLastOpenedOnEntityDeletion(final RecentActivityEvent event) {
         // if an entity is deleted, we can no longer see it in the lastOpened collection
         if (event.activityType().equals(ActivityType.DELETE)) {
-            DBObject query = new BasicDBObject();
+            DBObject query = new BasicDBObject(LastOpenedForUserDTO.FIELD_ITEMS + "." + LastOpenedDTO.FIELD_ID, new BasicDBObject("$eq", event.grn().entity()));
             final DBObject modifications = new BasicDBObject("$pull", new BasicDBObject(LastOpenedForUserDTO.FIELD_ITEMS, new BasicDBObject(LastOpenedDTO.FIELD_ID, event.grn().entity())));
             db.updateMulti(query, modifications);
         }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/startpage/lastOpened/LastOpenedService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/startpage/lastOpened/LastOpenedService.java
@@ -16,23 +16,27 @@
  */
 package org.graylog.plugins.views.startpage.lastOpened;
 
+import com.google.common.eventbus.EventBus;
+import com.google.common.eventbus.Subscribe;
+import com.mongodb.BasicDBObject;
+import com.mongodb.DBObject;
 import com.mongodb.DuplicateKeyException;
 import org.bson.types.ObjectId;
 import org.graylog.grn.GRNTypes;
 import org.graylog.plugins.views.search.permissions.SearchUser;
+import org.graylog.plugins.views.startpage.recentActivities.ActivityType;
+import org.graylog.plugins.views.startpage.recentActivities.RecentActivityEvent;
 import org.graylog.security.entities.EntityOwnershipService;
 import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
 import org.graylog2.database.MongoConnection;
 import org.graylog2.database.PaginatedDbService;
+import org.graylog2.users.events.UserDeletedEvent;
 import org.mongojack.DBQuery;
 import org.mongojack.WriteResult;
 
 import javax.inject.Inject;
 import java.util.Optional;
 
-/*
- * TODO: remove entity, if a user is deleted?
- */
 public class LastOpenedService extends PaginatedDbService<LastOpenedForUserDTO> {
     private static final String COLLECTION_NAME = "last_opened";
 
@@ -40,10 +44,12 @@ public class LastOpenedService extends PaginatedDbService<LastOpenedForUserDTO> 
 
     @Inject
     public LastOpenedService(MongoConnection mongoConnection,
-                                 MongoJackObjectMapperProvider mapper,
-                                final EntityOwnershipService entityOwnerShipService) {
+                             MongoJackObjectMapperProvider mapper,
+                             EventBus eventBus,
+                             final EntityOwnershipService entityOwnerShipService) {
         super(mongoConnection, mapper, LastOpenedForUserDTO.class, COLLECTION_NAME);
         this.entityOwnerShipService = entityOwnerShipService;
+        eventBus.register(this);
     }
 
     public Optional<LastOpenedForUserDTO> findForUser(final SearchUser searchUser) {
@@ -61,5 +67,20 @@ public class LastOpenedService extends PaginatedDbService<LastOpenedForUserDTO> 
         } catch (DuplicateKeyException e) {
             throw new IllegalStateException("Unable to create a last opened collection, collection with this id already exists : " + lastOpenedItems.id());
         }
+    }
+
+    @Subscribe
+    public void removeLastOpenedOnEntityDeletion(final RecentActivityEvent event) {
+        // if an entity is deleted, we can no longer see it in the lastOpened collection
+        if (event.activityType().equals(ActivityType.DELETE)) {
+            DBObject query = new BasicDBObject();
+            final DBObject modifications = new BasicDBObject("$pull", new BasicDBObject("items", new BasicDBObject("id", event.grn().entity())));
+            db.updateMulti(query, modifications);
+        }
+    }
+
+    @Subscribe
+    public void removeFavoriteEntityOnUserDeletion(final UserDeletedEvent event) {
+        db.remove(DBQuery.is(LastOpenedForUserDTO.FIELD_USER_ID, event.userId()));
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/startpage/lastOpened/LastOpenedService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/startpage/lastOpened/LastOpenedService.java
@@ -56,7 +56,11 @@ public class LastOpenedService extends PaginatedDbService<LastOpenedForUserDTO> 
     }
 
     public Optional<LastOpenedForUserDTO> findForUser(final SearchUser searchUser) {
-        return streamQuery(DBQuery.is(LastOpenedForUserDTO.FIELD_USER_ID, searchUser.getUser().getId())).findAny();
+        return findForUser(searchUser.getUser().getId());
+    }
+
+    Optional<LastOpenedForUserDTO> findForUser(final String userId) {
+        return streamQuery(DBQuery.is(LastOpenedForUserDTO.FIELD_USER_ID, userId)).findAny();
     }
 
     public Optional<LastOpenedForUserDTO> create(final LastOpenedForUserDTO lastOpenedItems, final SearchUser searchUser) {

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/startpage/lastOpened/LastOpenedService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/startpage/lastOpened/LastOpenedService.java
@@ -50,6 +50,8 @@ public class LastOpenedService extends PaginatedDbService<LastOpenedForUserDTO> 
         super(mongoConnection, mapper, LastOpenedForUserDTO.class, COLLECTION_NAME);
         this.entityOwnerShipService = entityOwnerShipService;
         eventBus.register(this);
+
+        db.createIndex(new BasicDBObject(LastOpenedForUserDTO.FIELD_USER_ID, 1));
     }
 
     public Optional<LastOpenedForUserDTO> findForUser(final SearchUser searchUser) {

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/startpage/lastOpened/LastOpenedService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/startpage/lastOpened/LastOpenedService.java
@@ -74,7 +74,7 @@ public class LastOpenedService extends PaginatedDbService<LastOpenedForUserDTO> 
         // if an entity is deleted, we can no longer see it in the lastOpened collection
         if (event.activityType().equals(ActivityType.DELETE)) {
             DBObject query = new BasicDBObject();
-            final DBObject modifications = new BasicDBObject("$pull", new BasicDBObject("items", new BasicDBObject("id", event.grn().entity())));
+            final DBObject modifications = new BasicDBObject("$pull", new BasicDBObject(LastOpenedForUserDTO.FIELD_ITEMS, new BasicDBObject(LastOpenedDTO.FIELD_ID, event.grn().entity())));
             db.updateMulti(query, modifications);
         }
     }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/startpage/recentActivities/RecentActivityService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/startpage/recentActivities/RecentActivityService.java
@@ -32,7 +32,6 @@ import org.graylog2.plugin.database.users.User;
 import org.mongojack.DBQuery;
 
 import javax.inject.Inject;
-import java.util.stream.Collectors;
 
 public class RecentActivityService extends PaginatedDbService<RecentActivityDTO> {
     private static final String COLLECTION_NAME = "recent_activity";
@@ -113,5 +112,9 @@ public class RecentActivityService extends PaginatedDbService<RecentActivityDTO>
         final var grns = permissionAndRoleResolver.resolveGrantees(principal).stream().map(GRN::toString).toList();
         var query = DBQuery.in(RecentActivityDTO.FIELD_GRANTEE, grns);
         return findPaginatedWithQueryAndSort(query, sort, page, perPage);
+    }
+
+    public void deleteAllEntriesForEntity(GRN grn) {
+        db.remove(DBQuery.is(RecentActivityDTO.FIELD_ITEM_GRN, grn.toString()));
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/startpage/recentActivities/RecentActivityService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/startpage/recentActivities/RecentActivityService.java
@@ -17,6 +17,7 @@
 package org.graylog.plugins.views.startpage.recentActivities;
 
 import com.google.common.eventbus.EventBus;
+import com.mongodb.BasicDBObject;
 import com.mongodb.BasicDBObjectBuilder;
 import org.graylog.grn.GRN;
 import org.graylog.grn.GRNRegistry;
@@ -69,6 +70,8 @@ public class RecentActivityService extends PaginatedDbService<RecentActivityDTO>
         this.grnRegistry = grnRegistry;
         this.permissionAndRoleResolver = permissionAndRoleResolver;
         this.eventBus = eventBus;
+
+        db.createIndex(new BasicDBObject(RecentActivityDTO.FIELD_ITEM_GRN, 1));
     }
 
     private void postRecentActivity(final RecentActivityEvent event) {

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/startpage/recentActivities/RecentActivityUpdatesListener.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/startpage/recentActivities/RecentActivityUpdatesListener.java
@@ -36,7 +36,13 @@ public class RecentActivityUpdatesListener {
     }
 
     @Subscribe
-    public void createRecentActivityFor(final RecentActivityEvent event) {
+    public void createUpdateRecentActivityFor(final RecentActivityEvent event) {
+        // first, if we delete an entity, we have to remove old entries from the Recent Activities collection because some info is no longer available from the catalog.
+        if(event.activityType().equals(ActivityType.DELETE)) {
+            recentActivityService.deleteAllEntriesForEntity(event.grn());
+        }
+
+        // save the new activity
         recentActivityService.save(RecentActivityDTO.builder()
                 .activityType(event.activityType())
                 .itemId(event.grn().entity())

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/favorites/FavoriteServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/favorites/FavoriteServiceTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.views.favorites;
+
+import com.google.common.eventbus.EventBus;
+import org.apache.shiro.authz.Permission;
+import org.graylog.grn.GRN;
+import org.graylog.grn.GRNRegistry;
+import org.graylog.grn.GRNTypes;
+import org.graylog.plugins.views.search.permissions.SearchUser;
+import org.graylog.plugins.views.search.rest.TestSearchUser;
+import org.graylog.plugins.views.search.rest.TestUser;
+import org.graylog.plugins.views.startpage.recentActivities.ActivityType;
+import org.graylog.plugins.views.startpage.recentActivities.RecentActivityEvent;
+import org.graylog.security.PermissionAndRoleResolver;
+import org.graylog.testing.GRNExtension;
+import org.graylog.testing.TestUserService;
+import org.graylog.testing.TestUserServiceExtension;
+import org.graylog.testing.mongodb.MongoDBExtension;
+import org.graylog.testing.mongodb.MongoDBTestService;
+import org.graylog.testing.mongodb.MongoJackExtension;
+import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
+import org.graylog2.plugin.database.users.User;
+import org.graylog2.users.events.UserDeletedEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MongoDBExtension.class)
+@ExtendWith(MongoJackExtension.class)
+@ExtendWith(GRNExtension.class)
+@ExtendWith(TestUserServiceExtension.class)
+public class FavoriteServiceTest {
+    FavoritesService favoritesService;
+    TestUserService testUserService;
+    GRNRegistry grnRegistry;
+
+    PermissionAndRoleResolver permissionAndRoleResolver;
+
+    User user;
+    User admin;
+    SearchUser searchUser;
+    SearchUser searchAdmin;
+
+    @BeforeEach
+    void setUp(MongoDBTestService mongodb,
+               MongoJackObjectMapperProvider mongoJackObjectMapperProvider,
+               GRNRegistry grnRegistry,
+               TestUserService testUserService) {
+
+        admin = TestUser.builder().withId("637748db06e1d74da0a54331").withUsername("local:admin").isLocalAdmin(true).build();
+        user = TestUser.builder().withId("637748db06e1d74da0a54330").withUsername("test").isLocalAdmin(false).build();
+        searchUser = TestSearchUser.builder().withUser(user).build();
+        searchAdmin = TestSearchUser.builder().withUser(admin).build();
+
+        permissionAndRoleResolver = new PermissionAndRoleResolver() {
+            @Override
+            public Set<Permission> resolvePermissionsForPrincipal(GRN principal) {
+                return null;
+            }
+
+            @Override
+            public Set<String> resolveRolesForPrincipal(GRN principal) {
+                return null;
+            }
+
+            @Override
+            public Set<GRN> resolveGrantees(GRN principal) {
+                return Set.of(grnRegistry.newGRN(GRNTypes.USER, user.getId()));
+            }
+        };
+
+        this.testUserService = testUserService;
+        this.grnRegistry = grnRegistry;
+        this.favoritesService = new FavoritesService(mongodb.mongoConnection(),
+                new EventBus(),
+                mongoJackObjectMapperProvider,
+                null,
+                null);
+    }
+
+    @Test
+    public void testRemoveOnUserDeletion() {
+        favoritesService.save(new FavoritesForUserDTO("user1", List.of(new FavoriteDTO("1", "view"), new FavoriteDTO("2", "view"))));
+        favoritesService.save(new FavoritesForUserDTO("user2", List.of(new FavoriteDTO("1", "view"), new FavoriteDTO("2", "view"))));
+        favoritesService.save(new FavoritesForUserDTO("user3", List.of(new FavoriteDTO("1", "view"), new FavoriteDTO("2", "view"))));
+
+        assertThat(favoritesService.streamAll().toList().size()).isEqualTo(3);
+        favoritesService.removeFavoriteEntityOnUserDeletion(UserDeletedEvent.create("user2", "user2"));
+        assertThat(favoritesService.streamAll().toList().size()).isEqualTo(2);
+        assertThat(favoritesService.findForUser("user1")).isNotEmpty();
+        assertThat(favoritesService.findForUser("user3")).isNotEmpty();
+    }
+
+    @Test
+    public void testRemoveOnEntityDeletion() {
+        favoritesService.save(new FavoritesForUserDTO("user1", List.of(new FavoriteDTO("2", "view"))));
+        favoritesService.save(new FavoritesForUserDTO("user2", List.of(new FavoriteDTO("1", "view"), new FavoriteDTO("2", "view"))));
+        favoritesService.save(new FavoritesForUserDTO("user3", List.of(new FavoriteDTO("1", "view"), new FavoriteDTO("2", "view"), new FavoriteDTO("3", "view"))));
+        favoritesService.save(new FavoritesForUserDTO("user4", List.of(new FavoriteDTO("1", "view"), new FavoriteDTO("4", "view"), new FavoriteDTO("3", "view"))));
+
+        assertThat(favoritesService.streamAll().toList().size()).isEqualTo(4);
+        favoritesService.removeFavoriteOnEntityDeletion(new RecentActivityEvent(ActivityType.DELETE, grnRegistry.newGRN(GRNTypes.SEARCH_FILTER, "2"), "user4"));
+        assertThat(favoritesService.streamAll().toList().size()).isEqualTo(4);
+
+        var fav1 = favoritesService.findForUser("user1").get();
+        assertThat(fav1.items().size()).isEqualTo(0);
+
+        var fav2 = favoritesService.findForUser("user2").get();
+        assertThat(fav2.items().size()).isEqualTo(1);
+        assertThat(fav2.items().get(0).id()).isEqualTo("1");
+
+        var fav3 = favoritesService.findForUser("user3").get();
+        assertThat(fav3.items().size()).isEqualTo(2);
+        assertThat(fav3.items().get(0).id()).isEqualTo("1");
+        assertThat(fav3.items().get(1).id()).isEqualTo("3");
+
+        var fav4 = favoritesService.findForUser("user4").get();
+        assertThat(fav4.items().size()).isEqualTo(3);
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/startpage/StartPageServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/startpage/StartPageServiceTest.java
@@ -116,7 +116,7 @@ public class StartPageServiceTest {
         var eventbus = new EventBus();
         var dbGrantService = new DBGrantService(mongodb.mongoConnection(), mongoJackObjectMapperProvider, grnRegistry);
         var entityOwnerShipService = new EntityOwnershipService(dbGrantService, grnRegistry);
-        var lastOpenedService = new LastOpenedService(mongodb.mongoConnection(), mongoJackObjectMapperProvider, entityOwnerShipService);
+        var lastOpenedService = new LastOpenedService(mongodb.mongoConnection(), mongoJackObjectMapperProvider, eventbus, entityOwnerShipService);
         var recentActivityService = new RecentActivityService(mongodb.mongoConnection(), mongoJackObjectMapperProvider, eventbus, grnRegistry, permissionAndRoleResolver);
         startPageService = new StartPageService(new TestCatalog(), lastOpenedService, recentActivityService, eventbus);
     }

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/startpage/lastOpened/LastOpenedServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/startpage/lastOpened/LastOpenedServiceTest.java
@@ -39,6 +39,7 @@ import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
 import org.graylog2.plugin.database.users.User;
 import org.graylog2.users.events.UserDeletedEvent;
 import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -103,9 +104,9 @@ public class LastOpenedServiceTest {
 
     @Test
     public void testRemoveOnUserDeletion() {
-        lastOpenedService.save(new LastOpenedForUserDTO("user1", List.of(new LastOpenedDTO("1", DateTime.now()), new LastOpenedDTO("2", DateTime.now()))));
-        lastOpenedService.save(new LastOpenedForUserDTO("user2", List.of(new LastOpenedDTO("1", DateTime.now()), new LastOpenedDTO("2", DateTime.now()))));
-        lastOpenedService.save(new LastOpenedForUserDTO("user3", List.of(new LastOpenedDTO("1", DateTime.now()), new LastOpenedDTO("2", DateTime.now()))));
+        lastOpenedService.save(new LastOpenedForUserDTO("user1", List.of(new LastOpenedDTO("1",DateTime.now(DateTimeZone.UTC)), new LastOpenedDTO("2",DateTime.now(DateTimeZone.UTC)))));
+        lastOpenedService.save(new LastOpenedForUserDTO("user2", List.of(new LastOpenedDTO("1",DateTime.now(DateTimeZone.UTC)), new LastOpenedDTO("2",DateTime.now(DateTimeZone.UTC)))));
+        lastOpenedService.save(new LastOpenedForUserDTO("user3", List.of(new LastOpenedDTO("1",DateTime.now(DateTimeZone.UTC)), new LastOpenedDTO("2",DateTime.now(DateTimeZone.UTC)))));
 
         assertThat(lastOpenedService.streamAll().toList().size()).isEqualTo(3);
         lastOpenedService.removeFavoriteEntityOnUserDeletion(UserDeletedEvent.create("user2", "user2"));
@@ -116,10 +117,10 @@ public class LastOpenedServiceTest {
 
     @Test
     public void testRemoveOnEntityDeletion() {
-        lastOpenedService.save(new LastOpenedForUserDTO("user1", List.of(new LastOpenedDTO("2", DateTime.now()))));
-        lastOpenedService.save(new LastOpenedForUserDTO("user2", List.of(new LastOpenedDTO("1", DateTime.now()), new LastOpenedDTO("2", DateTime.now()))));
-        lastOpenedService.save(new LastOpenedForUserDTO("user3", List.of(new LastOpenedDTO("1", DateTime.now()), new LastOpenedDTO("2", DateTime.now()), new LastOpenedDTO("3", DateTime.now()))));
-        lastOpenedService.save(new LastOpenedForUserDTO("user4", List.of(new LastOpenedDTO("1", DateTime.now()), new LastOpenedDTO("4", DateTime.now()), new LastOpenedDTO("3", DateTime.now()))));
+        lastOpenedService.save(new LastOpenedForUserDTO("user1", List.of(new LastOpenedDTO("2",DateTime.now(DateTimeZone.UTC)))));
+        lastOpenedService.save(new LastOpenedForUserDTO("user2", List.of(new LastOpenedDTO("1",DateTime.now(DateTimeZone.UTC)), new LastOpenedDTO("2", DateTime.now(DateTimeZone.UTC)))));
+        lastOpenedService.save(new LastOpenedForUserDTO("user3", List.of(new LastOpenedDTO("1",DateTime.now(DateTimeZone.UTC)), new LastOpenedDTO("2",DateTime.now(DateTimeZone.UTC)), new LastOpenedDTO("3",DateTime.now(DateTimeZone.UTC)))));
+        lastOpenedService.save(new LastOpenedForUserDTO("user4", List.of(new LastOpenedDTO("1",DateTime.now(DateTimeZone.UTC)), new LastOpenedDTO("4",DateTime.now(DateTimeZone.UTC)), new LastOpenedDTO("3",DateTime.now(DateTimeZone.UTC)))));
 
         assertThat(lastOpenedService.streamAll().toList().size()).isEqualTo(4);
         lastOpenedService.removeLastOpenedOnEntityDeletion(new RecentActivityEvent(ActivityType.DELETE, grnRegistry.newGRN(GRNTypes.SEARCH_FILTER, "2"), "user4"));

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/startpage/lastOpened/LastOpenedServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/startpage/lastOpened/LastOpenedServiceTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.views.startpage.lastOpened;
+
+import com.google.common.eventbus.EventBus;
+import org.apache.shiro.authz.Permission;
+import org.graylog.grn.GRN;
+import org.graylog.grn.GRNRegistry;
+import org.graylog.grn.GRNTypes;
+import org.graylog.plugins.views.favorites.FavoriteDTO;
+import org.graylog.plugins.views.favorites.FavoritesForUserDTO;
+import org.graylog.plugins.views.search.permissions.SearchUser;
+import org.graylog.plugins.views.search.rest.TestSearchUser;
+import org.graylog.plugins.views.search.rest.TestUser;
+import org.graylog.plugins.views.startpage.recentActivities.ActivityType;
+import org.graylog.plugins.views.startpage.recentActivities.RecentActivityEvent;
+import org.graylog.security.PermissionAndRoleResolver;
+import org.graylog.testing.GRNExtension;
+import org.graylog.testing.TestUserService;
+import org.graylog.testing.TestUserServiceExtension;
+import org.graylog.testing.mongodb.MongoDBExtension;
+import org.graylog.testing.mongodb.MongoDBTestService;
+import org.graylog.testing.mongodb.MongoJackExtension;
+import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
+import org.graylog2.plugin.database.users.User;
+import org.graylog2.users.events.UserDeletedEvent;
+import org.joda.time.DateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MongoDBExtension.class)
+@ExtendWith(MongoJackExtension.class)
+@ExtendWith(GRNExtension.class)
+@ExtendWith(TestUserServiceExtension.class)
+public class LastOpenedServiceTest {
+    LastOpenedService lastOpenedService;
+    TestUserService testUserService;
+    GRNRegistry grnRegistry;
+
+    PermissionAndRoleResolver permissionAndRoleResolver;
+
+    User user;
+    User admin;
+    SearchUser searchUser;
+    SearchUser searchAdmin;
+
+    @BeforeEach
+    void setUp(MongoDBTestService mongodb,
+               MongoJackObjectMapperProvider mongoJackObjectMapperProvider,
+               GRNRegistry grnRegistry,
+               TestUserService testUserService) {
+
+        admin = TestUser.builder().withId("637748db06e1d74da0a54331").withUsername("local:admin").isLocalAdmin(true).build();
+        user = TestUser.builder().withId("637748db06e1d74da0a54330").withUsername("test").isLocalAdmin(false).build();
+        searchUser = TestSearchUser.builder().withUser(user).build();
+        searchAdmin = TestSearchUser.builder().withUser(admin).build();
+
+        permissionAndRoleResolver = new PermissionAndRoleResolver() {
+            @Override
+            public Set<Permission> resolvePermissionsForPrincipal(GRN principal) {
+                return null;
+            }
+
+            @Override
+            public Set<String> resolveRolesForPrincipal(GRN principal) {
+                return null;
+            }
+
+            @Override
+            public Set<GRN> resolveGrantees(GRN principal) {
+                return Set.of(grnRegistry.newGRN(GRNTypes.USER, user.getId()));
+            }
+        };
+
+        this.testUserService = testUserService;
+        this.grnRegistry = grnRegistry;
+        this.lastOpenedService = new LastOpenedService(mongodb.mongoConnection(),
+                mongoJackObjectMapperProvider,
+                new EventBus(),
+                null);
+    }
+
+    @Test
+    public void testRemoveOnUserDeletion() {
+        lastOpenedService.save(new LastOpenedForUserDTO("user1", List.of(new LastOpenedDTO("1", DateTime.now()), new LastOpenedDTO("2", DateTime.now()))));
+        lastOpenedService.save(new LastOpenedForUserDTO("user2", List.of(new LastOpenedDTO("1", DateTime.now()), new LastOpenedDTO("2", DateTime.now()))));
+        lastOpenedService.save(new LastOpenedForUserDTO("user3", List.of(new LastOpenedDTO("1", DateTime.now()), new LastOpenedDTO("2", DateTime.now()))));
+
+        assertThat(lastOpenedService.streamAll().toList().size()).isEqualTo(3);
+        lastOpenedService.removeFavoriteEntityOnUserDeletion(UserDeletedEvent.create("user2", "user2"));
+        assertThat(lastOpenedService.streamAll().toList().size()).isEqualTo(2);
+        assertThat(lastOpenedService.findForUser("user1")).isNotEmpty();
+        assertThat(lastOpenedService.findForUser("user3")).isNotEmpty();
+    }
+
+    @Test
+    public void testRemoveOnEntityDeletion() {
+        lastOpenedService.save(new LastOpenedForUserDTO("user1", List.of(new LastOpenedDTO("2", DateTime.now()))));
+        lastOpenedService.save(new LastOpenedForUserDTO("user2", List.of(new LastOpenedDTO("1", DateTime.now()), new LastOpenedDTO("2", DateTime.now()))));
+        lastOpenedService.save(new LastOpenedForUserDTO("user3", List.of(new LastOpenedDTO("1", DateTime.now()), new LastOpenedDTO("2", DateTime.now()), new LastOpenedDTO("3", DateTime.now()))));
+        lastOpenedService.save(new LastOpenedForUserDTO("user4", List.of(new LastOpenedDTO("1", DateTime.now()), new LastOpenedDTO("4", DateTime.now()), new LastOpenedDTO("3", DateTime.now()))));
+
+        assertThat(lastOpenedService.streamAll().toList().size()).isEqualTo(4);
+        lastOpenedService.removeLastOpenedOnEntityDeletion(new RecentActivityEvent(ActivityType.DELETE, grnRegistry.newGRN(GRNTypes.SEARCH_FILTER, "2"), "user4"));
+        assertThat(lastOpenedService.streamAll().toList().size()).isEqualTo(4);
+
+        var last1 = lastOpenedService.findForUser("user1").get();
+        assertThat(last1.items().size()).isEqualTo(0);
+
+        var last2 = lastOpenedService.findForUser("user2").get();
+        assertThat(last2.items().size()).isEqualTo(1);
+        assertThat(last2.items().get(0).id()).isEqualTo("1");
+
+        var last3 = lastOpenedService.findForUser("user3").get();
+        assertThat(last3.items().size()).isEqualTo(2);
+        assertThat(last3.items().get(0).id()).isEqualTo("1");
+        assertThat(last3.items().get(1).id()).isEqualTo("3");
+
+        var last4 = lastOpenedService.findForUser("user4").get();
+        assertThat(last4.items().size()).isEqualTo(3);
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When an entity is deleted, preceding events in Recent Activity can no longer be displayed correctly and are removed now.

Also, deleted entities can no longer be a favorite or in the Last Opened list.

If a user is deleted, the Favorite & Last Opened collections for this user get removed, too.


/nocl

fixes https://github.com/Graylog2/graylog2-server/issues/14553 
fixes https://github.com/Graylog2/graylog2-server/issues/14403

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

cleanup

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
manual testing, TODO: create tests

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

