### PR TITLE
Disable more weak TLS ciphers by default

### DIFF
--- a/changelog/unreleased/issue-14428.toml
+++ b/changelog/unreleased/issue-14428.toml
@@ -1,0 +1,16 @@
+type = "changed"
+message = "Disable two TLS ciphers that are considered weak."
+
+issues = ["14428"]
+pulls = ["14592"]
+
+contributors = [""]
+
+details.user = """
+This change removes these two weak ciphers from our default configuration:
+
+ https://ciphersuite.info/cs/TLS_RSA_WITH_AES_128_GCM_SHA256/
+ https://ciphersuite.info/cs/TLS_RSA_WITH_AES_256_GCM_SHA384/
+
+If you need them, add TLSv1.1 to the `enabled_tls_protocols` setting.
+"""

--- a/graylog2-server/src/main/java/org/graylog2/bootstrap/CmdLineTool.java
+++ b/graylog2-server/src/main/java/org/graylog2/bootstrap/CmdLineTool.java
@@ -224,7 +224,7 @@ public abstract class CmdLineTool implements CliCommand {
         // Only restrict ciphers if insecure TLS protocols are explicitly enabled.
         // c.f. https://github.com/Graylog2/graylog2-server/issues/10944
         if (tlsProtocols == null || !(tlsProtocols.isEmpty() || tlsProtocols.contains("TLSv1") || tlsProtocols.contains("TLSv1.1"))) {
-            disabledAlgorithms.addAll(ImmutableSet.of("CBC", "3DES"));
+            disabledAlgorithms.addAll(ImmutableSet.of("CBC", "3DES", "TLS_RSA_WITH_AES_128_GCM_SHA256", "TLS_RSA_WITH_AES_256_GCM_SHA384"));
             Security.setProperty("jdk.tls.disabledAlgorithms", Strings.join(disabledAlgorithms, ", "));
         } else {
             // Remove explicitly enabled legacy TLS protocols from the disabledAlgorithms filter

--- a/graylog2-server/src/main/java/org/graylog2/plugin/inputs/transports/AbstractTcpTransport.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/inputs/transports/AbstractTcpTransport.java
@@ -380,7 +380,8 @@ public abstract class AbstractTcpTransport extends NettyTransport {
 
     private static Set<String> getSecureCipherSuites() {
         final Set<String> openSslCipherSuites = OpenSsl.availableOpenSslCipherSuites();
-        return openSslCipherSuites.stream().filter(s -> !(s.contains("CBC") || s.contains("AES128-SHA") || s.contains("AES256-SHA") )).collect(Collectors.toSet());
+        final Set<String> disabledAlgorithms = Set.of("CBC", "AES128-SHA", "AES256-SHA", "AES128-GCM-SHA256", "AES256-GCM-SHA384");
+        return openSslCipherSuites.stream().filter(s -> !disabledAlgorithms.contains(s)).collect(Collectors.toSet());
     }
 
     @ConfigClass

--- a/graylog2-server/src/main/java/org/graylog2/plugin/inputs/transports/AbstractTcpTransport.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/inputs/transports/AbstractTcpTransport.java
@@ -80,6 +80,7 @@ import java.security.GeneralSecurityException;
 import java.security.PrivateKey;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
+import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.LinkedHashMap;
 import java.util.Locale;
@@ -380,8 +381,9 @@ public abstract class AbstractTcpTransport extends NettyTransport {
 
     private static Set<String> getSecureCipherSuites() {
         final Set<String> openSslCipherSuites = OpenSsl.availableOpenSslCipherSuites();
-        final Set<String> disabledAlgorithms = Set.of("CBC", "AES128-SHA", "AES256-SHA", "AES128-GCM-SHA256", "AES256-GCM-SHA384");
-        return openSslCipherSuites.stream().filter(s -> !disabledAlgorithms.contains(s)).collect(Collectors.toSet());
+        final String[] disabledAlgorithms = {".*CBC.*", "AES128-SHA", "AES256-SHA", "ECDHE-RSA-AES128-SHA",
+                "ECDHE-RSA-AES256-SHA", "AES128-GCM-SHA256", "AES256-GCM-SHA384"};
+        return openSslCipherSuites.stream().filter(s -> Arrays.stream(disabledAlgorithms).noneMatch(s::matches)).collect(Collectors.toSet());
     }
 
     @ConfigClass


### PR DESCRIPTION

https://ciphersuite.info/cs/TLS_RSA_WITH_AES_128_GCM_SHA256/
https://ciphersuite.info/cs/TLS_RSA_WITH_AES_256_GCM_SHA384/

This causes no change in the compatibility test when using `testssl.sh`

```
 Running client simulations (HTTP) via sockets 

 Android 6.0                  TLSv1.2 ECDHE-RSA-AES128-GCM-SHA256, 256 bit ECDH (P-256)
 Android 7.0 (native)         TLSv1.2 ECDHE-RSA-AES256-GCM-SHA384, 256 bit ECDH (P-256)
 Android 8.1 (native)         TLSv1.2 ECDHE-RSA-AES256-GCM-SHA384, 253 bit ECDH (X25519)
 Android 9.0 (native)         TLSv1.3 TLS_AES_256_GCM_SHA384, 253 bit ECDH (X25519)
 Android 10.0 (native)        TLSv1.3 TLS_AES_256_GCM_SHA384, 253 bit ECDH (X25519)
 Android 11 (native)          TLSv1.3 TLS_AES_256_GCM_SHA384, 253 bit ECDH (X25519)
 Android 12 (native)          TLSv1.3 TLS_AES_256_GCM_SHA384, 253 bit ECDH (X25519)
 Chrome 79 (Win 10)           TLSv1.3 TLS_AES_256_GCM_SHA384, 253 bit ECDH (X25519)
 Chrome 101 (Win 10)          TLSv1.3 TLS_AES_256_GCM_SHA384, 253 bit ECDH (X25519)
 Firefox 66 (Win 8.1/10)      TLSv1.3 TLS_AES_256_GCM_SHA384, 253 bit ECDH (X25519)
 Firefox 100 (Win 10)         TLSv1.3 TLS_AES_256_GCM_SHA384, 253 bit ECDH (X25519)
 IE 6 XP                      No connection
 IE 8 Win 7                   No connection
 IE 8 XP                      No connection
 IE 11 Win 7                  TLSv1.2 DHE-RSA-AES256-GCM-SHA384, 2048 bit DH  (ffdhe2048)
 IE 11 Win 8.1                TLSv1.2 DHE-RSA-AES256-GCM-SHA384, 2048 bit DH  (ffdhe2048)
 IE 11 Win Phone 8.1          No connection
 IE 11 Win 10                 TLSv1.2 ECDHE-RSA-AES256-GCM-SHA384, 256 bit ECDH (P-256)
 Edge 15 Win 10               TLSv1.2 ECDHE-RSA-AES256-GCM-SHA384, 253 bit ECDH (X25519)
 Edge 101 Win 10 21H2         TLSv1.3 TLS_AES_256_GCM_SHA384, 253 bit ECDH (X25519)
 Safari 12.1 (iOS 12.2)       TLSv1.3 TLS_AES_256_GCM_SHA384, 253 bit ECDH (X25519)
 Safari 13.0 (macOS 10.14.6)  TLSv1.3 TLS_AES_256_GCM_SHA384, 253 bit ECDH (X25519)
 Safari 15.4 (macOS 12.3.1)   TLSv1.3 TLS_AES_256_GCM_SHA384, 253 bit ECDH (X25519)
 Java 7u25                    No connection
 Java 8u161                   TLSv1.2 ECDHE-RSA-AES256-GCM-SHA384, 256 bit ECDH (P-256)
 Java 11.0.2 (OpenJDK)        TLSv1.3 TLS_AES_256_GCM_SHA384, 256 bit ECDH (P-256)
 Java 17.0.3 (OpenJDK)        TLSv1.3 TLS_AES_256_GCM_SHA384, 253 bit ECDH (X25519)
 go 1.17.8                    TLSv1.3 TLS_AES_256_GCM_SHA384, 253 bit ECDH (X25519)
 LibreSSL 2.8.3 (Apple)       TLSv1.2 ECDHE-RSA-AES256-GCM-SHA384, 253 bit ECDH (X25519)
 OpenSSL 1.0.2e               TLSv1.2 ECDHE-RSA-AES256-GCM-SHA384, 256 bit ECDH (P-256)
 OpenSSL 1.1.0l (Debian)      TLSv1.2 ECDHE-RSA-AES256-GCM-SHA384, 253 bit ECDH (X25519)
 OpenSSL 1.1.1d (Debian)      TLSv1.3 TLS_AES_256_GCM_SHA384, 253 bit ECDH (X25519)
 OpenSSL 3.0.3 (git)          TLSv1.3 TLS_AES_256_GCM_SHA384, 253 bit ECDH (X25519)
 Apple Mail (16.0)            TLSv1.2 ECDHE-RSA-AES256-GCM-SHA384, 256 bit ECDH (P-256)
 Thunderbird (91.9)           TLSv1.3 TLS_AES_256_GCM_SHA384, 253 bit ECDH (X25519)

```

Fixes #14428 