### PR TITLE
Enable first inputs for cloud usage

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/inputs/misc/jsonpath/JsonPathInput.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/misc/jsonpath/JsonPathInput.java
@@ -59,6 +59,11 @@ public class JsonPathInput extends MessageInput {
         public Descriptor() {
             super(NAME, false, DocsHelper.PAGE_SENDING_JSONPATH.toString());
         }
+
+        @Override
+        public boolean isCloudCompatible() {
+            return true;
+        }
     }
 
 

--- a/graylog2-server/src/main/java/org/graylog2/inputs/random/FakeHttpMessageInput.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/random/FakeHttpMessageInput.java
@@ -60,6 +60,11 @@ public class FakeHttpMessageInput extends MessageInput {
         public Descriptor() {
             super(NAME, false, "");
         }
+
+        @Override
+        public boolean isCloudCompatible() {
+            return true;
+        }
     }
 
     public static class Config extends MessageInput.Config {

--- a/graylog2-server/src/main/java/org/graylog2/plugin/inputs/MessageInput.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/inputs/MessageInput.java
@@ -462,7 +462,7 @@ public abstract class MessageInput implements Stoppable {
         }
 
         public boolean isCloudCompatible() {
-            return true;
+            return false;
         }
     }
 


### PR DESCRIPTION
* Make inputs *not* cloud compatible by default
* Enable JSON Path Input in cloud
* Enable Random HTTP Input in cloud

/nocl