### PR TITLE
Handle deprecated short zone IDs correctly

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/scheduler/schedule/CronJobSchedule.java
+++ b/graylog2-server/src/main/java/org/graylog/scheduler/schedule/CronJobSchedule.java
@@ -25,7 +25,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
-import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import org.graylog.scheduler.JobSchedule;
 import org.graylog.scheduler.clock.JobSchedulerClock;
@@ -33,7 +32,6 @@ import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 
 import javax.annotation.Nullable;
-import javax.validation.constraints.Null;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
@@ -79,7 +77,7 @@ public abstract class CronJobSchedule implements JobSchedule {
     private ZonedDateTime getZonedDateTime(JobSchedulerClock clock) {
         final DateTime now = clock.nowUTC();
         Instant instant = Instant.ofEpochMilli(now.getMillis());
-        ZoneId zoneId = ZoneId.of(timezone().orElse(DEFAULT_TIMEZONE));
+        ZoneId zoneId = ZoneId.of(timezone().orElse(DEFAULT_TIMEZONE), ZoneId.SHORT_IDS);
         return ZonedDateTime.ofInstant(instant, zoneId);
     }
 

--- a/graylog2-server/src/test/java/org/graylog/scheduler/JobScheduleStrategiesTest.java
+++ b/graylog2-server/src/test/java/org/graylog/scheduler/JobScheduleStrategiesTest.java
@@ -79,7 +79,7 @@ public class JobScheduleStrategiesTest {
                 .jobDefinitionType("event-processor-execution-v1")
                 .schedule(CronJobSchedule.builder()
                         .cronExpression("0 0 1 * * ? *")
-                        .timezone("Europe/Vienna")
+                        .timezone("EST")
                         .build())
                 .build();
 
@@ -88,7 +88,8 @@ public class JobScheduleStrategiesTest {
         assertThat(nextTime)
                 .isNotNull()
                 .satisfies(dateTime ->  {
-                    assertThat(dateTime.getZone()).isEqualTo(DateTimeZone.forID("Europe/Vienna"));
+                    // EST is mapped to a fixed offset without daylight savings: https://docs.oracle.com/javase/8/docs/api/java/time/ZoneId.html#SHORT_IDS
+                    assertThat(dateTime.getZone()).isEqualTo(DateTimeZone.forID("-05:00"));
                     assertThat(dateTime.toString(DATE_FORMAT)).isEqualTo("14/06/2022 01:00:00");
                 });
     }


### PR DESCRIPTION
Java has deprecated short time zone IDs like EST (except for GMT and UTC).

We need to explicitly map these to the corresonding offset, to ensure backwards compatibility.