### PR TITLE
204 (No content) is returned on empty Optionals

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/shared/initializers/JerseyService.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/initializers/JerseyService.java
@@ -51,6 +51,7 @@ import org.graylog2.shared.rest.CORSFilter;
 import org.graylog2.shared.rest.EmbeddingControlFilter;
 import org.graylog2.shared.rest.NodeIdResponseFilter;
 import org.graylog2.shared.rest.NotAuthorizedResponseFilter;
+import org.graylog2.shared.rest.OptionalResponseFilter;
 import org.graylog2.shared.rest.PrintModelProcessor;
 import org.graylog2.shared.rest.RequestIdFilter;
 import org.graylog2.shared.rest.RestAccessLogFilter;
@@ -263,7 +264,8 @@ public class JerseyService extends AbstractIdleService {
                         XHRFilter.class,
                         NotAuthorizedResponseFilter.class,
                         WebAppNotFoundResponseFilter.class,
-                        EmbeddingControlFilter.class)
+                        EmbeddingControlFilter.class,
+                        OptionalResponseFilter.class)
                 // Replacing this with a lambda leads to missing subtypes - https://github.com/Graylog2/graylog2-server/pull/10617#discussion_r630236360
                 .register(new ContextResolver<ObjectMapper>() {
                     @Override

--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/OptionalResponseFilter.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/OptionalResponseFilter.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.shared.rest;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.core.Response;
+import java.util.Optional;
+
+public class OptionalResponseFilter implements ContainerResponseFilter {
+
+    @Override
+    public void filter(final ContainerRequestContext requestContext,
+                       ContainerResponseContext response) {
+        final Object entity = response.getEntity();
+        if (isEmptyOptional(entity)) {
+            response.setStatus(Response.Status.NO_CONTENT.getStatusCode());
+            response.setEntity(null);
+        }
+    }
+
+    private boolean isEmptyOptional(final Object entity) {
+        return entity instanceof Optional<?> && ((Optional<?>) entity).isEmpty();
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/shared/rest/OptionalResponseFilterTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/shared/rest/OptionalResponseFilterTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.shared.rest;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import java.util.Optional;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+@ExtendWith(MockitoExtension.class)
+class OptionalResponseFilterTest {
+
+    private OptionalResponseFilter toTest;
+    @Mock
+    private ContainerRequestContext requestContext;
+    @Mock
+    private ContainerResponseContext response;
+
+    @BeforeEach
+    void setUp() {
+        toTest = new OptionalResponseFilter();
+    }
+
+
+    @Test
+    void changesStatusToNoContentForEmptyOptional() {
+        doReturn(Optional.empty()).when(response).getEntity();
+        toTest.filter(requestContext, response);
+        verify(response).setStatus(204);
+        verify(response).setEntity(null);
+    }
+
+    @Test
+    void doesNothingOnPresentOptional() {
+        doReturn(Optional.of(new Object())).when(response).getEntity();
+        toTest.filter(requestContext, response);
+        verifyNoMoreInteractions(response);
+    }
+
+    @Test
+    void doesNothingOnNoOptional() {
+        doReturn(new Object()).when(response).getEntity();
+        toTest.filter(requestContext, response);
+        verifyNoMoreInteractions(response);
+    }
+
+}


### PR DESCRIPTION
## Description
204 (No content) status is returned on empty Optionals in REST.
/nocl

## Motivation and Context
So far 200(OK) was returned when endpoint returned empty Optional.
Imho 204 is much more appropriate status code for that situation.

## How Has This Been Tested?
Manually and with new unit test.

## Screenshots (if appropriate):
![Screenshot 2023-02-06 at 14-09-39 Graylog REST API browser](https://user-images.githubusercontent.com/100699120/216979675-b3d829be-c994-4423-862d-1295788c246e.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

