### PR TITLE
Add test for Mongo WriteConflict Error

### DIFF
--- a/graylog2-server/src/test/java/org/graylog/testing/containermatrix/MongodbServer.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/containermatrix/MongodbServer.java
@@ -17,9 +17,11 @@
 package org.graylog.testing.containermatrix;
 
 public enum MongodbServer {
-    MONGO5("5.0");
+    MONGO5("5.0"),
+    MONGO6("6.0"),
+    MONGO4("4.4");
 
-    public static final MongodbServer DEFAULT_VERSION = MONGO5;
+    public static final MongodbServer DEFAULT_VERSION = MONGO6;
 
     private final String version;
 

--- a/graylog2-server/src/test/java/org/graylog/testing/mongodb/MongoDBInstance.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/mongodb/MongoDBInstance.java
@@ -128,6 +128,9 @@ public class MongoDBInstance extends ExternalResource implements AutoCloseable {
             fixtureImporter.importResources(service.mongoDatabase());
         }
     }
+    public String getLogs() {
+        return service.getLogs();
+    }
 
     @Override
     protected void before() {

--- a/graylog2-server/src/test/java/org/graylog/testing/mongodb/MongoDBTestService.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/mongodb/MongoDBTestService.java
@@ -97,10 +97,15 @@ public class MongoDBTestService implements AutoCloseable {
 
         final MongoDbConfiguration mongoConfiguration = new MongoDbConfiguration();
         mongoConfiguration.setUri(uri());
+        container.getLogs();
 
         this.mongoConnection = new MongoConnectionImpl(mongoConfiguration);
         this.mongoConnection.connect();
         this.mongoConnection.getMongoDatabase().drop();
+    }
+
+    public String getLogs() {
+        return container.getLogs();
     }
 
     /**


### PR DESCRIPTION
If multiple nodes are running job schedulers,
they can trigger a warning in MongoDB since version 5.0.

I think this is because of this change, but I'm not 100% sure:
https://github.com/mongodb/mongo/commit/d295b6646fcc815e73ad3085b212ad14c8c6de01

This test runs nextRunnableTrigger() with 10 concurrent Threads and triggers the Warning in MongoDB.

Refs https://github.com/Graylog2/graylog-plugin-enterprise/issues/4664
