### PR TITLE
Running build before linting.

### DIFF
--- a/.github/workflows/fix-linter-hints.yml
+++ b/.github/workflows/fix-linter-hints.yml
@@ -12,9 +12,22 @@ jobs:
     defaults:
       run:
         working-directory: graylog2-web-interface
+    strategy:
+      matrix:
+        java-version: [ 17 ]
 
     steps:
+      - name: Freeing up more disk space
+        run: |
+          sudo rm -rf /usr/local/lib/android # will release about 10 GB if you don't need Android
+          sudo rm -rf /usr/share/dotnet # will release about 20GB if you don't need .NET
       - uses: actions/checkout@v2
+      - name: Set up JDK ${{ matrix.java-version }}
+        uses: actions/setup-java@v2
+        with:
+          java-version: ${{ matrix.java-version }}
+          distribution: temurin
+          cache: maven
       - name: Set up Yarn cache
         uses: actions/cache@v2
         with:
@@ -22,15 +35,20 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
           path: ~/.cache/yarn
-      - name: Install dependencies
-        run: yarn install
+      - name: Build with Maven
+        run: mvn -B --fail-fast -Pedantic -Dspotbugs.skip -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3 -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -DskipTests compile
+        env:
+          JAVA_OPTS: -Xmx6G
       - name: Resetting lockfile
+        working-directory: graylog2-web-interface
         run: git checkout yarn.lock
       - name: Run lint --fix
         continue-on-error: true
+        working-directory: graylog2-web-interface
         run: yarn lint --fix -o /tmp/report.json -f json
       - name: Submit Results
         continue-on-error: true
+        working-directory: graylog2-web-interface
         run: |
           PROBLEM_COUNT=`jq '. | map(.errorCount + .warningCount)|add' /tmp/report.json`
           CURRENT_REF=`git rev-parse HEAD`


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is extending the "Fix linter hints" workflow in a way that it is running `mvn compile` before running the linter. This way, the backend API types are generated before linting, allowing the linter to pick them up and e.g. reflect their priority in the order of imports correctly.

/nocl

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.