### PR TITLE
Make "time-size-optimzing" the new default rotation strategy

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchConfiguration.java
@@ -32,6 +32,7 @@ import org.graylog2.indexer.rotation.strategies.MessageCountRotationStrategy;
 import org.graylog2.indexer.rotation.strategies.SizeBasedRotationStrategy;
 import org.graylog2.indexer.rotation.strategies.TimeBasedRotationStrategy;
 import org.graylog2.indexer.rotation.strategies.TimeBasedSizeOptimizingStrategy;
+import org.graylog2.indexer.rotation.strategies.TimeBasedSizeOptimizingStrategyConfig;
 import org.joda.time.Period;
 
 import javax.annotation.Nullable;
@@ -46,6 +47,8 @@ public class ElasticsearchConfiguration {
     public static final String MAX_INDEX_RETENTION_PERIOD = "max_index_retention_period";
     public static final String DEFAULT_EVENTS_INDEX_PREFIX = "default_events_index_prefix";
     public static final String DEFAULT_SYSTEM_EVENTS_INDEX_PREFIX = "default_system_events_index_prefix";
+    public static final String TIME_SIZE_OPTIMIZING_ROTATION_MIN_LIFETIME = "time_size_optimizing_rotation_min_lifetime";
+    public static final String TIME_SIZE_OPTIMIZING_ROTATION_MAX_LIFETIME = "time_size_optimizing_rotation_max_lifetime";
     public static final String TIME_SIZE_OPTIMIZING_ROTATION_MIN_SHARD_SIZE = "time_size_optimizing_rotation_min_shard_size";
     public static final String TIME_SIZE_OPTIMIZING_ROTATION_MAX_SHARD_SIZE = "time_size_optimizing_rotation_max_shard_size";
     public static final String TIME_SIZE_OPTIMIZING_ROTATION_PERIOD = "time_size_optimizing_rotation_period";
@@ -84,7 +87,7 @@ public class ElasticsearchConfiguration {
     private String retentionStrategy = DeletionRetentionStrategy.NAME;
 
     @Parameter(value = "rotation_strategy", required = true)
-    private String rotationStrategy = SizeBasedRotationStrategy.NAME;
+    private String rotationStrategy = TimeBasedSizeOptimizingStrategy.NAME;
 
     // Rotation
     @Parameter(value = "elasticsearch_max_time_per_index", required = true)
@@ -115,6 +118,12 @@ public class ElasticsearchConfiguration {
 
     @Parameter(value = TIME_SIZE_OPTIMIZING_ROTATION_MAX_SHARD_SIZE)
     private Size timeSizeOptimizingRotationMaxShardSize = Size.gigabytes(50);
+
+    @Parameter(value = TIME_SIZE_OPTIMIZING_ROTATION_MIN_LIFETIME)
+    private Period timeSizeOptimizingRotationMinLifeTime = TimeBasedSizeOptimizingStrategyConfig.DEFAULT_LIFETIME_MIN;
+
+    @Parameter(value = TIME_SIZE_OPTIMIZING_ROTATION_MAX_LIFETIME)
+    private Period timeSizeOptimizingRotationMaxLifeTime = TimeBasedSizeOptimizingStrategyConfig.DEFAULT_LIFETIME_MAX;
 
     @Parameter(value = "elasticsearch_disable_version_check")
     private boolean disableVersionCheck = false;
@@ -236,6 +245,14 @@ public class ElasticsearchConfiguration {
         return timeSizeOptimizingRotationMaxShardSize;
     }
 
+    public Period getTimeSizeOptimizingRotationMinLifeTime() {
+        return timeSizeOptimizingRotationMinLifeTime;
+    }
+
+    public Period getTimeSizeOptimizingRotationMaxLifeTime() {
+        return timeSizeOptimizingRotationMaxLifeTime;
+    }
+
     public boolean isDisableVersionCheck() {
         return disableVersionCheck;
     }
@@ -267,6 +284,12 @@ public class ElasticsearchConfiguration {
             throw new ValidationException(f("\"%s=%s\" cannot be larger than \"%s=%s\"",
                     TIME_SIZE_OPTIMIZING_ROTATION_MIN_SHARD_SIZE, getTimeSizeOptimizingRotationMinShardSize(),
                     TIME_SIZE_OPTIMIZING_ROTATION_MAX_SHARD_SIZE, getTimeSizeOptimizingRotationMaxShardSize())
+            );
+        }
+        if (getTimeSizeOptimizingRotationMaxLifeTime().toStandardSeconds().compareTo(getTimeSizeOptimizingRotationMinLifeTime().toStandardSeconds()) <= 0) {
+            throw new ValidationException(f("\"%s=%s\" needs to be larger than \"%s=%s\"",
+                    TIME_SIZE_OPTIMIZING_ROTATION_MAX_LIFETIME, getTimeSizeOptimizingRotationMaxLifeTime(),
+                    TIME_SIZE_OPTIMIZING_ROTATION_MIN_LIFETIME, getTimeSizeOptimizingRotationMinLifeTime())
             );
         }
     }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/TimeBasedSizeOptimizingStrategy.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/TimeBasedSizeOptimizingStrategy.java
@@ -68,7 +68,10 @@ public class TimeBasedSizeOptimizingStrategy extends AbstractRotationStrategy {
 
     @Override
     public RotationStrategyConfig defaultConfiguration() {
-        return TimeBasedSizeOptimizingStrategyConfig.builder().build();
+        return TimeBasedSizeOptimizingStrategyConfig.builder()
+                .indexLifetimeMin(elasticsearchConfiguration.getTimeSizeOptimizingRotationMinLifeTime())
+                .indexLifetimeMax(elasticsearchConfiguration.getTimeSizeOptimizingRotationMaxLifeTime())
+                .build();
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/TimeBasedSizeOptimizingStrategyConfig.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/TimeBasedSizeOptimizingStrategyConfig.java
@@ -34,8 +34,8 @@ public abstract class TimeBasedSizeOptimizingStrategyConfig implements RotationS
     public static final String INDEX_LIFETIME_MIN = "index_lifetime_min";
     public static final String INDEX_LIFETIME_MAX = "index_lifetime_max";
 
-    private static final Period DEFAULT_LIFETIME_MIN = Period.days(30);
-    private static final Period DEFAULT_LIFETIME_MAX = Period.days(40);
+    public static final Period DEFAULT_LIFETIME_MIN = Period.days(30);
+    public static final Period DEFAULT_LIFETIME_MAX = Period.days(40);
     @JsonProperty(INDEX_LIFETIME_MIN)
     public abstract Period indexLifetimeMin();
 

--- a/graylog2-server/src/main/java/org/graylog2/migrations/MaintenanceStrategiesHelper.java
+++ b/graylog2-server/src/main/java/org/graylog2/migrations/MaintenanceStrategiesHelper.java
@@ -28,6 +28,8 @@ import org.graylog2.indexer.rotation.strategies.SizeBasedRotationStrategy;
 import org.graylog2.indexer.rotation.strategies.SizeBasedRotationStrategyConfig;
 import org.graylog2.indexer.rotation.strategies.TimeBasedRotationStrategy;
 import org.graylog2.indexer.rotation.strategies.TimeBasedRotationStrategyConfig;
+import org.graylog2.indexer.rotation.strategies.TimeBasedSizeOptimizingStrategy;
+import org.graylog2.indexer.rotation.strategies.TimeBasedSizeOptimizingStrategyConfig;
 import org.graylog2.plugin.cluster.ClusterConfigService;
 import org.graylog2.plugin.indexer.retention.RetentionStrategy;
 import org.graylog2.plugin.indexer.retention.RetentionStrategyConfig;
@@ -73,6 +75,13 @@ public class MaintenanceStrategiesHelper {
             case MessageCountRotationStrategy.NAME -> {
                 return ImmutablePair.of(MessageCountRotationStrategy.class.getCanonicalName(),
                         MessageCountRotationStrategyConfig.create(elasticsearchConfiguration.getMaxDocsPerIndex()));
+            }
+            case TimeBasedSizeOptimizingStrategy.NAME -> {
+                return ImmutablePair.of(TimeBasedSizeOptimizingStrategy.class.getCanonicalName(),
+                        TimeBasedSizeOptimizingStrategyConfig.builder()
+                                .indexLifetimeMin(elasticsearchConfiguration.getTimeSizeOptimizingRotationMinLifeTime())
+                                .indexLifetimeMax(elasticsearchConfiguration.getTimeSizeOptimizingRotationMaxLifeTime())
+                                .build());
             }
             default -> {
                 LOG.warn("Unknown retention strategy [{}]. Defaulting to [{}]",

--- a/graylog2-server/src/test/java/org/graylog2/configuration/ElasticsearchConfigurationTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/configuration/ElasticsearchConfigurationTest.java
@@ -45,7 +45,7 @@ public class ElasticsearchConfigurationTest {
         assertEquals(1, configuration.getIndexOptimizationMaxNumSegments());
         assertEquals(Duration.minutes(5), configuration.getIndexFieldTypePeriodicalFullRefreshInterval());
         assertEquals("delete", configuration.getRetentionStrategy());
-        assertEquals("size", configuration.getRotationStrategy());
+        assertEquals("time-size-optimizing", configuration.getRotationStrategy());
         assertEquals(Period.days(1), configuration.getMaxTimePerIndex());
         assertFalse(configuration.isRotateEmptyIndex());
         assertEquals(20000000, configuration.getMaxDocsPerIndex());

--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -321,16 +321,19 @@ stream_aware_field_types=false
 #index_field_type_periodical_full_refresh_interval = 5m
 
 # You can configure the default strategy used to determine when to rotate the currently active write index.
-# Multiple rotation strategies are supported, the default being "size":
+# Multiple rotation strategies are supported, the default being "time-size-optimizing":
+#   - "time-size-optimizing" tries to rotate daily, while focussing on optimal sized shards.
+#      The global default values can be configured with
+#       "time_size_optimizing_rotation_min_lifetime" and "time_size_optimizing_rotation_max_lifetime".
 #   - "count" of messages per index, use elasticsearch_max_docs_per_index below to configure
 #   - "size" per index, use elasticsearch_max_size_per_index below to configure
 #   - "time" interval between index rotations, use elasticsearch_max_time_per_index to configure
 # A strategy may be disabled by specifying the optional enabled_index_rotation_strategies list and excluding that strategy.
 #
-#enabled_index_rotation_strategies = count,size,time
+#enabled_index_rotation_strategies = count,size,time,time-size-optimizing
 
 # The default index rotation strategy to use.
-#rotation_strategy = size
+#rotation_strategy = time-size-optimizing
 
 # (Approximate) maximum number of documents in an Elasticsearch index before a new index
 # is being created, also see no_retention and elasticsearch_max_number_of_indices.


### PR DESCRIPTION
And make the default values configurable via server.conf

/jenkins-pr-deps https://github.com/Graylog2/graylog-plugin-enterprise/pull/4572
/nocl