### PR TITLE
Move managed Netty dependencies to top level pom.xml

### DIFF
--- a/graylog-project-parent/pom.xml
+++ b/graylog-project-parent/pom.xml
@@ -67,25 +67,6 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-bom</artifactId>
-                <version>${netty.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-tcnative-boringssl-static</artifactId>
-                <version>${netty-tcnative-boringssl-static.version}</version>
-                <classifier>osx-x86_64</classifier>
-            </dependency>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-tcnative-boringssl-static</artifactId>
-                <version>${netty-tcnative-boringssl-static.version}</version>
-                <classifier>linux-x86_64</classifier>
-            </dependency>
 
             <dependency>
                 <groupId>com.google.guava</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -251,6 +251,26 @@
                 <artifactId>httpcore-nio</artifactId>
                 <version>${apache-httpcore.version}</version>
             </dependency>
+            <!-- Ensure consistent Netty versions across dependencies and transitive dependencies -->
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-bom</artifactId>
+                <version>${netty.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-tcnative-boringssl-static</artifactId>
+                <version>${netty-tcnative-boringssl-static.version}</version>
+                <classifier>osx-x86_64</classifier>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-tcnative-boringssl-static</artifactId>
+                <version>${netty-tcnative-boringssl-static.version}</version>
+                <classifier>linux-x86_64</classifier>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
Fixes an issue in development when two different netty-tcnative versions are present in the classpath. The change also ensures that we use consistent Netty versions across all transitive dependencies.

Fixes #14602
Obsoletes https://github.com/Graylog2/graylog-plugin-enterprise-integrations/pull/991

/nocl