### PR TITLE
Add normalize function

### DIFF
--- a/changelog/unreleased/issue-6527.toml
+++ b/changelog/unreleased/issue-6527.toml
@@ -1,0 +1,5 @@
+type = "a" # One of: a(dded), c(hanged), d(eprecated), r(emoved), f(ixed), s(ecurity)
+message = "New pipeline rule function for normalizing message field names."
+
+issues = ["6527"]
+pulls = ["14636"]

--- a/changelog/unreleased/issue-6527.toml
+++ b/changelog/unreleased/issue-6527.toml
@@ -1,5 +1,5 @@
 type = "a" # One of: a(dded), c(hanged), d(eprecated), r(emoved), f(ixed), s(ecurity)
-message = "New pipeline rule function for normalizing message field names."
+message = "Add `normalize_fields` pipeline rule function for normalizing message field names."
 
 issues = ["6527"]
 pulls = ["14636"]

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ProcessorFunctionsModule.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ProcessorFunctionsModule.java
@@ -91,6 +91,7 @@ import org.graylog.plugins.pipelineprocessor.functions.messages.CloneMessage;
 import org.graylog.plugins.pipelineprocessor.functions.messages.CreateMessage;
 import org.graylog.plugins.pipelineprocessor.functions.messages.DropMessage;
 import org.graylog.plugins.pipelineprocessor.functions.messages.HasField;
+import org.graylog.plugins.pipelineprocessor.functions.messages.NormalizeFields;
 import org.graylog.plugins.pipelineprocessor.functions.messages.RemoveField;
 import org.graylog.plugins.pipelineprocessor.functions.messages.RemoveFromStream;
 import org.graylog.plugins.pipelineprocessor.functions.messages.RenameField;
@@ -160,6 +161,7 @@ public class ProcessorFunctionsModule extends PluginModule {
         addMessageProcessorFunction(SetFields.NAME, SetFields.class);
         addMessageProcessorFunction(RenameField.NAME, RenameField.class);
         addMessageProcessorFunction(RemoveField.NAME, RemoveField.class);
+        addMessageProcessorFunction(NormalizeFields.NAME, NormalizeFields.class);
 
         addMessageProcessorFunction(DropMessage.NAME, DropMessage.class);
         addMessageProcessorFunction(CreateMessage.NAME, CreateMessage.class);
@@ -282,7 +284,7 @@ public class ProcessorFunctionsModule extends PluginModule {
     }
 
     public static MapBinder<String, Function<?>> processorFunctionBinder(Binder binder) {
-        return MapBinder.newMapBinder(binder, TypeLiteral.get(String.class), new TypeLiteral<Function<?>>() {});
+        return MapBinder.newMapBinder(binder, TypeLiteral.get(String.class), new TypeLiteral<>() {});
     }
 
     public static void addMessageProcessorFunction(Binder binder, String name, Class<? extends Function<?>> functionClass) {

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/messages/NormalizeFields.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/messages/NormalizeFields.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog.plugins.pipelineprocessor.functions.messages;
 
 import com.google.common.collect.ImmutableList;

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/messages/NormalizeFields.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/messages/NormalizeFields.java
@@ -1,0 +1,45 @@
+package org.graylog.plugins.pipelineprocessor.functions.messages;
+
+import com.google.common.collect.ImmutableList;
+import org.graylog.plugins.pipelineprocessor.EvaluationContext;
+import org.graylog.plugins.pipelineprocessor.ast.functions.AbstractFunction;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionArgs;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionDescriptor;
+import org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor;
+import org.graylog2.plugin.Message;
+
+import java.util.Locale;
+import java.util.Map;
+
+import static org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor.type;
+
+public class NormalizeFields extends AbstractFunction<Void> {
+
+    public static final String NAME = "normalize_fields";
+    private final ParameterDescriptor<Message, Message> messageParam;
+
+    public NormalizeFields() {
+        messageParam = type("message", Message.class).optional().description("The message to use, defaults to '$message'").build();
+    }
+
+    @Override
+    public Void evaluate(FunctionArgs args, EvaluationContext context) {
+        final Message message = context.currentMessage();
+        final Map<String, Object> fields = message.getFields();
+        for (String key : fields.keySet()) {
+            message.removeField(key);
+            message.addField(key.toLowerCase(Locale.ROOT), fields.get(key));
+        }
+        return null;
+    }
+
+    @Override
+    public FunctionDescriptor<Void> descriptor() {
+        return FunctionDescriptor.<Void>builder()
+                .name(NAME)
+                .returnType(Void.class)
+                .params(ImmutableList.of(messageParam))
+                .description("Normalizes all field names by setting them to lowercase")
+                .build();
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
@@ -889,6 +889,8 @@ public class FunctionsSnippetsTest extends BaseParserTest {
         assertThat(message.getField("lower_case")).isEqualTo(lcVal);
         assertThat(message.getField("mixed_case")).isEqualTo(mcVal);
         assertThat(message.getField("upper_case")).isEqualTo(ucVal);
+        assertThat(message.getField("mIxEd_CaSe")).isNull();
+        assertThat(message.getField("UPPER_CASE")).isNull();
 
     }
 

--- a/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
@@ -95,6 +95,7 @@ import org.graylog.plugins.pipelineprocessor.functions.messages.CloneMessage;
 import org.graylog.plugins.pipelineprocessor.functions.messages.CreateMessage;
 import org.graylog.plugins.pipelineprocessor.functions.messages.DropMessage;
 import org.graylog.plugins.pipelineprocessor.functions.messages.HasField;
+import org.graylog.plugins.pipelineprocessor.functions.messages.NormalizeFields;
 import org.graylog.plugins.pipelineprocessor.functions.messages.RemoveField;
 import org.graylog.plugins.pipelineprocessor.functions.messages.RemoveFromStream;
 import org.graylog.plugins.pipelineprocessor.functions.messages.RenameField;
@@ -217,6 +218,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
         functions.put(SetFields.NAME, new SetFields());
         functions.put(RenameField.NAME, new RenameField());
         functions.put(RemoveField.NAME, new RemoveField());
+        functions.put(NormalizeFields.NAME, new NormalizeFields());
 
         functions.put(DropMessage.NAME, new DropMessage());
         functions.put(CreateMessage.NAME, new CreateMessage());
@@ -868,6 +870,26 @@ public class FunctionsSnippetsTest extends BaseParserTest {
         assertThat(message.hasField("field_1")).isFalse();
         assertThat(message.hasField("field_2")).isTrue();
         assertThat(message.hasField("field_b")).isTrue();
+    }
+
+    @Test
+    public void normalizeFields() {
+        final Rule rule = parser.parseRule(ruleForTest(), false);
+
+        final Message in = new Message("some message", "somehost.graylog.org", Tools.nowUTC());
+        final String lcVal = "lcVal";
+        final Integer mcVal = 2;
+        final boolean ucVal = true;
+        in.addField("lower_case", lcVal);
+        in.addField("mIxEd_CaSe", mcVal);
+        in.addField("UPPER_CASE", ucVal);
+
+        final Message message = evaluateRule(rule, in);
+
+        assertThat(message.getField("lower_case")).isEqualTo(lcVal);
+        assertThat(message.getField("mixed_case")).isEqualTo(mcVal);
+        assertThat(message.getField("upper_case")).isEqualTo(ucVal);
+
     }
 
     @Test

--- a/graylog2-server/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/normalizeFields.txt
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/normalizeFields.txt
@@ -1,0 +1,5 @@
+rule "debug"
+when true
+then
+    normalize_fields();
+end


### PR DESCRIPTION
## Description
Adds a `normalize_fields()` function for pipeline rules.
This function will convert all message field names to lower case. 

## Motivation and Context
closes #6527

## How Has This Been Tested?
Tested in pipeline rule for messages with mixed case fields.
Unit tests provided.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

