### PR TITLE
Stream pagination extended with simple filter expressions

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/database/filtering/DbFilterParser.java
+++ b/graylog2-server/src/main/java/org/graylog2/database/filtering/DbFilterParser.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.database.filtering;
+
+import com.mongodb.client.model.Filters;
+import org.bson.conversions.Bson;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+//TODO: discuss with FE format for more complex filters as well, mainly range filters
+public class DbFilterParser {
+
+    static final String FIELD_AND_VALUE_SEPARATOR = ":";
+    static final String WRONG_FILTER_EXPR_FORMAT_ERROR_MSG =
+            "Wrong filter expression, <field_name>" + FIELD_AND_VALUE_SEPARATOR + "<field_value> format should be used";
+
+    public List<Bson> parse(final List<String> filterExpressions) {
+        if (filterExpressions == null || filterExpressions.isEmpty()) {
+            return List.of();
+        }
+        return filterExpressions.stream()
+                .map(this::parseSingleExpression)
+                .collect(Collectors.toList());
+
+    }
+
+    public Bson parseSingleExpression(final String filterExpression) {
+        if (!filterExpression.contains(FIELD_AND_VALUE_SEPARATOR)) {
+            throw new IllegalArgumentException(WRONG_FILTER_EXPR_FORMAT_ERROR_MSG);
+        }
+        final String[] split = filterExpression.split(FIELD_AND_VALUE_SEPARATOR, 2);
+
+        if (split[0] == null || split[0].isEmpty()) {
+            throw new IllegalArgumentException(WRONG_FILTER_EXPR_FORMAT_ERROR_MSG);
+        }
+        if (split[1] == null || split[1].isEmpty()) {
+            throw new IllegalArgumentException(WRONG_FILTER_EXPR_FORMAT_ERROR_MSG);
+        }
+
+        return Filters.eq(split[0], split[1]);
+
+    }
+
+
+}

--- a/graylog2-server/src/main/java/org/graylog2/search/SearchQuery.java
+++ b/graylog2-server/src/main/java/org/graylog2/search/SearchQuery.java
@@ -88,7 +88,14 @@ public class SearchQuery {
         if (queryMap.isEmpty()) {
             return new Document();
         }
+        final List<Bson> dbQueries = toBsonFilterList();
+        return Filters.and(dbQueries);
+    }
 
+    public List<Bson> toBsonFilterList() {
+        if (queryMap.isEmpty()) {
+            return new ArrayList<>();
+        }
         final List<Bson> dbQueries = new ArrayList<>();
 
         for (Map.Entry<String, Collection<SearchQueryParser.FieldValue>> entry : queryMap.asMap().entrySet()) {
@@ -106,8 +113,7 @@ public class SearchQuery {
 
             dbQueries.add(Filters.and(queries));
         }
-
-        return Filters.and(dbQueries);
+        return dbQueries;
     }
 
     private List<Bson> toBson(String field, List<SearchQueryParser.FieldValue> values) {

--- a/graylog2-server/src/test/java/org/graylog2/database/filtering/DbFilterParserTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/database/filtering/DbFilterParserTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.database.filtering;
+
+import com.mongodb.client.model.Filters;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.graylog2.database.filtering.DbFilterParser.FIELD_AND_VALUE_SEPARATOR;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class DbFilterParserTest {
+
+    private DbFilterParser toTest;
+
+    @BeforeEach
+    void setUp() {
+        toTest = new DbFilterParser();
+    }
+
+    @Test
+    void returnsEmptyListOnNullFilterList() {
+        assertThat(toTest.parse(null))
+                .isEmpty();
+    }
+
+    @Test
+    void returnsEmptyListOnEmptyFilterList() {
+        assertThat(toTest.parse(List.of()))
+                .isEmpty();
+    }
+
+    @Test
+    void throwsExceptionsOnWrongFilterFormat() {
+        assertThrows(IllegalArgumentException.class, () -> toTest.parse(List.of("No separator")));
+        assertThrows(IllegalArgumentException.class, () -> toTest.parseSingleExpression("No separator"));
+        assertThrows(IllegalArgumentException.class, () -> toTest.parse(List.of(FIELD_AND_VALUE_SEPARATOR + "no field name")));
+        assertThrows(IllegalArgumentException.class, () -> toTest.parseSingleExpression(FIELD_AND_VALUE_SEPARATOR + "no field name"));
+        assertThrows(IllegalArgumentException.class, () -> toTest.parse(List.of("no field value" + FIELD_AND_VALUE_SEPARATOR)));
+        assertThrows(IllegalArgumentException.class, () -> toTest.parseSingleExpression("no field value" + FIELD_AND_VALUE_SEPARATOR));
+        assertThrows(IllegalArgumentException.class, () -> toTest.parse(
+                List.of("good" + FIELD_AND_VALUE_SEPARATOR + "one",
+                        "another" + FIELD_AND_VALUE_SEPARATOR + "good_one",
+                        "single wrong one is enough to throw exception"))
+        );
+    }
+
+    @Test
+    void parsesFilterExpressionCorrectly() {
+
+        assertEquals(Filters.eq("owner", "baldwin"),
+                toTest.parseSingleExpression("owner:baldwin"));
+
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Stream pagination extended with simple filter expressions.
For now, single-value filters are supported. More complex filters, as well as possible refactoring, will come in next PRs.

Implements basic BE part for issue #13852

/nocl

## Motivation and Context
FE needs a way to use filters created by users in Entity List to restrict results obtained from DB.

## How Has This Been Tested?
Unit tests have been added.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

