### PR TITLE
Make lookup table/periodicals startup less noisy.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/lookup/LookupDataAdapterRefreshService.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/LookupDataAdapterRefreshService.java
@@ -106,7 +106,7 @@ public class LookupDataAdapterRefreshService extends AbstractIdleService {
             // ConcurrentMap#computeIfAbsent() does not work here because scheduling a job is not idempotent.
             synchronized (futures) {
                 if (!futures.containsKey(instanceId)) {
-                    LOG.info("Adding job for <{}/{}/@{}> [interval={}ms]", dataAdapter.name(), dataAdapter.id(), instanceId, interval.getMillis());
+                    LOG.debug("Adding job for <{}/{}/@{}> [interval={}ms]", dataAdapter.name(), dataAdapter.id(), instanceId, interval.getMillis());
                     futures.put(instanceId, schedule(dataAdapter, interval));
                 } else {
                     LOG.warn("Job for <{}/{}/@{}> already exists, not adding it again.", dataAdapter.name(), dataAdapter.id(), instanceId);
@@ -128,7 +128,7 @@ public class LookupDataAdapterRefreshService extends AbstractIdleService {
         // Using the adapter object ID here to make it possible to have multiple jobs for the same adapter
         final String instanceId = objectId(dataAdapter);
         if (futures.containsKey(instanceId)) {
-            LOG.info("Removing job for <{}/{}/@{}>", dataAdapter.name(), dataAdapter.id(), instanceId);
+            LOG.debug("Removing job for <{}/{}/@{}>", dataAdapter.name(), dataAdapter.id(), instanceId);
         }
         // Try to cancel the job even if the check above fails to avoid race conditions
         cancel(futures.remove(instanceId));

--- a/graylog2-server/src/main/java/org/graylog2/lookup/LookupTableService.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/LookupTableService.java
@@ -418,12 +418,13 @@ public class LookupTableService extends AbstractIdleService {
     }
 
     protected void addListeners(LookupDataAdapter adapter, DataAdapterDto dto) {
-
-        adapter.addListener(new LoggingServiceListener(
-                        "Data Adapter",
-                        String.format(Locale.ENGLISH, "%s/%s [@%s]", dto.name(), dto.id(), objectId(adapter)),
-                        LOG),
-                scheduler);
+        if (LOG.isDebugEnabled()) {
+            adapter.addListener(new LoggingServiceListener(
+                            "Data Adapter",
+                            String.format(Locale.ENGLISH, "%s/%s [@%s]", dto.name(), dto.id(), objectId(adapter)),
+                            LOG),
+                    scheduler);
+        }
         // Each adapter needs to be added to the refresh scheduler
         adapter.addListener(adapterRefreshService.newServiceListener(adapter), scheduler);
     }
@@ -455,11 +456,13 @@ public class LookupTableService extends AbstractIdleService {
                 return null;
             }
             final LookupCache cache = factory.create(dto.id(), dto.name(), dto.config());
-            cache.addListener(new LoggingServiceListener(
-                            "Cache",
-                            String.format(Locale.ENGLISH, "%s/%s [@%s]", dto.name(), dto.id(), objectId(cache)),
-                            LOG),
-                    scheduler);
+            if (LOG.isDebugEnabled()) {
+                cache.addListener(new LoggingServiceListener(
+                                "Cache",
+                                String.format(Locale.ENGLISH, "%s/%s [@%s]", dto.name(), dto.id(), objectId(cache)),
+                                LOG),
+                        scheduler);
+            }
             return cache;
         } catch (Exception e) {
             LOG.error("Couldn't create cache <{}/{}>", dto.name(), dto.id(), e);
@@ -522,13 +525,13 @@ public class LookupTableService extends AbstractIdleService {
                 .build();
         final LookupCache newCache = table.cache();
         final LookupDataAdapter newAdapter = table.dataAdapter();
-        LOG.info("Starting lookup table {}/{} [@{}] using cache {}/{} [@{}], data adapter {}/{} [@{}]",
+        LOG.debug("Starting lookup table {}/{} [@{}] using cache {}/{} [@{}], data adapter {}/{} [@{}]",
                 table.name(), table.id(), objectId(table),
                 newCache.name(), newCache.id(), objectId(newCache),
                 newAdapter.name(), newAdapter.id(), objectId(newAdapter));
         final LookupTable previous = liveTables.put(dto.name(), table);
         if (previous != null) {
-            LOG.info("Replaced previous lookup table {} [@{}]", previous.name(), objectId(previous));
+            LOG.debug("Replaced previous lookup table {} [@{}]", previous.name(), objectId(previous));
         }
         return table;
     }

--- a/graylog2-server/src/main/java/org/graylog2/periodical/Periodicals.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/Periodicals.java
@@ -62,7 +62,7 @@ public class Periodicals {
                 t.start();
             }
         } else {
-            LOG.info(
+            LOG.debug(
                     "Starting [{}] periodical in [{}s], polling every [{}s].",
                     periodical.getClass().getCanonicalName(),
                     periodical.getInitialDelaySeconds(),

--- a/graylog2-server/src/main/java/org/graylog2/shared/initializers/PeriodicalsService.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/initializers/PeriodicalsService.java
@@ -100,21 +100,27 @@ public class PeriodicalsService extends AbstractIdleService {
             LOG.warn("Skipping start of {} periodicals which have already been started.", numOfPeriodicalsToSkip);
         }
 
+        int successes = 0;
+        int failures = 0;
         for (Periodical periodical : notYetStartedPeriodicals) {
             try {
                 periodical.initialize();
 
                 if (!periodical.startOnThisNode()) {
-                    LOG.info("Not starting [{}] periodical. Not configured to run on this node.", periodical.getClass().getCanonicalName());
+                    LOG.debug("Not starting [{}] periodical. Not configured to run on this node.", periodical.getClass().getCanonicalName());
+                    successes++;
                     continue;
                 }
 
                 // Register and start.
                 periodicals.registerAndStart(periodical);
+                successes++;
             } catch (Exception e) {
                 LOG.error("Could not initialize periodical.", e);
+                failures++;
             }
         }
+        LOG.info("Started [{}/{}] periodicals successfully, {} failed.", successes, notYetStartedPeriodicals.size(), failures);
     }
 
     private synchronized void stopPeriodicals(Collection<Periodical> periodicalsToStop) {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

While debugging a startup error, I noticed that starting up lookup tables (plus data adapters and caches) has become pretty noisy for a standard distribution due to the high number of shipped content, making debugging a startup harder. In most cases, logging the startup of each lookup table, data adapter and cache is not necessary, so this PR is changing their log level to `debug` and prints a summary with the number of started lookup tables, as well as the total number and the number of failures instead.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.