### PR TITLE
Avoiding `GET` APIs for cluster/deflector health. (`5.0`)

### DIFF
--- a/changelog/unreleased/issue-14164.toml
+++ b/changelog/unreleased/issue-14164.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Avoid `GET` APIs for cluster/deflector health to avoid overly long requests."
+
+issues = ["14164"]
+pulls = ["14177"]

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/ClusterAdapterES7.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/ClusterAdapterES7.java
@@ -27,12 +27,11 @@ import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.admin.cluster.
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.admin.cluster.settings.ClusterGetSettingsRequest;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.admin.cluster.settings.ClusterGetSettingsResponse;
-import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.support.IndicesOptions;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.client.Request;
-import org.graylog.shaded.elasticsearch7.org.elasticsearch.client.indices.GetIndexRequest;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.cluster.health.ClusterHealthStatus;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.common.unit.TimeValue;
 import org.graylog.storage.elasticsearch7.cat.CatApi;
+import org.graylog.storage.elasticsearch7.cat.IndexSummaryResponse;
 import org.graylog.storage.elasticsearch7.cat.NodeResponse;
 import org.graylog2.indexer.ElasticsearchException;
 import org.graylog2.indexer.cluster.ClusterAdapter;
@@ -55,6 +54,7 @@ import javax.inject.Named;
 import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -78,8 +78,8 @@ public class ClusterAdapterES7 implements ClusterAdapter {
     }
 
     @Override
-    public Optional<HealthStatus> health(Collection<String> indices) {
-        return clusterHealth(indices).map(response -> healthStatusFrom(response.getStatus()));
+    public Optional<HealthStatus> health() {
+        return clusterHealth().map(response -> healthStatusFrom(response.getStatus()));
     }
 
     private HealthStatus healthStatusFrom(ClusterHealthStatus status) {
@@ -177,13 +177,13 @@ public class ClusterAdapterES7 implements ClusterAdapter {
     }
 
     @Override
-    public Optional<String> clusterName(Collection<String> indices) {
-        return clusterHealth(indices).map(ClusterHealthResponse::getClusterName);
+    public Optional<String> clusterName() {
+        return clusterHealth().map(ClusterHealthResponse::getClusterName);
     }
 
     @Override
-    public Optional<ClusterHealth> clusterHealthStats(Collection<String> indices) {
-        return clusterHealth(indices)
+    public Optional<ClusterHealth> clusterHealthStats() {
+        return clusterHealth()
                 .map(this::clusterHealthFrom);
     }
 
@@ -256,8 +256,8 @@ public class ClusterAdapterES7 implements ClusterAdapter {
     }
 
     @Override
-    public ShardStats shardStats(Collection<String> indices) {
-        return clusterHealth(indices)
+    public ShardStats shardStats() {
+        return clusterHealth()
                 .map(response -> ShardStats.create(
                         response.getNumberOfNodes(),
                         response.getNumberOfDataNodes(),
@@ -271,15 +271,10 @@ public class ClusterAdapterES7 implements ClusterAdapter {
                 .orElseThrow(() -> new ElasticsearchException("Unable to retrieve shard stats."));
     }
 
-    private Optional<ClusterHealthResponse> clusterHealth(Collection<String> indices) {
-        final String[] indicesAry = indices.toArray(new String[0]);
+    private Optional<ClusterHealthResponse> clusterHealth() {
         try {
-            if (!indices.isEmpty() && !indicesExist(indicesAry)) {
-                return Optional.empty();
-            }
-            final ClusterHealthRequest request = new ClusterHealthRequest(indicesAry)
-                    .timeout(TimeValue.timeValueSeconds(Ints.saturatedCast(requestTimeout.toSeconds())))
-                    .indicesOptions(IndicesOptions.lenientExpand());
+            final ClusterHealthRequest request = new ClusterHealthRequest()
+                    .timeout(TimeValue.timeValueSeconds(Ints.saturatedCast(requestTimeout.toSeconds())));
             return Optional.of(client.execute((c, requestOptions) -> c.cluster().health(request, requestOptions)));
         } catch (org.graylog.shaded.elasticsearch7.org.elasticsearch.ElasticsearchException e) {
             if (LOG.isDebugEnabled()) {
@@ -291,10 +286,30 @@ public class ClusterAdapterES7 implements ClusterAdapter {
         }
     }
 
-    private boolean indicesExist(String... indices) {
-        final GetIndexRequest getIndexRequest = new GetIndexRequest(indices);
-        return client.execute((c, requestOptions) -> c.indices().exists(getIndexRequest, requestOptions));
+    @Override
+    public Optional<HealthStatus> deflectorHealth(Collection<String> indices) {
+        if (indices.isEmpty()) {
+            return Optional.of(HealthStatus.Green);
+        }
+
+        final Map<String, String> aliasMapping = catApi.aliases();
+        final Set<String> mappedIndices = indices
+                .stream()
+                .map(index -> aliasMapping.getOrDefault(index, index))
+                .collect(Collectors.toSet());
+
+        final Set<IndexSummaryResponse> indexSummaries = catApi.indices()
+                .stream()
+                .filter(indexSummary -> mappedIndices.contains(indexSummary.index()))
+                .collect(Collectors.toSet());
+
+        if (indexSummaries.size() < mappedIndices.size()) {
+            return Optional.empty();
+        }
+
+        return indexSummaries.stream()
+                .map(IndexSummaryResponse::health)
+                .map(HealthStatus::fromString)
+                .min(HealthStatus::compareTo);
     }
-
-
 }

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/cat/AliasSummaryResponse.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/cat/AliasSummaryResponse.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.storage.elasticsearch7.cat;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record AliasSummaryResponse(@JsonProperty("alias") String alias,
+                                   @JsonProperty("index") String index) {
+}

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/cat/IndexSummaryResponse.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/cat/IndexSummaryResponse.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.storage.elasticsearch7.cat;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record IndexSummaryResponse(@JsonProperty("index") String index,
+                                   @JsonProperty("status") String status,
+                                   @JsonProperty("health") String health) {
+}

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/ClusterAdapterES7Test.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/ClusterAdapterES7Test.java
@@ -21,6 +21,7 @@ import com.github.joschi.jadconfig.util.Duration;
 import com.google.common.io.Resources;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.ElasticsearchException;
 import org.graylog.storage.elasticsearch7.cat.CatApi;
+import org.graylog.storage.elasticsearch7.cat.IndexSummaryResponse;
 import org.graylog.storage.elasticsearch7.cat.NodeResponse;
 import org.graylog2.indexer.cluster.health.NodeDiskUsageStats;
 import org.graylog2.indexer.cluster.health.NodeFileDescriptorStats;
@@ -33,7 +34,8 @@ import org.junit.jupiter.api.Test;
 import org.testcontainers.shaded.com.google.common.collect.ImmutableList;
 
 import java.io.IOException;
-import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -50,7 +52,7 @@ class ClusterAdapterES7Test {
     private ElasticsearchClient client;
     private CatApi catApi;
     private PlainJsonApi jsonApi;
-    private ObjectMapper objectMapper = new ObjectMapperProvider().get();
+    private final ObjectMapper objectMapper = new ObjectMapperProvider().get();
 
     private ClusterAdapterES7 clusterAdapter;
 
@@ -107,7 +109,7 @@ class ClusterAdapterES7Test {
     @Test
     void returnsEmptyOptionalForHealthWhenElasticsearchExceptionThrown() {
         when(client.execute(any())).thenThrow(new ElasticsearchException("Exception"));
-        final Optional<HealthStatus> healthStatus = clusterAdapter.health(Collections.singletonList("foo_index"));
+        final Optional<HealthStatus> healthStatus = clusterAdapter.health();
         assertThat(healthStatus).isEmpty();
     }
 
@@ -154,6 +156,23 @@ class ClusterAdapterES7Test {
                         }
                 );
 
+    }
+
+    @Test
+    void testDeflectorHealth() {
+        when(catApi.aliases()).thenReturn(Map.of(
+                "foo_deflector", "foo_42",
+                "bar_deflector", "bar_17",
+                "baz_deflector", "baz_23"
+        ));
+
+        when(catApi.indices()).thenReturn(List.of(
+                new IndexSummaryResponse("foo_42", "", "RED"),
+                new IndexSummaryResponse("bar_17", "", "YELLOW"),
+                new IndexSummaryResponse("baz_23", "", "GREEN")
+        ));
+
+        assertThat(clusterAdapter.deflectorHealth(Set.of("foo_deflector", "bar_deflector", "baz_deflector"))).contains(HealthStatus.Red);
     }
 
     private void mockNodesResponse() throws IOException {

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/ClusterAdapterOS2.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/ClusterAdapterOS2.java
@@ -28,12 +28,14 @@ import org.graylog.shaded.opensearch2.org.opensearch.action.admin.cluster.health
 import org.graylog.shaded.opensearch2.org.opensearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.graylog.shaded.opensearch2.org.opensearch.action.admin.cluster.settings.ClusterGetSettingsRequest;
 import org.graylog.shaded.opensearch2.org.opensearch.action.admin.cluster.settings.ClusterGetSettingsResponse;
+import org.graylog.shaded.opensearch2.org.opensearch.action.search.SearchRequest;
 import org.graylog.shaded.opensearch2.org.opensearch.action.support.IndicesOptions;
 import org.graylog.shaded.opensearch2.org.opensearch.client.Request;
-import org.graylog.shaded.opensearch2.org.opensearch.client.indices.GetIndexRequest;
 import org.graylog.shaded.opensearch2.org.opensearch.cluster.health.ClusterHealthStatus;
 import org.graylog.shaded.opensearch2.org.opensearch.common.unit.TimeValue;
+import org.graylog.shaded.opensearch2.org.opensearch.search.builder.SearchSourceBuilder;
 import org.graylog.storage.opensearch2.cat.CatApi;
+import org.graylog.storage.opensearch2.cat.IndexSummaryResponse;
 import org.graylog.storage.opensearch2.cat.NodeResponse;
 import org.graylog2.indexer.ElasticsearchException;
 import org.graylog2.indexer.cluster.ClusterAdapter;
@@ -56,6 +58,7 @@ import javax.inject.Named;
 import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -79,8 +82,8 @@ public class ClusterAdapterOS2 implements ClusterAdapter {
     }
 
     @Override
-    public Optional<HealthStatus> health(Collection<String> indices) {
-        return clusterHealth(indices).map(response -> healthStatusFrom(response.getStatus()));
+    public Optional<HealthStatus> health() {
+        return clusterHealth().map(response -> healthStatusFrom(response.getStatus()));
     }
 
     private HealthStatus healthStatusFrom(ClusterHealthStatus status) {
@@ -178,13 +181,13 @@ public class ClusterAdapterOS2 implements ClusterAdapter {
     }
 
     @Override
-    public Optional<String> clusterName(Collection<String> indices) {
-        return clusterHealth(indices).map(ClusterHealthResponse::getClusterName);
+    public Optional<String> clusterName() {
+        return clusterHealth().map(ClusterHealthResponse::getClusterName);
     }
 
     @Override
-    public Optional<ClusterHealth> clusterHealthStats(Collection<String> indices) {
-        return clusterHealth(indices)
+    public Optional<ClusterHealth> clusterHealthStats() {
+        return clusterHealth()
                 .map(this::clusterHealthFrom);
     }
 
@@ -257,8 +260,8 @@ public class ClusterAdapterOS2 implements ClusterAdapter {
     }
 
     @Override
-    public ShardStats shardStats(Collection<String> indices) {
-        return clusterHealth(indices)
+    public ShardStats shardStats() {
+        return clusterHealth()
                 .map(response -> ShardStats.create(
                         response.getNumberOfNodes(),
                         response.getNumberOfDataNodes(),
@@ -272,15 +275,10 @@ public class ClusterAdapterOS2 implements ClusterAdapter {
                 .orElseThrow(() -> new ElasticsearchException("Unable to retrieve shard stats."));
     }
 
-    private Optional<ClusterHealthResponse> clusterHealth(Collection<String> indices) {
-        final String[] indicesAry = indices.toArray(new String[0]);
+    private Optional<ClusterHealthResponse> clusterHealth() {
         try {
-            if (!indices.isEmpty() && !indicesExist(indicesAry)) {
-                return Optional.empty();
-            }
-            final ClusterHealthRequest request = new ClusterHealthRequest(indicesAry)
-                    .timeout(TimeValue.timeValueSeconds(Ints.saturatedCast(requestTimeout.toSeconds())))
-                    .indicesOptions(IndicesOptions.lenientExpand());
+            final ClusterHealthRequest request = new ClusterHealthRequest()
+                    .timeout(TimeValue.timeValueSeconds(Ints.saturatedCast(requestTimeout.toSeconds())));
             return Optional.of(client.execute((c, requestOptions) -> c.cluster().health(request, requestOptions)));
         } catch (OpenSearchException e) {
             if (LOG.isDebugEnabled()) {
@@ -292,10 +290,30 @@ public class ClusterAdapterOS2 implements ClusterAdapter {
         }
     }
 
-    private boolean indicesExist(String... indices) {
-        final GetIndexRequest getIndexRequest = new GetIndexRequest(indices);
-        return client.execute((c, requestOptions) -> c.indices().exists(getIndexRequest, requestOptions));
+    @Override
+    public Optional<HealthStatus> deflectorHealth(Collection<String> indices) {
+        if (indices.isEmpty()) {
+            return Optional.of(HealthStatus.Green);
+        }
+
+        final Map<String, String> aliasMapping = catApi.aliases();
+        final Set<String> mappedIndices = indices
+                .stream()
+                .map(index -> aliasMapping.getOrDefault(index, index))
+                .collect(Collectors.toSet());
+
+        final Set<IndexSummaryResponse> indexSummaries = catApi.indices()
+                .stream()
+                .filter(indexSummary -> mappedIndices.contains(indexSummary.index()))
+                .collect(Collectors.toSet());
+
+        if (indexSummaries.size() < mappedIndices.size()) {
+            return Optional.empty();
+        }
+
+        return indexSummaries.stream()
+                .map(IndexSummaryResponse::health)
+                .map(HealthStatus::fromString)
+                .min(HealthStatus::compareTo);
     }
-
-
 }

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/cat/AliasSummaryResponse.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/cat/AliasSummaryResponse.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.storage.opensearch2.cat;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record AliasSummaryResponse(@JsonProperty("alias") String alias,
+                                   @JsonProperty("index") String index) {
+}

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/cat/CatApi.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/cat/CatApi.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -44,11 +45,26 @@ public class CatApi {
         this.client = client;
     }
 
+    public Map<String, String> aliases() {
+        final Request request = request("GET", "aliases");
+        request.addParameter("h", "alias,index");
+        final List<AliasSummaryResponse> response = perform(request, new TypeReference<List<AliasSummaryResponse>>() {}, "Unable to retrieve aliases");
+
+        return response.stream()
+                .collect(Collectors.toMap(AliasSummaryResponse::alias, AliasSummaryResponse::index));
+    }
+
     public List<NodeResponse> nodes() {
         final Request request = request("GET", "nodes");
         request.addParameter("h", "id,name,role,host,ip,fileDescriptorMax,diskUsed,diskTotal,diskUsedPercent");
         request.addParameter("full_id", "true");
-        return perform(request, new TypeReference<List<NodeResponse>>() {}, "Unable to retrieve nodes list");
+        return perform(request, new TypeReference<>() {}, "Unable to retrieve nodes list");
+    }
+
+    public List<IndexSummaryResponse> indices() {
+        final Request request = request("GET", "indices");
+        request.addParameter("h", "index,status,health");
+        return perform(request, new TypeReference<>() {}, "Unable to retrieve indices list");
     }
 
     public Set<String> indices(String index, Collection<String> status, String errorMessage) {

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/cat/IndexSummaryResponse.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/cat/IndexSummaryResponse.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.storage.opensearch2.cat;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record IndexSummaryResponse(@JsonProperty("index") String index,
+                                   @JsonProperty("status") String status,
+                                   @JsonProperty("health") String health) {
+}

--- a/graylog2-server/src/main/java/org/graylog2/indexer/cluster/Cluster.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/cluster/Cluster.java
@@ -67,7 +67,7 @@ public class Cluster {
      * @return the cluster health response
      */
     public Optional<HealthStatus> health() {
-        return clusterAdapter.health(allIndexWildcards());
+        return clusterAdapter.health();
     }
 
     private List<String> allIndexWildcards() {
@@ -83,7 +83,7 @@ public class Cluster {
      * @return the cluster health response
      */
     public Optional<HealthStatus> deflectorHealth() {
-        return clusterAdapter.health(Arrays.asList(indexSetRegistry.getWriteIndexAliases()));
+        return clusterAdapter.deflectorHealth(Arrays.asList(indexSetRegistry.getWriteIndexAliases()));
     }
 
     public Set<NodeFileDescriptorStats> getFileDescriptorStats() {
@@ -119,7 +119,7 @@ public class Cluster {
      * Check if the cluster health status is not {@literal RED} and that the
      * {@link IndexSetRegistry#isUp() deflector is up}.
      *
-     * @return {@code true} if the the cluster is healthy and the deflector is up, {@code false} otherwise
+     * @return {@code true} if the cluster is healthy and the deflector is up, {@code false} otherwise
      */
     public boolean isHealthy() {
         return health()
@@ -180,25 +180,24 @@ public class Cluster {
     }
 
     public Optional<String> clusterName() {
-        return clusterAdapter.clusterName(allIndexWildcards());
+        return clusterAdapter.clusterName();
     }
 
     public Optional<ClusterHealth> clusterHealthStats() {
-        return clusterAdapter.clusterHealthStats(allIndexWildcards());
+        return clusterAdapter.clusterHealthStats();
     }
 
     public ElasticsearchStats elasticsearchStats() {
-        final List<String> indices = Arrays.asList(indexSetRegistry.getIndexWildcards());
         final org.graylog2.system.stats.elasticsearch.ClusterStats clusterStats = clusterAdapter.clusterStats();
 
         final PendingTasksStats pendingTasksStats = clusterAdapter.pendingTasks();
 
-        final ShardStats shardStats = clusterAdapter.shardStats(indices);
+        final ShardStats shardStats = clusterAdapter.shardStats();
         final org.graylog2.system.stats.elasticsearch.ClusterHealth clusterHealth = org.graylog2.system.stats.elasticsearch.ClusterHealth.from(
                 shardStats,
                 pendingTasksStats
         );
-        final HealthStatus healthStatus = clusterAdapter.health(indices).orElseThrow(() -> new IllegalStateException("Unable to retrieve cluster health."));
+        final HealthStatus healthStatus = clusterAdapter.health().orElseThrow(() -> new IllegalStateException("Unable to retrieve cluster health."));
 
         return ElasticsearchStats.create(
                 clusterStats.clusterName(),

--- a/graylog2-server/src/main/java/org/graylog2/indexer/cluster/ClusterAdapter.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/cluster/ClusterAdapter.java
@@ -25,11 +25,12 @@ import org.graylog2.system.stats.elasticsearch.ClusterStats;
 import org.graylog2.system.stats.elasticsearch.ShardStats;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
 public interface ClusterAdapter {
-    Optional<HealthStatus> health(Collection<String> indices);
+    Optional<HealthStatus> health();
 
     Set<NodeFileDescriptorStats> fileDescriptorStats();
 
@@ -43,13 +44,15 @@ public interface ClusterAdapter {
 
     boolean isConnected();
 
-    Optional<String> clusterName(Collection<String> indices);
+    Optional<String> clusterName();
 
-    Optional<ClusterHealth> clusterHealthStats(Collection<String> indices);
+    Optional<ClusterHealth> clusterHealthStats();
 
     ClusterStats clusterStats();
 
     PendingTasksStats pendingTasks();
 
-    ShardStats shardStats(Collection<String> indices);
+    ShardStats shardStats();
+
+    Optional<HealthStatus> deflectorHealth(Collection<String> indices);
 }

--- a/graylog2-server/src/test/java/org/graylog2/indexer/cluster/ClusterIT.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/cluster/ClusterIT.java
@@ -97,15 +97,7 @@ public abstract class ClusterIT extends ElasticsearchBaseTest {
     }
 
     @Test
-    public void health_returns_empty_with_missing_index() {
-        when(indexSetRegistry.getIndexWildcards()).thenReturn(new String[]{"does_not_exist"});
-        final Optional<HealthStatus> health = cluster.health();
-        assertThat(health).isEmpty();
-    }
-
-    @Test
     public void health_returns_green_with_no_indices() {
-        when(indexSetRegistry.getIndexWildcards()).thenReturn(new String[]{});
         final Optional<HealthStatus> health = cluster.health();
         assertThat(health).contains(HealthStatus.Green);
     }
@@ -176,15 +168,7 @@ public abstract class ClusterIT extends ElasticsearchBaseTest {
     }
 
     @Test
-    public void isHealthy_returns_false_with_missing_index() {
-        when(indexSetRegistry.getIndexWildcards()).thenReturn(new String[]{"does-not-exist"});
-        when(indexSetRegistry.isUp()).thenReturn(true);
-        assertThat(cluster.isHealthy()).isFalse();
-    }
-
-    @Test
     public void isHealthy_returns_true_with_no_indices() {
-        when(indexSetRegistry.getIndexWildcards()).thenReturn(new String[]{});
         when(indexSetRegistry.isUp()).thenReturn(true);
         assertThat(cluster.isHealthy()).isTrue();
     }


### PR DESCRIPTION
**Note:** This is a backport of #14177 to `5.0`.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Prior to this change, retrieving the cluster/deflector health relied on Elasticsearch/Opensearch endpoints taking a list of indices as a query parameter and we passed e.g. the list of all existing index wildcards to this. This can lead to a request being generated that has a query string that is too big, if a high number of index sets exist, as seen in #14164.

Unfortunately, there are no endpoints for this taking the list of indices outside of a query parameter. Therefore this PR is now doing two things to fix this:

  - General cluster health is retrieved with the generic cluster health endpoint without passing index names. This returns a health status (red, yellow, green) in the same way, but is not specific to the indices used by Graylog.
  - Using the CAT API to resolve and retrieve the health for the individual deflector aliases configured. We do retrieve the complete list of aliases and indices and filter out the ones we are interested in. Due to the compact nature of the CAT API this should work well for a highly utilized ES/OS instance as well.

Fixes #14164.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.