### PR TITLE
Better messaging for grouping errors

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/events/processor/EventProcessorEngine.java
+++ b/graylog2-server/src/main/java/org/graylog/events/processor/EventProcessorEngine.java
@@ -99,7 +99,7 @@ public class EventProcessorEngine {
             throw e;
         } catch (Exception e) {
             metrics.recordException(eventProcessor, definitionId);
-            LOG.error("Caught an unhandled exception while executing event processor <{}/{}/{}> - Make sure to modify the event processor to throw only EventProcessorExecutionException so we get more context!",
+            LOG.error("Caught an unhandled exception while executing event processor <{}/{}/{}> - Make sure to modify the event processor to throw only EventProcessorException so we get more context!",
                     definition.config().type(), definition.title(), definition.id(), e);
             // Since we don't know what kind of error this is, we play safe and make this a temporary error.
             throw new EventProcessorException("Couldn't create events for: " + definition.toString(), false, definition, e);

--- a/graylog2-server/src/main/java/org/graylog/events/processor/aggregation/PivotAggregationSearch.java
+++ b/graylog2-server/src/main/java/org/graylog/events/processor/aggregation/PivotAggregationSearch.java
@@ -158,7 +158,7 @@ public class PivotAggregationSearch implements AggregationSearch {
         final PivotResult streamsResult = (PivotResult) streamQueryResult.searchTypes().get(STREAMS_PIVOT_ID);
 
         return AggregationResult.builder()
-                .keyResults(extractValues(pivotResult))
+                .keyResults( extractValues(pivotResult))
                 .effectiveTimerange(pivotResult.effectiveTimerange())
                 .totalAggregatedMessages(pivotResult.total())
                 .sourceStreams(extractSourceStreams(streamsResult))
@@ -319,7 +319,12 @@ public class PivotAggregationSearch implements AggregationSearch {
                 }
             }
 
-            DateTime resultTimestamp = DateTime.parse(timeKey).withZone(DateTimeZone.UTC);
+            DateTime resultTimestamp;
+            try{
+                resultTimestamp = DateTime.parse(timeKey).withZone(DateTimeZone.UTC);
+            } catch (IllegalArgumentException e) {
+                throw new IllegalStateException("Failed to create event for: " + eventDefinition.title() + " (possibly due to non-existing grouping fields)", e);
+            }
             results.add(AggregationKeyResult.builder()
                     .key(groupKey)
                     .timestamp(resultTimestamp)

--- a/graylog2-server/src/test/java/org/graylog/events/processor/aggregation/AggregationEventProcessorTest.java
+++ b/graylog2-server/src/test/java/org/graylog/events/processor/aggregation/AggregationEventProcessorTest.java
@@ -104,7 +104,7 @@ public class AggregationEventProcessorTest {
     }
 
     @Test
-    public void testEventsFromAggregationResult() {
+    public void testEventsFromAggregationResult() throws EventProcessorException {
         final DateTime now = DateTime.now(DateTimeZone.UTC);
         final AbsoluteRange timerange = AbsoluteRange.create(now.minusHours(1), now.minusHours(1).plusMillis(SEARCH_WINDOW_MS));
 
@@ -195,7 +195,7 @@ public class AggregationEventProcessorTest {
     }
 
     @Test
-    public void testEventsFromAggregationResultWithConditions() {
+    public void testEventsFromAggregationResultWithConditions() throws EventProcessorException {
         final DateTime now = DateTime.now(DateTimeZone.UTC);
         final AbsoluteRange timerange = AbsoluteRange.create(now.minusHours(1), now.minusHours(1).plusMillis(SEARCH_WINDOW_MS));
 
@@ -403,7 +403,7 @@ public class AggregationEventProcessorTest {
     }
 
     @Test
-    public void testEventsFromAggregationResultWithEmptyResultUsesEventDefinitionStreamAsSourceStreams() {
+    public void testEventsFromAggregationResultWithEmptyResultUsesEventDefinitionStreamAsSourceStreams() throws EventProcessorException {
         final DateTime now = DateTime.now(DateTimeZone.UTC);
         final AbsoluteRange timerange = AbsoluteRange.create(now.minusHours(1), now.minusHours(1).plusMillis(SEARCH_WINDOW_MS));
 
@@ -447,7 +447,7 @@ public class AggregationEventProcessorTest {
     }
 
     @Test
-    public void testEventsFromAggregationResultWithEmptyResultAndNoConfiguredStreamsUsesAllStreamsAsSourceStreams() {
+    public void testEventsFromAggregationResultWithEmptyResultAndNoConfiguredStreamsUsesAllStreamsAsSourceStreams() throws EventProcessorException {
         final DateTime now = DateTime.now(DateTimeZone.UTC);
         final AbsoluteRange timerange = AbsoluteRange.create(now.minusHours(1), now.minusHours(1).plusMillis(SEARCH_WINDOW_MS));
 


### PR DESCRIPTION
Resolves #14375 
/nocl

Catch exceptions related to invalid grouping and rethrow with a more actionable message.