### PR TITLE
Extend browser support back to Chrome 68.

### DIFF
--- a/changelog/unreleased/pr-14688.toml
+++ b/changelog/unreleased/pr-14688.toml
@@ -1,0 +1,5 @@
+type = "f"
+message = "Extend browser support back to Chrome 68."
+
+issues = ["14677"]
+pulls = ["14688"]

--- a/graylog2-web-interface/supportedBrowsers.js
+++ b/graylog2-web-interface/supportedBrowsers.js
@@ -16,7 +16,7 @@
  */
 const browserslist = require('browserslist');
 
-const targets = browserslist('defaults, not ie 11');
+const targets = browserslist('defaults, not ie 11, chrome 68');
 
 const supportedProducts = ['chrome', 'edge', 'firefox', 'ios_saf', 'opera', 'safari'];
 

--- a/graylog2-web-interface/webpack.config.js
+++ b/graylog2-web-interface/webpack.config.js
@@ -98,7 +98,7 @@ const webpackConfig = {
             target: supportedBrowsers,
           },
         },
-        exclude: /node_modules\/(?!graylog-web-plugin)|\.node_cache/,
+        exclude: /node_modules\/(?!(@react-hook|uuid|@?react-leaflet|graylog-web-plugin))|\.node_cache/,
       },
       {
         test: /\.(svg)(\?.+)?$/,


### PR DESCRIPTION
**Note:** This needs a backport to `5.0`.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This change is extending our browser support to go back to Chrome 68 in order to support outdated browser versions commonly found e.g. on smart TVs. The cut is made at Chrome 67 in order to support at least the [last three versions of webOS](https://webostv.developer.lge.com/develop/specifications/web-api-and-web-engine).

Fixes #14677.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.