### PR TITLE
Quote $ when escaping field values.

### DIFF
--- a/changelog/unreleased/pr-14692.toml
+++ b/changelog/unreleased/pr-14692.toml
@@ -1,0 +1,4 @@
+type = "f"
+message = "Escape $ properly when part of value that is added to query."
+
+pulls = ["14692"]

--- a/graylog2-web-interface/src/views/logic/queries/QueryHelper.test.ts
+++ b/graylog2-web-interface/src/views/logic/queries/QueryHelper.test.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import { escape } from './QueryHelper';
+
+describe('QueryHelper', () => {
+  it('quotes $ in values', () => {
+    expect(escape('foo$bar$')).toEqual('foo\\$bar\\$');
+  });
+});

--- a/graylog2-web-interface/src/views/logic/queries/QueryHelper.ts
+++ b/graylog2-web-interface/src/views/logic/queries/QueryHelper.ts
@@ -33,7 +33,7 @@ const escape = (searchTerm: string | number | undefined | null) => {
     escapedTerm = `"${escapedTerm}"`;
   } else {
     // Escape all lucene special characters from the source: && || : \ / + - ! ( ) { } [ ] ^ " ~ * ?
-    escapedTerm = String(escapedTerm).replace(/(&&|\|\||[:\\/+\-!(){}[\]^"~*?])/g, '\\$&');
+    escapedTerm = String(escapedTerm).replace(/(&&|\|\||[:\\/+\-!(){}[\]^"~*?$])/g, '\\$&');
   }
 
   return escapedTerm;


### PR DESCRIPTION
**Note:** This needs a backport to `5.0`.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Prior to this change, when a field value contains one or more `$` and the `Add to query`/`Exclude from results` value action were used, the `$` were not escaped. This could lead to parts of the query being mistaken as a parameter erroneously.

This change is now making sure that `$` as part of the value are escaped.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.