### PR TITLE
Fixup handling of dirty flag for views.

### DIFF
--- a/graylog2-web-interface/src/views/components/searchbar/saved-search/SearchActionsMenu.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/saved-search/SearchActionsMenu.tsx
@@ -107,10 +107,8 @@ const SearchActionsMenu = () => {
       .type(View.Type.Search)
       .build();
 
-    ViewManagementActions.update(newView)
-      .then(toggleFormModal)
-      .then(() => UserNotification.success(`Saving view "${newView.title}" was successful!`, 'Success!'))
-      .catch((error) => UserNotification.error(`Saving view failed: ${_extractErrorMessage(error)}`, 'Error!'));
+    dispatch(onSaveView(newView))
+      .then(toggleFormModal);
   };
 
   const saveAsSearch = async () => {

--- a/graylog2-web-interface/src/views/components/views/ViewHeader.tsx
+++ b/graylog2-web-interface/src/views/components/views/ViewHeader.tsx
@@ -29,7 +29,7 @@ import useViewTitle from 'views/hooks/useViewTitle';
 import useView from 'views/hooks/useView';
 import useAppDispatch from 'stores/useAppDispatch';
 import FavoriteIcon from 'views/components/FavoriteIcon';
-import { loadView } from 'views/logic/slices/viewSlice';
+import { updateView } from 'views/logic/slices/viewSlice';
 
 const links = {
   [View.Type.Dashboard]: {
@@ -84,7 +84,7 @@ const ViewHeader = () => {
 
   const typeText = view?.type?.toLocaleLowerCase();
   const title = useViewTitle();
-  const onChangeFavorite = useCallback((newValue) => dispatch(loadView(view.toBuilder().favorite(newValue).build())), [dispatch, view]);
+  const onChangeFavorite = useCallback((newValue) => dispatch(updateView(view.toBuilder().favorite(newValue).build())), [dispatch, view]);
 
   return (
     <Row>

--- a/graylog2-web-interface/src/views/logic/slices/viewSlice.ts
+++ b/graylog2-web-interface/src/views/logic/slices/viewSlice.ts
@@ -54,11 +54,21 @@ const viewSlice = createSlice({
       ...state,
       activeQuery: action.payload,
     }),
-    setView: (state: ViewState, action: PayloadAction<View>) => {
-      return ({
-        ...state,
-        view: action.payload,
-      });
+    setView: {
+      reducer(state: ViewState, action: PayloadAction<readonly [View, boolean | undefined]>) {
+        const [view, isDirty] = action.payload;
+
+        return ({
+          ...state,
+          view,
+          isDirty: isDirty === undefined ? state.isDirty : isDirty,
+        });
+      },
+      prepare(view: View, isDirty?: boolean) {
+        return {
+          payload: [view, isDirty] as const,
+        };
+      },
     },
     setIsNew: (state: ViewState, action: PayloadAction<boolean>) => ({
       ...state,
@@ -73,15 +83,25 @@ const viewSlice = createSlice({
 export const viewSliceReducer = viewSlice.reducer;
 export const { setView, selectQuery, setIsDirty, setIsNew } = viewSlice.actions;
 
-export const loadView = (newView: View, recreateSearch: boolean = false) => async (dispatch: AppDispatch, getState: () => RootState) => {
-  const view = selectView(getState());
+const isViewEqualForSearch = (view: View, newView: View) => {
   const oldWidgets = view?.state?.map((s) => s.widgets);
   const newWidgets = newView?.state?.map((s) => s.widgets);
 
-  if (recreateSearch || !isEqualForSearch(oldWidgets, newWidgets)) {
-    const updatedView = UpdateSearchForWidgets(newView);
-    const updatedSearch = await createSearch(updatedView.search);
-    const updatedViewWithSearch = updatedView.toBuilder().search(updatedSearch).build();
+  return isEqualForSearch(oldWidgets, newWidgets);
+};
+
+const _recreateSearch = async (newView: View) => {
+  const updatedView = UpdateSearchForWidgets(newView);
+  const updatedSearch = await createSearch(updatedView.search);
+
+  return updatedView.toBuilder().search(updatedSearch).build();
+};
+
+export const loadView = (newView: View, recreateSearch: boolean = false) => async (dispatch: AppDispatch, getState: () => RootState) => {
+  const view = selectView(getState());
+
+  if (recreateSearch || !isViewEqualForSearch(view, newView)) {
+    const updatedViewWithSearch = await _recreateSearch(newView);
 
     await dispatch(setView(updatedViewWithSearch));
 
@@ -89,6 +109,20 @@ export const loadView = (newView: View, recreateSearch: boolean = false) => asyn
   }
 
   return dispatch(setView(newView));
+};
+
+export const updateView = (newView: View, recreateSearch: boolean = false) => async (dispatch: AppDispatch, getState: () => RootState) => {
+  const view = selectView(getState());
+
+  if (recreateSearch || !isViewEqualForSearch(view, newView)) {
+    const updatedViewWithSearch = await _recreateSearch(newView);
+
+    await dispatch(setView(updatedViewWithSearch, true));
+
+    return dispatch(execute());
+  }
+
+  return dispatch(setView(newView, true));
 };
 
 export const updateQueries = (newQueries: Immutable.OrderedSet<Query>) => async (dispatch: AppDispatch, getState: () => RootState) => {
@@ -100,7 +134,7 @@ export const updateQueries = (newQueries: Immutable.OrderedSet<Query>) => async 
       .build())
     .build();
 
-  return dispatch(loadView(newView));
+  return dispatch(updateView(newView));
 };
 
 export const addQuery = (query: Query, viewState: ViewStateType) => async (dispatch: AppDispatch, getState: () => RootState) => {
@@ -116,7 +150,7 @@ export const addQuery = (query: Query, viewState: ViewStateType) => async (dispa
     .state(newViewStates)
     .build();
 
-  return dispatch(loadView(newView, true)).then(() => dispatch(selectQuery(query.id)));
+  return dispatch(updateView(newView, true)).then(() => dispatch(selectQuery(query.id)));
 };
 
 export const updateQuery = (queryId: QueryId, query: Query) => async (dispatch: AppDispatch, getState: () => RootState) => {
@@ -131,7 +165,7 @@ export const updateQuery = (queryId: QueryId, query: Query) => async (dispatch: 
     .search(newSearch)
     .build();
 
-  return dispatch(loadView(newView, true));
+  return dispatch(updateView(newView, true));
 };
 
 export const removeQuery = (queryId: string) => async (dispatch: AppDispatch, getState: () => RootState) => {
@@ -149,7 +183,7 @@ export const removeQuery = (queryId: string) => async (dispatch: AppDispatch, ge
   const indexedQueryIds = search.queries.map((query) => query.id).toList();
   const newActiveQuery = FindNewActiveQueryId(indexedQueryIds, activeQuery);
 
-  await dispatch(loadView(newView, true));
+  await dispatch(updateView(newView, true));
   await dispatch(selectQuery(newActiveQuery));
 };
 
@@ -199,7 +233,7 @@ export const mergeQueryTitles = (newQueryTitles: { queryId: QueryId, titlesMap: 
     .state(newState)
     .build();
 
-  return dispatch(loadView(newView));
+  return dispatch(updateView(newView));
 };
 
 export const setQueryString = (queryId: QueryId, newQueryString: string) => (dispatch: AppDispatch, getState: () => RootState) => {
@@ -237,7 +271,7 @@ export const updateViewState = (id: QueryId, newViewState: ViewStateType) => (di
     .state(newState)
     .build();
 
-  return dispatch(loadView(newView));
+  return dispatch(updateView(newView));
 };
 
 export const setParameters = (newParameters: Array<Parameter>) => async (dispatch: AppDispatch, getState: () => RootState) => {
@@ -249,5 +283,5 @@ export const setParameters = (newParameters: Array<Parameter>) => async (dispatc
 
   const newView = view.toBuilder().search(newSearch).build();
 
-  return dispatch(loadView(newView, true));
+  return dispatch(updateView(newView, true));
 };

--- a/graylog2-web-interface/src/views/logic/views/OnSaveNewDashboard.ts
+++ b/graylog2-web-interface/src/views/logic/views/OnSaveNewDashboard.ts
@@ -25,9 +25,9 @@ import type View from './View';
 export default (view: View) => async (dispatch: AppDispatch) => {
   try {
     const savedView = await ViewManagementActions.create(view);
-    dispatch(loadView(savedView));
-    dispatch(setIsDirty(false));
-    dispatch(setIsNew(false));
+    await dispatch(loadView(savedView));
+    await dispatch(setIsDirty(false));
+    await dispatch(setIsNew(false));
     loadDashboard(savedView.id);
     UserNotification.success(`Saving view "${view.title}" was successful!`, 'Success!');
   } catch (error) {

--- a/graylog2-web-interface/src/views/logic/views/OnSaveViewAction.ts
+++ b/graylog2-web-interface/src/views/logic/views/OnSaveViewAction.ts
@@ -19,6 +19,14 @@ import { ViewManagementActions } from 'views/stores/ViewManagementStore';
 import type View from 'views/logic/views/View';
 import type { AppDispatch } from 'stores/useAppDispatch';
 import { setIsNew, setIsDirty } from 'views/logic/slices/viewSlice';
+import type FetchError from 'logic/errors/FetchError';
+
+const _extractErrorMessage = (error: FetchError) => {
+  return (error
+    && error.additional
+    && error.additional.body
+    && error.additional.body.message) ? error.additional.body.message : error;
+};
 
 export default (view: View) => async (dispatch: AppDispatch) => {
   try {
@@ -27,6 +35,6 @@ export default (view: View) => async (dispatch: AppDispatch) => {
     dispatch(setIsDirty(false));
     UserNotification.success(`Saving view "${view.title}" was successful!`, 'Success!');
   } catch (error) {
-    UserNotification.error(`Saving view failed: ${error}`, 'Error!');
+    UserNotification.error(`Saving view failed: ${_extractErrorMessage(error)}`, 'Error!');
   }
 };


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Prior to this PR, in some cases updating the view did not result insetting the `dirty` flag. This change is fixing that by clearly separating actions for:

  - loading a view initially (`loadView`)
  - updating a previously loaded view (`updateView`)

the latter is now setting the dirty flag.

/nocl

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.