### PR TITLE
Integrate page size select in entity data table.

### DIFF
--- a/graylog2-web-interface/src/components/common/EntityDataTable/ColumnsVisibilitySelect.tsx
+++ b/graylog2-web-interface/src/components/common/EntityDataTable/ColumnsVisibilitySelect.tsx
@@ -109,8 +109,8 @@ const ColumnsVisibilitySelect = ({ onChange, selectedColumns, allColumns }: Prop
     <StyledDropdownButton title="Columns"
                           bsSize="small"
                           pullRight
+                          id="columns-visibility-select"
                           bsStyle="default">
-
       {sortedColumns.map((column) => (
         <ColumnListItem column={column}
                         onClick={onChange}

--- a/graylog2-web-interface/src/components/common/EntityDataTable/ColumnsVisibilitySelect.tsx
+++ b/graylog2-web-interface/src/components/common/EntityDataTable/ColumnsVisibilitySelect.tsx
@@ -16,7 +16,7 @@
  */
 import styled from 'styled-components';
 import * as React from 'react';
-import { useState, useRef, useMemo } from 'react';
+import { useMemo } from 'react';
 
 import { Checkbox, DropdownButton } from 'components/bootstrap';
 import type { Column } from 'components/common/EntityDataTable/types';
@@ -100,13 +100,6 @@ type Props = {
 }
 
 const ColumnsVisibilitySelect = ({ onChange, selectedColumns, allColumns }: Props) => {
-  const buttonRef = useRef();
-  const [showSelect, setShowSelect] = useState(false);
-
-  const toggleColumnSelect = () => {
-    setShowSelect((cur) => !cur);
-  };
-
   const sortedColumns = useMemo(
     () => allColumns.sort((col1, col2) => (naturalSort(col1.title, col2.title))),
     [allColumns],

--- a/graylog2-web-interface/src/components/common/EntityDataTable/ColumnsVisibilitySelect.tsx
+++ b/graylog2-web-interface/src/components/common/EntityDataTable/ColumnsVisibilitySelect.tsx
@@ -109,6 +109,7 @@ const ColumnsVisibilitySelect = ({ onChange, selectedColumns, allColumns }: Prop
     <StyledDropdownButton title="Columns"
                           bsSize="small"
                           pullRight
+                          aria-label="Configure visible columns"
                           id="columns-visibility-select"
                           bsStyle="default">
       {sortedColumns.map((column) => (

--- a/graylog2-web-interface/src/components/common/EntityDataTable/ColumnsVisibilitySelect.tsx
+++ b/graylog2-web-interface/src/components/common/EntityDataTable/ColumnsVisibilitySelect.tsx
@@ -16,21 +16,18 @@
  */
 import styled from 'styled-components';
 import * as React from 'react';
-import { Overlay } from 'react-overlays';
 import { useState, useRef, useMemo } from 'react';
 
-import { Checkbox, Button, Popover } from 'components/bootstrap';
+import { Checkbox, DropdownButton } from 'components/bootstrap';
 import type { Column } from 'components/common/EntityDataTable/types';
-import { Icon, Portal } from 'components/common';
 import TextOverflowEllipsis from 'components/common/TextOverflowEllipsis';
 import { defaultCompare as naturalSort } from 'logic/DefaultCompare';
+import MenuItem from 'components/bootstrap/MenuItem';
 
-const StyledPopover = styled(Popover)`
-  margin-right: 5px;
-  
-  .popover-content {
+const StyledDropdownButton = styled(DropdownButton)`
+  ~ .dropdown-menu {
+    min-width: auto;
     max-width: 180px;
-    padding: 5px 10px;
   }
 `;
 
@@ -51,7 +48,7 @@ const ColumnCheckbox = styled(Checkbox)`
   }
 `;
 
-const ListItem = styled.div`
+const ListItem = styled(MenuItem)`
   padding: 3px 0;
   cursor: pointer;
   display: flex;
@@ -89,7 +86,7 @@ const ColumnListItem = ({
   };
 
   return (
-    <ListItem role="menuitem" onClick={toggleVisibility} title={`${isSelected ? 'Hide' : 'Show'} ${column.title}`}>
+    <ListItem onSelect={toggleVisibility} title={`${isSelected ? 'Hide' : 'Show'} ${column.title}`}>
       <ColumnCheckbox checked={isSelected} onChange={toggleVisibility} />
       <ColumnTitle>{column.title}</ColumnTitle>
     </ListItem>
@@ -116,27 +113,19 @@ const ColumnsVisibilitySelect = ({ onChange, selectedColumns, allColumns }: Prop
   );
 
   return (
-    <>
-      <Button onClick={toggleColumnSelect} ref={buttonRef} bsSize="small" title="Select columns to display">
-        Columns <span className="caret" />
-      </Button>
+    <StyledDropdownButton title="Columns"
+                          bsSize="small"
+                          pullRight
+                          bsStyle="default">
 
-      {showSelect && (
-        <Portal>
-          <Overlay target={buttonRef.current} placement="bottom" show onHide={toggleColumnSelect} rootClose>
-            <StyledPopover id="columns-visibility-select">
-              {sortedColumns.map((column) => (
-                <ColumnListItem column={column}
-                                onClick={onChange}
-                                key={column.id}
-                                allColumns={allColumns}
-                                selectedColumns={selectedColumns} />
-              ))}
-            </StyledPopover>
-          </Overlay>
-        </Portal>
-      )}
-    </>
+      {sortedColumns.map((column) => (
+        <ColumnListItem column={column}
+                        onClick={onChange}
+                        key={column.id}
+                        allColumns={allColumns}
+                        selectedColumns={selectedColumns} />
+      ))}
+    </StyledDropdownButton>
   );
 };
 

--- a/graylog2-web-interface/src/components/common/EntityDataTable/ColumnsVisibilitySelect.tsx
+++ b/graylog2-web-interface/src/components/common/EntityDataTable/ColumnsVisibilitySelect.tsx
@@ -118,7 +118,7 @@ const ColumnsVisibilitySelect = ({ onChange, selectedColumns, allColumns }: Prop
   return (
     <>
       <Button onClick={toggleColumnSelect} ref={buttonRef} bsSize="small" title="Select columns to display">
-        <Icon name="cog" /> Columns
+        Columns <span className="caret" />
       </Button>
 
       {showSelect && (

--- a/graylog2-web-interface/src/components/common/EntityDataTable/EntityDataTable.test.tsx
+++ b/graylog2-web-interface/src/components/common/EntityDataTable/EntityDataTable.test.tsx
@@ -229,7 +229,7 @@ describe('<EntityDataTable />', () => {
                             bulkActions={() => <div />}
                             columnDefinitions={columnDefinitions} />);
 
-    userEvent.click(screen.getByRole('button', { name: /select columns to display/i }));
+    userEvent.click(screen.getByRole('button', { name: /configure visible columns/i }));
     userEvent.click(screen.getByRole('menuitem', { name: /show title/i }));
 
     expect(onColumnsChange).toHaveBeenCalledWith(['description', 'status', 'title']);

--- a/graylog2-web-interface/src/components/common/EntityDataTable/EntityDataTable.tsx
+++ b/graylog2-web-interface/src/components/common/EntityDataTable/EntityDataTable.tsx
@@ -20,7 +20,7 @@ import { useMemo, useState, useCallback, useRef } from 'react';
 import type * as Immutable from 'immutable';
 import { merge } from 'lodash';
 
-import { Button, Table, ButtonToolbar } from 'components/bootstrap';
+import { Button, Table, ButtonGroup, ButtonToolbar } from 'components/bootstrap';
 import { isPermitted, isAnyPermitted } from 'util/PermissionsMixin';
 import useCurrentUser from 'hooks/useCurrentUser';
 import StringUtils from 'util/StringUtils';
@@ -62,6 +62,12 @@ const BulkActionsWrapper = styled.div`
 
 const BulkActions = styled(ButtonToolbar)`
   margin-left: 5px;
+`;
+
+const LayoutConfigRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 5px;
 `;
 
 const filterAccessibleColumns = (
@@ -146,6 +152,7 @@ const EntityDataTable = <Entity extends EntityBase>({
   columnRenderers: customColumnRenderers,
   columnDefinitions,
   columnsOrder,
+  pageSizeSelect,
   data,
   onSortChange,
   rowActions,
@@ -200,11 +207,15 @@ const EntityDataTable = <Entity extends EntityBase>({
             </BulkActionsWrapper>
           )}
         </div>
-        <div>
-          <ColumnsVisibilitySelect allColumns={accessibleColumns}
-                                   selectedColumns={visibleColumns}
-                                   onChange={onColumnsChange} />
-        </div>
+        <LayoutConfigRow>
+          Show
+          <ButtonGroup>
+            {pageSizeSelect}
+            <ColumnsVisibilitySelect allColumns={accessibleColumns}
+                                     selectedColumns={visibleColumns}
+                                     onChange={onColumnsChange} />
+          </ButtonGroup>
+        </LayoutConfigRow>
       </ActionsRow>
       <ScrollContainer ref={tableRef}>
         <StyledTable striped condensed hover>

--- a/graylog2-web-interface/src/components/common/EntityDataTable/EntityDataTable.tsx
+++ b/graylog2-web-interface/src/components/common/EntityDataTable/EntityDataTable.tsx
@@ -30,6 +30,7 @@ import { CELL_PADDING, BULK_SELECT_COLUMN_WIDTH } from 'components/common/Entity
 import useColumnsWidths from 'components/common/EntityDataTable/hooks/useColumnsWidths';
 import useElementDimensions from 'hooks/useElementDimensions';
 import type { Sort } from 'stores/PaginationTypes';
+import { PageSizeSelect } from 'components/common';
 
 import TableHead from './TableHead';
 import TableRow from './TableRow';
@@ -137,6 +138,10 @@ type Props<Entity extends EntityBase> = {
   onColumnsChange: (columnIds: Array<string>) => void,
   /** Function to handle sort changes */
   onSortChange: (newSort: Sort) => void,
+  /** Function to handle page size changes */
+  onPageSizeChange?: (newPageSize: number) => void,
+  /** Active page size */
+  pageSize?: number
   /** Actions for each row. */
   rowActions?: (entity: Entity) => React.ReactNode,
   /** Which columns should be displayed. */
@@ -152,7 +157,8 @@ const EntityDataTable = <Entity extends EntityBase>({
   columnRenderers: customColumnRenderers,
   columnDefinitions,
   columnsOrder,
-  pageSizeSelect,
+  onPageSizeChange,
+  pageSize,
   data,
   onSortChange,
   rowActions,
@@ -164,6 +170,7 @@ const EntityDataTable = <Entity extends EntityBase>({
   const columnRenderers = merge(DefaultColumnRenderers, customColumnRenderers);
   const displayActionsCol = typeof rowActions === 'function';
   const displayBulkSelectCol = typeof bulkActions === 'function';
+  const displayPageSizeSelect = typeof onPageSizeChange === 'function';
 
   const accessibleColumns = useMemo(
     () => filterAccessibleColumns(columnDefinitions, currentUser.permissions),
@@ -210,7 +217,9 @@ const EntityDataTable = <Entity extends EntityBase>({
         <LayoutConfigRow>
           Show
           <ButtonGroup>
-            {pageSizeSelect}
+            {displayPageSizeSelect && (
+              <PageSizeSelect pageSize={pageSize} showLabel={false} onChange={onPageSizeChange} />
+            )}
             <ColumnsVisibilitySelect allColumns={accessibleColumns}
                                      selectedColumns={visibleColumns}
                                      onChange={onColumnsChange} />
@@ -256,8 +265,9 @@ EntityDataTable.defaultProps = {
   activeSort: undefined,
   bulkActions: undefined,
   columnRenderers: undefined,
-  rowActions: undefined,
   columnsOrder: [],
+  pageSizeSelect: undefined,
+  rowActions: undefined,
 };
 
 export default EntityDataTable;

--- a/graylog2-web-interface/src/components/common/EntityDataTable/EntityDataTable.tsx
+++ b/graylog2-web-interface/src/components/common/EntityDataTable/EntityDataTable.tsx
@@ -266,7 +266,8 @@ EntityDataTable.defaultProps = {
   bulkActions: undefined,
   columnRenderers: undefined,
   columnsOrder: [],
-  pageSizeSelect: undefined,
+  onPageSizeChange: undefined,
+  pageSize: undefined,
   rowActions: undefined,
 };
 

--- a/graylog2-web-interface/src/components/common/PageSizeSelect.tsx
+++ b/graylog2-web-interface/src/components/common/PageSizeSelect.tsx
@@ -46,6 +46,7 @@ const PageSizeSelect = ({ pageSizes, pageSize, onChange, className, showLabel }:
     <StyledDropdownButton className={className}
                           id="page-size-select"
                           title={`${pageSize} Rows`}
+                          aria-label="Configure page size"
                           pullRight
                           bsSize="small"
                           bsStyle="default">

--- a/graylog2-web-interface/src/components/common/PageSizeSelect.tsx
+++ b/graylog2-web-interface/src/components/common/PageSizeSelect.tsx
@@ -44,6 +44,7 @@ type Props = {
 const PageSizeSelect = ({ pageSizes, pageSize, onChange, className, showLabel }: Props) => {
   const select = (
     <StyledDropdownButton className={className}
+                          id="page-size-select"
                           title={`${pageSize} Rows`}
                           pullRight
                           bsSize="small"

--- a/graylog2-web-interface/src/components/common/PageSizeSelect.tsx
+++ b/graylog2-web-interface/src/components/common/PageSizeSelect.tsx
@@ -18,7 +18,7 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
-import { Input } from 'components/bootstrap';
+import { Input, DropdownButton, MenuItem } from 'components/bootstrap';
 
 const Wrapper = styled.div`
   margin-bottom: 5px;
@@ -44,21 +44,16 @@ type Props = {
   className?: string,
   pageSize: number,
   pageSizes: Array<number>,
-  onChange: (event: React.ChangeEvent<HTMLOptionElement>) => void,
+  onChange: (newPageSize: number) => void,
 };
 
 const PageSizeSelect = ({ pageSizes, pageSize, onChange, className }: Props) => (
-  <Wrapper className={`${className ?? ''} form-inline page-size pull-right`}>
-    <Input id="page-size"
-           type="select"
-           bsSize="small"
-           label="Show"
-           value={pageSize}
-           onChange={onChange}
-           formGroupClassName="page-size-select">
-      {pageSizes.map((size) => <option key={`option-${size}`} value={size}>{size}</option>)}
-    </Input>
-  </Wrapper>
+  <DropdownButton className={className}
+                  title={`${pageSize} rows`}
+                  bsSize="small"
+                  bsStyle="default">
+    {pageSizes.map((size) => <MenuItem key={`option-${size}`} onSelect={() => onChange(size)}>{size}</MenuItem>)}
+  </DropdownButton>
 );
 
 PageSizeSelect.propTypes = {

--- a/graylog2-web-interface/src/components/common/PageSizeSelect.tsx
+++ b/graylog2-web-interface/src/components/common/PageSizeSelect.tsx
@@ -18,54 +18,63 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
-import { Input, DropdownButton, MenuItem } from 'components/bootstrap';
+import { DropdownButton, MenuItem } from 'components/bootstrap';
+import { DEFAULT_PAGE_SIZES } from 'hooks/usePaginationQueryParameter';
 
-const Wrapper = styled.div`
-  margin-bottom: 5px;
-
-  && .form-group {
-    margin-bottom: 0;
-  }
-
-  .control-label {
-    padding-top: 0;
-    font-weight: normal;
-  }
-
-  .page-size-select {
-    display: flex;
-    align-items: baseline;
+const StyledDropdownButton = styled(DropdownButton)`
+  ~ .dropdown-menu {
+    min-width: auto;
   }
 `;
 
-const PAGE_SIZES = [10, 50, 100];
+const Container = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 3px;
+`;
 
 type Props = {
   className?: string,
   pageSize: number,
   pageSizes: Array<number>,
   onChange: (newPageSize: number) => void,
+  showLabel?: boolean
 };
 
-const PageSizeSelect = ({ pageSizes, pageSize, onChange, className }: Props) => (
-  <DropdownButton className={className}
-                  title={`${pageSize} rows`}
-                  bsSize="small"
-                  bsStyle="default">
-    {pageSizes.map((size) => <MenuItem key={`option-${size}`} onSelect={() => onChange(size)}>{size}</MenuItem>)}
-  </DropdownButton>
-);
+const PageSizeSelect = ({ pageSizes, pageSize, onChange, className, showLabel }: Props) => {
+  const select = (
+    <StyledDropdownButton className={className}
+                          title={`${pageSize} Rows`}
+                          bsSize="small"
+                          bsStyle="default">
+      {pageSizes.map((size) => <MenuItem key={`option-${size}`} onSelect={() => onChange(size)}>{size}</MenuItem>)}
+    </StyledDropdownButton>
+  );
+
+  if (showLabel) {
+    return (
+      <Container className={className}>
+        Show
+        {select}
+      </Container>
+    );
+  }
+
+  return select;
+};
 
 PageSizeSelect.propTypes = {
   className: PropTypes.string,
   onChange: PropTypes.func.isRequired,
   pageSize: PropTypes.number.isRequired,
   pageSizes: PropTypes.arrayOf(PropTypes.number),
+  showLabel: PropTypes.bool,
 };
 
 PageSizeSelect.defaultProps = {
   className: '',
-  pageSizes: PAGE_SIZES,
+  pageSizes: DEFAULT_PAGE_SIZES,
+  showLabel: true,
 };
 
 PageSizeSelect.defaultPageSizes = PAGE_SIZES;

--- a/graylog2-web-interface/src/components/common/PageSizeSelect.tsx
+++ b/graylog2-web-interface/src/components/common/PageSizeSelect.tsx
@@ -45,6 +45,7 @@ const PageSizeSelect = ({ pageSizes, pageSize, onChange, className, showLabel }:
   const select = (
     <StyledDropdownButton className={className}
                           title={`${pageSize} Rows`}
+                          pullRight
                           bsSize="small"
                           bsStyle="default">
       {pageSizes.map((size) => <MenuItem key={`option-${size}`} onSelect={() => onChange(size)}>{size}</MenuItem>)}
@@ -76,7 +77,5 @@ PageSizeSelect.defaultProps = {
   pageSizes: DEFAULT_PAGE_SIZES,
   showLabel: true,
 };
-
-PageSizeSelect.defaultPageSizes = PAGE_SIZES;
 
 export default PageSizeSelect;

--- a/graylog2-web-interface/src/components/common/PaginatedList.test.tsx
+++ b/graylog2-web-interface/src/components/common/PaginatedList.test.tsx
@@ -15,7 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import React from 'react';
-import { render, fireEvent } from 'wrappedTestingLibrary';
+import { render, fireEvent, screen } from 'wrappedTestingLibrary';
 import { useLocation } from 'react-router-dom';
 import type { Location } from 'history';
 
@@ -70,16 +70,18 @@ describe('PaginatedList', () => {
 
   it('should reset current page on page size change', () => {
     const onChangeStub = jest.fn();
-    const { getByLabelText } = render(
+    const { getByRole } = render(
       <PaginatedList totalItems={200}
                      onChange={onChangeStub}
                      activePage={3}>
         <div>The list</div>
       </PaginatedList>);
 
-    const pageSizeInput = getByLabelText('Show');
+    fireEvent.click(getByRole('button', {
+      name: /configure page size/i,
+    }));
 
-    fireEvent.change(pageSizeInput, { target: { value: 100 } });
+    fireEvent.click(screen.getByRole('menuitem', { name: /100/ }));
 
     expect(onChangeStub).toHaveBeenCalledWith(1, 100);
   });

--- a/graylog2-web-interface/src/components/common/PaginatedList.tsx
+++ b/graylog2-web-interface/src/components/common/PaginatedList.tsx
@@ -57,10 +57,7 @@ const ListBase = ({
     currentPageSize > 0 ? Math.ceil(totalItems / currentPageSize) : 0
   ), [currentPageSize, totalItems]);
 
-  const _onChangePageSize = useCallback((event: React.ChangeEvent<HTMLOptionElement>) => {
-    event.preventDefault();
-    const newPageSize = Number(event.target.value);
-
+  const _onChangePageSize = useCallback((newPageSize: number) => {
     setPagination({ page: INITIAL_PAGE, pageSize: newPageSize });
     if (onChange) onChange(INITIAL_PAGE, newPageSize);
   }, [onChange, setPagination]);

--- a/graylog2-web-interface/src/components/common/PaginatedList.tsx
+++ b/graylog2-web-interface/src/components/common/PaginatedList.tsx
@@ -74,7 +74,10 @@ const ListBase = ({
   return (
     <>
       {showPageSizeSelect && (
-        <PageSizeSelect pageSizes={pageSizes} pageSize={currentPageSize} onChange={_onChangePageSize} />
+        <PageSizeSelect pageSizes={pageSizes}
+                        pageSize={currentPageSize}
+                        onChange={_onChangePageSize}
+                        className="pull-right" />
       )}
 
       {children}

--- a/graylog2-web-interface/src/components/common/PaginatedList.tsx
+++ b/graylog2-web-interface/src/components/common/PaginatedList.tsx
@@ -76,6 +76,7 @@ const ListBase = ({
       {showPageSizeSelect && (
         <PageSizeSelect pageSizes={pageSizes}
                         pageSize={currentPageSize}
+                        showLabel
                         onChange={_onChangePageSize}
                         className="pull-right" />
       )}

--- a/graylog2-web-interface/src/components/content-packs/ContentPacksList.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPacksList.jsx
@@ -175,8 +175,8 @@ class ContentPacksList extends React.Component {
     this.setState({ filteredContentPacks: filteredItems });
   }
 
-  _itemsShownChange(event) {
-    this.setState({ pageSize: Number(event.target.value), currentPage: 1 });
+  _itemsShownChange(pageSize) {
+    this.setState({ pageSize, currentPage: 1 });
   }
 
   _onChangePage(nextPage) {

--- a/graylog2-web-interface/src/components/permissions/GranteesList.tsx
+++ b/graylog2-web-interface/src/components/permissions/GranteesList.tsx
@@ -41,6 +41,7 @@ const List = styled.div(({ theme }) => `
   >:nth-child(even) {
     background: ${theme.colors.table.backgroundAlt};
   };
+
   >:nth-child(odd) {
     background: ${theme.colors.table.background};
   };
@@ -51,7 +52,7 @@ const PaginationWrapper = styled.ul`
   justify-content: center;
 
   .pagination {
-    margin: 10px 0 0 0;
+    margin: 10px 0;
   }
 `;
 

--- a/graylog2-web-interface/src/components/permissions/GranteesList.tsx
+++ b/graylog2-web-interface/src/components/permissions/GranteesList.tsx
@@ -26,6 +26,7 @@ import type { ActiveShares, CapabilitiesList, SelectedGrantees } from 'logic/per
 import type EntityShareState from 'logic/permissions/EntityShareState';
 import type Grantee from 'logic/permissions/Grantee';
 import type Capability from 'logic/permissions/Capability';
+import { DEFAULT_PAGE_SIZES } from 'hooks/usePaginationQueryParameter';
 
 import GranteesListItem from './GranteesListItem';
 
@@ -89,7 +90,7 @@ const _paginatedGrantees = (selectedGrantees: SelectedGrantees, pageSize: number
 };
 
 const GranteesList = ({ activeShares, onDelete, onCapabilityChange, entityType, entityTypeTitle, availableCapabilities, selectedGrantees, className, title }: Props) => {
-  const initialPageSize = PageSizeSelect.defaultPageSizes[0];
+  const initialPageSize = DEFAULT_PAGE_SIZES[0];
   const [pageSize, setPageSize] = useState(initialPageSize);
   const [currentPage, setCurrentPage] = useState(1);
   const paginatedGrantees = _paginatedGrantees(selectedGrantees, pageSize, currentPage);
@@ -102,7 +103,7 @@ const GranteesList = ({ activeShares, onDelete, onCapabilityChange, entityType, 
       <Header>
         <h5>{title}</h5>
         {showPageSizeSelect && (
-          <StyledPageSizeSelect onChange={(event) => setPageSize(Number(event.target.value))} pageSize={pageSize} />
+          <StyledPageSizeSelect onChange={(newPageSize) => setPageSize(newPageSize)} pageSize={pageSize} />
         )}
       </Header>
       {paginatedGrantees.size > 0 ? (

--- a/graylog2-web-interface/src/components/streams/StreamsOverview/StreamsOverview.tsx
+++ b/graylog2-web-interface/src/components/streams/StreamsOverview/StreamsOverview.tsx
@@ -40,8 +40,6 @@ import {
 
 import CustomColumnRenderers from './ColumnRenderers';
 
-import PageSizeSelect from '../../common/PageSizeSelect';
-
 const useRefetchStreamsOnStoreChange = (refetchStreams: () => void) => {
   useEffect(() => {
     StreamsStore.onChange(() => refetchStreams());
@@ -83,14 +81,9 @@ const StreamsOverview = ({ indexSets }: Props) => {
     [paginatedStreams?.attributes],
   );
 
-  const onPageChange = useCallback((_newPage: number, newPageSize: number) => {
-    if (newPageSize) {
-      updateTableLayout({ perPage: newPageSize });
-    }
-  }, [updateTableLayout]);
-
-  const onChangePageSize = () => {
-
+  const onPageSizeChange = (newPageSize: number) => {
+    paginationQueryParameter.resetPage();
+    updateTableLayout({ perPage: newPageSize });
   };
 
   const onSearch = useCallback((newQuery: string) => {
@@ -107,8 +100,8 @@ const StreamsOverview = ({ indexSets }: Props) => {
   }, [updateTableLayout]);
 
   const onSortChange = useCallback((newSort: Sort) => {
-    updateTableLayout({ sort: newSort });
     paginationQueryParameter.resetPage();
+    updateTableLayout({ sort: newSort });
   }, [paginationQueryParameter, updateTableLayout]);
 
   const renderStreamActions = useCallback((listItem: Stream) => (
@@ -132,8 +125,7 @@ const StreamsOverview = ({ indexSets }: Props) => {
   const { elements, pagination: { total } } = paginatedStreams;
 
   return (
-    <PaginatedList onChange={onPageChange}
-                   pageSize={layoutConfig.pageSize}
+    <PaginatedList pageSize={layoutConfig.pageSize}
                    showPageSizeSelect={false}
                    totalItems={total}>
       <div style={{ marginBottom: 5 }}>
@@ -150,7 +142,8 @@ const StreamsOverview = ({ indexSets }: Props) => {
                                    columnsOrder={DEFAULT_LAYOUT.columnsOrder}
                                    onColumnsChange={onColumnsChange}
                                    onSortChange={onSortChange}
-                                   pageSizeSelect={<PageSizeSelect pageSize={layoutConfig.pageSize} onChange={onChangePageSize} />}
+                                   onPageSizeChange={onPageSizeChange}
+                                   pageSize={layoutConfig.pageSize}
                                    bulkActions={renderBulkActions}
                                    activeSort={layoutConfig.sort}
                                    rowActions={renderStreamActions}

--- a/graylog2-web-interface/src/components/streams/StreamsOverview/StreamsOverview.tsx
+++ b/graylog2-web-interface/src/components/streams/StreamsOverview/StreamsOverview.tsx
@@ -40,6 +40,8 @@ import {
 
 import CustomColumnRenderers from './ColumnRenderers';
 
+import PageSizeSelect from '../../common/PageSizeSelect';
+
 const useRefetchStreamsOnStoreChange = (refetchStreams: () => void) => {
   useEffect(() => {
     StreamsStore.onChange(() => refetchStreams());
@@ -87,6 +89,10 @@ const StreamsOverview = ({ indexSets }: Props) => {
     }
   }, [updateTableLayout]);
 
+  const onChangePageSize = () => {
+
+  };
+
   const onSearch = useCallback((newQuery: string) => {
     paginationQueryParameter.resetPage();
     setQuery(newQuery);
@@ -128,6 +134,7 @@ const StreamsOverview = ({ indexSets }: Props) => {
   return (
     <PaginatedList onChange={onPageChange}
                    pageSize={layoutConfig.pageSize}
+                   showPageSizeSelect={false}
                    totalItems={total}>
       <div style={{ marginBottom: 5 }}>
         <SearchForm onSearch={onSearch}
@@ -143,6 +150,7 @@ const StreamsOverview = ({ indexSets }: Props) => {
                                    columnsOrder={DEFAULT_LAYOUT.columnsOrder}
                                    onColumnsChange={onColumnsChange}
                                    onSortChange={onSortChange}
+                                   pageSizeSelect={<PageSizeSelect pageSize={layoutConfig.pageSize} onChange={onChangePageSize} />}
                                    bulkActions={renderBulkActions}
                                    activeSort={layoutConfig.sort}
                                    rowActions={renderStreamActions}

--- a/graylog2-web-interface/src/views/components/dashboard/DashboardsOverview/DashboardsOverview.tsx
+++ b/graylog2-web-interface/src/views/components/dashboard/DashboardsOverview/DashboardsOverview.tsx
@@ -78,13 +78,10 @@ const DashboardsOverview = () => {
     onSearch('');
   }, [onSearch]);
 
-  const onPageChange = useCallback(
-    (_newPage: number, newPageSize: number) => {
-      if (newPageSize) {
-        updateTableLayout({ perPage: newPageSize });
-      }
-    }, [updateTableLayout],
-  );
+  const onPageSizeChange = (newPageSize: number) => {
+    paginationQueryParameter.resetPage();
+    updateTableLayout({ perPage: newPageSize });
+  };
 
   const onSortChange = useCallback((newSort: Sort) => {
     updateTableLayout({ sort: newSort });
@@ -98,8 +95,8 @@ const DashboardsOverview = () => {
   const { list: dashboards, pagination, attributes } = paginatedDashboards;
 
   return (
-    <PaginatedList onChange={onPageChange}
-                   pageSize={layoutConfig.pageSize}
+    <PaginatedList pageSize={layoutConfig.pageSize}
+                   showPageSizeSelect={false}
                    totalItems={pagination.total}>
       <div style={{ marginBottom: 5 }}>
         <SearchForm onSearch={onSearch}
@@ -116,16 +113,18 @@ const DashboardsOverview = () => {
         <NoSearchResult>No dashboards have been found.</NoSearchResult>
       )}
       {!!dashboards?.length && (
-        <EntityDataTable<View> data={dashboards}
-                               visibleColumns={layoutConfig.displayedAttributes}
-                               onColumnsChange={onColumnsChange}
-                               onSortChange={onSortChange}
-                               activeSort={layoutConfig.sort}
-                               rowActions={renderDashboardActions}
-                               bulkActions={renderBulkActions}
-                               columnRenderers={customColumnRenderers}
-                               columnsOrder={DEFAULT_LAYOUT.columnsOrder}
-                               columnDefinitions={attributes} />
+        <EntityDataTable activeSort={layoutConfig.sort}
+                         bulkActions={renderBulkActions}
+                         columnDefinitions={attributes}
+                         columnRenderers={customColumnRenderers}
+                         columnsOrder={DEFAULT_LAYOUT.columnsOrder}
+                         data={dashboards}
+                         onColumnsChange={onColumnsChange}
+                         onPageSizeChange={onPageSizeChange}
+                         onSortChange={onSortChange}
+                         pageSize={layoutConfig.pageSize}
+                         rowActions={renderDashboardActions}
+                         visibleColumns={layoutConfig.displayedAttributes} />
       )}
     </PaginatedList>
   );

--- a/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchesList.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchesList.tsx
@@ -91,6 +91,21 @@ const SavedSearchesList = ({
         updateTableLayout({ perPage: newPageSize });
       }
     }, [updateTableLayout],
+  const onSearch = useCallback(
+    (newQuery: string) => setSearchParams((cur) => ({
+      ...cur,
+      query: newQuery,
+      page: DEFAULT_PAGINATION.page,
+    })),
+    [],
+  );
+  const onPageSizeChange = useCallback(
+    (newPageSize: number) => setSearchParams((cur) => ({
+      ...cur,
+      page: 1,
+      pageSize: newPageSize,
+    })),
+    [],
   );
 
   const onSortChange = useCallback((newSort: Sort) => {
@@ -130,9 +145,15 @@ const SavedSearchesList = ({
 
   return (
     <PaginatedList onChange={onPageChange}
+<<<<<<< HEAD
                    totalItems={pagination?.total}
                    pageSize={layoutConfig.pageSize}
                    activePage={activePage}
+=======
+                   activePage={searchParams.page}
+                   totalItems={pagination?.total}
+                   showPageSizeSelect={false}
+>>>>>>> a957fc3905 (Update saved searches overview.)
                    useQueryParameter={false}>
       <div style={{ marginBottom: '5px' }}>
         <SearchForm focusAfterMount
@@ -158,7 +179,13 @@ const SavedSearchesList = ({
                                onColumnsChange={onColumnsChange}
                                bulkActions={renderBulkActions}
                                onSortChange={onSortChange}
+<<<<<<< HEAD
                                activeSort={layoutConfig.sort}
+=======
+                               pageSize={searchParams.pageSize}
+                               onPageSizeChange={onPageSizeChange}
+                               activeSort={searchParams.sort}
+>>>>>>> a957fc3905 (Update saved searches overview.)
                                rowActions={renderSavedSearchActions}
                                columnRenderers={customColumnRenderers}
                                columnDefinitions={attributes} />

--- a/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchesList.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchesList.tsx
@@ -91,22 +91,11 @@ const SavedSearchesList = ({
         updateTableLayout({ perPage: newPageSize });
       }
     }, [updateTableLayout],
-  const onSearch = useCallback(
-    (newQuery: string) => setSearchParams((cur) => ({
-      ...cur,
-      query: newQuery,
-      page: DEFAULT_PAGINATION.page,
-    })),
-    [],
   );
-  const onPageSizeChange = useCallback(
-    (newPageSize: number) => setSearchParams((cur) => ({
-      ...cur,
-      page: 1,
-      pageSize: newPageSize,
-    })),
-    [],
-  );
+
+  const onPageSizeChange = useCallback((newPageSize: number) => {
+    setActivePage(newPageSize);
+  }, []);
 
   const onSortChange = useCallback((newSort: Sort) => {
     setActivePage(1);
@@ -145,15 +134,10 @@ const SavedSearchesList = ({
 
   return (
     <PaginatedList onChange={onPageChange}
-<<<<<<< HEAD
                    totalItems={pagination?.total}
                    pageSize={layoutConfig.pageSize}
                    activePage={activePage}
-=======
-                   activePage={searchParams.page}
-                   totalItems={pagination?.total}
                    showPageSizeSelect={false}
->>>>>>> a957fc3905 (Update saved searches overview.)
                    useQueryParameter={false}>
       <div style={{ marginBottom: '5px' }}>
         <SearchForm focusAfterMount
@@ -179,13 +163,9 @@ const SavedSearchesList = ({
                                onColumnsChange={onColumnsChange}
                                bulkActions={renderBulkActions}
                                onSortChange={onSortChange}
-<<<<<<< HEAD
                                activeSort={layoutConfig.sort}
-=======
                                pageSize={searchParams.pageSize}
                                onPageSizeChange={onPageSizeChange}
-                               activeSort={searchParams.sort}
->>>>>>> a957fc3905 (Update saved searches overview.)
                                rowActions={renderSavedSearchActions}
                                columnRenderers={customColumnRenderers}
                                columnDefinitions={attributes} />


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

With this PR we are changing the way we display the page size select for entity data tables.

Before:
![image](https://user-images.githubusercontent.com/46300478/219666441-6715c876-c750-43ce-b160-920bec487132.png)

After:
![image](https://user-images.githubusercontent.com/46300478/219666551-1c790ed3-df19-4d03-adea-abd04f313451.png)

We are now grouping the elements which allow configuring the table layout. Changing the element of the page size select from an input to a button also effects all other places where we use the page size select component. We could create a new component for the entity data table, but I see a benefit in unifying the styles.

/nocl