### PR TITLE
Close `ConfigurationForm` modal on save.

### DIFF
--- a/graylog2-web-interface/src/components/configurationforms/ConfigurationForm.jsx
+++ b/graylog2-web-interface/src/components/configurationforms/ConfigurationForm.jsx
@@ -102,9 +102,7 @@ class ConfigurationForm extends React.Component {
 
     submitAction(data);
 
-    if (this.modal && this.modal.close) {
-      this.modal.close();
-    }
+    this.setState({ showConfigurationModal: false });
   };
 
   // eslint-disable-next-line react/no-unused-class-component-methods
@@ -112,7 +110,7 @@ class ConfigurationForm extends React.Component {
     this.setState({ showConfigurationModal: true });
   };
 
-  _closeModal = () => {
+  onCancel = () => {
     const { cancelAction, titleValue } = this.props;
 
     this.setState($.extend(this._copyStateFromProps(this.props), { titleValue: titleValue, showConfigurationModal: false }));
@@ -195,7 +193,7 @@ class ConfigurationForm extends React.Component {
     return (
       <WrapperComponent show={this.state.showConfigurationModal}
                         title={title}
-                        onCancel={this._closeModal}
+                        onCancel={this.onCancel}
                         onSubmitForm={this._save}
                         submitButtonText={submitButtonText}>
         <fieldset>

--- a/graylog2-web-interface/src/components/configurationforms/ConfigurationForm.test.tsx
+++ b/graylog2-web-interface/src/components/configurationforms/ConfigurationForm.test.tsx
@@ -34,7 +34,7 @@ describe('ConfigurationForm', () => {
                            ref={formRef}
                            submitButtonText="Update entity"
                            typeName="placeholder" />
-        <button type="button" role="button" onClick={openForm}>Open modal</button>
+        <button type="button" onClick={openForm}>Open modal</button>
       </>
     );
   };

--- a/graylog2-web-interface/src/components/configurationforms/ConfigurationForm.test.tsx
+++ b/graylog2-web-interface/src/components/configurationforms/ConfigurationForm.test.tsx
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+
+import React, { useRef } from 'react';
+import { screen, render, waitFor } from 'wrappedTestingLibrary';
+import userEvent from '@testing-library/user-event';
+
+import ConfigurationForm from './ConfigurationForm';
+
+describe('ConfigurationForm', () => {
+  const SUT = ({ submitAction }: { submitAction: () => void }) => {
+    const formRef = useRef(undefined);
+    const openForm = () => formRef?.current?.open();
+
+    return (
+      <>
+        <ConfigurationForm submitAction={submitAction}
+                           title="Edit entity"
+                           titleValue="Entity title"
+                           ref={formRef}
+                           submitButtonText="Update entity"
+                           typeName="placeholder" />
+        <button type="button" role="button" onClick={openForm}>Open modal</button>
+      </>
+    );
+  };
+
+  it('should close modal on save', async () => {
+    const submitAction = jest.fn();
+
+    render(<SUT submitAction={submitAction} />);
+
+    userEvent.click(await screen.findByRole('button', {
+      name: /open modal/i,
+    }));
+
+    await screen.findByRole('heading', {
+      name: /edit entity/i,
+      hidden: true,
+    });
+
+    userEvent.click(await screen.findByRole('button', {
+      name: /update entity/i,
+      hidden: true,
+    }));
+
+    await waitFor(() => expect(submitAction).toHaveBeenCalledTimes(1));
+
+    await waitFor(() => expect(screen.queryByRole('heading', {
+      name: /edit entity/i,
+      hidden: true,
+    })).not.toBeInTheDocument());
+  });
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR is fixing the bug described in https://github.com/Graylog2/graylog2-server/issues/14619. We are now closing the `ConfigurationForm` modal on save. The component is being used for the input configuration.

Fixes https://github.com/Graylog2/graylog2-server/issues/14619

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

/nocl
