### PR TITLE
Avoid double-loading saved dashboard.

### DIFF
--- a/graylog2-web-interface/src/views/logic/views/OnSaveNewDashboard.ts
+++ b/graylog2-web-interface/src/views/logic/views/OnSaveNewDashboard.ts
@@ -16,18 +16,13 @@
  */
 import UserNotification from 'util/UserNotification';
 import { ViewManagementActions } from 'views/stores/ViewManagementStore';
-import type { AppDispatch } from 'stores/useAppDispatch';
-import { loadView, setIsDirty, setIsNew } from 'views/logic/slices/viewSlice';
 import { loadDashboard } from 'views/logic/views/Actions';
 
 import type View from './View';
 
-export default (view: View) => async (dispatch: AppDispatch) => {
+export default (view: View) => async () => {
   try {
     const savedView = await ViewManagementActions.create(view);
-    await dispatch(loadView(savedView));
-    await dispatch(setIsDirty(false));
-    await dispatch(setIsNew(false));
     loadDashboard(savedView.id);
     UserNotification.success(`Saving view "${view.title}" was successful!`, 'Success!');
   } catch (error) {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

In #14694 an error was introduced when saving a new dashboard. There was an erroneous assumption that `OnSaveNewDashboard` also needs to take care of loading the newly saved dashboard, even though the `loadDashboard` function takes care of it by redirecting to the responsible route.

This PR is fixing it by removing the double-loading from the action.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.