### PR TITLE
Add missing return statement in Migration for Aggregations/Pivots

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/migrations/V20230113095300_MigrateGlobalPivotLimitsToGroupingsInViews.java
+++ b/graylog2-server/src/main/java/org/graylog2/migrations/V20230113095300_MigrateGlobalPivotLimitsToGroupingsInViews.java
@@ -64,6 +64,7 @@ public class V20230113095300_MigrateGlobalPivotLimitsToGroupingsInViews extends 
     public void upgrade() {
         if (clusterConfigService.get(MigrationCompleted.class) != null) {
             LOG.debug("Migration already completed!");
+            return;
         }
 
         final List<ViewWidgetLimitMigration> widgetLimitMigrations = StreamSupport.stream(this.views.find().spliterator(), false)

--- a/graylog2-server/src/main/java/org/graylog2/migrations/V20230113095301_MigrateGlobalPivotLimitsToGroupingsInSearches.java
+++ b/graylog2-server/src/main/java/org/graylog2/migrations/V20230113095301_MigrateGlobalPivotLimitsToGroupingsInSearches.java
@@ -63,6 +63,7 @@ public class V20230113095301_MigrateGlobalPivotLimitsToGroupingsInSearches exten
     public void upgrade() {
         if (clusterConfigService.get(MigrationCompleted.class) != null) {
             LOG.debug("Migration already completed!");
+            return;
         }
 
         final List<SearchPivotLimitMigration> pivotLimitMigrations = StreamSupport.stream(this.searches.find().spliterator(), false)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This change adds a missing return statement when checking if the migration had already run. 

Before the change, it checked for an existing run but did not skip execution and ran again.
This creates no problems but additional runs are still unwanted/unnecessary.


/nocl

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

