### PR TITLE
Event definitions store last update time

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/events/contentpack/entities/EventDefinitionEntity.java
+++ b/graylog2-server/src/main/java/org/graylog/events/contentpack/entities/EventDefinitionEntity.java
@@ -37,7 +37,9 @@ import org.graylog2.contentpacks.model.entities.EntityV1;
 import org.graylog2.contentpacks.model.entities.ScopedContentPackEntity;
 import org.graylog2.contentpacks.model.entities.references.ValueReference;
 import org.graylog2.database.entities.DefaultEntityScope;
+import org.joda.time.DateTime;
 
+import javax.annotation.Nullable;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -56,12 +58,17 @@ public abstract class EventDefinitionEntity extends ScopedContentPackEntity impl
     private static final String FIELD_NOTIFICATIONS = "notifications";
     private static final String FIELD_STORAGE = "storage";
     private static final String FIELD_IS_SCHEDULED = "is_scheduled";
+    private static final String UPDATED_AT = "updated_at";
 
     @JsonProperty(FIELD_TITLE)
     public abstract ValueReference title();
 
     @JsonProperty(FIELD_DESCRIPTION)
     public abstract ValueReference description();
+
+    @Nullable
+    @JsonProperty(UPDATED_AT)
+    public abstract DateTime updatedAt();
 
     @JsonProperty(FIELD_PRIORITY)
     public abstract ValueReference priority();
@@ -109,6 +116,9 @@ public abstract class EventDefinitionEntity extends ScopedContentPackEntity impl
         @JsonProperty(FIELD_DESCRIPTION)
         public abstract Builder description(ValueReference description);
 
+        @JsonProperty(UPDATED_AT)
+        public abstract Builder updatedAt(DateTime updatedAt);
+
         @JsonProperty(FIELD_PRIORITY)
         public abstract Builder priority(ValueReference priority);
 
@@ -149,6 +159,7 @@ public abstract class EventDefinitionEntity extends ScopedContentPackEntity impl
         return EventDefinitionDto.builder()
                 .scope(scope() != null ? scope().asString(parameters) : DefaultEntityScope.NAME)
                 .title(title().asString(parameters))
+                .updatedAt(updatedAt())
                 .description(description().asString(parameters))
                 .priority(priority().asInteger(parameters))
                 .alert(alert().asBoolean(parameters))

--- a/graylog2-server/src/main/java/org/graylog/events/processor/DBEventDefinitionService.java
+++ b/graylog2-server/src/main/java/org/graylog/events/processor/DBEventDefinitionService.java
@@ -27,6 +27,8 @@ import org.graylog2.database.entities.EntityScopeService;
 import org.graylog2.database.entities.ScopedDbService;
 import org.graylog2.plugin.database.users.User;
 import org.graylog2.search.SearchQuery;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import org.mongojack.DBQuery;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -62,10 +64,20 @@ public class DBEventDefinitionService extends ScopedDbService<EventDefinitionDto
     }
 
     public EventDefinitionDto saveWithOwnership(EventDefinitionDto eventDefinitionDto, User user) {
-        final EventDefinitionDto dto = super.save(eventDefinitionDto);
+        final EventDefinitionDto dto = save(eventDefinitionDto);
         entityOwnerShipService.registerNewEventDefinition(dto.id(), user);
         return dto;
     }
+
+    @Override
+    public EventDefinitionDto save(final EventDefinitionDto entity) {
+        EventDefinitionDto enrichedWithUpdateDate = entity
+                .toBuilder()
+                .updatedAt(DateTime.now(DateTimeZone.UTC))
+                .build();
+        return super.save(enrichedWithUpdateDate);
+    }
+
 
     public int deleteUnregister(String id) {
         // Must ensure deletability and mutability before deleting, so that de-registration is only performed if entity exists

--- a/graylog2-server/src/main/java/org/graylog/events/processor/EventDefinition.java
+++ b/graylog2-server/src/main/java/org/graylog/events/processor/EventDefinition.java
@@ -22,6 +22,7 @@ import org.graylog.events.fields.EventFieldSpec;
 import org.graylog.events.notifications.EventNotificationHandler;
 import org.graylog.events.notifications.EventNotificationSettings;
 import org.graylog.events.processor.storage.EventStorageHandler;
+import org.joda.time.DateTime;
 
 import javax.annotation.Nullable;
 import java.util.Set;
@@ -33,6 +34,9 @@ public interface EventDefinition {
     String title();
 
     String description();
+
+    @Nullable
+    DateTime updatedAt();
 
     int priority();
 

--- a/graylog2-server/src/main/java/org/graylog/events/processor/EventDefinitionDto.java
+++ b/graylog2-server/src/main/java/org/graylog/events/processor/EventDefinitionDto.java
@@ -43,6 +43,7 @@ import org.graylog2.contentpacks.model.entities.references.ValueReference;
 import org.graylog2.database.entities.ScopedEntity;
 import org.graylog2.plugin.Message;
 import org.graylog2.plugin.rest.ValidationResult;
+import org.joda.time.DateTime;
 import org.mongojack.Id;
 import org.mongojack.ObjectId;
 
@@ -66,6 +67,7 @@ public abstract class EventDefinitionDto extends ScopedEntity implements EventDe
     private static final String FIELD_KEY_SPEC = "key_spec";
     private static final String FIELD_NOTIFICATION_SETTINGS = "notification_settings";
     private static final String FIELD_STORAGE = "storage";
+    private static final String UPDATED_AT = "updated_at";
 
     @Override
     @Id
@@ -81,6 +83,11 @@ public abstract class EventDefinitionDto extends ScopedEntity implements EventDe
     @Override
     @JsonProperty(FIELD_DESCRIPTION)
     public abstract String description();
+
+    @Override
+    @Nullable
+    @JsonProperty(UPDATED_AT)
+    public abstract DateTime updatedAt();
 
     @Override
     @JsonProperty(FIELD_PRIORITY)
@@ -171,6 +178,9 @@ public abstract class EventDefinitionDto extends ScopedEntity implements EventDe
         @JsonProperty(FIELD_DESCRIPTION)
         public abstract Builder description(String description);
 
+        @JsonProperty(UPDATED_AT)
+        public abstract Builder updatedAt(DateTime updatedAt);
+
         @JsonProperty(FIELD_PRIORITY)
         public abstract Builder priority(int priority);
 
@@ -234,6 +244,7 @@ public abstract class EventDefinitionDto extends ScopedEntity implements EventDe
 
         return EventDefinitionEntity.builder()
                 .scope(ValueReference.of(scope()))
+                .updatedAt(updatedAt())
                 .title(ValueReference.of(title()))
                 .description(ValueReference.of(description()))
                 .priority(ValueReference.of(priority()))

--- a/graylog2-server/src/main/java/org/graylog2/database/entities/ScopedDbService.java
+++ b/graylog2-server/src/main/java/org/graylog2/database/entities/ScopedDbService.java
@@ -75,7 +75,7 @@ public abstract class ScopedDbService<E extends ScopedEntity> extends PaginatedD
     }
 
     @Override
-    public final E save(E entity) {
+    public E save(E entity) {
 
         ensureValidScope(entity);
         if (entity.id() != null) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Event definitions store last update time.
Service storing event definitions ensures that proper date is stored in "updated_at" field of "event_definitions" collection.
/nocl

## Motivation and Context
It is required by FE to proceed with changes related to "Basic Alerting Integration" topic.

## How Has This Been Tested?
Manually.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

