### PR TITLE
Fixing editing metadata for dashboards.

### DIFF
--- a/graylog2-web-interface/src/views/components/DashboardActionsMenu.tsx
+++ b/graylog2-web-interface/src/views/components/DashboardActionsMenu.tsx
@@ -38,6 +38,7 @@ import useIsNew from 'views/hooks/useIsNew';
 import useHasUndeclaredParameters from 'views/logic/parameters/useHasUndeclaredParameters';
 import useAppDispatch from 'stores/useAppDispatch';
 import { updateView } from 'views/logic/slices/viewSlice';
+import OnSaveViewAction from 'views/logic/views/OnSaveViewAction';
 
 import DashboardPropertiesModal from './dashboard/DashboardPropertiesModal';
 import BigDisplayModeConfiguration from './dashboard/BigDisplayModeConfiguration';
@@ -91,7 +92,8 @@ const DashboardActionsMenu = () => {
 
     return dispatch(onSaveNewDashboard(newDashboard));
   }, [currentUser.permissions, dispatch, pluggableSaveViewControls, view.id]);
-  const _onSaveView = useCallback((updatedView) => dispatch(updateView(updatedView)), [dispatch]);
+  const _onSaveView = useCallback(() => dispatch(OnSaveViewAction(view)), [dispatch, view]);
+  const _onUpdateView = useCallback((updatedView) => dispatch(updateView(updatedView)), [dispatch]);
 
   return (
     <ButtonGroup>
@@ -142,7 +144,7 @@ const DashboardActionsMenu = () => {
                                   title="Editing dashboard"
                                   submitButtonText="Update dashboard"
                                   onClose={() => setEditDashboardOpen(false)}
-                                  onSave={_onSaveView} />
+                                  onSave={_onUpdateView} />
       )}
 
       {shareDashboardOpen && (

--- a/graylog2-web-interface/src/views/components/DashboardActionsMenu.tsx
+++ b/graylog2-web-interface/src/views/components/DashboardActionsMenu.tsx
@@ -22,7 +22,6 @@ import { DropdownButton, MenuItem, Button, ButtonGroup } from 'components/bootst
 import { Icon, ShareButton } from 'components/common';
 import ExportModal from 'views/components/export/ExportModal';
 import DebugOverlay from 'views/components/DebugOverlay';
-import onSaveView from 'views/logic/views/OnSaveViewAction';
 import onSaveNewDashboard from 'views/logic/views/OnSaveNewDashboard';
 import * as ViewPermissions from 'views/Permissions';
 import useSearchPageLayout from 'hooks/useSearchPageLayout';
@@ -38,6 +37,7 @@ import useView from 'views/hooks/useView';
 import useIsNew from 'views/hooks/useIsNew';
 import useHasUndeclaredParameters from 'views/logic/parameters/useHasUndeclaredParameters';
 import useAppDispatch from 'stores/useAppDispatch';
+import { updateView } from 'views/logic/slices/viewSlice';
 
 import DashboardPropertiesModal from './dashboard/DashboardPropertiesModal';
 import BigDisplayModeConfiguration from './dashboard/BigDisplayModeConfiguration';
@@ -91,7 +91,7 @@ const DashboardActionsMenu = () => {
 
     return dispatch(onSaveNewDashboard(newDashboard));
   }, [currentUser.permissions, dispatch, pluggableSaveViewControls, view.id]);
-  const _onSaveView = useCallback(() => dispatch(onSaveView(view)), [dispatch, view]);
+  const _onSaveView = useCallback((updatedView) => dispatch(updateView(updatedView)), [dispatch]);
 
   return (
     <ButtonGroup>


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

In #14707, editing metadata for a saved search was changed in a way that it does not automatically persist changes and instead relies on the saved search being saved afterwards.

This PR is doing the same for dashboards, fixing an issue where changing the view title through "Edit Metadata" is now reflected correctly afterwards.

/nocl

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.