### PR TITLE
Improve "no entities found" alters for entity overviews.

### DIFF
--- a/graylog2-web-interface/src/components/common/DataTable/DataTable.jsx
+++ b/graylog2-web-interface/src/components/common/DataTable/DataTable.jsx
@@ -24,6 +24,8 @@ import { tableCss } from 'components/bootstrap/Table';
 import Filter from './Filter';
 import DataTableElement from './DataTableElement';
 
+import NoEntitiesExist from '../NoEntitiesExist';
+
 const StyledTable = styled.table`
   ${tableCss}
 `;
@@ -32,9 +34,9 @@ const StyledTable = styled.table`
 const NoData = ({ noDataText }) => {
   if (typeof noDataText === 'string') {
     return (
-      <p>
+      <NoEntitiesExist>
         {noDataText}
-      </p>
+      </NoEntitiesExist>
     );
   }
 

--- a/graylog2-web-interface/src/components/common/NoEntitiesExist.tsx
+++ b/graylog2-web-interface/src/components/common/NoEntitiesExist.tsx
@@ -16,9 +16,14 @@
  */
 import * as React from 'react';
 import PropTypes from 'prop-types';
+import styled from 'styled-components';
 
 import { Alert } from 'components/bootstrap';
-import { Icon } from 'components/common';
+import Icon from 'components/common/Icon';
+
+const StyledIcon = styled(Icon)`
+  margin-right: 5px
+`;
 
 type Props = {
   children: React.ReactNode,
@@ -30,7 +35,7 @@ type Props = {
  * explain what that entity is and a link to create a new one please use <EmptyEntity>
 */
 const NoEntitiesExist = ({ children, className }: Props) => (
-  <Alert className={`${className ?? ''} no-bm`}><Icon name="info-circle" />&nbsp;{children}</Alert>
+  <Alert className={`${className ?? ''} no-bm`}><StyledIcon name="info-circle" />{children}</Alert>
 );
 
 NoEntitiesExist.propTypes = {

--- a/graylog2-web-interface/src/components/common/NoSearchResult.tsx
+++ b/graylog2-web-interface/src/components/common/NoSearchResult.tsx
@@ -16,9 +16,14 @@
  */
 import * as React from 'react';
 import PropTypes from 'prop-types';
+import styled from 'styled-components';
 
 import { Alert } from 'components/bootstrap';
-import { Icon } from 'components/common';
+import Icon from 'components/common/Icon';
+
+const StyledIcon = styled(Icon)`
+  margin-right: 5px
+`;
 
 type Props = {
   children: React.ReactNode,
@@ -30,7 +35,7 @@ type Props = {
  * Usage should include utilizing the `children` props to supply the user with a descriptive message.
 */
 const NoSearchResult = ({ children, className }: Props) => (
-  <Alert className={`${className ?? ''} no-bm`}><Icon name="info-circle" />&nbsp;{children}</Alert>
+  <Alert className={`${className ?? ''} no-bm`}><StyledIcon name="info-circle" />{children}</Alert>
 );
 
 NoSearchResult.propTypes = {

--- a/graylog2-web-interface/src/components/content-packs/ContentPacksList.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPacksList.jsx
@@ -30,7 +30,7 @@ import {
 } from 'components/bootstrap';
 import {
   Pagination, PageSizeSelect,
-  ModalSubmit,
+  ModalSubmit, NoSearchResult, NoEntitiesExist,
 } from 'components/common';
 import TypeAheadDataFilter from 'components/common/TypeAheadDataFilter';
 import BootstrapModalWrapper from 'components/bootstrap/BootstrapModalWrapper';
@@ -197,10 +197,10 @@ class ContentPacksList extends React.Component {
     const pageSizeSelect = <PageSizeSelect onChange={this._itemsShownChange} pageSize={pageSize} pageSizes={[10, 25, 50, 100]} />;
 
     const noContentMessage = contentPacks.length <= 0
-      ? 'No content packs found. Please create or upload one'
-      : 'No matching content packs found';
+      ? <NoEntitiesExist>No content packs found. Please create or upload one</NoEntitiesExist>
+      : <NoSearchResult>No matching content packs have been found</NoSearchResult>;
     const content = filteredContentPacks.length <= 0
-      ? (<div>{noContentMessage}</div>)
+      ? (<div className="has-bm">{noContentMessage}</div>)
       : (
         <ControlledTableList>
           <ControlledTableList.Header />
@@ -210,7 +210,7 @@ class ContentPacksList extends React.Component {
 
     return (
       <div>
-        <Row className="row-sm">
+        <Row className="has-bm">
           <Col md={5}>
             <TypeAheadDataFilter id="content-packs-filter"
                                  label="Filter"

--- a/graylog2-web-interface/src/components/grok-patterns/GrokPatterns.jsx
+++ b/graylog2-web-interface/src/components/grok-patterns/GrokPatterns.jsx
@@ -241,6 +241,7 @@ class GrokPatterns extends React.Component {
                                       headerCellFormatter={_headerCellFormatter}
                                       sortByKey="name"
                                       rows={patterns}
+                                      noDataText="No grok patterns have been found."
                                       dataRowFormatter={this._patternFormatter} />
                   </PaginatedList>
                 </Col>

--- a/graylog2-web-interface/src/components/pipelines/ProcessingTimelineComponent.tsx
+++ b/graylog2-web-interface/src/components/pipelines/ProcessingTimelineComponent.tsx
@@ -227,6 +227,7 @@ const ProcessingTimelineComponent = () => {
                    customFilter={searchFilter}
                    filterKeys={[]}
                    filterLabel="Filter Pipelines"
+                   noDataText="No pipelines have been found"
                    dataRowFormatter={_pipelineFormatter} />
       </StyledPaginatedList>
     </div>

--- a/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchesList.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchesList.tsx
@@ -148,7 +148,7 @@ const SavedSearchesList = ({
       )}
       {pagination?.total === 0 && searchParams.query && (
         <NoSearchResult>
-          No saved searches found.
+          No saved searches have been found.
         </NoSearchResult>
       )}
       {!!savedSearches?.length && (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is a follow-up for https://github.com/Graylog2/graylog2-server/pull/13683. It is improving the alerts we show if an overview does not contain an entity.
We are showing two different alerts. One in case no entities exists on the system an one i case no entites exists for the currently applied filter.

Before:
![image](https://user-images.githubusercontent.com/46300478/220321452-658458f4-cd8f-4395-aa73-fc3721fbda5e.png)

After:
![image](https://user-images.githubusercontent.com/46300478/220321461-42631a3e-143b-4bc4-957d-423ef05a716f.png)

/nocl