### PR TITLE
Changing default refresh interval to five seconds. (`5.0`)

### DIFF
--- a/changelog/unreleased/pr-14720.toml
+++ b/changelog/unreleased/pr-14720.toml
@@ -1,0 +1,5 @@
+type = "f"
+message = "Changing default refresh interval to five seconds."
+
+pulls = ["14720"]
+isses = ["Graylog2/graylog-plugin-enterprise#4567"]

--- a/graylog2-web-interface/src/views/stores/RefreshStore.ts
+++ b/graylog2-web-interface/src/views/stores/RefreshStore.ts
@@ -46,7 +46,7 @@ export const RefreshStore = singletonStore(
     init() {
       this.refreshConfig = {
         enabled: false,
-        interval: 1000,
+        interval: 5000,
       };
     },
 


### PR DESCRIPTION
**Note:** This is a backport of #14720 to `5.0`.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This tiny PR is changing the default interval for the auto-refresh from one second to five seconds. Many users are used to implicitly using the default interval which is chosen when a user clicks on the play button without explicitly selecting an interval. A one second interval might be too aggressive, causing too many searches to be executed. For long time ranges it might even cause long-running searches to pile up.

This is a low-hanging fruit, aiming to improve the situation. A follow-up will include making sure that no searches are executed when an existing search is still running.

Fixes Graylog2/graylog-plugin-enterprise#4567.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.