### PR TITLE
Allow user-configurable auto-refresh settings & default interval.

### DIFF
--- a/changelog/unreleased/pr-14742.toml
+++ b/changelog/unreleased/pr-14742.toml
@@ -1,0 +1,4 @@
+type = "a"
+message = "Allow user-configurable auto-refresh settings & default interval."
+
+pulls = ["14742"]

--- a/graylog2-server/src/main/java/org/graylog2/indexer/searches/SearchesClusterConfig.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/searches/SearchesClusterConfig.java
@@ -129,6 +129,7 @@ public abstract class SearchesClusterConfig {
                 .surroundingFilterFields(DEFAULT_SURROUNDING_FILTER_FIELDS)
                 .analysisDisabledFields(DEFAULT_ANALYSIS_DISABLED_FIELDS)
                 .autoRefreshTimerangeOptions(DEFAULT_AUTO_REFRESH_TIMERANGE_OPTIONS)
+                .defaultAutoRefreshOption(DEFAULT_AUTO_REFRESH_DEFAULT_OPTION)
                 .build();
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/indexer/searches/SearchesClusterConfig.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/searches/SearchesClusterConfig.java
@@ -69,6 +69,18 @@ public abstract class SearchesClusterConfig {
             .add("full_message")
             .build();
 
+    private static final Map<Period, String> DEFAULT_AUTO_REFRESH_TIMERANGE_OPTIONS = ImmutableMap.<Period, String>builder()
+            .put(Period.seconds(1), "1 second")
+            .put(Period.seconds(2), "2 second")
+            .put(Period.seconds(5), "5 seconds")
+            .put(Period.seconds(10), "10 seconds")
+            .put(Period.seconds(30), "30 seconds")
+            .put(Period.minutes(1), "1 minute")
+            .put(Period.minutes(5), "5 minutes")
+            .build();
+
+    private static final Period DEFAULT_AUTO_REFRESH_DEFAULT_OPTION = Period.seconds(5);
+
     @JsonProperty("query_time_range_limit")
     public abstract Period queryTimeRangeLimit();
 
@@ -84,18 +96,28 @@ public abstract class SearchesClusterConfig {
     @JsonProperty("analysis_disabled_fields")
     public abstract Set<String> analysisDisabledFields();
 
+    @JsonProperty("auto_refresh_timerange_options")
+    public abstract Map<Period, String> autoRefreshTimerangeOptions();
+
+    @JsonProperty("default_auto_refresh_option")
+    public abstract Period defaultAutoRefreshOption();
+
     @JsonCreator
     public static SearchesClusterConfig create(@JsonProperty("query_time_range_limit") Period queryTimeRangeLimit,
                                                @JsonProperty("relative_timerange_options") Map<Period, String> relativeTimerangeOptions,
                                                @JsonProperty("surrounding_timerange_options") Map<Period, String> surroundingTimerangeOptions,
                                                @JsonProperty("surrounding_filter_fields") Set<String> surroundingFilterFields,
-                                               @JsonProperty("analysis_disabled_fields") @Nullable Set<String> analysisDisabledFields) {
+                                               @JsonProperty("analysis_disabled_fields") @Nullable Set<String> analysisDisabledFields,
+                                               @JsonProperty("auto_refresh_timerange_options") @Nullable Map<Period, String> autoRefreshTimerangeOptions,
+                                               @JsonProperty("default_auto_refresh_option") Period defaultAutoRefreshOption) {
         return builder()
                 .queryTimeRangeLimit(queryTimeRangeLimit)
                 .relativeTimerangeOptions(relativeTimerangeOptions)
                 .surroundingTimerangeOptions(surroundingTimerangeOptions)
                 .surroundingFilterFields(surroundingFilterFields)
                 .analysisDisabledFields(analysisDisabledFields == null ? DEFAULT_ANALYSIS_DISABLED_FIELDS : analysisDisabledFields)
+                .autoRefreshTimerangeOptions(autoRefreshTimerangeOptions == null ? DEFAULT_AUTO_REFRESH_TIMERANGE_OPTIONS : autoRefreshTimerangeOptions)
+                .defaultAutoRefreshOption(defaultAutoRefreshOption == null ? DEFAULT_AUTO_REFRESH_DEFAULT_OPTION : defaultAutoRefreshOption)
                 .build();
     }
 
@@ -106,6 +128,7 @@ public abstract class SearchesClusterConfig {
                 .surroundingTimerangeOptions(DEFAULT_SURROUNDING_TIMERANGE_OPTIONS)
                 .surroundingFilterFields(DEFAULT_SURROUNDING_FILTER_FIELDS)
                 .analysisDisabledFields(DEFAULT_ANALYSIS_DISABLED_FIELDS)
+                .autoRefreshTimerangeOptions(DEFAULT_AUTO_REFRESH_TIMERANGE_OPTIONS)
                 .build();
     }
 
@@ -122,6 +145,8 @@ public abstract class SearchesClusterConfig {
         public abstract Builder surroundingTimerangeOptions(Map<Period, String> surroundingTimerangeOptions);
         public abstract Builder surroundingFilterFields(Set<String> surroundingFilterFields);
         public abstract Builder analysisDisabledFields(Set<String> analysisDisabledFields);
+        public abstract Builder autoRefreshTimerangeOptions(Map<Period, String> autoRefreshTimerangeOptions);
+        public abstract Builder defaultAutoRefreshOption(Period defaultAutoRefreshOption);
 
         public abstract SearchesClusterConfig build();
     }

--- a/graylog2-web-interface/src/components/configurations/TimeRangeOptionsForm.tsx
+++ b/graylog2-web-interface/src/components/configurations/TimeRangeOptionsForm.tsx
@@ -25,7 +25,17 @@ import ObjectUtils from 'util/ObjectUtils';
 /**
  * Expects `this.props.options` to be an array of period/description objects. `[{period: 'PT1S', description: 'yo'}]`
  */
-class TimeRangeOptionsForm extends React.Component {
+type Option = { period: string, description: string };
+type Props = {
+  options?: Array<Option>,
+  title: string,
+  help: React.ReactNode,
+  addButtonTitle?: string,
+  update: (options: Array<Option>) => void,
+  validator: (milliseconds: number, duration: string) => boolean,
+};
+
+class TimeRangeOptionsForm extends React.Component<Props> {
   static propTypes = {
     options: PropTypes.array,
     title: PropTypes.string.isRequired,
@@ -41,7 +51,7 @@ class TimeRangeOptionsForm extends React.Component {
     validator: () => true,
   };
 
-  _update = (options) => {
+  _update = (options: { period: string; description: string; }[]) => {
     this.props.update(options);
   };
 
@@ -54,7 +64,7 @@ class TimeRangeOptionsForm extends React.Component {
     }
   };
 
-  _onRemove = (removedIdx) => {
+  _onRemove = (removedIdx: number) => {
     return () => {
       const options = ObjectUtils.clone(this.props.options);
 
@@ -65,11 +75,11 @@ class TimeRangeOptionsForm extends React.Component {
     };
   };
 
-  _onChange = (changedIdx, field) => {
+  _onChange = (changedIdx: number, field: string) => {
     return (e) => {
       const options = ObjectUtils.clone(this.props.options);
 
-      options.forEach((o, idx) => {
+      options.forEach((_o, idx) => {
         if (idx === changedIdx) {
           let { value } = e.target;
 
@@ -96,6 +106,7 @@ class TimeRangeOptionsForm extends React.Component {
       const errorStyle = ISODurationUtils.durationStyle(period, this.props.validator, 'has-error');
 
       return (
+        // eslint-disable-next-line react/no-array-index-key
         <div key={`timerange-option-${idx}`}>
           <Row>
             <Col xs={4}>

--- a/graylog2-web-interface/src/components/configurations/TimeRangeOptionsSummary.tsx
+++ b/graylog2-web-interface/src/components/configurations/TimeRangeOptionsSummary.tsx
@@ -17,31 +17,31 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-class TimeRangeOptionsSummary extends React.Component {
-  static propTypes = {
-    options: PropTypes.object.isRequired,
-  };
+type Props = { options: { [key: string]: string } };
 
-  render() {
-    let timerangeOptionsSummary = null;
+const TimeRangeOptionsSummary = ({ options }: Props) => {
+  let timerangeOptionsSummary = null;
 
-    if (this.props.options) {
-      timerangeOptionsSummary = Object.keys(this.props.options).map((key, idx) => {
-        return (
-          <span key={`timerange-options-summary-${idx}`}>
-            <dt>{key}</dt>
-            <dd>{this.props.options[key]}</dd>
-          </span>
-        );
-      });
-    }
-
-    return (
-      <dl className="deflist">
-        {timerangeOptionsSummary}
-      </dl>
-    );
+  if (options) {
+    timerangeOptionsSummary = Object.keys(options).map((key) => {
+      return (
+        <span key={`timerange-options-summary-${key}`}>
+          <dt>{key}</dt>
+          <dd>{options[key]}</dd>
+        </span>
+      );
+    });
   }
-}
+
+  return (
+    <dl className="deflist">
+      {timerangeOptionsSummary}
+    </dl>
+  );
+};
+
+TimeRangeOptionsSummary.propTypes = {
+  options: PropTypes.object.isRequired,
+};
 
 export default TimeRangeOptionsSummary;

--- a/graylog2-web-interface/src/components/search/SearchConfig.ts
+++ b/graylog2-web-interface/src/components/search/SearchConfig.ts
@@ -21,4 +21,6 @@ export type SearchesConfig = {
   query_time_range_limit: string,
   relative_timerange_options: { [key: string]: string },
   analysis_disabled_fields: Array<string>,
+  auto_refresh_timerange_options: { [key: string]: string },
+  default_auto_refresh_option: string,
 };

--- a/graylog2-web-interface/src/components/search/SurroundingSearchButton.test.tsx
+++ b/graylog2-web-interface/src/components/search/SurroundingSearchButton.test.tsx
@@ -20,7 +20,6 @@ import { asElement, fireEvent, render } from 'wrappedTestingLibrary';
 import DrilldownContext from 'views/components/contexts/DrilldownContext';
 
 import SurroundingSearchButton from './SurroundingSearchButton';
-import type { SearchesConfig } from './SearchConfig';
 
 const getOption = (optionText, getByText) => {
   const button = getByText('Show surrounding messages');
@@ -31,10 +30,7 @@ const getOption = (optionText, getByText) => {
 };
 
 describe('SurroundingSearchButton', () => {
-  const searchConfig: SearchesConfig = {
-    analysis_disabled_fields: [],
-    query_time_range_limit: 'PT0S',
-    relative_timerange_options: {},
+  const searchConfig = {
     surrounding_filter_fields: [
       'somefield',
       'someotherfield',
@@ -44,7 +40,7 @@ describe('SurroundingSearchButton', () => {
       PT1M: 'Only a minute',
     },
   };
-  const TestComponent = (props) => (
+  const TestComponent = (props: Partial<React.ComponentProps<typeof SurroundingSearchButton>>) => (
     <SurroundingSearchButton searchConfig={searchConfig}
                              timestamp="2020-02-28T09:45:31.123Z"
                              id="foo-bar"
@@ -52,7 +48,7 @@ describe('SurroundingSearchButton', () => {
                              {...props} />
   );
 
-  const renderButton = (props = {}) => render(<TestComponent {...props} />);
+  const renderButton = (props: Partial<React.ComponentProps<typeof SurroundingSearchButton>> = {}) => render(<TestComponent {...props} />);
 
   it('renders a button with a "Show surrounding messages" caption', () => {
     const { getByText } = renderButton();

--- a/graylog2-web-interface/src/components/search/SurroundingSearchButton.tsx
+++ b/graylog2-web-interface/src/components/search/SurroundingSearchButton.tsx
@@ -26,16 +26,17 @@ import DrilldownContext from 'views/components/contexts/DrilldownContext';
 import type { SearchesConfig } from './SearchConfig';
 import SearchLink from './SearchLink';
 
-const buildTimeRangeOptions = ({ surrounding_timerange_options: surroundingTimerangeOptions = {} }) => Object.entries(surroundingTimerangeOptions)
-  .reduce((prev, [key, value]) => ({ ...prev, [moment.duration(key).asSeconds()]: value }), {});
+const buildTimeRangeOptions = ({ surrounding_timerange_options: surroundingTimerangeOptions = {} }: Pick<SearchesConfig, 'surrounding_timerange_options'>) => Object.fromEntries(
+  Object.entries(surroundingTimerangeOptions).map(([key, value]) => [moment.duration(key).asSeconds(), value]),
+);
 
-const buildFilterFields = (messageFields, searchConfig) => {
+const buildFilterFields = (messageFields: { [x: string]: unknown; }, searchConfig: Pick<SearchesConfig, 'surrounding_filter_fields'>) => {
   const { surrounding_filter_fields: surroundingFilterFields = [] } = searchConfig;
 
-  return surroundingFilterFields.reduce((prev, cur) => ({ ...prev, [cur]: messageFields[cur] }), {});
+  return Object.fromEntries(surroundingFilterFields.map((fieldName) => [fieldName, messageFields[fieldName]]));
 };
 
-const buildSearchLink = (id, from, to, filterFields, streams) => SearchLink.builder()
+const buildSearchLink = (id: string, from: string, to: string, filterFields: { [key: string]: unknown; }, streams: string[]) => SearchLink.builder()
   .timerange({ type: 'absolute', from, to })
   .streams(streams)
   .filterFields(filterFields)
@@ -43,7 +44,7 @@ const buildSearchLink = (id, from, to, filterFields, streams) => SearchLink.buil
   .build()
   .toURL();
 
-const searchLink = (range, timestamp, id, messageFields, searchConfig, streams) => {
+const searchLink = (range: string, timestamp: moment.MomentInput, id: string, messageFields: { [key: string]: unknown; }, searchConfig: Pick<SearchesConfig, 'surrounding_filter_fields'>, streams: string[]) => {
   const fromTime = moment(timestamp).subtract(Number(range), 'seconds').toISOString();
   const toTime = moment(timestamp).add(Number(range), 'seconds').toISOString();
   const filterFields = buildFilterFields(messageFields, searchConfig);
@@ -52,7 +53,7 @@ const searchLink = (range, timestamp, id, messageFields, searchConfig, streams) 
 };
 
 type Props = {
-  searchConfig: SearchesConfig,
+  searchConfig: Pick<SearchesConfig, 'surrounding_timerange_options' | 'surrounding_filter_fields'>,
   timestamp: string,
   id: string,
   messageFields: { [key: string]: unknown },

--- a/graylog2-web-interface/src/util/ObjectUtils.ts
+++ b/graylog2-web-interface/src/util/ObjectUtils.ts
@@ -15,7 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 const ObjectUtils = {
-  clone(object) {
+  clone<T>(object: T): T {
     return JSON.parse(JSON.stringify(object));
   },
 

--- a/graylog2-web-interface/src/views/components/messagelist/MessageActions.test.tsx
+++ b/graylog2-web-interface/src/views/components/messagelist/MessageActions.test.tsx
@@ -34,6 +34,11 @@ const searchConfig: SearchesConfig = {
     PT1S: '1 second',
     PT1M: 'Only a minute',
   },
+  auto_refresh_timerange_options: {
+    PT1S: '1 second',
+    PT1M: 'Only a minute',
+  },
+  default_auto_refresh_option: 'PT1M',
 };
 
 describe('MessageActions', () => {

--- a/graylog2-web-interface/src/views/components/searchbar/RefreshControls.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/RefreshControls.test.tsx
@@ -21,6 +21,8 @@ import 'helpers/mocking/react-dom_mock';
 import { RefreshActions } from 'views/stores/RefreshStore';
 import { asMock } from 'helpers/mocking';
 import useRefreshConfig from 'views/components/searchbar/useRefreshConfig';
+import useSearchConfiguration from 'hooks/useSearchConfiguration';
+import type { SearchesConfig } from 'components/search/SearchConfig';
 
 import RefreshControls from './RefreshControls';
 
@@ -36,7 +38,26 @@ jest.mock('views/stores/RefreshStore', () => ({
   RefreshStore: {},
 }));
 
+jest.mock('hooks/useSearchConfiguration');
+
+const autoRefreshOptions = {
+  PT1S: '1 second',
+  PT2S: '2 second',
+  PT5S: '5 second',
+  PT1M: '1 minute',
+  PT5M: '5 minutes',
+};
+
 describe('RefreshControls', () => {
+  beforeEach(() => {
+    asMock(useSearchConfiguration).mockReturnValue({
+      config: {
+        auto_refresh_timerange_options: autoRefreshOptions,
+        default_auto_refresh_option: 'PT5S',
+      } as unknown as SearchesConfig,
+    });
+  });
+
   describe('rendering', () => {
     it.each`
     enabled      | interval

--- a/graylog2-web-interface/src/views/components/searchbar/RefreshControls.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/RefreshControls.tsx
@@ -23,6 +23,7 @@ import { MenuItem, ButtonGroup, DropdownButton, Button } from 'components/bootst
 import { Icon, Pluralize } from 'components/common';
 import { RefreshActions } from 'views/stores/RefreshStore';
 import useRefreshConfig from 'views/components/searchbar/useRefreshConfig';
+import useSearchConfiguration from 'hooks/useSearchConfiguration';
 
 const FlexibleButtonGroup = styled(ButtonGroup)`
   display: flex;
@@ -46,18 +47,11 @@ const _onChange = (interval: number) => {
   RefreshActions.setInterval(interval);
 };
 
-const INTERVAL_OPTIONS = [
-  ['1 Second', 1000],
-  ['2 Seconds', 2000],
-  ['5 Seconds', 5000],
-  ['10 Seconds', 10000],
-  ['30 Seconds', 30000],
-  ['1 Minute', 60000],
-  ['5 Minutes', 300000],
-] as const;
+const durationToMS = (duration: string) => moment.duration(duration).asMilliseconds();
 
 const RefreshControls = () => {
   const refreshConfig = useRefreshConfig();
+  const { config: { auto_refresh_timerange_options: autoRefreshTimerangeOptions } } = useSearchConfiguration();
 
   useEffect(() => () => RefreshActions.disable(), []);
 
@@ -69,9 +63,9 @@ const RefreshControls = () => {
     }
   }, [refreshConfig?.enabled]);
 
-  const intervalOptions = INTERVAL_OPTIONS.map(([label, interval]) => {
-    return <MenuItem key={`RefreshControls-${label}`} onClick={() => _onChange(interval)}>{label}</MenuItem>;
-  });
+  const intervalOptions = Object.entries(autoRefreshTimerangeOptions).map(([interval, label]) => (
+    <MenuItem key={`RefreshControls-${label}`} onClick={() => _onChange(durationToMS(interval))}>{label}</MenuItem>
+  ));
   const intervalDuration = moment.duration(refreshConfig.interval);
   const naturalInterval = intervalDuration.asSeconds() < 60
     ? <span>{intervalDuration.asSeconds()} <Pluralize singular="second" plural="seconds" value={intervalDuration.asSeconds()} /></span>

--- a/graylog2-web-interface/src/views/components/searchbar/RefreshControls.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/RefreshControls.tsx
@@ -51,7 +51,7 @@ const durationToMS = (duration: string) => moment.duration(duration).asMilliseco
 
 const RefreshControls = () => {
   const refreshConfig = useRefreshConfig();
-  const { config: { auto_refresh_timerange_options: autoRefreshTimerangeOptions } } = useSearchConfiguration();
+  const { config: { auto_refresh_timerange_options: autoRefreshTimerangeOptions = {} } } = useSearchConfiguration();
 
   useEffect(() => () => RefreshActions.disable(), []);
 

--- a/graylog2-web-interface/test/fixtures/searchClusterConfig.ts
+++ b/graylog2-web-interface/test/fixtures/searchClusterConfig.ts
@@ -15,7 +15,9 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 
-const searchClusterConfig = {
+import type { SearchesConfig } from 'components/search/SearchConfig';
+
+const searchClusterConfig: SearchesConfig = {
   query_time_range_limit: 'PT0S',
   relative_timerange_options: {
     PT10M: 'Search in the last 5 minutes',
@@ -52,6 +54,16 @@ const searchClusterConfig = {
     'full_message',
     'message',
   ],
+  auto_refresh_timerange_options: {
+    PT1S: '1 second',
+    PT5S: '5 seconds',
+    PT10S: '10 seconds',
+    PT30S: '30 seconds',
+    PT1M: '1 minute',
+    PT5M: '5 minutes',
+    PT3M: '3 minutes',
+  },
+  default_auto_refresh_option: 'PT5S',
 };
 
 export default searchClusterConfig;


### PR DESCRIPTION
**Note:** This PR requires #14723 to be merged before.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is extending the search config in a way that the user can define which interval options are being presented. The current options (1s, 2s, 5s, 30s, 1m, 5m) are kept in a way that they are now the default options available.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/41929/220368548-4c3a505e-2462-4934-97a1-ae49e3140d3c.png)
![image](https://user-images.githubusercontent.com/41929/220368627-79c43bbe-673c-43f5-9650-e5d0595b2588.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.