### PR TITLE
Scheduling next search refresh only after current one completed. (`5.0`)

### DIFF
--- a/changelog/unreleased/pr-14723.toml
+++ b/changelog/unreleased/pr-14723.toml
@@ -1,0 +1,4 @@
+type = "f"
+message = "Scheduling next search refresh only after current one completed."
+
+pulls = ["14723"]

--- a/graylog2-web-interface/src/views/components/searchbar/RefreshControls.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/RefreshControls.test.tsx
@@ -15,16 +15,18 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import React from 'react';
-import { mount } from 'wrappedEnzyme';
+import { fireEvent, render, screen } from 'wrappedTestingLibrary';
 import 'helpers/mocking/react-dom_mock';
 
 import { RefreshActions } from 'views/stores/RefreshStore';
+import { asMock } from 'helpers/mocking';
+import useRefreshConfig from 'views/components/searchbar/useRefreshConfig';
 
 import RefreshControls from './RefreshControls';
 
 jest.useFakeTimers();
 
-jest.mock('stores/connect', () => (Component) => (props) => <Component {...({ ...props })} />);
+jest.mock('./useRefreshConfig');
 
 jest.mock('views/stores/RefreshStore', () => ({
   RefreshActions: {
@@ -36,12 +38,6 @@ jest.mock('views/stores/RefreshStore', () => ({
 
 describe('RefreshControls', () => {
   describe('rendering', () => {
-    const verifyRendering = ({ enabled, interval }) => {
-      const wrapper = mount(<RefreshControls refreshConfig={{ enabled, interval }} />);
-
-      expect(wrapper).toExist();
-    };
-
     it.each`
     enabled      | interval
     ${true}      | ${1000}
@@ -53,21 +49,28 @@ describe('RefreshControls', () => {
     ${true}      | ${300000}
     ${false}     | ${300000}
     ${false}     | ${1000}
-  `('renders refresh controlls with enabled: $enabled and interval: $interval', verifyRendering);
+  `('renders refresh controls with enabled: $enabled and interval: $interval', async ({ enabled, interval }) => {
+      asMock(useRefreshConfig).mockReturnValue({ enabled, interval });
+      render(<RefreshControls />);
+
+      await screen.findByLabelText(/refresh search controls/i);
+    });
   });
 
-  it('should start the interval', () => {
-    const wrapper = mount(<RefreshControls refreshConfig={{ enabled: false, interval: 1000 }} />);
+  it('should start the interval', async () => {
+    asMock(useRefreshConfig).mockReturnValue({ enabled: false, interval: 1000 });
+    render(<RefreshControls />);
 
-    wrapper.find('svg.fa-play').simulate('click');
+    fireEvent.click(await screen.findByTitle(/start refresh/i));
 
     expect(RefreshActions.enable).toHaveBeenCalled();
   });
 
-  it('should stop the interval', () => {
-    const wrapper = mount(<RefreshControls refreshConfig={{ enabled: true, interval: 1000 }} />);
+  it('should stop the interval', async () => {
+    asMock(useRefreshConfig).mockReturnValue({ enabled: true, interval: 1000 });
+    render(<RefreshControls />);
 
-    wrapper.find('svg.fa-pause').simulate('click');
+    fireEvent.click(await screen.findByTitle(/pause refresh/i));
 
     expect(RefreshActions.disable).toHaveBeenCalled();
   });

--- a/graylog2-web-interface/src/views/components/searchbar/RefreshControls.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/RefreshControls.tsx
@@ -14,15 +14,15 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import React from 'react';
-import PropTypes from 'prop-types';
+import * as React from 'react';
+import { useCallback, useEffect } from 'react';
 import moment from 'moment';
 import styled from 'styled-components';
 
-import connect from 'stores/connect';
 import { MenuItem, ButtonGroup, DropdownButton, Button } from 'components/bootstrap';
 import { Icon, Pluralize } from 'components/common';
-import { RefreshActions, RefreshStore } from 'views/stores/RefreshStore';
+import { RefreshActions } from 'views/stores/RefreshStore';
+import useRefreshConfig from 'views/components/searchbar/useRefreshConfig';
 
 const FlexibleButtonGroup = styled(ButtonGroup)`
   display: flex;
@@ -49,70 +49,48 @@ const _onChange = (interval: number) => {
   RefreshActions.setInterval(interval);
 };
 
-type RefreshConfig = {
-  interval: number,
-  enabled: boolean,
-};
+const INTERVAL_OPTIONS = [
+  ['1 Second', 1000],
+  ['2 Seconds', 2000],
+  ['5 Seconds', 5000],
+  ['10 Seconds', 10000],
+  ['30 Seconds', 30000],
+  ['1 Minute', 60000],
+  ['5 Minutes', 300000],
+] as const;
 
-type Props = {
-  refreshConfig: RefreshConfig,
-};
+const RefreshControls = () => {
+  const refreshConfig = useRefreshConfig();
 
-class RefreshControls extends React.Component<Props> {
-  static propTypes = {
-    refreshConfig: PropTypes.exact({
-      interval: PropTypes.number.isRequired,
-      enabled: PropTypes.bool.isRequired,
-    }).isRequired,
-  };
+  useEffect(() => () => RefreshActions.disable(), []);
 
-  static INTERVAL_OPTIONS: Array<[string, number]> = [
-    ['1 Second', 1000],
-    ['2 Seconds', 2000],
-    ['5 Seconds', 5000],
-    ['10 Seconds', 10000],
-    ['30 Seconds', 30000],
-    ['1 Minute', 60000],
-    ['5 Minutes', 300000],
-  ];
-
-  componentWillUnmount(): void {
-    RefreshActions.disable();
-  }
-
-  _toggleEnable = (): void => {
-    const { refreshConfig } = this.props;
-
+  const _toggleEnable = useCallback(() => {
     if (refreshConfig.enabled) {
       RefreshActions.disable();
     } else {
       RefreshActions.enable();
     }
-  };
+  }, [refreshConfig?.enabled]);
 
-  render() {
-    const { refreshConfig } = this.props;
+  const intervalOptions = INTERVAL_OPTIONS.map(([label, interval]) => {
+    return <MenuItem key={`RefreshControls-${label}`} onClick={() => _onChange(interval)}>{label}</MenuItem>;
+  });
+  const intervalDuration = moment.duration(refreshConfig.interval);
+  const naturalInterval = intervalDuration.asSeconds() < 60
+    ? <span>{intervalDuration.asSeconds()} <Pluralize singular="second" plural="seconds" value={intervalDuration.asSeconds()} /></span>
+    : <span>{intervalDuration.asMinutes()} <Pluralize singular="minute" plural="minutes" value={intervalDuration.asMinutes()} /></span>;
 
-    const intervalOptions = RefreshControls.INTERVAL_OPTIONS.map(([label, interval]: [string, number]) => {
-      return <MenuItem key={`RefreshControls-${label}`} onClick={() => _onChange(interval)}>{label}</MenuItem>;
-    });
-    const intervalDuration = moment.duration(refreshConfig.interval);
-    const naturalInterval = intervalDuration.asSeconds() < 60
-      ? <span>{intervalDuration.asSeconds()} <Pluralize singular="second" plural="seconds" value={intervalDuration.asSeconds()} /></span>
-      : <span>{intervalDuration.asMinutes()} <Pluralize singular="minute" plural="minutes" value={intervalDuration.asMinutes()} /></span>;
+  return (
+    <FlexibleButtonGroup aria-label="Refresh Search Controls">
+      <Button onClick={_toggleEnable} title={refreshConfig.enabled ? 'Pause Refresh' : 'Start Refresh'}>
+        {refreshConfig.enabled ? <Icon name="pause" /> : <Icon name="play" />}
+      </Button>
 
-    return (
-      <FlexibleButtonGroup aria-label="Refresh Search Controls">
-        <Button onClick={this._toggleEnable}>
-          {refreshConfig.enabled ? <Icon name="pause" /> : <Icon name="play" />}
-        </Button>
+      <DropdownButton title={<ButtonLabel refreshConfigEnabled={refreshConfig.enabled} naturalInterval={naturalInterval} />} id="refresh-options-dropdown">
+        {intervalOptions}
+      </DropdownButton>
+    </FlexibleButtonGroup>
+  );
+};
 
-        <DropdownButton title={<ButtonLabel refreshConfigEnabled={refreshConfig.enabled} naturalInterval={naturalInterval} />} id="refresh-options-dropdown">
-          {intervalOptions}
-        </DropdownButton>
-      </FlexibleButtonGroup>
-    );
-  }
-}
-
-export default connect(RefreshControls, { refreshConfig: RefreshStore });
+export default RefreshControls;

--- a/graylog2-web-interface/src/views/components/searchbar/useRefreshConfig.ts
+++ b/graylog2-web-interface/src/views/components/searchbar/useRefreshConfig.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import { useStore } from 'stores/connect';
+import { RefreshStore } from 'views/stores/RefreshStore';
+
+const useRefreshConfig = () => useStore(RefreshStore);
+export default useRefreshConfig;

--- a/graylog2-web-interface/src/views/pages/ShowDashboardInBigDisplayMode.test.tsx
+++ b/graylog2-web-interface/src/views/pages/ShowDashboardInBigDisplayMode.test.tsx
@@ -21,6 +21,7 @@ import { StoreMock as MockStore } from 'helpers/mocking';
 import { RefreshActions } from 'views/stores/RefreshStore';
 import View from 'views/logic/views/View';
 import _ShowDashboardInBigDisplayMode from 'views/pages/ShowDashboardInBigDisplayMode';
+import mockAction from 'helpers/mocking/MockAction';
 
 const mockView = View.builder()
   .type(View.Type.Dashboard)
@@ -67,7 +68,7 @@ const ShowDashboardInBigDisplayMode = _ShowDashboardInBigDisplayMode as React.Co
 
 describe('ShowDashboardInBigDisplayMode', () => {
   beforeEach(() => {
-    RefreshActions.disable = jest.fn();
+    RefreshActions.disable = mockAction(jest.fn());
   });
 
   afterEach(() => {


### PR DESCRIPTION
**Note:** This is a backport of #14723 to `5.0`.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is changing the auto-refresh logic in a way that the next auto-refresh will be scheduled when the most recent one has completed.  This avoids the scenario that when the time a search execution takes exceeds the auto-refresh interval, that new search executions are triggered while there are still one or more in progress, leading to piling up search executions needlessly.

Fixes Graylog2/graylog-plugin-enterprise#3642.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.