### PR TITLE
Unify height of data table and message table header.

### DIFF
--- a/graylog2-web-interface/src/views/Constants.ts
+++ b/graylog2-web-interface/src/views/Constants.ts
@@ -107,3 +107,5 @@ export const availableTimeRangeTypes = [
   { type: 'absolute' as const, name: 'Absolute' },
   { type: 'keyword' as const, name: 'Keyword' },
 ];
+
+export const VISUALIZATION_TABLE_HEADER_HEIGHT = 28;

--- a/graylog2-web-interface/src/views/components/datatable/Headers.tsx
+++ b/graylog2-web-interface/src/views/components/datatable/Headers.tsx
@@ -21,6 +21,7 @@ import styled, { css } from 'styled-components';
 import type { OrderedMap } from 'immutable';
 import Immutable from 'immutable';
 
+import { VISUALIZATION_TABLE_HEADER_HEIGHT } from 'views/Constants';
 import Field from 'views/components/Field';
 import type FieldType from 'views/logic/fieldtypes/FieldType';
 import Value from 'views/components/Value';
@@ -37,11 +38,19 @@ import InteractiveContext from 'views/components/contexts/InteractiveContext';
 
 import styles from './DataTable.css';
 
-const StyledTh = styled.th(({ isNumeric }: { isNumeric: boolean }) => css`
+const StyledTh = styled.th`
+  && {
+    height: ${VISUALIZATION_TABLE_HEADER_HEIGHT}px;
+    padding: 0 5px;
+    vertical-align: middle;
+  }
+`;
+
+const DefaultTh = styled(StyledTh)(({ isNumeric }: { isNumeric: boolean }) => css`
   ${isNumeric ? 'text-align: right;' : ''}
 `);
 
-const CenteredTh = styled.th`
+const CenteredTh = styled(StyledTh)`
   text-align: center;
 `;
 
@@ -92,7 +101,7 @@ const HeaderField = ({ activeQuery, fields, field, prefix = '', span = 1, title 
   }, [togglePin, prefix, field]);
 
   return (
-    <StyledTh ref={thRef} isNumeric={type.isNumeric()} key={`${prefix}${field}`} colSpan={span} className={styles.leftAligned}>
+    <DefaultTh ref={thRef} isNumeric={type.isNumeric()} key={`${prefix}${field}`} colSpan={span} className={styles.leftAligned}>
       <Field name={field} queryId={activeQuery} type={type}>{title}</Field>
       {showPinIcon && <PinIcon data-testid={`pin-${prefix}${field}`} type="button" onClick={_togglePin} className={isPinned ? 'active' : ''}><Icon name="thumbtack" /></PinIcon>}
       {sortable && sortType && (
@@ -103,7 +112,7 @@ const HeaderField = ({ activeQuery, fields, field, prefix = '', span = 1, title 
                      sortConfigMap={sortConfigMap}
                      type={sortType} />
       )}
-    </StyledTh>
+    </DefaultTh>
   );
 };
 

--- a/graylog2-web-interface/src/views/components/widgets/MessageTable.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageTable.tsx
@@ -32,6 +32,7 @@ import type { BackendMessage, Message } from 'views/components/messagelist/Types
 import FieldSortIcon from 'views/components/widgets/FieldSortIcon';
 import Field from 'views/components/Field';
 import MessageTableProviders from 'views/components/messagelist/MessageTableProviders';
+import { VISUALIZATION_TABLE_HEADER_HEIGHT } from 'views/Constants';
 
 import InteractiveContext from '../contexts/InteractiveContext';
 
@@ -87,8 +88,9 @@ const TableHead = styled.thead(({ theme }) => css`
   
   && > tr > th {
     min-width: 50px;
-    min-height: 28px;
+    height: ${VISUALIZATION_TABLE_HEADER_HEIGHT}px;
     padding: 0 5px;
+    vertical-align: center;
     border: 0;
     font-size: ${theme.fonts.size.small};
     font-weight: normal;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

With this PR we are unifying the height of the data table and message table header.

Before:

![image](https://user-images.githubusercontent.com/46300478/220676452-f99bdc7c-52b7-4e57-a3e5-5eaf6211d331.png)

After:

![image](https://user-images.githubusercontent.com/46300478/220676615-7c1b8ad7-0ac4-42f6-88ec-a3eb7a97e0ef.png)

/nocl