### PR TITLE
Display entity data table bulk actions as dropdown.

### DIFF
--- a/graylog2-web-interface/src/components/common/EntityDataTable/BulkActionsDropdown.tsx
+++ b/graylog2-web-interface/src/components/common/EntityDataTable/BulkActionsDropdown.tsx
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import { useCallback } from 'react';
+
+import MenuItem from 'components/bootstrap/MenuItem';
+import { DropdownButton } from 'components/bootstrap';
+
+type Props = {
+  children: React.ReactNode,
+  selectedEntities: Array<string>,
+  setSelectedEntities: React.Dispatch<React.SetStateAction<Array<string>>>
+
+};
+
+const BulkActionsDropdown = ({ selectedEntities, setSelectedEntities, children }: Props) => {
+  const cancelEntitySelection = useCallback(() => setSelectedEntities([]), [setSelectedEntities]);
+
+  return (
+    <DropdownButton bsSize="small"
+                    title="Bulk actions"
+                    disabled={!selectedEntities?.length}>
+      {children}
+      <MenuItem divider />
+      <MenuItem onClick={cancelEntitySelection}>Cancel selection</MenuItem>
+    </DropdownButton>
+  );
+};
+
+export default BulkActionsDropdown;

--- a/graylog2-web-interface/src/components/common/EntityDataTable/BulkActionsDropdown.tsx
+++ b/graylog2-web-interface/src/components/common/EntityDataTable/BulkActionsDropdown.tsx
@@ -33,6 +33,7 @@ const BulkActionsDropdown = ({ selectedEntities, setSelectedEntities, children }
   return (
     <DropdownButton bsSize="small"
                     title="Bulk actions"
+                    id="bulk-actions-dropdown"
                     disabled={!selectedEntities?.length}>
       {children}
       <MenuItem divider />

--- a/graylog2-web-interface/src/components/common/EntityDataTable/BulkActionsRow.tsx
+++ b/graylog2-web-interface/src/components/common/EntityDataTable/BulkActionsRow.tsx
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import styled from 'styled-components';
+
+import StringUtils from 'util/StringUtils';
+
+const Container = styled.div`
+  display: flex;
+  align-items: center;
+`;
+
+const SelectedEntitiesAmount = styled.div`
+  margin-left: 5px;
+`;
+
+type Props = {
+  bulkActions: (selectedEntities: Array<string>, setSelectedEntities: (streamIds: Array<string>) => void) => React.ReactNode,
+  selectedEntities: Array<string>,
+  setSelectedEntities: React.Dispatch<React.SetStateAction<Array<string>>>
+
+};
+
+const BulkActionsRow = ({ selectedEntities, setSelectedEntities, bulkActions: bulkActionsDropdown }: Props) => (
+  <Container>
+    {bulkActionsDropdown(selectedEntities, setSelectedEntities)}
+    {!!selectedEntities.length && (
+      <SelectedEntitiesAmount>
+        {selectedEntities.length} {StringUtils.pluralize(selectedEntities.length, 'item', 'items')} selected
+      </SelectedEntitiesAmount>
+    )}
+  </Container>
+);
+
+export default BulkActionsRow;

--- a/graylog2-web-interface/src/components/common/EntityDataTable/EntityDataTable.tsx
+++ b/graylog2-web-interface/src/components/common/EntityDataTable/EntityDataTable.tsx
@@ -20,10 +20,9 @@ import { useMemo, useState, useCallback, useRef } from 'react';
 import type * as Immutable from 'immutable';
 import { merge } from 'lodash';
 
-import { Button, Table, ButtonGroup, ButtonToolbar } from 'components/bootstrap';
+import { Table, ButtonGroup } from 'components/bootstrap';
 import { isPermitted, isAnyPermitted } from 'util/PermissionsMixin';
 import useCurrentUser from 'hooks/useCurrentUser';
-import StringUtils from 'util/StringUtils';
 import ColumnsVisibilitySelect from 'components/common/EntityDataTable/ColumnsVisibilitySelect';
 import DefaultColumnRenderers from 'components/common/EntityDataTable/DefaultColumnRenderers';
 import { CELL_PADDING, BULK_SELECT_COLUMN_WIDTH } from 'components/common/EntityDataTable/Constants';
@@ -32,6 +31,7 @@ import useElementDimensions from 'hooks/useElementDimensions';
 import type { Sort } from 'stores/PaginationTypes';
 import { PageSizeSelect } from 'components/common';
 
+import BulkActionsRow from './BulkActionsRow';
 import TableHead from './TableHead';
 import TableRow from './TableRow';
 import type { ColumnRenderers, Column, EntityBase } from './types';
@@ -54,15 +54,6 @@ const ActionsRow = styled.div`
   justify-content: space-between;
   margin-bottom: 10px;
   min-height: 22px;
-`;
-
-const BulkActionsWrapper = styled.div`
-  display: flex;
-  align-items: center;
-`;
-
-const BulkActions = styled(ButtonToolbar)`
-  margin-left: 5px;
 `;
 
 const LayoutConfigRow = styled.div`
@@ -125,7 +116,7 @@ type Props<Entity extends EntityBase> = {
   /** Currently active sort */
   activeSort?: Sort,
   /** Supported batch operations */
-  bulkActions?: (selectedEntities: Array<string>, setSelectedEntities: (streamIds: Array<string>) => void) => React.ReactNode
+  bulkActions?: (selectedEntities: Array<string>, setSelectedEntities: (streamIds: Array<string>) => void) => React.ReactNode,
   /** List of all available columns. */
   columnDefinitions: Array<Column>,
   /** Custom cell and header renderer for a column */
@@ -198,20 +189,14 @@ const EntityDataTable = <Entity extends EntityBase>({
     }));
   }, []);
 
-  const unselectAllItems = useCallback(() => setSelectedEntities([]), []);
-
   return (
     <>
       <ActionsRow>
         <div>
-          {(displayBulkSelectCol && !!selectedEntities?.length) && (
-            <BulkActionsWrapper>
-              {selectedEntities.length} {StringUtils.pluralize(selectedEntities.length, 'item', 'items')} selected
-              <BulkActions>
-                {bulkActions(selectedEntities, setSelectedEntities)}
-                <Button bsSize="xsmall" onClick={unselectAllItems}>Cancel</Button>
-              </BulkActions>
-            </BulkActionsWrapper>
+          {displayBulkSelectCol && (
+            <BulkActionsRow bulkActions={bulkActions}
+                            selectedEntities={selectedEntities}
+                            setSelectedEntities={setSelectedEntities} />
           )}
         </div>
         <LayoutConfigRow>

--- a/graylog2-web-interface/src/components/streams/StreamsOverview/BulkActions.test.tsx
+++ b/graylog2-web-interface/src/components/streams/StreamsOverview/BulkActions.test.tsx
@@ -42,8 +42,14 @@ jest.mock('@graylog/server-api', () => ({
 }));
 
 describe('StreamsOverview BulkActionsRow', () => {
+  const openActionsDropdown = async () => {
+    await screen.findByRole('button', {
+      name: /bulk actions/i,
+    });
+  };
+
   const assignIndexSet = async () => {
-    userEvent.click(await screen.findByRole('button', { name: /assign index set/i }));
+    userEvent.click(await screen.findByRole('menuitem', { name: /assign index set/i }));
 
     await screen.findByRole('heading', {
       name: /assign index set to 2 streams/i,
@@ -69,7 +75,7 @@ describe('StreamsOverview BulkActionsRow', () => {
   };
 
   const deleteStreams = async () => {
-    userEvent.click(await screen.findByRole('button', { name: /delete/i }));
+    userEvent.click(await screen.findByRole('menuitem', { name: /delete/i }));
   };
 
   beforeEach(() => {
@@ -81,6 +87,7 @@ describe('StreamsOverview BulkActionsRow', () => {
                         setSelectedStreamIds={() => {}}
                         indexSets={indexSets} />);
 
+    await openActionsDropdown();
     await assignIndexSet();
 
     await waitFor(() => expect(Streams.assignToIndexSet).toHaveBeenCalledWith('index-set-id-2', ['stream-id-1', 'stream-id-2']));
@@ -95,6 +102,7 @@ describe('StreamsOverview BulkActionsRow', () => {
                         setSelectedStreamIds={() => {}}
                         indexSets={indexSets} />);
 
+    await openActionsDropdown();
     await assignIndexSet();
 
     await waitFor(() => expect(UserNotification.error).toHaveBeenCalledWith('Assigning index set failed with status: Error: Unexpected error!', 'Error'));
@@ -108,6 +116,7 @@ describe('StreamsOverview BulkActionsRow', () => {
                         setSelectedStreamIds={setSelectedStreamIds}
                         indexSets={indexSets} />);
 
+    await openActionsDropdown();
     await deleteStreams();
 
     expect(window.confirm).toHaveBeenCalledWith('Do you really want to remove 2 streams?');

--- a/graylog2-web-interface/src/components/streams/StreamsOverview/BulkActions.test.tsx
+++ b/graylog2-web-interface/src/components/streams/StreamsOverview/BulkActions.test.tsx
@@ -41,7 +41,7 @@ jest.mock('@graylog/server-api', () => ({
   },
 }));
 
-describe('StreamsOverview BulkActions', () => {
+describe('StreamsOverview BulkActionsRow', () => {
   const assignIndexSet = async () => {
     userEvent.click(await screen.findByRole('button', { name: /assign index set/i }));
 

--- a/graylog2-web-interface/src/components/streams/StreamsOverview/BulkActions.tsx
+++ b/graylog2-web-interface/src/components/streams/StreamsOverview/BulkActions.tsx
@@ -20,7 +20,7 @@ import { Formik, Form } from 'formik';
 import { useQueryClient } from '@tanstack/react-query';
 
 import { Streams } from '@graylog/server-api';
-import { Button, Modal } from 'components/bootstrap';
+import { Modal } from 'components/bootstrap';
 import StringUtils from 'util/StringUtils';
 import fetch from 'logic/rest/FetchProvider';
 import { qualifyUrl } from 'util/URLUtils';
@@ -30,6 +30,8 @@ import UserNotification from 'util/UserNotification';
 import ModalSubmit from 'components/common/ModalSubmit';
 import IfPermitted from 'components/common/IfPermitted';
 import type { IndexSet } from 'stores/indices/IndexSetsStore';
+import MenuItem from 'components/bootstrap/MenuItem';
+import BulkActionsDropdown from 'components/common/EntityDataTable/BulkActionsDropdown';
 
 import IndexSetSelect from '../IndexSetSelect';
 
@@ -153,10 +155,12 @@ const BulkActions = ({ selectedStreamIds, setSelectedStreamIds, indexSets }: Pro
 
   return (
     <>
-      <IfPermitted permissions="indexsets:read">
-        <Button bsSize="xsmall" bsStyle="info" onClick={toggleAssignIndexSetModal}>Assign index set</Button>
-      </IfPermitted>
-      <Button bsSize="xsmall" bsStyle="danger" onClick={onDelete}>Delete</Button>
+      <BulkActionsDropdown selectedEntities={selectedStreamIds} setSelectedEntities={setSelectedStreamIds}>
+        <IfPermitted permissions="indexsets:read">
+          <MenuItem onSelect={toggleAssignIndexSetModal}>Assign index set</MenuItem>
+        </IfPermitted>
+        <MenuItem onSelect={onDelete}>Delete</MenuItem>
+      </BulkActionsDropdown>
       {showIndexSetModal && (
         <AssignIndexSetModal selectedStreamIds={selectedStreamIds}
                              setSelectedStreamIds={setSelectedStreamIds}

--- a/graylog2-web-interface/src/views/components/dashboard/DashboardsOverview/BulkActions.test.tsx
+++ b/graylog2-web-interface/src/views/components/dashboard/DashboardsOverview/BulkActions.test.tsx
@@ -32,8 +32,14 @@ jest.mock('util/UserNotification', () => ({
 }));
 
 describe('DashboardsOverview BulkActionsRow', () => {
+  const openActionsDropdown = async () => {
+    await screen.findByRole('button', {
+      name: /bulk actions/i,
+    });
+  };
+
   const deleteDashboards = async () => {
-    userEvent.click(await screen.findByRole('button', { name: /delete/i }));
+    userEvent.click(await screen.findByRole('menuitem', { name: /delete/i }));
   };
 
   beforeEach(() => {
@@ -47,6 +53,7 @@ describe('DashboardsOverview BulkActionsRow', () => {
     render(<BulkActions selectedDashboardIds={['dashboard-id-1', 'dashboard-id-2']}
                         setSelectedDashboardIds={setSelectedDashboardIds} />);
 
+    await openActionsDropdown();
     await deleteDashboards();
 
     expect(window.confirm).toHaveBeenCalledWith('Do you really want to remove 2 dashboards?');
@@ -73,6 +80,7 @@ describe('DashboardsOverview BulkActionsRow', () => {
     render(<BulkActions selectedDashboardIds={['dashboard-id-1', 'dashboard-id-2']}
                         setSelectedDashboardIds={setSelectedDashboardIds} />);
 
+    await openActionsDropdown();
     await deleteDashboards();
 
     expect(window.confirm).toHaveBeenCalledWith('Do you really want to remove 2 dashboards?');

--- a/graylog2-web-interface/src/views/components/dashboard/DashboardsOverview/BulkActions.test.tsx
+++ b/graylog2-web-interface/src/views/components/dashboard/DashboardsOverview/BulkActions.test.tsx
@@ -31,7 +31,7 @@ jest.mock('util/UserNotification', () => ({
   success: jest.fn(),
 }));
 
-describe('DashboardsOverview BulkActions', () => {
+describe('DashboardsOverview BulkActionsRow', () => {
   const deleteDashboards = async () => {
     userEvent.click(await screen.findByRole('button', { name: /delete/i }));
   };

--- a/graylog2-web-interface/src/views/components/dashboard/DashboardsOverview/BulkActions.tsx
+++ b/graylog2-web-interface/src/views/components/dashboard/DashboardsOverview/BulkActions.tsx
@@ -18,11 +18,12 @@ import * as React from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { useCallback } from 'react';
 
-import { Button } from 'components/bootstrap';
+import BulkActionsDropdown from 'components/common/EntityDataTable/BulkActionsDropdown';
 import StringUtils from 'util/StringUtils';
 import fetch from 'logic/rest/FetchProvider';
 import { qualifyUrl } from 'util/URLUtils';
 import UserNotification from 'util/UserNotification';
+import MenuItem from 'components/bootstrap/MenuItem';
 
 const VIEWS_BULK_DELETE_API_ROUTE = '/views/bulk_delete';
 
@@ -62,7 +63,9 @@ const BulkActions = ({ selectedDashboardIds, setSelectedDashboardIds }: Props) =
   }, [descriptor, queryClient, selectedItemsAmount, selectedDashboardIds, setSelectedDashboardIds]);
 
   return (
-    <Button bsSize="xsmall" bsStyle="danger" onClick={onDelete}>Delete</Button>
+    <BulkActionsDropdown selectedEntities={selectedDashboardIds} setSelectedEntities={setSelectedDashboardIds}>
+      <MenuItem onSelect={onDelete}>Delete</MenuItem>
+    </BulkActionsDropdown>
   );
 };
 

--- a/graylog2-web-interface/src/views/components/searchbar/saved-search/BulkActions.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/saved-search/BulkActions.test.tsx
@@ -32,8 +32,14 @@ jest.mock('util/UserNotification', () => ({
 }));
 
 describe('SavedSearches BulkActionsRow', () => {
+  const openActionsDropdown = async () => {
+    await screen.findByRole('button', {
+      name: /bulk actions/i,
+    });
+  };
+
   const deleteSavedSearch = async () => {
-    userEvent.click(await screen.findByRole('button', { name: /delete/i }));
+    userEvent.click(await screen.findByRole('menuitem', { name: /delete/i }));
   };
 
   beforeEach(() => {
@@ -47,6 +53,7 @@ describe('SavedSearches BulkActionsRow', () => {
     render(<BulkActions selectedSavedSearchIds={['saved-search-id-1', 'saved-search-id-2']}
                         setSelectedSavedSearchIds={setSelectedSavedSearchIds} />);
 
+    await openActionsDropdown();
     await deleteSavedSearch();
 
     expect(window.confirm).toHaveBeenCalledWith('Do you really want to remove 2 saved searches?');
@@ -73,6 +80,7 @@ describe('SavedSearches BulkActionsRow', () => {
     render(<BulkActions selectedSavedSearchIds={['saved-search-id-1', 'saved-search-id-2']}
                         setSelectedSavedSearchIds={setSelectedSavedSearchIds} />);
 
+    await openActionsDropdown();
     await deleteSavedSearch();
 
     expect(window.confirm).toHaveBeenCalledWith('Do you really want to remove 2 saved searches?');

--- a/graylog2-web-interface/src/views/components/searchbar/saved-search/BulkActions.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/saved-search/BulkActions.test.tsx
@@ -31,7 +31,7 @@ jest.mock('util/UserNotification', () => ({
   success: jest.fn(),
 }));
 
-describe('SavedSearches BulkActions', () => {
+describe('SavedSearches BulkActionsRow', () => {
   const deleteSavedSearch = async () => {
     userEvent.click(await screen.findByRole('button', { name: /delete/i }));
   };

--- a/graylog2-web-interface/src/views/components/searchbar/saved-search/BulkActions.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/saved-search/BulkActions.tsx
@@ -18,11 +18,12 @@ import * as React from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { useCallback } from 'react';
 
-import { Button } from 'components/bootstrap';
+import { MenuItem } from 'components/bootstrap';
 import StringUtils from 'util/StringUtils';
 import fetch from 'logic/rest/FetchProvider';
 import { qualifyUrl } from 'util/URLUtils';
 import UserNotification from 'util/UserNotification';
+import BulkActionsDropdown from 'components/common/EntityDataTable/BulkActionsDropdown';
 
 const VIEWS_BULK_DELETE_API_ROUTE = '/views/bulk_delete';
 
@@ -62,7 +63,9 @@ const BulkActions = ({ selectedSavedSearchIds, setSelectedSavedSearchIds }: Prop
   }, [descriptor, queryClient, selectedItemsAmount, selectedSavedSearchIds, setSelectedSavedSearchIds]);
 
   return (
-    <Button bsSize="xsmall" bsStyle="danger" onClick={onDelete}>Delete</Button>
+    <BulkActionsDropdown selectedEntities={selectedSavedSearchIds} setSelectedEntities={setSelectedSavedSearchIds}>
+      <MenuItem onSelect={onDelete}>Delete</MenuItem>
+    </BulkActionsDropdown>
   );
 };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

With this PR we are changing the way we display bulk actions for the entity data table.

Before:
<img width="360" alt="image" src="https://user-images.githubusercontent.com/46300478/215070588-b87e9715-8378-4b39-af9c-ca0a929b8d35.png">

After:
<img width="247" alt="image" src="https://user-images.githubusercontent.com/46300478/215070446-5d2a55c0-ac95-4561-a794-a0d2bd5206f9.png">

The new layout has a few benefits:
- it scales better, there are cases where we might will have over 10 bulk actions
- it looks cleaner, especially with many bulk actions
- it is easier to style the surrounding layout, because the bulk actions button width will not change a lot
- we unify the UI with similar cases in the application

Please note, one behaviour is not perfect. when a `Menuitem` is wrapped with another component like `IfPermitted`, we do not close the dropdown immediately on select. I prefer fixing this behaviour globally for `DropdownButton` in another PR.