### PR TITLE
Bump version of json-path to 2.7.0

### DIFF
--- a/changelog/unreleased/pr-14768.toml
+++ b/changelog/unreleased/pr-14768.toml
@@ -1,0 +1,6 @@
+type = "s"
+message = "Bump version of json-path to 2.7.0 to address CVE-2021-27568."
+
+issues = ["Graylog2/graylog-plugin-enterprise#3674"]
+pulls = ["14768"]
+

--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
         <jmte.version>5.0.0</jmte.version>
         <joda-time.version>2.10.6</joda-time.version>
         <jool.version>0.9.14</jool.version>
-        <json-path.version>2.4.0</json-path.version>
+        <json-path.version>2.7.0</json-path.version>
         <kafka.version>2.7.0</kafka.version>
         <kafka09.version>0.9.0.1-6</kafka09.version>
         <log4j.version>2.17.1</log4j.version>


### PR DESCRIPTION
Upgrade json-path 2.7.0. Implicitly this also upgrades json-smart to 2.4.7.

json-path is mainly used in testing, as well as JSONpath Codec and HTTPJsonPath data adapter.

Resolves Graylog2/graylog-plugin-enterprise#3674