### PR TITLE
Prevent unneeded search execution when opening new search.

### DIFF
--- a/graylog2-web-interface/src/views/components/contexts/WidgetFocusContext.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/WidgetFocusContext.tsx
@@ -30,7 +30,13 @@ export type WidgetEditingState = {
   focusing: true,
 }
 
-export type FocusContextState = WidgetFocusingState | WidgetEditingState;
+type InitialState = {
+  id: undefined,
+  editing: false,
+  focusing: false,
+}
+
+export type FocusContextState = WidgetFocusingState | WidgetEditingState | InitialState;
 
 export type WidgetFocusContextType = {
   focusedWidget: FocusContextState | undefined,

--- a/graylog2-web-interface/src/views/components/contexts/WidgetFocusProvider.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/WidgetFocusProvider.tsx
@@ -83,6 +83,12 @@ type SyncStateArgs = {
   focusUriParams: FocusUriParams,
 }
 
+const emptyFocusContext: FocusContextState = {
+  editing: false,
+  focusing: false,
+  id: undefined,
+};
+
 const useSyncStateWithQueryParams = ({ focusedWidget, focusUriParams, setFocusedWidget, widgetIds }: SyncStateArgs) => {
   const dispatch = useAppDispatch();
 
@@ -93,7 +99,7 @@ const useSyncStateWithQueryParams = ({ focusedWidget, focusUriParams, setFocused
       focusing: focusUriParams.focusing || focusUriParams.editing,
     } as FocusContextState;
 
-    if (!isEqual(focusedWidget, nextFocusedWidget)) {
+    if (!isEqual(focusedWidget ?? emptyFocusContext, nextFocusedWidget)) {
       if (focusUriParams.id && !widgetIds.includes(focusUriParams.id)) {
         return;
       }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This change is preventing one unneeded search execution when starting a new search. It is caused by the widget focus provider which compares the current focus state (which is initially `undefined`) with the next one when syncing with query parameters. At this point, the next one can also be `{ editing: false, focusing: false, id: undefined }`, what is semantically identical, but not equal to `undefined`, causing a state change.

Therefore, this change is now making sure that if the current focus state is `undefined`, the initial object `{ editing: false, focusing: false, id: undefined }` will be used for the equality check instead.

/nocl

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.