### PR TITLE
Fix page size handling for dashboards and streams overview.

### DIFF
--- a/graylog2-web-interface/src/components/common/PaginatedList.tsx
+++ b/graylog2-web-interface/src/components/common/PaginatedList.tsx
@@ -100,7 +100,7 @@ const ListBasedOnQueryParams = ({
   pageSizes,
   ...props
 }: Required<Props> & { pageSize: number }) => {
-  const { page: currentPage, pageSize: currentPageSize, setPagination } = usePaginationQueryParameter(pageSizes, props.pageSize);
+  const { page: currentPage, pageSize: currentPageSize, setPagination } = usePaginationQueryParameter(pageSizes, props.pageSize, props.showPageSizeSelect);
 
   return <ListBase {...props} currentPage={currentPage} currentPageSize={currentPageSize} setPagination={setPagination} pageSizes={pageSizes} />;
 };

--- a/graylog2-web-interface/src/components/streams/StreamsOverview/StreamsOverview.tsx
+++ b/graylog2-web-interface/src/components/streams/StreamsOverview/StreamsOverview.tsx
@@ -62,13 +62,13 @@ type Props = {
 const StreamsOverview = ({ indexSets }: Props) => {
   const [filters, setFilters] = useState<Filters>();
   const [query, setQuery] = useState('');
-  const paginationQueryParameter = usePaginationQueryParameter(undefined, DEFAULT_LAYOUT.pageSize);
   const { layoutConfig, isLoading: isLoadingLayoutPreferences } = useTableLayout({
     entityTableId: ENTITY_TABLE_ID,
-    defaultPageSize: paginationQueryParameter.pageSize,
+    defaultPageSize: DEFAULT_LAYOUT.pageSize,
     defaultDisplayedAttributes: DEFAULT_LAYOUT.displayedColumns,
     defaultSort: DEFAULT_LAYOUT.sort,
   });
+  const paginationQueryParameter = usePaginationQueryParameter(undefined, layoutConfig.pageSize, false);
   const { mutate: updateTableLayout } = useUpdateUserLayoutPreferences(ENTITY_TABLE_ID);
   const { data: paginatedStreams, refetch: refetchStreams } = useStreams({
     query,
@@ -87,7 +87,7 @@ const StreamsOverview = ({ indexSets }: Props) => {
   );
 
   const onPageSizeChange = (newPageSize: number) => {
-    paginationQueryParameter.resetPage();
+    paginationQueryParameter.setPagination({ page: 1, pageSize: newPageSize });
     updateTableLayout({ perPage: newPageSize });
   };
 

--- a/graylog2-web-interface/src/hooks/usePaginationQueryParameter.test.ts
+++ b/graylog2-web-interface/src/hooks/usePaginationQueryParameter.test.ts
@@ -142,4 +142,23 @@ describe('usePaginationQueryParameter custom hook', () => {
 
     expect(mockHistoryReplace).toHaveBeenCalledWith(`example.org?page=1&pageSize=${currentPageSize}`);
   });
+
+  it('should always use provided page size and not update pageSize query param, when syncPageSizeFromQuery is false', () => {
+    const queryParamsPage = 3;
+    const providedPageSize = 20;
+
+    asMock(useLocation).mockReturnValue({
+      search: `?page=${queryParamsPage}&pageSize=50`,
+      pathname: 'example.org',
+    } as Location<{ search: string }>);
+
+    const { result } = renderHook(() => usePaginationQueryParameter(undefined, providedPageSize, false));
+
+    expect(result.current.page).toEqual(queryParamsPage);
+    expect(result.current.pageSize).toEqual(providedPageSize);
+
+    result.current.setPagination({ page: 4, pageSize: 100 });
+
+    expect(mockHistoryReplace).toHaveBeenCalledWith('example.org?page=4');
+  });
 });

--- a/graylog2-web-interface/src/hooks/usePaginationQueryParameter.ts
+++ b/graylog2-web-interface/src/hooks/usePaginationQueryParameter.ts
@@ -29,7 +29,11 @@ export type PaginationQueryParameterResult = {
   setPagination: (payload: { page?: number, pageSize?: number }) => void;
 };
 
-const usePaginationQueryParameter = (PAGE_SIZES: number[] = DEFAULT_PAGE_SIZES, propsPageSize: number = DEFAULT_PAGE_SIZES[0], syncPageSizeFromQuery: boolean = true): PaginationQueryParameterResult => {
+const usePaginationQueryParameter = (
+  PAGE_SIZES: number[] = DEFAULT_PAGE_SIZES,
+  propsPageSize: number = DEFAULT_PAGE_SIZES[0],
+  syncPageSizeFromQuery: boolean = true,
+): PaginationQueryParameterResult => {
   const { page: pageQueryParameter, pageSize: pageSizeQueryParameter } = useQuery();
   const history = useHistory();
   const { search, pathname } = useLocation();
@@ -50,13 +54,7 @@ const usePaginationQueryParameter = (PAGE_SIZES: number[] = DEFAULT_PAGE_SIZES, 
   const pageSize = determinePageSize();
 
   const setPagination = ({ page: newPage = page, pageSize: newPageSize = pageSize }: { page?: number, pageSize?: number }) => {
-    const params: { page: string, pageSize?: string } = { page: String(newPage) };
-
-    if (syncPageSizeFromQuery) {
-      params.pageSize = String(newPageSize);
-    }
-
-    const uri = new URI(query).setSearch(params);
+    const uri = new URI(query).setSearch({ page: newPage, pageSize: syncPageSizeFromQuery ? String(newPageSize) : undefined });
     history.replace(uri.toString());
   };
 

--- a/graylog2-web-interface/src/hooks/usePaginationQueryParameter.ts
+++ b/graylog2-web-interface/src/hooks/usePaginationQueryParameter.ts
@@ -29,7 +29,7 @@ export type PaginationQueryParameterResult = {
   setPagination: (payload: { page?: number, pageSize?: number }) => void;
 };
 
-const usePaginationQueryParameter = (PAGE_SIZES: number[] = DEFAULT_PAGE_SIZES, defaultPageSize: number = DEFAULT_PAGE_SIZES[0]): PaginationQueryParameterResult => {
+const usePaginationQueryParameter = (PAGE_SIZES: number[] = DEFAULT_PAGE_SIZES, propsPageSize: number = DEFAULT_PAGE_SIZES[0], syncPageSizeFromQuery: boolean = true): PaginationQueryParameterResult => {
   const { page: pageQueryParameter, pageSize: pageSizeQueryParameter } = useQuery();
   const history = useHistory();
   const { search, pathname } = useLocation();
@@ -38,10 +38,25 @@ const usePaginationQueryParameter = (PAGE_SIZES: number[] = DEFAULT_PAGE_SIZES, 
   const page = (Number.isInteger(pageQueryParameterAsNumber) && pageQueryParameterAsNumber > 0) ? pageQueryParameterAsNumber : DEFAULT_PAGE;
 
   const pageSizeQueryParameterAsNumber = Number(pageSizeQueryParameter);
-  const pageSize = (Number.isInteger(pageSizeQueryParameterAsNumber) && PAGE_SIZES?.includes(pageSizeQueryParameterAsNumber)) ? pageSizeQueryParameterAsNumber : defaultPageSize;
+
+  const determinePageSize = () => {
+    if (!syncPageSizeFromQuery) {
+      return propsPageSize;
+    }
+
+    return (Number.isInteger(pageSizeQueryParameterAsNumber) && PAGE_SIZES?.includes(pageSizeQueryParameterAsNumber)) ? pageSizeQueryParameterAsNumber : propsPageSize;
+  };
+
+  const pageSize = determinePageSize();
 
   const setPagination = ({ page: newPage = page, pageSize: newPageSize = pageSize }: { page?: number, pageSize?: number }) => {
-    const uri = new URI(query).setSearch({ page: String(newPage), pageSize: String(newPageSize) });
+    const params: { page: string, pageSize?: string } = { page: String(newPage) };
+
+    if (syncPageSizeFromQuery) {
+      params.pageSize = String(newPageSize);
+    }
+
+    const uri = new URI(query).setSearch(params);
     history.replace(uri.toString());
   };
 

--- a/graylog2-web-interface/src/views/components/dashboard/DashboardsOverview/DashboardsOverview.tsx
+++ b/graylog2-web-interface/src/views/components/dashboard/DashboardsOverview/DashboardsOverview.tsx
@@ -41,13 +41,13 @@ const renderBulkActions = (
 
 const DashboardsOverview = () => {
   const [query, setQuery] = useState('');
-  const paginationQueryParameter = usePaginationQueryParameter(undefined, DEFAULT_LAYOUT.pageSize);
   const { layoutConfig, isLoading: isLoadingLayoutPreferences } = useTableLayout({
     entityTableId: ENTITY_TABLE_ID,
-    defaultPageSize: paginationQueryParameter.pageSize,
+    defaultPageSize: DEFAULT_LAYOUT.pageSize,
     defaultDisplayedAttributes: DEFAULT_LAYOUT.displayedColumns,
     defaultSort: DEFAULT_LAYOUT.sort,
   });
+  const paginationQueryParameter = usePaginationQueryParameter(undefined, layoutConfig.pageSize, false);
   const searchParams = useMemo(() => ({
     query,
     page: paginationQueryParameter.page,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Before this change there was a problem with the pagination on the streams and dashboards overview.
To reproduce the problem you need:
- 15 entities
- an initial page size of 10, when you open the page
- change the page size to 50
- change the page size to 10
 
Now you will no longer see the pagination. We mainly make sure `usePaginationQueryParameter` is returning the correct page size and we also no longer sync the page size with the URL since it is saved as a user setting.

Longterm we should change the way we maintain the currently selected page and page size.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

/nocl
