### PR TITLE
Fix the way we display long field names in aggregation grouping configuration.

### DIFF
--- a/changelog/unreleased/issue-14787.toml
+++ b/changelog/unreleased/issue-14787.toml
@@ -2,3 +2,4 @@ type = "fixed"
 message = "Fix the way we display long field names in aggregation grouping configuration."
 
 issues = ["14787"]
+pulls = ["14789"]

--- a/changelog/unreleased/issue-14787.toml
+++ b/changelog/unreleased/issue-14787.toml
@@ -1,0 +1,4 @@
+type = "fixed"
+message = "Fix the way we display long field names in aggregation grouping configuration."
+
+issues = ["14787"]

--- a/graylog2-web-interface/src/views/components/aggregationwizard/ElementConfigurationContainer.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/ElementConfigurationContainer.tsx
@@ -39,6 +39,7 @@ const ElementActions = styled.div`
 
 const ElementConfiguration = styled.div`
   flex: 1;
+  overflow: auto;
 `;
 
 const DragHandle = styled.div`


### PR DESCRIPTION
_Please note, this PR needs a backport for 5.0_

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

As described in https://github.com/Graylog2/graylog2-server/issues/14787 we do no display fields with long names well in the aggregation grouping configuration.

Before:
![image](https://user-images.githubusercontent.com/46300478/221586170-b2feeaa8-6f7e-469d-a2ea-6e6ac78fd003.png)


After:

![image](https://user-images.githubusercontent.com/46300478/221585559-f02c53d0-60b0-4d05-b9f7-1896e1df85f7.png)


Fixes https://github.com/Graylog2/graylog2-server/issues/14787

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
