### PR TITLE
Mention new InputService#allByType method in UPGRADING.md

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -99,7 +99,7 @@ The following Java Code API changes have been made.
 | `IndexSetValidator#validateRetentionPeriod`  | The method argument have changed from `IndexSetConfig` to `RotationStrategyConfig, RetentionStrategyConfig` |
 | `ElasticsearchConfiguration#getIndexPrefix`  | The method name has changed to `getDefaultIndexPrefix`                                                      |
 | `ElasticsearchConfiguration#getTemplateName` | The method name has changed to `getDefaultIndexTemplateName`                                                |
-| `InputService.allByType(String type)`        | This method was introduced in Graylog 5.0.4 and 5.1.0. All implementors will need to define the method.     |
+| `InputService#allByType(String type)`        | This method was introduced in Graylog 5.0.4 and 5.1.0. All implementors will need to define the method.     |
 
 All previously deprecated index set configuration properties in `org.graylog2.configuration.ElasticsearchConfiguration`
 have been un-deprecated, as Graylog intends to maintain them going forward. 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -99,6 +99,7 @@ The following Java Code API changes have been made.
 | `IndexSetValidator#validateRetentionPeriod`  | The method argument have changed from `IndexSetConfig` to `RotationStrategyConfig, RetentionStrategyConfig` |
 | `ElasticsearchConfiguration#getIndexPrefix`  | The method name has changed to `getDefaultIndexPrefix`                                                      |
 | `ElasticsearchConfiguration#getTemplateName` | The method name has changed to `getDefaultIndexTemplateName`                                                |
+| `InputService.allByType(String type)`        | This method was introduced in Graylog 5.0.4 and 5.1.0. All implementors will need to define the method.     |
 
 All previously deprecated index set configuration properties in `org.graylog2.configuration.ElasticsearchConfiguration`
 have been un-deprecated, as Graylog intends to maintain them going forward. 


### PR DESCRIPTION
A new method `InputService#allByType(String type)` was added in https://github.com/Graylog2/graylog2-server/pull/14515. This PR updates the `UPGRADING.md` document accordingly, so that users will know they need to update classes that implement `InputService`.

/nocl