### PR TITLE
Mention new InputService#allByType method in UPGRADING.md (5.0)

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -107,10 +107,11 @@ The following Java Code API deprecations have been made in 5.0.
 
 The following Java Code API changes have been made in 5.0.
 
-| File                                                                                                   | Description                                              |
-|--------------------------------------------------------------------------------------------------------|----------------------------------------------------------|
-| `PaginatedPipelineService.java` | Concrete implementation has been changed to an interface |
-| `PaginatedRuleService.java`     | Concrete implementation has been changed to an interface |
+| File                                  | Description                                                                                   |
+|---------------------------------------|-----------------------------------------------------------------------------------------------|
+| `PaginatedPipelineService.java`       | Concrete implementation has been changed to an interface                                      |
+| `PaginatedRuleService.java`           | Concrete implementation has been changed to an interface                                      |
+| `InputService#allByType(String type)` | This method was introduced in Graylog 5.0.4. All implementors will need to define the method. |
 
 ## Configuration File Changes
 


### PR DESCRIPTION
A new method `InputService#allByType(String type)` was added in https://github.com/Graylog2/graylog2-server/pull/14671 for `5.0`. This PR updates the `UPGRADING.md` document accordingly, so that users will know they need to update classes that implement `InputService`.

/nocl