### PR TITLE
Support encrypted values in new method InputService#allByType

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/inputs/InputService.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/InputService.java
@@ -27,6 +27,7 @@ import org.graylog2.shared.inputs.NoSuchInputTypeException;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 public interface InputService extends PersistedService {
@@ -44,7 +45,9 @@ public interface InputService extends PersistedService {
 
     Input find(String id) throws NotFoundException;
 
-    List<Input> allByType(String type);
+    default List<Input> allByType(String type) {
+        return all().stream().filter(input -> Objects.equals(input.getType(), type)).toList();
+    }
 
     Set<Input> findByIds(Collection<String> ids);
 

--- a/graylog2-server/src/main/java/org/graylog2/inputs/InputServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/InputServiceImpl.java
@@ -128,7 +128,7 @@ public class InputServiceImpl extends PersistedServiceImpl implements InputServi
     public List<Input> allByType(final String type) {
         final ImmutableList.Builder<Input> inputs = ImmutableList.builder();
         for (final DBObject o : query(InputImpl.class, new BasicDBObject(MessageInput.FIELD_TYPE, type))) {
-            inputs.add(new InputImpl((ObjectId) o.get(InputImpl.FIELD_ID), o.toMap()));
+            inputs.add(createFromDbObject(o));
         }
         return inputs.build();
     }

--- a/graylog2-server/src/test/java/org/graylog2/inputs/InputServiceImplTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/inputs/InputServiceImplTest.java
@@ -183,11 +183,17 @@ public class InputServiceImplTest {
 
         assertThat(id).isNotBlank();
 
-        final Input input = inputService.find(id);
-        assertThat(input.getConfiguration()).hasEntrySatisfying("encrypted", value -> {
-            assertThat(value).isInstanceOf(EncryptedValue.class);
-            assertThat(value).isEqualTo(secret);
-        });
+        assertThat(inputService.find(id)).satisfies(input ->
+                assertThat(input.getConfiguration()).hasEntrySatisfying("encrypted", value -> {
+                    assertThat(value).isInstanceOf(EncryptedValue.class);
+                    assertThat(value).isEqualTo(secret);
+                }));
+
+        assertThat(inputService.allByType("test type")).hasSize(1).first().satisfies(input ->
+                assertThat(input.getConfiguration()).hasEntrySatisfying("encrypted", value -> {
+                    assertThat(value).isInstanceOf(EncryptedValue.class);
+                    assertThat(value).isEqualTo(secret);
+                }));
     }
 
 }


### PR DESCRIPTION
A new method `InputService#allByType` has been added in https://github.com/Graylog2/graylog2-server/pull/14515 after implementing support for encrypted values has been started in #14459. Thus, the new method was not covered in  #14459 and now doesn't return encrypted values as expected.

This PR fixes this.

Also, I added a default implementation to the `InputSerfvice` interface so that other implementations don't break.

/nocl