### PR TITLE
Update download-maven-plugin version to 1.6.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -195,8 +195,7 @@
 
         <!-- Plugin versions -->
         <license-maven.version>4.0.rc2</license-maven.version>
-        <!-- Downgraded to 1.3.0 because of this issue: https://github.com/maven-download-plugin/maven-download-plugin/issues/80 -->
-        <download-maven-plugin.version>1.3.0</download-maven-plugin.version>
+        <download-maven-plugin.version>1.6.8</download-maven-plugin.version>
     </properties>
 
     <repositories>
@@ -505,6 +504,17 @@
                     <!-- we don't care about assembling the parent, just run the goal on the project, pretty please -->
                     <ignoreMissingDescriptor>true</ignoreMissingDescriptor>
                     <tarLongFileMode>posix</tarLongFileMode>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>com.googlecode.maven-download-plugin</groupId>
+                <artifactId>download-maven-plugin</artifactId>
+                <version>${download-maven-plugin.version}</version>
+                <configuration>
+                    <!-- Avoid metadata problems with the cache directory of older plugin versions. Bump the rev when updating the download-maven-plugin. -->
+                    <cacheDirectory>${settings.localRepository}/.cache/download-maven-plugin-rev1</cacheDirectory>
+                    <followRedirects>true</followRedirects>
+                    <retries>5</retries>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
The referenced issue is still open, so we use a new cache directory to avoid any compatibility problems with previous versions.

/nocl