### PR TITLE
Add default InputService.allByType() method (5.0)

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/inputs/InputService.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/InputService.java
@@ -27,6 +27,7 @@ import org.graylog2.shared.inputs.NoSuchInputTypeException;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 public interface InputService extends PersistedService {
@@ -44,7 +45,9 @@ public interface InputService extends PersistedService {
 
     Input find(String id) throws NotFoundException;
 
-    List<Input> allByType(String type);
+    default List<Input> allByType(String type) {
+        return all().stream().filter(input -> Objects.equals(input.getType(), type)).toList();
+    }
 
     Set<Input> findByIds(Collection<String> ids);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add default `InputService.allByType()` method to allow backwards-compatibility. Existing implementations of InputService will not need to define the method.

Backports the default method portion from the original implementation in https://github.com/Graylog2/graylog2-server/pull/14804.

/nocl

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The original introduction of the `InputService.findByType()` method in https://github.com/Graylog2/graylog2-server/pull/14671 was not backwards-compatible. Such breaking API changes should be avoided in minor bug fix releases. This change assures backwards-compatibility and does not break existing usages of the `InputService` (such as the Forwarder, for example).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Verified that the existing usage of the method in `AzureCheckpointStoreCleanupService` continues to function correctly. 
- Checked out this branch in the `forwarder` (with all other submodules at `5.0`) and verified that the Forwarder build is successful.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

