### PR TITLE
Adding word wrap for header columns of tables in print. (`5.0`)

### DIFF
--- a/changelog/unreleased/pr-14805.toml
+++ b/changelog/unreleased/pr-14805.toml
@@ -1,0 +1,5 @@
+type = "f"
+message = "Preventing accidental hiding of columns in reporting widgets."
+
+pulls = ["14805"]
+issues = ["Graylog2/graylog-plugin-enterprise#4761"]

--- a/changelog/unreleased/pr-14822.toml
+++ b/changelog/unreleased/pr-14822.toml
@@ -1,5 +1,5 @@
 type = "f"
 message = "Preventing accidental hiding of columns in reporting widgets."
 
-pulls = ["14805"]
+pulls = ["14822"]
 issues = ["Graylog2/graylog-plugin-enterprise#4761"]

--- a/graylog2-web-interface/src/components/bootstrap/Table.jsx
+++ b/graylog2-web-interface/src/components/bootstrap/Table.jsx
@@ -129,6 +129,13 @@ const tableCss = css(({ theme }) => css`
   }
 
   ${variantRowStyles}
+  
+  @media print {
+    &.table > thead > tr > th {
+      white-space: break-spaces;
+      word-break: break-all;
+    }
+  }
 `);
 
 const Table = styled(BootstrapTable)`

--- a/graylog2-web-interface/src/views/components/datatable/MessagesTable.tsx
+++ b/graylog2-web-interface/src/views/components/datatable/MessagesTable.tsx
@@ -140,6 +140,12 @@ const StyledTable = styled(Table)(({ theme, $stickyHeader, $borderedHeader }: { 
   th:hover i.sort-order-item {
     color: ${theme.colors.global.textAlt};
   }
+  
+  @media print {
+    tr.fields-row > td {
+      min-width: 0px;
+    }
+  }
 `);
 
 type Props = {


### PR DESCRIPTION
**Note:** This is a backport of #14805 to `5.0`.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is changing the layout of table headers/cells for print media to add a) word breaks and b) remove existing min widths. This is supposed to prevent any scrollbars showing up for print media, so no columns are hidden because they are overflowing the container.

Fixes Graylog2/graylog-plugin-enterprise#4761.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.