### PR TITLE
DataNode: exclude downloads from assembly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ dependency-reduced-pom.xml
 
 **/hs_err_pid*.log
 
+data-node/bin/*

--- a/data-node-distribution/src/main/assembly/datanode.xml
+++ b/data-node-distribution/src/main/assembly/datanode.xml
@@ -24,6 +24,9 @@
             <includes>
                 <include>*/**</include>
             </includes>
+            <excludes>
+                <exclude>download/*</exclude>
+            </excludes>
         </fileSet>
         <fileSet>
             <directory>${project.basedir}/../data-node/target/lib</directory>


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Keeping the download itself is necessary for now to build the docker-containers in IT tests. 
But it should not be included in our tarballs.

Also, added the bin dir to `.gitignore`

/nocl

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

