### PR TITLE
Adding word wrap for header columns of message table in print. (backport for 5.0)

### DIFF
--- a/changelog/unreleased/pr-14823.toml
+++ b/changelog/unreleased/pr-14823.toml
@@ -1,0 +1,4 @@
+type = "f"
+message = "Preventing accidental hiding of columns in message list widget for reporting."
+
+pulls = ["14823"]

--- a/graylog2-web-interface/src/views/components/widgets/MessageTable.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageTable.tsx
@@ -59,8 +59,9 @@ const Table = styled.table(({ theme }) => css`
     td {
       border: 1px ${theme.colors.gray[80]} solid !important;
       left: 0;
-      padding: 5px;
+      padding: 5px !important;
       position: static;
+      min-width: 0 !important;
     }
   }
 `);

--- a/graylog2-web-interface/src/views/components/widgets/MessageTable.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageTable.tsx
@@ -51,6 +51,8 @@ const Table = styled.table(({ theme }) => css`
     th {
       font-weight: bold !important;
       font-size: inherit !important;
+      white-space: break-spaces !important;
+      word-break: break-all !important;
     }
 
     th,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
_This is a backport of https://github.com/Graylog2/graylog2-server/pull/14823 for `5.0`_

## Description
<!--- Describe your changes in detail -->

This is a follow-up for https://github.com/Graylog2/graylog2-server/pull/14805. With this PR we are fixing the described problem for the message list widget. Please have a look at the mentioned PR for more information.

Related to https://github.com/Graylog2/graylog-plugin-enterprise/issues/4761

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

/nocl

