### PR TITLE
Triggering field type refresh in tests when relying on field type.

### DIFF
--- a/full-backend-tests/pom.xml
+++ b/full-backend-tests/pom.xml
@@ -153,6 +153,12 @@
             <groupId>com.google.auto.value</groupId>
             <artifactId>auto-value</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <version>${awaitility.version}</version>
+            <scope>test</scope>
+        </dependency>
 
         <!-- our basic test libraries, please only add infrastructure dependencies here -->
         <dependency>

--- a/full-backend-tests/src/test/java/org/graylog/testing/utils/SearchUtils.java
+++ b/full-backend-tests/src/test/java/org/graylog/testing/utils/SearchUtils.java
@@ -17,16 +17,11 @@
 package org.graylog.testing.utils;
 
 import io.restassured.specification.RequestSpecification;
-import org.graylog.plugins.views.search.rest.MappedFieldTypeDTO;
 import org.graylog.testing.backenddriver.SearchDriver;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
-import java.util.Set;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 
 public final class SearchUtils {
 
@@ -58,18 +53,5 @@ public final class SearchUtils {
             return true;
         }
         return false;
-    }
-
-    public static Set<MappedFieldTypeDTO> waitForFieldTypeDefinitions(RequestSpecification requestSpecification, String... fieldName) {
-        final Set<String> expectedFields = Arrays.stream(fieldName).collect(Collectors.toSet());
-        return WaitUtils.waitForObject(() -> {
-            final List<MappedFieldTypeDTO> knownTypes = SearchDriver.getFieldTypes(requestSpecification);
-            final Set<MappedFieldTypeDTO> filtered = knownTypes.stream().filter(t -> expectedFields.contains(t.name())).collect(Collectors.toSet());
-            if (filtered.size() == expectedFields.size()) {
-                return Optional.of(filtered);
-            } else {
-                return Optional.empty();
-            }
-        }, "Timed out waiting for field definition");
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/IndexFieldTypePollerPeriodical.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/IndexFieldTypePollerPeriodical.java
@@ -40,6 +40,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import javax.inject.Named;
+import javax.inject.Singleton;
 import java.time.Instant;
 import java.util.Collection;
 import java.util.LinkedHashSet;
@@ -53,6 +54,7 @@ import java.util.stream.Collectors;
 /**
  * {@link Periodical} that creates and maintains index field type information in the database.
  */
+@Singleton
 public class IndexFieldTypePollerPeriodical extends Periodical {
     private static final Logger LOG = LoggerFactory.getLogger(IndexFieldTypePollerPeriodical.class);
 

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/RestResourcesModule.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/RestResourcesModule.java
@@ -65,6 +65,7 @@ import org.graylog2.rest.resources.system.UrlWhitelistResource;
 import org.graylog2.rest.resources.system.contentpacks.CatalogResource;
 import org.graylog2.rest.resources.system.contentpacks.ContentPackResource;
 import org.graylog2.rest.resources.system.debug.DebugEventsResource;
+import org.graylog2.rest.resources.system.debug.DebugFieldTypesResource;
 import org.graylog2.rest.resources.system.debug.DebugStreamsResource;
 import org.graylog2.rest.resources.system.indexer.FailuresResource;
 import org.graylog2.rest.resources.system.indexer.IndexSetDefaultsResource;
@@ -134,6 +135,7 @@ public class RestResourcesModule extends Graylog2Module {
         if(Boolean.parseBoolean(System.getenv("GRAYLOG_ENABLE_DEBUG_RESOURCES"))) {
             // TODO: move the DebugEventsResource under this env property check as well?
             addSystemRestResource(DebugStreamsResource.class);
+            addSystemRestResource(DebugFieldTypesResource.class);
         }
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/debug/DebugFieldTypesResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/debug/DebugFieldTypesResource.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog2.rest.resources.system.debug;
 
 import io.swagger.annotations.Api;

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/debug/DebugFieldTypesResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/debug/DebugFieldTypesResource.java
@@ -1,0 +1,34 @@
+package org.graylog2.rest.resources.system.debug;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import org.apache.shiro.authz.annotation.RequiresAuthentication;
+import org.graylog2.indexer.fieldtypes.IndexFieldTypePollerPeriodical;
+
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+@RequiresAuthentication
+@Api(value = "System/Debug/Field Types", description = "For triggering field type refreshs.")
+@Path("/system/debug/field_types")
+@Produces(MediaType.APPLICATION_JSON)
+public class DebugFieldTypesResource {
+    private final IndexFieldTypePollerPeriodical poller;
+
+    public DebugFieldTypesResource(IndexFieldTypePollerPeriodical poller) {
+        this.poller = poller;
+    }
+
+    @POST
+    @Path("/refresh")
+    @ApiOperation(value = "Get information about currently active stream router engine.")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response triggerFieldTypesRefresh() {
+        this.poller.doRun();
+
+        return Response.ok().build();
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/debug/DebugFieldTypesResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/debug/DebugFieldTypesResource.java
@@ -19,6 +19,7 @@ package org.graylog2.rest.resources.system.debug;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import org.apache.shiro.authz.annotation.RequiresAuthentication;
+import org.graylog2.audit.jersey.NoAuditEvent;
 import org.graylog2.indexer.fieldtypes.IndexFieldTypePollerPeriodical;
 
 import javax.ws.rs.POST;
@@ -42,6 +43,7 @@ public class DebugFieldTypesResource {
     @Path("/refresh")
     @ApiOperation(value = "Get information about currently active stream router engine.")
     @Produces(MediaType.APPLICATION_JSON)
+    @NoAuditEvent("Only used for tests.")
     public Response triggerFieldTypesRefresh() {
         this.poller.doRun();
 

--- a/graylog2-server/src/test/java/org/graylog/testing/completebackend/apis/FieldTypes.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/completebackend/apis/FieldTypes.java
@@ -44,6 +44,7 @@ public class FieldTypes implements GraylogRestApi {
     }
 
     public Set<MappedFieldTypeDTO> waitForFieldTypeDefinitions(String... fieldName) {
+        triggerFieldTypesRefresh();
         final Set<String> expectedFields = Arrays.stream(fieldName).collect(Collectors.toSet());
         return waitForObject(() -> {
             final List<MappedFieldTypeDTO> knownTypes = getFieldTypes();
@@ -55,4 +56,13 @@ public class FieldTypes implements GraylogRestApi {
             }
         }, "Timed out waiting for field definition");
     }
+    private void triggerFieldTypesRefresh() {
+        given()
+                .spec(this.requestSpecification)
+                .when()
+                .post("/system/debug/field_types/refresh")
+                .then()
+                .statusCode(200);
+    }
+
 }

--- a/graylog2-server/src/test/java/org/graylog/testing/completebackend/apis/Streams.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/completebackend/apis/Streams.java
@@ -120,7 +120,7 @@ public final class Streams implements GraylogRestApi {
             RetryerBuilder.<String>newBuilder()
                     .withWaitStrategy(WaitStrategies.fixedWait(100, TimeUnit.MILLISECONDS))
                     .withStopStrategy(StopStrategies.stopAfterDelay(10, TimeUnit.SECONDS))
-                    .retryIfResult(r -> r.equals(existingEngineFingerprint))
+                    .retryIfResult(r -> r != null && r.equals(existingEngineFingerprint))
                     .build()
                     .call(this::getStreamRouterEngineFingerprint);
         } catch (ExecutionException | RetryException e) {

--- a/graylog2-server/src/test/java/org/graylog/testing/completebackend/apis/inputs/GelfInputApi.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/completebackend/apis/inputs/GelfInputApi.java
@@ -109,7 +109,7 @@ public final class GelfInputApi implements GraylogRestApi {
     }
 
     public void postMessage(int mappedPort,
-                            @SuppressWarnings("SameParameterValue") String messageJson) {
+                            String messageJson) {
         gelfEndpoint(mappedPort)
                 .body(messageJson)
                 .expect().response().statusCode(202)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is triggering a field type refresh explicitly when waiting in tests for a new field type to manifest from 10s to 60s, hopefully improving potential false negatives. On the side, it also cleans up the waiting implementation by using awaitility and removes an unused method.

/nocl

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.