### PR TITLE
Improve order of actions in stream actions menu.

### DIFF
--- a/graylog2-web-interface/src/components/streams/StreamsOverview/StreamActions.tsx
+++ b/graylog2-web-interface/src/components/streams/StreamsOverview/StreamActions.tsx
@@ -137,34 +137,26 @@ const StreamActions = ({
               : <span>{stream.disabled ? 'Start Stream' : 'Stop Stream'}</span>}
             {isDefaultStream && <DefaultStreamHelp />}
           </MenuItem>
-          <MenuItem divider />
-        </IfPermitted>
-        <IfPermitted permissions={[`streams:edit:${stream.id}`]}>
-          <LinkContainer to={Routes.stream_edit(stream.id)}>
-            <MenuItem disabled={isDefaultStream || isNotEditable}>
-              Manage Rules {isDefaultStream && <DefaultStreamHelp />}
-            </MenuItem>
-          </LinkContainer>
-        </IfPermitted>
-        <IfPermitted permissions={`streams:edit:${stream.id}`}>
-          <MenuItem onSelect={toggleUpdateModal} disabled={isDefaultStream}>
-            Edit stream {isDefaultStream && <DefaultStreamHelp />}
-          </MenuItem>
         </IfPermitted>
         <IfPermitted permissions={`streams:edit:${stream.id}`}>
           <MenuItem onSelect={toggleStreamRuleModal} disabled={isDefaultStream}>
             Quick add rule {isDefaultStream && <DefaultStreamHelp />}
           </MenuItem>
         </IfPermitted>
-        <IfPermitted permissions={['streams:create', `streams:read:${stream.id}`]}>
-          <MenuItem onSelect={toggleCloneModal} disabled={isDefaultStream}>
-            Clone this stream {isDefaultStream && <DefaultStreamHelp />}
+        <IfPermitted permissions={`streams:edit:${stream.id}`}>
+          <MenuItem onSelect={toggleUpdateModal} disabled={isDefaultStream}>
+            Edit stream {isDefaultStream && <DefaultStreamHelp />}
           </MenuItem>
         </IfPermitted>
-        <IfPermitted permissions={`streams:edit:${stream.id}`}>
-          <LinkContainer to={Routes.stream_alerts(stream.id)}>
-            <MenuItem>
-              Manage Alerts
+
+        <IfPermitted permissions={[`streams:edit:${stream.id}`]}>
+          <MenuItem divider />
+        </IfPermitted>
+
+        <IfPermitted permissions={[`streams:edit:${stream.id}`]}>
+          <LinkContainer to={Routes.stream_edit(stream.id)}>
+            <MenuItem disabled={isDefaultStream || isNotEditable}>
+              Manage Rules {isDefaultStream && <DefaultStreamHelp />}
             </MenuItem>
           </LinkContainer>
         </IfPermitted>
@@ -177,13 +169,28 @@ const StreamActions = ({
             </LinkContainer>
           </IfPermitted>
         </HideOnCloud>
-        <MenuItem onSelect={setStartpage} disabled={currentUser.readOnly}>
-          Set as startpage
-        </MenuItem>
+        <IfPermitted permissions={`streams:edit:${stream.id}`}>
+          <LinkContainer to={Routes.stream_alerts(stream.id)}>
+            <MenuItem>
+              Manage Alerts
+            </MenuItem>
+          </LinkContainer>
+        </IfPermitted>
 
         <IfPermitted permissions={`streams:edit:${stream.id}`}>
           <MenuItem divider />
         </IfPermitted>
+
+        <MenuItem onSelect={setStartpage} disabled={currentUser.readOnly}>
+          Set as startpage
+        </MenuItem>
+
+        <IfPermitted permissions={['streams:create', `streams:read:${stream.id}`]}>
+          <MenuItem onSelect={toggleCloneModal} disabled={isDefaultStream}>
+            Clone this stream {isDefaultStream && <DefaultStreamHelp />}
+          </MenuItem>
+        </IfPermitted>
+
         <IfPermitted permissions={`streams:edit:${stream.id}`}>
           <MenuItem onSelect={onDelete} disabled={isDefaultStream}>
             Delete this stream {isDefaultStream && <DefaultStreamHelp />}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

With this PR we are slightly improving the order of actions in the stream action menu by grouping them.

Before:
![image](https://user-images.githubusercontent.com/46300478/222207304-3719360a-6f21-43b5-a12b-aa4b302623ab.png)


After:
![image](https://user-images.githubusercontent.com/46300478/222206812-d3aac9c3-1041-40f4-bb49-3e04a64bb824.png)

/nocl