### PR TITLE
Improve column rendering in entity data table (handle camel case attributes, allow defining column render for attribute types)

### DIFF
--- a/graylog2-web-interface/src/components/common/EntityDataTable/DefaultColumnRenderers.tsx
+++ b/graylog2-web-interface/src/components/common/EntityDataTable/DefaultColumnRenderers.tsx
@@ -22,31 +22,31 @@ import { Timestamp } from 'components/common';
 
 const DefaultColumnRenderers = {
   created_at: {
-    renderCell: (entity: { created_at: string }) => (
-      <Timestamp dateTime={entity.created_at} />
+    renderCell: (createdAt: string) => (
+      <Timestamp dateTime={createdAt} />
     ),
     staticWidth: 160,
   },
   description: {
-    renderCell: (entity: { description: string }) => (
+    renderCell: (description: string) => (
       <TextOverflowEllipsis>
-        {entity.description}
+        {description}
       </TextOverflowEllipsis>
     ),
     width: 2,
   },
   summary: {
-    renderCell: (entity: { summary: string }) => (
+    renderCell: (summary: string) => (
       <TextOverflowEllipsis>
-        {entity.summary}
+        {summary}
       </TextOverflowEllipsis>
     ),
     width: 1.5,
   },
   owner: {
-    renderCell: (entity: { owner: string }) => (
+    renderCell: (owner: string) => (
       <TextOverflowEllipsis>
-        {entity.owner}
+        {owner}
       </TextOverflowEllipsis>
     ),
     staticWidth: 120,

--- a/graylog2-web-interface/src/components/common/EntityDataTable/DefaultColumnRenderers.tsx
+++ b/graylog2-web-interface/src/components/common/EntityDataTable/DefaultColumnRenderers.tsx
@@ -21,40 +21,37 @@ import TextOverflowEllipsis from 'components/common/TextOverflowEllipsis';
 import { Timestamp } from 'components/common';
 
 const DefaultColumnRenderers = {
-  created_at: {
-    renderCell: (createdAt: string) => (
-      <Timestamp dateTime={createdAt} />
-    ),
-    staticWidth: 160,
+  types: {
+    DATE: {
+      renderCell: (dateTime: string) => (
+        <Timestamp dateTime={dateTime} />
+      ),
+      staticWidth: 160,
+    },
+    STRING: {
+      renderCell: (text: string) => (
+        <TextOverflowEllipsis>
+          {text}
+        </TextOverflowEllipsis>
+      ),
+    },
   },
-  description: {
-    renderCell: (description: string) => (
-      <TextOverflowEllipsis>
-        {description}
-      </TextOverflowEllipsis>
-    ),
-    width: 2,
+  attributes: {
+    description: {
+      width: 2,
+    },
+    summary: {
+      width: 1.5,
+    },
+    owner: {
+      staticWidth: 120,
+    },
+    favorite: {
+      renderHeader: () => '',
+      staticWidth: 30,
+    },
   },
-  summary: {
-    renderCell: (summary: string) => (
-      <TextOverflowEllipsis>
-        {summary}
-      </TextOverflowEllipsis>
-    ),
-    width: 1.5,
-  },
-  owner: {
-    renderCell: (owner: string) => (
-      <TextOverflowEllipsis>
-        {owner}
-      </TextOverflowEllipsis>
-    ),
-    staticWidth: 120,
-  },
-  favorite: {
-    renderHeader: () => '',
-    staticWidth: 30,
-  },
+
 };
 
 export default DefaultColumnRenderers;

--- a/graylog2-web-interface/src/components/common/EntityDataTable/EntityDataTable.test.tsx
+++ b/graylog2-web-interface/src/components/common/EntityDataTable/EntityDataTable.test.tsx
@@ -85,7 +85,7 @@ describe('<EntityDataTable />', () => {
                             onColumnsChange={() => {}}
                             columnRenderers={{
                               title: {
-                                renderCell: (listItem) => `The title: ${listItem.title}`,
+                                renderCell: (title: string) => `The title: ${title}`,
                                 renderHeader: (column) => `Custom ${column.title} Header`,
                               },
                             }}

--- a/graylog2-web-interface/src/components/common/EntityDataTable/EntityDataTable.test.tsx
+++ b/graylog2-web-interface/src/components/common/EntityDataTable/EntityDataTable.test.tsx
@@ -38,15 +38,16 @@ describe('<EntityDataTable />', () => {
     { id: 'description', title: 'Description', type: 'STRING', sortable: true },
     { id: 'stream', title: 'Stream', type: 'STRING', sortable: true },
     { id: 'status', title: 'Status', type: 'STRING', sortable: true, permissions: ['status:read'] },
+    { id: 'created_at', title: 'Created At', type: 'STRING', sortable: true },
   ];
 
   const visibleColumns = ['title', 'description', 'status'];
   const data = [
     {
       id: 'row-id',
-      title: 'Row title',
-      description: 'Row description',
-      stream: 'Row stream',
+      title: 'Entity title',
+      description: 'Entity description',
+      stream: 'Entity stream',
       status: 'enabled',
     },
   ];
@@ -61,7 +62,7 @@ describe('<EntityDataTable />', () => {
     await screen.findByRole('columnheader', { name: /title/i });
     await screen.findByRole('columnheader', { name: /status/i });
 
-    await screen.findByText('Row title');
+    await screen.findByText('Entity title');
     await screen.findByText('enabled');
 
     expect(screen.queryByRole('columnheader', { name: /stream/i })).not.toBeInTheDocument();
@@ -76,7 +77,7 @@ describe('<EntityDataTable />', () => {
                             columnDefinitions={columnDefinitions} />);
 
     await screen.findByRole('columnheader', { name: /description/i });
-    await screen.findByText('Row description');
+    await screen.findByText('Entity description');
   });
 
   it('should render custom cell and header renderer', async () => {
@@ -95,7 +96,7 @@ describe('<EntityDataTable />', () => {
                             columnDefinitions={columnDefinitions} />);
 
     await screen.findByRole('columnheader', { name: /custom title header/i });
-    await screen.findByText('The title: Row title');
+    await screen.findByText('The title: Entity title');
   });
 
   it('should merge attribute and type column renderers renderer', async () => {
@@ -119,9 +120,9 @@ describe('<EntityDataTable />', () => {
                             columnDefinitions={columnDefinitions} />);
 
     await screen.findByRole('columnheader', { name: /custom header for type - title/i });
-    await screen.findByText('Custom Cell For Attribute - Row title');
+    await screen.findByText('Custom Cell For Attribute - Entity title');
 
-    expect(screen.queryByText('Custom Cell For Type - Row title')).not.toBeInTheDocument();
+    expect(screen.queryByText('Custom Cell For Type - Entity title')).not.toBeInTheDocument();
   });
 
   it('should render row actions', async () => {
@@ -132,7 +133,7 @@ describe('<EntityDataTable />', () => {
                                                            rowActions={(row) => `Custom actions for ${row.title}`}
                                                            columnDefinitions={columnDefinitions} />);
 
-    await screen.findByText('Custom actions for Row title');
+    await screen.findByText('Custom actions for Entity title');
   });
 
   it('should not render column if user does not have required permissions', () => {
@@ -262,5 +263,33 @@ describe('<EntityDataTable />', () => {
     userEvent.click(screen.getByRole('menuitem', { name: /show title/i }));
 
     expect(onColumnsChange).toHaveBeenCalledWith(['description', 'status', 'title']);
+  });
+
+  it('should hande entities with camel case attributes', async () => {
+    const dataWithCamelCaseAttributes = [
+      {
+        id: 'row-id',
+        title: 'Entity title',
+        description: 'Entity description',
+        stream: 'Entity stream',
+        status: 'enabled',
+        createdAt: '2021-01-01',
+      },
+    ];
+
+    render(<EntityDataTable visibleColumns={[...visibleColumns, 'created_at']}
+                            data={dataWithCamelCaseAttributes}
+                            onSortChange={() => {}}
+                            onColumnsChange={() => {}}
+                            columnRenderers={{
+                              attributes: {
+                                created_at: {
+                                  renderCell: (createdAt: string) => `Custom Cell For Created At - ${createdAt}`,
+                                },
+                              },
+                            }}
+                            columnDefinitions={columnDefinitions} />);
+
+    await screen.findByText('Custom Cell For Created At - 2021-01-01');
   });
 });

--- a/graylog2-web-interface/src/components/common/EntityDataTable/EntityDataTable.tsx
+++ b/graylog2-web-interface/src/components/common/EntityDataTable/EntityDataTable.tsx
@@ -95,6 +95,7 @@ const useElementsWidths = <Entity extends EntityBase>({
   columns: Array<Column>,
   columnRenderers: ColumnRenderers<Entity>,
   displayBulkSelectCol: boolean
+  entityAttributesAreCamelCase: boolean
 }) => {
   const tableRef = useRef<HTMLTableElement>();
   const actionsRef = useRef<HTMLDivElement>();
@@ -116,13 +117,14 @@ const useElementsWidths = <Entity extends EntityBase>({
 type Props<Entity extends EntityBase> = {
   /** Currently active sort */
   activeSort?: Sort,
-  /** Supported batch operations */
+  entityAttributesAreCamelCase?: boolean,
+  /** Supported bulk actions */
   bulkActions?: (selectedEntities: Array<string>, setSelectedEntities: (streamIds: Array<string>) => void) => React.ReactNode,
-  /** List of all available columns. */
+  /** List of all available columns. Column ids need to be snake case. */
   columnDefinitions: Array<Column>,
-  /** Custom cell and header renderer for a column */
+  /** Custom cell and header renderer for a column. Column ids need to be snake case. */
   columnRenderers?: ColumnRenderers<Entity>,
-  /** Define default columns order */
+  /** Define default columns order. Column ids need to be snake case. */
   columnsOrder?: Array<string>,
   /** The table data. */
   data: Readonly<Array<Entity>>,
@@ -145,6 +147,7 @@ type Props<Entity extends EntityBase> = {
  */
 const EntityDataTable = <Entity extends EntityBase>({
   activeSort,
+  entityAttributesAreCamelCase,
   bulkActions,
   columnRenderers: customColumnRenderers,
   columnDefinitions,
@@ -178,6 +181,7 @@ const EntityDataTable = <Entity extends EntityBase>({
     columns,
     columnRenderers,
     displayBulkSelectCol,
+    entityAttributesAreCamelCase,
   });
 
   const onToggleEntitySelect = useCallback((itemId: string) => {
@@ -231,6 +235,7 @@ const EntityDataTable = <Entity extends EntityBase>({
               <TableRow entity={entity}
                         key={entity.id}
                         index={index}
+                        entityAttributesAreCamelCase={entityAttributesAreCamelCase}
                         actionsRef={actionsRef}
                         onToggleEntitySelect={onToggleEntitySelect}
                         columnRenderers={columnRenderers}
@@ -255,6 +260,7 @@ EntityDataTable.defaultProps = {
   onPageSizeChange: undefined,
   pageSize: undefined,
   rowActions: undefined,
+  entityAttributesAreCamelCase: true,
 };
 
 export default EntityDataTable;

--- a/graylog2-web-interface/src/components/common/EntityDataTable/EntityDataTable.tsx
+++ b/graylog2-web-interface/src/components/common/EntityDataTable/EntityDataTable.tsx
@@ -131,6 +131,10 @@ const mergeColumnsRenderers = <Entity extends EntityBase>(columns: Array<Column>
 type Props<Entity extends EntityBase> = {
   /** Currently active sort */
   activeSort?: Sort,
+  /**
+   * The column ids are always snake case. By default, entity attributes are camel case.
+   * This prop controls if the column ids need to be transformed to camel case to connect them with the entity attributes.
+   */
   entityAttributesAreCamelCase?: boolean,
   /** Supported bulk actions */
   bulkActions?: (selectedEntities: Array<string>, setSelectedEntities: (streamIds: Array<string>) => void) => React.ReactNode,

--- a/graylog2-web-interface/src/components/common/EntityDataTable/TableCell.tsx
+++ b/graylog2-web-interface/src/components/common/EntityDataTable/TableCell.tsx
@@ -16,6 +16,7 @@
  */
 import * as React from 'react';
 import styled from 'styled-components';
+import { camelCase } from 'lodash';
 
 import type { Column, ColumnRenderer, EntityBase } from './types';
 
@@ -27,12 +28,16 @@ const TableCell = <Entity extends EntityBase>({
   column,
   columnRenderer,
   entity,
+  entityAttributesAreCamelCase,
 }: {
   column: Column
   columnRenderer: ColumnRenderer<Entity> | undefined,
   entity: Entity,
+  entityAttributesAreCamelCase: boolean,
 }) => {
-  const content = typeof columnRenderer?.renderCell === 'function' ? columnRenderer.renderCell(entity, column) : entity[column.id];
+  const attributeKey = entityAttributesAreCamelCase ? camelCase(column.id) : column.id;
+  const attributeValue = entity[attributeKey];
+  const content = typeof columnRenderer?.renderCell === 'function' ? columnRenderer.renderCell(attributeValue, entity, column) : attributeValue;
 
   return (<Td>{content}</Td>);
 };

--- a/graylog2-web-interface/src/components/common/EntityDataTable/TableHead.tsx
+++ b/graylog2-web-interface/src/components/common/EntityDataTable/TableHead.tsx
@@ -22,7 +22,7 @@ import SortIcon from 'components/streams/StreamsOverview/SortIcon';
 import type { Sort } from 'stores/PaginationTypes';
 
 import BulkSelectHead from './BulkSelectHead';
-import type { Column, ColumnRenderer, ColumnRenderers, EntityBase } from './types';
+import type { Column, ColumnRenderer, EntityBase, ColumnRenderersByAttribute } from './types';
 
 const Th = styled.th<{ $width: number | undefined }>(({ $width }) => css`
   width: ${$width ? `${$width}px` : 'auto'};
@@ -69,7 +69,7 @@ const TableHead = <Entity extends EntityBase>({
   activeSort,
   columns,
   columnsOrder,
-  columnRenderers,
+  columnRenderersByAttribute,
   columnsWidths,
   data,
   displayActionsCol,
@@ -83,7 +83,7 @@ const TableHead = <Entity extends EntityBase>({
   columns: Array<Column>,
   columnsWidths: { [columnId: string]: number },
   columnsOrder: Array<string>,
-  columnRenderers: ColumnRenderers<Entity>,
+  columnRenderersByAttribute: ColumnRenderersByAttribute<Entity>,
   data: Readonly<Array<Entity>>,
   displayActionsCol: boolean,
   displayBulkSelectCol: boolean,
@@ -105,7 +105,7 @@ const TableHead = <Entity extends EntityBase>({
                           setSelectedEntities={setSelectedEntities} />
         )}
         {sortedColumns.map((column) => {
-          const columnRenderer = columnRenderers[column.id];
+          const columnRenderer = columnRenderersByAttribute[column.id];
 
           return (
             <TableHeader<Entity> columnRenderer={columnRenderer}

--- a/graylog2-web-interface/src/components/common/EntityDataTable/TableRow.tsx
+++ b/graylog2-web-interface/src/components/common/EntityDataTable/TableRow.tsx
@@ -21,7 +21,7 @@ import { useCallback } from 'react';
 import ButtonToolbar from 'components/bootstrap/ButtonToolbar';
 
 import TableCell from './TableCell';
-import type { ColumnRenderers, Column, EntityBase } from './types';
+import type { ColumnRenderersByAttribute, Column, EntityBase } from './types';
 import RowCheckbox from './RowCheckbox';
 
 const ActionsCell = styled.th`
@@ -39,7 +39,7 @@ const ActionsRef = styled.div`
 type Props<Entity extends EntityBase> = {
   actionsRef: React.RefObject<HTMLDivElement>
   columns: Array<Column>,
-  columnRenderers: ColumnRenderers<Entity>,
+  columnRenderersByAttribute: ColumnRenderersByAttribute<Entity>,
   displaySelect: boolean,
   displayActions: boolean,
   entity: Entity,
@@ -52,7 +52,7 @@ type Props<Entity extends EntityBase> = {
 
 const TableRow = <Entity extends EntityBase>({
   columns,
-  columnRenderers,
+  columnRenderersByAttribute,
   displaySelect,
   displayActions,
   entity,
@@ -80,7 +80,7 @@ const TableRow = <Entity extends EntityBase>({
         </td>
       )}
       {columns.map((column) => {
-        const columnRenderer = columnRenderers[column.id];
+        const columnRenderer = columnRenderersByAttribute[column.id];
 
         return (
           <TableCell columnRenderer={columnRenderer}

--- a/graylog2-web-interface/src/components/common/EntityDataTable/TableRow.tsx
+++ b/graylog2-web-interface/src/components/common/EntityDataTable/TableRow.tsx
@@ -47,6 +47,7 @@ type Props<Entity extends EntityBase> = {
   isSelected: boolean,
   onToggleEntitySelect: (entityId: string) => void,
   rowActions?: (entity: Entity) => React.ReactNode,
+  entityAttributesAreCamelCase: boolean,
 };
 
 const TableRow = <Entity extends EntityBase>({
@@ -60,6 +61,7 @@ const TableRow = <Entity extends EntityBase>({
   rowActions,
   index,
   actionsRef,
+  entityAttributesAreCamelCase,
 }: Props<Entity>) => {
   const toggleRowSelect = useCallback(
     () => onToggleEntitySelect(entity.id),
@@ -82,6 +84,7 @@ const TableRow = <Entity extends EntityBase>({
 
         return (
           <TableCell columnRenderer={columnRenderer}
+                     entityAttributesAreCamelCase={entityAttributesAreCamelCase}
                      entity={entity}
                      column={column}
                      key={`${entity.id}-${column.id}`} />

--- a/graylog2-web-interface/src/components/common/EntityDataTable/hooks/useColumnsWidth.test.tsx
+++ b/graylog2-web-interface/src/components/common/EntityDataTable/hooks/useColumnsWidth.test.tsx
@@ -20,14 +20,14 @@ import useColumnsWidths from './useColumnsWidths';
 
 describe('useColumnsWidths hook test', () => {
   it('should calculate width for columns with flexible width', async () => {
-    const columnRenderers = {
+    const columnRenderersByAttribute = {
       title: { width: 1 },
       description: { width: 2 },
     };
     const columnsIds = ['title', 'description'];
 
     const { result } = renderHook(() => useColumnsWidths({
-      columnRenderers,
+      columnRenderersByAttribute,
       columnsIds,
       actionsColWidth: 0,
       bulkSelectColWidth: 0,
@@ -41,11 +41,15 @@ describe('useColumnsWidths hook test', () => {
   });
 
   it('should use default width for columns without column renderers', async () => {
-    const columnRenderers = { title: { width: 1 } };
+    const columnRenderersByAttribute = {
+      title: {
+        width: 1,
+      },
+    };
     const columnsIds = ['title', 'description'];
 
     const { result } = renderHook(() => useColumnsWidths({
-      columnRenderers,
+      columnRenderersByAttribute,
       columnsIds,
       actionsColWidth: 0,
       bulkSelectColWidth: 0,
@@ -59,14 +63,14 @@ describe('useColumnsWidths hook test', () => {
   });
 
   it('should consider width of bulk select and actions col', async () => {
-    const columnRenderers = {
+    const columnRenderersByAttribute = {
       title: { width: 1 },
       description: { width: 2 },
     };
     const columnsIds = ['title', 'description'];
 
     const { result } = renderHook(() => useColumnsWidths({
-      columnRenderers,
+      columnRenderersByAttribute,
       columnsIds,
       actionsColWidth: 50,
       bulkSelectColWidth: 20,

--- a/graylog2-web-interface/src/components/common/EntityDataTable/hooks/useColumnsWidths.ts
+++ b/graylog2-web-interface/src/components/common/EntityDataTable/hooks/useColumnsWidths.ts
@@ -16,28 +16,27 @@
  */
 import { useState, useLayoutEffect } from 'react';
 
-import type { ColumnRenderers } from 'components/common/EntityDataTable';
 import {
   DEFAULT_COL_MIN_WIDTH,
   DEFAULT_COL_WIDTH,
 } from 'components/common/EntityDataTable/Constants';
 
-import type { EntityBase } from '../types';
+import type { EntityBase, ColumnRenderersByAttribute } from '../types';
 
 const assignableTableWidth = ({
   tableWidth,
   actionsColWidth,
   bulkSelectColWidth,
   columnsIds,
-  columnRenderers,
+  columnRenderersByAttribute,
 }: {
   actionsColWidth: number,
   bulkSelectColWidth: number,
-  columnRenderers: { [columnId: string]: { staticWidth?: number } }
+  columnRenderersByAttribute: { [columnId: string]: { staticWidth?: number } }
   columnsIds: Array<string>,
   tableWidth: number,
 }) => {
-  const staticColsWidth = columnsIds.reduce((total, id) => total + (columnRenderers[id]?.staticWidth ?? 0), 0);
+  const staticColsWidth = columnsIds.reduce((total, id) => total + (columnRenderersByAttribute[id]?.staticWidth ?? 0), 0);
 
   return tableWidth - bulkSelectColWidth - actionsColWidth - staticColsWidth;
 };
@@ -45,14 +44,14 @@ const assignableTableWidth = ({
 const columnsWidth = ({
   assignableWidth,
   columnsIds,
-  columnRenderers,
+  columnRenderersByAttribute,
 }: {
   assignableWidth: number,
-  columnRenderers: { [columnId: string]: { staticWidth?: number, width?: number, minWidth?: number } }
+  columnRenderersByAttribute: { [columnId: string]: { staticWidth?: number, width?: number, minWidth?: number } }
   columnsIds: Array<string>,
 }) => {
   const totalFlexColumns = columnsIds.reduce((total, id) => {
-    const { staticWidth, width = DEFAULT_COL_WIDTH } = columnRenderers[id] ?? {};
+    const { staticWidth, width = DEFAULT_COL_WIDTH } = columnRenderersByAttribute[id] ?? {};
 
     if (staticWidth) {
       return total;
@@ -64,7 +63,7 @@ const columnsWidth = ({
   const flexColWidth = assignableWidth / totalFlexColumns;
 
   return Object.fromEntries(columnsIds.map((id) => {
-    const { staticWidth, width = DEFAULT_COL_WIDTH, minWidth = DEFAULT_COL_MIN_WIDTH } = columnRenderers[id] ?? {};
+    const { staticWidth, width = DEFAULT_COL_WIDTH, minWidth = DEFAULT_COL_MIN_WIDTH } = columnRenderersByAttribute[id] ?? {};
     const targetWidth = staticWidth ?? (flexColWidth * width);
 
     return [id, (!staticWidth && targetWidth < minWidth) ? minWidth : targetWidth];
@@ -74,13 +73,13 @@ const columnsWidth = ({
 const useColumnsWidths = <Entity extends EntityBase>({
   actionsColWidth,
   bulkSelectColWidth,
-  columnRenderers,
+  columnRenderersByAttribute,
   columnsIds,
   tableWidth,
 }: {
   actionsColWidth: number,
   bulkSelectColWidth: number,
-  columnRenderers: ColumnRenderers<Entity>,
+  columnRenderersByAttribute: ColumnRenderersByAttribute<Entity>,
   columnsIds: Array<string>,
   tableWidth: number,
 },
@@ -95,7 +94,7 @@ const useColumnsWidths = <Entity extends EntityBase>({
     // Calculate available width for columns which do not have a static width
     const assignableWidth = assignableTableWidth({
       actionsColWidth,
-      columnRenderers,
+      columnRenderersByAttribute,
       columnsIds,
       bulkSelectColWidth,
       tableWidth,
@@ -104,9 +103,9 @@ const useColumnsWidths = <Entity extends EntityBase>({
     setColumnWidths(columnsWidth({
       assignableWidth,
       columnsIds,
-      columnRenderers,
+      columnRenderersByAttribute,
     }));
-  }, [actionsColWidth, bulkSelectColWidth, columnRenderers, columnsIds, tableWidth]);
+  }, [actionsColWidth, bulkSelectColWidth, columnRenderersByAttribute, columnsIds, tableWidth]);
 
   return columnsWidths;
 };

--- a/graylog2-web-interface/src/components/common/EntityDataTable/types.ts
+++ b/graylog2-web-interface/src/components/common/EntityDataTable/types.ts
@@ -42,8 +42,13 @@ export type ColumnRenderer<Entity extends EntityBase> = {
   staticWidth?: number, // px
 }
 
+export type ColumnRenderersByAttribute<Entity extends EntityBase> = {
+  [attributeId: string]: ColumnRenderer<Entity>
+}
+
 export type ColumnRenderers<Entity extends EntityBase> = {
-  [columnId: string]: ColumnRenderer<Entity>
+  attributes?: ColumnRenderersByAttribute<Entity>,
+  types?: { [type: string]: ColumnRenderer<Entity> },
 }
 
 export type TableLayoutPreferences = {

--- a/graylog2-web-interface/src/components/common/EntityDataTable/types.ts
+++ b/graylog2-web-interface/src/components/common/EntityDataTable/types.ts
@@ -34,7 +34,7 @@ export type Column = {
 
 // A column render should have either a `width` and optionally a `minWidth` or only a `staticWidth`.
 export type ColumnRenderer<Entity extends EntityBase> = {
-  renderCell?: (entity: Entity, column: Column) => React.ReactNode,
+  renderCell?: (value: unknown, entity: Entity, column: Column) => React.ReactNode,
   renderHeader?: (column: Column) => React.ReactNode,
   textAlign?: string,
   minWidth?: number, // px

--- a/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitionsContainer.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitionsContainer.tsx
@@ -45,25 +45,27 @@ const CUSTOM_COLUMN_DEFINITIONS = [
 const INITIAL_COLUMNS = ['title', 'description', 'priority', 'scheduling', 'status'];
 const COLUMNS_ORDER = ['title', 'description', 'priority', 'status', 'scheduling'];
 const customColumnRenderers = (): ColumnRenderers<EventDefinition> => ({
-  title: {
-    renderCell: (title: string, eventDefinition) => (
-      <Link to={Routes.ALERTS.DEFINITIONS.show(eventDefinition.id)}>{title}</Link>
-    ),
-  },
-  scheduling: {
-    renderCell: (_scheduling: string, eventDefinition) => (
-      <SchedulingCell definition={eventDefinition} />
-    ),
-  },
-  status: {
-    renderCell: (_status: string, eventDefinition) => (
-      <StatusCell status={eventDefinition?.scheduler?.is_scheduled}
-                  isSystemEvent={isSystemEventDefinition(eventDefinition)} />
-    ),
-    staticWidth: 100,
-  },
-  prority: {
-    staticWidth: 50,
+  attributes: {
+    title: {
+      renderCell: (title: string, eventDefinition) => (
+        <Link to={Routes.ALERTS.DEFINITIONS.show(eventDefinition.id)}>{title}</Link>
+      ),
+    },
+    scheduling: {
+      renderCell: (_scheduling: string, eventDefinition) => (
+        <SchedulingCell definition={eventDefinition} />
+      ),
+    },
+    status: {
+      renderCell: (_status: string, eventDefinition) => (
+        <StatusCell status={eventDefinition?.scheduler?.is_scheduled}
+                    isSystemEvent={isSystemEventDefinition(eventDefinition)} />
+      ),
+      staticWidth: 100,
+    },
+    prority: {
+      staticWidth: 50,
+    },
   },
 });
 

--- a/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitionsContainer.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitionsContainer.tsx
@@ -46,17 +46,17 @@ const INITIAL_COLUMNS = ['title', 'description', 'priority', 'scheduling', 'stat
 const COLUMNS_ORDER = ['title', 'description', 'priority', 'status', 'scheduling'];
 const customColumnRenderers = (): ColumnRenderers<EventDefinition> => ({
   title: {
-    renderCell: (eventDefinition) => (
-      <Link to={Routes.ALERTS.DEFINITIONS.show(eventDefinition.id)}>{eventDefinition.title}</Link>
+    renderCell: (title: string, eventDefinition) => (
+      <Link to={Routes.ALERTS.DEFINITIONS.show(eventDefinition.id)}>{title}</Link>
     ),
   },
   scheduling: {
-    renderCell: (eventDefinition) => (
+    renderCell: (_scheduling: string, eventDefinition) => (
       <SchedulingCell definition={eventDefinition} />
     ),
   },
   status: {
-    renderCell: (eventDefinition) => (
+    renderCell: (_status: string, eventDefinition) => (
       <StatusCell status={eventDefinition?.scheduler?.is_scheduled}
                   isSystemEvent={isSystemEventDefinition(eventDefinition)} />
     ),
@@ -148,7 +148,8 @@ const EventDefinitionsContainer = () => {
                                             activeSort={searchParams.sort}
                                             rowActions={renderEventDefinitionActions}
                                             columnRenderers={columnRenderers}
-                                            columnDefinitions={columnDefinitions} />
+                                            columnDefinitions={columnDefinitions}
+                                            entityAttributesAreCamelCase={false} />
         )}
       </div>
     </PaginatedList>

--- a/graylog2-web-interface/src/components/event-notifications/event-notifications/EventNotificationsContainer.tsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notifications/EventNotificationsContainer.tsx
@@ -38,12 +38,12 @@ const INITIAL_COLUMNS = ['title', 'description', 'type', 'created_at'];
 const COLUMNS_ORDER = ['title', 'description', 'type', 'created_at'];
 const customColumnRenderers = (testResults: TestResults): ColumnRenderers<EventNotification> => ({
   title: {
-    renderCell: (notification) => {
+    renderCell: (_title: string, notification) => {
       return <NotificationTitle notification={notification} testResults={testResults} />;
     },
   },
   type: {
-    renderCell: (notification) => (
+    renderCell: (_type: string, notification) => (
       <NotificationConfigTypeCell notification={notification} />
     ),
   },

--- a/graylog2-web-interface/src/components/event-notifications/event-notifications/EventNotificationsContainer.tsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notifications/EventNotificationsContainer.tsx
@@ -37,15 +37,17 @@ import useNotificationTest from '../hooks/useNotificationTest';
 const INITIAL_COLUMNS = ['title', 'description', 'type', 'created_at'];
 const COLUMNS_ORDER = ['title', 'description', 'type', 'created_at'];
 const customColumnRenderers = (testResults: TestResults): ColumnRenderers<EventNotification> => ({
-  title: {
-    renderCell: (_title: string, notification) => {
-      return <NotificationTitle notification={notification} testResults={testResults} />;
+  attributes: {
+    title: {
+      renderCell: (_title: string, notification) => {
+        return <NotificationTitle notification={notification} testResults={testResults} />;
+      },
     },
-  },
-  type: {
-    renderCell: (_type: string, notification) => (
-      <NotificationConfigTypeCell notification={notification} />
-    ),
+    type: {
+      renderCell: (_type: string, notification) => (
+        <NotificationConfigTypeCell notification={notification} />
+      ),
+    },
   },
 });
 

--- a/graylog2-web-interface/src/components/streams/StreamsOverview/ColumnRenderers.tsx
+++ b/graylog2-web-interface/src/components/streams/StreamsOverview/ColumnRenderers.tsx
@@ -34,25 +34,27 @@ const DefaultLabel = styled(Label)`
   vertical-align: inherit;
 `;
 const customColumnRenderers = (indexSets: Array<IndexSet>): ColumnRenderers<Stream> => ({
-  title: {
-    renderCell: (title: string, stream) => (
-      <>
-        <Link to={Routes.stream_search(stream.id)}>{title}</Link>
-        {stream.is_default && <DefaultLabel bsStyle="primary" bsSize="xsmall">Default</DefaultLabel>}
-      </>
-    ),
-  },
-  index_set_title: {
-    renderCell: (_index_set_title: string, stream) => <IndexSetCell indexSets={indexSets} stream={stream} />,
-    width: 0.7,
-  },
-  throughput: {
-    renderCell: (_throughput: string, stream) => <ThroughputCell stream={stream} />,
-    staticWidth: 120,
-  },
-  disabled: {
-    renderCell: (_disabled: string, stream) => <StatusCell stream={stream} />,
-    staticWidth: 100,
+  attributes: {
+    title: {
+      renderCell: (title: string, stream) => (
+        <>
+          <Link to={Routes.stream_search(stream.id)}>{title}</Link>
+          {stream.is_default && <DefaultLabel bsStyle="primary" bsSize="xsmall">Default</DefaultLabel>}
+        </>
+      ),
+    },
+    index_set_title: {
+      renderCell: (_index_set_title: string, stream) => <IndexSetCell indexSets={indexSets} stream={stream} />,
+      width: 0.7,
+    },
+    throughput: {
+      renderCell: (_throughput: string, stream) => <ThroughputCell stream={stream} />,
+      staticWidth: 120,
+    },
+    disabled: {
+      renderCell: (_disabled: string, stream) => <StatusCell stream={stream} />,
+      staticWidth: 100,
+    },
   },
 });
 

--- a/graylog2-web-interface/src/components/streams/StreamsOverview/ColumnRenderers.tsx
+++ b/graylog2-web-interface/src/components/streams/StreamsOverview/ColumnRenderers.tsx
@@ -35,23 +35,23 @@ const DefaultLabel = styled(Label)`
 `;
 const customColumnRenderers = (indexSets: Array<IndexSet>): ColumnRenderers<Stream> => ({
   title: {
-    renderCell: (stream) => (
+    renderCell: (title: string, stream) => (
       <>
-        <Link to={Routes.stream_search(stream.id)}>{stream.title}</Link>
+        <Link to={Routes.stream_search(stream.id)}>{title}</Link>
         {stream.is_default && <DefaultLabel bsStyle="primary" bsSize="xsmall">Default</DefaultLabel>}
       </>
     ),
   },
   index_set_title: {
-    renderCell: (stream) => <IndexSetCell indexSets={indexSets} stream={stream} />,
+    renderCell: (_index_set_title: string, stream) => <IndexSetCell indexSets={indexSets} stream={stream} />,
     width: 0.7,
   },
   throughput: {
-    renderCell: (stream) => <ThroughputCell stream={stream} />,
+    renderCell: (_throughput: string, stream) => <ThroughputCell stream={stream} />,
     staticWidth: 120,
   },
   disabled: {
-    renderCell: (stream) => <StatusCell stream={stream} />,
+    renderCell: (_disabled: string, stream) => <StatusCell stream={stream} />,
     staticWidth: 100,
   },
 });

--- a/graylog2-web-interface/src/components/streams/StreamsOverview/StreamsOverview.tsx
+++ b/graylog2-web-interface/src/components/streams/StreamsOverview/StreamsOverview.tsx
@@ -163,7 +163,8 @@ const StreamsOverview = ({ indexSets }: Props) => {
                                    activeSort={layoutConfig.sort}
                                    rowActions={renderStreamActions}
                                    columnRenderers={columnRenderers}
-                                   columnDefinitions={columnDefinitions} />
+                                   columnDefinitions={columnDefinitions}
+                                   entityAttributesAreCamelCase={false} />
         )}
       </div>
     </PaginatedList>

--- a/graylog2-web-interface/src/views/components/dashboard/DashboardsOverview/DashboardsOverview.tsx
+++ b/graylog2-web-interface/src/views/components/dashboard/DashboardsOverview/DashboardsOverview.tsx
@@ -113,18 +113,18 @@ const DashboardsOverview = () => {
         <NoSearchResult>No dashboards have been found.</NoSearchResult>
       )}
       {!!dashboards?.length && (
-        <EntityDataTable activeSort={layoutConfig.sort}
-                         bulkActions={renderBulkActions}
-                         columnDefinitions={attributes}
-                         columnRenderers={customColumnRenderers}
-                         columnsOrder={DEFAULT_LAYOUT.columnsOrder}
-                         data={dashboards}
-                         onColumnsChange={onColumnsChange}
-                         onPageSizeChange={onPageSizeChange}
-                         onSortChange={onSortChange}
-                         pageSize={layoutConfig.pageSize}
-                         rowActions={renderDashboardActions}
-                         visibleColumns={layoutConfig.displayedAttributes} />
+        <EntityDataTable<View> activeSort={layoutConfig.sort}
+                               bulkActions={renderBulkActions}
+                               columnDefinitions={attributes}
+                               columnRenderers={customColumnRenderers}
+                               columnsOrder={DEFAULT_LAYOUT.columnsOrder}
+                               data={dashboards}
+                               onColumnsChange={onColumnsChange}
+                               onPageSizeChange={onPageSizeChange}
+                               onSortChange={onSortChange}
+                               pageSize={layoutConfig.pageSize}
+                               rowActions={renderDashboardActions}
+                               visibleColumns={layoutConfig.displayedAttributes} />
       )}
     </PaginatedList>
   );

--- a/graylog2-web-interface/src/views/components/dashboard/DashboardsOverview/useColumnRenderers.tsx
+++ b/graylog2-web-interface/src/views/components/dashboard/DashboardsOverview/useColumnRenderers.tsx
@@ -32,11 +32,11 @@ export const useColumnRenderers = (
   const requirementsProvided = usePluginEntities('views.requires.provided');
   const customColumnRenderers: ColumnRenderers<View> = useMemo(() => ({
     title: {
-      renderCell: (dashboard) => <TitleCell dashboard={dashboard} requirementsProvided={requirementsProvided} />,
+      renderCell: (_title: string, dashboard) => <TitleCell dashboard={dashboard} requirementsProvided={requirementsProvided} />,
     },
     favorite: {
-      renderCell: (dashboard) => (
-        <FavoriteIcon isFavorite={dashboard.favorite}
+      renderCell: (favorite: boolean, dashboard) => (
+        <FavoriteIcon isFavorite={favorite}
                       grn={createGRN('dashboard', dashboard.id)}
                       onChange={(newValue) => {
                         queryClient.setQueriesData(['dashboards', 'overview', searchParams], (cur: {

--- a/graylog2-web-interface/src/views/components/dashboard/DashboardsOverview/useColumnRenderers.tsx
+++ b/graylog2-web-interface/src/views/components/dashboard/DashboardsOverview/useColumnRenderers.tsx
@@ -31,30 +31,32 @@ export const useColumnRenderers = (
   const queryClient = useQueryClient();
   const requirementsProvided = usePluginEntities('views.requires.provided');
   const customColumnRenderers: ColumnRenderers<View> = useMemo(() => ({
-    title: {
-      renderCell: (_title: string, dashboard) => <TitleCell dashboard={dashboard} requirementsProvided={requirementsProvided} />,
-    },
-    favorite: {
-      renderCell: (favorite: boolean, dashboard) => (
-        <FavoriteIcon isFavorite={favorite}
-                      grn={createGRN('dashboard', dashboard.id)}
-                      onChange={(newValue) => {
-                        queryClient.setQueriesData(['dashboards', 'overview', searchParams], (cur: {
-                          list: Readonly<Array<View>>,
-                          pagination: { total: number }
-                        }) => ({
-                          ...cur,
-                          list: cur.list.map((view) => {
-                            if (view.id === dashboard.id) {
-                              return view.toBuilder().favorite(newValue).build();
-                            }
+    attributes: {
+      title: {
+        renderCell: (_title: string, dashboard) => <TitleCell dashboard={dashboard} requirementsProvided={requirementsProvided} />,
+      },
+      favorite: {
+        renderCell: (favorite: boolean, dashboard) => (
+          <FavoriteIcon isFavorite={favorite}
+                        grn={createGRN('dashboard', dashboard.id)}
+                        onChange={(newValue) => {
+                          queryClient.setQueriesData(['dashboards', 'overview', searchParams], (cur: {
+                            list: Readonly<Array<View>>,
+                            pagination: { total: number }
+                          }) => ({
+                            ...cur,
+                            list: cur.list.map((view) => {
+                              if (view.id === dashboard.id) {
+                                return view.toBuilder().favorite(newValue).build();
+                              }
 
-                            return view;
-                          }),
-                        }
-                        ));
-                      }} />
-      ),
+                              return view;
+                            }),
+                          }
+                          ));
+                        }} />
+        ),
+      },
     },
   }), [queryClient, requirementsProvided, searchParams]);
 

--- a/graylog2-web-interface/src/views/components/searchbar/saved-search/useColumnRenderes.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/saved-search/useColumnRenderes.tsx
@@ -50,7 +50,7 @@ const useColumnRenderers = (
 
   return ({
     title: {
-      renderCell: (search) => (
+      renderCell: (title: string, search) => (
         <ViewLoaderContext.Consumer key={search.id}>
           {(loaderFunc) => {
             const onClick = (e) => {
@@ -61,7 +61,7 @@ const useColumnRenderers = (
             return (
               <Link onClick={onClick}
                     to={Routes.getPluginRoute('SEARCH_VIEWID')(search.id)}>
-                {search.title}
+                {title}
               </Link>
             );
           }}
@@ -69,8 +69,8 @@ const useColumnRenderers = (
       ),
     },
     favorite: {
-      renderCell: (search) => (
-        <FavoriteIcon isFavorite={search.favorite}
+      renderCell: (favorite: boolean, search) => (
+        <FavoriteIcon isFavorite={favorite}
                       grn={createGRN('search', search.id)}
                       onChange={(newValue) => {
                         queryClient.setQueriesData(['saved-searches', 'overview', searchParams], (cur: {

--- a/graylog2-web-interface/src/views/components/searchbar/saved-search/useColumnRenderes.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/saved-search/useColumnRenderes.tsx
@@ -49,48 +49,49 @@ const useColumnRenderers = (
   const queryClient = useQueryClient();
 
   return ({
-    title: {
-      renderCell: (title: string, search) => (
-        <ViewLoaderContext.Consumer key={search.id}>
-          {(loaderFunc) => {
-            const onClick = (e) => {
-              e.preventDefault();
-              onLoad(onLoadSavedSearch, search.id, loaderFunc);
-            };
+    attributes: {
+      title: {
+        renderCell: (title: string, search) => (
+          <ViewLoaderContext.Consumer key={search.id}>
+            {(loaderFunc) => {
+              const onClick = (e) => {
+                e.preventDefault();
+                onLoad(onLoadSavedSearch, search.id, loaderFunc);
+              };
 
-            return (
-              <Link onClick={onClick}
-                    to={Routes.getPluginRoute('SEARCH_VIEWID')(search.id)}>
-                {title}
-              </Link>
-            );
-          }}
-        </ViewLoaderContext.Consumer>
-      ),
-    },
-    favorite: {
-      renderCell: (favorite: boolean, search) => (
-        <FavoriteIcon isFavorite={favorite}
-                      grn={createGRN('search', search.id)}
-                      onChange={(newValue) => {
-                        queryClient.setQueriesData(['saved-searches', 'overview', searchParams], (cur: {
+              return (
+                <Link onClick={onClick}
+                      to={Routes.getPluginRoute('SEARCH_VIEWID')(search.id)}>
+                  {title}
+                </Link>
+              );
+            }}
+          </ViewLoaderContext.Consumer>
+        ),
+      },
+      favorite: {
+        renderCell: (favorite: boolean, search) => (
+          <FavoriteIcon isFavorite={favorite}
+                        grn={createGRN('search', search.id)}
+                        onChange={(newValue) => {
+                          queryClient.setQueriesData(['saved-searches', 'overview', searchParams], (cur: {
                           list: Array<View>,
                           pagination: { total: number }
                         }) => {
-                          return ({
-                            ...cur,
-                            list: cur.list.map((view) => {
-                              if (view.id === search.id) {
-                                return view.toBuilder().favorite(newValue).build();
-                              }
+                            return ({
+                              ...cur,
+                              list: cur.list.map((view) => {
+                                if (view.id === search.id) {
+                                  return view.toBuilder().favorite(newValue).build();
+                                }
 
-                              return view;
-                            }),
-                          }
-                          );
-                        });
-                      }} />
-      ),
+                                return view;
+                              }),
+                            });
+                          });
+                        }} />
+        ),
+      },
     },
   });
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is improving the rendering of columns in the entity data table. We are now
- Handing entities with camel case attributes correctly. The column meta data is defined in snake case, but some entities like saved searches and dashboards have camel case attributes. We are now transforming the camel case attributes to snake case to fix the mapping.
- It is now possible to define a column renderer for attributes types. Columns have a type like `DATE`, since we often want to render e.g. date times the same way, it makes sense to define the column renderers per type. Otherwise we would have to define the same logic for each date attribute.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

/nocl