### PR TITLE
Revert "Apply new index set defaults to default index set (#14778)"

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/migrations/V20161116172100_DefaultIndexSetMigration.java
+++ b/graylog2-server/src/main/java/org/graylog2/migrations/V20161116172100_DefaultIndexSetMigration.java
@@ -20,19 +20,23 @@ import org.graylog2.configuration.ElasticsearchConfiguration;
 import org.graylog2.indexer.indexset.DefaultIndexSetConfig;
 import org.graylog2.indexer.indexset.DefaultIndexSetCreated;
 import org.graylog2.indexer.indexset.IndexSetConfig;
-import org.graylog2.indexer.indexset.IndexSetConfigFactory;
 import org.graylog2.indexer.indexset.IndexSetService;
+import org.graylog2.indexer.management.IndexManagementConfig;
 import org.graylog2.plugin.cluster.ClusterConfigService;
 import org.graylog2.plugin.indexer.retention.RetentionStrategy;
+import org.graylog2.plugin.indexer.retention.RetentionStrategyConfig;
 import org.graylog2.plugin.indexer.rotation.RotationStrategy;
+import org.graylog2.plugin.indexer.rotation.RotationStrategyConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import javax.inject.Provider;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.Map;
 
+import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -46,21 +50,18 @@ public class V20161116172100_DefaultIndexSetMigration extends Migration {
     private final Map<String, Provider<RetentionStrategy>> retentionStrategies;
     private final IndexSetService indexSetService;
     private final ClusterConfigService clusterConfigService;
-    private final IndexSetConfigFactory indexSetConfigFactory;
 
     @Inject
     public V20161116172100_DefaultIndexSetMigration(final ElasticsearchConfiguration elasticsearchConfiguration,
                                                     final Map<String, Provider<RotationStrategy>> rotationStrategies,
                                                     final Map<String, Provider<RetentionStrategy>> retentionStrategies,
                                                     final IndexSetService indexSetService,
-                                                    final ClusterConfigService clusterConfigService,
-                                                    IndexSetConfigFactory indexSetConfigFactory) {
+                                                    final ClusterConfigService clusterConfigService) {
         this.elasticsearchConfiguration = elasticsearchConfiguration;
         this.rotationStrategies = requireNonNull(rotationStrategies);
         this.retentionStrategies = requireNonNull(retentionStrategies);
         this.indexSetService = indexSetService;
         this.clusterConfigService = clusterConfigService;
-        this.indexSetConfigFactory = indexSetConfigFactory;
     }
 
     @Override
@@ -75,12 +76,24 @@ public class V20161116172100_DefaultIndexSetMigration extends Migration {
             return;
         }
 
-        final IndexSetConfig config = indexSetConfigFactory.createDefault()
+        final IndexManagementConfig indexManagementConfig = clusterConfigService.get(IndexManagementConfig.class);
+
+        checkState(indexManagementConfig != null, "Couldn't find index management configuration");
+
+        final IndexSetConfig config = IndexSetConfig.builder()
                 .title("Default index set")
                 .description("The Graylog default index set")
                 .isRegular(true)
                 .indexPrefix(elasticsearchConfiguration.getDefaultIndexPrefix())
+                .shards(elasticsearchConfiguration.getShards())
+                .replicas(elasticsearchConfiguration.getReplicas())
+                .rotationStrategy(getRotationStrategyConfig(indexManagementConfig))
+                .retentionStrategy(getRetentionStrategyConfig(indexManagementConfig))
+                .creationDate(ZonedDateTime.now(ZoneOffset.UTC))
+                .indexAnalyzer(elasticsearchConfiguration.getAnalyzer())
                 .indexTemplateName(elasticsearchConfiguration.getDefaultIndexTemplateName())
+                .indexOptimizationMaxNumSegments(elasticsearchConfiguration.getIndexOptimizationMaxNumSegments())
+                .indexOptimizationDisabled(elasticsearchConfiguration.isDisableIndexOptimization())
                 .build();
 
         final IndexSetConfig savedConfig = indexSetService.save(config);
@@ -90,4 +103,33 @@ public class V20161116172100_DefaultIndexSetMigration extends Migration {
         LOG.debug("Successfully created default index set: {}", savedConfig);
     }
 
+    private RotationStrategyConfig getRotationStrategyConfig(IndexManagementConfig indexManagementConfig) {
+        final String strategyName = indexManagementConfig.rotationStrategy();
+        final Provider<RotationStrategy> provider = rotationStrategies.get(strategyName);
+        checkState(provider != null, "Couldn't retrieve rotation strategy provider for <" + strategyName + ">");
+
+        final RotationStrategy rotationStrategy = provider.get();
+        @SuppressWarnings("unchecked")
+        final Class<RotationStrategyConfig> configClass = (Class<RotationStrategyConfig>) rotationStrategy.configurationClass();
+
+        final RotationStrategyConfig rotationStrategyConfig = clusterConfigService.get(configClass);
+        checkState(rotationStrategyConfig != null, "Couldn't retrieve rotation strategy config for <" + strategyName + ">");
+
+        return rotationStrategyConfig;
+    }
+
+    private RetentionStrategyConfig getRetentionStrategyConfig(IndexManagementConfig indexManagementConfig) {
+        final String strategyName = indexManagementConfig.retentionStrategy();
+        final Provider<RetentionStrategy> provider = retentionStrategies.get(strategyName);
+        checkState(provider != null, "Couldn't retrieve retention strategy provider for <" + strategyName + ">");
+
+        final RetentionStrategy retentionStrategy = provider.get();
+        @SuppressWarnings("unchecked")
+        final Class<RetentionStrategyConfig> configClass = (Class<RetentionStrategyConfig>) retentionStrategy.configurationClass();
+
+        final RetentionStrategyConfig retentionStrategyConfig = clusterConfigService.get(configClass);
+        checkState(retentionStrategyConfig != null, "Couldn't retrieve retention strategy config for <" + strategyName + ">");
+
+        return retentionStrategyConfig;
+    }
 }

--- a/graylog2-server/src/test/java/org/graylog2/migrations/V20161116172100_DefaultIndexSetMigrationTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/migrations/V20161116172100_DefaultIndexSetMigrationTest.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.migrations;
+
+import org.graylog2.configuration.ElasticsearchConfiguration;
+import org.graylog2.indexer.IndexSet;
+import org.graylog2.indexer.indexset.DefaultIndexSetConfig;
+import org.graylog2.indexer.indexset.DefaultIndexSetCreated;
+import org.graylog2.indexer.indexset.IndexSetConfig;
+import org.graylog2.indexer.indexset.IndexSetService;
+import org.graylog2.indexer.management.IndexManagementConfig;
+import org.graylog2.plugin.cluster.ClusterConfigService;
+import org.graylog2.plugin.indexer.retention.RetentionStrategy;
+import org.graylog2.plugin.indexer.retention.RetentionStrategyConfig;
+import org.graylog2.plugin.indexer.rotation.RotationStrategy;
+import org.graylog2.plugin.indexer.rotation.RotationStrategyConfig;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+public class V20161116172100_DefaultIndexSetMigrationTest {
+    @Rule
+    public final MockitoRule mockitoRule = MockitoJUnit.rule();
+    @Rule
+    public final ExpectedException expectedException = ExpectedException.none();
+
+    @Mock
+    private IndexSetService indexSetService;
+    @Mock
+    private ClusterConfigService clusterConfigService;
+
+    private final ElasticsearchConfiguration elasticsearchConfiguration = new ElasticsearchConfiguration();
+    private RotationStrategy rotationStrategy = new StubRotationStrategy();
+    private RetentionStrategy retentionStrategy = new StubRetentionStrategy();
+    private Migration migration;
+
+
+    @Before
+    public void setUpService() throws Exception {
+        migration = new V20161116172100_DefaultIndexSetMigration(
+                elasticsearchConfiguration,
+                Collections.singletonMap("test", () -> rotationStrategy),
+                Collections.singletonMap("test", () -> retentionStrategy),
+                indexSetService,
+                clusterConfigService);
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    public void upgradeCreatesDefaultIndexSet() throws Exception {
+        final StubRotationStrategyConfig rotationStrategyConfig = new StubRotationStrategyConfig();
+        final StubRetentionStrategyConfig retentionStrategyConfig = new StubRetentionStrategyConfig();
+        final IndexSetConfig savedIndexSetConfig = IndexSetConfig.builder()
+                .id("id")
+                .title("title")
+                .indexPrefix("prefix")
+                .shards(1)
+                .replicas(0)
+                .rotationStrategy(rotationStrategyConfig)
+                .retentionStrategy(retentionStrategyConfig)
+                .creationDate(ZonedDateTime.of(2016, 10, 12, 0, 0, 0, 0, ZoneOffset.UTC))
+                .indexAnalyzer("standard")
+                .indexTemplateName("prefix-template")
+                .indexOptimizationMaxNumSegments(1)
+                .indexOptimizationDisabled(false)
+                .build();
+        when(clusterConfigService.get(IndexManagementConfig.class)).thenReturn(IndexManagementConfig.create("test", "test"));
+        when(clusterConfigService.get(StubRotationStrategyConfig.class)).thenReturn(rotationStrategyConfig);
+        when(clusterConfigService.get(StubRetentionStrategyConfig.class)).thenReturn(retentionStrategyConfig);
+        when(indexSetService.save(any(IndexSetConfig.class))).thenReturn(savedIndexSetConfig);
+
+        final ArgumentCaptor<IndexSetConfig> indexSetConfigCaptor = ArgumentCaptor.forClass(IndexSetConfig.class);
+
+        migration.upgrade();
+
+        verify(indexSetService).save(indexSetConfigCaptor.capture());
+        verify(clusterConfigService).write(DefaultIndexSetConfig.create("id"));
+        verify(clusterConfigService).write(DefaultIndexSetCreated.create());
+
+        final IndexSetConfig capturedIndexSetConfig = indexSetConfigCaptor.getValue();
+        assertThat(capturedIndexSetConfig.id()).isNull();
+        assertThat(capturedIndexSetConfig.title()).isEqualTo("Default index set");
+        assertThat(capturedIndexSetConfig.description()).isEqualTo("The Graylog default index set");
+        assertThat(capturedIndexSetConfig.indexPrefix()).isEqualTo(elasticsearchConfiguration.getDefaultIndexPrefix());
+        assertThat(capturedIndexSetConfig.shards()).isEqualTo(elasticsearchConfiguration.getShards());
+        assertThat(capturedIndexSetConfig.replicas()).isEqualTo(elasticsearchConfiguration.getReplicas());
+        assertThat(capturedIndexSetConfig.rotationStrategy()).isInstanceOf(StubRotationStrategyConfig.class);
+        assertThat(capturedIndexSetConfig.retentionStrategy()).isInstanceOf(StubRetentionStrategyConfig.class);
+        assertThat(capturedIndexSetConfig.indexAnalyzer()).isEqualTo(elasticsearchConfiguration.getAnalyzer());
+        assertThat(capturedIndexSetConfig.indexTemplateName()).isEqualTo(elasticsearchConfiguration.getDefaultIndexTemplateName());
+        assertThat(capturedIndexSetConfig.indexOptimizationMaxNumSegments()).isEqualTo(elasticsearchConfiguration.getIndexOptimizationMaxNumSegments());
+        assertThat(capturedIndexSetConfig.indexOptimizationDisabled()).isEqualTo(elasticsearchConfiguration.isDisableIndexOptimization());
+    }
+
+    @Test
+    public void upgradeThrowsIllegalStateExceptionIfIndexManagementConfigIsMissing() throws Exception {
+        when(clusterConfigService.get(IndexManagementConfig.class)).thenReturn(null);
+
+        expectedException.expect(IllegalStateException.class);
+        expectedException.expectMessage("Couldn't find index management configuration");
+
+        migration.upgrade();
+    }
+
+    @Test
+    public void upgradeThrowsIllegalStateExceptionIfRotationStrategyIsMissing() throws Exception {
+        when(clusterConfigService.get(IndexManagementConfig.class)).thenReturn(IndexManagementConfig.create("foobar", "test"));
+
+        expectedException.expect(IllegalStateException.class);
+        expectedException.expectMessage("Couldn't retrieve rotation strategy provider for <foobar>");
+
+        migration.upgrade();
+    }
+
+    @Test
+    public void upgradeThrowsIllegalStateExceptionIfRetentionStrategyIsMissing() throws Exception {
+        when(clusterConfigService.get(StubRotationStrategyConfig.class)).thenReturn(new StubRotationStrategyConfig());
+        when(clusterConfigService.get(IndexManagementConfig.class)).thenReturn(IndexManagementConfig.create("test", "foobar"));
+
+        expectedException.expect(IllegalStateException.class);
+        expectedException.expectMessage("Couldn't retrieve retention strategy provider for <foobar>");
+
+        migration.upgrade();
+    }
+
+    @Test
+    public void migrationDoesNotRunAgainIfMigrationWasSuccessfulBefore() throws Exception {
+        when(clusterConfigService.get(DefaultIndexSetCreated.class)).thenReturn(DefaultIndexSetCreated.create());
+        migration.upgrade();
+
+        verify(clusterConfigService).get(DefaultIndexSetCreated.class);
+        verifyNoMoreInteractions(clusterConfigService);
+        verifyZeroInteractions(indexSetService);
+    }
+
+    private static class StubRotationStrategy implements RotationStrategy {
+        @Override
+        public void rotate(IndexSet indexSet) {
+        }
+
+        @Override
+        public Class<? extends RotationStrategyConfig> configurationClass() {
+            return StubRotationStrategyConfig.class;
+        }
+
+        @Override
+        public RotationStrategyConfig defaultConfiguration() {
+            return new StubRotationStrategyConfig();
+        }
+
+        @Override
+        public String getStrategyName() {
+            return "StubRotationStrategy";
+        }
+    }
+
+    private static class StubRotationStrategyConfig implements RotationStrategyConfig {
+        @Override
+        public String type() {
+            return StubRotationStrategy.class.getCanonicalName();
+        }
+    }
+
+    private static class StubRetentionStrategy implements RetentionStrategy {
+        @Override
+        public void retain(IndexSet indexSet) {
+        }
+
+        @Override
+        public Class<? extends RetentionStrategyConfig> configurationClass() {
+            return StubRetentionStrategyConfig.class;
+        }
+
+        @Override
+        public RetentionStrategyConfig defaultConfiguration() {
+            return new StubRetentionStrategyConfig();
+        }
+    }
+
+    private static class StubRetentionStrategyConfig implements RetentionStrategyConfig {
+        @Override
+        public String type() {
+            return StubRetentionStrategy.class.getCanonicalName();
+        }
+
+        @Override
+        public int maxNumberOfIndices() {
+            return 0;
+        }
+    }
+}


### PR DESCRIPTION
The new field type polling interval breaks integration tests. Revert that change until we have that fixed.

Thanks @dennisoelkers for finding this!

This reverts commit 5d41c2a38f0ede7957bb8d564b05251e0fc81094.

/nocl