### PR TITLE
Changing back default field type refresh interval.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/configuration/IndexSetsDefaultConfigurationFactory.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/IndexSetsDefaultConfigurationFactory.java
@@ -17,6 +17,7 @@
 package org.graylog2.configuration;
 
 import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.graylog2.indexer.indexset.IndexSetConfig;
 import org.graylog2.migrations.MaintenanceStrategiesHelper;
 import org.graylog2.plugin.indexer.retention.RetentionStrategyConfig;
 import org.graylog2.plugin.indexer.rotation.RotationStrategyConfig;
@@ -46,7 +47,7 @@ public class IndexSetsDefaultConfigurationFactory {
                 .replicas(elasticsearchConfiguration.getReplicas())
                 .indexOptimizationDisabled(elasticsearchConfiguration.isDisableIndexOptimization())
                 .indexOptimizationMaxNumSegments(elasticsearchConfiguration.getIndexOptimizationMaxNumSegments())
-                .fieldTypeRefreshInterval(elasticsearchConfiguration.getIndexFieldTypePeriodicalFullRefreshInterval().toSeconds())
+                .fieldTypeRefreshInterval(IndexSetConfig.DEFAULT_FIELD_TYPE_REFRESH_INTERVAL.getStandardSeconds())
                 .fieldTypeRefreshIntervalUnit(TimeUnit.SECONDS)
                 .rotationStrategyClass(rotationConfig.left)
                 .rotationStrategyConfig(rotationConfig.right)

--- a/graylog2-server/src/main/java/org/graylog2/indexer/indexset/IndexSetConfig.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indexset/IndexSetConfig.java
@@ -57,7 +57,7 @@ public abstract class IndexSetConfig implements Comparable<IndexSetConfig> {
 
     public static final String DEFAULT_INDEX_TEMPLATE_TYPE = MessageIndexTemplateProvider.MESSAGE_TEMPLATE_TYPE;
 
-    private static final Duration DEFAULT_FIELD_TYPE_REFRESH_INTERVAL = Duration.standardSeconds(5L);
+    public static final Duration DEFAULT_FIELD_TYPE_REFRESH_INTERVAL = Duration.standardSeconds(5L);
 
     @JsonProperty("id")
     @Nullable

--- a/graylog2-server/src/main/java/org/graylog2/indexer/indexset/IndexSetConfigFactory.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indexset/IndexSetConfigFactory.java
@@ -84,8 +84,7 @@ public class IndexSetConfigFactory {
                 .indexAnalyzer(elasticsearchConfiguration.getAnalyzer())
                 .indexOptimizationMaxNumSegments(elasticsearchConfiguration.getIndexOptimizationMaxNumSegments())
                 .indexOptimizationDisabled(elasticsearchConfiguration.isDisableIndexOptimization())
-                .fieldTypeRefreshInterval(Duration.millis(
-                        elasticsearchConfiguration.getIndexFieldTypePeriodicalFullRefreshInterval().toMilliseconds()));
+                .fieldTypeRefreshInterval(IndexSetConfig.DEFAULT_FIELD_TYPE_REFRESH_INTERVAL);
     }
 
     private static ZonedDateTime getCreationDate() {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

In #13018, the default field type refresh interval was accidentally changed from 5s to 5m, due to using the `index_field_type_periodical_full_refresh_interval` configuration setting for the new default. This setting means something else, it is used in _addition_ to the field type refresh interval to determine when a _full_ refresh should be run.

This PR is changing back the default field type refresh interval to 5
seconds.

/nocl

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.