### PR TITLE
Allow specifying optional `id` for inline search filters.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchfilters/model/InlineQueryStringSearchFilter.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchfilters/model/InlineQueryStringSearchFilter.java
@@ -17,6 +17,7 @@
 package org.graylog.plugins.views.search.searchfilters.model;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -35,6 +36,7 @@ public abstract class InlineQueryStringSearchFilter implements UsedSearchFilter,
     public abstract String title();
 
     @JsonProperty(ID_FIELD)
+    @JsonInclude(JsonInclude.Include.NON_ABSENT)
     public abstract Optional<String> id();
 
     @JsonProperty(DESCRIPTION_FIELD)

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchfilters/model/InlineQueryStringSearchFilter.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchfilters/model/InlineQueryStringSearchFilter.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
 
 import javax.annotation.Nullable;
+import java.util.Optional;
 
 @AutoValue
 @JsonTypeName(UsedSearchFilter.INLINE_QUERY_STRING_SEARCH_FILTER)
@@ -32,6 +33,9 @@ public abstract class InlineQueryStringSearchFilter implements UsedSearchFilter,
     @JsonProperty(TITLE_FIELD)
     @Nullable
     public abstract String title();
+
+    @JsonProperty(ID_FIELD)
+    public abstract Optional<String> id();
 
     @JsonProperty(DESCRIPTION_FIELD)
     @Nullable
@@ -64,6 +68,9 @@ public abstract class InlineQueryStringSearchFilter implements UsedSearchFilter,
 
         @JsonProperty(TITLE_FIELD)
         public abstract Builder title(String title);
+
+        @JsonProperty(ID_FIELD)
+        public abstract Builder id(@Nullable String id);
 
         @JsonProperty(DESCRIPTION_FIELD)
         public abstract Builder description(String description);

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchfilters/model/ReferencedQueryStringSearchFilter.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchfilters/model/ReferencedQueryStringSearchFilter.java
@@ -29,7 +29,7 @@ import javax.annotation.Nullable;
 @JsonDeserialize(builder = ReferencedQueryStringSearchFilter.Builder.class)
 public abstract class ReferencedQueryStringSearchFilter implements ReferencedSearchFilter, QueryStringSearchFilter {
 
-    @JsonProperty
+    @JsonProperty(ID_FIELD)
     @Override
     public abstract String id();
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchfilters/model/UsedSearchFilter.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchfilters/model/UsedSearchFilter.java
@@ -33,6 +33,7 @@ public interface UsedSearchFilter {
     String TYPE = "type";
 
     String TITLE_FIELD = "title";
+    String ID_FIELD = "id";
     String DESCRIPTION_FIELD = "description";
     String QUERY_STRING_FIELD = "queryString";
     String NEGATION_FIELD = "negation";


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is adding an optional `id` attribute to inline search filters, allowing the consumer to specify the attribute in order to make locating inline search filters by reference possible.

/nocl

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.