### PR TITLE
Document removal of deprecated AWS inputs

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -90,7 +90,16 @@ Unless user-specified defaults are specified, the following new defaults will be
 - Shards: 1 (previously 4 in many cases)
 - Rotation Strategy: Time Size Optimizing - 30-40 days (previously Index Time [1D] in many cases)
 
-# API Changes
+## Removal of deprecated Inputs
+
+The following inputs are no longer available:
+- AWS Logs (deprecated)
+- AWS Flow Logs (deprecated)
+
+The inputs were marked as deprecated since Graylog version `3.2.0`.
+If you still run any of those inputs, please configure the alternative "Kinesis/CloudWatch" input instead ahead of upgrading.
+
+## Java API Changes
 The following Java Code API changes have been made.
 
 | File/method                                  | Description                                                                                                 |


### PR DESCRIPTION
Mention the removal of deprecated inputs in upgrade notes.

Actual removal is performed in https://github.com/Graylog2/graylog-plugin-aws/pull/674

/nocl
