### PR TITLE
General endpoint for providing entity suggestions

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/ViewsBindings.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/ViewsBindings.java
@@ -55,7 +55,6 @@ import org.graylog.plugins.views.search.filter.OrFilter;
 import org.graylog.plugins.views.search.filter.QueryStringFilter;
 import org.graylog.plugins.views.search.filter.StreamFilter;
 import org.graylog.plugins.views.search.rest.DashboardsResource;
-import org.graylog.plugins.views.startpage.StartPageResource;
 import org.graylog.plugins.views.search.rest.ExportJobsResource;
 import org.graylog.plugins.views.search.rest.FieldTypesResource;
 import org.graylog.plugins.views.search.rest.MessageExportFormatFilter;
@@ -102,7 +101,6 @@ import org.graylog.plugins.views.search.validation.validators.InvalidOperatorsVa
 import org.graylog.plugins.views.search.validation.validators.UnknownFieldsValidator;
 import org.graylog.plugins.views.search.views.RequiresParameterSupport;
 import org.graylog.plugins.views.search.views.ViewRequirements;
-import org.graylog.plugins.views.startpage.recentActivities.RecentActivityUpdatesListener;
 import org.graylog.plugins.views.search.views.widgets.aggregation.AggregationConfigDTO;
 import org.graylog.plugins.views.search.views.widgets.aggregation.AreaVisualizationConfigDTO;
 import org.graylog.plugins.views.search.views.widgets.aggregation.AutoIntervalDTO;
@@ -119,12 +117,15 @@ import org.graylog.plugins.views.search.views.widgets.aggregation.WorldMapVisual
 import org.graylog.plugins.views.search.views.widgets.aggregation.sort.PivotSortConfig;
 import org.graylog.plugins.views.search.views.widgets.aggregation.sort.SeriesSortConfig;
 import org.graylog.plugins.views.search.views.widgets.messagelist.MessageListConfigDTO;
+import org.graylog.plugins.views.startpage.StartPageResource;
+import org.graylog.plugins.views.startpage.recentActivities.RecentActivityUpdatesListener;
 import org.graylog2.contentpacks.facades.DashboardEntityCreator;
 import org.graylog2.contentpacks.facades.DashboardFacade;
 import org.graylog2.indexer.fieldtypes.MappedFieldTypesService;
 import org.graylog2.indexer.fieldtypes.MappedFieldTypesServiceImpl;
 import org.graylog2.plugin.PluginConfigBean;
 import org.graylog2.rest.MoreMediaTypes;
+import org.graylog2.rest.resources.suggestions.EntitySuggestionResource;
 
 import java.util.Set;
 
@@ -152,6 +153,7 @@ public class ViewsBindings extends ViewsModule {
         addSystemRestResource(ViewsResource.class);
         addSystemRestResource(SuggestionsResource.class);
         addSystemRestResource(QueryValidationResource.class);
+        addSystemRestResource(EntitySuggestionResource.class);
 
         addPermissions(ViewsRestPermissions.class);
 

--- a/graylog2-server/src/main/java/org/graylog2/bindings/PersistenceServicesBindings.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/PersistenceServicesBindings.java
@@ -20,6 +20,8 @@ import com.google.inject.AbstractModule;
 import com.google.inject.multibindings.OptionalBinder;
 import org.graylog2.cluster.NodeService;
 import org.graylog2.cluster.NodeServiceImpl;
+import org.graylog2.database.suggestions.EntitySuggestionService;
+import org.graylog2.database.suggestions.MongoEntitySuggestionService;
 import org.graylog2.indexer.IndexFailureService;
 import org.graylog2.indexer.IndexFailureServiceImpl;
 import org.graylog2.indexer.ranges.IndexRangeService;
@@ -59,5 +61,6 @@ public class PersistenceServicesBindings extends AbstractModule {
         bind(MongoDBSessionService.class).to(MongoDBSessionServiceImpl.class);
         bind(InputStatusService.class).to(MongoInputStatusService.class).asEagerSingleton();
         bind(EntityListPreferencesService.class).to(EntityListPreferencesServiceImpl.class);
+        bind(EntitySuggestionService.class).to(MongoEntitySuggestionService.class);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/database/suggestions/EntitySuggestion.java
+++ b/graylog2-server/src/main/java/org/graylog2/database/suggestions/EntitySuggestion.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.database.suggestions;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record EntitySuggestion(@JsonProperty("id") String id,
+                               @JsonProperty("value") String value) {
+}

--- a/graylog2-server/src/main/java/org/graylog2/database/suggestions/EntitySuggestionResponse.java
+++ b/graylog2-server/src/main/java/org/graylog2/database/suggestions/EntitySuggestionResponse.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.database.suggestions;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.graylog2.database.PaginatedList;
+
+import java.util.List;
+
+public record EntitySuggestionResponse(@JsonProperty("suggestions") List<EntitySuggestion> suggestions,
+                                       @JsonProperty("pagination") PaginatedList.PaginationInfo pagination) {
+}

--- a/graylog2-server/src/main/java/org/graylog2/database/suggestions/EntitySuggestionService.java
+++ b/graylog2-server/src/main/java/org/graylog2/database/suggestions/EntitySuggestionService.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.database.suggestions;
+
+import org.apache.shiro.subject.Subject;
+
+public interface EntitySuggestionService {
+
+    EntitySuggestionResponse suggest(final String collection,
+                                     final String valueColumn,
+                                     final String query,
+                                     final int page,
+                                     final int perPage,
+                                     final Subject subject);
+}

--- a/graylog2-server/src/main/java/org/graylog2/database/suggestions/MongoEntitySuggestionService.java
+++ b/graylog2-server/src/main/java/org/graylog2/database/suggestions/MongoEntitySuggestionService.java
@@ -21,26 +21,33 @@ import com.mongodb.client.MongoCollection;
 import com.mongodb.client.model.Filters;
 import com.mongodb.client.model.Projections;
 import com.mongodb.client.model.Sorts;
+import org.apache.shiro.authz.permission.AllPermission;
 import org.apache.shiro.subject.Subject;
 import org.bson.BsonDocument;
 import org.bson.Document;
 import org.bson.conversions.Bson;
 import org.graylog2.database.MongoConnection;
 import org.graylog2.database.PaginatedList;
+import org.graylog2.indexer.indexset.MongoIndexSetService;
+import org.graylog2.shared.security.RestPermissions;
 
 import javax.inject.Inject;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
-//TODO: permissions
-//TODO: collection name -> permission name mapping
+//TODO: Suggestions won't be provided to users that have permissions to just some of the entities in the collection
 public class MongoEntitySuggestionService implements EntitySuggestionService {
 
     private final MongoConnection mongoConnection;
+    //TODO: It would be great to have a mechanism to automatically map collection to proper permission. For now this mapping will be hardcoded for supported collections.
+    private final Map<String, String> mongoCollectionToPermission = new HashMap<>();
 
     @Inject
     public MongoEntitySuggestionService(final MongoConnection mongoConnection) {
         this.mongoConnection = mongoConnection;
+        this.mongoCollectionToPermission.put(MongoIndexSetService.COLLECTION_NAME, RestPermissions.INDEXSETS_READ);
     }
 
     @Override
@@ -50,6 +57,12 @@ public class MongoEntitySuggestionService implements EntitySuggestionService {
                                             final int page,
                                             final int perPage,
                                             final Subject subject) {
+
+        if (!hasAllPermission(subject) && !hasReadPermissionForWholeCollection(subject, collection)) {
+            return new EntitySuggestionResponse(List.of(),
+                    PaginatedList.PaginationInfo.create(0, 0, page, perPage));
+        }
+
         final MongoCollection<Document> mongoCollection = mongoConnection.getMongoDatabase().getCollection(collection);
 
         Bson bsonFilter = (query != null && !query.isEmpty()) ?
@@ -80,6 +93,19 @@ public class MongoEntitySuggestionService implements EntitySuggestionService {
                         page,
                         perPage));
 
+    }
+
+    public boolean hasAllPermission(final Subject subject) {
+        return subject.isPermitted(new AllPermission());
+    }
+
+    public boolean hasReadPermissionForWholeCollection(final Subject subject,
+                                                       final String collection) {
+        final String permission = mongoCollectionToPermission.get(collection);
+        if (permission == null) {
+            return false;
+        }
+        return subject.isPermitted(permission + ":*");
     }
 
 

--- a/graylog2-server/src/main/java/org/graylog2/database/suggestions/MongoEntitySuggestionService.java
+++ b/graylog2-server/src/main/java/org/graylog2/database/suggestions/MongoEntitySuggestionService.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.database.suggestions;
+
+import com.mongodb.client.FindIterable;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.Projections;
+import com.mongodb.client.model.Sorts;
+import org.apache.shiro.subject.Subject;
+import org.bson.BsonDocument;
+import org.bson.Document;
+import org.bson.conversions.Bson;
+import org.graylog2.database.MongoConnection;
+import org.graylog2.database.PaginatedList;
+
+import javax.inject.Inject;
+import java.util.ArrayList;
+import java.util.List;
+
+//TODO: permissions
+//TODO: collection name -> permission name mapping
+public class MongoEntitySuggestionService implements EntitySuggestionService {
+
+    private final MongoConnection mongoConnection;
+
+    @Inject
+    public MongoEntitySuggestionService(final MongoConnection mongoConnection) {
+        this.mongoConnection = mongoConnection;
+    }
+
+    @Override
+    public EntitySuggestionResponse suggest(final String collection,
+                                            final String valueColumn,
+                                            final String query,
+                                            final int page,
+                                            final int perPage,
+                                            final Subject subject) {
+        final MongoCollection<Document> mongoCollection = mongoConnection.getMongoDatabase().getCollection(collection);
+
+        Bson bsonFilter = (query != null && !query.isEmpty()) ?
+                Filters.regex(valueColumn, query, "i") :
+                new BsonDocument();
+
+        final FindIterable<Document> documents = mongoCollection
+                .find(bsonFilter)
+                .projection(Projections.include(valueColumn))
+                .sort(Sorts.ascending(valueColumn))
+                .limit(perPage)
+                .skip((page - 1) * perPage);
+
+        final List<EntitySuggestion> suggestions = documents
+                .map(doc ->
+                        new EntitySuggestion(
+                                doc.getObjectId("_id").toString(),
+                                doc.getString(valueColumn)
+                        )
+                )
+                .into(new ArrayList<>());
+
+        final long total = mongoCollection.countDocuments(bsonFilter);
+
+        return new EntitySuggestionResponse(suggestions,
+                PaginatedList.PaginationInfo.create((int) total,
+                        suggestions.size(),
+                        page,
+                        perPage));
+
+    }
+
+
+}

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/suggestions/EntitySuggestionResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/suggestions/EntitySuggestionResource.java
@@ -36,7 +36,7 @@ import javax.ws.rs.core.MediaType;
 import static org.graylog2.shared.rest.documentation.generator.Generator.CLOUD_VISIBLE;
 
 @RequiresAuthentication
-@Api(value = "Entity Suggestions", tags = {CLOUD_VISIBLE})
+@Api(value = "EntitySuggestions", tags = {CLOUD_VISIBLE})
 @Path("/entity_suggestions")
 @Produces(MediaType.APPLICATION_JSON)
 public class EntitySuggestionResource extends RestResource {

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/suggestions/EntitySuggestionResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/suggestions/EntitySuggestionResource.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.rest.resources.suggestions;
+
+import com.codahale.metrics.annotation.Timed;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import org.apache.shiro.authz.annotation.RequiresAuthentication;
+import org.graylog2.database.suggestions.EntitySuggestionResponse;
+import org.graylog2.database.suggestions.EntitySuggestionService;
+import org.graylog2.shared.rest.resources.RestResource;
+
+import javax.inject.Inject;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+
+import static org.graylog2.shared.rest.documentation.generator.Generator.CLOUD_VISIBLE;
+
+@RequiresAuthentication
+@Api(value = "Entity Suggestions", tags = {CLOUD_VISIBLE})
+@Path("/entity_suggestions")
+@Produces(MediaType.APPLICATION_JSON)
+public class EntitySuggestionResource extends RestResource {
+
+    private final EntitySuggestionService entitySuggestionService;
+
+    @Inject
+    public EntitySuggestionResource(final EntitySuggestionService entitySuggestionService) {
+        this.entitySuggestionService = entitySuggestionService;
+    }
+
+    @GET
+    @Timed
+    @ApiOperation(value = "Get a paginated list of suggested entities")
+    public EntitySuggestionResponse getPage(@ApiParam(name = "collection")
+                                            @QueryParam("collection") String collection,
+                                            @ApiParam(name = "column")
+                                            @QueryParam("column") String column,
+                                            @ApiParam(name = "page")
+                                            @QueryParam("page") @DefaultValue("1") int page,
+                                            @ApiParam(name = "per_page")
+                                            @QueryParam("per_page") @DefaultValue("10") int perPage,
+                                            @ApiParam(name = "query")
+                                            @QueryParam("query") @DefaultValue("") String query) {
+
+        return entitySuggestionService.suggest(collection, column, query, page, perPage, getSubject());
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
General endpoint for providing entity suggestions.
Part of BE implementation of [#14827](https://github.com/Graylog2/graylog2-server/issues/14827)
/nocl

## Motivation and Context
Introduction of filters in Entity Lists creates a need for suggesting related entities in filters.
I.e. we want to filter streams by index_sets. In order to achieve it, we need to be able to provide a list of existing index_sets in the system. 
There is no need to provide full information about index_sets -> their ids and textual representations are absolutely enough for filter suggestions.

There is also a strong preference towards single, general suggestion endpoint, so that BE does not have to implement a new one for each type of entity.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![Screenshot 2023-03-06 at 15-24-15 Graylog REST API browser](https://user-images.githubusercontent.com/100699120/223137509-28829c82-ce5c-470b-91d0-0ebc625b82af.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

