### PR TITLE
Introduce flag to mark inputs as not compatible with forwarder

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/plugin/inputs/MessageInput.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/inputs/MessageInput.java
@@ -414,6 +414,10 @@ public abstract class MessageInput implements Stoppable {
         return descriptor.isCloudCompatible();
     }
 
+    public boolean isForwarderCompatible() {
+        return descriptor.isForwarderCompatible();
+    }
+
     public interface Factory<M> {
         M create(Configuration configuration);
 
@@ -451,7 +455,7 @@ public abstract class MessageInput implements Stoppable {
         }
     }
 
-    public static class Descriptor extends AbstractDescriptor {
+    public static abstract class Descriptor extends AbstractDescriptor {
         public Descriptor() {
             super();
         }
@@ -462,6 +466,10 @@ public abstract class MessageInput implements Stoppable {
 
         public boolean isCloudCompatible() {
             return false;
+        }
+
+        public boolean isForwarderCompatible() {
+            return true;
         }
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/shared/inputs/InputDescription.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/inputs/InputDescription.java
@@ -46,6 +46,10 @@ public class InputDescription {
         return descriptor.isCloudCompatible();
     }
 
+    public boolean isForwarderCompatible() {
+        return descriptor.isForwarderCompatible();
+    }
+
     public Map<String, Map<String, Object>> getRequestedConfiguration() {
         return config.combinedRequestedConfiguration().asList();
     }


### PR DESCRIPTION
Adds a boolean `isForwarderCompatible` method to mark inputs as not being compatible with Forwarders.

Prerequisite for https://github.com/Graylog2/graylog-plugin-enterprise/pull/4818

/nocl 
