### PR TITLE
Range filters for Entity Lists. Creation date is filterable.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/DashboardsResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/DashboardsResource.java
@@ -62,7 +62,7 @@ public class DashboardsResource extends RestResource {
     private static final List<EntityAttribute> attributes = List.of(
             EntityAttribute.builder().id("_id").title("id").type(SearchQueryField.Type.OBJECT_ID).hidden(true).searchable(true).build(),
             EntityAttribute.builder().id(ViewDTO.FIELD_TITLE).title("Title").searchable(true).build(),
-            EntityAttribute.builder().id(ViewDTO.FIELD_CREATED_AT).title("Created").type(SearchQueryField.Type.DATE).build(),
+            EntityAttribute.builder().id(ViewDTO.FIELD_CREATED_AT).title("Created").type(SearchQueryField.Type.DATE).filterable(true).build(),
             EntityAttribute.builder().id(ViewDTO.FIELD_DESCRIPTION).title("Description").searchable(true).build(),
             EntityAttribute.builder().id(ViewDTO.FIELD_SUMMARY).title("Summary").searchable(true).build(),
             EntityAttribute.builder().id(ViewDTO.FIELD_OWNER).title("Owner").build(),

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SavedSearchesResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SavedSearchesResource.java
@@ -60,7 +60,7 @@ public class SavedSearchesResource extends RestResource {
     private static final List<EntityAttribute> attributes = List.of(
             EntityAttribute.builder().id("_id").title("id").type(SearchQueryField.Type.OBJECT_ID).hidden(true).searchable(true).build(),
             EntityAttribute.builder().id(ViewDTO.FIELD_TITLE).title("Title").searchable(true).build(),
-            EntityAttribute.builder().id(ViewDTO.FIELD_CREATED_AT).title("Created").type(SearchQueryField.Type.DATE).build(),
+            EntityAttribute.builder().id(ViewDTO.FIELD_CREATED_AT).title("Created").type(SearchQueryField.Type.DATE).filterable(true).build(),
             EntityAttribute.builder().id(ViewDTO.FIELD_DESCRIPTION).title("Description").build(),
             EntityAttribute.builder().id(ViewDTO.FIELD_SUMMARY).title("Summary").build(),
             EntityAttribute.builder().id(ViewDTO.FIELD_OWNER).title("Owner").build(),

--- a/graylog2-server/src/main/java/org/graylog2/database/filtering/DbFilterExpressionParser.java
+++ b/graylog2-server/src/main/java/org/graylog2/database/filtering/DbFilterExpressionParser.java
@@ -140,7 +140,7 @@ public class DbFilterExpressionParser {
     }
 
     private boolean isFilterable(final EntityAttribute attr) {
-        return attr.filterable() != null && attr.filterable();
+        return Boolean.TRUE.equals(attr.filterable());
     }
 
 }

--- a/graylog2-server/src/main/java/org/graylog2/database/filtering/DbFilterExpressionParser.java
+++ b/graylog2-server/src/main/java/org/graylog2/database/filtering/DbFilterExpressionParser.java
@@ -19,6 +19,7 @@ package org.graylog2.database.filtering;
 import com.mongodb.client.model.Filters;
 import org.bson.conversions.Bson;
 import org.graylog2.rest.resources.entities.EntityAttribute;
+import org.graylog2.search.SearchQueryField;
 
 import java.util.List;
 import java.util.Map;
@@ -26,32 +27,25 @@ import java.util.stream.Collectors;
 
 import static java.util.stream.Collectors.groupingBy;
 
-//TODO: discuss with FE format for more complex filters as well, mainly range filters
 public class DbFilterExpressionParser {
 
     static final String FIELD_AND_VALUE_SEPARATOR = ":";
+    static final String RANGE_VALUES_SEPARATOR = "><";
     static final String WRONG_FILTER_EXPR_FORMAT_ERROR_MSG =
             "Wrong filter expression, <field_name>" + FIELD_AND_VALUE_SEPARATOR + "<field_value> format should be used";
-
-    private record SingleValueFilter(String field, Object value) {
-
-        Bson toBson() {
-            return Filters.eq(field(), value());
-        }
-    }
 
     public List<Bson> parse(final List<String> filterExpressions,
                             final List<EntityAttribute> attributes) {
         if (filterExpressions == null || filterExpressions.isEmpty()) {
             return List.of();
         }
-        final Map<String, List<SingleValueFilter>> groupedByField = filterExpressions.stream()
+        final Map<String, List<Filter>> groupedByField = filterExpressions.stream()
                 .map(expr -> parseSingleExpressionInner(expr, attributes))
-                .collect(groupingBy(SingleValueFilter::field));
+                .collect(groupingBy(Filter::field));
 
         return groupedByField.values().stream()
                 .map(grouped -> grouped.stream()
-                        .map(SingleValueFilter::toBson)
+                        .map(Filter::toBson)
                         .collect(Collectors.toList()))
                 .map(groupedFilters -> {
                     if (groupedFilters.size() == 1) {
@@ -64,26 +58,49 @@ public class DbFilterExpressionParser {
     }
 
     public Bson parseSingleExpression(final String filterExpression, final List<EntityAttribute> attributes) {
-        final SingleValueFilter filter = parseSingleExpressionInner(filterExpression, attributes);
-        return Filters.eq(filter.field(), filter.value());
+        final Filter filter = parseSingleExpressionInner(filterExpression, attributes);
+        return filter.toBson();
     }
 
-    private SingleValueFilter parseSingleExpressionInner(final String filterExpression, final List<EntityAttribute> attributes) {
+    private Filter parseSingleExpressionInner(final String filterExpression, final List<EntityAttribute> attributes) {
         if (!filterExpression.contains(FIELD_AND_VALUE_SEPARATOR)) {
             throw new IllegalArgumentException(WRONG_FILTER_EXPR_FORMAT_ERROR_MSG);
         }
         final String[] split = filterExpression.split(FIELD_AND_VALUE_SEPARATOR, 2);
 
-        if (split[0] == null || split[0].isEmpty()) {
+        final String fieldPart = split[0];
+        if (fieldPart == null || fieldPart.isEmpty()) {
             throw new IllegalArgumentException(WRONG_FILTER_EXPR_FORMAT_ERROR_MSG);
         }
-        if (split[1] == null || split[1].isEmpty()) {
+        final String valuePart = split[1];
+        if (valuePart == null || valuePart.isEmpty()) {
             throw new IllegalArgumentException(WRONG_FILTER_EXPR_FORMAT_ERROR_MSG);
         }
 
-        final EntityAttribute attributeMetaData = getAttributeMetaData(attributes, split[0]);
+        final EntityAttribute attributeMetaData = getAttributeMetaData(attributes, fieldPart);
 
-        return new SingleValueFilter(attributeMetaData.id(), attributeMetaData.type().getMongoValueConverter().apply(split[1]));
+        final SearchQueryField.Type fieldType = attributeMetaData.type();
+        if (isRangeValueExpression(valuePart, fieldType)) {
+            if (valuePart.startsWith(RANGE_VALUES_SEPARATOR)) {
+                return new RangeFilter(attributeMetaData.id(),
+                        null,
+                        fieldType.getMongoValueConverter().apply(valuePart.substring(RANGE_VALUES_SEPARATOR.length()))
+                );
+            } else if (valuePart.endsWith(RANGE_VALUES_SEPARATOR)) {
+                return new RangeFilter(attributeMetaData.id(),
+                        fieldType.getMongoValueConverter().apply(valuePart.substring(0, valuePart.length() - RANGE_VALUES_SEPARATOR.length())),
+                        null
+                );
+            } else {
+                final String[] ranges = valuePart.split(RANGE_VALUES_SEPARATOR);
+                return new RangeFilter(attributeMetaData.id(),
+                        fieldType.getMongoValueConverter().apply(ranges[0]),
+                        fieldType.getMongoValueConverter().apply(ranges[1])
+                );
+            }
+        } else {
+            return new SingleValueFilter(attributeMetaData.id(), fieldType.getMongoValueConverter().apply(valuePart));
+        }
 
     }
 
@@ -105,6 +122,10 @@ public class DbFilterExpressionParser {
             throw new IllegalArgumentException(attributeName + " is not a field that can be used for filtering");
         }
 
+    }
+
+    private boolean isRangeValueExpression(String valuePart, SearchQueryField.Type fieldType) {
+        return SearchQueryField.Type.NUMERIC_TYPES.contains(fieldType) && valuePart.contains(RANGE_VALUES_SEPARATOR);
     }
 
     private boolean isFilterable(final EntityAttribute attr) {

--- a/graylog2-server/src/main/java/org/graylog2/database/filtering/Filter.java
+++ b/graylog2-server/src/main/java/org/graylog2/database/filtering/Filter.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.database.filtering;
+
+import org.bson.conversions.Bson;
+
+interface Filter {
+    String field();
+
+    Bson toBson();
+}

--- a/graylog2-server/src/main/java/org/graylog2/database/filtering/RangeFilter.java
+++ b/graylog2-server/src/main/java/org/graylog2/database/filtering/RangeFilter.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.database.filtering;
+
+import com.mongodb.client.model.Filters;
+import org.bson.BsonDocument;
+import org.bson.conversions.Bson;
+
+import java.util.ArrayList;
+import java.util.List;
+
+record RangeFilter(String field, Object from, Object to) implements Filter {
+
+    @Override
+    public Bson toBson() {
+        List<Bson> rangeFilters = new ArrayList<>(2);
+        if (from() != null) {
+            rangeFilters.add(Filters.gte(field(), from()));
+        }
+        if (to() != null) {
+            rangeFilters.add(Filters.lte(field(), to()));
+        }
+        if (!rangeFilters.isEmpty()) {
+            return Filters.and(rangeFilters);
+        } else {
+            return new BsonDocument();
+        }
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/database/filtering/SingleValueFilter.java
+++ b/graylog2-server/src/main/java/org/graylog2/database/filtering/SingleValueFilter.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.database.filtering;
+
+import com.mongodb.client.model.Filters;
+import org.bson.conversions.Bson;
+
+record SingleValueFilter(String field, Object value) implements Filter {
+
+    @Override
+    public Bson toBson() {
+        return Filters.eq(field(), value());
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/StreamResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/StreamResource.java
@@ -127,7 +127,7 @@ public class StreamResource extends RestResource {
             EntityAttribute.builder().id(StreamDTO.FIELD_ID).title("id").type(SearchQueryField.Type.OBJECT_ID).hidden(true).searchable(true).build(),
             EntityAttribute.builder().id(StreamDTO.FIELD_TITLE).title("Title").searchable(true).build(),
             EntityAttribute.builder().id(StreamDTO.FIELD_DESCRIPTION).title("Description").searchable(true).build(),
-            EntityAttribute.builder().id(StreamDTO.FIELD_CREATED_AT).title("Created").type(SearchQueryField.Type.DATE).build(),
+            EntityAttribute.builder().id(StreamDTO.FIELD_CREATED_AT).title("Created").type(SearchQueryField.Type.DATE).filterable(true).build(),
             EntityAttribute.builder().id(StreamDTO.FIELD_INDEX_SET_ID).title("Index set id").hidden(true).filterable(true).build(),
             EntityAttribute.builder().id("disabled").title("Status").type(SearchQueryField.Type.BOOLEAN).filterable(true).filterOptions(Set.of(
                     FilterOption.create("true", "Paused"),

--- a/graylog2-server/src/main/java/org/graylog2/search/SearchQueryField.java
+++ b/graylog2-server/src/main/java/org/graylog2/search/SearchQueryField.java
@@ -29,7 +29,7 @@ public class SearchQueryField {
 
     public enum Type {
         STRING(value -> value),
-        DATE(value -> dateParser.parseDate(value).toDate()),
+        DATE(value -> dateParser.parseDate(value)),
         INT(value -> Integer.parseInt(value)),
         LONG(value -> Long.parseLong(value)),
         OBJECT_ID(value -> new ObjectId(value)),

--- a/graylog2-server/src/main/java/org/graylog2/search/SearchQueryField.java
+++ b/graylog2-server/src/main/java/org/graylog2/search/SearchQueryField.java
@@ -19,6 +19,8 @@ package org.graylog2.search;
 import org.bson.types.ObjectId;
 import org.graylog2.utilities.date.MultiFormatDateParser;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.function.Function;
 
 public class SearchQueryField {
@@ -27,11 +29,13 @@ public class SearchQueryField {
 
     public enum Type {
         STRING(value -> value),
-        DATE(value -> dateParser.parseDate(value)),
+        DATE(value -> dateParser.parseDate(value).toDate()),
         INT(value -> Integer.parseInt(value)),
         LONG(value -> Long.parseLong(value)),
         OBJECT_ID(value -> new ObjectId(value)),
         BOOLEAN(value -> Boolean.parseBoolean(value));
+
+        public static final Collection<Type> NUMERIC_TYPES = List.of(DATE, LONG, INT);
 
         private final Function<String, Object> mongoValueConverter;
 

--- a/graylog2-server/src/test/java/org/graylog2/database/filtering/DbFilterExpressionParserTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/database/filtering/DbFilterExpressionParserTest.java
@@ -195,4 +195,95 @@ class DbFilterExpressionParserTest {
                                 .build())
                 ));
     }
+
+    @Test
+    void parsesFilterExpressionCorrectlyForDateRanges() {
+        final String fromString = "2012-12-12 12:12:12";
+        final String toString = "2022-12-12 12:12:12";
+
+        final List<EntityAttribute> entityAttributes = List.of(EntityAttribute.builder()
+                .id("created_at")
+                .title("Creation Date")
+                .type(SearchQueryField.Type.DATE)
+                .filterable(true)
+                .build());
+
+        assertEquals(
+                Filters.and(
+                        Filters.gte("created_at",
+                                new DateTime(2012, 12, 12, 12, 12, 12, DateTimeZone.UTC)),
+                        Filters.lte("created_at",
+                                new DateTime(2022, 12, 12, 12, 12, 12, DateTimeZone.UTC))
+                ),
+
+                toTest.parseSingleExpression("created_at:" + fromString + DbFilterExpressionParser.RANGE_VALUES_SEPARATOR + toString,
+                        entityAttributes
+                ));
+    }
+
+    @Test
+    void parsesFilterExpressionCorrectlyForOpenDateRanges() {
+        final String dateString = "2012-12-12 12:12:12";
+        final DateTime dateObject = new DateTime(2012, 12, 12, 12, 12, 12, DateTimeZone.UTC);
+
+        final List<EntityAttribute> entityAttributes = List.of(EntityAttribute.builder()
+                .id("created_at")
+                .title("Creation Date")
+                .type(SearchQueryField.Type.DATE)
+                .filterable(true)
+                .build());
+
+        assertEquals(
+                Filters.and(
+                        Filters.gte("created_at", dateObject)
+                ),
+                toTest.parseSingleExpression("created_at:" + dateString + DbFilterExpressionParser.RANGE_VALUES_SEPARATOR,
+                        entityAttributes
+                ));
+
+        assertEquals(
+                Filters.and(
+                        Filters.lte("created_at", dateObject)
+                ),
+                toTest.parseSingleExpression("created_at:" + DbFilterExpressionParser.RANGE_VALUES_SEPARATOR + dateString,
+                        entityAttributes
+                ));
+    }
+
+    @Test
+    void parsesFilterExpressionCorrectlyForIntRanges() {
+        final List<EntityAttribute> entityAttributes = List.of(EntityAttribute.builder()
+                .id("number")
+                .title("Number")
+                .type(SearchQueryField.Type.INT)
+                .filterable(true)
+                .build());
+
+        assertEquals(
+                Filters.and(
+                        Filters.gte("number", 42),
+                        Filters.lte("number", 53)
+                ),
+
+                toTest.parseSingleExpression("number:42" + DbFilterExpressionParser.RANGE_VALUES_SEPARATOR + "53",
+                        entityAttributes
+                ));
+    }
+
+    @Test
+    void parsesFilterExpressionForStringFieldsCorrectlyEvenIfValueContainsRangeSeparator() {
+        final List<EntityAttribute> entityAttributes = List.of(EntityAttribute.builder()
+                .id("text")
+                .title("Text")
+                .type(SearchQueryField.Type.STRING)
+                .filterable(true)
+                .build());
+
+        assertEquals(
+                Filters.eq("text", "42" + DbFilterExpressionParser.RANGE_VALUES_SEPARATOR + "53"),
+
+                toTest.parseSingleExpression("text:42" + DbFilterExpressionParser.RANGE_VALUES_SEPARATOR + "53",
+                        entityAttributes
+                ));
+    }
 }

--- a/graylog2-server/src/test/java/org/graylog2/database/filtering/DbFilterExpressionParserTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/database/filtering/DbFilterExpressionParserTest.java
@@ -171,7 +171,7 @@ class DbFilterExpressionParserTest {
     @Test
     void parsesFilterExpressionCorrectlyForDateType() {
 
-        assertEquals(Filters.eq("created_at", new DateTime(2012, 12, 12, 12, 12, 12, DateTimeZone.UTC)),
+        assertEquals(Filters.eq("created_at", new DateTime(2012, 12, 12, 12, 12, 12, DateTimeZone.UTC).toDate()),
                 toTest.parseSingleExpression("created_at:2012-12-12 12:12:12",
                         List.of(EntityAttribute.builder()
                                 .id("created_at")
@@ -211,9 +211,9 @@ class DbFilterExpressionParserTest {
         assertEquals(
                 Filters.and(
                         Filters.gte("created_at",
-                                new DateTime(2012, 12, 12, 12, 12, 12, DateTimeZone.UTC)),
+                                new DateTime(2012, 12, 12, 12, 12, 12, DateTimeZone.UTC).toDate()),
                         Filters.lte("created_at",
-                                new DateTime(2022, 12, 12, 12, 12, 12, DateTimeZone.UTC))
+                                new DateTime(2022, 12, 12, 12, 12, 12, DateTimeZone.UTC).toDate())
                 ),
 
                 toTest.parseSingleExpression("created_at:" + fromString + DbFilterExpressionParser.RANGE_VALUES_SEPARATOR + toString,
@@ -235,7 +235,7 @@ class DbFilterExpressionParserTest {
 
         assertEquals(
                 Filters.and(
-                        Filters.gte("created_at", dateObject)
+                        Filters.gte("created_at", dateObject.toDate())
                 ),
                 toTest.parseSingleExpression("created_at:" + dateString + DbFilterExpressionParser.RANGE_VALUES_SEPARATOR,
                         entityAttributes
@@ -243,7 +243,7 @@ class DbFilterExpressionParserTest {
 
         assertEquals(
                 Filters.and(
-                        Filters.lte("created_at", dateObject)
+                        Filters.lte("created_at", dateObject.toDate())
                 ),
                 toTest.parseSingleExpression("created_at:" + DbFilterExpressionParser.RANGE_VALUES_SEPARATOR + dateString,
                         entityAttributes


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Filters used in paginated endpoints for Streams, Dashboards and Saved Searches have been upgraded, so that they can accept ranges for dates and numbers.
Example range filter looks like that:
`created_at:2022-07-03><2023-03-03`
Created_at attribute has been changes to "filterable", so that it can be now used to filter paginated results.

BE part for #14828.
/nocl

## Motivation and Context
FE wants to filter results by date in Entity List.

## How Has This Been Tested?
Unit tests have been expanded.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

