### PR TITLE
Fix sun.reflect.Reflection.getCallerClass warning with Java >= 9

### DIFF
--- a/changelog/unreleased/pr-14884.toml
+++ b/changelog/unreleased/pr-14884.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Fix `WARNING: sun.reflect.Reflection.getCallerClass is not supported.` on server startup."
+
+issues = ["#7223","#9802", "#11634"]
+pulls = ["14884"]

--- a/graylog2-server/pom.xml
+++ b/graylog2-server/pom.xml
@@ -803,6 +803,9 @@
                         <transformer
                                 implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                             <mainClass>${mainClass}</mainClass>
+                            <manifestEntries>
+                                <Multi-Release>true</Multi-Release>
+                            </manifestEntries>
                         </transformer>
                     </transformers>
                     <shadedArtifactAttached>true</shadedArtifactAttached>


### PR DESCRIPTION
Enable the Multi-Release flag for the ManifestResourceTransformer in the shade plugin. Without this, the JVM cannot take advantage of the class files for newer JVM versions and hence logs the warning because slower compatibility clases will be used at runtime.

Fixes the following warning on server startup:

    WARNING: sun.reflect.Reflection.getCallerClass is not supported.
    This will impact performance.

See: https://openjdk.org/jeps/238

Refs #7223
Refs #9802
Refs #11634