### PR TITLE
Limit search execution to current (dashboard) page.

### DIFF
--- a/changelog/unreleased/issue-6867.toml
+++ b/changelog/unreleased/issue-6867.toml
@@ -1,0 +1,5 @@
+type = "f" # One of: a(dded), c(hanged), d(eprecated), r(emoved), f(ixed), s(ecurity)
+message = "Only executed widgets of current page ond dashboards."
+
+issues = ["6867"]
+pulls = ["14890"]

--- a/full-backend-tests/src/test/java/org/graylog/plugins/views/SearchSyncIT.java
+++ b/full-backend-tests/src/test/java/org/graylog/plugins/views/SearchSyncIT.java
@@ -148,6 +148,20 @@ public class SearchSyncIT {
     }
 
     @ContainerMatrixTest
+    void testRequestStoredSearchWithGlobalOverrideKeepingOnlySingleQuery() throws ExecutionException, RetryException {
+        final String jobId = executeStoredSearch("61977043c1f17d26b45c8a0b", Collections.singletonMap(
+                "global_override", Collections.singletonMap(
+                        "keep_queries", Collections.singleton("f1446410-a082-4871-b3bf-d69aa42d0c97")
+                )
+        ));
+
+        retrieveSearchResults(jobId)
+                .body("execution.completed_exceptionally", equalTo(false))
+                .body("results", not(hasKey("f1446410-a082-4871-b3bf-d69aa42d0c96")))
+                .body("results.f1446410-a082-4871-b3bf-d69aa42d0c97.search_types", hasKey("01c76680-377b-4930-86e2-a55fdb867b58"));
+    }
+
+    @ContainerMatrixTest
     void testThatQueryOrderStaysConsistentInV1() {
         given()
                 .config(sut.withGraylogBackendFailureConfig())

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/Query.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/Query.java
@@ -125,7 +125,7 @@ public abstract class Query implements ContentPackable<QueryEntity>, UsesSearchF
             return this;
         }
 
-        if (state.timerange().isPresent() || state.query().isPresent() || !state.searchTypes().isEmpty() || !state.keepSearchTypes().isEmpty()) {
+        if (state.timerange().isPresent() || state.query().isPresent() || !state.searchTypes().isEmpty() || !state.keepSearchTypes().isEmpty() || !state.keepQueries().isEmpty()) {
             final Builder builder = toBuilder();
 
             if (state.timerange().isPresent() || state.query().isPresent()) {

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/Search.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/Search.java
@@ -108,8 +108,10 @@ public abstract class Search implements ContentPackable<SearchEntity>, Parameter
             builder.parameters(parameters);
         }
 
-        if (executionState.queries() != null || executionState.globalOverride() != null) {
+        var globalOverride = executionState.globalOverride();
+        if (executionState.queries() != null || globalOverride != null) {
             final ImmutableSet<Query> queries = queries().stream()
+                    .filter(query -> globalOverride.keepQueries().isEmpty() || globalOverride.keepQueries().contains(query.id()))
                     .map(query -> query.applyExecutionState(executionState))
                     .collect(toImmutableSet());
             builder.queries(queries);

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/ExecutionStateGlobalOverride.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/ExecutionStateGlobalOverride.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.graylog.plugins.views.search.engine.BackendQuery;
@@ -49,6 +50,9 @@ public abstract class ExecutionStateGlobalOverride {
     @JsonProperty
     public abstract ImmutableSet<String> keepSearchTypes();
 
+    @JsonProperty
+    public abstract ImmutableSet<String> keepQueries();
+
     public abstract Builder toBuilder();
 
     public static Builder builder() {
@@ -61,7 +65,8 @@ public abstract class ExecutionStateGlobalOverride {
                 limit().isPresent() ||
                 offset().isPresent() ||
                 !searchTypes().isEmpty() ||
-                !keepSearchTypes().isEmpty();
+                !keepSearchTypes().isEmpty() ||
+                !keepQueries().isEmpty();
     }
 
     public static ExecutionStateGlobalOverride empty() {
@@ -92,11 +97,16 @@ public abstract class ExecutionStateGlobalOverride {
         public abstract Builder keepSearchTypes(ImmutableSet<String> keepSearchTypes);
 
         @JsonProperty
+        public abstract Builder keepQueries(ImmutableSet<String> keepQueries);
+
+        @JsonProperty
         public abstract Builder searchTypes(ImmutableMap<String, SearchTypeExecutionState> searchTypes);
 
         public abstract ImmutableMap.Builder<String, SearchTypeExecutionState> searchTypesBuilder();
 
         public abstract ImmutableSet.Builder<String> keepSearchTypesBuilder();
+
+        public abstract ImmutableSet.Builder<String> keepQueriesBuilder();
 
         public abstract ExecutionStateGlobalOverride build();
     }

--- a/graylog2-web-interface/src/views/components/QueryBar.test.tsx
+++ b/graylog2-web-interface/src/views/components/QueryBar.test.tsx
@@ -54,6 +54,7 @@ jest.mock('stores/useAppDispatch');
 jest.mock('views/logic/slices/viewSlice', () => ({
   ...jest.requireActual('views/logic/slices/viewSlice'),
   removeQuery: jest.fn(() => async () => {}),
+  selectQuery: jest.fn(() => async () => {}),
 }));
 
 const QueryBar = () => (
@@ -100,7 +101,7 @@ describe('QueryBar', () => {
 
     fireEvent.click(nextTab);
 
-    await waitFor(() => expect(dispatch).toHaveBeenCalledWith(selectQuery('baz')));
+    await waitFor(() => expect(selectQuery).toHaveBeenCalledWith('baz'));
   });
 
   it('allows closing current tab', async () => {

--- a/graylog2-web-interface/src/views/components/dashboard/bigdisplay/CycleQueryTab.test.tsx
+++ b/graylog2-web-interface/src/views/components/dashboard/bigdisplay/CycleQueryTab.test.tsx
@@ -42,6 +42,11 @@ const CycleQueryTab = ({ view, activeQuery, ...props }: AdditionalProps & React.
 
 jest.mock('stores/useAppDispatch');
 
+jest.mock('views/logic/slices/viewSlice', () => ({
+  ...jest.requireActual('views/logic/slices/viewSlice'),
+  selectQuery: jest.fn(() => async () => {}),
+}));
+
 describe('CycleQueryTab', () => {
   const search = Search.create().toBuilder().queries([
     Query.builder().id('foo').build(),
@@ -88,7 +93,7 @@ describe('CycleQueryTab', () => {
 
     jest.advanceTimersByTime(1000);
 
-    expect(dispatch).toHaveBeenCalledWith(selectQuery('baz'));
+    expect(selectQuery).toHaveBeenCalledWith('baz');
   });
 
   it('should switch to first tab if current one is the last', () => {
@@ -99,7 +104,7 @@ describe('CycleQueryTab', () => {
 
     jest.advanceTimersByTime(1000);
 
-    expect(dispatch).toHaveBeenCalledWith(selectQuery('foo'));
+    expect(selectQuery).toHaveBeenCalledWith('foo');
   });
 
   it('should switch to next tab skipping gaps after interval', () => {
@@ -110,7 +115,7 @@ describe('CycleQueryTab', () => {
 
     jest.advanceTimersByTime(1000);
 
-    expect(dispatch).toHaveBeenCalledWith(selectQuery('baz'));
+    expect(selectQuery).toHaveBeenCalledWith('baz');
   });
 
   it('should switch to next tab defaulting to all tabs if `tabs` prop` is left out', () => {
@@ -121,7 +126,7 @@ describe('CycleQueryTab', () => {
 
     jest.advanceTimersByTime(1000);
 
-    expect(dispatch).toHaveBeenCalledWith(selectQuery('bar'));
+    expect(selectQuery).toHaveBeenCalledWith('bar');
   });
 
   it('triggers tab change after the correct interval has passed', async () => {

--- a/graylog2-web-interface/src/views/components/queries/QueryTitle.tsx
+++ b/graylog2-web-interface/src/views/components/queries/QueryTitle.tsx
@@ -52,7 +52,7 @@ const QueryTitle = ({ active, allowsClosing, id, onClose, openEditModal, openCop
   }, [title]);
 
   const _onDuplicate = useCallback(() => dispatch(duplicateQuery(id))
-    .then(({ payload }) => setDashboardPage(payload)), [dispatch, id, setDashboardPage]);
+    .then((queryId) => setDashboardPage(queryId)), [dispatch, id, setDashboardPage]);
 
   return (
     <>

--- a/graylog2-web-interface/src/views/logic/search/GlobalOverride.ts
+++ b/graylog2-web-interface/src/views/logic/search/GlobalOverride.ts
@@ -26,6 +26,7 @@ type InternalState = {
   timerange?: TimeRange,
   query?: QueryString,
   keepSearchTypes?: string[],
+  keepQueries?: string[],
   searchTypes?: SearchTypeOptions,
 };
 
@@ -33,14 +34,15 @@ type JsonRepresentation = {
   timerange?: TimeRange,
   query?: QueryString,
   keep_search_types?: string[],
+  keep_queries?: string[],
   search_types?: SearchTypeOptions,
 };
 
 export default class GlobalOverride {
   private readonly _value: InternalState;
 
-  constructor(timerange?: TimeRange, query?: QueryString, keepSearchTypes?: string[], searchTypes?: SearchTypeOptions) {
-    this._value = { timerange, query, keepSearchTypes, searchTypes };
+  constructor(timerange?: TimeRange, query?: QueryString, keepSearchTypes?: string[], searchTypes?: SearchTypeOptions, keepQueries?: string[]) {
+    this._value = { timerange, query, keepSearchTypes, searchTypes, keepQueries };
   }
 
   get timerange(): TimeRange | undefined | null {
@@ -55,19 +57,23 @@ export default class GlobalOverride {
     return this._value.keepSearchTypes;
   }
 
+  get keepQueries(): string[] | undefined | null {
+    return this._value.keepQueries;
+  }
+
   get searchTypes(): SearchTypeOptions | undefined | null {
     return this._value.searchTypes;
   }
 
   toBuilder(): Builder {
-    const { timerange, query, keepSearchTypes, searchTypes } = this._value;
+    const { timerange, query, keepSearchTypes, searchTypes, keepQueries } = this._value;
 
     // eslint-disable-next-line @typescript-eslint/no-use-before-define
-    return new Builder(Immutable.Map({ timerange, query, keepSearchTypes, searchTypes }));
+    return new Builder(Immutable.Map({ timerange, query, keepSearchTypes, searchTypes, keepQueries }));
   }
 
-  static create(timerange?: TimeRange, query?: QueryString, keepSearchTypes?: string[], searchTypes?: SearchTypeOptions): GlobalOverride {
-    return new GlobalOverride(timerange, query, keepSearchTypes, searchTypes);
+  static create(timerange?: TimeRange, query?: QueryString, keepSearchTypes?: string[], searchTypes?: SearchTypeOptions, keepQueries?: string[]): GlobalOverride {
+    return new GlobalOverride(timerange, query, keepSearchTypes, searchTypes, keepQueries);
   }
 
   static empty(): GlobalOverride {
@@ -75,20 +81,21 @@ export default class GlobalOverride {
   }
 
   toJSON(): JsonRepresentation {
-    const { timerange, query, keepSearchTypes, searchTypes } = this._value;
+    const { timerange, query, keepSearchTypes, keepQueries, searchTypes } = this._value;
 
     return {
       timerange,
       query,
       keep_search_types: keepSearchTypes,
+      keep_queries: keepQueries,
       search_types: searchTypes,
     };
   }
 
   static fromJSON(value: JsonRepresentation): GlobalOverride {
-    const { timerange, query, keep_search_types, search_types } = value;
+    const { timerange, query, keep_search_types, search_types, keep_queries } = value;
 
-    return GlobalOverride.create(timerange, query, keep_search_types, search_types);
+    return GlobalOverride.create(timerange, query, keep_search_types, search_types, keep_queries);
   }
 }
 
@@ -113,13 +120,17 @@ class Builder {
     return new Builder(this.value.set('keepSearchTypes', keepSearchTypes));
   }
 
+  keepQueries(keepQueries: string[]): Builder {
+    return new Builder(this.value.set('keepQueries', keepQueries));
+  }
+
   searchTypes(searchTypes: SearchTypeOptions): Builder {
     return new Builder(this.value.set('searchTypes', searchTypes));
   }
 
   build(): GlobalOverride {
-    const { timerange, query, keepSearchTypes, searchTypes } = this.value.toObject();
+    const { timerange, query, keepSearchTypes, searchTypes, keepQueries } = this.value.toObject();
 
-    return new GlobalOverride(timerange, query, keepSearchTypes, searchTypes);
+    return new GlobalOverride(timerange, query, keepSearchTypes, searchTypes, keepQueries);
   }
 }

--- a/graylog2-web-interface/src/views/logic/slices/executeSearch.ts
+++ b/graylog2-web-interface/src/views/logic/slices/executeSearch.ts
@@ -40,13 +40,17 @@ const executeSearch = (
   view: View,
   widgetsToSearch: string[],
   executionStateParam: SearchExecutionState,
+  keepQueries: string[] = [],
 ): Promise<SearchExecutionResult> => {
   const { widgetMapping, search } = view;
 
-  let executionStateBuilder = executionStateParam.toBuilder();
+  const globalOverride = (executionStateParam.globalOverride ?? GlobalOverride.empty()).toBuilder()
+    .keepQueries(keepQueries)
+    .build();
+
+  let executionStateBuilder = executionStateParam.toBuilder().globalOverride(globalOverride);
 
   if (widgetsToSearch) {
-    const { globalOverride = GlobalOverride.empty() } = executionStateParam;
     const keepSearchTypes = widgetsToSearch.map((widgetId) => widgetMapping.get(widgetId))
       .reduce((acc, searchTypeSet) => [...acc, ...searchTypeSet.toArray()], globalOverride.keepSearchTypes || []);
     const newGlobalOverride = globalOverride.toBuilder().keepSearchTypes(keepSearchTypes).build();

--- a/graylog2-web-interface/src/views/logic/slices/searchExecutionSlice.ts
+++ b/graylog2-web-interface/src/views/logic/slices/searchExecutionSlice.ts
@@ -26,7 +26,7 @@ import { parseSearch } from 'views/logic/slices/searchMetadataSlice';
 import executeSearch from 'views/logic/slices/executeSearch';
 import type View from 'views/logic/views/View';
 import GlobalOverride from 'views/logic/search/GlobalOverride';
-import { selectView, selectParameters } from 'views/logic/slices/viewSelectors';
+import { selectView, selectParameters, selectActiveQuery } from 'views/logic/slices/viewSelectors';
 import {
   selectGlobalOverride,
   selectWidgetsToSearch,
@@ -103,11 +103,12 @@ export const searchExecutionSliceReducer = searchExecutionSlice.reducer;
 
 export const executeWithExecutionState = (
   view: View, widgetsToSearch: Array<string>, executionState: SearchExecutionState, resultMapper: (newResult: SearchExecutionResult) => SearchExecutionResult,
-) => (dispatch: AppDispatch) => dispatch(parseSearch(view.search))
+) => (dispatch: AppDispatch, getState: GetState) => dispatch(parseSearch(view.search))
   .then(() => {
     dispatch(loading());
+    const activeQuery = selectActiveQuery(getState());
 
-    return executeSearch(view, widgetsToSearch, executionState)
+    return executeSearch(view, widgetsToSearch, executionState, [activeQuery])
       .then(resultMapper)
       .then((result) => dispatch(finishedLoading(result)));
   });


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is adding a performance optimization so that only the widgets for the current dashboard page are being executed. For searches, this does not make any difference, as there is always a single page only. For dashboards with lots of widgets (or long time ranges), this can make a big difference regarding search execution times, as widgets which are not currently visible will not be executed.

To achieve this, the following is done in this PR:

  - A parameter `keep_queries` is added to the global override, which
    can be used to select queries which are executed only
  - In the frontend, the currently active query id will always be put
    into the `keep_queries` parameter in the global override

Fixes #6867.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.