### PR TITLE
Improve forwarder compatibility

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/plugin/IOState.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/IOState.java
@@ -41,7 +41,9 @@ public class IOState<T extends Stoppable> {
         FAILED,
         STOPPING,
         STOPPED,
-        TERMINATED
+        TERMINATED,
+        FAILING,
+        UNRECOGNIZED // not a real state, but this helps with forwarder compatibility (see StateReportHandler)
     }
 
     protected T stoppable;


### PR DESCRIPTION
Introducing a new IOState on Forwarder Inputs that the server does not understand will lead to failing ReportState grpc calls.

Unknown enums are converted to UNRECOGNIZED by protobuf. Having this state, allows us to keep compatibility with newer forwarders.

/nocl