### PR TITLE
Retrieve subject initially when constructing `SearchUser`.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/ExecutionState.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/ExecutionState.java
@@ -77,7 +77,6 @@ public abstract class ExecutionState {
             return this;
         }
 
-
         public abstract ImmutableMap.Builder<String, Object> additionalParametersBuilder();
 
         @JsonProperty("additional_parameters")

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/contexts/SearchUserFactory.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/contexts/SearchUserFactory.java
@@ -51,8 +51,12 @@ public class SearchUserFactory implements Factory<SearchUser> {
     public SearchUser provide() {
         final UserContext userContext = serviceLocator.getService(UserContext.class);
         final SecurityContext securityContext = serviceLocator.getService(SecurityContext.class);
-        return new SearchUser(userContext.getUser(), (permission) -> this.isPermitted(securityContext, permission),
-                (permission, instanceId) -> this.isPermitted(securityContext, permission, instanceId), permittedStreams,
+        final Subject subject = getSubject(securityContext);
+        return new SearchUser(
+                userContext.getUser(),
+                subject::isPermitted,
+                (perm, id) -> subject.isPermitted(perm + ":" + id),
+                permittedStreams,
                 viewResolvers);
     }
 
@@ -71,14 +75,6 @@ public class SearchUserFactory implements Factory<SearchUser> {
 
         final ShiroPrincipal principal = (ShiroPrincipal) p;
         return principal.getSubject();
-    }
-
-    protected boolean isPermitted(SecurityContext securityContext, String permission, String instanceId) {
-        return getSubject(securityContext).isPermitted(permission + ":" + instanceId);
-    }
-
-    protected boolean isPermitted(SecurityContext securityContext, String permission) {
-        return getSubject(securityContext).isPermitted(permission);
     }
 
     @Override


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Prior to this PR, in the constructed `SearchUser` instance, the subject was resolved for every call. This lead to the `SearchUser` being unusable in other threads than the one of the request, because for resolving the subject the `ThreadContext` is required.

This PR is now resolving the subject upon construction and keeps the reference to it in the `SearchUser` instance. This has the potential to change the behavior in a subtle way, because due to a single reference being kept instead of resolving the subject for each call, the subject might have changed before between calls and does not do anymore. The behavior now is potentially more consistent for short-running tasks, because the subject is consistent for a single request.

/nocl

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.