### PR TITLE
Avoid excessive index creation for AccessToken

### DIFF
--- a/changelog/unreleased/pr-14926.toml
+++ b/changelog/unreleased/pr-14926.toml
@@ -1,0 +1,5 @@
+type = "f"
+message = "Avoid excessive index creation for AccessToken."
+
+pulls = ["14926"]
+issues = ["Graylog2/graylog-plugin-enterprise#4850"]

--- a/graylog2-server/src/main/java/org/graylog2/bindings/PersistenceServicesBindings.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/PersistenceServicesBindings.java
@@ -56,8 +56,8 @@ public class PersistenceServicesBindings extends AbstractModule {
         bind(InputService.class).to(InputServiceImpl.class);
         bind(UserService.class).to(UserServiceImpl.class);
         OptionalBinder.newOptionalBinder(binder(), UserManagementService.class)
-                      .setDefault().to(UserManagementServiceImpl.class);
-        bind(AccessTokenService.class).to(AccessTokenServiceImpl.class);
+                .setDefault().to(UserManagementServiceImpl.class);
+        bind(AccessTokenService.class).to(AccessTokenServiceImpl.class).asEagerSingleton();
         bind(MongoDBSessionService.class).to(MongoDBSessionServiceImpl.class);
         bind(InputStatusService.class).to(MongoInputStatusService.class).asEagerSingleton();
         bind(EntityListPreferencesService.class).to(EntityListPreferencesServiceImpl.class);

--- a/graylog2-server/src/main/java/org/graylog2/security/AccessTokenServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/security/AccessTokenServiceImpl.java
@@ -32,6 +32,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 import java.math.BigInteger;
 import java.security.SecureRandom;
 import java.util.HashMap;
@@ -45,6 +46,7 @@ import java.util.stream.Collectors;
  * The token value will automatically be encrypted/decrypted when storing/loading the token object from the database.
  * That means the token value is encrypted at rest but the loaded {@link AccessToken} always contains the plain text value.
  */
+@Singleton
 public class AccessTokenServiceImpl extends PersistedServiceImpl implements AccessTokenService {
     private static final Logger LOG = LoggerFactory.getLogger(AccessTokenServiceImpl.class);
 


### PR DESCRIPTION
resolves https://github.com/Graylog2/graylog-plugin-enterprise/issues/4850

## Description
Makes `AccessTokenServiceImpl` a singleton to create index only once on startup.

## Motivation and Context
createIndex for AccessToken was reportedly called >1000 times in 30 minutes, leading to database load.
Can be seen by adding a breakpoint into the constructor.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.