### PR TITLE
ShiroAuthFilter log back to .info()

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/shared/security/ShiroAuthenticationFilter.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/security/ShiroAuthenticationFilter.java
@@ -50,7 +50,7 @@ public class ShiroAuthenticationFilter implements ContainerRequestFilter {
                     LOG.debug("Unable to authenticate user, account is locked.", e);
                     throw new NotAuthorizedException(e, "Basic realm=\"Graylog Server\"");
                 } catch (AuthenticationException e) {
-                    LOG.info("Unable to authenticate user.", e);
+                    LOG.debug("Unable to authenticate user.", e);
                     throw new NotAuthorizedException(e, "Basic realm=\"Graylog Server\"");
                 }
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
We included the `.info()` in #14863 in one line to find an error - but the log-output also now logs an Exception that is actually part of the auth-process. It's ok to see this during debug but not during normal operation.
So this is changed back to `.debug()` so it's not polluting the logs.

/nocl
 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

