### PR TITLE
Backport - Navigation in Sidecar Admin broken if collector is selected (#14925)

### DIFF
--- a/changelog/unreleased/pr-14925.toml
+++ b/changelog/unreleased/pr-14925.toml
@@ -1,0 +1,5 @@
+type = "f"
+message = "Fix pagination of sidecar admin page when collectors are selected."
+
+issues = ["14924"]
+pulls = ["14925"]

--- a/graylog2-web-interface/src/components/sidecars/administration/CollectorsAdministration.tsx
+++ b/graylog2-web-interface/src/components/sidecars/administration/CollectorsAdministration.tsx
@@ -344,6 +344,11 @@ const CollectorsAdministration = ({
     onFilter();
   };
 
+  const handlePageChange = (page: number, pageSize: number) => {
+    setSelected([]);
+    onPageChange(page, pageSize);
+  };
+
   const selectedSidecarCollectorPairs = selected.map((selectedSidecarCollectorId) => {
     return sidecarCollectorPairs.find(({ sidecar, collector }) => sidecarCollectorId(sidecar, collector) === selectedSidecarCollectorId);
   });
@@ -373,7 +378,7 @@ const CollectorsAdministration = ({
     <PaginatedListContainer>
       <PaginatedList pageSizes={PAGE_SIZES}
                      totalItems={pagination.total}
-                     onChange={onPageChange}>
+                     onChange={handlePageChange}>
         <SidecarSearchForm query={query} onSearch={handleSearch} onReset={handleReset} />
         <FiltersSummary collectors={collectors}
                         configurations={configurations}


### PR DESCRIPTION
* fix: clear selected before pagination

(cherry picked from commit 751f73740f0716b8af1c9f732c6e909a0871f1de)

closes #14924 , backport for #14925 
