### PR TITLE
Improve auth token handling for proxied resources

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/ProxiedResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/ProxiedResource.java
@@ -128,17 +128,28 @@ public abstract class ProxiedResource extends RestResource {
     /**
      * Gets an authentication token to be used in an Authorization header of forwarded requests by extracting
      * authentication information from the original request.
+     * <p>
+     * Only extracts an auth token from the request if the request is authenticated. This is to make sure that
+     * forwarded requests will also not be authenticated.
+     * <p>
+     * If the request is authenticated, but not by means of an authentication token, this method will fail with
+     * a {@link NotAuthorizedException} because we can't easily make up a token to use for forwarded requests in that
+     * case.
      *
-     * @return An authentication token if one could be extracted from the original requeest. Null otherwise.
+     * @return An authentication token if the request was authenticated and one could be extracted from the original
+     * request. Null otherwise.
      * @throws NotAuthorizedException if the original request was authenticated, but no authentication token could
      *                                be created from the request headers.
      */
     @Nullable
     protected String getAuthenticationToken() {
-        if (getSubject().isAuthenticated() && authenticationToken == null) {
-            throw new NotAuthorizedException("Basic realm=\"Graylog Server\"");
+        if (getSubject().isAuthenticated()) {
+            if (authenticationToken == null) {
+                throw new NotAuthorizedException("Basic realm=\"Graylog Server\"");
+            }
+            return authenticationToken;
         }
-        return authenticationToken;
+        return null;
     }
 
     /**

--- a/graylog2-server/src/test/java/org/graylog2/rest/resources/cluster/ClusterLookupTableResourceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/rest/resources/cluster/ClusterLookupTableResourceTest.java
@@ -104,7 +104,9 @@ public class ClusterLookupTableResourceTest {
 
             @Override
             protected Subject getSubject() {
-                return mock(Subject.class);
+                final Subject subject = mock(Subject.class);
+                when(subject.isAuthenticated()).thenReturn(true);
+                return subject;
             }
         };
     }


### PR DESCRIPTION
Make authentication token handling for proxied resources a bit more obvious:

- Add explaining JavaDoc
- Explicitly don't add an authentication token to forwarded requests if the original request was unauthenticated

/nocl