### PR TITLE
(Backport 4.3) - Updated MongoInputStatusService to use correct Subscribe import

### DIFF
--- a/changelog/unreleased/issue-14952.toml
+++ b/changelog/unreleased/issue-14952.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Fixed bug causing input status data not to be removed when an input was deleted."
+
+issues = ["14952"]
+pulls = ["14954","Graylog2/forwarder#99"]

--- a/graylog2-server/src/main/java/org/graylog2/inputs/persistence/MongoInputStatusService.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/persistence/MongoInputStatusService.java
@@ -17,9 +17,9 @@
 package org.graylog2.inputs.persistence;
 
 import com.google.common.eventbus.EventBus;
+import com.google.common.eventbus.Subscribe;
 import com.mongodb.DB;
 import com.mongodb.DBCollection;
-import org.apache.shiro.event.Subscribe;
 import org.bson.types.ObjectId;
 import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
 import org.graylog2.database.MongoConnection;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
4.3 Backport of: https://github.com/Graylog2/graylog2-server/pull/14954

Updated the `MongoInputStatusService` import for `@Subscribe` to use `com.google.common.eventbus.Subscribe` instead of `org.apache.shiro.event.Subscribe`.

## Description
<!--- Describe your changes in detail -->
The `handleInputDeleted` method was never being called because of the incorrect import for the `@Subscribe` annotation. Because of this an input's entries in the `input_status` MongoDB collection were never removed after an input was deleted.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Resolves: https://github.com/Graylog2/graylog2-server/issues/14952

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally in development environment.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
