### PR TITLE
Return validation failure message string

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/events/rest/EventDefinitionsResource.java
+++ b/graylog2-server/src/main/java/org/graylog/events/rest/EventDefinitionsResource.java
@@ -304,7 +304,7 @@ public class EventDefinitionsResource extends RestResource implements PluginRest
             ValidationResult validationResult = new ValidationResult()
                 .addError("dependency", msg)
                 .addContext("dependency_ids", dependenciesIds);
-            throw new ValidationFailureException(validationResult);
+            throw new ValidationFailureException(validationResult, msg);
         }
 
         eventDefinitionDto.ifPresent(d ->

--- a/graylog2-server/src/main/java/org/graylog2/plugin/rest/ValidationFailureException.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/rest/ValidationFailureException.java
@@ -23,6 +23,11 @@ public class ValidationFailureException extends RuntimeException {
         this.validationResult = validationResult;
     }
 
+    public ValidationFailureException(ValidationResult validationResult, String message) {
+        super(message);
+        this.validationResult = validationResult;
+    }
+
     public ValidationResult getValidationResult() {
         return validationResult;
     }


### PR DESCRIPTION
/nocl

#14792 detects dependencies when deleting event definitions and returns a corresponding `ValidationFailureException`.  
However, the error message does not make it to the UI when this is performed via bulk execution, because it is only being returned in the `errors` list, and not in the exception's detail message. But it is the latter that is used:

https://github.com/Graylog2/graylog2-server/blob/7f51399fa2477fa7580409cd7ed11fe4e53707c2/graylog2-server/src/main/java/org/graylog2/rest/bulk/SequentialBulkExecutor.java#L100-L101