### PR TITLE
Backport 4.3 - Avoid excessive index creation for AccessToken (#14926)

### DIFF
--- a/changelog/unreleased/pr-14926.toml
+++ b/changelog/unreleased/pr-14926.toml
@@ -1,0 +1,5 @@
+type = "f"
+message = "Avoid excessive index creation for AccessToken."
+
+pulls = ["14926"]
+issues = ["Graylog2/graylog-plugin-enterprise#4850"]

--- a/graylog2-server/src/main/java/org/graylog2/security/AccessTokenServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/security/AccessTokenServiceImpl.java
@@ -32,6 +32,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 import java.math.BigInteger;
 import java.security.SecureRandom;
 import java.util.HashMap;
@@ -45,6 +46,7 @@ import java.util.stream.Collectors;
  * The token value will automatically be encrypted/decrypted when storing/loading the token object from the database.
  * That means the token value is encrypted at rest but the loaded {@link AccessToken} always contains the plain text value.
  */
+@Singleton
 public class AccessTokenServiceImpl extends PersistedServiceImpl implements AccessTokenService {
     private static final Logger LOG = LoggerFactory.getLogger(AccessTokenServiceImpl.class);
 


### PR DESCRIPTION
* fix: make AccessTokenServiceImpl a singleton

* changelog

(cherry picked from commit 69943053d97247a469540581661c9b4d4a525347)


