### PR TITLE
Optimize service bindings in PersistenceServiceBindings

### DIFF
--- a/changelog/unreleased/pr-14965.toml
+++ b/changelog/unreleased/pr-14965.toml
@@ -1,0 +1,5 @@
+type = "c"
+message = "Make sure all bindings which use createIndex are threadsafe and make them singletons."
+
+pulls = ["14965"]
+issues = ["Graylog2/graylog-plugin-enterprise#4862"]

--- a/graylog2-server/src/main/java/org/graylog2/bindings/PersistenceServicesBindings.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/PersistenceServicesBindings.java
@@ -48,17 +48,17 @@ import org.graylog2.users.UserServiceImpl;
 public class PersistenceServicesBindings extends AbstractModule {
     @Override
     protected void configure() {
-        bind(SystemMessageService.class).to(SystemMessageServiceImpl.class);
-        bind(NotificationService.class).to(NotificationServiceImpl.class);
-        bind(IndexFailureService.class).to(IndexFailureServiceImpl.class);
+        bind(SystemMessageService.class).to(SystemMessageServiceImpl.class).asEagerSingleton();
+        bind(NotificationService.class).to(NotificationServiceImpl.class).asEagerSingleton();
+        bind(IndexFailureService.class).to(IndexFailureServiceImpl.class).asEagerSingleton();
         bind(NodeService.class).to(NodeServiceImpl.class);
         bind(IndexRangeService.class).to(MongoIndexRangeService.class).asEagerSingleton();
         bind(InputService.class).to(InputServiceImpl.class);
-        bind(UserService.class).to(UserServiceImpl.class);
+        bind(UserService.class).to(UserServiceImpl.class).asEagerSingleton();
         OptionalBinder.newOptionalBinder(binder(), UserManagementService.class)
                 .setDefault().to(UserManagementServiceImpl.class);
         bind(AccessTokenService.class).to(AccessTokenServiceImpl.class).asEagerSingleton();
-        bind(MongoDBSessionService.class).to(MongoDBSessionServiceImpl.class);
+        bind(MongoDBSessionService.class).to(MongoDBSessionServiceImpl.class).asEagerSingleton();
         bind(InputStatusService.class).to(MongoInputStatusService.class).asEagerSingleton();
         bind(EntityListPreferencesService.class).to(EntityListPreferencesServiceImpl.class);
         bind(EntitySuggestionService.class).to(MongoEntitySuggestionService.class);

--- a/graylog2-server/src/main/java/org/graylog2/indexer/ranges/MongoIndexRangeService.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/ranges/MongoIndexRangeService.java
@@ -48,6 +48,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
+import javax.inject.Singleton;
 import java.util.Iterator;
 import java.util.SortedSet;
 import java.util.concurrent.TimeUnit;
@@ -56,6 +57,7 @@ import static org.graylog2.audit.AuditEventTypes.ES_INDEX_RANGE_CREATE;
 import static org.graylog2.audit.AuditEventTypes.ES_INDEX_RANGE_DELETE;
 import static org.graylog2.indexer.indices.Indices.checkIfHealthy;
 
+@Singleton
 public class MongoIndexRangeService implements IndexRangeService {
     private static final Logger LOG = LoggerFactory.getLogger(MongoIndexRangeService.class);
     private static final String COLLECTION_NAME = "index_ranges";
@@ -79,25 +81,25 @@ public class MongoIndexRangeService implements IndexRangeService {
         this.auditEventSender = auditEventSender;
         this.nodeId = nodeId;
         this.collection = JacksonDBCollection.wrap(
-            mongoConnection.getDatabase().getCollection(COLLECTION_NAME),
-            MongoIndexRange.class,
-            ObjectId.class,
-            objectMapperProvider.get());
+                mongoConnection.getDatabase().getCollection(COLLECTION_NAME),
+                MongoIndexRange.class,
+                ObjectId.class,
+                objectMapperProvider.get());
 
         eventBus.register(this);
 
         collection.createIndex(new BasicDBObject(MongoIndexRange.FIELD_INDEX_NAME, 1));
         collection.createIndex(BasicDBObjectBuilder.start()
-            .add(MongoIndexRange.FIELD_BEGIN, 1)
-            .add(MongoIndexRange.FIELD_END, 1)
-            .get());
+                .add(MongoIndexRange.FIELD_BEGIN, 1)
+                .add(MongoIndexRange.FIELD_END, 1)
+                .get());
     }
 
     @Override
     public IndexRange get(String index) throws NotFoundException {
         final DBQuery.Query query = DBQuery.and(
-            DBQuery.notExists("start"),
-            DBQuery.is(IndexRange.FIELD_INDEX_NAME, index));
+                DBQuery.notExists("start"),
+                DBQuery.is(IndexRange.FIELD_INDEX_NAME, index));
         final MongoIndexRange indexRange = collection.findOne(query);
         if (indexRange == null) {
             throw new NotFoundException("Index range for index <" + index + "> not found.");

--- a/graylog2-server/src/main/java/org/graylog2/notifications/NotificationServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/notifications/NotificationServiceImpl.java
@@ -39,6 +39,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
@@ -49,6 +50,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static org.graylog2.audit.AuditEventTypes.SYSTEM_NOTIFICATION_CREATE;
 import static org.graylog2.audit.AuditEventTypes.SYSTEM_NOTIFICATION_DELETE;
 
+@Singleton
 public class NotificationServiceImpl extends PersistedServiceImpl implements NotificationService {
     private static final Logger LOG = LoggerFactory.getLogger(NotificationServiceImpl.class);
 

--- a/graylog2-server/src/main/java/org/graylog2/system/activities/SystemMessageServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/system/activities/SystemMessageServiceImpl.java
@@ -25,16 +25,18 @@ import org.bson.types.ObjectId;
 import org.graylog2.database.CollectionName;
 import org.graylog2.database.MongoConnection;
 import org.graylog2.database.PersistedServiceImpl;
-import org.graylog2.indexer.IndexFailureImpl;
 import org.mongojack.DBSort;
 
 import javax.inject.Inject;
+import javax.inject.Singleton;
 import java.util.List;
 import java.util.Map;
 
+@Singleton
 public class SystemMessageServiceImpl extends PersistedServiceImpl implements SystemMessageService {
     private static final int MAX_COLLECTION_BYTES = 50 * 1024 * 1024;
-    private final int PER_PAGE = 30;
+    private static final int PER_PAGE = 30;
+
     @Inject
     public SystemMessageServiceImpl(MongoConnection mongoConnection) {
         super(mongoConnection);

--- a/graylog2-server/src/main/java/org/graylog2/users/UserServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/users/UserServiceImpl.java
@@ -54,6 +54,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -69,6 +70,7 @@ import java.util.stream.Collectors;
 import static com.google.common.base.Preconditions.checkArgument;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
+@Singleton
 public class UserServiceImpl extends PersistedServiceImpl implements UserService {
     private static final Logger LOG = LoggerFactory.getLogger(UserServiceImpl.class);
 


### PR DESCRIPTION
## Description

make sure all bindings which use `createIndex()` in the constructor are threadsafe and make them a singleton.

Also use `asEagerSingleton()` and annotation for all singletons.

resolves https://github.com/Graylog2/graylog-plugin-enterprise/issues/4862

## Motivation and Context
`createIndex` makes unnecessary calls to mongoDB.
Eager instantiation helps in finding binding bugs, since they will show up immediately at startup.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

