### PR TITLE
Fix permission checks for role "Event Notification Creator"

### DIFF
--- a/changelog/unreleased/pr-14974.toml
+++ b/changelog/unreleased/pr-14974.toml
@@ -1,0 +1,5 @@
+type = "f"
+message = "Fix error on missing permission when creating email event notifications. Adds `users:list` permission to role User Inspector"
+
+pulls = ["14974"]
+issues = ["Graylog2/graylog-plugin-enterprise#4886"]

--- a/graylog2-server/src/main/java/org/graylog2/shared/security/RestPermissions.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/security/RestPermissions.java
@@ -316,7 +316,7 @@ public class RestPermissions implements PluginPermissions {
                     RestPermissions.EVENT_NOTIFICATIONS_CREATE
             )),
             BuiltinRole.create("User Inspector", "Allows listing all user accounts (built-in)", ImmutableSet.of(
-                    RestPermissions.USERS_READ
+                    RestPermissions.USERS_READ, RestPermissions.USERS_LIST
             ))
     ).build();
 

--- a/graylog2-web-interface/src/components/event-notifications/event-notification-types/EmailNotificationForm.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-types/EmailNotificationForm.jsx
@@ -19,7 +19,7 @@ import PropTypes from 'prop-types';
 import cloneDeep from 'lodash/cloneDeep';
 import get from 'lodash/get';
 
-import { MultiSelect, SourceCodeEditor, TimezoneSelect } from 'components/common';
+import { IfPermitted, MultiSelect, SourceCodeEditor, TimezoneSelect } from 'components/common';
 import UsersSelectField from 'components/users/UsersSelectField';
 import { ControlLabel, FormGroup, HelpBlock, Input } from 'components/bootstrap';
 import { getValueFromInput } from 'util/FormsUtils';
@@ -163,16 +163,19 @@ class EmailNotificationForm extends React.Component {
                  value={config.sender || ''}
                  onChange={this.handleChange} />
         </HideOnCloud>
-        <FormGroup controlId="notification-user-recipients"
-                   validationState={validation.errors.recipients ? 'error' : null}>
-          <ControlLabel>User recipient(s) <small className="text-muted">(Optional)</small></ControlLabel>
-          <UsersSelectField id="notification-user-recipients"
-                            value={Array.isArray(config.user_recipients) ? config.user_recipients.join(',') : ''}
-                            onChange={this.handleRecipientsChange('user_recipients')} />
-          <HelpBlock>
-            {get(validation, 'errors.recipients[0]', 'Select Graylog users that will receive this Notification.')}
-          </HelpBlock>
-        </FormGroup>
+
+        <IfPermitted permissions="users:list">
+          <FormGroup controlId="notification-user-recipients"
+                     validationState={validation.errors.recipients ? 'error' : null}>
+            <ControlLabel>User recipient(s) <small className="text-muted">(Optional)</small></ControlLabel>
+            <UsersSelectField id="notification-user-recipients"
+                              value={Array.isArray(config.user_recipients) ? config.user_recipients.join(',') : ''}
+                              onChange={this.handleRecipientsChange('user_recipients')} />
+            <HelpBlock>
+              {get(validation, 'errors.recipients[0]', 'Select Graylog users that will receive this Notification.')}
+            </HelpBlock>
+          </FormGroup>
+        </IfPermitted>
 
         <FormGroup controlId="notification-email-recipients"
                    validationState={validation.errors.recipients ? 'error' : null}>


### PR DESCRIPTION
## Description
Users with role "Event Notification Creator" got an error when trying to create a email notification.
This was caused by the user selection dropdown in that notification type's form checking if the user has the permission `users:list` and returning undefined. The permission check was moved into the form and prevents the whole field from showing when the user does not have the permission.

Additionally, the permission was added to the role "User inspector", which only had `users:read` previously to be able to assign a sensible role which actually has this permission.

## Motivation and Context
closes https://github.com/Graylog2/graylog-plugin-enterprise/issues/4886

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

