### PR TITLE
Use singleton scope to bind some services

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/security/DBGrantService.java
+++ b/graylog2-server/src/main/java/org/graylog/security/DBGrantService.java
@@ -30,6 +30,7 @@ import org.mongojack.DBQuery;
 
 import javax.annotation.Nullable;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.Collection;
@@ -43,6 +44,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
+@Singleton
 public class DBGrantService extends PaginatedDbService<GrantDTO> {
     public static final String COLLECTION_NAME = "grants";
 
@@ -194,9 +196,9 @@ public class DBGrantService extends PaginatedDbService<GrantDTO> {
 
     public Map<GRN, Set<GRN>> getOwnersForTargets(Collection<GRN> targets) {
         return db.find(DBQuery.and(
-                DBQuery.in(GrantDTO.FIELD_TARGET, targets),
-                DBQuery.is(GrantDTO.FIELD_CAPABILITY, Capability.OWN)
-        )).toArray()
+                        DBQuery.in(GrantDTO.FIELD_TARGET, targets),
+                        DBQuery.is(GrantDTO.FIELD_CAPABILITY, Capability.OWN)
+                )).toArray()
                 .stream()
                 .collect(Collectors.groupingBy(
                         GrantDTO::target,

--- a/graylog2-server/src/main/java/org/graylog2/bindings/PersistenceServicesBindings.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/PersistenceServicesBindings.java
@@ -17,6 +17,7 @@
 package org.graylog2.bindings;
 
 import com.google.inject.AbstractModule;
+import com.google.inject.Scopes;
 import com.google.inject.multibindings.OptionalBinder;
 import org.graylog2.cluster.NodeService;
 import org.graylog2.cluster.NodeServiceImpl;
@@ -54,7 +55,7 @@ public class PersistenceServicesBindings extends AbstractModule {
         bind(NodeService.class).to(NodeServiceImpl.class);
         bind(IndexRangeService.class).to(MongoIndexRangeService.class).asEagerSingleton();
         bind(InputService.class).to(InputServiceImpl.class);
-        bind(UserService.class).to(UserServiceImpl.class);
+        bind(UserService.class).to(UserServiceImpl.class).in(Scopes.SINGLETON);
         OptionalBinder.newOptionalBinder(binder(), UserManagementService.class)
                 .setDefault().to(UserManagementServiceImpl.class);
         bind(AccessTokenService.class).to(AccessTokenServiceImpl.class).asEagerSingleton();

--- a/graylog2-server/src/main/java/org/graylog2/bindings/PersistenceServicesBindings.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/PersistenceServicesBindings.java
@@ -50,7 +50,7 @@ public class PersistenceServicesBindings extends AbstractModule {
     @Override
     protected void configure() {
         bind(SystemMessageService.class).to(SystemMessageServiceImpl.class);
-        bind(NotificationService.class).to(NotificationServiceImpl.class);
+        bind(NotificationService.class).to(NotificationServiceImpl.class).in(Scopes.SINGLETON);
         bind(IndexFailureService.class).to(IndexFailureServiceImpl.class);
         bind(NodeService.class).to(NodeServiceImpl.class);
         bind(IndexRangeService.class).to(MongoIndexRangeService.class).asEagerSingleton();

--- a/graylog2-server/src/main/java/org/graylog2/notifications/NotificationServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/notifications/NotificationServiceImpl.java
@@ -39,6 +39,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
@@ -49,6 +50,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static org.graylog2.audit.AuditEventTypes.SYSTEM_NOTIFICATION_CREATE;
 import static org.graylog2.audit.AuditEventTypes.SYSTEM_NOTIFICATION_DELETE;
 
+@Singleton
 public class NotificationServiceImpl extends PersistedServiceImpl implements NotificationService {
     private static final Logger LOG = LoggerFactory.getLogger(NotificationServiceImpl.class);
 

--- a/graylog2-server/src/main/java/org/graylog2/users/UserServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/users/UserServiceImpl.java
@@ -54,6 +54,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -69,6 +70,7 @@ import java.util.stream.Collectors;
 import static com.google.common.base.Preconditions.checkArgument;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
+@Singleton
 public class UserServiceImpl extends PersistedServiceImpl implements UserService {
     private static final Logger LOG = LoggerFactory.getLogger(UserServiceImpl.class);
 


### PR DESCRIPTION
Some services ensure that proper indexes exist in MongoDB in their constructor.

If the services are not bound as singletons, we issue a bunch of unnecessary index create calls e.g. for REST API requests.

Together with https://github.com/Graylog2/graylog-plugin-enterprise/pull/4888 this is the effect:

Before:
![image](https://user-images.githubusercontent.com/886541/226323773-4db8a6dd-1d05-4bc9-b9a9-1f467a200729.png)

After:
![image](https://user-images.githubusercontent.com/886541/226322764-ea4c55ce-50b5-464a-87db-0d1dd30a55bd.png)

/nocl

