### PR TITLE
Remove stacktrace from error page

### DIFF
--- a/changelog/unreleased/pr-14978.toml
+++ b/changelog/unreleased/pr-14978.toml
@@ -1,0 +1,5 @@
+type = "c"
+message = "Remove stack trace from the generic server error response."
+
+pulls = ["14978"]
+issues = ["Graylog2/graylog-plugin-enterprise#4891"]

--- a/graylog2-server/src/main/java/org/graylog2/rest/GraylogErrorPageGenerator.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/GraylogErrorPageGenerator.java
@@ -25,8 +25,6 @@ import org.glassfish.grizzly.http.server.Request;
 
 import javax.inject.Inject;
 import java.io.IOException;
-import java.io.PrintWriter;
-import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 
@@ -56,20 +54,8 @@ public class GraylogErrorPageGenerator implements ErrorPageGenerator {
         }
 
         if (exception != null) {
-            String stacktrace = "";
             String exceptionString = Objects.nonNull(exception.getMessage()) ? exception.getMessage() : "Null";
-            try (final StringWriter stringWriter = new StringWriter();
-                 final PrintWriter printWriter = new PrintWriter(stringWriter)) {
-                exception.printStackTrace(printWriter);
-                printWriter.flush();
-                stringWriter.flush();
-                stacktrace = stringWriter.toString();
-            } catch (IOException ignored) {
-                // Ignore
-            }
-            modelBuilder
-                    .put("exception", StringEscapeUtils.escapeHtml4(exceptionString))
-                    .put("stacktrace", StringEscapeUtils.escapeHtml4(stacktrace));
+            modelBuilder.put("exception", StringEscapeUtils.escapeHtml4(exceptionString));
         }
 
         return engine.transform(template, modelBuilder.build());

--- a/graylog2-server/src/main/resources/error.html.template
+++ b/graylog2-server/src/main/resources/error.html.template
@@ -10,10 +10,6 @@
 ${if exception}
 <h2>Reason</h2>
 <p>${exception}</p>
-<h2>Stacktrace</h2>
-<p><pre>
-${stacktrace}
-</pre></p>
 ${end}
 </body>
 </html>


### PR DESCRIPTION
Resolves Graylog2/graylog-plugin-enterprise#4891

Remove stack trace from server error page.