### PR TITLE
add content type option filter

### DIFF
--- a/changelog/unreleased/pr-14987.toml
+++ b/changelog/unreleased/pr-14987.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Sending new header on server response X-Content-Type-Options:nosniff"
+
+issues = ["Graylog2/graylog-plugin-enterprise#4890"]
+pull = ["14987"]

--- a/graylog2-server/src/main/java/org/graylog2/shared/initializers/JerseyService.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/initializers/JerseyService.java
@@ -48,6 +48,7 @@ import org.graylog2.plugin.rest.PluginRestResource;
 import org.graylog2.rest.MoreMediaTypes;
 import org.graylog2.rest.filter.WebAppNotFoundResponseFilter;
 import org.graylog2.shared.rest.CORSFilter;
+import org.graylog2.shared.rest.ContentTypeOptionFilter;
 import org.graylog2.shared.rest.EmbeddingControlFilter;
 import org.graylog2.shared.rest.NodeIdResponseFilter;
 import org.graylog2.shared.rest.NotAuthorizedResponseFilter;
@@ -265,7 +266,8 @@ public class JerseyService extends AbstractIdleService {
                         NotAuthorizedResponseFilter.class,
                         WebAppNotFoundResponseFilter.class,
                         EmbeddingControlFilter.class,
-                        OptionalResponseFilter.class)
+                        OptionalResponseFilter.class,
+                        ContentTypeOptionFilter.class)
                 // Replacing this with a lambda leads to missing subtypes - https://github.com/Graylog2/graylog2-server/pull/10617#discussion_r630236360
                 .register(new ContextResolver<ObjectMapper>() {
                     @Override

--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/ContentTypeOptionFilter.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/ContentTypeOptionFilter.java
@@ -1,0 +1,15 @@
+package org.graylog2.shared.rest;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+import java.io.IOException;
+
+public class ContentTypeOptionFilter implements ContainerResponseFilter {
+    public static final String X_CONTENT_TYPE_OPTIONS = "X-Content-Type-Options";
+
+    @Override
+    public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) throws IOException {
+        responseContext.getHeaders().add(X_CONTENT_TYPE_OPTIONS, "nosniff");
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/ContentTypeOptionFilter.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/ContentTypeOptionFilter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog2.shared.rest;
 
 import javax.ws.rs.container.ContainerRequestContext;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adding new Filter thats sending new header on server response X-Content-Type-Options:nosniff
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fixes Graylog2/graylog-plugin-enterprise#4890
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally, check header responses in the webinterface
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

