### PR TITLE
Disable ParameterizedHttpClientProviderTest

### DIFF
--- a/graylog2-server/src/test/java/org/graylog2/shared/bindings/providers/ParameterizedHttpClientProviderTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/shared/bindings/providers/ParameterizedHttpClientProviderTest.java
@@ -40,6 +40,7 @@ import java.security.NoSuchAlgorithmException;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+@Ignore("This test is flaky. Maybe a race within MockWebServer")
 public class ParameterizedHttpClientProviderTest {
 
     private final MockWebServer server = new MockWebServer();


### PR DESCRIPTION
It has shown random test failures on jenkins and github.

Maybe for the same reason we disabled the
OkHttpClientProviderTest (#7799)

/nocl