### PR TITLE
Avoid opening node details in new tab. (`5.0`)

### DIFF
--- a/changelog/unreleased/pr-14762.toml
+++ b/changelog/unreleased/pr-14762.toml
@@ -1,0 +1,4 @@
+type = "f"
+message = "Avoid full-page refresh when showing node details from message details."
+
+pulls = ["14762"]

--- a/changelog/unreleased/pr-14992.toml
+++ b/changelog/unreleased/pr-14992.toml
@@ -1,4 +1,4 @@
 type = "f"
 message = "Avoid full-page refresh when showing node details from message details."
 
-pulls = ["14762"]
+pulls = ["14992"]

--- a/graylog2-web-interface/src/views/components/messagelist/NodeName.tsx
+++ b/graylog2-web-interface/src/views/components/messagelist/NodeName.tsx
@@ -16,39 +16,44 @@
  */
 import * as React from 'react';
 import PropTypes from 'prop-types';
+import styled from 'styled-components';
 
 import Routes from 'routing/Routes';
 import { Icon } from 'components/common';
 import { useStore } from 'stores/connect';
 import { NodesStore } from 'stores/nodes/NodesStore';
+import { Link } from 'components/common/router';
 
 type NodeId = string;
 type Props = {
   nodeId: NodeId,
 };
 
+const BreakWord = styled.span`
+  wordBreak: 'break-word';
+`;
+
 const NodeName = ({ nodeId }: Props) => {
-  const nodes = useStore(NodesStore, (state) => state?.nodes ?? {});
-  const node = nodes[nodeId];
+  const node = useStore(NodesStore, (state) => state?.nodes?.[nodeId]);
 
   if (node) {
     const nodeURL = Routes.node(nodeId);
 
     return (
-      <a href={nodeURL}>
+      <Link to={nodeURL}>
         <Icon name="code-branch" />
         &nbsp;
-        <span style={{ wordBreak: 'break-word' }}>
+        <BreakWord>
           {node.short_node_id}
-        </span>&nbsp;/&nbsp;
-        <span style={{ wordBreak: 'break-word' }}>
+        </BreakWord>&nbsp;/&nbsp;
+        <BreakWord>
           {node.hostname}
-        </span>
-      </a>
+        </BreakWord>
+      </Link>
     );
   }
 
-  return <span style={{ wordBreak: 'break-word' }}>stopped node</span>;
+  return <BreakWord>stopped node</BreakWord>;
 };
 
 NodeName.propTypes = {


### PR DESCRIPTION
**Note:** This is a backport of #14762 to `5.0`.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Prior to this PR, clicking on the link to a node did open its details page after doing a full page refresh. This is inconsistent with other parts of the product and disrupts the user flow due to a longer loading time.

This change is now making sure that we are using the internal router to get to the new page.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.