### PR TITLE
Datanode periodical for NodeService pings

### DIFF
--- a/data-node/pom.xml
+++ b/data-node/pom.xml
@@ -413,6 +413,12 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
 
         <dependency>
             <groupId>io.rest-assured</groupId>

--- a/data-node/src/main/java/org/graylog/datanode/bindings/PeriodicalBindings.java
+++ b/data-node/src/main/java/org/graylog/datanode/bindings/PeriodicalBindings.java
@@ -19,11 +19,10 @@ package org.graylog.datanode.bindings;
 import com.google.inject.AbstractModule;
 import com.google.inject.multibindings.Multibinder;
 import org.graylog.datanode.periodicals.ClusterManagerDiscovery;
+import org.graylog.datanode.periodicals.NodePingPeriodical;
 import org.graylog.datanode.periodicals.OpensearchNodeHeartbeat;
 import org.graylog2.events.ClusterEventCleanupPeriodical;
 import org.graylog2.events.ClusterEventPeriodical;
-import org.graylog2.periodical.NodePingThread;
-import org.graylog2.periodical.UserSessionTerminationPeriodical;
 import org.graylog2.plugin.periodical.Periodical;
 
 public class PeriodicalBindings extends AbstractModule {
@@ -35,6 +34,6 @@ public class PeriodicalBindings extends AbstractModule {
         periodicalBinder.addBinding().to(OpensearchNodeHeartbeat.class);
         periodicalBinder.addBinding().to(ClusterManagerDiscovery.class);
 //        periodicalBinder.addBinding().to(UserSessionTerminationPeriodical.class);
-//        periodicalBinder.addBinding().to(NodePingThread.class);
+        periodicalBinder.addBinding().to(NodePingPeriodical.class);
     }
 }

--- a/data-node/src/main/java/org/graylog/datanode/management/OpensearchProcess.java
+++ b/data-node/src/main/java/org/graylog/datanode/management/OpensearchProcess.java
@@ -29,6 +29,7 @@ public interface OpensearchProcess extends ManagableProcess {
 
     Object nodeName();
 
+    boolean isLeaderNode();
     void setLeaderNode(boolean isManagerNode);
 
     String opensearchVersion();

--- a/data-node/src/main/java/org/graylog/datanode/management/OpensearchProcessImpl.java
+++ b/data-node/src/main/java/org/graylog/datanode/management/OpensearchProcessImpl.java
@@ -133,6 +133,7 @@ class OpensearchProcessImpl implements OpensearchProcess, ProcessListener {
         this.isLeaderNode = isLeaderNode;
     }
 
+    @Override
     public boolean isLeaderNode() {
         return isLeaderNode;
     }

--- a/data-node/src/main/java/org/graylog/datanode/periodicals/NodePingPeriodical.java
+++ b/data-node/src/main/java/org/graylog/datanode/periodicals/NodePingPeriodical.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.datanode.periodicals;
+
+import org.graylog.datanode.Configuration;
+import org.graylog.datanode.management.OpensearchProcess;
+import org.graylog2.cluster.Node;
+import org.graylog2.cluster.NodeNotFoundException;
+import org.graylog2.cluster.NodeService;
+import org.graylog2.plugin.Tools;
+import org.graylog2.plugin.periodical.Periodical;
+import org.graylog2.plugin.system.NodeId;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+import javax.inject.Inject;
+import java.net.URI;
+
+public class NodePingPeriodical extends Periodical {
+
+    private static final Logger LOG = LoggerFactory.getLogger(NodePingPeriodical.class);
+
+    private final NodeService nodeService;
+    private final NodeId nodeId;
+    private final Configuration configuration;
+    private final OpensearchProcess managedOpenSearch;
+
+    @Inject
+    public NodePingPeriodical(NodeService nodeService, NodeId nodeId, Configuration configuration, OpensearchProcess managedOpenSearch) {
+        this.nodeService = nodeService;
+        this.nodeId = nodeId;
+        this.configuration = configuration;
+        this.managedOpenSearch = managedOpenSearch;
+    }
+
+    @Override
+    public boolean runsForever() {
+        return false;
+    }
+
+    @Override
+    public boolean stopOnGracefulShutdown() {
+        return false;
+    }
+
+    @Override
+    public boolean startOnThisNode() {
+        return true;
+    }
+
+    @Override
+    public boolean isDaemon() {
+        return true;
+    }
+
+    @Override
+    public int getInitialDelaySeconds() {
+        return 0;
+    }
+
+    @Override
+    public int getPeriodSeconds() {
+        return 1;
+    }
+
+    @Nonnull
+    @Override
+    protected Logger getLogger() {
+        return LOG;
+    }
+
+    @Override
+    public void doRun() {
+
+        final boolean isLeader = managedOpenSearch.isLeaderNode();
+        final URI httpPublishUri = configuration.getHttpPublishUri();
+        try {
+            final Node node = nodeService.byNodeId(nodeId);
+            nodeService.markAsAlive(node, isLeader, httpPublishUri);
+        } catch (NodeNotFoundException e) {
+            LOG.warn("Did not find meta info of this node. Re-registering.");
+            nodeService.registerServer(nodeId.getNodeId(),
+                    isLeader,
+                    httpPublishUri,
+                    Tools.getLocalCanonicalHostname());
+        }
+    }
+}

--- a/data-node/src/main/java/org/graylog/datanode/periodicals/NodePingPeriodical.java
+++ b/data-node/src/main/java/org/graylog/datanode/periodicals/NodePingPeriodical.java
@@ -90,8 +90,7 @@ public class NodePingPeriodical extends Periodical {
         final boolean isLeader = managedOpenSearch.isLeaderNode();
         final URI httpPublishUri = configuration.getHttpPublishUri();
         try {
-            final Node node = nodeService.byNodeId(nodeId);
-            nodeService.markAsAlive(node, isLeader, httpPublishUri);
+            nodeService.markAsAlive(nodeId, isLeader, httpPublishUri);
         } catch (NodeNotFoundException e) {
             LOG.warn("Did not find meta info of this node. Re-registering.");
             nodeService.registerServer(nodeId.getNodeId(),

--- a/data-node/src/test/java/org/graylog/datanode/periodicals/NodePingPeriodicalTest.java
+++ b/data-node/src/test/java/org/graylog/datanode/periodicals/NodePingPeriodicalTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.datanode.periodicals;
+
+import org.assertj.core.api.Assertions;
+import org.graylog.datanode.periodicals.NodePingPeriodical;
+import org.graylog2.cluster.NodeNotFoundException;
+import org.graylog2.cluster.NodeService;
+import org.graylog2.plugin.system.NodeId;
+import org.graylog2.plugin.system.SimpleNodeId;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import java.net.URI;
+
+class NodePingPeriodicalTest {
+
+    @Test
+    void doRun() throws NodeNotFoundException {
+
+        final SimpleNodeId nodeID = new SimpleNodeId("5ca1ab1e-0000-4000-a000-000000000000");
+        final URI uri = URI.create("http://localhost:8999");
+        final NodeService nodeService = Mockito.mock(NodeService.class);
+
+        final NodePingPeriodical task = new NodePingPeriodical(
+                nodeService,
+                nodeID,
+                uri,
+                () -> true
+        );
+
+        task.doRun();
+
+        final ArgumentCaptor<NodeId> nodeIdCaptor = ArgumentCaptor.forClass(NodeId.class);
+        final ArgumentCaptor<Boolean> isLeaderCaptor = ArgumentCaptor.forClass(Boolean.class);
+        final ArgumentCaptor<URI> uriCaptor = ArgumentCaptor.forClass(URI.class);
+        Mockito.verify(nodeService).markAsAlive(nodeIdCaptor.capture(), isLeaderCaptor.capture(), uriCaptor.capture());
+
+        Assertions.assertThat(nodeIdCaptor.getValue().getNodeId()).isEqualTo("5ca1ab1e-0000-4000-a000-000000000000");
+        Assertions.assertThat(isLeaderCaptor.getValue()).isTrue();
+        Assertions.assertThat(uriCaptor.getValue().toString()).isEqualTo("http://localhost:8999");
+    }
+
+
+    @Test
+    void doRunWithRegister() throws NodeNotFoundException {
+
+        final SimpleNodeId nodeID = new SimpleNodeId("5ca1ab1e-0000-4000-a000-000000000000");
+        final URI uri = URI.create("http://localhost:8999");
+
+        final NodeService nodeService = Mockito.mock(NodeService.class);
+
+        Mockito.doThrow(new NodeNotFoundException("Node not found")).when(nodeService).markAsAlive(nodeID, true, uri);
+
+        final NodePingPeriodical task = new NodePingPeriodical(
+                nodeService,
+                nodeID,
+                uri,
+                () -> true
+        );
+
+        task.doRun();
+
+        final ArgumentCaptor<String> nodeIdCaptor = ArgumentCaptor.forClass(String.class);
+        final ArgumentCaptor<Boolean> isLeaderCaptor = ArgumentCaptor.forClass(Boolean.class);
+        final ArgumentCaptor<URI> uriCaptor = ArgumentCaptor.forClass(URI.class);
+        final ArgumentCaptor<String> hostnameCapture = ArgumentCaptor.forClass(String.class);
+        Mockito.verify(nodeService).registerServer(nodeIdCaptor.capture(), isLeaderCaptor.capture(), uriCaptor.capture(), hostnameCapture.capture());
+
+        Assertions.assertThat(nodeIdCaptor.getValue()).isEqualTo("5ca1ab1e-0000-4000-a000-000000000000");
+        Assertions.assertThat(isLeaderCaptor.getValue()).isTrue();
+        Assertions.assertThat(uriCaptor.getValue().toString()).isEqualTo("http://localhost:8999");
+        Assertions.assertThat(hostnameCapture.getValue()).isNotBlank();
+    }
+}

--- a/data-node/src/test/java/org/graylog/datanode/periodicals/NodePingPeriodicalTest.java
+++ b/data-node/src/test/java/org/graylog/datanode/periodicals/NodePingPeriodicalTest.java
@@ -16,14 +16,10 @@
  */
 package org.graylog.datanode.periodicals;
 
-import org.assertj.core.api.Assertions;
-import org.graylog.datanode.periodicals.NodePingPeriodical;
 import org.graylog2.cluster.NodeNotFoundException;
 import org.graylog2.cluster.NodeService;
-import org.graylog2.plugin.system.NodeId;
 import org.graylog2.plugin.system.SimpleNodeId;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 import java.net.URI;
@@ -46,14 +42,10 @@ class NodePingPeriodicalTest {
 
         task.doRun();
 
-        final ArgumentCaptor<NodeId> nodeIdCaptor = ArgumentCaptor.forClass(NodeId.class);
-        final ArgumentCaptor<Boolean> isLeaderCaptor = ArgumentCaptor.forClass(Boolean.class);
-        final ArgumentCaptor<URI> uriCaptor = ArgumentCaptor.forClass(URI.class);
-        Mockito.verify(nodeService).markAsAlive(nodeIdCaptor.capture(), isLeaderCaptor.capture(), uriCaptor.capture());
-
-        Assertions.assertThat(nodeIdCaptor.getValue().getNodeId()).isEqualTo("5ca1ab1e-0000-4000-a000-000000000000");
-        Assertions.assertThat(isLeaderCaptor.getValue()).isTrue();
-        Assertions.assertThat(uriCaptor.getValue().toString()).isEqualTo("http://localhost:8999");
+        Mockito.verify(nodeService).markAsAlive(
+                Mockito.eq(nodeID),
+                Mockito.eq(true),
+                Mockito.eq(uri));
     }
 
 
@@ -76,15 +68,11 @@ class NodePingPeriodicalTest {
 
         task.doRun();
 
-        final ArgumentCaptor<String> nodeIdCaptor = ArgumentCaptor.forClass(String.class);
-        final ArgumentCaptor<Boolean> isLeaderCaptor = ArgumentCaptor.forClass(Boolean.class);
-        final ArgumentCaptor<URI> uriCaptor = ArgumentCaptor.forClass(URI.class);
-        final ArgumentCaptor<String> hostnameCapture = ArgumentCaptor.forClass(String.class);
-        Mockito.verify(nodeService).registerServer(nodeIdCaptor.capture(), isLeaderCaptor.capture(), uriCaptor.capture(), hostnameCapture.capture());
-
-        Assertions.assertThat(nodeIdCaptor.getValue()).isEqualTo("5ca1ab1e-0000-4000-a000-000000000000");
-        Assertions.assertThat(isLeaderCaptor.getValue()).isTrue();
-        Assertions.assertThat(uriCaptor.getValue().toString()).isEqualTo("http://localhost:8999");
-        Assertions.assertThat(hostnameCapture.getValue()).isNotBlank();
+        Mockito.verify(nodeService).registerServer(
+                Mockito.eq(nodeID.getNodeId()),
+                Mockito.eq(true),
+                Mockito.eq(uri),
+                Mockito.any()
+        );
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/cluster/NodeService.java
+++ b/graylog2-server/src/main/java/org/graylog2/cluster/NodeService.java
@@ -37,9 +37,7 @@ public interface NodeService extends PersistedService {
 
     void dropOutdated();
 
-    void markAsAlive(Node node, boolean isLeader, String restTransportAddress);
-
-    void markAsAlive(Node node, boolean isLeader, URI restTransportAddress);
+    void markAsAlive(NodeId node, boolean isLeader, URI restTransportAddress) throws NodeNotFoundException;
 
     boolean isOnlyLeader(NodeId nodeIde);
 

--- a/graylog2-server/src/main/java/org/graylog2/periodical/NodePingThread.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/NodePingThread.java
@@ -65,8 +65,7 @@ public class NodePingThread extends Periodical {
     public synchronized void doRun() {
         final boolean isLeader = leaderElectionService.isLeader();
         try {
-            Node node = nodeService.byNodeId(serverStatus.getNodeId());
-            nodeService.markAsAlive(node, isLeader, httpConfiguration.getHttpPublishUri().resolve(HttpConfiguration.PATH_API));
+            nodeService.markAsAlive(serverStatus.getNodeId(), isLeader, httpConfiguration.getHttpPublishUri().resolve(HttpConfiguration.PATH_API));
         } catch (NodeNotFoundException e) {
             LOG.warn("Did not find meta info of this node. Re-registering.");
             nodeService.registerServer(serverStatus.getNodeId().toString(),


### PR DESCRIPTION
Added missing node ping for datanode 

Additionally there is a small refactoring included, that removes the need to query Node from the DB before we can trigger markAsAlive. This saves one mongodb query every second on each node. The newly created markAsAlive method also prepares a bit of infrastructure for the usage of the `$currentDate`. This will help us to use the mongodb time and avoid out-of-sync clock of different nodes. But the full implementation will have to happen in a separate PR. It's too invasive and requires backwards compatibility changes.

/nocl

## Motivation and Context
Needed to keep overview over active nodes connected to the graylog server.

## How Has This Been Tested?
Manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

