### PR TITLE
Backport 4.3: Fix off by one error in aggregation search

### DIFF
--- a/changelog/unreleased/pr-15009.toml
+++ b/changelog/unreleased/pr-15009.toml
@@ -1,0 +1,4 @@
+type = "f"
+message = "Fixes an off-by-one error that could result in an aggregation search failing silently."
+
+pulls = ["15009"]

--- a/graylog2-server/src/main/java/org/graylog/events/processor/aggregation/PivotAggregationSearch.java
+++ b/graylog2-server/src/main/java/org/graylog/events/processor/aggregation/PivotAggregationSearch.java
@@ -144,7 +144,7 @@ public class PivotAggregationSearch implements AggregationSearch {
             });
 
             // If we have only EmptyParameterErrors, just return an empty Result
-            if (! (errors.stream().filter(e -> !(e instanceof EmptyParameterError)).count() > 1)) {
+            if (errors.stream().allMatch(e -> e instanceof EmptyParameterError)) {
                 return AggregationResult.empty();
             }
             if (errors.size() > 1) {


### PR DESCRIPTION
One line fix for an off by one error in aggregation search.

This is a backport of a fix that was unrelated to, but included with #14746.