### PR TITLE
Add CIDR Range lookup support to CSV file data adapters

### DIFF
--- a/changelog/unreleased/pr-15016.toml
+++ b/changelog/unreleased/pr-15016.toml
@@ -1,0 +1,4 @@
+type = "added"
+message = "Added support for CIDR lookups in CSV file data adapters"
+
+pulls = ["15016"]

--- a/graylog2-server/src/main/java/org/graylog2/utilities/ReservedIpChecker.java
+++ b/graylog2-server/src/main/java/org/graylog2/utilities/ReservedIpChecker.java
@@ -25,7 +25,6 @@ import java.net.UnknownHostException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 public class ReservedIpChecker {
@@ -61,7 +60,7 @@ public class ReservedIpChecker {
     private List<IpSubnet> loadReservedIpBlocks() {
 
         return Arrays.stream(RESERVED_IPV4_BLOCKS)
-                .map(stringToSubnet())
+                .map(ReservedIpChecker::stringToSubnet)
                 .filter(Optional::isPresent)
                 .map(Optional::get)
                 .collect(Collectors.toList());
@@ -79,20 +78,18 @@ public class ReservedIpChecker {
         return ipBlocks.stream().anyMatch(e -> subnetContainsAddress(e, address));
     }
 
-    private static Function<String, Optional<IpSubnet>> stringToSubnet() {
-        return line -> {
-            IpSubnet subnet;
-            try {
-                subnet = new IpSubnet(line);
-            } catch (UnknownHostException ignore) {
-                subnet = null;
-            }
+    public static Optional<IpSubnet> stringToSubnet(String range) {
+        IpSubnet subnet;
+        try {
+            subnet = new IpSubnet(range);
+        } catch (UnknownHostException ignore) {
+            subnet = null;
+        }
 
-            return Optional.ofNullable(subnet);
-        };
+        return Optional.ofNullable(subnet);
     }
 
-    private static boolean subnetContainsAddress(IpSubnet subnet, String targetAddress) {
+    public static boolean subnetContainsAddress(IpSubnet subnet, String targetAddress) {
         try {
             return subnet.contains(targetAddress);
         } catch (UnknownHostException ignore) {

--- a/graylog2-web-interface/src/components/lookup-tables/adapters/CSVFileAdapterDocumentation.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/adapters/CSVFileAdapterDocumentation.jsx
@@ -31,6 +31,11 @@ class CSVFileAdapterDocumentation extends React.Component {
 '10.0.0.1';'e4:b2:12:d1:48:28';'server1'
 '10.0.0.2';'e4:b2:11:d1:58:34';'server2'`;
 
+    const csvFile3 = `"cidr","subnet"
+"192.168.100.0/24","Finance Department subnet"
+"192.168.101.0/24","IT Department subnet"
+"192.168.102.0/24","HR Department subnet"`;
+
     return (
       <div>
         <p>The CSV data adapter can read key value pairs from a CSV file.</p>
@@ -72,6 +77,26 @@ class CSVFileAdapterDocumentation extends React.Component {
 
         <h5 style={{ marginBottom: 10 }}>CSV File</h5>
         <pre>{csvFile2}</pre>
+
+        <h3 style={{ marginBottom: 10 }}>CIDR Lookups</h3>
+        <p style={{ marginBottom: 10, padding: 0 }}>
+          If this data adapter will be used to lookup IP address keys against CIDR addresses<br />
+          then it should be marked as a CIDR lookup. For example:<br />
+        </p>
+
+        <h5 style={{ marginBottom: 10 }}>Configuration</h5>
+        <p style={{ marginBottom: 10, padding: 0 }}>
+          Separator: <code>,</code><br />
+          Quote character: <code>"</code><br />
+          Key column: <code>cidr</code><br />
+          Value column: <code>subnet</code><br />
+          CIDR lookup: <code>true</code>
+        </p>
+
+        <h5 style={{ marginBottom: 10 }}>CSV File</h5>
+        <pre>{csvFile3}</pre>
+
+        <p>Given this CSV file and configuration looking up the key 192.168.101.64 would return 'IT Department subnet'.</p>
       </div>
     );
   }

--- a/graylog2-web-interface/src/components/lookup-tables/adapters/CSVFileAdapterFieldSet.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/adapters/CSVFileAdapterFieldSet.jsx
@@ -104,6 +104,14 @@ class CSVFileAdapterFieldSet extends React.Component {
                onChange={this.props.handleFormEvent}
                help="Enable if the key lookup should be case-insensitive."
                wrapperClassName="col-md-offset-3 col-md-9" />
+        <Input type="checkbox"
+               id="cidr_lookup"
+               name="cidr_lookup"
+               label="CIDR lookup"
+               checked={config.cidr_lookup}
+               onChange={this.props.handleFormEvent}
+               help="Enable if the keys in the lookup table are in CIDR notation and lookups will be done with IPs"
+               wrapperClassName="col-md-offset-3 col-md-9" />
       </fieldset>
     );
   }

--- a/graylog2-web-interface/src/components/lookup-tables/adapters/CSVFileAdapterSummary.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/adapters/CSVFileAdapterSummary.jsx
@@ -41,6 +41,8 @@ class CSVFileAdapterSummary extends React.Component {
         <dd>{config.check_interval} seconds</dd>
         <dt>Case-insensitive lookup</dt>
         <dd>{config.case_insensitive_lookup ? 'yes' : 'no'}</dd>
+        <dt>CIDR lookup</dt>
+        <dd>{config.cidr_lookup ? 'yes' : 'no'}</dd>
       </dl>
     );
   }

--- a/graylog2-web-interface/src/logic/lookup-tables/types.ts
+++ b/graylog2-web-interface/src/logic/lookup-tables/types.ts
@@ -46,6 +46,7 @@ export type LookupTableDataAdapterConfig = {
   value_column?: string,
   check_interval?: number,
   case_insensitive_lookup?: boolean,
+  cidr_lookup?: boolean,
 };
 
 export type LookupTableAdapter = GenericEntityType & {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Adds the capability to match lookup key values to CIDR-formatted entries

## Description
<!--- Describe your changes in detail -->
Adds a `CIDR Lookup` configuration option to CSV File data adapters that when enabled will change how lookups are performed. Instead of being an exact text match it will check an IP address against the CIDR addresses in the CSV file.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Will enable customers to enrich event data by CIDR

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local dev environment 
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [in progress] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

