### PR TITLE
Using database time for node heartbeats.

### DIFF
--- a/changelog/unreleased/pr-15018.toml
+++ b/changelog/unreleased/pr-15018.toml
@@ -1,0 +1,4 @@
+type = "c"
+message = "Using database time for node registration and heartbeat"
+
+pull = ["15018"]

--- a/graylog2-server/src/main/java/org/graylog2/cluster/NodeImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/cluster/NodeImpl.java
@@ -18,6 +18,7 @@ package org.graylog2.cluster;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.bson.types.BSONTimestamp;
 import org.bson.types.ObjectId;
 import org.graylog2.database.DbEntity;
 import org.graylog2.database.PersistedImpl;
@@ -58,7 +59,11 @@ public class NodeImpl extends PersistedImpl implements Node {
 
     @Override
     public DateTime getLastSeen() {
-        return new DateTime(((Integer) fields.getOrDefault("last_seen", 0)) * 1000L, DateTimeZone.UTC);
+        final Object rawLastSeen = fields.get("last_seen");
+        if (rawLastSeen instanceof BSONTimestamp) {
+            return new DateTime(((BSONTimestamp) rawLastSeen).getTime() * 1000L, DateTimeZone.UTC);
+        }
+        return new DateTime(((Integer) rawLastSeen) * 1000L, DateTimeZone.UTC);
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/cluster/NodeImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/cluster/NodeImpl.java
@@ -60,6 +60,9 @@ public class NodeImpl extends PersistedImpl implements Node {
     @Override
     public DateTime getLastSeen() {
         final Object rawLastSeen = fields.get("last_seen");
+        if (rawLastSeen == null) {
+            throw new IllegalStateException("Last seen timestamp of node is unexpectedly null!");
+        }
         if (rawLastSeen instanceof BSONTimestamp) {
             return new DateTime(((BSONTimestamp) rawLastSeen).getTime() * 1000L, DateTimeZone.UTC);
         }

--- a/graylog2-server/src/main/java/org/graylog2/cluster/NodeService.java
+++ b/graylog2-server/src/main/java/org/graylog2/cluster/NodeService.java
@@ -25,7 +25,7 @@ import java.util.Map;
 public interface NodeService extends PersistedService {
     Node.Type type();
 
-    String registerServer(String nodeId, boolean isLeader, URI httpPublishUri, String hostname);
+    boolean registerServer(String nodeId, boolean isLeader, URI httpPublishUri, String hostname);
 
     Node byNodeId(String nodeId) throws NodeNotFoundException;
 

--- a/graylog2-server/src/main/java/org/graylog2/cluster/NodeServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/cluster/NodeServiceImpl.java
@@ -94,8 +94,6 @@ public class NodeServiceImpl extends PersistedServiceImpl implements NodeService
 
     @Override
     public Map<String, Node> allActive(Node.Type type) {
-        Map<String, Node> nodes = Maps.newHashMap();
-
         final BasicDBObject query = new BasicDBObject(Map.of(
                 "$and", List.of(
                         Map.of("type", type.toString()),

--- a/graylog2-server/src/main/java/org/graylog2/cluster/NodeServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/cluster/NodeServiceImpl.java
@@ -164,7 +164,7 @@ public class NodeServiceImpl extends PersistedServiceImpl implements NodeService
                 )
         ));
 
-        return query(NodeImpl.class, query).isEmpty();
+        return count(NodeImpl.class, query) == 0;
     }
 
     @Override
@@ -179,6 +179,6 @@ public class NodeServiceImpl extends PersistedServiceImpl implements NodeService
                 )
         ));
 
-        return !query(NodeImpl.class, query).isEmpty();
+        return count(NodeImpl.class, query) > 0;
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/cluster/NodeServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/cluster/NodeServiceImpl.java
@@ -30,11 +30,14 @@ import org.graylog2.plugin.system.NodeId;
 
 import javax.inject.Inject;
 import java.net.URI;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 public class NodeServiceImpl extends PersistedServiceImpl implements NodeService {
     private final long pingTimeout;
+    private final static Map<String, Object> lastSeenField = Map.of("last_seen", Map.of("$type", "timestamp"));
 
     @Inject
     public NodeServiceImpl(final MongoConnection mongoConnection, Configuration configuration) {
@@ -51,29 +54,25 @@ public class NodeServiceImpl extends PersistedServiceImpl implements NodeService
     }
 
     @Override
-    public String registerServer(String nodeId, boolean isLeader, URI httpPublishUri, String hostname) {
-        Map<String, Object> fields = Maps.newHashMap();
-        fields.put("last_seen", Tools.getUTCTimestamp());
-        fields.put("node_id", nodeId);
-        fields.put("type", type().toString());
-        fields.put("is_leader", isLeader);
-        fields.put("transport_address", httpPublishUri.toString());
-        fields.put("hostname", hostname);
+    public boolean registerServer(String nodeId, boolean isLeader, URI httpPublishUri, String hostname) {
+        final Map<String, Object> fields = Map.of(
+                "$set", Map.of(
+                        "node_id", nodeId,
+                        "type", type().toString(),
+                        "is_leader", isLeader,
+                        "transport_address", httpPublishUri.toString(),
+                        "hostname", hostname
+                ),
+                "$currentDate", lastSeenField
+        );
 
-        try {
-            Node node;
-            try {
-                // Update existing node object.
-                final String objectId = byNodeId(nodeId).getId();
-                node = new NodeImpl(new ObjectId(objectId), fields);
-            } catch (NodeNotFoundException e) {
-                // Create new node object.
-                node = new NodeImpl(fields);
-            }
-            return save(node);
-        } catch (ValidationException e) {
-            throw new RuntimeException("Validation failed.", e);
-        }
+        final WriteResult result = this.collection(NodeImpl.class).update(
+                new BasicDBObject("node_id", nodeId),
+                new BasicDBObject(fields),
+                true,
+                false
+        );
+        return result.getN() == 1;
     }
 
     @Override
@@ -97,18 +96,15 @@ public class NodeServiceImpl extends PersistedServiceImpl implements NodeService
     public Map<String, Node> allActive(Node.Type type) {
         Map<String, Node> nodes = Maps.newHashMap();
 
-        BasicDBObject query = new BasicDBObject();
-        query.put("last_seen", new BasicDBObject("$gte", Tools.getUTCTimestamp() - pingTimeout));
-        query.put("type", type.toString());
+        final BasicDBObject query = new BasicDBObject(Map.of(
+                "$and", List.of(
+                        Map.of("type", type.toString()),
+                        recentHeartbeat()
+                )));
 
-        for (DBObject obj : query(NodeImpl.class, query)) {
-            Node node = new NodeImpl((ObjectId) obj.get("_id"), obj.toMap());
-            String nodeId = (String) obj.get("node_id");
-
-            nodes.put(nodeId, node);
-        }
-
-        return nodes;
+        return query(NodeImpl.class, query)
+                .stream()
+                .collect(Collectors.toMap(obj -> (String)obj.get("node_id"), obj -> new NodeImpl((ObjectId) obj.get("_id"), obj.toMap())));
     }
 
     @Override
@@ -124,8 +120,7 @@ public class NodeServiceImpl extends PersistedServiceImpl implements NodeService
 
     @Override
     public void dropOutdated() {
-        BasicDBObject query = new BasicDBObject();
-        query.put("last_seen", new BasicDBObject("$lt", Tools.getUTCTimestamp() - pingTimeout));
+        final BasicDBObject query = new BasicDBObject("$not", recentHeartbeat());
 
         destroyAll(NodeImpl.class, query);
     }
@@ -136,14 +131,13 @@ public class NodeServiceImpl extends PersistedServiceImpl implements NodeService
     public void markAsAlive(NodeId node, boolean isLeader, URI restTransportAddress) throws NodeNotFoundException {
         BasicDBObject query = new BasicDBObject("node_id", node.getNodeId());
 
-        final BasicDBObject fields = new BasicDBObject();
-        fields.put("is_leader", isLeader);
-        fields.put("transport_address", restTransportAddress.toString());
-        fields.put("last_seen", Tools.getUTCTimestamp()); // TODO: deprecate and remove in later releases and use last_seen_date only!
-        final BasicDBObject update = new BasicDBObject("$set", fields);
-
-        // using $currentDate will persist the database date, avoiding time sync problems across different nodes
-        //update.put("$currentDate", new BasicDBObject("last_seen_date", new BasicDBObject("$type", "date")));
+        final BasicDBObject update = new BasicDBObject(Map.of(
+                "$set", Map.of(
+                        "is_leader", isLeader,
+                        "transport_address", restTransportAddress.toString()
+                ),
+                "$currentDate", lastSeenField
+        ));
 
         final WriteResult result = super.collection(NodeImpl.class).update(query, update);
 
@@ -153,24 +147,38 @@ public class NodeServiceImpl extends PersistedServiceImpl implements NodeService
         }
     }
 
+    private Map<String, Object> recentHeartbeat() {
+        return Map.of("$where", "this.last_seen >= Timestamp(new Date().getTime() / 1000 - " + pingTimeout + ", 1)");
+    }
+
     @Override
     public boolean isOnlyLeader(NodeId nodeId) {
-        BasicDBObject query = new BasicDBObject();
-        query.put("type", Node.Type.SERVER.toString());
-        query.put("last_seen", new BasicDBObject("$gte", Tools.getUTCTimestamp() - pingTimeout));
-        query.put("node_id", new BasicDBObject("$ne", nodeId.getNodeId()));
-        query.put("is_leader", true);
+        final BasicDBObject query = new BasicDBObject(Map.of(
+                "$and", List.of(
+                        recentHeartbeat(),
+                        Map.of(
+                                "type", Node.Type.SERVER.toString(),
+                                "node_id", new BasicDBObject("$ne", nodeId.getNodeId()),
+                                "is_leader", true
+                        )
+                )
+        ));
 
-        return query(NodeImpl.class, query).size() == 0;
+        return query(NodeImpl.class, query).isEmpty();
     }
 
     @Override
     public boolean isAnyLeaderPresent() {
-        BasicDBObject query = new BasicDBObject();
-        query.put("type", Node.Type.SERVER.toString());
-        query.put("last_seen", new BasicDBObject("$gte", Tools.getUTCTimestamp() - pingTimeout));
-        query.put("is_leader", true);
+        final BasicDBObject query = new BasicDBObject(Map.of(
+                "$and", List.of(
+                        recentHeartbeat(),
+                        Map.of(
+                                "type", Node.Type.SERVER.toString(),
+                                "is_leader", true
+                        )
+                )
+        ));
 
-        return query(NodeImpl.class, query).size() > 0;
+        return !query(NodeImpl.class, query).isEmpty();
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/cluster/NodeServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/cluster/NodeServiceImpl.java
@@ -118,7 +118,7 @@ public class NodeServiceImpl extends PersistedServiceImpl implements NodeService
 
     @Override
     public void dropOutdated() {
-        final BasicDBObject query = new BasicDBObject("$not", recentHeartbeat());
+        final BasicDBObject query = new BasicDBObject("$nor", List.of(recentHeartbeat()));
 
         destroyAll(NodeImpl.class, query);
     }

--- a/graylog2-server/src/test/java/org/graylog2/cluster/NodeServiceImplTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/cluster/NodeServiceImplTest.java
@@ -38,6 +38,7 @@ import java.net.URI;
 import java.time.Duration;
 import java.util.AbstractMap;
 import java.util.Calendar;
+import java.util.Locale;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -139,7 +140,7 @@ public class NodeServiceImplTest {
     public void testLastSeenBackwardsCompatibility() throws NodeNotFoundException, ValidationException {
         nodeService.registerServer(nodeId.getNodeId(), true, TRANSPORT_URI, LOCAL_CANONICAL_HOSTNAME);
         final Node node = nodeService.byNodeId(nodeId);
-        final Calendar cal = Calendar.getInstance();
+        final Calendar cal = Calendar.getInstance(Locale.ROOT);
 
         cal.add(Calendar.MILLISECOND, -2 * STALE_LEADER_TIMEOUT_MS);
         final int ts = (int) (cal.getTime().getTime() / 1000);

--- a/graylog2-server/src/test/java/org/graylog2/cluster/NodeServiceImplTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/cluster/NodeServiceImplTest.java
@@ -33,6 +33,8 @@ import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
 import java.net.URI;
+import java.util.AbstractMap;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -112,9 +114,18 @@ public class NodeServiceImplTest {
 
         final Node node = nodeService.byNodeId(nodeId);
 
-        Assertions.assertThat(node.isLeader()).isFalse();
-        Assertions.assertThat(node.getTransportAddress()).isEqualTo("http://10.0.0.1:12901");
-        Assertions.assertThat(node.getLastSeen()).isNotNull().isInstanceOf(DateTime.class);
+        assertThat(node.isLeader()).isFalse();
+        assertThat(node.getTransportAddress()).isEqualTo("http://10.0.0.1:12901");
+        assertThat(node.getLastSeen()).isNotNull().isInstanceOf(DateTime.class);
+    }
 
+    @Test
+    public void testAllActive() throws NodeNotFoundException {
+        assertThat(nodeService.allActive().keySet()).isEmpty();
+        nodeService.registerServer(nodeId.getNodeId(), true, TRANSPORT_URI, LOCAL_CANONICAL_HOSTNAME);
+        assertThat(nodeService.allActive().keySet()).containsExactly(nodeId.getNodeId());
+
+        nodeService.markAsAlive(nodeId, false, TRANSPORT_URI);
+        assertThat(nodeService.allActive().keySet()).containsExactly(nodeId.getNodeId());
     }
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is a refactoring of the queries used for:

  - registering new nodes
  - sending the heartbeat/marking nodes as alive
  - finding alive/dead nodes

The improvement is that the DB time is used for the timestamps instead of the node's clock. This is achieved by using `$currentDate` for registering/updating a node entry and a `$where` JS fragment using `new Date()` for finding dead/alive nodes.

The benefit of this is that there is no need for a very exact clock synchronization of the noeds anymore. In the past, if a node clock was late by more than 2 seconds (or the non-default ping timeout), then a node would always be marked as dead.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.