### PR TITLE
Pull down global context providers to be wrapped in router.

### DIFF
--- a/graylog2-web-interface/src/pages/LoggedInPage.tsx
+++ b/graylog2-web-interface/src/pages/LoggedInPage.tsx
@@ -19,17 +19,14 @@ import React from 'react';
 import AppRouter from 'routing/AppRouter';
 import ThemeAndUserProvider from 'contexts/ThemeAndUserProvider';
 import StreamsProvider from 'contexts/StreamsProvider';
-import GlobalContextProviders from 'contexts/GlobalContextProviders';
 import DefaultQueryClientProvider from 'contexts/DefaultQueryClientProvider';
 
 const LoggedInPage = () => (
   <DefaultQueryClientProvider>
     <ThemeAndUserProvider>
-      <GlobalContextProviders>
-        <StreamsProvider>
-          <AppRouter />
-        </StreamsProvider>
-      </GlobalContextProviders>
+      <StreamsProvider>
+        <AppRouter />
+      </StreamsProvider>
     </ThemeAndUserProvider>
   </DefaultQueryClientProvider>
 );

--- a/graylog2-web-interface/src/routing/AppRouter.test.tsx
+++ b/graylog2-web-interface/src/routing/AppRouter.test.tsx
@@ -37,6 +37,7 @@ jest.mock('components/errors/RouterErrorBoundary', () => mockComponent('RouterEr
 
 jest.mock('pages/StartPage', () => () => <>This is the start page</>);
 jest.mock('hooks/usePluginEntities');
+jest.mock('contexts/GlobalContextProviders', () => ({ children }: React.PropsWithChildren<{}>) => children);
 
 jest.mock('util/AppConfig', () => ({
   gl2AppPathPrefix: jest.fn(() => ''),

--- a/graylog2-web-interface/src/routing/AppRouter.tsx
+++ b/graylog2-web-interface/src/routing/AppRouter.tsx
@@ -105,6 +105,7 @@ import {
 } from 'pages';
 import RouterErrorBoundary from 'components/errors/RouterErrorBoundary';
 import usePluginEntities from 'hooks/usePluginEntities';
+import GlobalContextProviders from 'contexts/GlobalContextProviders';
 
 const renderPluginRoute = ({ path, component: Component, parentComponent, requiredFeatureFlag }: PluginRoute) => {
   if (requiredFeatureFlag && !AppConfig.isFeatureEnabled(requiredFeatureFlag)) {
@@ -140,7 +141,7 @@ const AppRouter = () => {
 
     {
       path: RoutePaths.STARTPAGE,
-      element: <App />,
+      element: <GlobalContextProviders><App /></GlobalContextProviders>,
       children: [
         { path: RoutePaths.STARTPAGE, element: <StartPage /> },
         { path: RoutePaths.SEARCH, element: <DelegatedSearchPage /> },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This change is pulling down the `GlobalContextProviders` component to render the defined providers below the configured router instead of on top of it. This leads to avoiding issues where components rendered from the provider require access to the router context.

/nocl

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.