### PR TITLE
Backport50: Remove redundant permission checks for events and notifications

### DIFF
--- a/changelog/unreleased/issue-14940.toml
+++ b/changelog/unreleased/issue-14940.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Fix visibility of events and notification definition pages."
+
+issues = ["14940"]
+pulls = ["15052"]

--- a/graylog2-web-interface/src/components/events/EventsPageNavigation.tsx
+++ b/graylog2-web-interface/src/components/events/EventsPageNavigation.tsx
@@ -22,8 +22,8 @@ import { Row } from 'components/bootstrap';
 
 const NAV_ITEMS = [
   { title: 'Alerts & Events', path: Routes.ALERTS.LIST, exactPathMatch: true },
-  { title: 'Event Definitions', path: Routes.ALERTS.DEFINITIONS.LIST, permissions: 'eventdefinitions:read' },
-  { title: 'Notifications', path: Routes.ALERTS.NOTIFICATIONS.LIST, permissions: 'eventnotifications:read' },
+  { title: 'Event Definitions', path: Routes.ALERTS.DEFINITIONS.LIST},
+  { title: 'Notifications', path: Routes.ALERTS.NOTIFICATIONS.LIST},
 ];
 
 const EventsPageNavigation = () => (

--- a/graylog2-web-interface/src/components/events/EventsPageNavigation.tsx
+++ b/graylog2-web-interface/src/components/events/EventsPageNavigation.tsx
@@ -22,8 +22,8 @@ import { Row } from 'components/bootstrap';
 
 const NAV_ITEMS = [
   { title: 'Alerts & Events', path: Routes.ALERTS.LIST, exactPathMatch: true },
-  { title: 'Event Definitions', path: Routes.ALERTS.DEFINITIONS.LIST},
-  { title: 'Notifications', path: Routes.ALERTS.NOTIFICATIONS.LIST},
+  { title: 'Event Definitions', path: Routes.ALERTS.DEFINITIONS.LIST },
+  { title: 'Notifications', path: Routes.ALERTS.NOTIFICATIONS.LIST },
 ];
 
 const EventsPageNavigation = () => (


### PR DESCRIPTION
See #14940

Remove permissions checks on navigation elements, per linked issue.