### PR TITLE
Only check read access in the CSV File adapter

### DIFF
--- a/changelog/unreleased/pr-15058.toml
+++ b/changelog/unreleased/pr-15058.toml
@@ -1,0 +1,6 @@
+type = "fixed"
+message = "Fixed CSV File adapter to only verify file read access"
+
+issues = ["14998"]
+pulls = ["15058"]
+

--- a/graylog2-server/src/main/java/org/graylog2/lookup/adapters/CSVFileDataAdapter.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/adapters/CSVFileDataAdapter.java
@@ -125,10 +125,10 @@ public class CSVFileDataAdapter extends LookupDataAdapter {
             return;
         }
 
-        if (!Files.isWritable(Paths.get(config.path()))) {
-            String error = f("The specified file [%s] does not exist or is not writable. " +
+        if (!Files.isReadable(Paths.get(config.path()))) {
+            String error = f("The specified file [%s] does not exist or is not readable. " +
                             "To resolve this error, edit the adapter [%s] and specify a new path, or restore the file " +
-                            "or access to it.",
+                            "or read access to it.",
                     config.path(), name);
             LOG.error(error);
             setError(new IllegalStateException(error));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
https://github.com/Graylog2/graylog2-server/pull/14670 introduced some improvements for CSV File adapter error handling, but, it added a check that erroneously verified file write access instead of just read access on file refreshes. This PR fixes that, and changes the check to only verify that read access is present. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #14998

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Remove write access to the CSV file that a CSV File adapter instance is using (for example `chmod -w my-lookup-file.csv`). Verify that the adapter starts up and refreshes successfully when the refresh interval passes. A lower refresh interval can be set to test his more quickly.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

