### PR TITLE
Only check read access in the CSV File adapter (5.0)

### DIFF
--- a/changelog/unreleased/pr-15058.toml
+++ b/changelog/unreleased/pr-15058.toml
@@ -1,0 +1,6 @@
+type = "fixed"
+message = "Fixed CSV File adapter to only verify file read access"
+
+issues = ["14998"]
+pulls = ["15058"]
+

--- a/graylog2-server/src/main/java/org/graylog2/lookup/adapters/CSVFileDataAdapter.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/adapters/CSVFileDataAdapter.java
@@ -125,10 +125,10 @@ public class CSVFileDataAdapter extends LookupDataAdapter {
             return;
         }
 
-        if (!Files.isWritable(Paths.get(config.path()))) {
-            String error = f("The specified file [%s] does not exist or is not writable. " +
+        if (!Files.isReadable(Paths.get(config.path()))) {
+            String error = f("The specified file [%s] does not exist or is not readable. " +
                             "To resolve this error, edit the adapter [%s] and specify a new path, or restore the file " +
-                            "or access to it.",
+                            "or read access to it.",
                     config.path(), name);
             LOG.error(error);
             setError(new IllegalStateException(error));


### PR DESCRIPTION
Backport https://github.com/Graylog2/graylog2-server/pull/15058 to the `5.0` branch.