### PR TITLE
DataNode: config option to enforce single-node type

### DIFF
--- a/changelog/unreleased/pr-15070.toml
+++ b/changelog/unreleased/pr-15070.toml
@@ -1,4 +1,4 @@
 type = "c"
-message = "datanode: switch to be able to force single-node type"
+message = "datanode: add conf option to be able to force single-node type"
 
 pull = ["15070"]

--- a/changelog/unreleased/pr-15070.toml
+++ b/changelog/unreleased/pr-15070.toml
@@ -1,0 +1,4 @@
+type = "c"
+message = "datanode: switch to be able to force single-node type"
+
+pull = ["15070"]

--- a/data-node/src/main/java/org/graylog/datanode/Configuration.java
+++ b/data-node/src/main/java/org/graylog/datanode/Configuration.java
@@ -218,6 +218,8 @@ public class Configuration extends BaseConfiguration {
     @Parameter(value = "root_email")
     private String rootEmail = "";
 
+    @Parameter(value = "single_node_only")
+    private boolean singleNodeOnly = false;
 
     public String getNodeIdFile() {
         return nodeIdFile;
@@ -279,6 +281,10 @@ public class Configuration extends BaseConfiguration {
 
     public Optional<String> getOpensearchNetworkHostHost() {
         return Optional.ofNullable(opensearchNetworkHostHost);
+    }
+
+    public boolean isSingleNodeOnly() {
+        return singleNodeOnly;
     }
 
     public static class NodeIdFileValidator implements Validator<String> {

--- a/data-node/src/main/java/org/graylog/datanode/configuration/ConfigurationProvider.java
+++ b/data-node/src/main/java/org/graylog/datanode/configuration/ConfigurationProvider.java
@@ -61,7 +61,11 @@ public class ConfigurationProvider implements Provider<OpensearchConfiguration> 
         final LinkedHashMap<String, String> config = new LinkedHashMap<>();
         config.put("path.data", Path.of(localConfiguration.getOpensearchDataLocation()).resolve(localConfiguration.getDatanodeNodeName()).toAbsolutePath().toString());
         config.put("path.logs", Path.of(localConfiguration.getOpensearchLogsLocation()).resolve(localConfiguration.getDatanodeNodeName()).toAbsolutePath().toString());
-        //config.put("discovery.type", "single-node");
+        if(localConfiguration.isSingleNodeOnly()) {
+            config.put("discovery.type", "single-node");
+        } else {
+            config.put("cluster.initial_master_nodes", "node1");
+        }
 
         // listen on all interfaces
         config.put("network.bind_host", "0.0.0.0");
@@ -69,7 +73,6 @@ public class ConfigurationProvider implements Provider<OpensearchConfiguration> 
         localConfiguration.getOpensearchNetworkHostHost().ifPresent(
                 networkHost -> config.put("network.host", networkHost));
 
-        config.put("cluster.initial_master_nodes", "node1");
 
         final Path transportKeystorePath = Path.of(localConfiguration.getOpensearchConfigLocation())
                 .resolve(localConfiguration.getDatanodeTransportCertificate());


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
On macOS, the OpenSearch bootstrap checks might fail (missing JNA etc.) so we have to enforce a single-node configuration. I did this as an explicit switch because we have to refactor this part of the config anyway during the preflight-config regarding eventual cluster-specfic config.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

