### PR TITLE
Move index creation to constructor of AccessTokenServiceImpl

### DIFF
--- a/changelog/unreleased/issue-15012.toml
+++ b/changelog/unreleased/issue-15012.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Improve performance by avoiding unnecessary attempts to create index for access tokens."
+
+issues = ["15012"]
+pulls = [""]

--- a/graylog2-server/src/main/java/org/graylog2/security/AccessTokenServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/security/AccessTokenServiceImpl.java
@@ -58,6 +58,9 @@ public class AccessTokenServiceImpl extends PersistedServiceImpl implements Acce
         super(mongoConnection);
         this.cipher = accessTokenCipher;
         collection(AccessTokenImpl.class).createIndex(new BasicDBObject(AccessTokenImpl.TOKEN_TYPE, 1));
+
+        // make sure we cannot overwrite an existing access token
+        collection(AccessTokenImpl.class).createIndex(new BasicDBObject(AccessTokenImpl.TOKEN, 1), new BasicDBObject("unique", true));
     }
 
     @Override
@@ -138,8 +141,6 @@ public class AccessTokenServiceImpl extends PersistedServiceImpl implements Acce
 
     @Override
     public String save(AccessToken accessToken) throws ValidationException {
-        // make sure we cannot overwrite an existing access token
-        collection(AccessTokenImpl.class).createIndex(new BasicDBObject(AccessTokenImpl.TOKEN, 1), new BasicDBObject("unique", true));
         return super.save(encrypt(accessToken));
     }
 


### PR DESCRIPTION
Resolves #15012 

Avoid performance issues by creating the index only once. See linked issue for details.