### PR TITLE
Cache last access time of authentication tokens

### DIFF
--- a/changelog/unreleased/issue-15013.toml
+++ b/changelog/unreleased/issue-15013.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Avoid excessive DB requests for maintaining token last access time."
+
+issues = ["15013"]
+pulls = [""]

--- a/graylog2-server/src/main/java/org/graylog2/security/AccessTokenService.java
+++ b/graylog2-server/src/main/java/org/graylog2/security/AccessTokenService.java
@@ -18,9 +18,11 @@ package org.graylog2.security;
 
 import org.graylog2.plugin.database.PersistedService;
 import org.graylog2.plugin.database.ValidationException;
+import org.joda.time.DateTime;
 
 import javax.annotation.Nullable;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 /**
  * @author Dennis Oelkers <dennis@torch.sh>
@@ -37,9 +39,11 @@ public interface AccessTokenService extends PersistedService {
 
     AccessToken create(String username, String name);
 
-    void touch(AccessToken accessToken) throws ValidationException;
+    DateTime touch(AccessToken accessToken) throws ValidationException;
 
     String save(AccessToken accessToken) throws ValidationException;
 
     int deleteAllForUser(String username);
+
+    public void setLastAccessCache(long duration, TimeUnit unit);
 }

--- a/graylog2-server/src/main/java/org/graylog2/security/AccessTokenServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/security/AccessTokenServiceImpl.java
@@ -16,6 +16,10 @@
  */
 package org.graylog2.security;
 
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
 import com.google.common.collect.Maps;
 import com.mongodb.BasicDBObject;
 import com.mongodb.BasicDBObjectBuilder;
@@ -27,6 +31,7 @@ import org.graylog2.database.MongoConnection;
 import org.graylog2.database.PersistedServiceImpl;
 import org.graylog2.plugin.Tools;
 import org.graylog2.plugin.database.ValidationException;
+import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,6 +43,8 @@ import java.security.SecureRandom;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 /**
@@ -52,13 +59,15 @@ public class AccessTokenServiceImpl extends PersistedServiceImpl implements Acce
 
     private static final SecureRandom RANDOM = new SecureRandom();
     private final AccessTokenCipher cipher;
+    private LoadingCache<String, DateTime> lastAccessCache;
 
     @Inject
     public AccessTokenServiceImpl(MongoConnection mongoConnection, AccessTokenCipher accessTokenCipher) {
         super(mongoConnection);
         this.cipher = accessTokenCipher;
-        collection(AccessTokenImpl.class).createIndex(new BasicDBObject(AccessTokenImpl.TOKEN_TYPE, 1));
+        setLastAccessCache(30, TimeUnit.SECONDS);
 
+        collection(AccessTokenImpl.class).createIndex(new BasicDBObject(AccessTokenImpl.TOKEN_TYPE, 1));
         // make sure we cannot overwrite an existing access token
         collection(AccessTokenImpl.class).createIndex(new BasicDBObject(AccessTokenImpl.TOKEN, 1), new BasicDBObject("unique", true));
     }
@@ -134,9 +143,14 @@ public class AccessTokenServiceImpl extends PersistedServiceImpl implements Acce
     }
 
     @Override
-    public void touch(AccessToken accessToken) throws ValidationException {
-        accessToken.getFields().put(AccessTokenImpl.LAST_ACCESS, Tools.nowUTC());
-        save(accessToken);
+    public DateTime touch(AccessToken accessToken) throws ValidationException {
+        LOG.info("touch");
+        try {
+            return lastAccessCache.get(accessToken.getId());
+        } catch (ExecutionException e) {
+            LOG.debug("Ignoring error: " + e.getMessage());
+            return null;
+        }
     }
 
     @Override
@@ -179,5 +193,25 @@ public class AccessTokenServiceImpl extends PersistedServiceImpl implements Acce
         } else {
             return new AccessTokenImpl(new ObjectId(token.getId()), fields);
         }
+    }
+
+    @VisibleForTesting
+    @Override
+    public void setLastAccessCache(long duration, TimeUnit unit) {
+        lastAccessCache = CacheBuilder.newBuilder()
+                .expireAfterAccess(duration, unit)
+                .build(new CacheLoader<>() {
+                    @Override
+                    public DateTime load(String id) throws Exception {
+                        AccessToken accessToken = loadById(id);
+                        DateTime now = Tools.nowUTC();
+                        if (accessToken != null) {
+                            accessToken.getFields().put(AccessTokenImpl.LAST_ACCESS, Tools.nowUTC());
+                            LOG.debug("Accesstoken: saving access time");
+                            save(accessToken);
+                        }
+                        return now;
+                    }
+                });
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/security/AccessTokenServiceImplTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/security/AccessTokenServiceImplTest.java
@@ -33,6 +33,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
@@ -163,12 +164,13 @@ public class AccessTokenServiceImplTest {
     @Test
     @MongoDBFixtures("accessTokensSingleToken.json")
     public void testTouch() throws Exception {
+        accessTokenService.setLastAccessCache(1, TimeUnit.NANOSECONDS);
         final AccessToken token = accessTokenService.load("foobar");
-        final DateTime initialLastAccess = token.getLastAccess();
+        final DateTime firstAccess = accessTokenService.touch(token);
 
-        accessTokenService.touch(token);
-
-        assertThat(token.getLastAccess()).isGreaterThan(initialLastAccess);
+        Thread.sleep(1,0);
+        final DateTime secondAccess = accessTokenService.touch(token);
+        assertThat(secondAccess).isGreaterThan(firstAccess);
     }
 
     @Test


### PR DESCRIPTION
Resolves #15013 
Introduce a cache for last access time. Items expire after a set duration, ensuring that they stay reasonably fresh without being refreshed more often than is useful.

See linked issue for details.