### PR TITLE
Fix file permissions for the data node dist/ folder

### DIFF
--- a/data-node-distribution/src/main/assembly/datanode.xml
+++ b/data-node-distribution/src/main/assembly/datanode.xml
@@ -21,6 +21,8 @@
         <fileSet>
             <directory>${project.basedir}/../data-node/target/opensearch</directory>
             <outputDirectory>dist</outputDirectory>
+            <fileMode>0644</fileMode>
+            <directoryMode>0755</directoryMode>
             <includes>
                 <include>*/**</include>
             </includes>


### PR DESCRIPTION
Some OpenSearch files had 660 permissions which is problematic when the process that runs OpenSearch is running under a different user account than the owner of the file permissions.

