### PR TITLE
Makee Reflux promises cancellable.

### DIFF
--- a/graylog2-web-interface/src/index.tsx
+++ b/graylog2-web-interface/src/index.tsx
@@ -20,6 +20,7 @@ import 'webpack-entry';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { PluginManifest, PluginStore } from 'graylog-web-plugin/plugin';
+import Reflux from 'reflux';
 
 import AppFacade from 'routing/AppFacade';
 import GraylogThemeProvider from 'theme/GraylogThemeProvider';
@@ -27,6 +28,9 @@ import CustomizationProvider from 'contexts/CustomizationProvider';
 import ViewsBindings from 'views/bindings';
 import ThreatIntelBindings from 'threatintel/bindings';
 import GlobalThemeStyles from 'theme/GlobalThemeStyles';
+import CancellablePromise from 'logic/rest/CancellablePromise';
+
+Reflux.setPromiseFactory((handlers) => CancellablePromise.of(new Promise(handlers)));
 
 PluginStore.register(new PluginManifest({}, ViewsBindings));
 PluginStore.register(new PluginManifest({}, ThreatIntelBindings));


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

In #15032, we are removing `bluebird`, which served as the promise implementation for Reflux before. This lead to promises used by Reflux not being cancellable anymore. In one case we do relied on this, namely when unmounting the `LoginPage` component.

Therefore this PR makes use of our own `CancellablePromise` to be used in the Reflux promise factory to make sure that promises created by Reflux are still cancellable.

Fixes #15112.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.