### PR TITLE
Fix isFreshInstallation preflight check

### DIFF
--- a/changelog/unreleased/pr-15141.toml
+++ b/changelog/unreleased/pr-15141.toml
@@ -1,0 +1,4 @@
+type = "fixed"
+message = "Fix isFreshInstallation flag in setups with newly registred datanodes"
+
+pulls = ["15141"]

--- a/data-node/src/main/java/org/graylog/datanode/bootstrap/ServerBootstrap.java
+++ b/data-node/src/main/java/org/graylog/datanode/bootstrap/ServerBootstrap.java
@@ -146,7 +146,7 @@ public abstract class ServerBootstrap extends CmdLineTool {
             throw e;
         }
 
-        if (mongoDBPreflightCheck.dbIsEmpty()) {
+        if (mongoDBPreflightCheck.isFreshInstallation()) {
             registerFreshInstallation();
         }
     }

--- a/graylog2-server/src/main/java/org/graylog2/bootstrap/ServerBootstrap.java
+++ b/graylog2-server/src/main/java/org/graylog2/bootstrap/ServerBootstrap.java
@@ -165,7 +165,7 @@ public abstract class ServerBootstrap extends CmdLineTool {
             throw e;
         }
 
-        if (mongoDBPreflightCheck.dbIsEmpty()) {
+        if (mongoDBPreflightCheck.isFreshInstallation()) {
             registerFreshInstallation();
         }
     }

--- a/graylog2-server/src/main/java/org/graylog2/bootstrap/preflight/MongoDBPreflightCheck.java
+++ b/graylog2-server/src/main/java/org/graylog2/bootstrap/preflight/MongoDBPreflightCheck.java
@@ -42,7 +42,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 public class MongoDBPreflightCheck {
     private static final Logger LOG = LoggerFactory.getLogger(MongoDBPreflightCheck.class);
-    public static final String CLUSTER_CONFIG_COLLECTION_NAME = "cluster_config";
+    private static final String CLUSTER_CONFIG_COLLECTION_NAME = "cluster_config";
 
     private final int mongoVersionProbeAttempts;
     private final MongoConnection mongoConnection;

--- a/graylog2-server/src/main/java/org/graylog2/bootstrap/preflight/MongoDBPreflightCheck.java
+++ b/graylog2-server/src/main/java/org/graylog2/bootstrap/preflight/MongoDBPreflightCheck.java
@@ -86,7 +86,6 @@ public class MongoDBPreflightCheck {
                     .build()
                     .call(() -> {
                         try (MongoClient mongoClient = mongoConnection.connect()) {
-                            // Detect an empty, pristine database. It should have no collections
                             detectFreshInstallation();
                             return MongoDBVersionCheck.getVersion(mongoClient);
                         }

--- a/graylog2-server/src/main/java/org/graylog2/bootstrap/preflight/MongoDBPreflightCheck.java
+++ b/graylog2-server/src/main/java/org/graylog2/bootstrap/preflight/MongoDBPreflightCheck.java
@@ -34,6 +34,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import javax.inject.Named;
+import java.util.HashSet;
 import java.util.Objects;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -41,11 +42,12 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 public class MongoDBPreflightCheck {
     private static final Logger LOG = LoggerFactory.getLogger(MongoDBPreflightCheck.class);
+    public static final String CLUSTER_CONFIG_COLLECTION_NAME = "cluster_config";
 
     private final int mongoVersionProbeAttempts;
     private final MongoConnection mongoConnection;
 
-    private final AtomicBoolean dbIsEmpty;
+    private final AtomicBoolean isFreshInstallation;
 
     @Inject
     public MongoDBPreflightCheck(@Named(value = "mongodb_version_probe_attempts") int mongoVersionProbeAttempts,
@@ -53,11 +55,11 @@ public class MongoDBPreflightCheck {
         this.mongoVersionProbeAttempts = mongoVersionProbeAttempts;
         // We build our own MongoConnection instance here, so we can close it without interfering with other users
         this.mongoConnection = new MongoConnectionImpl(configuration);
-        dbIsEmpty = new AtomicBoolean(false);
+        isFreshInstallation = new AtomicBoolean(false);
     }
 
-    public boolean dbIsEmpty() {
-        return dbIsEmpty.get();
+    public boolean isFreshInstallation() {
+        return isFreshInstallation.get();
     }
 
     public void runCheck() throws PreflightCheckException {
@@ -83,10 +85,9 @@ public class MongoDBPreflightCheck {
                     .withStopStrategy(mongoVersionProbeAttempts == 0 ? StopStrategies.neverStop() : StopStrategies.stopAfterAttempt(mongoVersionProbeAttempts))
                     .build()
                     .call(() -> {
-                        try (MongoClient mongoClient = (MongoClient) mongoConnection.connect()) {
+                        try (MongoClient mongoClient = mongoConnection.connect()) {
                             // Detect an empty, pristine database. It should have no collections
-                            final String firstCollectionName = mongoConnection.getMongoDatabase().listCollectionNames().first();
-                            dbIsEmpty.set(firstCollectionName == null);
+                            detectFreshInstallation();
                             return MongoDBVersionCheck.getVersion(mongoClient);
                         }
                     });
@@ -96,5 +97,19 @@ public class MongoDBPreflightCheck {
         } catch (ExecutionException | RetryException e) {
             throw new PreflightCheckException("Failed to retrieve MongoDB version.", e);
         }
+    }
+
+    /**
+     * The fresh installation detecion is based on the presence of the cluster_config collection. If this
+     * collection exists, we assume that the installation is not fresh. We can't use empty database for this
+     * verification - datanodes may register itself into the nodes collection and maybe even persist some more
+     * information in other collections.
+     */
+    private void detectFreshInstallation() {
+        final boolean configurationExists = mongoConnection.getMongoDatabase()
+                .listCollectionNames()
+                .into(new HashSet<>())
+                .contains(CLUSTER_CONFIG_COLLECTION_NAME);
+        this.isFreshInstallation.set(!configurationExists);
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/bootstrap/preflight/MongoDBPreflightCheckTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/bootstrap/preflight/MongoDBPreflightCheckTest.java
@@ -37,16 +37,16 @@ public abstract class MongoDBPreflightCheckTest {
     }
 
     @Test
-    public void testEmptyDBisEmpty() {
+    public void testIsFreshInstallation() {
         mongoDBPreflightCheck.runCheck();
-        assertThat(mongoDBPreflightCheck.dbIsEmpty()).isTrue();
+        assertThat(mongoDBPreflightCheck.isFreshInstallation()).isTrue();
     }
 
     @Test
     @MongoDBFixtures("MongoDBPreflightCheckTest.json")
-    public void testNonEmptyDBisNotEmpty() {
+    public void testNonEmptyDBFreshInstallation() {
         mongoDBPreflightCheck.runCheck();
-        assertThat(mongoDBPreflightCheck.dbIsEmpty()).isFalse();
+        assertThat(mongoDBPreflightCheck.isFreshInstallation()).isFalse();
     }
 
     @Test

--- a/graylog2-server/src/test/resources/org/graylog2/bootstrap/preflight/MongoDBPreflightCheckTest.json
+++ b/graylog2-server/src/test/resources/org/graylog2/bootstrap/preflight/MongoDBPreflightCheckTest.json
@@ -1,5 +1,5 @@
 {
-  "some_collection": [
+  "cluster_config": [
     {
       "_id": {
         "$oid": "54e3deadbeefdeadbeefaffe"


### PR DESCRIPTION
With the introduction of Datanodes and Preflight UI, we have also enabled hearthbeat checks that persist some data into the nodes collection. These entries could break the `isFreshInstallation` flag in the graylog server, if the datanode starts before the graylog server.

## Description
This PR changes the `isFreshInstallation` logic, which is now based on the existence of the `cluster_config` collection.

## How Has This Been Tested?
Adapted existing unit tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

