### PR TITLE
Add undo reset button to encrypted form fields

### DIFF
--- a/changelog/unreleased/issue-14767.toml
+++ b/changelog/unreleased/issue-14767.toml
@@ -2,4 +2,4 @@ type = "added"
 message = "Added an "Undo Reset" button to fields in input configuration forms"
 
 issues = ["14767"]
-pulls = [""]
+pulls = ["15147", "graylog-plugin-enterprise#4964"]

--- a/changelog/unreleased/issue-14767.toml
+++ b/changelog/unreleased/issue-14767.toml
@@ -1,0 +1,5 @@
+type = "added"
+message = "Added an "Undo Reset" button to fields in input configuration forms"
+
+issues = ["14767"]
+pulls = [""]

--- a/graylog2-web-interface/src/components/configurationforms/BooleanField.tsx
+++ b/graylog2-web-interface/src/components/configurationforms/BooleanField.tsx
@@ -25,7 +25,7 @@ import type { BooleanField as BooleanFieldType } from 'components/configurationf
 type Props = {
   autoFocus?: boolean,
   field: BooleanFieldType,
-  onChange: (title: string, value: boolean) => void,
+  onChange: (title: string, value: boolean, dirty?: boolean) => void,
   title: string,
   typeName: string,
   value?: boolean,

--- a/graylog2-web-interface/src/components/configurationforms/ConfigurationForm.tsx
+++ b/graylog2-web-interface/src/components/configurationforms/ConfigurationForm.tsx
@@ -174,9 +174,9 @@ const ConfigurationForm = forwardRef(<Configuration extends object>({
     setTitleValue(value);
   };
 
-  const handleChange = (field: string, value: ConfigurationFieldValue) => {
+  const handleChange = (field: string, value: ConfigurationFieldValue, dirty: boolean = true) => {
     setValues({ ...values, ...{ [field]: value } });
-    setFieldStates({ ...fieldStates, ...{ [field]: { dirty: true } } });
+    setFieldStates({ ...fieldStates, ...{ [field]: { dirty } } });
   };
 
   const renderConfigField = (configField, key, autoFocus) => {

--- a/graylog2-web-interface/src/components/configurationforms/ConfigurationFormField.tsx
+++ b/graylog2-web-interface/src/components/configurationforms/ConfigurationFormField.tsx
@@ -35,7 +35,7 @@ type Props = {
   configValue: FieldValue | EncryptedFieldValue<FieldValue>,
   dirty: boolean,
   autoFocus: boolean,
-  onChange: (field: string, value: FieldValue | EncryptedFieldValue<FieldValue>) => void,
+  onChange: (field: string, value: FieldValue | EncryptedFieldValue<FieldValue>, dirty?: boolean) => void,
 };
 
 const ConfigurationFormField = ({ typeName, configField, configKey, configValue, dirty, autoFocus, onChange }: Props) => {

--- a/graylog2-web-interface/src/components/configurationforms/DropdownField.tsx
+++ b/graylog2-web-interface/src/components/configurationforms/DropdownField.tsx
@@ -25,7 +25,7 @@ import { optionalMarker } from 'components/configurationforms/FieldHelpers';
 type Props = {
   autoFocus?: boolean,
   field: DropdownFieldType,
-  onChange: (title: string, value: string) => void,
+  onChange: (title: string, value: string, dirty?: boolean) => void,
   title: string,
   typeName: string,
   value: string,

--- a/graylog2-web-interface/src/components/configurationforms/EncryptedInlineBinaryField.tsx
+++ b/graylog2-web-interface/src/components/configurationforms/EncryptedInlineBinaryField.tsx
@@ -69,6 +69,7 @@ const EncryptedInlineBinaryField = ({ field, title, typeName, dirty, onChange, v
 
   const handleUndoReset = () => {
     setIsResetted(false);
+    setFileName(undefined);
     onChange(title, { is_set: true }, false);
   };
 

--- a/graylog2-web-interface/src/components/configurationforms/EncryptedInlineBinaryField.tsx
+++ b/graylog2-web-interface/src/components/configurationforms/EncryptedInlineBinaryField.tsx
@@ -27,7 +27,7 @@ type Props = {
   autoFocus: boolean,
   field: InlineBinaryFieldType,
   dirty: boolean,
-  onChange: (title: string, value: any) => void,
+  onChange: (title: string, value: any, dirty?: boolean) => void,
   title: string,
   typeName: string,
   value?: EncryptedFieldValue<string>,
@@ -39,6 +39,7 @@ const FileContent = styled.span`
 
 const EncryptedInlineBinaryField = ({ field, title, typeName, dirty, onChange, value, autoFocus }: Props) => {
   const [fileName, setFileName] = useState(undefined);
+  const [isResetted, setIsResetted] = useState<boolean>(false);
   const isValuePresent = value.is_set;
   const isRequired = !field.is_optional;
   const showReadOnly = !dirty && isValuePresent;
@@ -61,16 +62,36 @@ const EncryptedInlineBinaryField = ({ field, title, typeName, dirty, onChange, v
     }
   };
 
+  const handleReset = () => {
+    setIsResetted(true);
+    onChange(title, { delete_value: true });
+  };
+
+  const handleUndoReset = () => {
+    setIsResetted(false);
+    onChange(title, { is_set: true }, false);
+  };
+
   const resetButton = () => {
     if (isValuePresent) {
       return (
-        <Button type="button" onClick={() => onChange(title, { delete_value: true })}>
+        <Button type="button" onClick={handleReset}>
           Reset
         </Button>
       );
     }
 
     return null;
+  };
+
+  const undoResetButton = () => {
+    if (!isResetted) return null;
+
+    return (
+      <Button type="button" onClick={handleUndoReset}>
+        Undo Reset
+      </Button>
+    );
   };
 
   const removeButton = () => {
@@ -116,7 +137,7 @@ const EncryptedInlineBinaryField = ({ field, title, typeName, dirty, onChange, v
              required={isRequired}
              help={field.description}
              autoFocus={autoFocus}
-             buttonAfter={removeButton()}>
+             buttonAfter={<>{removeButton()}{undoResetButton()}</>}>
         <FileContent>{fileName}</FileContent>
       </Input>
     ) : (
@@ -126,6 +147,7 @@ const EncryptedInlineBinaryField = ({ field, title, typeName, dirty, onChange, v
              label={labelContent}
              required={isRequired}
              help={field.description}
+             buttonAfter={undoResetButton()}
              onChange={(e) => handleFileUpload(e.target.files[0])}
              autoFocus={autoFocus} />
     )

--- a/graylog2-web-interface/src/components/configurationforms/ListField.tsx
+++ b/graylog2-web-interface/src/components/configurationforms/ListField.tsx
@@ -26,7 +26,7 @@ import { optionalMarker } from 'components/configurationforms/FieldHelpers';
 type Props = {
   autoFocus?: boolean,
   field: ListFieldType,
-  onChange: (title: string, value: Array<string>) => void,
+  onChange: (title: string, value: Array<string>, dirty?: boolean) => void,
   title: string,
   typeName: string,
   value: Array<string> | string,

--- a/graylog2-web-interface/src/components/configurationforms/NumberField.tsx
+++ b/graylog2-web-interface/src/components/configurationforms/NumberField.tsx
@@ -26,7 +26,7 @@ import type { NumberField as NumberFieldType } from './types';
 type Props = {
   autoFocus?: boolean,
   field: NumberFieldType,
-  onChange: (title: string, value: number) => void,
+  onChange: (title: string, value: number, dirty?: boolean) => void,
   title: string,
   typeName: string,
   value: number,

--- a/graylog2-web-interface/src/components/configurationforms/TextField.tsx
+++ b/graylog2-web-interface/src/components/configurationforms/TextField.tsx
@@ -15,7 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { useState } from 'react';
 
 import { Button, Input } from 'components/bootstrap';
 import { hasAttribute, optionalMarker } from 'components/configurationforms/FieldHelpers';
@@ -27,7 +27,7 @@ type Props = {
   autoFocus: boolean,
   field: TextFieldType,
   dirty: boolean,
-  onChange: (title: string, value: string | EncryptedFieldValue<string>) => void,
+  onChange: (title: string, value: string | EncryptedFieldValue<string>, dirty?: boolean) => void,
   title: string,
   typeName: string,
   value?: string | EncryptedFieldValue<string>,
@@ -38,6 +38,7 @@ const TextField = ({ field, title, typeName, dirty, onChange, value, autoFocus }
   const showReadOnlyEncrypted = field.is_encrypted && !dirty && typeof value !== 'string' && value.is_set;
   const fieldType = (!hasAttribute(field.attributes, 'textarea') && (hasAttribute(field.attributes, 'is_password') || showReadOnlyEncrypted) ? 'password' : 'text');
   const fieldId = `${typeName}-${title}`;
+  const [isResetted, setIsResetted] = useState<boolean>(false);
 
   const labelContent = <>{field.human_name} {optionalMarker(field)}</>;
 
@@ -63,13 +64,31 @@ const TextField = ({ field, title, typeName, dirty, onChange, value, autoFocus }
     }
   };
 
+  const handleReset = () => {
+    setIsResetted(true);
+    onChange(title, { delete_value: true });
+  };
+
+  const handleUndoReset = () => {
+    setIsResetted(false);
+    onChange(title, { is_set: true }, false);
+  };
+
   const buttonAfter = () => {
+    if (isResetted) {
+      return (
+        <Button type="button" onClick={handleUndoReset}>
+          Undo Reset
+        </Button>
+      );
+    }
+
     if (!showReadOnlyEncrypted) {
       return null;
     }
 
     return (
-      <Button type="button" onClick={() => onChange(title, { delete_value: true })}>
+      <Button type="button" onClick={handleReset}>
         Reset
       </Button>
     );

--- a/graylog2-web-interface/src/components/configurationforms/TitleField.tsx
+++ b/graylog2-web-interface/src/components/configurationforms/TitleField.tsx
@@ -23,7 +23,7 @@ import type { TextField as TextFieldType } from './types';
 
 type Props = {
   helpText?: string,
-  onChange: (title: string, value: string) => void,
+  onChange: (title: string, value: string, dirty?: boolean) => void,
   typeName: string,
   value: string,
 };


### PR DESCRIPTION
Part of https://github.com/Graylog2/graylog2-server/issues/14764
This PR adds an undo reset button to encrypted form fields.

Related: https://github.com/Graylog2/graylog-plugin-enterprise/pull/4964

## Description
The "Undo Reset" button is only shown on encrypted text fields and inline binary file uploads after the user clicks "reset".

## Motivation and Context
When editing encrypting fields, the user wants to be able to undo an accidental reset of the field.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

![Monosnap screencast 2023-04-04 17-55-11](https://user-images.githubusercontent.com/3169354/229849512-3e4f9a92-4f42-429b-8c4d-7eed9a93a73b.gif)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

