### PR TITLE
Input form: Only reset title when initial title changes or modal is closed

### DIFF
--- a/graylog2-web-interface/src/components/configurationforms/ConfigurationForm.tsx
+++ b/graylog2-web-interface/src/components/configurationforms/ConfigurationForm.tsx
@@ -76,9 +76,12 @@ const ConfigurationForm = forwardRef(<Configuration extends object>({
     }
 
     setValues({ ...defaultValues, ...initialValues });
-    setTitleValue(initialTitleValue);
     setFieldStates({});
-  }, [showConfigurationModal, configFields, initialValues, initialTitleValue]);
+  }, [showConfigurationModal, configFields, initialValues]);
+
+  useEffect(() => {
+    setTitleValue(initialTitleValue);
+  }, [initialTitleValue, showConfigurationModal]);
 
   const getFormData = (): ConfigurationFormData<Configuration> => {
     const data: ConfigurationFormData<Configuration> = {


### PR DESCRIPTION
Fixes https://github.com/Graylog2/graylog2-server/issues/14955

<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR fixes the bug by making sure that the title is only set to `initialTitle` when `initialTitle` changes or the modal closes/opens. 
Previously it was also reset when other props like `configFields` changed.


## Screenshots (if appropriate):
![Monosnap screencast 2023-04-05 14-09-56](https://user-images.githubusercontent.com/3169354/230076390-33cd7108-ff6c-473c-a47d-1db8fffbeaef.gif)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

