### PR TITLE
Fix z-index of dashboard tabs dropdown. (backport of #15091 for 5.0)

### DIFF
--- a/changelog/unreleased/issue-15073.toml
+++ b/changelog/unreleased/issue-15073.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Fix overlay problem with data table header and dashboard tabs dropdown."
+
+issues = ["15073"]
+pulls = ["15091"]

--- a/graylog2-web-interface/src/views/components/AdaptableQueryTabs.tsx
+++ b/graylog2-web-interface/src/views/components/AdaptableQueryTabs.tsx
@@ -79,7 +79,6 @@ const StyledQueryNav = styled(Nav)(({ theme }) => css`
     }
 
     > li.active {
-      z-index: 1;
       display: flex;
       flex-direction: column;
       align-items: center;


### PR DESCRIPTION
_Please note, this is a backport of #15091 for 5.0_

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

As described in https://github.com/Graylog2/graylog2-server/issues/15073 the "more dashboard tabs" dropdown can be displayed behind the data table header.

The fix suggested by @drewmiranda-gl works well. I tested it with all widget types and did not found a problem.

Fixes #15073

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
