### PR TITLE
Fix OpenSearch permissions in data node tarball

### DIFF
--- a/data-node-distribution/src/main/assembly/datanode.xml
+++ b/data-node-distribution/src/main/assembly/datanode.xml
@@ -21,8 +21,6 @@
         <fileSet>
             <directory>${project.basedir}/../data-node/target/opensearch</directory>
             <outputDirectory>dist</outputDirectory>
-            <fileMode>0644</fileMode>
-            <directoryMode>0755</directoryMode>
             <includes>
                 <include>*/**</include>
             </includes>

--- a/data-node/pom.xml
+++ b/data-node/pom.xml
@@ -462,6 +462,11 @@
                     <artifactId>exec-maven-plugin</artifactId>
                     <version>3.0.0</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-antrun-plugin</artifactId>
+                    <version>3.1.0</version>
+                </plugin>
             </plugins>
         </pluginManagement>
 
@@ -541,6 +546,31 @@
                                     <replacement>$1-linux-aarch64/</replacement>
                                 </org.codehaus.plexus.components.io.filemappers.RegExpFileMapper>
                             </fileMappers>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>fix-opensearch-config-permissions</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <!-- Some config files in opensearch-*/config/ use 660 permissions. That's a problem
+                                     when running OpenSearch under a different user account than the owner of the
+                                     OpenSearch config files. (OS packages or container image)
+                                -->
+                                <chmod dir="${project.build.directory}/opensearch"
+                                       includes="opensearch-*/config/**"
+                                       perm="ugo+r" />
+                            </target>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
We tried to use fileSet/fileMode to make the OpenSearch config permissions work when running OpenSearch with a different user.

That didn't work because the fileMode changed all files and removed the executable bit from all executable scripts.

Now we use the Maven antrun plugin to set the permissions on the OpenSearch files right after extraction.
