### PR TITLE
Implement node heartbeats without server-side scripting.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/cluster/NodeServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/cluster/NodeServiceImpl.java
@@ -30,7 +30,6 @@ import org.graylog2.plugin.system.NodeId;
 
 import javax.inject.Inject;
 import java.net.URI;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -136,10 +135,6 @@ public class NodeServiceImpl extends PersistedServiceImpl implements NodeService
                 new BasicDBObject("$match", Map.of("$and", match)),
                 new BasicDBObject("$unset", "last_seen_date")
         );
-    }
-
-    private List<? extends DBObject> recentHeartbeat() {
-        return recentHeartbeat(Collections.emptyList());
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/cluster/NodeServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/cluster/NodeServiceImpl.java
@@ -16,7 +16,9 @@
  */
 package org.graylog2.cluster;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
+import com.mongodb.AggregationOptions;
 import com.mongodb.BasicDBObject;
 import com.mongodb.DBObject;
 import com.mongodb.WriteResult;
@@ -24,16 +26,19 @@ import org.bson.types.ObjectId;
 import org.graylog2.Configuration;
 import org.graylog2.database.MongoConnection;
 import org.graylog2.database.PersistedServiceImpl;
-import org.graylog2.plugin.Tools;
-import org.graylog2.plugin.database.ValidationException;
 import org.graylog2.plugin.system.NodeId;
 
 import javax.inject.Inject;
 import java.net.URI;
+import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
+import java.util.Spliterator;
+import java.util.Spliterators;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 public class NodeServiceImpl extends PersistedServiceImpl implements NodeService {
     private final long pingTimeout;
@@ -46,7 +51,7 @@ public class NodeServiceImpl extends PersistedServiceImpl implements NodeService
 
     public NodeServiceImpl(final MongoConnection mongoConnection, final int staleLeaderTimeout) {
         super(mongoConnection);
-        this.pingTimeout = TimeUnit.MILLISECONDS.toSeconds(staleLeaderTimeout);
+        this.pingTimeout = staleLeaderTimeout;
     }
 
     public Node.Type type() {
@@ -92,17 +97,14 @@ public class NodeServiceImpl extends PersistedServiceImpl implements NodeService
         return byNodeId(nodeId.getNodeId());
     }
 
+    private Stream<DBObject> aggregate(List<? extends DBObject> pipeline) {
+        return cursorToStream(this.collection(NodeImpl.class).aggregate(pipeline, AggregationOptions.builder().build()));
+    }
+
     @Override
     public Map<String, Node> allActive(Node.Type type) {
-        final BasicDBObject query = new BasicDBObject(Map.of(
-                "$and", List.of(
-                        Map.of("type", type.toString()),
-                        recentHeartbeat()
-                )));
-
-        return query(NodeImpl.class, query)
-                .stream()
-                .collect(Collectors.toMap(obj -> (String)obj.get("node_id"), obj -> new NodeImpl((ObjectId) obj.get("_id"), obj.toMap())));
+        return aggregate(recentHeartbeat(List.of(Map.of("type", type.toString()))))
+                .collect(Collectors.toMap(obj -> (String) obj.get("node_id"), obj -> new NodeImpl((ObjectId) obj.get("_id"), obj.toMap())));
     }
 
     @Override
@@ -116,11 +118,40 @@ public class NodeServiceImpl extends PersistedServiceImpl implements NodeService
         return nodes;
     }
 
+    private List<? extends DBObject> recentHeartbeat(List<? extends Map<String, Object>> additionalMatches) {
+        var match = ImmutableList.builder()
+                .add(Map.of("$expr", Map.of("$gte", List.of("$last_seen_date", Map.of("$subtract", List.of("$$NOW", this.pingTimeout))))))
+                .addAll(additionalMatches)
+                .build();
+        return List.of(
+                new BasicDBObject("$addFields", Map.of("last_seen_date", Map.of("$toDate", Map.of("$dateToString", Map.of("date", "$last_seen"))))),
+                new BasicDBObject("$match", Map.of("$and", match)),
+                new BasicDBObject("$unset", "last_seen_date")
+        );
+    }
+
+    private List<? extends DBObject> recentHeartbeat() {
+        return recentHeartbeat(Collections.emptyList());
+    }
+
     @Override
     public void dropOutdated() {
-        final BasicDBObject query = new BasicDBObject("$nor", List.of(recentHeartbeat()));
+        var outdatedIds = aggregate(List.of(
+                new BasicDBObject("$addFields", Map.of("last_seen_date", Map.of("$toDate", Map.of("$dateToString", Map.of("date", "$last_seen"))))),
+                new BasicDBObject("$match", Map.of("$expr", Map.of("$lt", List.of("$last_seen_date", Map.of("$subtract", List.of("$$NOW", this.pingTimeout)))))),
+                new BasicDBObject("$project", Map.of("_id", "$_id"))
+        ))
+                .map(obj -> obj.get("_id"))
+                .toList();
 
-        destroyAll(NodeImpl.class, query);
+        if (!outdatedIds.isEmpty()) {
+            final BasicDBObject query = new BasicDBObject("_id", Map.of("$in", outdatedIds));
+            destroyAll(NodeImpl.class, query);
+        }
+    }
+
+    private Stream<DBObject> cursorToStream(Iterator<DBObject> cursor) {
+        return StreamSupport.stream(Spliterators.spliteratorUnknownSize(cursor, Spliterator.ORDERED), false);
     }
 
     /**
@@ -145,38 +176,24 @@ public class NodeServiceImpl extends PersistedServiceImpl implements NodeService
         }
     }
 
-    private Map<String, Object> recentHeartbeat() {
-        return Map.of("$where", "this.last_seen >= Timestamp(new Date().getTime() / 1000 - " + pingTimeout + ", 1)");
-    }
-
     @Override
     public boolean isOnlyLeader(NodeId nodeId) {
-        final BasicDBObject query = new BasicDBObject(Map.of(
-                "$and", List.of(
-                        recentHeartbeat(),
-                        Map.of(
-                                "type", Node.Type.SERVER.toString(),
-                                "node_id", new BasicDBObject("$ne", nodeId.getNodeId()),
-                                "is_leader", true
-                        )
+        return aggregate(recentHeartbeat(List.of(
+                Map.of(
+                        "type", Node.Type.SERVER.toString(),
+                        "node_id", new BasicDBObject("$ne", nodeId.getNodeId()),
+                        "is_leader", true
                 )
-        ));
-
-        return count(NodeImpl.class, query) == 0;
+        ))).findAny().isEmpty();
     }
 
     @Override
     public boolean isAnyLeaderPresent() {
-        final BasicDBObject query = new BasicDBObject(Map.of(
-                "$and", List.of(
-                        recentHeartbeat(),
-                        Map.of(
-                                "type", Node.Type.SERVER.toString(),
-                                "is_leader", true
-                        )
+        return aggregate(recentHeartbeat(List.of(
+                Map.of(
+                        "type", Node.Type.SERVER.toString(),
+                        "is_leader", true
                 )
-        ));
-
-        return count(NodeImpl.class, query) > 0;
+        ))).findAny().isPresent();
     }
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is refactoring the node heartbeats to replace the usage of the `$where`-clause (which requires server-side scripting) with an aggregation pipeline using date arithmetics using the `$$NOW` global variable.

Due to the lack of type coercion, it is not backwards compatible with the previous format of the `last_seen` field.

/nocl

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.