### PR TITLE
Security update to shiro-core 1.11.0

### DIFF
--- a/changelog/unreleased/pr-15187.toml
+++ b/changelog/unreleased/pr-15187.toml
@@ -1,0 +1,4 @@
+type = "s"
+message = "Update to Apache Shiro dependency to version 1.11.0. (the fixed CVEs don't affect Graylog)"
+
+pulls = ["15187"]

--- a/pom.xml
+++ b/pom.xml
@@ -154,7 +154,7 @@
         <retrofit.version>2.9.0</retrofit.version>
         <scala.version>2.13.4</scala.version>
         <semver4j.version>2.2.0-graylog.1</semver4j.version>
-        <shiro.version>1.5.2</shiro.version>
+        <shiro.version>1.11.0</shiro.version>
         <oshi.version>5.3.7</oshi.version>
         <siv-mode.version>1.4.1</siv-mode.version>
         <slf4j.version>1.7.30</slf4j.version>


### PR DESCRIPTION
Release notes:

- https://shiro.apache.org/blog/2023/01/13/apache-shiro-1110-released.html
- https://shiro.apache.org/blog/2022/11/19/apache-shiro-1101-released.html
- https://shiro.apache.org/blog/2022/10/10/apache-shiro-1100-released.html
- https://shiro.apache.org/blog/2022/06/28/apache-shiro-191-released.html
- https://shiro.apache.org/blog/2022/03/22/apache-shiro-190-released.html
- https://shiro.apache.org/blog/2021/v1.8.0.html
- https://shiro.apache.org/blog/2021/v1.7.1.html
- https://shiro.apache.org/blog/2020/v1.7.0.html
- https://shiro.apache.org/blog/2020/v1.6.0.html
- https://shiro.apache.org/blog/2020/05/03/apache-shiro-1.5.3-released.html

Fixed CVEs:

- CVE-2022-32532 - Doesn't affect Graylog because we don't run in a servlet container
- CVE-2022-40664 - Doesn't affect Graylog because we don't run in a servlet container
- CVE-2023-22602 - Doesn't affect Graylog because the issue is Spring Boot specific