### PR TITLE
Security update to snakeyaml version 2.0

### DIFF
--- a/changelog/unreleased/pr-15188.toml
+++ b/changelog/unreleased/pr-15188.toml
@@ -1,0 +1,4 @@
+type = "s"
+message = "Update snakeyaml version to 2.0. (fixes CVE-2022-1471)"
+
+pulls = ["15188"]

--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
         <HdrHistogram.version>2.1.12</HdrHistogram.version>
         <hibernate-validator.version>6.1.2.Final</hibernate-validator.version>
         <hk2.version>2.6.1</hk2.version> <!-- The HK2 version should match the version being used by Jersey -->
-        <jackson.version>2.13.4.20221013</jackson.version>
+        <jackson.version>2.14.2</jackson.version>
         <!-- TODO: Remove snakeyaml dependency management below when updating to Jackson >= 2.15 -->
         <snakeyaml.version>2.0</snakeyaml.version>
         <jadconfig.version>0.14.0</jadconfig.version>

--- a/pom.xml
+++ b/pom.xml
@@ -118,6 +118,8 @@
         <hibernate-validator.version>6.1.2.Final</hibernate-validator.version>
         <hk2.version>2.6.1</hk2.version> <!-- The HK2 version should match the version being used by Jersey -->
         <jackson.version>2.13.4.20221013</jackson.version>
+        <!-- TODO: Remove snakeyaml dependency management below when updating to Jackson >= 2.15 -->
+        <snakeyaml.version>2.0</snakeyaml.version>
         <jadconfig.version>0.14.0</jadconfig.version>
         <java-semver.version>0.9.0</java-semver.version>
         <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
@@ -269,6 +271,14 @@
                 <artifactId>netty-tcnative-boringssl-static</artifactId>
                 <version>${netty-tcnative-boringssl-static.version}</version>
                 <classifier>linux-x86_64</classifier>
+            </dependency>
+
+            <!-- Manage snakeyaml version until jackson-dataformat-yaml 2.15 is
+                 out to fix a security vulnerability. -->
+            <dependency>
+                <groupId>org.yaml</groupId>
+                <artifactId>snakeyaml</artifactId>
+                <version>${snakeyaml.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Manage the snakeyaml dependency to use version 2.0.

Release notes: https://bitbucket.org/snakeyaml/snakeyaml/wiki/Changes

Addresses CVE-2022-1471.
https://github.com/google/security-research/security/advisories/GHSA-mjmj-j48q-9wg2