### PR TITLE
Fixed calculation and expression of CPU load in OshiProbe to be consistent in OsStats

### DIFF
--- a/changelog/unreleased/pr-15195.toml
+++ b/changelog/unreleased/pr-15195.toml
@@ -1,0 +1,12 @@
+# PLEASE REMOVE COMMENTS AND OPTIONAL FIELDS! THANKS!
+
+# Entry type according to https://keepachangelog.com/en/1.0.0/
+# One of: a(dded), c(hanged), d(eprecated), r(emoved), f(ixed), s(ecurity)
+type = "fixed"
+message = "Fixed calculation and expression of CPU load in OshiProbe."
+
+issues = [""]
+pulls = ["15195"]
+
+contributors = ["panxt"]
+

--- a/changelog/unreleased/pr-15195.toml
+++ b/changelog/unreleased/pr-15195.toml
@@ -6,7 +6,7 @@ type = "fixed"
 message = "Fixed calculation and expression of CPU load in OshiProbe."
 
 issues = [""]
-pulls = ["15195"]
+pulls = ["15195", "15183" ]
 
 contributors = ["panxt"]
 

--- a/graylog2-server/src/main/java/org/graylog2/shared/system/stats/os/OshiOsProbe.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/system/stats/os/OshiOsProbe.java
@@ -74,6 +74,7 @@ public class OshiOsProbe implements OsProbe {
         long steal = ticks[TickType.STEAL.getIndex()] - prevTicks[TickType.STEAL.getIndex()];
 
         long totalCpu = user + nice + system + idle + iowait + irq + softirq + steal;
+        totalCpu = totalCpu == 0 ? 1 : totalCpu; // avoid division by zero
 
         short sys = (short) (100 * system / totalCpu);
         short us = (short) (100 * user / totalCpu);

--- a/graylog2-server/src/main/java/org/graylog2/shared/system/stats/os/OshiOsProbe.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/system/stats/os/OshiOsProbe.java
@@ -22,6 +22,7 @@ import oshi.hardware.CentralProcessor.TickType;
 import oshi.hardware.GlobalMemory;
 import oshi.hardware.HardwareAbstractionLayer;
 import oshi.hardware.VirtualMemory;
+import oshi.util.Util;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -59,6 +60,8 @@ public class OshiOsProbe implements OsProbe {
         final CentralProcessor centralProcessor = hardware.getProcessor();
 
         long[] prevTicks = centralProcessor.getSystemCpuLoadTicks();
+        // Wait a second...
+        Util.sleep(1000);
         long[] ticks = centralProcessor.getSystemCpuLoadTicks();
         short user = (short) (ticks[TickType.USER.getIndex()] - prevTicks[TickType.USER.getIndex()]);
         short sys = (short) (ticks[TickType.SYSTEM.getIndex()] - prevTicks[TickType.SYSTEM.getIndex()]);
@@ -71,7 +74,7 @@ public class OshiOsProbe implements OsProbe {
         final Processor proc = Processor.create(
                 processorIdentifier.getName(),
                 processorIdentifier.getVendor(),
-                ((int) processorIdentifier.getVendorFreq() / 1000000),
+                (int) (processorIdentifier.getVendorFreq() / 1000000),
                 centralProcessor.getLogicalProcessorCount(),
                 centralProcessor.getPhysicalPackageCount(),
                 centralProcessor.getLogicalProcessorCount() / totalSockets,

--- a/graylog2-server/src/main/java/org/graylog2/shared/system/stats/os/OshiOsProbe.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/system/stats/os/OshiOsProbe.java
@@ -63,10 +63,22 @@ public class OshiOsProbe implements OsProbe {
         // Wait a second...
         Util.sleep(1000);
         long[] ticks = centralProcessor.getSystemCpuLoadTicks();
-        short user = (short) (ticks[TickType.USER.getIndex()] - prevTicks[TickType.USER.getIndex()]);
-        short sys = (short) (ticks[TickType.SYSTEM.getIndex()] - prevTicks[TickType.SYSTEM.getIndex()]);
-        short idle = (short) (ticks[TickType.IDLE.getIndex()] - prevTicks[TickType.IDLE.getIndex()]);
-        short steal = (short) (ticks[TickType.STEAL.getIndex()] - prevTicks[TickType.STEAL.getIndex()]);
+
+        long user = ticks[TickType.USER.getIndex()] - prevTicks[TickType.USER.getIndex()];
+        long nice = ticks[TickType.NICE.getIndex()] - prevTicks[TickType.NICE.getIndex()];
+        long system = ticks[TickType.SYSTEM.getIndex()] - prevTicks[TickType.SYSTEM.getIndex()];
+        long idle = ticks[TickType.IDLE.getIndex()] - prevTicks[TickType.IDLE.getIndex()];
+        long iowait = ticks[TickType.IOWAIT.getIndex()] - prevTicks[TickType.IOWAIT.getIndex()];
+        long irq = ticks[TickType.IRQ.getIndex()] - prevTicks[TickType.IRQ.getIndex()];
+        long softirq = ticks[TickType.SOFTIRQ.getIndex()] - prevTicks[TickType.SOFTIRQ.getIndex()];
+        long steal = ticks[TickType.STEAL.getIndex()] - prevTicks[TickType.STEAL.getIndex()];
+
+        long totalCpu = user + nice + system + idle + iowait + irq + softirq + steal;
+
+        short sys = (short) (100 * system / totalCpu);
+        short us = (short) (100 * user / totalCpu);
+        short id = (short) (100 * idle / totalCpu);
+        short st = (short) (100 * steal / totalCpu);
 
         final CentralProcessor.ProcessorIdentifier processorIdentifier = centralProcessor.getProcessorIdentifier();
         final int totalSockets = centralProcessor.getPhysicalPackageCount() > 0 ? centralProcessor.getPhysicalPackageCount() : 1;
@@ -80,9 +92,9 @@ public class OshiOsProbe implements OsProbe {
                 centralProcessor.getLogicalProcessorCount() / totalSockets,
                 -1,
                 sys,
-                user,
-                idle,
-                steal);
+                us,
+                id,
+                st);
 
 
         return OsStats.create(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
Fixed calculation and expression of CPU load in OshiProbe to be consistent in OsStats.
 It's related to https://github.com/Graylog2/graylog2-server/pull/15183
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.


