### PR TITLE
Update json-path to 2.8.0 to fix a security issue in json-smart

### DIFF
--- a/changelog/unreleased/pr-15190.toml
+++ b/changelog/unreleased/pr-15190.toml
@@ -1,0 +1,4 @@
+type = "s"
+message = "Update json-path to 2.8.0 to fix a security issue in json-smart."
+
+pulls = ["15190"]

--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
         <jmte.version>5.0.0</jmte.version>
         <joda-time.version>2.10.6</joda-time.version>
         <jool.version>0.9.14</jool.version>
-        <json-path.version>2.7.0</json-path.version>
+        <json-path.version>2.8.0</json-path.version>
         <kafka.version>2.7.0</kafka.version>
         <kafka09.version>0.9.0.1-6</kafka09.version>
         <log4j.version>2.17.1</log4j.version>


### PR DESCRIPTION
* Update json-path to 2.8.0 to fix a security issue in json-smart

Fixes CVE-2023-1370 in the json-smart transitive dependency.

* Add changelog

(cherry picked from commit cf665f1032b8d8a3254bd6341ffa8607bcd2d9d1)