### PR TITLE
Update netty from 4.1.84 to 4.1.91

### DIFF
--- a/changelog/unreleased/pr-15186.toml
+++ b/changelog/unreleased/pr-15186.toml
@@ -1,0 +1,5 @@
+type = "security"
+message = "Update Netty from 4.1.84 to 4.1.91"
+
+pulls = ["15186"]
+

--- a/pom.xml
+++ b/pom.xml
@@ -141,8 +141,8 @@
         <mongodb-driver.version>4.7.1</mongodb-driver.version>
         <mongojack.version>2.10.1.2</mongojack.version>
         <natty.version>0.13</natty.version>
-        <netty.version>4.1.84.Final</netty.version>
-        <netty-tcnative-boringssl-static.version>2.0.54.Final</netty-tcnative-boringssl-static.version>
+        <netty.version>4.1.91.Final</netty.version>
+        <netty-tcnative-boringssl-static.version>2.0.59.Final</netty-tcnative-boringssl-static.version>
         <okhttp.version>3.14.6</okhttp.version>
         <okta-sdk.version>8.2.1</okta-sdk.version>
         <opencsv.version>2.3</opencsv.version>


### PR DESCRIPTION
netty-tcnative from 2.0.54 to 2.0.59

fixed CVEs

- HAProxyMessageDecoder Stack Exhaustion DoS (CVE-2022-41881)
- HTTP Response splitting from assigning header value iterator (CVE-2022-41915)

(cherry picked from commit a0a6af0f85179a3f152b303b319d3fff6ac2300c)