### PR TITLE
CSR command with code generating sample CSR

### DIFF
--- a/data-node/src/main/java/org/graylog/datanode/bootstrap/Main.java
+++ b/data-node/src/main/java/org/graylog/datanode/bootstrap/Main.java
@@ -23,6 +23,7 @@ import org.graylog.datanode.bootstrap.commands.CliCommandHelp;
 import org.graylog.datanode.bootstrap.commands.ShowVersion;
 import org.graylog.security.certutil.CertutilCa;
 import org.graylog.security.certutil.CertutilCert;
+import org.graylog.security.certutil.CertutilCsr;
 import org.graylog.security.certutil.CertutilHttp;
 import org.graylog2.bootstrap.CliCommand;
 import org.graylog2.bootstrap.CliCommandsProvider;
@@ -38,6 +39,7 @@ public class Main {
                         CertutilCa.class,
                         CertutilCert.class,
                         CertutilHttp.class,
+                        CertutilCsr.class,
                         ShowVersion.class,
                         CliCommandHelp.class));
 

--- a/graylog2-server/src/main/java/org/graylog/security/certutil/CertutilCsr.java
+++ b/graylog2-server/src/main/java/org/graylog/security/certutil/CertutilCsr.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.security.certutil;
+
+import com.github.rvesse.airline.annotations.Command;
+import com.github.rvesse.airline.annotations.Option;
+import org.bouncycastle.asn1.DEROctetString;
+import org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers;
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.asn1.x509.Extension;
+import org.bouncycastle.asn1.x509.Extensions;
+import org.bouncycastle.asn1.x509.GeneralName;
+import org.bouncycastle.asn1.x509.GeneralNames;
+import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+import org.bouncycastle.pkcs.PKCS10CertificationRequest;
+import org.bouncycastle.pkcs.PKCS10CertificationRequestBuilder;
+import org.bouncycastle.pkcs.jcajce.JcaPKCS10CertificationRequestBuilder;
+import org.graylog.security.certutil.console.CommandLineConsole;
+import org.graylog.security.certutil.console.SystemConsole;
+import org.graylog.security.certutil.csr.CsrFileStorage;
+import org.graylog.security.certutil.csr.CsrStorage;
+import org.graylog.security.certutil.privatekey.PrivateKeyEncryptedFileStorage;
+import org.graylog.security.certutil.privatekey.PrivateKeyEncryptedStorage;
+import org.graylog2.bootstrap.CliCommand;
+
+import javax.security.auth.x500.X500Principal;
+import java.security.KeyPairGenerator;
+
+
+@Command(name = "csr", description = "Create CSR", groupNames = {"certutil"})
+public class CertutilCsr implements CliCommand {
+
+    @Option(name = "--privateKey", description = "Keystore with private key")
+    protected String privateKeyFilename = "csr-private-key.key";
+
+    @Option(name = "--csrFile", description = "Keystore with private key")
+    protected String csrFilename = "csr.csr";
+
+    private final CommandLineConsole console;
+    private final PrivateKeyEncryptedStorage privateKeyEncryptedFileStorage;
+    private final CsrStorage csrFileStorage;
+
+    public CertutilCsr() {
+        this.console = new SystemConsole();
+        this.privateKeyEncryptedFileStorage = new PrivateKeyEncryptedFileStorage(privateKeyFilename);
+        this.csrFileStorage = new CsrFileStorage(csrFilename);
+    }
+
+    public CertutilCsr(final String privateKeyFilename,
+                       final String csrFilename,
+                       final CommandLineConsole console) {
+        this.privateKeyFilename = privateKeyFilename;
+        this.csrFilename = csrFilename;
+        this.console = console;
+        this.privateKeyEncryptedFileStorage = new PrivateKeyEncryptedFileStorage(privateKeyFilename);
+        this.csrFileStorage = new CsrFileStorage(csrFilename);
+    }
+
+    @Override
+    public void run() {
+        console.printLine("This tool will generate a CSR for the datanode");
+        char[] privKeyPassword = this.console.readPassword("Enter password to protect your private key : ");
+
+        try {
+            console.printLine("Generating CSR for the datanode");
+            KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");
+            java.security.KeyPair certKeyPair = keyGen.generateKeyPair();
+
+            privateKeyEncryptedFileStorage.writeEncryptedKey(privKeyPassword, certKeyPair.getPrivate());
+
+            Extension subjectAltName = new Extension(Extension.subjectAlternativeName, false,
+                    new DEROctetString(new GeneralNames(new GeneralName(new X500Name("CN=Alt Name")))));
+
+            PKCS10CertificationRequestBuilder p10Builder = new JcaPKCS10CertificationRequestBuilder(
+                    new X500Principal("CN=localhost"), certKeyPair.getPublic())
+                    .addAttribute(
+                            PKCSObjectIdentifiers.pkcs_9_at_extensionRequest,
+                            new Extensions(subjectAltName));
+            JcaContentSignerBuilder csBuilder = new JcaContentSignerBuilder("SHA256withRSA");
+            ContentSigner signer = csBuilder.build(certKeyPair.getPrivate());
+            PKCS10CertificationRequest csr = p10Builder.build(signer);
+
+            csrFileStorage.writeCsr(csr);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/graylog2-server/src/main/java/org/graylog/security/certutil/csr/CsrFileStorage.java
+++ b/graylog2-server/src/main/java/org/graylog/security/certutil/csr/CsrFileStorage.java
@@ -26,6 +26,7 @@ import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.Reader;
+import java.nio.charset.Charset;
 import java.security.Security;
 
 public record CsrFileStorage(String csrFilename) implements CsrStorage {
@@ -38,7 +39,7 @@ public record CsrFileStorage(String csrFilename) implements CsrStorage {
     public void writeCsr(PKCS10CertificationRequest csr)
             throws IOException, OperatorCreationException {
 
-        try (JcaPEMWriter jcaPEMWriter = new JcaPEMWriter(new FileWriter(csrFilename))) {
+        try (JcaPEMWriter jcaPEMWriter = new JcaPEMWriter(new FileWriter(csrFilename, Charset.defaultCharset()))) {
             jcaPEMWriter.writeObject(csr);
         }
     }
@@ -47,7 +48,7 @@ public record CsrFileStorage(String csrFilename) implements CsrStorage {
     public PKCS10CertificationRequest readCsr()
             throws IOException, OperatorCreationException {
 
-        Reader pemReader = new BufferedReader(new FileReader(csrFilename));
+        Reader pemReader = new BufferedReader(new FileReader(csrFilename, Charset.defaultCharset()));
         PEMParser pemParser = new PEMParser(pemReader);
         Object parsedObj = pemParser.readObject();
         if (parsedObj instanceof PKCS10CertificationRequest) {

--- a/graylog2-server/src/main/java/org/graylog/security/certutil/csr/CsrFileStorage.java
+++ b/graylog2-server/src/main/java/org/graylog/security/certutil/csr/CsrFileStorage.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.security.certutil.csr;
+
+import org.bouncycastle.openssl.PEMParser;
+import org.bouncycastle.openssl.jcajce.JcaPEMWriter;
+import org.bouncycastle.operator.OperatorCreationException;
+import org.bouncycastle.pkcs.PKCS10CertificationRequest;
+
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.Reader;
+import java.security.Security;
+
+public record CsrFileStorage(String csrFilename) implements CsrStorage {
+
+    static {
+        Security.addProvider(new org.bouncycastle.jce.provider.BouncyCastleProvider());
+    }
+
+    @Override
+    public void writeCsr(PKCS10CertificationRequest csr)
+            throws IOException, OperatorCreationException {
+
+        try (JcaPEMWriter jcaPEMWriter = new JcaPEMWriter(new FileWriter(csrFilename))) {
+            jcaPEMWriter.writeObject(csr);
+        }
+    }
+
+    @Override
+    public PKCS10CertificationRequest readCsr()
+            throws IOException, OperatorCreationException {
+
+        Reader pemReader = new BufferedReader(new FileReader(csrFilename));
+        PEMParser pemParser = new PEMParser(pemReader);
+        Object parsedObj = pemParser.readObject();
+        if (parsedObj instanceof PKCS10CertificationRequest) {
+            return (PKCS10CertificationRequest) parsedObj;
+        }
+        return null;
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/security/certutil/csr/CsrStorage.java
+++ b/graylog2-server/src/main/java/org/graylog/security/certutil/csr/CsrStorage.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.security.certutil.csr;
+
+import org.bouncycastle.operator.OperatorCreationException;
+import org.bouncycastle.pkcs.PKCS10CertificationRequest;
+
+import java.io.IOException;
+
+public interface CsrStorage {
+
+    void writeCsr(PKCS10CertificationRequest csr)
+            throws IOException, OperatorCreationException;
+
+    PKCS10CertificationRequest readCsr()
+            throws IOException, OperatorCreationException;
+}

--- a/graylog2-server/src/main/java/org/graylog/security/certutil/privatekey/PrivateKeyEncryptedFileStorage.java
+++ b/graylog2-server/src/main/java/org/graylog/security/certutil/privatekey/PrivateKeyEncryptedFileStorage.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.security.certutil.privatekey;
+
+import org.bouncycastle.asn1.nist.NISTObjectIdentifiers;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.openssl.PEMParser;
+import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
+import org.bouncycastle.openssl.jcajce.JcaPEMWriter;
+import org.bouncycastle.operator.InputDecryptorProvider;
+import org.bouncycastle.operator.OperatorCreationException;
+import org.bouncycastle.pkcs.PKCS8EncryptedPrivateKeyInfo;
+import org.bouncycastle.pkcs.PKCS8EncryptedPrivateKeyInfoBuilder;
+import org.bouncycastle.pkcs.PKCSException;
+import org.bouncycastle.pkcs.jcajce.JcaPKCS8EncryptedPrivateKeyInfoBuilder;
+import org.bouncycastle.pkcs.jcajce.JcePKCSPBEInputDecryptorProviderBuilder;
+import org.bouncycastle.pkcs.jcajce.JcePKCSPBEOutputEncryptorBuilder;
+
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.security.PrivateKey;
+import java.security.Security;
+
+public record PrivateKeyEncryptedFileStorage(String privateKeyFilename) implements PrivateKeyEncryptedStorage {
+
+    static {
+        Security.addProvider(new org.bouncycastle.jce.provider.BouncyCastleProvider());
+    }
+
+    @Override
+    public void writeEncryptedKey(char[] passwd, PrivateKey privateKey)
+            throws IOException, OperatorCreationException {
+
+        JcaPEMWriter pemWriter = new JcaPEMWriter(new FileWriter(privateKeyFilename));
+        PKCS8EncryptedPrivateKeyInfoBuilder pkcs8Builder =
+                new JcaPKCS8EncryptedPrivateKeyInfoBuilder(privateKey);
+        pemWriter.writeObject(pkcs8Builder.build(new JcePKCSPBEOutputEncryptorBuilder(
+                NISTObjectIdentifiers.id_aes256_CBC)
+                .setProvider(BouncyCastleProvider.PROVIDER_NAME)
+                .build(passwd)));
+        pemWriter.close();
+
+    }
+
+    @Override
+    public PrivateKey readEncryptedKey(char[] password)
+            throws IOException, OperatorCreationException, PKCSException {
+        PEMParser parser = new PEMParser(new FileReader(privateKeyFilename));
+        PKCS8EncryptedPrivateKeyInfo encPrivKeyInfo = (PKCS8EncryptedPrivateKeyInfo) parser.readObject();
+        InputDecryptorProvider pkcs8Prov = new JcePKCSPBEInputDecryptorProviderBuilder()
+                .setProvider(BouncyCastleProvider.PROVIDER_NAME)
+                .build(password);
+        JcaPEMKeyConverter converter = new JcaPEMKeyConverter().setProvider(BouncyCastleProvider.PROVIDER_NAME);
+        return converter.getPrivateKey(encPrivKeyInfo.decryptPrivateKeyInfo(pkcs8Prov));
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/security/certutil/privatekey/PrivateKeyEncryptedFileStorage.java
+++ b/graylog2-server/src/main/java/org/graylog/security/certutil/privatekey/PrivateKeyEncryptedFileStorage.java
@@ -33,6 +33,7 @@ import org.bouncycastle.pkcs.jcajce.JcePKCSPBEOutputEncryptorBuilder;
 import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.security.PrivateKey;
 import java.security.Security;
 
@@ -46,7 +47,7 @@ public record PrivateKeyEncryptedFileStorage(String privateKeyFilename) implemen
     public void writeEncryptedKey(char[] passwd, PrivateKey privateKey)
             throws IOException, OperatorCreationException {
 
-        JcaPEMWriter pemWriter = new JcaPEMWriter(new FileWriter(privateKeyFilename));
+        JcaPEMWriter pemWriter = new JcaPEMWriter(new FileWriter(privateKeyFilename, Charset.defaultCharset()));
         PKCS8EncryptedPrivateKeyInfoBuilder pkcs8Builder =
                 new JcaPKCS8EncryptedPrivateKeyInfoBuilder(privateKey);
         pemWriter.writeObject(pkcs8Builder.build(new JcePKCSPBEOutputEncryptorBuilder(
@@ -60,7 +61,7 @@ public record PrivateKeyEncryptedFileStorage(String privateKeyFilename) implemen
     @Override
     public PrivateKey readEncryptedKey(char[] password)
             throws IOException, OperatorCreationException, PKCSException {
-        PEMParser parser = new PEMParser(new FileReader(privateKeyFilename));
+        PEMParser parser = new PEMParser(new FileReader(privateKeyFilename, Charset.defaultCharset()));
         PKCS8EncryptedPrivateKeyInfo encPrivKeyInfo = (PKCS8EncryptedPrivateKeyInfo) parser.readObject();
         InputDecryptorProvider pkcs8Prov = new JcePKCSPBEInputDecryptorProviderBuilder()
                 .setProvider(BouncyCastleProvider.PROVIDER_NAME)

--- a/graylog2-server/src/main/java/org/graylog/security/certutil/privatekey/PrivateKeyEncryptedStorage.java
+++ b/graylog2-server/src/main/java/org/graylog/security/certutil/privatekey/PrivateKeyEncryptedStorage.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.security.certutil.privatekey;
+
+import org.bouncycastle.operator.OperatorCreationException;
+import org.bouncycastle.pkcs.PKCSException;
+
+import java.io.IOException;
+import java.security.PrivateKey;
+
+public interface PrivateKeyEncryptedStorage {
+
+    void writeEncryptedKey(char[] passwd, PrivateKey privateKey) throws IOException, OperatorCreationException;
+
+    PrivateKey readEncryptedKey(char[] password) throws IOException, OperatorCreationException, PKCSException;
+}

--- a/graylog2-server/src/test/java/org/graylog/security/certutil/csr/CsrFileStorageTest.java
+++ b/graylog2-server/src/test/java/org/graylog/security/certutil/csr/CsrFileStorageTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.security.certutil.csr;
+
+import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+import org.bouncycastle.pkcs.PKCS10CertificationRequest;
+import org.bouncycastle.pkcs.PKCS10CertificationRequestBuilder;
+import org.bouncycastle.pkcs.jcajce.JcaPKCS10CertificationRequestBuilder;
+import org.junit.jupiter.api.Test;
+
+import javax.security.auth.x500.X500Principal;
+import java.security.KeyPairGenerator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class CsrFileStorageTest {
+
+    @Test
+    void testCsrStorageSaveAndRetrieve() throws Exception {
+        KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");
+        java.security.KeyPair certKeyPair = keyGen.generateKeyPair();
+        PKCS10CertificationRequestBuilder p10Builder = new JcaPKCS10CertificationRequestBuilder(
+                new X500Principal("CN=localhost"), certKeyPair.getPublic());
+        JcaContentSignerBuilder csBuilder = new JcaContentSignerBuilder("SHA256withRSA");
+        ContentSigner signer = csBuilder.build(certKeyPair.getPrivate());
+        PKCS10CertificationRequest csr = p10Builder.build(signer);
+
+        CsrFileStorage csrFileStorage = new CsrFileStorage("test.csr");
+        csrFileStorage.writeCsr(csr);
+        final PKCS10CertificationRequest readCsr = csrFileStorage.readCsr();
+
+        assertEquals(csr, readCsr);
+    }
+
+
+}

--- a/graylog2-server/src/test/java/org/graylog/security/certutil/privatekey/PrivateKeyEncryptedFileStorageTest.java
+++ b/graylog2-server/src/test/java/org/graylog/security/certutil/privatekey/PrivateKeyEncryptedFileStorageTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.security.certutil.privatekey;
+
+import org.bouncycastle.pkcs.PKCSException;
+import org.junit.jupiter.api.Test;
+
+import java.security.KeyPairGenerator;
+import java.security.PrivateKey;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class PrivateKeyEncryptedFileStorageTest {
+
+    @Test
+    void testKeyStorageSaveAndRetrieve() throws Exception {
+        PrivateKeyEncryptedFileStorage privateKeyEncryptedFileStorage = new PrivateKeyEncryptedFileStorage("temp.key");
+        char[] passwd = "password".toCharArray();
+
+        KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");
+        java.security.KeyPair certKeyPair = keyGen.generateKeyPair();
+        final PrivateKey privateKey = certKeyPair.getPrivate();
+
+        privateKeyEncryptedFileStorage.writeEncryptedKey(passwd, privateKey);
+        final PrivateKey readPrivateKey = privateKeyEncryptedFileStorage.readEncryptedKey(passwd);
+
+        assertEquals(privateKey, readPrivateKey);
+    }
+
+    @Test
+    void testKeyStorageThrowsExceptionWhenUsingWrongPasswordDuringRead() throws Exception {
+        PrivateKeyEncryptedFileStorage privateKeyEncryptedFileStorage = new PrivateKeyEncryptedFileStorage("temp.key");
+        char[] passwd = "password".toCharArray();
+
+        KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");
+        java.security.KeyPair certKeyPair = keyGen.generateKeyPair();
+        final PrivateKey privateKey = certKeyPair.getPrivate();
+
+        privateKeyEncryptedFileStorage.writeEncryptedKey(passwd, privateKey);
+        assertThrows(PKCSException.class, () -> privateKeyEncryptedFileStorage.readEncryptedKey("wrong password".toCharArray()));
+    }
+}


### PR DESCRIPTION
## Description
CSR command with code generating sample CSR.
It does the following things:
1. Generate public/private key file.
2. Stores private key so that it can be used after certificate eventually gets signed.
3. Creates CSR.
4. Stores CSR in the file.

It is not a final solution, but rather a step in the proper direction.
Further development will need to be postponed untill the start of next shape-up cycle.

/nocl

## How Has This Been Tested?
With new unit tests and manually.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

