### PR TITLE
Fix mixed-up event scheduling information

### DIFF
--- a/graylog2-web-interface/src/components/event-definitions/event-definitions/SchedulingCell.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definitions/SchedulingCell.tsx
@@ -138,8 +138,8 @@ const SchedulingCell = ({ definition } : Props) => {
   const {
     title,
     config: {
-      search_within_ms: executeEveryMs,
-      execute_every_ms: searchWithinMs,
+      search_within_ms: searchWithinMs,
+      execute_every_ms: executeEveryMs,
     },
     scheduler,
   } = definition;


### PR DESCRIPTION
Scheduling information in the event definitions table is mixed up. "search within ms" and "execute every ms" need to be permutated.

![image](https://user-images.githubusercontent.com/886541/231760746-18b98ecc-f57a-477b-b128-ae6144779a73.png)

This PR does that.

/nocl