### PR TITLE
Opensearch dist dir autodetection

### DIFF
--- a/changelog/unreleased/pr-15216.toml
+++ b/changelog/unreleased/pr-15216.toml
@@ -1,0 +1,4 @@
+type = "a"
+message = "Added autodetection of opensearch distribution in datanode."
+
+pulls = ["15216"]

--- a/data-node/src/main/java/org/graylog/datanode/Configuration.java
+++ b/data-node/src/main/java/org/graylog/datanode/Configuration.java
@@ -49,8 +49,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
-import static org.graylog2.shared.utilities.StringUtils.f;
-
 /**
  * Helper class to hold configuration of Graylog
  */
@@ -74,10 +72,7 @@ public class Configuration extends BaseConfiguration {
     private boolean disableNativeSystemStatsCollector = false;
 
     @Parameter(value = "opensearch_location")
-    private String opensearchLocation = "dist/opensearch-2.5.0";
-
-    @Parameter(value = "opensearch_version")
-    private String opensearchVersion = "2.5.0";
+    private String opensearchDistributionRoot = "dist";
 
     @Parameter(value = "opensearch_data_location")
     private String opensearchDataLocation = "data";
@@ -153,28 +148,12 @@ public class Configuration extends BaseConfiguration {
         return isLeader;
     }
 
+    public String getOpensearchDistributionRoot() {
+        return opensearchDistributionRoot;
+    }
+
     public String getOpensearchConfigLocation() {
         return opensearchConfigLocation;
-    }
-
-    public String getOpensearchLocation() {
-        // If the configured location exists, just use it.
-        if (Files.exists(Path.of(opensearchLocation))) {
-            return opensearchLocation;
-        }
-
-        // Otherwise check if the architecture dependent distribution exists.
-        final var osArch = System.getProperty("os.arch");
-        return switch (osArch) {
-            case "amd64" -> f("%s-linux-x64", opensearchLocation);
-            case "aarch64" -> f("%s-linux-aarch64", opensearchLocation);
-            default ->
-                    throw new UnsupportedOperationException("Unsupported OpenSearch distribution architecture: " + osArch);
-        };
-    }
-
-    public String getOpensearchVersion() {
-        return opensearchVersion;
     }
 
     public String getOpensearchDataLocation() {

--- a/data-node/src/main/java/org/graylog/datanode/OpensearchDistribution.java
+++ b/data-node/src/main/java/org/graylog/datanode/OpensearchDistribution.java
@@ -86,6 +86,7 @@ public record OpensearchDistribution(Path directory, String version, @Nullable S
             case "amd64" -> "x64";
             case "x86_64" -> "x64";
             case "aarch64" -> "aarch64";
+            case "arm64" -> "aarch64";
             default ->
                     throw new UnsupportedOperationException("Unsupported OpenSearch distribution architecture: " + osArch);
         };

--- a/data-node/src/main/java/org/graylog/datanode/OpensearchDistribution.java
+++ b/data-node/src/main/java/org/graylog/datanode/OpensearchDistribution.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.datanode;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public record OpensearchDistribution(Path directory, String version, @Nullable String platform,
+                                     @Nullable String architecture) {
+
+    private static final Logger LOG = LoggerFactory.getLogger(OpensearchDistribution.class);
+    public static final Pattern FULL_NAME_PATTERN = Pattern.compile("opensearch-(.*)-(.+)-(.+)");
+    public static final Pattern SHORT_NAME_PATTERN = Pattern.compile("opensearch-(.*)");
+
+    public OpensearchDistribution(Path path, String version) {
+        this(path, version, null, null);
+    }
+
+    public static OpensearchDistribution detectInDirectory(Path directory) throws IOException {
+        final var osArch = System.getProperty("os.arch");
+        return detectInDirectory(directory, osArch);
+    }
+
+    static OpensearchDistribution detectInDirectory(Path rootDistDirectory, String osArch) throws IOException {
+        Objects.requireNonNull(rootDistDirectory, "Dist directory needs to be provided");
+
+        // if the base directory points directly to one opensearch distribution, we should return it directly.
+        // If the format doesn't fit, we'll look for opensearch distributions in this root directory.
+        final Optional<OpensearchDistribution> distDirectory = parse(rootDistDirectory);
+        return distDirectory.orElseGet(() -> detectInSubdirectory(rootDistDirectory, osArch));
+
+    }
+
+    private static OpensearchDistribution detectInSubdirectory(Path directory, String osArch) {
+        final List<OpensearchDistribution> opensearchDistributions;
+        try (
+                var files = Files.list(directory);
+        ) {
+            opensearchDistributions = files
+                    .filter(Files::isDirectory)
+                    .flatMap(f -> parse(f).stream())
+                    .toList();
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to list content of provided directory " + directory.toAbsolutePath(), e);
+        }
+
+        if (opensearchDistributions.isEmpty()) {
+            throw new IllegalArgumentException("Could not detect any opensearch distribution in " + directory.toAbsolutePath());
+        }
+
+        LOG.info("Found following opensearch distributions: " + opensearchDistributions.stream().map(d -> d.directory().toAbsolutePath()).toList());
+
+        final var archCode = archCode(osArch);
+
+        return findByArchitecture(opensearchDistributions, archCode)
+                .orElseGet(() -> findWithoutArchitecture(opensearchDistributions)
+                        .orElseThrow(() -> new IllegalArgumentException("No Opensearch distribution found for architecture " + osArch)));
+    }
+
+    private static String archCode(final String osArch) {
+        return switch (osArch) {
+            case "amd64" -> "x64";
+            case "x86_64" -> "x64";
+            case "aarch64" -> "aarch64";
+            default ->
+                    throw new UnsupportedOperationException("Unsupported OpenSearch distribution architecture: " + osArch);
+        };
+    }
+
+    private static Optional<OpensearchDistribution> findByArchitecture(List<OpensearchDistribution> available, String archCode) {
+        return available.stream()
+                .filter(d -> archCode.equals(d.architecture()))
+                .findAny();
+    }
+
+    private static Optional<OpensearchDistribution> findWithoutArchitecture(List<OpensearchDistribution> available) {
+        return available.stream().filter(d -> d.architecture() == null).findFirst();
+    }
+
+    private static Optional<OpensearchDistribution> parse(Path path) {
+        final String filename = path.getFileName().toString();
+        final Matcher matcher = FULL_NAME_PATTERN.matcher(filename);
+        if (matcher.matches()) {
+            return Optional.of(new OpensearchDistribution(path, matcher.group(1), matcher.group(2), matcher.group(3)));
+        } else {
+            final Matcher shortMatcher = SHORT_NAME_PATTERN.matcher(filename);
+            if (shortMatcher.matches()) {
+                return Optional.of(new OpensearchDistribution(path, shortMatcher.group(1)));
+            } else {
+                return Optional.empty();
+            }
+        }
+    }
+}

--- a/data-node/src/main/java/org/graylog/datanode/OpensearchDistributionProvider.java
+++ b/data-node/src/main/java/org/graylog/datanode/OpensearchDistributionProvider.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.datanode;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+import javax.inject.Singleton;
+import java.io.IOException;
+import java.nio.file.Path;
+
+@Singleton
+public class OpensearchDistributionProvider implements Provider<OpensearchDistribution> {
+
+    private final OpensearchDistribution opensearchDistribution;
+
+    @Inject
+    public OpensearchDistributionProvider(Configuration configuration) throws IOException {
+        this.opensearchDistribution = OpensearchDistribution.detectInDirectory(Path.of(configuration.getOpensearchDistributionRoot()));
+    }
+
+    @Override
+    public OpensearchDistribution get() {
+        return opensearchDistribution;
+    }
+}

--- a/data-node/src/main/java/org/graylog/datanode/bindings/OpensearchDistributionBindings.java
+++ b/data-node/src/main/java/org/graylog/datanode/bindings/OpensearchDistributionBindings.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.datanode.bindings;
+
+import com.google.inject.AbstractModule;
+import org.graylog.datanode.OpensearchDistribution;
+import org.graylog.datanode.OpensearchDistributionProvider;
+
+public class OpensearchDistributionBindings extends AbstractModule {
+    @Override
+    protected void configure() {
+        bind(OpensearchDistribution.class).toProvider(OpensearchDistributionProvider.class);
+    }
+}

--- a/data-node/src/main/java/org/graylog/datanode/bootstrap/OpensearchBinPreflightCheck.java
+++ b/data-node/src/main/java/org/graylog/datanode/bootstrap/OpensearchBinPreflightCheck.java
@@ -16,7 +16,7 @@
  */
 package org.graylog.datanode.bootstrap;
 
-import org.graylog.datanode.Configuration;
+import org.graylog.datanode.OpensearchDistribution;
 import org.graylog2.bootstrap.preflight.PreflightCheck;
 import org.graylog2.bootstrap.preflight.PreflightCheckException;
 import org.slf4j.Logger;
@@ -37,8 +37,8 @@ public class OpensearchBinPreflightCheck implements PreflightCheck {
     private static final Logger LOG = LoggerFactory.getLogger(OpensearchBinPreflightCheck.class);
 
     @Inject
-    public OpensearchBinPreflightCheck(Configuration configuration) {
-        this(Path.of(configuration.getOpensearchLocation()));
+    public OpensearchBinPreflightCheck(OpensearchDistribution opensearchDistribution) {
+        this(opensearchDistribution.directory());
     }
 
     protected OpensearchBinPreflightCheck(Path opensearchBaseDirectory) {

--- a/data-node/src/main/java/org/graylog/datanode/bootstrap/ServerBootstrap.java
+++ b/data-node/src/main/java/org/graylog/datanode/bootstrap/ServerBootstrap.java
@@ -29,6 +29,7 @@ import org.graylog.datanode.Configuration;
 import org.graylog.datanode.bindings.ConfigurationModule;
 import org.graylog.datanode.bindings.GenericBindings;
 import org.graylog.datanode.bindings.GenericInitializerBindings;
+import org.graylog.datanode.bindings.OpensearchDistributionBindings;
 import org.graylog.datanode.bindings.PreflightChecksBindings;
 import org.graylog.datanode.bindings.SchedulerBindings;
 import org.graylog2.bootstrap.preflight.MongoDBPreflightCheck;
@@ -155,7 +156,9 @@ public abstract class ServerBootstrap extends CmdLineTool {
         return Guice.createInjector(
                 new IsDevelopmentBindings(),
                 new NamedConfigParametersModule(jadConfig.getConfigurationBeans()),
-                new ConfigurationModule(configuration)
+                new ConfigurationModule(configuration),
+                new OpensearchDistributionBindings()
+
         );
     }
 
@@ -165,6 +168,7 @@ public abstract class ServerBootstrap extends CmdLineTool {
                 new NamedConfigParametersModule(jadConfig.getConfigurationBeans()),
                 new ConfigurationModule(configuration),
                 new PreflightChecksBindings(),
+                new OpensearchDistributionBindings(),
                 new Module() {
                     @Override
                     public void configure(Binder binder) {
@@ -277,6 +281,7 @@ public abstract class ServerBootstrap extends CmdLineTool {
 //        result.add(new SharedPeriodicalBindings());
         result.add(new SchedulerBindings());
         result.add(new GenericInitializerBindings());
+        result.add(new OpensearchDistributionBindings());
 //        result.add(new SystemStatsModule(configuration.isDisableNativeSystemStatsCollector()));
 
         return result;

--- a/data-node/src/main/java/org/graylog/datanode/configuration/ConfigurationProvider.java
+++ b/data-node/src/main/java/org/graylog/datanode/configuration/ConfigurationProvider.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import org.bouncycastle.openssl.jcajce.JcaPEMWriter;
 import org.graylog.datanode.Configuration;
+import org.graylog.datanode.OpensearchDistribution;
 import org.graylog.datanode.process.OpensearchConfiguration;
 import org.graylog2.jackson.TypeReferences;
 import org.graylog2.security.hashing.BCryptPasswordAlgorithm;
@@ -55,10 +56,10 @@ public class ConfigurationProvider implements Provider<OpensearchConfiguration> 
     private final OpensearchConfiguration configuration;
 
     @Inject
-    public ConfigurationProvider(Configuration localConfiguration, DataNodeConfig sharedConfiguration) throws KeyStoreException, CertificateException, IOException, NoSuchAlgorithmException, UnrecoverableKeyException {
+    public ConfigurationProvider(Configuration localConfiguration, DataNodeConfig sharedConfiguration, OpensearchDistribution opensearchDistribution) throws KeyStoreException, CertificateException, IOException, NoSuchAlgorithmException, UnrecoverableKeyException {
         final var cfg = sharedConfiguration.test();
 
-        final Path opensearchConfigDir = Path.of(localConfiguration.getOpensearchLocation()).resolve("config");
+        final Path opensearchConfigDir = opensearchDistribution.directory().resolve("config");
 
         final LinkedHashMap<String, String> config = new LinkedHashMap<>();
         config.put("path.data", Path.of(localConfiguration.getOpensearchDataLocation()).resolve(localConfiguration.getDatanodeNodeName()).toAbsolutePath().toString());
@@ -150,9 +151,10 @@ public class ConfigurationProvider implements Provider<OpensearchConfiguration> 
             config.put("plugins.security.ssl.http.pemtrustedcas_filepath", "http-ca.pem");
         }
 
+
         configuration = new OpensearchConfiguration(
-                localConfiguration.getOpensearchVersion(),
-                Path.of(localConfiguration.getOpensearchLocation()),
+                opensearchDistribution.version(),
+                opensearchDistribution.directory(),
                 localConfiguration.getOpensearchHttpPort(),
                 localConfiguration.getOpensearchTransportPort(),
                 localConfiguration.getRestApiUsername(),

--- a/data-node/src/test/java/org/graylog/datanode/OpensearchDistributionTest.java
+++ b/data-node/src/test/java/org/graylog/datanode/OpensearchDistributionTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.datanode;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+class OpensearchDistributionTest {
+
+    @TempDir
+    private Path tempDir;
+
+    @TempDir
+    private Path tempDirWithoutArch;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        Files.createDirectory(tempDir.resolve("opensearch-2.5.0-linux-x64"));
+        Files.createDirectory(tempDir.resolve("opensearch-2.5.0-linux-aarch64"));
+        Files.createDirectory(tempDir.resolve("somethingelse")); // just to include something which is not OS dist
+
+        Files.createDirectory(tempDirWithoutArch.resolve("opensearch-2.4.1"));
+        Files.createDirectory(tempDir.resolve(".config")); // just to include something which is not OS dist
+    }
+
+    @Test
+    void testDetection() throws IOException {
+        final OpensearchDistribution x64 = OpensearchDistribution.detectInDirectory(tempDir, "amd64");
+        Assertions.assertThat(x64.version()).isEqualTo("2.5.0");
+        Assertions.assertThat(x64.platform()).isEqualTo("linux");
+        Assertions.assertThat(x64.architecture()).isEqualTo("x64");
+
+        final OpensearchDistribution mac = OpensearchDistribution.detectInDirectory(tempDir, "x86_64");
+        Assertions.assertThat(mac.version()).isEqualTo("2.5.0");
+        Assertions.assertThat(mac.platform()).isEqualTo("linux");
+        Assertions.assertThat(mac.architecture()).isEqualTo("x64");
+
+        final OpensearchDistribution aarch64 = OpensearchDistribution.detectInDirectory(tempDir, "aarch64");
+        Assertions.assertThat(aarch64.version()).isEqualTo("2.5.0");
+        Assertions.assertThat(aarch64.platform()).isEqualTo("linux");
+        Assertions.assertThat(aarch64.architecture()).isEqualTo("aarch64");
+    }
+
+    @Test
+    void testDetectionUnknownArch() {
+        Assertions.assertThatThrownBy(() -> OpensearchDistribution.detectInDirectory(tempDir, "nonsense"))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessage("Unsupported OpenSearch distribution architecture: nonsense");
+    }
+
+    @Test
+    void testDetectionWithoutArch() throws IOException {
+        final OpensearchDistribution dist = OpensearchDistribution.detectInDirectory(tempDirWithoutArch, "amd64");
+        Assertions.assertThat(dist.version()).isEqualTo("2.4.1");
+        Assertions.assertThat(dist.architecture()).isNull();
+        Assertions.assertThat(dist.platform()).isNull();
+    }
+
+    @Test
+    void testBackwardsCompatibility() throws IOException {
+        // we are not pointing to the root directory which should contain different OS distributions but rather directly to one
+        // specific distribution.
+        final OpensearchDistribution dist = OpensearchDistribution.detectInDirectory(tempDir.resolve("opensearch-2.5.0-linux-x64"), "amd64");
+        Assertions.assertThat(dist.version()).isEqualTo("2.5.0");
+        Assertions.assertThat(dist.platform()).isEqualTo("linux");
+        Assertions.assertThat(dist.architecture()).isEqualTo("x64");
+    }
+}

--- a/data-node/src/test/java/org/graylog/datanode/testinfra/DatanodeContainerizedBackend.java
+++ b/data-node/src/test/java/org/graylog/datanode/testinfra/DatanodeContainerizedBackend.java
@@ -46,8 +46,7 @@ public class DatanodeContainerizedBackend {
         this.datanodeContainer = createDatanodeContainer(
                 "node1",
                 hooks, createDockerImageFile(getOpensearchVersion()),
-                getDatanodeVersion(),
-                getOpensearchVersion());
+                getDatanodeVersion());
     }
 
     public DatanodeContainerizedBackend(Network network, GenericContainer<?> mongodbContainer, String nodeName, DatanodeDockerHooks hooks) {
@@ -57,16 +56,15 @@ public class DatanodeContainerizedBackend {
                 nodeName,
                 hooks,
                 createDockerImageFile(getOpensearchVersion()),
-                getDatanodeVersion(),
-                getOpensearchVersion());
+                getDatanodeVersion());
     }
 
-    private GenericContainer<?> createDatanodeContainer(String nodeName, DatanodeDockerHooks customizer, ImageFromDockerfile image, String datanodeVersion, String opensearchVersion) {
+    private GenericContainer<?> createDatanodeContainer(String nodeName, DatanodeDockerHooks customizer, ImageFromDockerfile image, String datanodeVersion) {
         GenericContainer<?> container = new GenericContainer<>(image)
                 .withExposedPorts(DATANODE_REST_PORT, DATANODE_OPENSEARCH_PORT)
                 .withNetwork(network)
 
-                .withEnv("GRAYLOG_DATANODE_OPENSEARCH_LOCATION", IMAGE_WORKING_DIR + "/opensearch-" + opensearchVersion)
+                .withEnv("GRAYLOG_DATANODE_OPENSEARCH_LOCATION", IMAGE_WORKING_DIR)
                 .withEnv("GRAYLOG_DATANODE_OPENSEARCH_DATA_LOCATION", IMAGE_WORKING_DIR + "/data")
                 .withEnv("GRAYLOG_DATANODE_OPENSEARCH_LOGS_LOCATION", IMAGE_WORKING_DIR + "/logs")
                 .withEnv("GRAYLOG_DATANODE_OPENSEARCH_CONFIG_LOCATION", IMAGE_WORKING_DIR + "/config")

--- a/misc/datanode.conf
+++ b/misc/datanode.conf
@@ -1,6 +1,9 @@
 # defaults
+
+# Root directory of opensearch distribution
+opensearch_location = dist/
+
 # locations of bin, data and log directories
-opensearch_location = dist/opensearch-2.4.1
 opensearch_config_location = config
 opensearch_data_location = data
 opensearch_logs_location = logs


### PR DESCRIPTION
This PR removes the need to provide exact path to the opensearch distribution and opensearch version. We can autodetect both from the root distribution directory.


## Motivation and Context
Before this PR it was needed to point to the exact opensearch distribution directory in the datanode.conf. But adding this full path in the configuration would prevent us from updating to a newer version of opensearch - the user would have to change the path every time. 

With autodetection we only need a base directory that will hold opensearch distribution. The rest - opensearch location, version and architecture can be autodetected during runtime. 

The autodetection handles 3 typical cases, all of them dealing with different `opensearch_location` target:

- The property points to a directory that holds different distributions of opensearch for different architectures. Each distribution in its own subdirectory. The naming of the subdirectories follows opensearch-version-platform-architecture pattern (opensearch-2.5.0-linux-aarch64)
- The property points directly to an exact location of the opensearch distribution
- The property points to a directory with OS distribution in subdirectory following opensearch-version pattern (opensearch-2.5.0) 

The autodetection first tries to verify if the target is directly the distribution (matching dir name). If not, it tries to detect available distributions and find one for the specific arch. And lastly it will try to find any opensearch distribution.

## How Has This Been Tested?
Added unit tests, adapted existing integration tests (+docker image).

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

