### PR TITLE
Fix global json-path library config modification in test class

### DIFF
--- a/graylog2-server/src/test/java/org/graylog/events/conditions/BooleanNumberConditionsVisitorTest.java
+++ b/graylog2-server/src/test/java/org/graylog/events/conditions/BooleanNumberConditionsVisitorTest.java
@@ -46,29 +46,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class BooleanNumberConditionsVisitorTest {
     private static ObjectMapper objectMapper = new ObjectMapperProvider().get();
 
-    @BeforeClass
-    public static void classSetUp() {
-        Configuration.setDefaults(new Configuration.Defaults() {
-            private final JsonProvider jsonProvider = new JacksonJsonProvider(objectMapper);
-            private final MappingProvider mappingProvider = new JacksonMappingProvider(objectMapper);
-
-            @Override
-            public JsonProvider jsonProvider() {
-                return jsonProvider;
-            }
-
-            @Override
-            public Set<Option> options() {
-                return EnumSet.noneOf(Option.class);
-            }
-
-            @Override
-            public MappingProvider mappingProvider() {
-                return mappingProvider;
-            }
-        });
-    }
-
     @Test
     public void testTrue() throws Exception {
         assertThat(Expr.True.create().accept(new BooleanNumberConditionsVisitor())).isTrue();

--- a/graylog2-server/src/test/java/org/graylog2/inputs/codecs/EncodingTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/inputs/codecs/EncodingTest.java
@@ -40,7 +40,7 @@ class EncodingTest {
     final String jsonString = "{"
             + "\"version\": \"1.1\","
             + "\"" + MSG_FIELD + "\": \"" + MESSAGE + "\","
-            + "\"host\": \"example.org\""
+            + "\"host\": \"example.org\","
             + "}";
     RawMessage rawUTF8 = new RawMessage(jsonString.getBytes(StandardCharsets.UTF_8));
     RawMessage rawUTF16 = new RawMessage(jsonString.getBytes(StandardCharsets.UTF_16));


### PR DESCRIPTION
The "BooleanNumberConditionsVisitorTest" test was globally modifying the configuration of the json-path library.

Since we are using two forked JVMs to run the tests, the changed json-path configuration sometimes affected the "EncodingTest" test class. That dependend on the distribution of the test files over the forked JVMs and the order the tests are executed.

With surefire 2.22.1 the problem never showed up for some reason. With surefire 3.0.0 the problem showed up more often that it did not. This is probably due to the fork runner implementation changes in vesion 3.0.0.

This change also restores the trailing comma in the JSON example in "EncodingTest" that got removed in the surefire update.

/nocl