### PR TITLE
Fix resetting GuiceInjectorHolder during preflight web

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/bootstrap/ServerBootstrap.java
+++ b/graylog2-server/src/main/java/org/graylog2/bootstrap/ServerBootstrap.java
@@ -35,11 +35,9 @@ import org.graylog2.Configuration;
 import org.graylog2.audit.AuditActor;
 import org.graylog2.audit.AuditEventSender;
 import org.graylog2.bindings.ConfigurationModule;
-import org.graylog2.bindings.MongoDBModule;
 import org.graylog2.bootstrap.preflight.MongoDBPreflightCheck;
 import org.graylog2.bootstrap.preflight.PreflightCheckException;
 import org.graylog2.bootstrap.preflight.PreflightCheckService;
-import org.graylog2.bootstrap.preflight.PreflightConfig;
 import org.graylog2.bootstrap.preflight.PreflightConfigService;
 import org.graylog2.bootstrap.preflight.PreflightWebModule;
 import org.graylog2.bootstrap.preflight.ServerPreflightChecksModule;
@@ -80,7 +78,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -175,23 +172,29 @@ public abstract class ServerBootstrap extends CmdLineTool {
 
         final Injector preflightInjector = getPreflightInjector(modules);
         GuiceInjectorHolder.setInjector(preflightInjector);
+        try {
+            doRunWithPreflightInjector(preflightInjector);
+        } finally {
+            GuiceInjectorHolder.resetInjector();
+        }
+    }
 
+    private void doRunWithPreflightInjector(Injector preflightInjector) {
         final PreflightConfigService preflightConfigService = preflightInjector.getInstance(PreflightConfigService.class);
 
         final Supplier<Boolean> shouldRun = () -> preflightConfigService.getPersistedConfig().isEmpty() || configuration.enablePreflightWebserver();
 
-        if(!shouldRun.get()) {
+        if (!shouldRun.get()) {
             return;
         }
 
         LOG.info("Fresh installation detected, starting configuration webserver");
 
-
         final ServiceManager serviceManager = preflightInjector.getInstance(ServiceManager.class);
         try {
             serviceManager.startAsync().awaitHealthy();
             // wait till the marker document appears
-            while(shouldRun.get()) {
+            while (shouldRun.get()) {
                 try {
                     LOG.debug("Preflight config still in progress, waiting for the marker document");
                     Thread.sleep(1000);
@@ -199,10 +202,8 @@ public abstract class ServerBootstrap extends CmdLineTool {
                     throw new RuntimeException(e);
                 }
             }
-
         } finally {
             serviceManager.stopAsync().awaitStopped();
-            GuiceInjectorHolder.resetInjector();
         }
     }
 


### PR DESCRIPTION
Fix resetting guice injection holder when preflight feature flag is set but the preflight is already configured/skipped. 

/nocl

## How Has This Been Tested?
Manually

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

