### PR TITLE
Use telemetry configuration to set connect-src value in CSP header

### DIFF
--- a/full-backend-tests/src/test/java/org/graylog/testing/fullbackend/FiltersIT.java
+++ b/full-backend-tests/src/test/java/org/graylog/testing/fullbackend/FiltersIT.java
@@ -36,6 +36,7 @@ public class FiltersIT {
 
     @ContainerMatrixTest
     void cspDocumentationBrowser() {
+        String expected = CSP.CSP_SWAGGER + "connect-src https://telemetry.graylog.cloud;";
         given()
                 .spec(api.requestSpecification())
                 .when()
@@ -43,11 +44,12 @@ public class FiltersIT {
                 .then()
                 .statusCode(200)
                 .assertThat().header(CSPResponseFilter.CSP_HEADER,
-                        Matchers.equalTo(CSP.CSP_SWAGGER));
+                        Matchers.equalTo(expected));
     }
 
     @ContainerMatrixTest
     void cspWebInterfaceAssets() {
+        String expected = CSP.CSP_DEFAULT + "connect-src https://telemetry.graylog.cloud;";
         given()
                 .spec(api.requestSpecification())
                 .basePath("/")
@@ -56,11 +58,12 @@ public class FiltersIT {
                 .then()
                 .statusCode(200)
                 .assertThat().header(CSPResponseFilter.CSP_HEADER,
-                        Matchers.equalTo(CSP.CSP_DEFAULT));
+                        Matchers.equalTo(expected));
     }
 
     @ContainerMatrixTest
     void cspWebAppNotFound() {
+        String expected = CSP.CSP_DEFAULT + "connect-src https://telemetry.graylog.cloud;";
         given()
                 .spec(api.requestSpecification())
                 .basePath("/")
@@ -68,6 +71,6 @@ public class FiltersIT {
                 .get("streams")
                 .then()
                 .assertThat().header(CSPResponseFilter.CSP_HEADER,
-                        Matchers.equalTo(CSP.CSP_DEFAULT));
+                        Matchers.equalTo(expected));
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/filter/WebAppNotFoundResponseFilter.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/filter/WebAppNotFoundResponseFilter.java
@@ -17,7 +17,7 @@
 package org.graylog2.rest.filter;
 
 import org.graylog2.configuration.HttpConfiguration;
-import org.graylog2.shared.rest.resources.annotations.CSP;
+import org.graylog2.shared.rest.resources.annotations.CSPDynamicFeature;
 import org.graylog2.web.IndexHtmlGenerator;
 
 import javax.annotation.Priority;
@@ -37,10 +37,12 @@ import static org.graylog2.shared.rest.CSPResponseFilter.CSP_HEADER;
 @Priority(Priorities.ENTITY_CODER)
 public class WebAppNotFoundResponseFilter implements ContainerResponseFilter {
     private final IndexHtmlGenerator indexHtmlGenerator;
+    private final CSPDynamicFeature cspDynamicFeature;
 
     @Inject
-    public WebAppNotFoundResponseFilter(IndexHtmlGenerator indexHtmlGenerator) {
+    public WebAppNotFoundResponseFilter(IndexHtmlGenerator indexHtmlGenerator, CSPDynamicFeature cspDynamicFeature) {
         this.indexHtmlGenerator = indexHtmlGenerator;
+        this.cspDynamicFeature = cspDynamicFeature;
     }
 
     @Override
@@ -63,7 +65,7 @@ public class WebAppNotFoundResponseFilter implements ContainerResponseFilter {
             responseContext.getHeaders().putSingle("X-UA-Compatible", "IE=edge");
         }
         if (!responseContext.getHeaders().containsKey(CSP_HEADER)) {
-            responseContext.getHeaders().add(CSP_HEADER, CSP.CSP_DEFAULT);
+            responseContext.getHeaders().add(CSP_HEADER, cspDynamicFeature.dynamicCspString());
         }
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/annotations/CSPDynamicFeature.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/annotations/CSPDynamicFeature.java
@@ -16,10 +16,12 @@
  */
 package org.graylog2.shared.rest.resources.annotations;
 
+import org.graylog2.configuration.TelemetryConfiguration;
 import org.graylog2.shared.rest.CSPResponseFilter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.inject.Inject;
 import javax.ws.rs.container.DynamicFeature;
 import javax.ws.rs.container.ResourceInfo;
 import javax.ws.rs.core.FeatureContext;
@@ -27,6 +29,25 @@ import java.lang.reflect.Method;
 
 public class CSPDynamicFeature implements DynamicFeature {
     private static final Logger LOG = LoggerFactory.getLogger(CSPDynamicFeature.class);
+    private final String connectSrc;
+
+    @Inject
+    public CSPDynamicFeature(TelemetryConfiguration telemetryConfiguration) {
+        this.connectSrc = telemetryConfiguration.isTelemetryEnabled()
+                ? "connect-src " + telemetryConfiguration.getTelemetryApiHost() + ";"
+                : "";
+    }
+
+    public String dynamicCspString() {
+        return dynamicCspString(CSP.CSP_DEFAULT);
+    }
+
+    public String dynamicCspString(String staticCspString) {
+        if (!staticCspString.contains("connect-src")) {
+            return staticCspString + connectSrc;
+        }
+        return staticCspString;
+    }
 
     @Override
     public void configure(ResourceInfo resourceInfo, FeatureContext context) {
@@ -34,10 +55,10 @@ public class CSPDynamicFeature implements DynamicFeature {
         final Class<?> resourceClass = resourceInfo.getResourceClass();
         String cspValue = null;
         if (resourceClass != null && resourceClass.isAnnotationPresent(CSP.class)) {
-            cspValue = resourceClass.getAnnotation(CSP.class).value();
+            cspValue = dynamicCspString(resourceClass.getAnnotation(CSP.class).value());
             LOG.debug("CSP class annotation for {}: {}", resourceClass.getSimpleName(), cspValue);
         } else if (resourceMethod != null && resourceMethod.isAnnotationPresent(CSP.class)) {
-            cspValue = resourceMethod.getAnnotation(CSP.class).value();
+            cspValue = dynamicCspString(resourceMethod.getAnnotation(CSP.class).value());
             LOG.debug("CSP method annotation for {}: {}", resourceMethod.getName(), cspValue);
         }
         if (cspValue != null) {

--- a/graylog2-server/src/test/java/org/graylog2/rest/filter/WebAppNotFoundResponseFilterTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/rest/filter/WebAppNotFoundResponseFilterTest.java
@@ -16,6 +16,7 @@
  */
 package org.graylog2.rest.filter;
 
+import org.graylog2.shared.rest.resources.annotations.CSPDynamicFeature;
 import org.graylog2.web.IndexHtmlGenerator;
 import org.junit.Before;
 import org.junit.Rule;
@@ -56,6 +57,8 @@ public class WebAppNotFoundResponseFilterTest {
     private ContainerResponseContext responseContext;
     @Mock
     private IndexHtmlGenerator indexHtmlGenerator;
+    @Mock
+    private CSPDynamicFeature cspDynamicFeature;
 
     private WebAppNotFoundResponseFilter filter;
     private MultivaluedHashMap<String, Object> responseHeaders;
@@ -65,7 +68,7 @@ public class WebAppNotFoundResponseFilterTest {
         responseHeaders = new MultivaluedHashMap<>();
         when(indexHtmlGenerator.get(any())).thenReturn("index.html");
         when(responseContext.getHeaders()).thenReturn(responseHeaders);
-        filter = new WebAppNotFoundResponseFilter(indexHtmlGenerator);
+        filter = new WebAppNotFoundResponseFilter(indexHtmlGenerator, cspDynamicFeature);
     }
 
     @Test


### PR DESCRIPTION
Resolves #15238
/nocl fixing an unreleased feature, which already has a CL

Telemetry needs to connect to an external URL. Dynamically modify the CSP header, when telemetry is enabled.
