### PR TITLE
show edit  telemetry setting for builtin admin

### DIFF
--- a/changelog/unreleased/issue-15244.toml
+++ b/changelog/unreleased/issue-15244.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Fix show telemetry settings for local admin."
+
+issues = ["15244"]
+pulls = ["15247"]

--- a/graylog2-web-interface/src/components/users/UserDetails/UserDetails.tsx
+++ b/graylog2-web-interface/src/components/users/UserDetails/UserDetails.tsx
@@ -21,6 +21,7 @@ import type User from 'logic/users/User';
 import SectionGrid from 'components/common/Section/SectionGrid';
 import TelemetrySettingsDetails from 'logic/telemetry/TelemetrySettingsDetails';
 import useCurrentUser from 'hooks/useCurrentUser';
+import TelemetrySettingsConfig from 'logic/telemetry/TelemetrySettingsConfig';
 
 import PreferencesSection from './PreferencesSection';
 import ProfileSection from './ProfileSection';
@@ -37,6 +38,7 @@ type Props = {
 
 const UserDetails = ({ user }: Props) => {
   const currentUser = useCurrentUser();
+  const isLocalAdmin = currentUser.id === 'local:admin';
 
   if (!user) {
     return <Spinner />;
@@ -61,9 +63,14 @@ const UserDetails = ({ user }: Props) => {
             <IfPermitted permissions={`teams:edit:${user.username}`}>
               <TeamsSection user={user} />
             </IfPermitted>
-            {(currentUser.id === user.id) && (
+            {(currentUser.id === user.id) && !isLocalAdmin && (
               <IfPermitted permissions={`users:edit:${user.username}`}>
                 <TelemetrySettingsDetails />
+              </IfPermitted>
+            )}
+            {(currentUser.id === user.id) && isLocalAdmin && (
+              <IfPermitted permissions={`users:edit:${user.username}`}>
+                <TelemetrySettingsConfig />
               </IfPermitted>
             )}
           </div>

--- a/graylog2-web-interface/src/logic/telemetry/TelemetrySettingsConfig.tsx
+++ b/graylog2-web-interface/src/logic/telemetry/TelemetrySettingsConfig.tsx
@@ -24,10 +24,12 @@ import type { UserTelemetrySettings } from 'stores/telemetry/TelemetrySettingsSt
 import {
   TelemetrySettingsActions,
 } from 'stores/telemetry/TelemetrySettingsStore';
+import AppConfig from 'util/AppConfig';
 import TelemetryInfoText from 'logic/telemetry/TelemetryInfoText';
 
 const TelemetrySettingsConfig = () => {
   const [settings, setSettings] = useState<UserTelemetrySettings | undefined>(undefined);
+  const { enabled: isTelemetryEnabled } = AppConfig.telemetry() || {};
 
   useEffect(() => {
     TelemetrySettingsActions.get().then((result) => {
@@ -59,6 +61,7 @@ const TelemetrySettingsConfig = () => {
                    label="Enable telemetry">
               <FormikFormGroup label="enabled"
                                name="telemetry_enabled"
+                               disabled={!isTelemetryEnabled}
                                formGroupClassName="form-group no-bm"
                                type="checkbox" />
             </Input>
@@ -67,7 +70,7 @@ const TelemetrySettingsConfig = () => {
               <Col xs={12}>
                 <div className="pull-right">
                   <Button bsStyle="success"
-                          disabled={isSubmitting || !isValid}
+                          disabled={isSubmitting || !isValid || !isTelemetryEnabled}
                           title="Update Preferences"
                           type="submit">
                     Update telemetry


### PR DESCRIPTION
This change adds telemetry setting form to the user profile view for built-in admin user.

fix #15244

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

