### PR TITLE
Add wild card connect-src to CSP for telemetry and auth

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/annotations/CSP.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/annotations/CSP.java
@@ -24,8 +24,8 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE, ElementType.METHOD})
 public @interface CSP {
-    final String CSP_DEFAULT = "default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-eval'; img-src 'self' data:;";
-    final String CSP_SWAGGER = "style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-eval' 'unsafe-inline'; img-src 'self' data:;";
+    final String CSP_DEFAULT = "default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-eval'; img-src 'self' data:; connect-src *";
+    final String CSP_SWAGGER = "style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-eval' 'unsafe-inline'; img-src 'self' data:; connect-src *";
 
     String value();
 }


### PR DESCRIPTION
/nocl Fix for an unreleased feature 

Telemetry and auth need to connect to external targets. 
As an interim solution, we allow all external connections.