### PR TITLE
Fix: replay search on event definitions should honor event keys/issue 14813

### DIFF
--- a/changelog/unreleased/pr-15265.toml
+++ b/changelog/unreleased/pr-15265.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Add events roup by fields as part of the search query"
+
+issues = ["14813"]
+pulls = ["15265" ]

--- a/graylog2-web-interface/src/components/event-definitions/replay-search/EventInfoBar.test.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/replay-search/EventInfoBar.test.tsx
@@ -104,9 +104,9 @@ describe('<EventInfoBar />', () => {
       );
   });
 
-  it('Always shows fields: Priority, Execute search every, Search within, Description, Notifications, Aggregation conditions', async () => {
+  it('Always shows fields: Priority, Execute search every, Search within, Description, Notifications, Aggregation conditions for event definitions', async () => {
     setMockedHookCache({
-      isEvent: true,
+      isEventDefinition: true,
     });
 
     render(<EventInfoComponent />);
@@ -129,6 +129,28 @@ describe('<EventInfoBar />', () => {
 
     expect(field1Condition.children[0]).toHaveStyle({ backgroundColor: 'rgb(255, 255, 255)' });
     expect(field2Condition.children[0]).toHaveStyle({ backgroundColor: 'rgb(0, 0, 0)' });
+  });
+
+  it('Always shows fields: Priority, Execute search every, Search within, Description, Notifications, Group-By Fields for event', async () => {
+    setMockedHookCache({
+      isEvent: true,
+    });
+
+    render(<EventInfoComponent />);
+
+    const priority = await screen.findByTitle('Priority');
+    const execution = await screen.findByTitle('Execute search every');
+    const searchWithin = await screen.findByTitle('Search within');
+    const description = await screen.findByTitle('Description');
+    const notifications = await screen.findByTitle('Notifications');
+    const aggregationConditions = await screen.findByTitle('Group-By Fields');
+
+    expect(priority).toHaveTextContent('Normal');
+    expect(execution).toHaveTextContent('1 minute');
+    expect(searchWithin).toHaveTextContent('1 minute');
+    expect(description).toHaveTextContent('Test description');
+    expect(notifications).toHaveTextContent('Email notification');
+    expect(aggregationConditions).toHaveTextContent('field4:value4');
   });
 
   it('Shows event timestamp and event definition link for event', async () => {

--- a/graylog2-web-interface/src/components/event-definitions/replay-search/EventInfoBar.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/replay-search/EventInfoBar.tsx
@@ -56,8 +56,8 @@ const Value = styled.div`
 `;
 
 const EventInfoBar = () => {
-  useHighlightValuesForEventDefinition();
   const { isEventDefinition, isEvent, isAlert } = useAlertAndEventDefinitionData();
+  useHighlightValuesForEventDefinition(isEventDefinition);
   const [open, setOpen] = useState<boolean>(true);
 
   const toggleOpen = useCallback((e: SyntheticEvent) => {

--- a/graylog2-web-interface/src/components/event-definitions/replay-search/hooks/useAttributeComponents.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/replay-search/hooks/useAttributeComponents.tsx
@@ -26,6 +26,7 @@ import { extractDurationAndUnit } from 'components/common/TimeUnitInput';
 import { Timestamp, HoverForHelp } from 'components/common';
 import { Link } from 'components/common/router';
 import Routes from 'routing/Routes';
+import { concatQueryStrings } from 'views/logic/queries/QueryHelper';
 
 import AggregationConditions from '../AggreagtionConditions';
 import Notifications from '../Notifications';
@@ -35,11 +36,12 @@ const AlertTimestamp = styled(Timestamp)(({ theme }) => css`
 `);
 
 const useAttributeComponents = () => {
-  const { eventData, eventDefinition, isEventDefinition } = useAlertAndEventDefinitionData();
+  const { eventData, eventDefinition, isEventDefinition, isEvent, isAlert } = useAlertAndEventDefinitionData();
 
   const searchWithin = extractDurationAndUnit(eventDefinition.config.search_within_ms, TIME_UNITS);
   const executeEvery = extractDurationAndUnit(eventDefinition.config.execute_every_ms, TIME_UNITS);
   const isEDUpdatedAfterEvent = !isEventDefinition && moment(eventDefinition.updated_at).diff(eventData.timestamp) > 0;
+  const queryStringFromGrouping = (isEvent || isAlert) && concatQueryStrings(Object.entries(eventData.group_by_fields).map(([field, value]) => `${field}:${value}`), { withBrackets: false });
 
   return useMemo(() => [
     { title: 'Timestamp', content: <Timestamp dateTime={eventData?.timestamp} />, show: !isEventDefinition },
@@ -80,17 +82,14 @@ const useAttributeComponents = () => {
     {
       title: 'Aggregation conditions',
       content: <AggregationConditions />,
+      show: isEventDefinition,
     },
-  ], [
-    eventData?.timestamp,
-    eventDefinition,
-    executeEvery?.duration,
-    executeEvery?.unit,
-    isEDUpdatedAfterEvent,
-    isEventDefinition,
-    searchWithin?.duration,
-    searchWithin?.unit,
-  ]);
+    {
+      title: 'Group-By Fields',
+      content: queryStringFromGrouping,
+      show: !!queryStringFromGrouping,
+    },
+  ], [eventData?.timestamp, eventDefinition.description, eventDefinition.id, eventDefinition.priority, eventDefinition.title, eventDefinition.updated_at, executeEvery.duration, executeEvery.unit, isEDUpdatedAfterEvent, isEventDefinition, queryStringFromGrouping, searchWithin.duration, searchWithin.unit]);
 };
 
 export default useAttributeComponents;

--- a/graylog2-web-interface/src/components/events/events/EventFields.tsx
+++ b/graylog2-web-interface/src/components/events/events/EventFields.tsx
@@ -17,7 +17,7 @@
 import React from 'react';
 
 type Props = {
-  fields: Object[],
+  fields: {[key: string]: string} | Object[],
 };
 
 const EventFields = ({ fields }: Props) => {

--- a/graylog2-web-interface/src/components/events/events/types.ts
+++ b/graylog2-web-interface/src/components/events/events/types.ts
@@ -32,7 +32,7 @@ export type Event = {
   timerange_end: string,
   key: string,
   fields: Object[],
-  group_by_fields: Object[],
+  group_by_fields: {[key: string]: string},
   source_streams: string[],
   replay_info: EventReplayInfo | undefined,
   alert: boolean | undefined,

--- a/graylog2-web-interface/src/hooks/useHighlightValuesForEventDefinition.tsx
+++ b/graylog2-web-interface/src/hooks/useHighlightValuesForEventDefinition.tsx
@@ -40,12 +40,12 @@ export const conditionToExprMapper: {[name: string]: ValueExpr} = {
   equal: '==',
 };
 
-const useHighlightValuesForEventDefinition = () => {
+const useHighlightValuesForEventDefinition = (shouldRun: boolean) => {
   const dispatch = useAppDispatch();
   const { aggregations } = useAlertAndEventDefinitionData();
 
   return useEffect(() => {
-    if (aggregations?.length) {
+    if (aggregations?.length && shouldRun) {
       const valuesToHighlight = aggregations.map(({ fnSeries, value, expr }) => ({
         value,
         field: fnSeries,
@@ -54,7 +54,7 @@ const useHighlightValuesForEventDefinition = () => {
       }));
       if (valuesToHighlight.length) dispatch(createHighlightingRules(valuesToHighlight));
     }
-  }, [aggregations, dispatch]);
+  }, [aggregations, dispatch, shouldRun]);
 };
 
 export default useHighlightValuesForEventDefinition;

--- a/graylog2-web-interface/src/views/logic/queries/QueryHelper.test.ts
+++ b/graylog2-web-interface/src/views/logic/queries/QueryHelper.test.ts
@@ -14,10 +14,36 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import { escape } from './QueryHelper';
+import { concatQueryStrings, escape } from './QueryHelper';
 
 describe('QueryHelper', () => {
   it('quotes $ in values', () => {
     expect(escape('foo$bar$')).toEqual('foo\\$bar\\$');
+  });
+
+  describe('concatQueryStrings', () => {
+    it('concat queries by default with AND and brackets', () => {
+      const result = concatQueryStrings(['filed1:value1 OR field2:value2', 'field3:value3']);
+
+      expect(result).toEqual('(filed1:value1 OR field2:value2) AND (field3:value3)');
+    });
+
+    it('concat queries with custom operator and without brackets', () => {
+      const result = concatQueryStrings(['filed1:value1 OR field2:value2', 'field3:value3'], { operator: 'OR', withBrackets: false });
+
+      expect(result).toEqual('filed1:value1 OR field2:value2 OR field3:value3');
+    });
+
+    it('filtrate empty query strings', () => {
+      const result = concatQueryStrings(['     ', 'filed1:value1 OR field2:value2', ' ', 'field3:value3', '']);
+
+      expect(result).toEqual('(filed1:value1 OR field2:value2) AND (field3:value3)');
+    });
+
+    it('doesnt wrap in brackets if we have only one query string', () => {
+      const result = concatQueryStrings(['     ', 'filed1:value1 OR field2:value2', ' ', '']);
+
+      expect(result).toEqual('filed1:value1 OR field2:value2');
+    });
   });
 });

--- a/graylog2-web-interface/src/views/logic/queries/QueryHelper.ts
+++ b/graylog2-web-interface/src/views/logic/queries/QueryHelper.ts
@@ -52,7 +52,10 @@ const addToQuery = (oldQuery: string, newTerm: string, operator: string = 'AND')
 };
 
 const concatQueryStrings = (queryStrings: Array<string>, { operator = 'AND', withBrackets = true } = {}): string => {
-  return queryStrings.map((s) => (withBrackets ? `(${s})` : s)).join(` ${operator} `);
+  const withRemovedEmpty = queryStrings.filter((s: string) => !!s.trim());
+  const showBracketsForChild = withBrackets && withRemovedEmpty.length > 1;
+
+  return withRemovedEmpty.map((s) => (showBracketsForChild ? `(${s})` : s)).join(` ${operator} `);
 };
 
 export { isPhrase, escape, addToQuery, concatQueryStrings };

--- a/graylog2-web-interface/src/views/logic/valueactions/createEventDefinition/hooks/useUrlConfigData.test.tsx
+++ b/graylog2-web-interface/src/views/logic/valueactions/createEventDefinition/hooks/useUrlConfigData.test.tsx
@@ -124,7 +124,7 @@ describe('useUrlConfigData', () => {
         'action',
         'http_method',
       ],
-      query: '((http_method:GET))',
+      query: '(http_method:GET)',
       search_within_ms: 300000,
       streams: [
         'streamId-1',

--- a/graylog2-web-interface/src/views/logic/views/UseCreateViewForEvent.test.ts
+++ b/graylog2-web-interface/src/views/logic/views/UseCreateViewForEvent.test.ts
@@ -18,9 +18,8 @@ import { renderHook } from 'wrappedTestingLibrary/hooks';
 import ObjectID from 'bson-objectid';
 
 import {
-  mockedMappedAggregation, mockedViewWithOneAggregation,
-  mockedViewWithTwoAggregations,
-  mockEventData, mockEventDefinitionOneAggregation,
+  mockedViewWithMessageAndBarWidget,
+  mockEventData,
   mockEventDefinitionTwoAggregations,
 } from 'helpers/mocking/EventAndEventDefinitions_mock';
 import { UseCreateViewForEvent } from 'views/logic/views/UseCreateViewForEvent';
@@ -41,11 +40,9 @@ const counter = () => {
 
 const generateIdCounterTwoAggregations = counter();
 const objectIdCounterTwoAggregations = counter();
-const generateIdCounterOneAggregation = counter();
-const objectIdCounterOneAggregations = counter();
 
 const mockedGenerateIdTwoAggregations = () => {
-  const idSet = ['query-id', 'mc-widget-id', 'allm-widget-id', 'field1-widget-id', 'field2-widget-id', 'summary-widget-id'];
+  const idSet = ['query-id', 'mc-widget-id', 'allm-widget-id'];
   const index = generateIdCounterTwoAggregations();
 
   return idSet[index];
@@ -54,20 +51,6 @@ const mockedGenerateIdTwoAggregations = () => {
 const mockedObjectIdTwoAggregations = () => {
   const idSet = ['', 'view-id', 'search-id'];
   const index = objectIdCounterTwoAggregations();
-
-  return idSet[index];
-};
-
-const mockedObjectIdOneAggregation = () => {
-  const idSet = ['', 'view-id', 'search-id'];
-  const index = objectIdCounterOneAggregations();
-
-  return idSet[index];
-};
-
-const mockedGenerateIdOneAggregation = () => {
-  const idSet = ['query-id', 'mc-widget-id', 'allm-widget-id', 'field1-widget-id'];
-  const index = generateIdCounterOneAggregation();
 
   return idSet[index];
 };
@@ -98,29 +81,16 @@ describe('UseCreateViewForEvent', () => {
     jest.clearAllMocks();
   });
 
-  it('should create view with 2 aggregation widgets and one summary', async () => {
+  it('should create view with message and message count widgets', async () => {
     asMock(generateId).mockImplementation(mockedGenerateIdTwoAggregations);
 
     asMock(ObjectID).mockImplementation(() => ({
       toString: () => mockedObjectIdTwoAggregations(),
     }) as ObjectID);
 
-    const { result } = renderHook(() => UseCreateViewForEvent({ eventData: mockEventData.event, eventDefinition: mockEventDefinitionTwoAggregations, aggregations: mockedMappedAggregation }));
+    const { result } = renderHook(() => UseCreateViewForEvent({ eventData: mockEventData.event, eventDefinition: mockEventDefinitionTwoAggregations }));
     const view = await result.current.then((r) => r);
 
-    expect(withCurrentDate(view)).toEqual(withCurrentDate(mockedViewWithTwoAggregations));
-  });
-
-  it('should create view with 1 aggregation widgets and without summary', async () => {
-    asMock(generateId).mockImplementation(mockedGenerateIdOneAggregation);
-
-    asMock(ObjectID).mockImplementation(() => ({
-      toString: () => mockedObjectIdOneAggregation(),
-    }) as ObjectID);
-
-    const { result } = renderHook(() => UseCreateViewForEvent({ eventData: mockEventData.event, eventDefinition: mockEventDefinitionOneAggregation, aggregations: [mockedMappedAggregation[0]] }));
-    const view = await result.current.then((r) => r);
-
-    expect(withCurrentDate(view)).toEqual(withCurrentDate(mockedViewWithOneAggregation));
+    expect(withCurrentDate(view)).toEqual(withCurrentDate(mockedViewWithMessageAndBarWidget));
   });
 });

--- a/graylog2-web-interface/src/views/logic/views/UseCreateViewForEvent.ts
+++ b/graylog2-web-interface/src/views/logic/views/UseCreateViewForEvent.ts
@@ -16,7 +16,6 @@
  */
 import { useMemo } from 'react';
 import * as Immutable from 'immutable';
-import uniq from 'lodash/uniq';
 
 import View from 'views/logic/views/View';
 import type { AbsoluteTimeRange, ElasticsearchQueryString, RelativeTimeRangeStartOnly } from 'views/logic/queries/Query';
@@ -30,134 +29,39 @@ import ViewState from 'views/logic/views/ViewState';
 import { allMessagesTable, resultHistogram } from 'views/logic/Widgets';
 import WidgetPosition from 'views/logic/widgets/WidgetPosition';
 import { DecoratorsActions } from 'stores/decorators/DecoratorsStore';
-import generateId from 'logic/generateId';
-import pivotForField from 'views/logic/searchtypes/aggregation/PivotGenerator';
-import FieldType from 'views/logic/fieldtypes/FieldType';
-import AggregationWidget from 'views/logic/aggregationbuilder/AggregationWidget';
-import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
-import Series from 'views/logic/aggregationbuilder/Series';
-import type Pivot from 'views/logic/aggregationbuilder/Pivot';
-import type { EventDefinitionAggregation } from 'hooks/useEventDefinition';
-import SortConfig from 'views/logic/aggregationbuilder/SortConfig';
-import Direction from 'views/logic/aggregationbuilder/Direction';
 import type { ParameterJson } from 'views/logic/parameters/Parameter';
 import Parameter from 'views/logic/parameters/Parameter';
+import { concatQueryStrings } from 'views/logic/queries/QueryHelper';
 
-const AGGREGATION_WIDGET_HEIGHT = 3;
-
-export const getAggregationWidget = ({ rowPivots, fnSeries, sort = [] }: {
-  rowPivots: Array<Pivot>,
-  fnSeries: Array<Series>,
-  sort?: Array<SortConfig>
-}) => {
-  return AggregationWidget.builder()
-    .id(generateId())
-    .config(
-      AggregationWidgetConfig.builder()
-        .columnPivots([])
-        .rowPivots(rowPivots)
-        .series(fnSeries)
-        .sort(sort)
-        .visualization('table')
-        .rollup(true)
-        .build(),
-    )
-    .build();
-};
-
-const createViewPosition = ({ index, SUMMARY_ROW_DELTA }) => {
-  const isEven = (index + 1) % 2 === 0;
-  const col = isEven ? 7 : 1;
-  const HEIGHT_DELTA = index >= 2 ? AGGREGATION_WIDGET_HEIGHT : 0;
-  const row = Math.ceil((index + 1) / 2) + HEIGHT_DELTA + SUMMARY_ROW_DELTA;
-
-  return new WidgetPosition(col, row, AGGREGATION_WIDGET_HEIGHT, 6);
-};
-
-const createViewWidget = ({ field, groupBy, fnSeries, expr }) => {
-  const rowPivots = [pivotForField(uniq([field, ...groupBy].filter((v) => !!v)), new FieldType('value', [], []))];
-  const fnSeriesForFunc = Series.forFunction(fnSeries);
-  const direction = ['>', '>=', '=='].includes(expr) ? Direction.Descending : Direction.Ascending;
-  const sort = [new SortConfig(SortConfig.SERIES_TYPE, fnSeries, direction)];
-
-  return getAggregationWidget({ rowPivots, fnSeries: [fnSeriesForFunc], sort });
-};
-
-const getSummaryAggregation = ({ aggregations, groupBy }) => {
-  const { summaryFnSeries, summaryRowPivots, summaryTitle } = aggregations.reduce((res, { field, value, expr, fnSeries }) => {
-    const concatTitle = `${fnSeries} ${expr} ${value}`;
-    res.summaryFnSeries.push(fnSeries);
-    if (field) res.summaryRowPivots.push(field);
-    res.summaryTitle = `${res.summaryTitle} ${concatTitle}`;
-
-    return res;
-  }, {
-    summaryFnSeries: [],
-    summaryRowPivots: [],
-    summaryTitle: 'Summary: ',
-  });
-
-  const summaryWidget = getAggregationWidget({
-    rowPivots: [pivotForField(uniq([...summaryRowPivots, ...groupBy]), new FieldType('value', [], []))],
-    fnSeries: summaryFnSeries.map((s) => Series.forFunction(s)),
-  });
-
-  return ({
-    summaryTitle,
-    summaryWidget,
-    summaryPosition: new WidgetPosition(1, 1, AGGREGATION_WIDGET_HEIGHT, Infinity),
-  });
-};
-
-export const WidgetsGenerator = async ({ streams, aggregations, groupBy }) => {
+export const WidgetsGenerator = async ({ streams }) => {
   const decorators = await DecoratorsActions.list();
   const byStreamId = matchesDecoratorStream(streams);
   const streamDecorators = decorators?.length ? decorators.filter(byStreamId) : [];
   const histogram = resultHistogram();
   const messageTable = allMessagesTable(undefined, streamDecorators);
-  const needsSummaryAggregations = aggregations.length > 1;
-  const SUMMARY_ROW_DELTA = needsSummaryAggregations ? AGGREGATION_WIDGET_HEIGHT : 0;
-  const { aggregationWidgets, aggregationTitles, aggregationPositions } = aggregations.reduce((res, { field, value, expr, fnSeries }, index) => {
-    const widget = createViewWidget({ fnSeries, field, groupBy, expr });
-    res.aggregationWidgets.push(widget);
-    res.aggregationTitles[widget.id] = `${fnSeries} ${expr} ${value}`;
-    res.aggregationPositions[widget.id] = createViewPosition({ index, SUMMARY_ROW_DELTA });
-
-    return res;
-  }, { aggregationTitles: {}, aggregationWidgets: [], aggregationPositions: {} });
 
   const widgets = [
-    ...aggregationWidgets,
     histogram,
     messageTable,
   ];
 
   const titles = {
     widget: {
-      ...aggregationTitles,
       [histogram.id]: 'Message Count',
       [messageTable.id]: 'All Messages',
     },
   };
 
   const positions = {
-    ...aggregationPositions,
-    [histogram.id]: new WidgetPosition(1, AGGREGATION_WIDGET_HEIGHT * aggregationWidgets.length + 1 + SUMMARY_ROW_DELTA, 2, Infinity),
-    [messageTable.id]: new WidgetPosition(1, AGGREGATION_WIDGET_HEIGHT * aggregationWidgets.length + 3 + SUMMARY_ROW_DELTA, 6, Infinity),
+    [histogram.id]: new WidgetPosition(1, 1, 2, Infinity),
+    [messageTable.id]: new WidgetPosition(1, 3, 6, Infinity),
   };
-
-  if (needsSummaryAggregations) {
-    const { summaryTitle, summaryWidget, summaryPosition } = getSummaryAggregation({ aggregations, groupBy });
-    widgets.push(summaryWidget);
-    titles.widget[summaryWidget.id] = summaryTitle;
-    positions[summaryWidget.id] = summaryPosition;
-  }
 
   return { titles, widgets, positions };
 };
 
-export const ViewStateGenerator = async ({ streams, aggregations, groupBy }: {groupBy: Array<string>, streams: string | string[] | undefined, aggregations: Array<any>}) => {
-  const { titles, widgets, positions } = await WidgetsGenerator({ streams, aggregations, groupBy });
+export const ViewStateGenerator = async ({ streams }: { streams: string | string[] | undefined }) => {
+  const { titles, widgets, positions } = await WidgetsGenerator({ streams });
 
   return ViewState.create()
     .toBuilder()
@@ -171,22 +75,18 @@ export const ViewGenerator = async ({
   streams,
   timeRange,
   queryString,
-  aggregations,
-  groupBy,
   queryParameters,
 }: {
   streams: string | string[] | undefined | null,
   timeRange: AbsoluteTimeRange | RelativeTimeRangeStartOnly,
   queryString: ElasticsearchQueryString,
-  aggregations: Array<EventDefinitionAggregation>
-  groupBy: Array<string>,
   queryParameters: Array<ParameterJson>,
 },
 ) => {
   const query = QueryGenerator(streams, undefined, timeRange, queryString);
   const search = Search.create().toBuilder().queries([query]).parameters(queryParameters.map((param) => Parameter.fromJSON(param)))
     .build();
-  const viewState = await ViewStateGenerator({ streams, aggregations, groupBy });
+  const viewState = await ViewStateGenerator({ streams });
 
   const view = View.create()
     .toBuilder()
@@ -200,8 +100,10 @@ export const ViewGenerator = async ({
 };
 
 export const UseCreateViewForEvent = (
-  { eventData, eventDefinition, aggregations }: { eventData: Event, eventDefinition: EventDefinition, aggregations: Array<EventDefinitionAggregation> },
+  { eventData, eventDefinition }: { eventData: Event, eventDefinition: EventDefinition },
 ) => {
+  const queryStringFromGrouping = concatQueryStrings(Object.entries(eventData.group_by_fields).map(([field, value]) => `${field}:${value}`), { withBrackets: false });
+  const eventQueryString = eventData?.replay_info?.query || '';
   const { streams } = eventData.replay_info;
   const timeRange: AbsoluteTimeRange = {
     type: 'absolute',
@@ -210,15 +112,13 @@ export const UseCreateViewForEvent = (
   };
   const queryString: ElasticsearchQueryString = {
     type: 'elasticsearch',
-    query_string: eventData?.replay_info?.query || '',
+    query_string: concatQueryStrings([eventQueryString, queryStringFromGrouping]),
   };
 
   const queryParameters = eventDefinition?.config?.query_parameters || [];
 
-  const groupBy = eventDefinition.config.group_by;
-
   return useMemo(
-    () => ViewGenerator({ streams, timeRange, queryString, aggregations, groupBy, queryParameters }),
+    () => ViewGenerator({ streams, timeRange, queryString, queryParameters }),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [],
   );

--- a/graylog2-web-interface/src/views/logic/views/UseCreateViewForEvent.ts
+++ b/graylog2-web-interface/src/views/logic/views/UseCreateViewForEvent.ts
@@ -31,7 +31,7 @@ import WidgetPosition from 'views/logic/widgets/WidgetPosition';
 import { DecoratorsActions } from 'stores/decorators/DecoratorsStore';
 import type { ParameterJson } from 'views/logic/parameters/Parameter';
 import Parameter from 'views/logic/parameters/Parameter';
-import { concatQueryStrings } from 'views/logic/queries/QueryHelper';
+import { concatQueryStrings, escape } from 'views/logic/queries/QueryHelper';
 
 export const WidgetsGenerator = async ({ streams }) => {
   const decorators = await DecoratorsActions.list();
@@ -102,7 +102,7 @@ export const ViewGenerator = async ({
 export const UseCreateViewForEvent = (
   { eventData, eventDefinition }: { eventData: Event, eventDefinition: EventDefinition },
 ) => {
-  const queryStringFromGrouping = concatQueryStrings(Object.entries(eventData.group_by_fields).map(([field, value]) => `${field}:${value}`), { withBrackets: false });
+  const queryStringFromGrouping = concatQueryStrings(Object.entries(eventData.group_by_fields).map(([field, value]) => `${field}:${escape(value)}`), { withBrackets: false });
   const eventQueryString = eventData?.replay_info?.query || '';
   const { streams } = eventData.replay_info;
   const timeRange: AbsoluteTimeRange = {

--- a/graylog2-web-interface/src/views/logic/views/UseCreateViewForEventDefinition.ts
+++ b/graylog2-web-interface/src/views/logic/views/UseCreateViewForEventDefinition.ts
@@ -14,13 +14,189 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-
 import { useMemo } from 'react';
+import * as Immutable from 'immutable';
+import uniq from 'lodash/uniq';
 
+import View from 'views/logic/views/View';
+import type { AbsoluteTimeRange, ElasticsearchQueryString, RelativeTimeRangeStartOnly } from 'views/logic/queries/Query';
 import type { EventDefinition } from 'logic/alerts/types';
+import QueryGenerator from 'views/logic/queries/QueryGenerator';
+import Search from 'views/logic/search/Search';
+import { matchesDecoratorStream } from 'views/logic/views/ViewStateGenerator';
+import UpdateSearchForWidgets from 'views/logic/views/UpdateSearchForWidgets';
+import ViewState from 'views/logic/views/ViewState';
+import { allMessagesTable, resultHistogram } from 'views/logic/Widgets';
+import WidgetPosition from 'views/logic/widgets/WidgetPosition';
+import { DecoratorsActions } from 'stores/decorators/DecoratorsStore';
+import generateId from 'logic/generateId';
+import pivotForField from 'views/logic/searchtypes/aggregation/PivotGenerator';
+import FieldType from 'views/logic/fieldtypes/FieldType';
+import AggregationWidget from 'views/logic/aggregationbuilder/AggregationWidget';
+import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
+import Series from 'views/logic/aggregationbuilder/Series';
+import type Pivot from 'views/logic/aggregationbuilder/Pivot';
 import type { EventDefinitionAggregation } from 'hooks/useEventDefinition';
-import type { ElasticsearchQueryString, RelativeTimeRangeStartOnly } from 'views/logic/queries/Query';
-import { ViewGenerator } from 'views/logic/views/UseCreateViewForEvent';
+import SortConfig from 'views/logic/aggregationbuilder/SortConfig';
+import Direction from 'views/logic/aggregationbuilder/Direction';
+import type { ParameterJson } from 'views/logic/parameters/Parameter';
+import Parameter from 'views/logic/parameters/Parameter';
+
+const AGGREGATION_WIDGET_HEIGHT = 3;
+
+export const getAggregationWidget = ({ rowPivots, fnSeries, sort = [] }: {
+  rowPivots: Array<Pivot>,
+  fnSeries: Array<Series>,
+  sort?: Array<SortConfig>
+}) => {
+  return AggregationWidget.builder()
+    .id(generateId())
+    .config(
+      AggregationWidgetConfig.builder()
+        .columnPivots([])
+        .rowPivots(rowPivots)
+        .series(fnSeries)
+        .sort(sort)
+        .visualization('table')
+        .rollup(true)
+        .build(),
+    )
+    .build();
+};
+
+const createViewPosition = ({ index, SUMMARY_ROW_DELTA }) => {
+  const isEven = (index + 1) % 2 === 0;
+  const col = isEven ? 7 : 1;
+  const HEIGHT_DELTA = index >= 2 ? AGGREGATION_WIDGET_HEIGHT : 0;
+  const row = Math.ceil((index + 1) / 2) + HEIGHT_DELTA + SUMMARY_ROW_DELTA;
+
+  return new WidgetPosition(col, row, AGGREGATION_WIDGET_HEIGHT, 6);
+};
+
+const createViewWidget = ({ field, groupBy, fnSeries, expr }) => {
+  const rowPivots = [pivotForField(uniq([field, ...groupBy].filter((v) => !!v)), new FieldType('value', [], []))];
+  const fnSeriesForFunc = Series.forFunction(fnSeries);
+  const direction = ['>', '>=', '=='].includes(expr) ? Direction.Descending : Direction.Ascending;
+  const sort = [new SortConfig(SortConfig.SERIES_TYPE, fnSeries, direction)];
+
+  return getAggregationWidget({ rowPivots, fnSeries: [fnSeriesForFunc], sort });
+};
+
+const getSummaryAggregation = ({ aggregations, groupBy }) => {
+  const { summaryFnSeries, summaryRowPivots, summaryTitle } = aggregations.reduce((res, { field, value, expr, fnSeries }) => {
+    const concatTitle = `${fnSeries} ${expr} ${value}`;
+    res.summaryFnSeries.push(fnSeries);
+    if (field) res.summaryRowPivots.push(field);
+    res.summaryTitle = `${res.summaryTitle} ${concatTitle}`;
+
+    return res;
+  }, {
+    summaryFnSeries: [],
+    summaryRowPivots: [],
+    summaryTitle: 'Summary: ',
+  });
+
+  const summaryWidget = getAggregationWidget({
+    rowPivots: [pivotForField(uniq([...summaryRowPivots, ...groupBy]), new FieldType('value', [], []))],
+    fnSeries: summaryFnSeries.map((s) => Series.forFunction(s)),
+  });
+
+  return ({
+    summaryTitle,
+    summaryWidget,
+    summaryPosition: new WidgetPosition(1, 1, AGGREGATION_WIDGET_HEIGHT, Infinity),
+  });
+};
+
+export const WidgetsGenerator = async ({ streams, aggregations, groupBy }) => {
+  const decorators = await DecoratorsActions.list();
+  const byStreamId = matchesDecoratorStream(streams);
+  const streamDecorators = decorators?.length ? decorators.filter(byStreamId) : [];
+  const histogram = resultHistogram();
+  const messageTable = allMessagesTable(undefined, streamDecorators);
+  const needsSummaryAggregations = aggregations.length > 1;
+  const SUMMARY_ROW_DELTA = needsSummaryAggregations ? AGGREGATION_WIDGET_HEIGHT : 0;
+  const { aggregationWidgets, aggregationTitles, aggregationPositions } = aggregations.reduce((res, { field, value, expr, fnSeries }, index) => {
+    const widget = createViewWidget({ fnSeries, field, groupBy, expr });
+    res.aggregationWidgets.push(widget);
+    res.aggregationTitles[widget.id] = `${fnSeries} ${expr} ${value}`;
+    res.aggregationPositions[widget.id] = createViewPosition({ index, SUMMARY_ROW_DELTA });
+
+    return res;
+  }, { aggregationTitles: {}, aggregationWidgets: [], aggregationPositions: {} });
+
+  const widgets = [
+    ...aggregationWidgets,
+    histogram,
+    messageTable,
+  ];
+
+  const titles = {
+    widget: {
+      ...aggregationTitles,
+      [histogram.id]: 'Message Count',
+      [messageTable.id]: 'All Messages',
+    },
+  };
+
+  const positions = {
+    ...aggregationPositions,
+    [histogram.id]: new WidgetPosition(1, AGGREGATION_WIDGET_HEIGHT * aggregationWidgets.length + 1 + SUMMARY_ROW_DELTA, 2, Infinity),
+    [messageTable.id]: new WidgetPosition(1, AGGREGATION_WIDGET_HEIGHT * aggregationWidgets.length + 3 + SUMMARY_ROW_DELTA, 6, Infinity),
+  };
+
+  if (needsSummaryAggregations) {
+    const { summaryTitle, summaryWidget, summaryPosition } = getSummaryAggregation({ aggregations, groupBy });
+    widgets.push(summaryWidget);
+    titles.widget[summaryWidget.id] = summaryTitle;
+    positions[summaryWidget.id] = summaryPosition;
+  }
+
+  return { titles, widgets, positions };
+};
+
+export const ViewStateGenerator = async ({ streams, aggregations, groupBy }: {groupBy: Array<string>, streams: string | string[] | undefined, aggregations: Array<any>}) => {
+  const { titles, widgets, positions } = await WidgetsGenerator({ streams, aggregations, groupBy });
+
+  return ViewState.create()
+    .toBuilder()
+    .titles(titles)
+    .widgets(Immutable.List(widgets))
+    .widgetPositions(positions)
+    .build();
+};
+
+export const ViewGenerator = async ({
+  streams,
+  timeRange,
+  queryString,
+  aggregations,
+  groupBy,
+  queryParameters,
+}: {
+  streams: string | string[] | undefined | null,
+  timeRange: AbsoluteTimeRange | RelativeTimeRangeStartOnly,
+  queryString: ElasticsearchQueryString,
+  aggregations: Array<EventDefinitionAggregation>
+  groupBy: Array<string>,
+  queryParameters: Array<ParameterJson>,
+  },
+) => {
+  const query = QueryGenerator(streams, undefined, timeRange, queryString);
+  const search = Search.create().toBuilder().queries([query]).parameters(queryParameters.map((param) => Parameter.fromJSON(param)))
+    .build();
+  const viewState = await ViewStateGenerator({ streams, aggregations, groupBy });
+
+  const view = View.create()
+    .toBuilder()
+    .newId()
+    .type(View.Type.Search)
+    .state({ [query.id]: viewState })
+    .search(search)
+    .build();
+
+  return UpdateSearchForWidgets(view);
+};
 
 const useCreateViewForEventDefinition = (
   {

--- a/graylog2-web-interface/src/views/pages/EventReplaySearchPage.tsx
+++ b/graylog2-web-interface/src/views/pages/EventReplaySearchPage.tsx
@@ -28,8 +28,8 @@ import useAlertAndEventDefinitionData from 'hooks/useAlertAndEventDefinitionData
 import EventInfoBar from 'components/event-definitions/replay-search/EventInfoBar';
 
 const EventView = () => {
-  const { eventData, eventDefinition, aggregations } = useAlertAndEventDefinitionData();
-  const view = useCreateViewForEvent({ eventData, eventDefinition, aggregations });
+  const { eventData, eventDefinition } = useAlertAndEventDefinitionData();
+  const view = useCreateViewForEvent({ eventData, eventDefinition });
 
   return (
     <SearchPage view={view}

--- a/graylog2-web-interface/test/helpers/mocking/EventAndEventDefinitions_mock.ts
+++ b/graylog2-web-interface/test/helpers/mocking/EventAndEventDefinitions_mock.ts
@@ -63,7 +63,7 @@ export const mockEventData = {
         '001',
       ],
     },
-    group_by_fields: [{}],
+    group_by_fields: { field4: 'value4' },
 
   } as Event,
 };
@@ -267,10 +267,32 @@ const widgetsWithTwoAggregations = [
   messageTable,
   summaryWidget,
 ];
+
+const widgetsWithMessageAndBar = [
+  histogram,
+  messageTable,
+];
 const searchTwoAggregations = Search.create().toBuilder().id('search-id').queries([
   query
     .toBuilder()
     .searchTypes(Array(5).fill({
+      filters: [],
+      type: 'AGGREGATION',
+      typeDefinition: {},
+    })).build()])
+  .build();
+const queryForEvent = QueryGenerator(eventData.replay_info.streams, 'query-id', {
+  type: 'absolute',
+  from: eventData?.replay_info?.timerange_start,
+  to: eventData?.replay_info?.timerange_end,
+}, {
+  type: 'elasticsearch',
+  query_string: `(${eventData.replay_info.query}) AND (field4:value4)`,
+});
+const searchMessageAndBar = Search.create().toBuilder().id('search-id').queries([
+  queryForEvent
+    .toBuilder()
+    .searchTypes(Array(2).fill({
       filters: [],
       type: 'AGGREGATION',
       typeDefinition: {},
@@ -306,6 +328,32 @@ export const mockedViewWithTwoAggregations = View.create()
       .build(),
   })
   .search(searchTwoAggregations)
+  .build();
+
+export const mockedViewWithMessageAndBarWidget = View.create()
+  .toBuilder()
+  .id('view-id')
+  .type(View.Type.Search)
+  .state({
+    'query-id': ViewState.create()
+      .toBuilder()
+      .titles({
+        widget: {
+          'mc-widget-id': 'Message Count',
+          'allm-widget-id': 'All Messages',
+        },
+      })
+      .widgetMapping(Immutable.Map(
+        ['mc-widget-id', 'allm-widget-id'].map((item) => [item, Immutable.Set([undefined])]),
+      ))
+      .widgets(widgetsWithMessageAndBar)
+      .widgetPositions({
+        'mc-widget-id': new WidgetPosition(1, 1, 2, Infinity),
+        'allm-widget-id': new WidgetPosition(1, 3, 6, Infinity),
+      })
+      .build(),
+  })
+  .search(searchMessageAndBar)
   .build();
 
 const searchOneAggregation = Search.create().toBuilder().id('search-id').queries([query.toBuilder().searchTypes(Array(3).fill({


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pr:
- for event add `group by fields` as part of the search query
- removes aggregation widgets for event
- update concat query string helper function

## Motivation and Context
fix: [14813](https://github.com/Graylog2/graylog2-server/issues/14813)

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

