### PR TITLE
Avoid telemetry initialization when settings are missing.

### DIFF
--- a/graylog2-web-interface/src/logic/telemetry/TelemetryInit.tsx
+++ b/graylog2-web-interface/src/logic/telemetry/TelemetryInit.tsx
@@ -65,7 +65,7 @@ const TelemetryInit = ({ children }: { children: React.ReactElement }) => {
     }
   }, [currentUser]);
 
-  if ((settings && !settings.telemetry_enabled) || !host || !key) {
+  if ((!settings?.telemetry_enabled) || !host || !key) {
     return children;
   }
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

An error in the condition of the `TelemetryInit` component lead to telemetry initialization when telemetry settings have not been loaded yet, even though it is disabled.

This change is now fixing, avoiding telemetry initialization in case of the settings not being loaded yet.

/nocl

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.