### PR TITLE
Enable inputs in cloud

### DIFF
--- a/graylog2-server/src/main/resources/org/graylog2/featureflag/feature-flag.config
+++ b/graylog2-server/src/main/resources/org/graylog2/featureflag/feature-flag.config
@@ -58,5 +58,6 @@
 # Enabling search filters per default now for everybody
 search_filter=on
 scripting_api_preview=on
+
 # Enabling inputs in cloud environment
-cloud_inputs=off
+cloud_inputs=on


### PR DESCRIPTION
Switches cloud inputs on by default by setting the feature flag to "on".

/nocl