### PR TITLE
Fix: replay search on event definitions should honor event keys

### DIFF
--- a/changelog/unreleased/pr-15270.toml
+++ b/changelog/unreleased/pr-15270.toml
@@ -1,5 +1,0 @@
-type = "fixed"
-message = "Add events group by fields as part of the search query"
-
-issues = ["14813"]
-pulls = ["15270" ]

--- a/changelog/unreleased/pr-15270.toml
+++ b/changelog/unreleased/pr-15270.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Add events group by fields as part of the search query"
+
+issues = ["14813"]
+pulls = ["15270" ]

--- a/graylog2-web-interface/src/components/events/events/EventFields.tsx
+++ b/graylog2-web-interface/src/components/events/events/EventFields.tsx
@@ -17,7 +17,7 @@
 import React from 'react';
 
 type Props = {
-  fields: Object[],
+  fields: Object[] | {[key: string]: string},
 };
 
 const EventFields = ({ fields }: Props) => {

--- a/graylog2-web-interface/src/components/events/events/types.ts
+++ b/graylog2-web-interface/src/components/events/events/types.ts
@@ -32,7 +32,7 @@ export type Event = {
   timerange_end: string,
   key: string,
   fields: Object[],
-  group_by_fields: Object[],
+  group_by_fields: {[key: string]: string},
   source_streams: string[],
   replay_info: EventReplayInfo | undefined,
   alert: boolean | undefined,

--- a/graylog2-web-interface/src/views/logic/queries/QueryHelper.test.ts
+++ b/graylog2-web-interface/src/views/logic/queries/QueryHelper.test.ts
@@ -14,10 +14,36 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import { escape } from './QueryHelper';
+import { concatQueryStrings, escape } from './QueryHelper';
 
 describe('QueryHelper', () => {
   it('quotes $ in values', () => {
     expect(escape('foo$bar$')).toEqual('foo\\$bar\\$');
+  });
+
+  describe('concatQueryStrings', () => {
+    it('concat queries by default with AND and brackets', () => {
+      const result = concatQueryStrings(['filed1:value1 OR field2:value2', 'field3:value3']);
+
+      expect(result).toEqual('(filed1:value1 OR field2:value2) AND (field3:value3)');
+    });
+
+    it('concat queries with custom operator and without brackets', () => {
+      const result = concatQueryStrings(['filed1:value1 OR field2:value2', 'field3:value3'], { operator: 'OR', withBrackets: false });
+
+      expect(result).toEqual('filed1:value1 OR field2:value2 OR field3:value3');
+    });
+
+    it('filtrate empty query strings', () => {
+      const result = concatQueryStrings(['     ', 'filed1:value1 OR field2:value2', ' ', 'field3:value3', '']);
+
+      expect(result).toEqual('(filed1:value1 OR field2:value2) AND (field3:value3)');
+    });
+
+    it('doesnt wrap in brackets if we have only one query string', () => {
+      const result = concatQueryStrings(['     ', 'filed1:value1 OR field2:value2', ' ', '']);
+
+      expect(result).toEqual('filed1:value1 OR field2:value2');
+    });
   });
 });

--- a/graylog2-web-interface/src/views/logic/queries/QueryHelper.ts
+++ b/graylog2-web-interface/src/views/logic/queries/QueryHelper.ts
@@ -52,7 +52,10 @@ const addToQuery = (oldQuery: string, newTerm: string, operator: string = 'AND')
 };
 
 const concatQueryStrings = (queryStrings: Array<string>, { operator = 'AND', withBrackets = true } = {}): string => {
-  return queryStrings.map((s) => (withBrackets ? `(${s})` : s)).join(` ${operator} `);
+  const withRemovedEmpty = queryStrings.filter((s: string) => !!s.trim());
+  const showBracketsForChild = withBrackets && withRemovedEmpty.length > 1;
+
+  return withRemovedEmpty.map((s) => (showBracketsForChild ? `(${s})` : s)).join(` ${operator} `);
 };
 
 export { isPhrase, escape, addToQuery, concatQueryStrings };

--- a/graylog2-web-interface/src/views/logic/valueactions/createEventDefinition/hooks/useUrlConfigData.test.tsx
+++ b/graylog2-web-interface/src/views/logic/valueactions/createEventDefinition/hooks/useUrlConfigData.test.tsx
@@ -124,7 +124,7 @@ describe('useUrlConfigData', () => {
         'action',
         'http_method',
       ],
-      query: '((http_method:GET))',
+      query: '(http_method:GET)',
       search_within_ms: 300000,
       streams: [
         'streamId-1',

--- a/graylog2-web-interface/src/views/logic/views/UseCreateViewForEvent.ts
+++ b/graylog2-web-interface/src/views/logic/views/UseCreateViewForEvent.ts
@@ -42,6 +42,7 @@ import SortConfig from 'views/logic/aggregationbuilder/SortConfig';
 import Direction from 'views/logic/aggregationbuilder/Direction';
 import type { ParameterJson } from 'views/logic/parameters/Parameter';
 import Parameter from 'views/logic/parameters/Parameter';
+import { concatQueryStrings, escape } from 'views/logic/queries/QueryHelper';
 
 const AGGREGATION_WIDGET_HEIGHT = 3;
 
@@ -202,6 +203,8 @@ export const ViewGenerator = async ({
 export const UseCreateViewForEvent = (
   { eventData, eventDefinition, aggregations }: { eventData: Event, eventDefinition: EventDefinition, aggregations: Array<EventDefinitionAggregation> },
 ) => {
+  const queryStringFromGrouping = concatQueryStrings(Object.entries(eventData.group_by_fields).map(([field, value]) => `${field}:${escape(value)}`), { withBrackets: false });
+  const eventQueryString = eventData?.replay_info?.query || '';
   const { streams } = eventData.replay_info;
   const timeRange: AbsoluteTimeRange = {
     type: 'absolute',
@@ -210,7 +213,7 @@ export const UseCreateViewForEvent = (
   };
   const queryString: ElasticsearchQueryString = {
     type: 'elasticsearch',
-    query_string: eventData?.replay_info?.query || '',
+    query_string: concatQueryStrings([eventQueryString, queryStringFromGrouping]),
   };
 
   const queryParameters = eventDefinition?.config?.query_parameters || [];

--- a/graylog2-web-interface/test/helpers/mocking/EventAndEventDefinitions_mock.ts
+++ b/graylog2-web-interface/test/helpers/mocking/EventAndEventDefinitions_mock.ts
@@ -63,7 +63,7 @@ export const mockEventData = {
         '001',
       ],
     },
-    group_by_fields: [{}],
+    group_by_fields: { field4: 'value4' },
 
   } as Event,
 };
@@ -205,7 +205,7 @@ const query = QueryGenerator(eventData.replay_info.streams, 'query-id', {
   to: eventData?.replay_info?.timerange_end,
 }, {
   type: 'elasticsearch',
-  query_string: eventData?.replay_info?.query || '',
+  query_string: '(http_method: GET) AND (field4:value4)',
 });
 
 const histogram = resultHistogram('mc-widget-id');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pr:
- for event add `group by fields` as part of the search query
- update concat query string helper function

## Motivation and Context
fix: [14813](https://github.com/Graylog2/graylog2-server/issues/14813)

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

/nocl