### PR TITLE
Fixing nested deserialization of decorators from views.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/decorators/DecoratorImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/decorators/DecoratorImpl.java
@@ -16,6 +16,7 @@
  */
 package org.graylog2.decorators;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -82,17 +83,17 @@ public abstract class DecoratorImpl implements Decorator, Comparable {
     public abstract Builder toBuilder();
 
     @JsonCreator
-    public static DecoratorImpl create(@JsonProperty(FIELD_ID) @Id @ObjectId @Nullable String id,
+    public static DecoratorImpl create(@JsonProperty(FIELD_ID) @JsonAlias("_" + FIELD_ID) @Id @ObjectId @Nullable String id,
                                        @JsonProperty(FIELD_TYPE) String type,
                                        @JsonProperty(FIELD_CONFIG) Map<String, Object> config,
                                        @JsonProperty(FIELD_STREAM) Optional<String> stream,
                                        @JsonProperty(FIELD_ORDER) int order) {
         return new AutoValue_DecoratorImpl.Builder()
-            .id(id)
-            .type(type)
-            .config(config)
-            .stream(stream)
-            .order(order)
+                .id(id)
+                .type(type)
+                .config(config)
+                .stream(stream)
+                .order(order)
             .build();
     }
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is fixing up nested deserialization of decorators in saved searches/dashboards. When including the `favorite` flag, a pipeline is being used to enrich the documents with the flag instead of retrieving documents directly. This alters deserialization bypassing MongoJack partially and therefore not transforming the `_id` field of nested documents to `id`.

Therefore, this change is now making sure that deserialization of decorators support both `_id` and `id` fields.

Fixes #15086.

/nocl

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.