### PR TITLE
Showing all streams in decorator configuration.

### DIFF
--- a/changelog/unreleased/pr-15280.toml
+++ b/changelog/unreleased/pr-15280.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Show all streams in global decorators configuration, fixing display problem"
+
+issues = ["13465", "13467"]
+pulls = ["15280"]

--- a/graylog2-web-interface/src/components/configurations/DecoratorsConfig.tsx
+++ b/graylog2-web-interface/src/components/configurations/DecoratorsConfig.tsx
@@ -66,13 +66,11 @@ const DecoratorsConfig = () => {
     .sort((d1, d2) => d1.order - d2.order);
   const readOnlyDecoratorItems = sortedDecorators.map((decorator) => formatDecorator(decorator, currentDecorators, types));
 
-  const streamOptions = streams.filter(({ id }) => Object.keys(decoratorsGroupedByStream).includes(id));
-
   return (
     <div>
       <h2>Decorators Configuration</h2>
       <p>Select the stream for which you want to see the set of default decorators.</p>
-      <StreamSelect streams={streamOptions} onChange={setCurrentStream} value={currentStream} />
+      <StreamSelect streams={streams} onChange={setCurrentStream} value={currentStream} />
       <DecoratorList decorators={readOnlyDecoratorItems} disableDragging />
       <IfPermitted permissions="decorators:edit">
         <Button bsStyle="info" bsSize="xs" onClick={openModal}>Edit configuration</Button>


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Prior to this PR, in the `System` -> `Configuration` -> `Decorators` dialog, we were only showing streams as options if they have any decorators configured. This could lead to the default option (`All Messages` stream) being shown with its numeric id only.

This change is now showing all streams as options, regardless if they have decorators configured or not. This fixes the display problem and avoids confusion for the user because streams do not show up.

Fixes #13465.
Fixes #13467.

Refs #14546.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.