### PR TITLE
Combine dashboard and widget query when replaying search for dashboard widget

### DIFF
--- a/changelog/unreleased/issue-14885.toml
+++ b/changelog/unreleased/issue-14885.toml
@@ -1,0 +1,5 @@
+type = "f"
+message = "Combine dashboard and widget query when replaying search for dashboard widget."
+
+issues = ["14885"]
+pulls = ["15285"]

--- a/graylog2-web-interface/src/views/components/contexts/DrilldownContext.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/DrilldownContext.tsx
@@ -18,6 +18,7 @@ import * as React from 'react';
 
 import type { QueryString, TimeRange } from 'views/logic/queries/Query';
 import { createElasticsearchQueryString } from 'views/logic/queries/Query';
+import { DEFAULT_TIMERANGE } from 'views/Constants';
 
 export type Drilldown = {
   query: QueryString,
@@ -28,7 +29,7 @@ export type Drilldown = {
 const defaultValue: Drilldown = {
   query: createElasticsearchQueryString(''),
   streams: [],
-  timerange: { type: 'relative', from: 300 },
+  timerange: DEFAULT_TIMERANGE,
 };
 
 const DrilldownContext = React.createContext<Drilldown>(defaultValue);

--- a/graylog2-web-interface/src/views/components/contexts/DrilldownContextProvider.test.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/DrilldownContextProvider.test.tsx
@@ -76,7 +76,7 @@ describe('DrilldownContextProvider', () => {
         wrapper);
     });
 
-    it('passes query & timerange of global override, streams of widget', () => {
+    it('passes timerange of global override, streams of widget and combined query of global override and widget', () => {
       asMock(useViewType).mockReturnValue(View.Type.Dashboard);
 
       asMock(useGlobalOverride)
@@ -89,7 +89,7 @@ describe('DrilldownContextProvider', () => {
 
       expectDrilldown(['stream1', 'stream2'],
         { type: 'absolute', from: '2020-01-10T13:23:42.000Z', to: '2020-01-10T14:23:42.000Z' },
-        { type: 'elasticsearch', query_string: 'something:"else"' },
+        { type: 'elasticsearch', query_string: '(foo:42) AND (something:"else")' },
         wrapper);
     });
   });

--- a/graylog2-web-interface/src/views/components/contexts/DrilldownContextProvider.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/DrilldownContextProvider.tsx
@@ -36,8 +36,8 @@ const useDrillDownContextValue = (widget: Widget, globalOverride: GlobalOverride
   if (viewType === View.Type.Dashboard) {
     const { streams, timerange, query } = widget;
     const dashboardAndWidgetQueryString = globalOverride?.query?.query_string
-      ? concatQueryStrings([query.query_string, globalOverride?.query.query_string])
-      : query.query_string;
+      ? concatQueryStrings([query?.query_string, globalOverride.query.query_string])
+      : query?.query_string;
 
     return ({
       streams,

--- a/graylog2-web-interface/src/views/components/contexts/DrilldownContextProvider.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/DrilldownContextProvider.tsx
@@ -24,6 +24,8 @@ import type GlobalOverride from 'views/logic/search/GlobalOverride';
 import useViewType from 'views/hooks/useViewType';
 import useCurrentQuery from 'views/logic/queries/useCurrentQuery';
 import useGlobalOverride from 'views/hooks/useGlobalOverride';
+import { DEFAULT_TIMERANGE } from 'views/Constants';
+import { concatQueryStrings } from 'views/logic/queries/QueryHelper';
 
 import DrilldownContext from './DrilldownContext';
 import type { Drilldown } from './DrilldownContext';
@@ -33,11 +35,14 @@ const useDrillDownContextValue = (widget: Widget, globalOverride: GlobalOverride
 
   if (viewType === View.Type.Dashboard) {
     const { streams, timerange, query } = widget;
+    const dashboardAndWidgetQueryString = globalOverride?.query?.query_string
+      ? concatQueryStrings([query.query_string, globalOverride?.query.query_string])
+      : query.query_string;
 
     return ({
       streams,
-      timerange: (globalOverride && globalOverride.timerange ? globalOverride.timerange : timerange) || { type: 'relative', from: 300 },
-      query: (globalOverride && globalOverride.query ? globalOverride.query : query) || createElasticsearchQueryString(''),
+      timerange: (globalOverride?.timerange ? globalOverride.timerange : timerange) || DEFAULT_TIMERANGE,
+      query: createElasticsearchQueryString(dashboardAndWidgetQueryString || ''),
     });
   }
 


### PR DESCRIPTION
_Please note this PR needs a backport for 4.3 and 5.0_

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


Widgets have an action called replay search. It will open a new search with the same search query, streams and time range like the widget. On a dashboard, when there is a dashboard query filter, we combine the dashboard query and widget query. This was not reflected in the replay search functionality. By default we used the widget query, but when a dashboard query filter was present we were only using the dashboard query filter.

With this PR we are also combining the queries when replaying the search for a dashboard widget.

Please have a look at https://github.com/Graylog2/graylog2-server/issues/14885 for more information.

Fixes https://github.com/Graylog2/graylog2-server/issues/14885

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

