### PR TITLE
Make InputRegistry threadsafe

### DIFF
--- a/changelog/unreleased/issue-15277.toml
+++ b/changelog/unreleased/issue-15277.toml
@@ -1,0 +1,4 @@
+type = "fixed"
+message = "Fix ConcurrentModificationException when listing input states."
+
+issues = ["15277"]

--- a/graylog2-server/src/main/java/org/graylog2/shared/inputs/InputRegistry.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/inputs/InputRegistry.java
@@ -18,25 +18,28 @@ package org.graylog2.shared.inputs;
 
 
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
 import org.graylog2.plugin.IOState;
 import org.graylog2.plugin.inputs.MessageInput;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Singleton;
-import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Stream;
 
 @Singleton
-public class InputRegistry extends HashSet<IOState<MessageInput>> {
+public class InputRegistry {
     private static final Logger LOG = LoggerFactory.getLogger(InputRegistry.class);
 
+    private final Set<IOState<MessageInput>> inputStates = Sets.newConcurrentHashSet();
+
     public Set<IOState<MessageInput>> getInputStates() {
-        return ImmutableSet.copyOf(this);
+        return ImmutableSet.copyOf(inputStates);
     }
 
     public IOState<MessageInput> getInputState(String inputId) {
-        for (IOState<MessageInput> inputState : this) {
+        for (IOState<MessageInput> inputState : inputStates) {
             if (inputState.getStoppable().getPersistId().equals(inputId)) {
                 return inputState;
             }
@@ -47,7 +50,7 @@ public class InputRegistry extends HashSet<IOState<MessageInput>> {
 
     public Set<IOState<MessageInput>> getRunningInputs() {
         ImmutableSet.Builder<IOState<MessageInput>> runningInputs = ImmutableSet.builder();
-        for (IOState<MessageInput> inputState : this) {
+        for (IOState<MessageInput> inputState : inputStates) {
             if (inputState.getState() == IOState.Type.RUNNING) {
                 runningInputs.add(inputState);
             }
@@ -56,7 +59,7 @@ public class InputRegistry extends HashSet<IOState<MessageInput>> {
     }
 
     public boolean hasTypeRunning(Class klazz) {
-        for (IOState<MessageInput> inputState : this) {
+        for (IOState<MessageInput> inputState : inputStates) {
             if (inputState.getStoppable().getClass().equals(klazz)) {
                 return true;
             }
@@ -70,7 +73,7 @@ public class InputRegistry extends HashSet<IOState<MessageInput>> {
     }
 
     public MessageInput getRunningInput(String inputId) {
-        for (IOState<MessageInput> inputState : this) {
+        for (IOState<MessageInput> inputState : inputStates) {
             if (inputState.getStoppable().getId().equals(inputId)) {
                 return inputState.getStoppable();
             }
@@ -80,7 +83,7 @@ public class InputRegistry extends HashSet<IOState<MessageInput>> {
     }
 
     public IOState<MessageInput> getRunningInputState(String inputStateId) {
-        for (IOState<MessageInput> inputState : this) {
+        for (IOState<MessageInput> inputState : inputStates) {
             if (inputState.getStoppable().getId().equals(inputStateId)) {
                 return inputState;
             }
@@ -96,7 +99,7 @@ public class InputRegistry extends HashSet<IOState<MessageInput>> {
             inputState.setState(IOState.Type.TERMINATED);
         }
 
-        return super.remove(inputState);
+        return inputStates.remove(inputState);
     }
 
     public boolean remove(IOState<MessageInput> inputState) {
@@ -120,4 +123,11 @@ public class InputRegistry extends HashSet<IOState<MessageInput>> {
         return inputState;
     }
 
+    public boolean add(IOState<MessageInput> messageInputIOState) {
+        return inputStates.add(messageInputIOState);
+    }
+
+    public Stream<IOState<MessageInput>> stream() {
+        return inputStates.stream();
+    }
 }

--- a/graylog2-server/src/test/java/org/graylog2/shared/inputs/InputRegistryTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/shared/inputs/InputRegistryTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.shared.inputs;
+
+import org.graylog2.plugin.IOState;
+import org.junit.jupiter.api.Test;
+
+import java.util.stream.IntStream;
+
+import static org.mockito.Mockito.mock;
+
+class InputRegistryTest {
+
+    @Test
+    void testThreadSafe() {
+        // test which was failing pretty reliably back in the days when the input registry was not threadsafe
+        final InputRegistry inputRegistry = new InputRegistry();
+        IntStream.range(0, 100).parallel().forEach(i -> {
+            if (i % 2 == 0) {
+                var ignored = inputRegistry.stream().toList();
+            } else {
+                //noinspection unchecked
+                inputRegistry.add(mock((IOState.class)));
+            }
+        });
+    }
+
+}


### PR DESCRIPTION
Make `InputRegistry` threadsafe by delegating methods to a threadsafe collection instead of directly extending `HashSet`.

Note: I couldn't reproduce #15277, but I've seen the error myself at least once before. However, the `InputRegistry` was not threadsafe, and it's reasonable to assume this is causing issues.

Fixes #15277
