### PR TITLE
Fix sidecar process button position issue on safari

### DIFF
--- a/changelog/unreleased/issue-14939.toml
+++ b/changelog/unreleased/issue-14939.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Fix sidecar process button position issue on safari"
+
+issues = ["14939"]
+pulls = ["15293"]

--- a/graylog2-web-interface/src/components/sidecars/administration/CollectorsAdministration.tsx
+++ b/graylog2-web-interface/src/components/sidecars/administration/CollectorsAdministration.tsx
@@ -47,6 +47,11 @@ const HeaderComponentsWrapper = styled.div(({ theme }) => css`
   .btn-link {
     color: ${theme.colors.variant.darker.default};
   }
+
+  .btn-toolbar {
+    display: flex;
+    max-height: 29px;
+  }
 `);
 
 const CollectorEntry = styled.div`


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fixes https://github.com/Graylog2/graylog2-server/issues/14939

## Screenshots (if appropriate):
<img width="1507" alt="Screenshot 2023-04-19 at 17 14 38" src="https://user-images.githubusercontent.com/106236152/233121434-9e4c6d5e-6a28-4926-972b-45e4dce538bd.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

