### PR TITLE
Moving from Reflections to ClassGraph when scanning for DB enities

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/database/dbcatalog/DbEntitiesCatalog.java
+++ b/graylog2-server/src/main/java/org/graylog2/database/dbcatalog/DbEntitiesCatalog.java
@@ -55,4 +55,8 @@ public class DbEntitiesCatalog {
     public Optional<DbEntityCatalogEntry> getByCollectionName(final String collection) {
         return Optional.ofNullable(entitiesByCollectionName.get(collection));
     }
+
+    public int size() {
+        return entitiesByCollectionName.size();
+    }
 }

--- a/graylog2-server/src/main/java/org/graylog2/database/dbcatalog/DbEntitiesScanner.java
+++ b/graylog2-server/src/main/java/org/graylog2/database/dbcatalog/DbEntitiesScanner.java
@@ -16,6 +16,7 @@
  */
 package org.graylog2.database.dbcatalog;
 
+import com.google.common.base.Stopwatch;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 import org.graylog2.database.dbcatalog.impl.ClassGraphDbEntitiesScanningMethod;
@@ -49,9 +50,10 @@ public class DbEntitiesScanner implements Provider<DbEntitiesCatalog> {
 
     @Override
     public DbEntitiesCatalog get() {
-        long startTimeMs = System.currentTimeMillis();
+        final Stopwatch stopwatch = Stopwatch.createStarted();
         final DbEntitiesCatalog catalog = dbEntitiesScanningMethod.scan(packagesToScan, packagesToExclude, chainingClassLoader);
-        LOG.info("{} entities have been scanned and added to DB Entity Catalog, it took {} ms", catalog.size(), System.currentTimeMillis() - startTimeMs);
+        stopwatch.stop();
+        LOG.info("{} entities have been scanned and added to DB Entity Catalog, it took {}", catalog.size(), stopwatch);
         return catalog;
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/database/dbcatalog/DbEntitiesScanner.java
+++ b/graylog2-server/src/main/java/org/graylog2/database/dbcatalog/DbEntitiesScanner.java
@@ -41,7 +41,7 @@ public class DbEntitiesScanner implements Provider<DbEntitiesCatalog> {
         this.packagesToExclude = new String[]{"org.graylog.shaded", "org.graylog.storage", "org.graylog2.migrations"};
     }
 
-    DbEntitiesScanner(final String[] packagesToScan, String[] packagesToExclude) {
+    DbEntitiesScanner(final String[] packagesToScan, final String[] packagesToExclude) {
         this.chainingClassLoader = null;
         this.packagesToScan = packagesToScan;
         this.packagesToExclude = packagesToExclude;
@@ -51,7 +51,7 @@ public class DbEntitiesScanner implements Provider<DbEntitiesCatalog> {
     public DbEntitiesCatalog get() {
         long startTimeMs = System.currentTimeMillis();
         final DbEntitiesCatalog catalog = dbEntitiesScanningMethod.scan(packagesToScan, packagesToExclude, chainingClassLoader);
-        LOG.info(catalog.size() + " entities have been scanned and added to DB Entity Catalog, it took " + (System.currentTimeMillis() - startTimeMs) + " ms");
+        LOG.info("{} entities have been scanned and added to DB Entity Catalog, it took {} ms", catalog.size(), System.currentTimeMillis() - startTimeMs);
         return catalog;
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/database/dbcatalog/DbEntitiesScanner.java
+++ b/graylog2-server/src/main/java/org/graylog2/database/dbcatalog/DbEntitiesScanner.java
@@ -38,7 +38,7 @@ public class DbEntitiesScanner implements Provider<DbEntitiesCatalog> {
     public DbEntitiesScanner(final ChainingClassLoader chainingClassLoader) {
         this.chainingClassLoader = chainingClassLoader;
         this.packagesToScan = new String[]{"org.graylog2", "org.graylog"};
-        this.packagesToExclude = new String[]{"org.graylog.shaded", "org.graylog.storage"};
+        this.packagesToExclude = new String[]{"org.graylog.shaded", "org.graylog.storage", "org.graylog2.migrations"};
     }
 
     DbEntitiesScanner(final String[] packagesToScan, String[] packagesToExclude) {

--- a/graylog2-server/src/main/java/org/graylog2/database/dbcatalog/DbEntitiesScanner.java
+++ b/graylog2-server/src/main/java/org/graylog2/database/dbcatalog/DbEntitiesScanner.java
@@ -29,6 +29,7 @@ public class DbEntitiesScanner implements Provider<DbEntitiesCatalog> {
     private static final Logger LOG = LoggerFactory.getLogger(DbEntitiesScanner.class);
 
     private final String[] packagesToScan;
+    private final String[] packagesToExclude;
     private final ChainingClassLoader chainingClassLoader;
     private final DbEntitiesScanningMethod dbEntitiesScanningMethod = new ClassGraphDbEntitiesScanningMethod();
 
@@ -36,18 +37,20 @@ public class DbEntitiesScanner implements Provider<DbEntitiesCatalog> {
     @Inject
     public DbEntitiesScanner(final ChainingClassLoader chainingClassLoader) {
         this.chainingClassLoader = chainingClassLoader;
-        this.packagesToScan = new String[]{"org.graylog2", "org.graylog.plugins"};
+        this.packagesToScan = new String[]{"org.graylog2", "org.graylog"};
+        this.packagesToExclude = new String[]{"org.graylog.shaded", "org.graylog.storage"};
     }
 
-    DbEntitiesScanner(String[] packagesToScan) {
+    DbEntitiesScanner(final String[] packagesToScan, String[] packagesToExclude) {
         this.chainingClassLoader = null;
         this.packagesToScan = packagesToScan;
+        this.packagesToExclude = packagesToExclude;
     }
 
     @Override
     public DbEntitiesCatalog get() {
         long startTimeMs = System.currentTimeMillis();
-        final DbEntitiesCatalog catalog = dbEntitiesScanningMethod.scan(packagesToScan, chainingClassLoader);
+        final DbEntitiesCatalog catalog = dbEntitiesScanningMethod.scan(packagesToScan, packagesToExclude, chainingClassLoader);
         LOG.info(catalog.size() + " entities have been scanned and added to DB Entity Catalog, it took " + (System.currentTimeMillis() - startTimeMs) + " ms");
         return catalog;
     }

--- a/graylog2-server/src/main/java/org/graylog2/database/dbcatalog/impl/ClassGraphDbEntitiesScanningMethod.java
+++ b/graylog2-server/src/main/java/org/graylog2/database/dbcatalog/impl/ClassGraphDbEntitiesScanningMethod.java
@@ -37,7 +37,7 @@ public class ClassGraphDbEntitiesScanningMethod implements DbEntitiesScanningMet
 
         List<DbEntityCatalogEntry> dbEntities = new LinkedList<>();
         ClassGraph classGraph = new ClassGraph()
-                .enableAllInfo()
+                .enableAnnotationInfo()
                 .acceptPackages(packagesToScan);
         if (chainingClassLoader != null) {
             //Unfortunately, ClassGraph does not work correctly if provided with ChainingClassLoader as a whole

--- a/graylog2-server/src/main/java/org/graylog2/database/dbcatalog/impl/ClassGraphDbEntitiesScanningMethod.java
+++ b/graylog2-server/src/main/java/org/graylog2/database/dbcatalog/impl/ClassGraphDbEntitiesScanningMethod.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.database.dbcatalog.impl;
+
+import io.github.classgraph.AnnotationInfo;
+import io.github.classgraph.AnnotationParameterValueList;
+import io.github.classgraph.ClassGraph;
+import io.github.classgraph.ClassInfo;
+import io.github.classgraph.ClassInfoList;
+import io.github.classgraph.ScanResult;
+import org.graylog2.database.DbEntity;
+import org.graylog2.database.dbcatalog.DbEntitiesCatalog;
+import org.graylog2.database.dbcatalog.DbEntityCatalogEntry;
+import org.graylog2.shared.plugins.ChainingClassLoader;
+
+import java.util.LinkedList;
+import java.util.List;
+
+public class ClassGraphDbEntitiesScanningMethod implements DbEntitiesScanningMethod {
+
+    @Override
+    public DbEntitiesCatalog scan(final String[] packagesToScan, final ChainingClassLoader chainingClassLoader) {
+
+        List<DbEntityCatalogEntry> dbEntities = new LinkedList<>();
+        ClassGraph classGraph = new ClassGraph()
+                .enableAllInfo()
+                .acceptPackages(packagesToScan);
+        if (chainingClassLoader != null) {
+            //Unfortunately, ClassGraph does not work correctly if provided with ChainingClassLoader as a whole
+            //You have to manually add all class loaders from ChainingClassLoader
+            for (ClassLoader cl : chainingClassLoader.getClassLoaders()) {
+                classGraph = classGraph.addClassLoader(cl);
+            }
+        }
+
+        try (ScanResult scanResult = classGraph.scan()) {
+            final String annotationName = DbEntity.class.getCanonicalName();
+            ClassInfoList classInfoList = scanResult.getClassesWithAnnotation(annotationName);
+            for (ClassInfo classInfo : classInfoList) {
+                AnnotationInfo annotationInfo = classInfo.getAnnotationInfo(annotationName);
+                AnnotationParameterValueList paramVals = annotationInfo.getParameterValues();
+                dbEntities.add(new DbEntityCatalogEntry(
+                        paramVals.get("collection").getValue().toString(),
+                        paramVals.get("titleField").getValue().toString(),
+                        classInfo.loadClass(),
+                        paramVals.get("readPermission").getValue().toString()
+                ));
+            }
+
+            return new DbEntitiesCatalog(dbEntities);
+        }
+    }
+
+
+}

--- a/graylog2-server/src/main/java/org/graylog2/database/dbcatalog/impl/ClassGraphDbEntitiesScanningMethod.java
+++ b/graylog2-server/src/main/java/org/graylog2/database/dbcatalog/impl/ClassGraphDbEntitiesScanningMethod.java
@@ -33,12 +33,16 @@ import java.util.List;
 public class ClassGraphDbEntitiesScanningMethod implements DbEntitiesScanningMethod {
 
     @Override
-    public DbEntitiesCatalog scan(final String[] packagesToScan, final ChainingClassLoader chainingClassLoader) {
+    public DbEntitiesCatalog scan(final String[] packagesToScan,
+                                  final String[] packagesToExclude,
+                                  final ChainingClassLoader chainingClassLoader) {
 
         List<DbEntityCatalogEntry> dbEntities = new LinkedList<>();
         ClassGraph classGraph = new ClassGraph()
                 .enableAnnotationInfo()
-                .acceptPackages(packagesToScan);
+                .acceptPackages(packagesToScan)
+                .rejectPackages(packagesToExclude);
+
         if (chainingClassLoader != null) {
             //Unfortunately, ClassGraph does not work correctly if provided with ChainingClassLoader as a whole
             //You have to manually add all class loaders from ChainingClassLoader

--- a/graylog2-server/src/main/java/org/graylog2/database/dbcatalog/impl/ClassGraphDbEntitiesScanningMethod.java
+++ b/graylog2-server/src/main/java/org/graylog2/database/dbcatalog/impl/ClassGraphDbEntitiesScanningMethod.java
@@ -41,7 +41,9 @@ public class ClassGraphDbEntitiesScanningMethod implements DbEntitiesScanningMet
         ClassGraph classGraph = new ClassGraph()
                 .enableAnnotationInfo()
                 .acceptPackages(packagesToScan)
-                .rejectPackages(packagesToExclude);
+                .rejectPackages(packagesToExclude)
+                .filterClasspathElements(classpathElementPathStr -> classpathElementPathStr.contains("graylog"))
+                .disableRuntimeInvisibleAnnotations();
 
         if (chainingClassLoader != null) {
             //Unfortunately, ClassGraph does not work correctly if provided with ChainingClassLoader as a whole

--- a/graylog2-server/src/main/java/org/graylog2/database/dbcatalog/impl/DbEntitiesScanningMethod.java
+++ b/graylog2-server/src/main/java/org/graylog2/database/dbcatalog/impl/DbEntitiesScanningMethod.java
@@ -21,5 +21,7 @@ import org.graylog2.shared.plugins.ChainingClassLoader;
 
 public interface DbEntitiesScanningMethod {
 
-    DbEntitiesCatalog scan(final String[] packagesToScan, final ChainingClassLoader chainingClassLoader);
+    DbEntitiesCatalog scan(final String[] packagesToScan,
+                           final String[] packagesToExclude,
+                           final ChainingClassLoader chainingClassLoader);
 }

--- a/graylog2-server/src/main/java/org/graylog2/database/dbcatalog/impl/DbEntitiesScanningMethod.java
+++ b/graylog2-server/src/main/java/org/graylog2/database/dbcatalog/impl/DbEntitiesScanningMethod.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.database.dbcatalog.impl;
+
+import org.graylog2.database.dbcatalog.DbEntitiesCatalog;
+import org.graylog2.shared.plugins.ChainingClassLoader;
+
+public interface DbEntitiesScanningMethod {
+
+    DbEntitiesCatalog scan(final String[] packagesToScan, final ChainingClassLoader chainingClassLoader);
+}

--- a/graylog2-server/src/main/java/org/graylog2/database/dbcatalog/impl/ReflectionsDbEntitiesScanningMethod.java
+++ b/graylog2-server/src/main/java/org/graylog2/database/dbcatalog/impl/ReflectionsDbEntitiesScanningMethod.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.database.dbcatalog.impl;
+
+import org.graylog2.database.DbEntity;
+import org.graylog2.database.dbcatalog.DbEntitiesCatalog;
+import org.graylog2.database.dbcatalog.DbEntityCatalogEntry;
+import org.graylog2.shared.plugins.ChainingClassLoader;
+import org.reflections.Reflections;
+import org.reflections.scanners.Scanners;
+import org.reflections.util.ConfigurationBuilder;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class ReflectionsDbEntitiesScanningMethod implements DbEntitiesScanningMethod {
+
+    @Override
+    public DbEntitiesCatalog scan(final String[] packagesToScan, final ChainingClassLoader chainingClassLoader) {
+        final ConfigurationBuilder configuration = new ConfigurationBuilder();
+        if (chainingClassLoader != null) {
+            configuration.setClassLoaders(new ClassLoader[]{chainingClassLoader});
+            Stream.of(packagesToScan).forEach(pkg -> {
+                configuration.forPackage(pkg, chainingClassLoader);
+            });
+        } else {
+            configuration.forPackages(packagesToScan);
+        }
+        configuration.setScanners(Scanners.TypesAnnotated);
+
+        final Reflections reflections = new Reflections(configuration);
+
+        final List<DbEntityCatalogEntry> dbEntities = reflections.getTypesAnnotatedWith(DbEntity.class).stream()
+                .map(
+                        type -> {
+                            final DbEntity annotation = type.getAnnotation(DbEntity.class);
+
+                            return new DbEntityCatalogEntry(
+                                    annotation.collection(),
+                                    annotation.titleField(),
+                                    type,
+                                    annotation.readPermission());
+
+                        }
+                ).collect(Collectors.toList());
+
+        return new DbEntitiesCatalog(dbEntities);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/database/dbcatalog/impl/ReflectionsDbEntitiesScanningMethod.java
+++ b/graylog2-server/src/main/java/org/graylog2/database/dbcatalog/impl/ReflectionsDbEntitiesScanningMethod.java
@@ -30,12 +30,15 @@ import java.util.stream.Stream;
 
 @Deprecated
 /**
+ * Exluding packages not implemented, as this method is deprecated.
  * @deprecated {@link ClassGraphDbEntitiesScanningMethod} performs better
  */
 public class ReflectionsDbEntitiesScanningMethod implements DbEntitiesScanningMethod {
 
     @Override
-    public DbEntitiesCatalog scan(final String[] packagesToScan, final ChainingClassLoader chainingClassLoader) {
+    public DbEntitiesCatalog scan(final String[] packagesToScan,
+                                  final String[] packagesToExclude,
+                                  final ChainingClassLoader chainingClassLoader) {
         final ConfigurationBuilder configuration = new ConfigurationBuilder();
         if (chainingClassLoader != null) {
             configuration.setClassLoaders(new ClassLoader[]{chainingClassLoader});

--- a/graylog2-server/src/main/java/org/graylog2/database/dbcatalog/impl/ReflectionsDbEntitiesScanningMethod.java
+++ b/graylog2-server/src/main/java/org/graylog2/database/dbcatalog/impl/ReflectionsDbEntitiesScanningMethod.java
@@ -28,6 +28,10 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+@Deprecated
+/**
+ * @deprecated {@link ClassGraphDbEntitiesScanningMethod} performs better
+ */
 public class ReflectionsDbEntitiesScanningMethod implements DbEntitiesScanningMethod {
 
     @Override

--- a/graylog2-server/src/test/java/org/graylog2/database/dbcatalog/DbEntitiesScannerTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/database/dbcatalog/DbEntitiesScannerTest.java
@@ -17,10 +17,12 @@
 package org.graylog2.database.dbcatalog;
 
 
+import org.graylog2.cluster.NodeImpl;
 import org.graylog2.indexer.indexset.IndexSetConfig;
 import org.graylog2.users.UserImpl;
 import org.junit.jupiter.api.Test;
 
+import static org.graylog2.database.DbEntity.NOBODY_ALOWED;
 import static org.graylog2.shared.security.RestPermissions.INDEXSETS_READ;
 import static org.graylog2.shared.security.RestPermissions.USERS_READ;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -39,6 +41,19 @@ class DbEntitiesScannerTest {
         assertSame(entryByCollectionName, entryByModelClass);
 
         assertEquals(new DbEntityCatalogEntry("index_sets", "title", IndexSetConfig.class, INDEXSETS_READ), entryByCollectionName);
+    }
+
+    @Test
+    void testScansEntitiesWithDefaultReadPermissionFieldProperly() {
+        DbEntitiesScanner scanner = new DbEntitiesScanner(new String[]{"org.graylog2.cluster"});
+        final DbEntitiesCatalog dbEntitiesCatalog = scanner.get();
+
+        final DbEntityCatalogEntry entryByCollectionName = dbEntitiesCatalog.getByCollectionName("nodes").get();
+        final DbEntityCatalogEntry entryByModelClass = dbEntitiesCatalog.getByModelClass(NodeImpl.class).get();
+
+        assertSame(entryByCollectionName, entryByModelClass);
+
+        assertEquals(new DbEntityCatalogEntry("nodes", "node_id", NodeImpl.class, NOBODY_ALOWED), entryByCollectionName);
     }
 
     @Test

--- a/graylog2-server/src/test/java/org/graylog2/database/dbcatalog/DbEntitiesScannerTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/database/dbcatalog/DbEntitiesScannerTest.java
@@ -22,17 +22,20 @@ import org.graylog2.indexer.indexset.IndexSetConfig;
 import org.graylog2.users.UserImpl;
 import org.junit.jupiter.api.Test;
 
+import java.util.Optional;
+
 import static org.graylog2.database.DbEntity.NOBODY_ALOWED;
 import static org.graylog2.shared.security.RestPermissions.INDEXSETS_READ;
 import static org.graylog2.shared.security.RestPermissions.USERS_READ;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
 class DbEntitiesScannerTest {
 
     @Test
     void testScansEntitiesWithDefaultTitleFieldProperly() {
-        DbEntitiesScanner scanner = new DbEntitiesScanner(new String[]{"org.graylog2.indexer.indexset"});
+        DbEntitiesScanner scanner = new DbEntitiesScanner(new String[]{"org.graylog2.indexer.indexset"}, new String[]{});
         final DbEntitiesCatalog dbEntitiesCatalog = scanner.get();
 
         final DbEntityCatalogEntry entryByCollectionName = dbEntitiesCatalog.getByCollectionName("index_sets").get();
@@ -44,8 +47,24 @@ class DbEntitiesScannerTest {
     }
 
     @Test
+    void testExcludingPackagesWorkCorrectly() {
+        DbEntitiesScanner scanner = new DbEntitiesScanner(
+                new String[]{"org.graylog2.indexer"},
+                new String[]{"org.graylog2.indexer.indexset"}
+        );
+        final DbEntitiesCatalog dbEntitiesCatalog = scanner.get();
+
+        final Optional<DbEntityCatalogEntry> entryByCollectionName = dbEntitiesCatalog.getByCollectionName("index_sets");
+        final Optional<DbEntityCatalogEntry> entryByModelClass = dbEntitiesCatalog.getByModelClass(IndexSetConfig.class);
+
+        assertFalse(entryByCollectionName.isPresent());
+        assertFalse(entryByModelClass.isPresent());
+
+    }
+
+    @Test
     void testScansEntitiesWithDefaultReadPermissionFieldProperly() {
-        DbEntitiesScanner scanner = new DbEntitiesScanner(new String[]{"org.graylog2.cluster"});
+        DbEntitiesScanner scanner = new DbEntitiesScanner(new String[]{"org.graylog2.cluster"}, new String[]{});
         final DbEntitiesCatalog dbEntitiesCatalog = scanner.get();
 
         final DbEntityCatalogEntry entryByCollectionName = dbEntitiesCatalog.getByCollectionName("nodes").get();
@@ -58,7 +77,7 @@ class DbEntitiesScannerTest {
 
     @Test
     void testScansEntitiesWithCustomTitleFieldProperly() {
-        DbEntitiesScanner scanner = new DbEntitiesScanner(new String[]{"org.graylog2.users"});
+        DbEntitiesScanner scanner = new DbEntitiesScanner(new String[]{"org.graylog2.users"}, new String[]{});
         final DbEntitiesCatalog dbEntitiesCatalog = scanner.get();
 
         final DbEntityCatalogEntry entryByCollectionName = dbEntitiesCatalog.getByCollectionName(UserImpl.COLLECTION_NAME).get();

--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
         <bouncycastle.version>1.69</bouncycastle.version>
         <caffeine.version>2.8.1</caffeine.version>
         <cef-parser.version>0.0.1.10</cef-parser.version>
-        <classgraph.version>4.8.102</classgraph.version>
+        <classgraph.version>4.8.157</classgraph.version>
         <commons-codec.version>1.14</commons-codec.version>
         <commons-email.version>1.5</commons-email.version>
         <commons-validator.version>1.6</commons-validator.version>


### PR DESCRIPTION
## Description
DbEntityScanner now uses ClassGraph instead of Reflections.
ClassGraph library has been updated to the latest version.
/nocl

## Motivation and Context
Reflections based scanning took too much time on certain AWS environments.

## How Has This Been Tested?
Manually and with unit tests.
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

