### PR TITLE
Handle `undefined`/`null` when concatenating query strings.

### DIFF
--- a/graylog2-web-interface/src/views/logic/queries/QueryHelper.test.ts
+++ b/graylog2-web-interface/src/views/logic/queries/QueryHelper.test.ts
@@ -23,27 +23,33 @@ describe('QueryHelper', () => {
 
   describe('concatQueryStrings', () => {
     it('concat queries by default with AND and brackets', () => {
-      const result = concatQueryStrings(['filed1:value1 OR field2:value2', 'field3:value3']);
+      const result = concatQueryStrings(['field1:value1 OR field2:value2', 'field3:value3']);
 
-      expect(result).toEqual('(filed1:value1 OR field2:value2) AND (field3:value3)');
+      expect(result).toEqual('(field1:value1 OR field2:value2) AND (field3:value3)');
     });
 
     it('concat queries with custom operator and without brackets', () => {
-      const result = concatQueryStrings(['filed1:value1 OR field2:value2', 'field3:value3'], { operator: 'OR', withBrackets: false });
+      const result = concatQueryStrings(['field1:value1 OR field2:value2', 'field3:value3'], { operator: 'OR', withBrackets: false });
 
-      expect(result).toEqual('filed1:value1 OR field2:value2 OR field3:value3');
+      expect(result).toEqual('field1:value1 OR field2:value2 OR field3:value3');
     });
 
     it('filtrate empty query strings', () => {
-      const result = concatQueryStrings(['     ', 'filed1:value1 OR field2:value2', ' ', 'field3:value3', '']);
+      const result = concatQueryStrings(['     ', 'field1:value1 OR field2:value2', ' ', 'field3:value3', '']);
 
-      expect(result).toEqual('(filed1:value1 OR field2:value2) AND (field3:value3)');
+      expect(result).toEqual('(field1:value1 OR field2:value2) AND (field3:value3)');
     });
 
     it('doesnt wrap in brackets if we have only one query string', () => {
-      const result = concatQueryStrings(['     ', 'filed1:value1 OR field2:value2', ' ', '']);
+      const result = concatQueryStrings(['     ', 'field1:value1 OR field2:value2', ' ', '']);
 
-      expect(result).toEqual('filed1:value1 OR field2:value2');
+      expect(result).toEqual('field1:value1 OR field2:value2');
+    });
+
+    it('handles null query strings', () => {
+      const result = concatQueryStrings([undefined, 'field1:value1 OR field2:value2', null, '']);
+
+      expect(result).toEqual('field1:value1 OR field2:value2');
     });
   });
 });

--- a/graylog2-web-interface/src/views/logic/queries/QueryHelper.ts
+++ b/graylog2-web-interface/src/views/logic/queries/QueryHelper.ts
@@ -52,7 +52,7 @@ const addToQuery = (oldQuery: string, newTerm: string, operator: string = 'AND')
 };
 
 const concatQueryStrings = (queryStrings: Array<string>, { operator = 'AND', withBrackets = true } = {}): string => {
-  const withRemovedEmpty = queryStrings.filter((s: string) => !!s.trim());
+  const withRemovedEmpty = queryStrings.filter((s: string) => !!(s?.trim()));
   const showBracketsForChild = withBrackets && withRemovedEmpty.length > 1;
 
   return withRemovedEmpty.map((s) => (showBracketsForChild ? `(${s})` : s)).join(` ${operator} `);


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Prior to this PR, an exception was thrown when creating a message table widget on a dashboard with a global override query being set. This is caused by the query string concatenation function not handling `undefined` properly.

This PR is fixing this, by treating `undefined`/`null` as query strings identical to blank query strings.

Fixes #15304.

/nocl

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.