### PR TITLE
Fix query parser's tokenizer state after regex has ended.

### DIFF
--- a/changelog/unreleased/pr-15306.toml
+++ b/changelog/unreleased/pr-15306.toml
@@ -1,0 +1,6 @@
+type = "fixed"
+message = "Fix query parser's tokenizer state after regex has ended."
+
+issues = ["Graylog2/graylog-plugin-enterprise#5014"]
+pulls = ["15306"]
+

--- a/graylog2-web-interface/src/views/components/searchbar/queryinput/custom-lucene-mode.js
+++ b/graylog2-web-interface/src/views/components/searchbar/queryinput/custom-lucene-mode.js
@@ -89,7 +89,7 @@ ace.define('ace/mode/lucene_highlight_rules', ['require', 'exports', 'module', '
         }, {
           token: 'string.regexp.end',
           regex: '/[sxngimy]*',
-          next: 'no_regex',
+          next: 'start',
         }, {
           token: 'invalid',
           regex: /\{\d+\b,?\d*\}[+*]|[+*$^?][+*]|[$^][?]|\?{3,}/,
@@ -110,7 +110,7 @@ ace.define('ace/mode/lucene_highlight_rules', ['require', 'exports', 'module', '
         }, {
           token: 'empty',
           regex: '$',
-          next: 'no_regex',
+          next: 'start',
         }, {
           defaultToken: 'string.regexp',
         },
@@ -129,7 +129,7 @@ ace.define('ace/mode/lucene_highlight_rules', ['require', 'exports', 'module', '
         }, {
           token: 'empty',
           regex: '$',
-          next: 'no_regex',
+          next: 'start',
         }, {
           defaultToken: 'string.regexp.charachterclass',
         },


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The integrated lucene mode of ace is broken regarding regex handling. It is forwarding to a missing `no_regex` state when regexes are ending, resulting in an exception being thrown when parsing a regex in a query string.

This PR is fixing this, by forwarding to the `start` state after a regex has ended.

Fixes Graylog2/graylog-plugin-enterprise#5014.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.