### PR TITLE
fix: Condition is missing when creating event definition from search

### DIFF
--- a/graylog2-web-interface/src/components/event-definitions/hooks/useEventDefinitionConfigFromUrl.test.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/hooks/useEventDefinitionConfigFromUrl.test.tsx
@@ -1,0 +1,200 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import React from 'react';
+import { renderHook } from 'wrappedTestingLibrary/hooks';
+
+import useEventDefinitionConfigFromUrl from 'components/event-definitions/hooks/useEventDefinitionConfigFromUrl';
+import asMock from 'helpers/mocking/AsMock';
+import useQuery from 'routing/useQuery';
+import {
+  urlConfigWithAggString,
+  urlConfigWithFunctionAggString,
+  urlConfigWithoutAggString,
+} from 'fixtures/createEventDefinitionFromValue';
+
+jest.mock('routing/useQuery', () => jest.fn());
+
+const wrapper = ({ children }) => (
+  <div>
+    {children}
+  </div>
+);
+
+describe('useEventDefinitionConfigFromUrl', () => {
+  it('return data with conditions part when function, field and value exist', async () => {
+    asMock(useQuery).mockReturnValue({ config: urlConfigWithAggString });
+    const { result, waitFor } = renderHook(() => useEventDefinitionConfigFromUrl(), { wrapper });
+    await waitFor(() => !!result.current);
+
+    expect(result.current).toEqual(
+      {
+        configFromUrl: {
+          conditions: {
+            expression: {
+              left: {
+                expr: 'number-ref',
+                ref: 'count-action',
+              },
+              right: {
+                expr: 'number',
+                value: 400,
+              },
+            },
+          },
+          group_by: [
+            'action',
+            'action',
+            'http_method',
+          ],
+          query: '(http_method:GET) AND ((http_method:GET)) AND (action:show)',
+          query_parameters: [
+            {
+              data_type: 'any',
+              default_value: 'GET',
+              description: '',
+              key: 'lt',
+              lookup_table: 'http_method',
+              name: 'newParameter',
+              optional: false,
+              title: 'lt',
+              type: 'lut-parameter-v1',
+            },
+          ],
+          search_within_ms: 300000,
+          series: [
+            {
+              field: 'action',
+              function: 'count',
+              id: 'count-action',
+            },
+          ],
+          streams: [
+            'streamId-1',
+            'streamId-2',
+          ],
+          type: 'aggregation-v1',
+        },
+        hasUrlConfig: true,
+      },
+    );
+  });
+
+  it('return data with conditions part when only function and value exist', async () => {
+    asMock(useQuery).mockReturnValue({ config: urlConfigWithFunctionAggString });
+    const { result, waitFor } = renderHook(() => useEventDefinitionConfigFromUrl(), { wrapper });
+    await waitFor(() => !!result.current);
+
+    expect(result.current).toEqual(
+      {
+        configFromUrl: {
+          conditions: {
+            expression: {
+              left: {
+                expr: 'number-ref',
+                ref: 'count-undefined',
+              },
+              right: {
+                expr: 'number',
+                value: 400,
+              },
+            },
+          },
+          group_by: [
+            'action',
+            'action',
+            'http_method',
+          ],
+          query: '(http_method:GET) AND ((http_method:GET)) AND (action:show)',
+          query_parameters: [
+            {
+              data_type: 'any',
+              default_value: 'GET',
+              description: '',
+              key: 'lt',
+              lookup_table: 'http_method',
+              name: 'newParameter',
+              optional: false,
+              title: 'lt',
+              type: 'lut-parameter-v1',
+            },
+          ],
+          search_within_ms: 300000,
+          series: [
+            {
+              function: 'count',
+              id: 'count-undefined',
+            },
+          ],
+          streams: [
+            'streamId-1',
+            'streamId-2',
+          ],
+          type: 'aggregation-v1',
+        },
+        hasUrlConfig: true,
+      },
+    );
+  });
+
+  it('return data without conditions part when function not exist', async () => {
+    asMock(useQuery).mockReturnValue({ config: urlConfigWithoutAggString });
+    const { result, waitFor } = renderHook(() => useEventDefinitionConfigFromUrl(), { wrapper });
+    await waitFor(() => !!result.current);
+
+    expect(result.current).toEqual(
+      {
+        configFromUrl: {
+          group_by: [],
+          query: '(http_method:GET) AND ((http_method:GET)) AND (action:show)',
+          query_parameters: [
+            {
+              data_type: 'any',
+              default_value: 'GET',
+              description: '',
+              key: 'lt',
+              lookup_table: 'http_method',
+              name: 'newParameter',
+              optional: false,
+              title: 'lt',
+              type: 'lut-parameter-v1',
+            },
+          ],
+          search_within_ms: 300000,
+          streams: [
+            'streamId-1',
+            'streamId-2',
+          ],
+          type: 'aggregation-v1',
+        },
+        hasUrlConfig: true,
+      },
+    );
+  });
+
+  it('return hasUrlConfig when no url config data', async () => {
+    asMock(useQuery).mockReturnValue({ config: {} });
+    const { result, waitFor } = renderHook(() => useEventDefinitionConfigFromUrl(), { wrapper });
+    await waitFor(() => !!result.current);
+
+    expect(result.current).toEqual(
+      {
+        configFromUrl: undefined,
+        hasUrlConfig: false,
+      },
+    );
+  });
+});

--- a/graylog2-web-interface/src/components/event-definitions/hooks/useEventDefinitionConfigFromUrl.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/hooks/useEventDefinitionConfigFromUrl.tsx
@@ -16,6 +16,7 @@
  */
 
 import { useMemo } from 'react';
+import isEmpty from 'lodash/isEmpty';
 
 import useQuery from 'routing/useQuery';
 import type { ParameterJson } from 'views/logic/parameters/Parameter';
@@ -51,7 +52,7 @@ const useEventDefinitionConfigFromUrl = (): { hasUrlConfig: boolean; configFromU
   } = useQuery();
 
   return useMemo(() => {
-    if (!urlConfig) return ({ hasUrlConfig: false, configFromUrl: undefined });
+    if (!urlConfig || isEmpty(urlConfig)) return ({ hasUrlConfig: false, configFromUrl: undefined });
     const parsedUrlConfig: EventDefinitionURLConfig = JSON.parse(urlConfig as string);
     const {
       type,
@@ -65,7 +66,7 @@ const useEventDefinitionConfigFromUrl = (): { hasUrlConfig: boolean; configFromU
       loc_query_parameters,
     } = parsedUrlConfig;
 
-    const aggData = (agg_function && agg_field && agg_value) ? {
+    const aggData = (agg_function && agg_value) ? {
       conditions: {
         expression: {
           expr: undefined,

--- a/graylog2-web-interface/src/views/logic/valueactions/createEventDefinition/hooks/useUrlConfigData.test.tsx
+++ b/graylog2-web-interface/src/views/logic/valueactions/createEventDefinition/hooks/useUrlConfigData.test.tsx
@@ -18,7 +18,7 @@ import React from 'react';
 import { renderHook } from 'wrappedTestingLibrary/hooks';
 
 import {
-  ltParamJSON,
+  ltParamJSON, urlConfigWithAgg,
 } from 'fixtures/createEventDefinitionFromValue';
 import useUrlConfigData from 'views/logic/valueactions/createEventDefinition/hooks/useUrlConfigData';
 
@@ -58,37 +58,7 @@ describe('useUrlConfigData', () => {
     }), { wrapper });
     await waitFor(() => !!result.current);
 
-    expect(result.current).toEqual({
-      agg_field: 'action',
-      agg_function: 'count',
-      agg_value: 400,
-      group_by: [
-        'action',
-        'action',
-        'http_method',
-      ],
-      loc_query_parameters: [
-        {
-          binding: undefined,
-          data_type: 'any',
-          default_value: 'GET',
-          description: '',
-          key: 'lt',
-          lookup_table: 'http_method',
-          name: 'newParameter',
-          optional: false,
-          title: 'lt',
-          type: 'lut-parameter-v1',
-        },
-      ],
-      query: '(http_method:GET) AND ((http_method:GET)) AND (action:show)',
-      search_within_ms: 300000,
-      streams: [
-        'streamId-1',
-        'streamId-2',
-      ],
-      type: 'aggregation-v1',
-    });
+    expect(result.current).toEqual(urlConfigWithAgg);
   });
 
   it('ignore non-selected values', async () => {

--- a/graylog2-web-interface/test/fixtures/createEventDefinitionFromValue.ts
+++ b/graylog2-web-interface/test/fixtures/createEventDefinitionFromValue.ts
@@ -209,3 +209,95 @@ export const modalDataResult = {
   searchWithinMs: 300000,
   streams: 'streamId-1-title, streamId-2-title',
 };
+
+export const urlConfigWithAgg = {
+  agg_field: 'action',
+  agg_function: 'count',
+  agg_value: 400,
+  group_by: [
+    'action',
+    'action',
+    'http_method',
+  ],
+  loc_query_parameters: [
+    {
+      binding: undefined,
+      data_type: 'any',
+      default_value: 'GET',
+      description: '',
+      key: 'lt',
+      lookup_table: 'http_method',
+      name: 'newParameter',
+      optional: false,
+      title: 'lt',
+      type: 'lut-parameter-v1',
+    },
+  ],
+  query: '(http_method:GET) AND ((http_method:GET)) AND (action:show)',
+  search_within_ms: 300000,
+  streams: [
+    'streamId-1',
+    'streamId-2',
+  ],
+  type: 'aggregation-v1',
+};
+
+export const urlConfigWithFunctionAgg = {
+  agg_function: 'count',
+  agg_value: 400,
+  group_by: [
+    'action',
+    'action',
+    'http_method',
+  ],
+  loc_query_parameters: [
+    {
+      binding: undefined,
+      data_type: 'any',
+      default_value: 'GET',
+      description: '',
+      key: 'lt',
+      lookup_table: 'http_method',
+      name: 'newParameter',
+      optional: false,
+      title: 'lt',
+      type: 'lut-parameter-v1',
+    },
+  ],
+  query: '(http_method:GET) AND ((http_method:GET)) AND (action:show)',
+  search_within_ms: 300000,
+  streams: [
+    'streamId-1',
+    'streamId-2',
+  ],
+  type: 'aggregation-v1',
+};
+
+export const urlConfigWithoutAgg = {
+  group_by: [],
+  loc_query_parameters: [
+    {
+      binding: undefined,
+      data_type: 'any',
+      default_value: 'GET',
+      description: '',
+      key: 'lt',
+      lookup_table: 'http_method',
+      name: 'newParameter',
+      optional: false,
+      title: 'lt',
+      type: 'lut-parameter-v1',
+    },
+  ],
+  query: '(http_method:GET) AND ((http_method:GET)) AND (action:show)',
+  search_within_ms: 300000,
+  streams: [
+    'streamId-1',
+    'streamId-2',
+  ],
+  type: 'aggregation-v1',
+};
+
+export const urlConfigWithAggString = JSON.stringify(urlConfigWithAgg);
+export const urlConfigWithFunctionAggString = JSON.stringify(urlConfigWithFunctionAgg);
+export const urlConfigWithoutAggString = JSON.stringify(urlConfigWithoutAgg);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR fix bug, when the condition is absent and the field doesn't exist. Also, PR adds tests 

## Motivation and Context
fix: https://github.com/Graylog2/graylog2-server/issues/15309

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

/nocl
