### PR TITLE
Only display dashboard delete action when user has the required permissions.

### DIFF
--- a/graylog2-web-interface/src/views/components/dashboard/DashboardsOverview/DashboardActions.test.tsx
+++ b/graylog2-web-interface/src/views/components/dashboard/DashboardsOverview/DashboardActions.test.tsx
@@ -19,6 +19,7 @@ import { render, waitFor, screen } from 'wrappedTestingLibrary';
 import * as React from 'react';
 import userEvent from '@testing-library/user-event';
 import { PluginStore } from 'graylog-web-plugin/plugin';
+import Immutable from 'immutable';
 
 import { asMock } from 'helpers/mocking';
 import { ViewManagementActions } from 'views/stores/ViewManagementStore';
@@ -26,7 +27,6 @@ import DashboardActions from 'views/components/dashboard/DashboardsOverview/Dash
 import { simpleView } from 'views/test/ViewFixtures';
 import useCurrentUser from 'hooks/useCurrentUser';
 import { adminUser } from 'fixtures/users';
-import Immutable from 'immutable';
 
 jest.mock('hooks/useCurrentUser');
 
@@ -80,18 +80,16 @@ describe('DashboardActions', () => {
     expect(ViewManagementActions.delete).toHaveBeenCalledWith(expect.objectContaining({ id: 'foo' }));
   });
 
-
   it('does not offer deletion when user has only read permissions', async () => {
-    const currentUser = adminUser.toBuilder().permissions(Immutable.List([`view:read:${simpleDashboard.id}`])).build()
+    const currentUser = adminUser.toBuilder().permissions(Immutable.List([`view:read:${simpleDashboard.id}`])).build();
     asMock(useCurrentUser).mockReturnValue(currentUser);
 
     render(<DashboardActions dashboard={simpleDashboard} refetchDashboards={() => Promise.resolve()} />);
 
     userEvent.click(await screen.findByText('More'));
-    expect(screen.queryByRole('button', { name: /delete/i })).not.toBeInTheDocument()
+
+    expect(screen.queryByRole('button', { name: /delete/i })).not.toBeInTheDocument();
   });
-
-
 
   describe('supports dashboard deletion hook', () => {
     const deletingDashboard = jest.fn(() => Promise.resolve(true));

--- a/graylog2-web-interface/src/views/components/dashboard/DashboardsOverview/DashboardActions.test.tsx
+++ b/graylog2-web-interface/src/views/components/dashboard/DashboardsOverview/DashboardActions.test.tsx
@@ -24,6 +24,11 @@ import { asMock } from 'helpers/mocking';
 import { ViewManagementActions } from 'views/stores/ViewManagementStore';
 import DashboardActions from 'views/components/dashboard/DashboardsOverview/DashboardActions';
 import { simpleView } from 'views/test/ViewFixtures';
+import useCurrentUser from 'hooks/useCurrentUser';
+import { adminUser } from 'fixtures/users';
+import Immutable from 'immutable';
+
+jest.mock('hooks/useCurrentUser');
 
 jest.mock('views/stores/ViewManagementStore', () => ({
   ViewManagementActions: {
@@ -44,6 +49,7 @@ describe('DashboardActions', () => {
   beforeEach(() => {
     oldWindowConfirm = window.confirm;
     window.confirm = jest.fn();
+    asMock(useCurrentUser).mockReturnValue(adminUser);
   });
 
   afterEach(() => {
@@ -53,7 +59,7 @@ describe('DashboardActions', () => {
   it('does not delete dashboard when user clicks cancel', async () => {
     asMock(window.confirm).mockReturnValue(false);
 
-    render(<DashboardActions dashboard={simpleView()} refetchDashboards={() => Promise.resolve()} />);
+    render(<DashboardActions dashboard={simpleDashboard} refetchDashboards={() => Promise.resolve()} />);
 
     await clickDashboardAction('Delete');
 
@@ -65,7 +71,7 @@ describe('DashboardActions', () => {
   it('deletes dashboard when user confirms deletion', async () => {
     asMock(window.confirm).mockReturnValue(true);
 
-    render(<DashboardActions dashboard={simpleView()} refetchDashboards={() => Promise.resolve()} />);
+    render(<DashboardActions dashboard={simpleDashboard} refetchDashboards={() => Promise.resolve()} />);
 
     await clickDashboardAction('Delete');
 
@@ -73,6 +79,19 @@ describe('DashboardActions', () => {
 
     expect(ViewManagementActions.delete).toHaveBeenCalledWith(expect.objectContaining({ id: 'foo' }));
   });
+
+
+  it('does not offer deletion when user has only read permissions', async () => {
+    const currentUser = adminUser.toBuilder().permissions(Immutable.List([`view:read:${simpleDashboard.id}`])).build()
+    asMock(useCurrentUser).mockReturnValue(currentUser);
+
+    render(<DashboardActions dashboard={simpleDashboard} refetchDashboards={() => Promise.resolve()} />);
+
+    userEvent.click(await screen.findByText('More'));
+    expect(screen.queryByRole('button', { name: /delete/i })).not.toBeInTheDocument()
+  });
+
+
 
   describe('supports dashboard deletion hook', () => {
     const deletingDashboard = jest.fn(() => Promise.resolve(true));

--- a/graylog2-web-interface/src/views/components/dashboard/DashboardsOverview/DashboardActions.tsx
+++ b/graylog2-web-interface/src/views/components/dashboard/DashboardsOverview/DashboardActions.tsx
@@ -19,7 +19,7 @@ import styled, { css } from 'styled-components';
 import type { DefaultTheme } from 'styled-components';
 import { PluginStore } from 'graylog-web-plugin/plugin';
 
-import { ShareButton } from 'components/common';
+import { IfPermitted, ShareButton } from 'components/common';
 import OverlayDropdownButton from 'components/common/OverlayDropdownButton';
 import { MenuItem } from 'components/bootstrap';
 import type View from 'views/logic/views/View';
@@ -81,9 +81,11 @@ const DashboardActions = ({ dashboard, refetchDashboards }: Props) => {
             <MenuItem divider />
           </>
         ) : null}
-        <MenuItem onClick={onDashboardDelete}>
-          <DeleteItem role="button">Delete</DeleteItem>
-        </MenuItem>
+        <IfPermitted permissions={[`view:edit:${dashboard.id}`, 'view:edit']} anyPermissions>
+          <MenuItem onClick={onDashboardDelete}>
+            <DeleteItem role="button">Delete</DeleteItem>
+          </MenuItem>
+        </IfPermitted>
       </OverlayDropdownButton>
       {showShareModal && (
         <EntityShareModal entityId={dashboard.id}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Before this change the delete buttons in the dashboards overview were always visible even when the user only had read permissions for a dashboard.

Fixes https://github.com/Graylog2/graylog2-server/issues/15261

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

/nocl
