### PR TITLE
Let cookie auth take precedence over basic auth.

### DIFF
--- a/changelog/unreleased/pr-15329.toml
+++ b/changelog/unreleased/pr-15329.toml
@@ -1,0 +1,6 @@
+type = "f"
+message = "Let cookie auth take precedence over basic auth. "
+
+issues = ["6831"]
+pulls = ["15329"]
+

--- a/graylog2-server/src/main/java/org/graylog2/shared/security/ShiroSecurityContextFilter.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/security/ShiroSecurityContextFilter.java
@@ -137,12 +137,12 @@ public class ShiroSecurityContextFilter implements ContainerRequestFilter {
         if ("token".equalsIgnoreCase(credential)) {
             return new AccessTokenAuthToken(userName, host);
         }
-        if (!Strings.isNullOrEmpty(userName) && !Strings.isNullOrEmpty(credential)) {
-            return new UsernamePasswordToken(userName, credential, host);
-        }
         if (cookies.containsKey(SESSION_COOKIE_NAME)) {
             final Cookie authenticationCookie = cookies.get(SESSION_COOKIE_NAME);
             return new SessionIdToken(authenticationCookie.getValue(), host, remoteAddr);
+        }
+        if (!Strings.isNullOrEmpty(userName) && !Strings.isNullOrEmpty(credential)) {
+            return new UsernamePasswordToken(userName, credential, host);
         }
 
         return new PossibleTrustedHeaderToken(host, remoteAddr);


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This change is making sure that cookie auth has precedence over basic auth during the authentication process of the REST API. This allows us to put a proxy in front of Graylog that does basic auth separately, without the need of user databases being in sync with Graylog's user database.

What this does not solve is API access through tokens as basic auth headers. This needs a separate fix and will most probably require an additional, separate header being user for the token.

Fixes #6831.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Caddy, configured with basic auth was used to reverse proxy the Graylog frontend/API. General functionality tests were performed with it.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.