### PR TITLE
Fix wrong conversion of default timeout for proxied resources

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/RemoteInterfaceProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/RemoteInterfaceProvider.java
@@ -44,7 +44,7 @@ public class RemoteInterfaceProvider {
                                    ) {
         this.objectMapper = objectMapper;
         this.okHttpClient = okHttpClient;
-        this.defaultProxyTimeout = Duration.ofMillis(defaultProxyTimeout.toMicroseconds());
+        this.defaultProxyTimeout = Duration.ofMillis(defaultProxyTimeout.toMilliseconds());
     }
 
     public <T> T get(Node node, final String authorizationToken, Class<T> interfaceClass, Duration timeout) {


### PR DESCRIPTION
There is a conversion error when reading the `proxied_requests_default_call_timeout` setting. For some calls, the actual timeout being used was higher by a factor of 1000.

I noticed this when looking at requests like the following:

```
http://localhost:8080/api/cluster/aaa02d2d-1c2c-426b-9dca-daa2a38c828a/metrics/namespace/org
```

/nocl