### PR TITLE
Only check size of indices which are open during rotation. (`4.3`)

### DIFF
--- a/changelog/unreleased/issue-13872.toml
+++ b/changelog/unreleased/issue-13872.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Fix time-based rotation check when closed indices are present."
+
+issues = ["13872"]
+pulls = ["15336"]

--- a/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/TimeBasedRotationStrategy.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/TimeBasedRotationStrategy.java
@@ -43,7 +43,6 @@ import javax.inject.Singleton;
 import java.text.MessageFormat;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 import static com.google.common.base.Preconditions.checkState;
@@ -238,13 +237,10 @@ public class TimeBasedRotationStrategy extends AbstractRotationStrategy {
     }
 
     private boolean isEmptyIndexSet(IndexSet indexSet) {
-        final Set<String> allIndices = indices.getIndices(indexSet);
-        for (String index : allIndices) {
-            if (indices.numberOfMessages(index) > 0) {
-                return false;
-            }
-        }
-        return true;
+        return indices.getIndices(indexSet)
+                .stream()
+                .filter(indices::isOpen)
+                .noneMatch(indexName -> indices.numberOfMessages(indexName) > 0);
     }
 
     private Pair<Period, Boolean> getNormalizedRotationPeriod(TimeBasedRotationStrategyConfig config) {

--- a/graylog2-server/src/test/java/org/graylog2/indexer/rotation/strategies/TimeBasedRotationStrategyTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/rotation/strategies/TimeBasedRotationStrategyTest.java
@@ -86,6 +86,7 @@ public class TimeBasedRotationStrategyTest {
         when(indexSetConfig.title()).thenReturn("index-set-title");
         when(indices.getIndices(eq(indexSet))).thenReturn(Collections.singleton(IGNORED));
         when(indices.numberOfMessages(eq(IGNORED))).thenReturn(20L);
+        when(indices.isOpen(anyString())).thenReturn(true);
         rotationStrategy = new TimeBasedRotationStrategy(indices, nodeId, auditEventSender, configuration);
     }
 


### PR DESCRIPTION
**Note:** This is a backport of #15326 to `4.3`.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Prior to this PR, when an index set had configured a time-based rotation strategy and at least one index matching its naming scheme existed which was closed, the rotation check failed. This was because initially a check was performed if the index set is empty. This was done by checking all existing indices matching the naming scheme of the index set for their size, failing with an exception for closed indices.

This change is now filtering out closed indices in that check, treating them as if they are empty. This avoids the exception being thrown, allowing rotation (checks) to continue.

Fixes #13872.
Fixes Graylog2/graylog-plugin-enterprise#4908.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.