### PR TITLE
Add handler for more than 2 items in translatedPath for creating valuePath

### DIFF
--- a/graylog2-web-interface/src/views/components/datatable/DataTableEntry.tsx
+++ b/graylog2-web-interface/src/views/components/datatable/DataTableEntry.tsx
@@ -106,8 +106,12 @@ const DataTableEntry = ({ columnPivots, fields, series, columnPivotValues, value
   ));
   const columnPivotFields = flatten(columnPivotValues.map((columnPivotValueKeys) => {
     const translatedPath = flatten(columnPivotValueKeys.map((value, idx) => [columnPivots[idx], value]));
-    const [k, v]: Array<string> = translatedPath;
-    const parentValuePath = [...valuePath, { [k]: v }];
+    const parentValuePath = [...valuePath];
+
+    for (let i = 0; i < translatedPath.length; i += 2) {
+      const [k, v]: Array<string> = translatedPath.slice(i, i + 2);
+      parentValuePath.push({ [k]: v });
+    }
 
     return series.map(({ effectiveName, function: fn }) => {
       const fullPath = [].concat(translatedPath, [effectiveName]);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
In the previous version, in the code, we expect only 2 items [k, v] in the translated path, but in fact, we had 2xN items. This PR handle case when we have several pairs of [k, v]

## Motivation and Context
fix: https://github.com/Graylog2/graylog2-server/issues/15125
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

/nocl