### PR TITLE
Revert connect-src to wildcard

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -108,6 +108,8 @@ The following Java Code API changes have been made.
 | `IndexSetValidator#validateRetentionPeriod`  | The method argument have changed from `IndexSetConfig` to `RotationStrategyConfig, RetentionStrategyConfig` |
 | `ElasticsearchConfiguration#getIndexPrefix`  | The method name has changed to `getDefaultIndexPrefix`                                                      |
 | `ElasticsearchConfiguration#getTemplateName` | The method name has changed to `getDefaultIndexTemplateName`                                                |
+| `AuthServiceBackendConfig#externalHTTPHosts` | This method was added to the interface                                                                      |
+
 
 All previously deprecated index set configuration properties in `org.graylog2.configuration.ElasticsearchConfiguration`
 have been un-deprecated, as Graylog intends to maintain them going forward. 

--- a/full-backend-tests/src/test/java/org/graylog/testing/fullbackend/FiltersIT.java
+++ b/full-backend-tests/src/test/java/org/graylog/testing/fullbackend/FiltersIT.java
@@ -28,7 +28,6 @@ import static io.restassured.RestAssured.given;
 
 @ContainerMatrixTestsConfiguration(serverLifecycle = Lifecycle.CLASS, withMailServerEnabled = true)
 public class FiltersIT {
-    private static final String CONNECT_SRC = "connect-src 'self' https://telemetry.graylog.cloud";
     private final GraylogApis api;
 
     public FiltersIT(GraylogApis api) {
@@ -37,7 +36,7 @@ public class FiltersIT {
 
     @ContainerMatrixTest
     void cspDocumentationBrowser() {
-        String expected = CSP.CSP_SWAGGER + CONNECT_SRC;
+        String expected = CSP.CSP_SWAGGER;
         given()
                 .spec(api.requestSpecification())
                 .when()
@@ -50,7 +49,7 @@ public class FiltersIT {
 
     @ContainerMatrixTest
     void cspWebInterfaceAssets() {
-        String expected = CSP.CSP_DEFAULT + CONNECT_SRC;
+        String expected = CSP.CSP_DEFAULT;
         given()
                 .spec(api.requestSpecification())
                 .basePath("/")
@@ -64,7 +63,7 @@ public class FiltersIT {
 
     @ContainerMatrixTest
     void cspWebAppNotFound() {
-        String expected = CSP.CSP_DEFAULT + CONNECT_SRC;
+        String expected = CSP.CSP_DEFAULT;
         given()
                 .spec(api.requestSpecification())
                 .basePath("/")

--- a/graylog2-server/src/main/java/org/graylog/security/authservice/AuthServiceBackendConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/security/authservice/AuthServiceBackendConfig.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import org.graylog2.plugin.rest.ValidationResult;
 
 import java.util.List;
+import java.util.Optional;
 
 @JsonTypeInfo(
         use = JsonTypeInfo.Id.NAME,
@@ -40,7 +41,9 @@ public interface AuthServiceBackendConfig {
     }
 
     @JsonIgnore
-    List<String> hostAllowList();
+    default Optional<List<String>> externalHTTPHosts() {
+        return Optional.empty();
+    }
 
     interface Builder<SELF> {
         @JsonProperty(TYPE_FIELD)
@@ -54,7 +57,7 @@ public interface AuthServiceBackendConfig {
         }
 
         @Override
-        public List<String> hostAllowList() {
+        public Optional<List<String>> externalHTTPHosts() {
             throw new UnsupportedOperationException();
         }
     }

--- a/graylog2-server/src/main/java/org/graylog/security/authservice/backend/ADAuthServiceBackendConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/security/authservice/backend/ADAuthServiceBackendConfig.java
@@ -104,11 +104,6 @@ public abstract class ADAuthServiceBackendConfig implements AuthServiceBackendCo
     }
 
     @Override
-    public List<String> hostAllowList() {
-        return servers().stream().map(HostAndPort::host).toList();
-    }
-
-    @Override
     public LDAPConnectorConfig getLDAPConnectorConfig() {
         return LDAPConnectorConfig.builder()
                 .serverList(servers().stream()

--- a/graylog2-server/src/main/java/org/graylog/security/authservice/backend/LDAPAuthServiceBackendConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/security/authservice/backend/LDAPAuthServiceBackendConfig.java
@@ -115,11 +115,6 @@ public abstract class LDAPAuthServiceBackendConfig implements AuthServiceBackend
     }
 
     @Override
-    public List<String> hostAllowList() {
-        return servers().stream().map(HostAndPort::host).toList();
-    }
-
-    @Override
     public LDAPConnectorConfig getLDAPConnectorConfig() {
         return LDAPConnectorConfig.builder()
                 .serverList(servers().stream()

--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/csp/CSP.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/csp/CSP.java
@@ -24,8 +24,8 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE, ElementType.METHOD})
 public @interface CSP {
-    final String CSP_DEFAULT = "default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-eval'; img-src 'self' data:;";
-    final String CSP_SWAGGER = "style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-eval' 'unsafe-inline'; img-src 'self' data:;";
+    final String CSP_DEFAULT = "default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-eval'; img-src 'self' data:; connect-src *";
+    final String CSP_SWAGGER = "style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-eval' 'unsafe-inline'; img-src 'self' data:; connect-src *";
 
     String value();
 }

--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/csp/CSPServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/csp/CSPServiceImpl.java
@@ -19,14 +19,17 @@ package org.graylog2.shared.rest.resources.csp;
 import org.graylog.security.authservice.DBAuthServiceBackendService;
 import org.graylog2.configuration.TelemetryConfiguration;
 import org.graylog2.rest.PaginationParameters;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import java.util.stream.Collectors;
 
 public class CSPServiceImpl implements CSPService {
+    private static final Logger LOG = LoggerFactory.getLogger(CSPServiceImpl.class);
     private final String telemetryApiHost;
     private final DBAuthServiceBackendService dbService;
-    private String connectSrcValue;
+    private volatile String connectSrcValue;
 
     @Inject
     protected CSPServiceImpl(TelemetryConfiguration telemetryConfiguration, DBAuthServiceBackendService dbService) {
@@ -38,9 +41,12 @@ public class CSPServiceImpl implements CSPService {
     @Override
     public void buildConnectSrc() {
         final String hostList = dbService.findPaginated(new PaginationParameters(), x -> true).stream()
-                .map(dto -> String.join(" ", dto.config().hostAllowList()))
+                .map(dto -> dto.config().externalHTTPHosts())
+                .filter(optList -> optList.isPresent())
+                .map(optList -> String.join(" ", optList.get()))
                 .collect(Collectors.joining(" "));
         connectSrcValue = "'self' " + telemetryApiHost + " " + hostList;
+        LOG.debug("Updated CSP: {}", connectSrcValue);
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/documentation/DocumentationResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/documentation/DocumentationResource.java
@@ -29,6 +29,7 @@ import org.graylog2.rest.RestTools;
 import org.graylog2.shared.plugins.DocumentationRestResourceClasses;
 import org.graylog2.shared.rest.documentation.generator.Generator;
 import org.graylog2.shared.rest.resources.RestResource;
+import org.graylog2.shared.rest.resources.csp.CSP;
 
 import javax.inject.Inject;
 import javax.ws.rs.GET;
@@ -49,6 +50,7 @@ import static org.graylog2.shared.initializers.JerseyService.PLUGIN_PREFIX;
 
 @Api(value = "Documentation", description = "Documentation of this API in JSON format.")
 @Path("/api-docs")
+@CSP(value = CSP.CSP_SWAGGER)
 public class DocumentationResource extends RestResource {
 
     private final Generator generator;


### PR DESCRIPTION
/nocl Minor change to existing feature that has a CL
Resolves #15344 

An interim solution for Content Security Policy, while we work on dynamically populating the `connect-src`  (#15305). 
This PR retains code for a CSP service developed to date, to facilitate further development. Also include the interface change for `AuthServiceBackendConfig`, so 5.2 will not need to break compatibility with 5.1.

## How Tested
Locally tested these scenarios:
- regular UI
- API browser
- login with DB and Okta
- world map widget

/jenkins-pr-deps Graylog2/graylog-plugin-enterprise#5085
