### PR TITLE
Set dashboard not dirty after first save.

### DIFF
--- a/graylog2-web-interface/src/views/logic/views/OnSaveNewDashboard.test.ts
+++ b/graylog2-web-interface/src/views/logic/views/OnSaveNewDashboard.test.ts
@@ -20,6 +20,7 @@ import UserNotification from 'util/UserNotification';
 import mockDispatch from 'views/test/mockDispatch';
 import type { RootState } from 'views/types';
 import type { HistoryFunction } from 'routing/useHistory';
+import { setIsDirty, setIsNew } from 'views/logic/slices/viewSlice';
 
 import View from './View';
 import OriginalOnSaveNewDashboard from './OnSaveNewDashboard';
@@ -65,6 +66,24 @@ describe('OnSaveNewDashboard', () => {
     await dispatch(OnSaveNewDashboard(view));
 
     expect(loadDashboard).toHaveBeenCalled();
+  });
+
+  it('sets dirty flag to false', async () => {
+    const view = View.create();
+    const dispatch = mockDispatch({ view: { view } } as RootState);
+
+    await dispatch(OnSaveNewDashboard(view));
+
+    expect(dispatch).toHaveBeenCalledWith(setIsDirty(false));
+  });
+
+  it('sets new flag to false', async () => {
+    const view = View.create();
+    const dispatch = mockDispatch({ view: { view } } as RootState);
+
+    await dispatch(OnSaveNewDashboard(view));
+
+    expect(dispatch).toHaveBeenCalledWith(setIsNew(false));
   });
 
   it('redirects to saved view', async () => {

--- a/graylog2-web-interface/src/views/logic/views/OnSaveNewDashboard.ts
+++ b/graylog2-web-interface/src/views/logic/views/OnSaveNewDashboard.ts
@@ -18,12 +18,16 @@ import UserNotification from 'util/UserNotification';
 import { ViewManagementActions } from 'views/stores/ViewManagementStore';
 import { loadDashboard } from 'views/logic/views/Actions';
 import type { HistoryFunction } from 'routing/useHistory';
+import type { AppDispatch } from 'stores/useAppDispatch';
+import { setIsDirty, setIsNew } from 'views/logic/slices/viewSlice';
 
 import type View from './View';
 
-export default (view: View, history: HistoryFunction) => async () => {
+export default (view: View, history: HistoryFunction) => async (dispatch: AppDispatch) => {
   try {
     const savedView = await ViewManagementActions.create(view);
+    dispatch(setIsDirty(false));
+    dispatch(setIsNew(false));
     loadDashboard(history, savedView.id);
     UserNotification.success(`Saving view "${view.title}" was successful!`, 'Success!');
   } catch (error) {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is making sure that the dirty flag of a dashboard is set to `false` after it was saved as (or initially) and before redirecting to the new dashboard id.

This prevents the confirmation prompt showing up needlessly indicating that the current dashboard has been changed and that these changes will be lost.


Fixes #15345.

/nocl Fixing a regression which was introduced in 5.1 development.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.