### PR TITLE
Only display delete icon for saved searches when user has required permissions. (4.3)

### DIFF
--- a/changelog/unreleased/pr-15351.toml
+++ b/changelog/unreleased/pr-15351.toml
@@ -1,0 +1,4 @@
+type = "f"
+message = "Only display delete icon for saved searches when user has required permissions."
+
+pulls = ["15190"]

--- a/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchList.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchList.test.tsx
@@ -23,9 +23,9 @@ import View from 'views/logic/views/View';
 import ViewLoaderContext from 'views/logic/ViewLoaderContext';
 import { SavedSearchesActions } from 'views/stores/SavedSearchesStore';
 import { adminUser } from 'fixtures/users';
-import useCurrentUser from 'hooks/useCurrentUser';
 
 import SavedSearchList from './SavedSearchList';
+import CurrentUserContext from 'contexts/CurrentUserContext';
 
 const createPaginatedSearches = (count = 1) => {
   const views: Array<View> = [];
@@ -63,13 +63,7 @@ jest.mock('views/stores/SavedSearchesStore', () => ({
   },
 }));
 
-jest.mock('hooks/useCurrentUser');
-
 describe('SavedSearchList', () => {
-  beforeEach(() => {
-    asMock(useCurrentUser).mockReturnValue(adminUser);
-  });
-
   describe('render the SavedSearchList', () => {
     it('should render empty', async () => {
       const views = createPaginatedSearches(0);
@@ -117,9 +111,13 @@ describe('SavedSearchList', () => {
       asMock(SavedSearchesActions.search).mockReturnValueOnce(views);
       const onDelete = jest.fn(() => Promise.resolve(views[0]));
 
-      render(<SavedSearchList toggleModal={() => {}}
-                              deleteSavedSearch={onDelete}
-                              activeSavedSearchId="search-id-0" />);
+      render(
+        <CurrentUserContext.Provider value={adminUser}>
+          <SavedSearchList toggleModal={() => {}}
+                           deleteSavedSearch={onDelete}
+                           activeSavedSearchId="search-id-0" />
+        </CurrentUserContext.Provider>
+      );
 
       await screen.findByText('search-title-0');
       const deleteBtn = screen.getByTitle('Delete search search-title-0');
@@ -156,11 +154,13 @@ describe('SavedSearchList', () => {
     const views = createPaginatedSearches(1);
     asMock(SavedSearchesActions.search).mockReturnValueOnce(views);
     const currentUser = adminUser.toBuilder().permissions(Immutable.List(['view:read:search-id-0}'])).build();
-    asMock(useCurrentUser).mockReturnValue(currentUser);
 
-    render(<SavedSearchList toggleModal={() => {}}
-                            deleteSavedSearch={jest.fn()}
-                            activeSavedSearchId="search-id-0" />);
+    render(
+      <CurrentUserContext.Provider value={currentUser}>
+        <SavedSearchList toggleModal={() => {}}
+                         deleteSavedSearch={jest.fn()}
+                         activeSavedSearchId="search-id-0" />
+      </CurrentUserContext.Provider>);
 
     await screen.findByText('search-title-0');
 

--- a/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchList.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchList.tsx
@@ -22,7 +22,7 @@ import styled from 'styled-components';
 import type { PaginatedViews } from 'views/stores/ViewManagementStore';
 import { SavedSearchesActions } from 'views/stores/SavedSearchesStore';
 import { Alert, Modal, ListGroup, ListGroupItem, Button } from 'components/bootstrap';
-import { Icon, PaginatedList, SearchForm, Spinner } from 'components/common';
+import { Icon, PaginatedList, SearchForm, Spinner, IfPermitted } from 'components/common';
 import type View from 'views/logic/views/View';
 import ViewLoaderContext from 'views/logic/ViewLoaderContext';
 import { ViewManagementActions } from 'views/stores/ViewManagementStore';
@@ -149,12 +149,14 @@ const SavedSearchList = ({ toggleModal, deleteSavedSearch, activeSavedSearchId }
                                      header={savedSearch.title}
                                      active={savedSearch.id === activeSavedSearchId}>
                         {savedSearch.summary}
-                        <DeleteButton onClick={(e) => onDelete(e, savedSearches, deleteSavedSearch, savedSearch.id)}
-                                      role="button"
-                                      title={`Delete search ${savedSearch.title}`}
-                                      tabIndex={0}>
-                          <Icon name="trash-alt" />
-                        </DeleteButton>
+                        <IfPermitted permissions={[`view:edit:${savedSearch.id}`, 'view:edit']} anyPermissions>
+                          <DeleteButton onClick={(e) => onDelete(e, savedSearches, deleteSavedSearch, savedSearch.id)}
+                                        role="button"
+                                        title={`Delete search ${savedSearch.title}`}
+                                        tabIndex={0}>
+                            <Icon name="trash-alt" />
+                          </DeleteButton>
+                        </IfPermitted>
                       </ListGroupItem>
                     )}
                   </ViewLoaderContext.Consumer>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Before this change the delete buttons in the saved searches overview were always visible, even when the user only had read permissions for a saved search.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

