### PR TITLE
Add title for more actions dropdown in streams and dashboards overview for better accessibility

### DIFF
--- a/graylog2-web-interface/src/components/common/OverlayDropdownButton.tsx
+++ b/graylog2-web-interface/src/components/common/OverlayDropdownButton.tsx
@@ -66,6 +66,7 @@ const OverlayDropdownButton = ({
                          <Button bsSize={bsSize}
                                  className="dropdown-toggle"
                                  ref={toggleTarget}
+                                 aria-label={buttonTitle}
                                  title={buttonTitle}
                                  disabled={disabled}
                                  onClick={onToggle}>

--- a/graylog2-web-interface/src/components/streams/StreamsOverview/StreamActions.tsx
+++ b/graylog2-web-interface/src/components/streams/StreamsOverview/StreamActions.tsx
@@ -162,6 +162,7 @@ const StreamActions = ({
                    bsSize="xsmall" />
       <OverlayDropdownButton title="More"
                              bsSize="xsmall"
+                             buttonTitle="More actions"
                              disabled={isNotEditable}
                              dropdownZIndex={1000}>
         <IfPermitted permissions={[`streams:changestate:${stream.id}`, `streams:edit:${stream.id}`]} anyPermissions>

--- a/graylog2-web-interface/src/views/components/dashboard/DashboardsOverview/DashboardActions.tsx
+++ b/graylog2-web-interface/src/views/components/dashboard/DashboardsOverview/DashboardActions.tsx
@@ -74,7 +74,7 @@ const DashboardActions = ({ dashboard, refetchDashboards }: Props) => {
                    entityId={dashboard.id}
                    entityType="dashboard"
                    onClick={() => setShowShareModal(true)} />
-      <OverlayDropdownButton bsSize="xsmall" title="More">
+      <OverlayDropdownButton bsSize="xsmall" title="More" buttonTitle="More actions">
         {dashboardActions.length > 0 ? (
           <>
             {dashboardActions}


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

With https://github.com/Graylog2/graylog2-server/pull/15350 we unified the name of the "More actions" dropdown in the saved searches, dashboards and streams overview. The title is now just "More". With this PR we are defining a `title` and `aria-label` as well ("More Actions") to improve the accessibility.

/nocl