### PR TITLE
Use wildcard for CSP img-src

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/csp/CSP.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/csp/CSP.java
@@ -24,8 +24,8 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE, ElementType.METHOD})
 public @interface CSP {
-    final String CSP_DEFAULT = "default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-eval'; img-src 'self' data:; connect-src *";
-    final String CSP_SWAGGER = "style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-eval' 'unsafe-inline'; img-src 'self' data:; connect-src *";
+    final String CSP_DEFAULT = "default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-eval'; img-src *; connect-src *";
+    final String CSP_SWAGGER = "style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-eval' 'unsafe-inline'; img-src *; connect-src *";
 
     String value();
 }


### PR DESCRIPTION
/nocl change to an unreleased feature
Resolves #15344 

Use wildcard for the image source in CSP, while we implement a more configurable solution for the next release.