### PR TITLE
Fix GELF output blocking and output processing race condition

### DIFF
--- a/changelog/unreleased/issue-9917.toml
+++ b/changelog/unreleased/issue-9917.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Fix GELF output to not block output processing."
+
+issues = ["9917"]
+pulls = [""]

--- a/graylog2-server/src/main/java/org/graylog2/outputs/OutputRegistry.java
+++ b/graylog2-server/src/main/java/org/graylog2/outputs/OutputRegistry.java
@@ -27,6 +27,7 @@ import com.google.common.collect.Sets;
 import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
 import com.google.common.util.concurrent.UncheckedExecutionException;
+import com.swrve.ratelimitedlogger.RateLimitedLog;
 import org.graylog2.database.NotFoundException;
 import org.graylog2.notifications.Notification;
 import org.graylog2.notifications.NotificationService;
@@ -46,6 +47,7 @@ import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
+import java.time.Duration;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Callable;
@@ -57,6 +59,10 @@ import java.util.stream.Collectors;
 @Singleton
 public class OutputRegistry {
     private static final Logger LOG = LoggerFactory.getLogger(OutputRegistry.class);
+    private static final Logger RATE_LIMITED_LOG = RateLimitedLog.withRateLimit(LOG)
+            .maxRate(1)
+            .every(Duration.ofSeconds(5))
+            .build();
 
     private final Cache<String, MessageOutput> runningMessageOutputs;
     private final MessageOutput defaultMessageOutput;
@@ -143,7 +149,9 @@ public class OutputRegistry {
                 return this.runningMessageOutputs.get(id, loadForIdAndStream(id, stream));
             }
         } catch (ExecutionException | UncheckedExecutionException e) {
-            if (!(e.getCause() instanceof NotFoundException)) {
+            if (e.getCause() instanceof NotFoundException || e.getCause() instanceof IllegalArgumentException) {
+                RATE_LIMITED_LOG.debug("Unable to fetch output <{}> for stream <{}/{}>: {}", id, stream.getTitle(), stream.getId(), e.getMessage());
+            } else {
                 final int number = faultCount.addAndGet(1);
                 if (e.getCause() instanceof InsufficientLicenseException licenseException) {
                     LOG.error("Unable to fetch output {}, fault #{}: {}", id, number,
@@ -179,8 +187,17 @@ public class OutputRegistry {
         return new Callable<>() {
             @Override
             public MessageOutput call() throws Exception {
-                final Output output = outputService.load(id);
-                return launchOutput(output, stream);
+                // Check if the output is still assigned to the given stream before loading and starting it.
+                // The stream assignment of the output could have been removed while the message object went
+                // through processing and output buffer processing handling.
+                // Without this check, we would start the output again after it has been stopped by removing it
+                // from a stream.
+                final Stream dbStream = streamService.load(stream.getId());
+                if (dbStream.getOutputs().stream().map(Output::getId).anyMatch(id::equalsIgnoreCase)) {
+                    final Output output = outputService.load(id);
+                    return launchOutput(output, stream);
+                }
+                throw new IllegalArgumentException("Output not assigned to stream");
             }
         };
     }

--- a/graylog2-server/src/test/java/org/graylog2/outputs/GelfOutputTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/outputs/GelfOutputTest.java
@@ -41,10 +41,11 @@ public class GelfOutputTest {
         final GelfMessage gelfMessage = new GelfMessage("Test");
         final GelfOutput gelfOutput = Mockito.spy(new GelfOutput(transport));
         doReturn(gelfMessage).when(gelfOutput).toGELFMessage(message);
+        when(transport.trySend(gelfMessage)).thenReturn(true);
 
         gelfOutput.write(message);
 
-        verify(transport).send(eq(gelfMessage));
+        verify(transport).trySend(eq(gelfMessage));
     }
 
     @Test


### PR DESCRIPTION
Switch from GelfTransport#send() to GelfTransport#trySend() to avoid blocking output threads. We retry the send operation as long as the output is running.
This fixes an issue where removing an output from a stream or deleting it doesn't unblock processing. (with a slow output target)

A race condition in OutputRegistry was contributing to the problem.

When the OutputRegistry didn't have a cached output instance, we loaded the output configuration from the database and started the output. The problem is that each message holds a stream object that might be outdated because the output could have been removed since adding the stream object to the message object.

So instead of just starting an output, we need to check if the output is still assigned to the stream.

Fixes #9917
Fixes Graylog2/graylog-plugin-enterprise#4623