### PR TITLE
Match longest prefix when checking for CIDR lookups

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/utilities/IpSubnet.java
+++ b/graylog2-server/src/main/java/org/graylog2/utilities/IpSubnet.java
@@ -140,6 +140,9 @@ public class IpSubnet {
         return (st == -1 || st == 0) && (te == -1 || te == 0);
     }
 
+    public int getPrefixLength() {
+        return prefixLength;
+    }
 
     @Override
     public boolean equals(Object o) {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Match the longest CIDR prefix when doing CIDR lookups. Right now a lookup that matches two different ranges will just return the first match instead of the most specific.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

