### PR TITLE
Fix concurrency issue in SystemJobManager

### DIFF
--- a/changelog/unreleased/pr-15400.toml
+++ b/changelog/unreleased/pr-15400.toml
@@ -1,0 +1,4 @@
+type = "f"
+message = "Fixed possible unwanted concurrency in SystemJobManager"
+
+pulls = ["15400"]

--- a/graylog2-server/src/main/java/org/graylog2/system/jobs/SystemJobManager.java
+++ b/graylog2-server/src/main/java/org/graylog2/system/jobs/SystemJobManager.java
@@ -67,7 +67,7 @@ public class SystemJobManager {
         return submitWithDelay(job, 0, TimeUnit.SECONDS);
     }
 
-    public String submitWithDelay(final SystemJob job, final long delay, TimeUnit timeUnit) throws SystemJobConcurrencyException {
+    public synchronized String submitWithDelay(final SystemJob job, final long delay, TimeUnit timeUnit) throws SystemJobConcurrencyException {
         // for immediate jobs, check allowed concurrency right now
         if (delay == 0) {
             checkAllowedConcurrency(job);

--- a/graylog2-server/src/test/java/org/graylog2/system/jobs/SystemJobManagerTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/system/jobs/SystemJobManagerTest.java
@@ -17,6 +17,7 @@
 package org.graylog2.system.jobs;
 
 import com.codahale.metrics.MetricRegistry;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.common.util.concurrent.Uninterruptibles;
 import org.assertj.core.api.Assertions;
 import org.graylog2.system.activities.SystemMessageActivityWriter;
@@ -86,7 +87,7 @@ public class SystemJobManagerTest {
     public void testSubmitThrowsExceptionIfMaxConcurrencyLevelReached() throws Exception {
         SystemJobManager manager = new SystemJobManager(systemMessageActivityWriter, new MetricRegistry());
 
-        final ExecutorService executorService = Executors.newFixedThreadPool(3);
+        final ExecutorService executorService = Executors.newFixedThreadPool(2, new ThreadFactoryBuilder().setNameFormat("job-trigger-%d").build());
 
         LongRunningJob job1 = new LongRunningJob(3);
         LongRunningJob job2 = new LongRunningJob(3);

--- a/graylog2-server/src/test/java/org/graylog2/system/jobs/SystemJobManagerTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/system/jobs/SystemJobManagerTest.java
@@ -106,7 +106,7 @@ public class SystemJobManagerTest {
         final boolean terminatedSuccessfully = executorService.awaitTermination(5, TimeUnit.SECONDS);
         Assertions.assertThat(terminatedSuccessfully).isTrue();
 
-        // now futures are either a job ID or null if the execution failed due to
+        // now futures are either an optional with job ID or empty optional if the execution failed due to a  SystemJobConcurrencyException
         Assertions.assertThat(futures)
                 .extracting(Future::get)
                 .filteredOn(Optional::isEmpty)


### PR DESCRIPTION
The SystemJobManager is checking and preventing unwanted concurrent tasks. But the implementation was not bulletproof and it was possible to run more tasks even if the concurrency was disabled for them.

## Description
The `jobs` map is a ConcurrentHashMap, but this is not enough to prevent two tasks starting in the same time. The concurrency check and putting a task into this map happens not atomically and any delay between these two operation would allow starting another task.

The easiest and reliable solution is to mark the whole `submitWithDelay` as _synchronized_. 

## How Has This Been Tested?
Addapted the existing concurrency test to actually start tasks concurrently, set to 100 repetitions of the test, verified before and after the _synchronized_ fix.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

