### PR TITLE
Improve responsiveness of message details header. (Backport of #15359 for 5.0)

### DIFF
--- a/graylog2-web-interface/src/components/search/MessageDetailsTitle.jsx
+++ b/graylog2-web-interface/src/components/search/MessageDetailsTitle.jsx
@@ -18,8 +18,6 @@ import React from 'react';
 import styled, { css } from 'styled-components';
 
 const Title = styled.h3(({ theme }) => css`
-  height: 30px;
-
   a {
     color: ${theme.colors.global.textDefault};
   }

--- a/graylog2-web-interface/src/views/components/messagelist/MessageActions.tsx
+++ b/graylog2-web-interface/src/views/components/messagelist/MessageActions.tsx
@@ -66,7 +66,7 @@ const _getTestAgainstStreamButton = (streams: Immutable.List<any>, index: string
 
 const MessageActions = ({ index, id, fields, decorationStats, disabled, disableSurroundingSearch, disableTestAgainstStream, showOriginal, toggleShowOriginal, streams, searchConfig }: Props) => {
   if (disabled) {
-    return <ButtonGroup className="pull-right" bsSize="small" />;
+    return <ButtonGroup bsSize="small" />;
   }
 
   const messageUrl = index ? Routes.message_show(index, id) : '#';
@@ -83,7 +83,7 @@ const MessageActions = ({ index, id, fields, decorationStats, disabled, disableS
   const showChanges = decorationStats && <Button onClick={toggleShowOriginal} active={showOriginal}>Show changes</Button>;
 
   return (
-    <ButtonGroup className="pull-right" bsSize="small">
+    <ButtonGroup bsSize="small">
       {showChanges}
       <Button href={messageUrl}>Permalink</Button>
 

--- a/graylog2-web-interface/src/views/components/messagelist/MessageDetail.tsx
+++ b/graylog2-web-interface/src/views/components/messagelist/MessageDetail.tsx
@@ -19,6 +19,7 @@ import * as React from 'react';
 import { useState, useMemo } from 'react';
 import Immutable from 'immutable';
 import ImmutablePropTypes from 'react-immutable-proptypes';
+import styled from 'styled-components';
 
 import { AdditionalContext } from 'views/logic/ActionContext';
 import { Link } from 'components/common/router';
@@ -52,6 +53,13 @@ const _formatMessageTitle = (index, id) => {
 
   return <span>{id} <Label bsStyle="warning">Not stored</Label></span>;
 };
+
+const Header = styled.div`
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 6px
+`;
 
 type Props = {
   allStreams?: Immutable.List<Stream>,
@@ -129,22 +137,23 @@ const MessageDetail = ({
         <>
           <Row className="row-sm">
             <Col md={12}>
-              <MessageActions index={index}
-                              id={id}
-                              fields={fields}
-                              decorationStats={decorationStats}
-                              disabled={disableMessageActions}
-                              disableSurroundingSearch={disableSurroundingSearch}
-                              disableTestAgainstStream={disableTestAgainstStream}
-                              showOriginal={showOriginal}
-                              toggleShowOriginal={_toggleShowOriginal}
-                              searchConfig={searchesClusterConfig}
-                              streams={allStreams} />
-              <MessageDetailsTitle>
-                <Icon name="envelope" />
-                &nbsp;
-                {messageTitle}
-              </MessageDetailsTitle>
+              <Header>
+                <MessageDetailsTitle>
+                  <Icon name="envelope" />&nbsp;{messageTitle}
+                </MessageDetailsTitle>
+                <MessageActions index={index}
+                                id={id}
+                                fields={fields}
+                                decorationStats={decorationStats}
+                                disabled={disableMessageActions}
+                                disableSurroundingSearch={disableSurroundingSearch}
+                                disableTestAgainstStream={disableTestAgainstStream}
+                                showOriginal={showOriginal}
+                                toggleShowOriginal={_toggleShowOriginal}
+                                searchConfig={searchesClusterConfig}
+                                streams={allStreams} />
+
+              </Header>
             </Col>
           </Row>
           <Row id={`sticky-augmentations-boundary-${message.id}`}>


### PR DESCRIPTION
_Please note, this is a backport of #15359 for 5.0_

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Small fix to improve the responsiveness  of the message details title and actions.


Before (with a small resolution): 
![image](https://user-images.githubusercontent.com/46300478/234568676-53da913e-51e6-42b7-b824-8b810206c06f.png)

![image](https://user-images.githubusercontent.com/46300478/234568872-3e5ed96a-68d9-4892-94ef-7ffc170759fc.png)



After (with a small resolution):
![image](https://user-images.githubusercontent.com/46300478/234568580-a64d20a6-9a38-4229-bd05-e2ac890d84c7.png)

/nocl
