### PR TITLE
Fix padding for form input descriptions. (Backport of #15360 for 5.0)

### DIFF
--- a/graylog2-web-interface/src/components/common/InputDescription.tsx
+++ b/graylog2-web-interface/src/components/common/InputDescription.tsx
@@ -44,7 +44,7 @@ const InputDescription = ({ className, error, help }: Props) => {
   }
 
   return (
-    <HelpBlock className={className}>
+    <HelpBlock className={`${className ?? ''} input-description`}>
       {error && (
         <ErrorMessage>
           {error}

--- a/graylog2-web-interface/src/theme/GlobalThemeStyles.js
+++ b/graylog2-web-interface/src/theme/GlobalThemeStyles.js
@@ -475,6 +475,10 @@ const GlobalThemeStyles = createGlobalStyle(({ theme }) => css`
     margin-left: 20px;
   }
 
+  .form-horizontal .input-description {
+    margin-bottom: 0 !important;
+  }
+
   form.extractor-form .control-group label {
     display: inline-block;
   }


### PR DESCRIPTION
_Please note, this is a backport of https://github.com/Graylog2/graylog2-server/pull/15360 for 5.0_
_This PR needs to be merged together with https://github.com/Graylog2/graylog-plugin-enterprise/pull/5122_


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

With https://github.com/Graylog2/graylog2-server/pull/14756 we changed the padding for input descriptions.
It looked good for forms with the class `form-horizontal`, but it looked bad in other cases.

For example for the index set form:
![image](https://user-images.githubusercontent.com/46300478/234575839-4564f984-2f0e-4d82-9d97-92c9eb8c5fa1.png)


With this change we fix the padding for all cases:
![image](https://user-images.githubusercontent.com/46300478/234576050-912d29b4-61d7-437f-8036-babe454045bc.png)

/jenkins-pr-deps https://github.com/Graylog2/graylog-plugin-enterprise/pull/5122

/nocl
