### PR TITLE
Move zstd dependency into the server

### DIFF
--- a/graylog-project-parent/pom.xml
+++ b/graylog-project-parent/pom.xml
@@ -342,6 +342,11 @@
                     </exclusion>
                 </exclusions>
             </dependency>
+            <dependency>
+                <groupId>com.github.luben</groupId>
+                <artifactId>zstd-jni</artifactId>
+                <version>${zstd.version}</version>
+            </dependency>
 
             <dependency>
                 <groupId>com.rabbitmq</groupId>

--- a/graylog2-server/pom.xml
+++ b/graylog2-server/pom.xml
@@ -588,6 +588,10 @@
             <groupId>com.jayway.jsonpath</groupId>
             <artifactId>json-path</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.github.luben</groupId>
+            <artifactId>zstd-jni</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>com.github.zafarkhaja</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -169,6 +169,7 @@
         <validation-api.version>2.0.1.Final</validation-api.version>
         <zkclient.version>0.11</zkclient.version>
         <zookeeper.version>3.5.7</zookeeper.version>
+        <zstd.version>1.5.4-1</zstd.version>
         <cron-utils.version>9.1.6</cron-utils.version>
         <asciitable.version>0.3.2</asciitable.version>
         <commons-net.version>3.6</commons-net.version>


### PR DESCRIPTION
We only had this as an enterprise dependency.
The server could use it through a transititive dependency of kafka-client. This however was version 1.4.5-6

which has an issue on M1 Macs: https://github.com/luben/zstd-jni/issues/153


/nocl

