### PR TITLE
Fix uniq key react warning for investigation plugins.

### DIFF
--- a/graylog2-web-interface/src/components/events/events/EventDetails.tsx
+++ b/graylog2-web-interface/src/components/events/events/EventDetails.tsx
@@ -35,7 +35,11 @@ type Props = {
 const EventDetails = ({ event, eventDefinitionContext }: Props) => {
   const eventDefinitionTypes = usePluginEntities('eventDefinitionTypes');
   const pluggableEventActions = usePluginEntities('views.components.eventActions');
-  const eventActions = useMemo(() => pluggableEventActions.map((PluggableEventAction) => <PluggableEventAction event={event} />), [pluggableEventActions, event]);
+  const eventActions = useMemo(() => pluggableEventActions.map(
+    ({ component: PluggableEventAction, key }) => (
+      <PluggableEventAction key={key} event={event} />
+    ),
+  ), [pluggableEventActions, event]);
 
   const plugin = useMemo(() => {
     if (event.event_definition_type === undefined) {

--- a/graylog2-web-interface/src/views/components/messagelist/MessageActions.tsx
+++ b/graylog2-web-interface/src/views/components/messagelist/MessageActions.tsx
@@ -80,7 +80,9 @@ const MessageActions = ({
   searchConfig,
 }: Props) => {
   const pluggableMenuActions = usePluginEntities('views.components.widgets.messageTable.messageActions');
-  const menuActions = useMemo(() => pluggableMenuActions.map((PluggableMenuAction) => <PluggableMenuAction id={id} index={index} />), [id, index, pluggableMenuActions]);
+  const menuActions = useMemo(() => pluggableMenuActions.map(
+    ({ component: PluggableMenuAction, key }) => <PluggableMenuAction key={key} id={id} index={index} />,
+  ), [id, index, pluggableMenuActions]);
 
   if (disabled) {
     return <ButtonGroup bsSize="small" />;

--- a/graylog2-web-interface/src/views/components/searchbar/saved-search/SearchActionsMenu.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/saved-search/SearchActionsMenu.tsx
@@ -102,7 +102,11 @@ const SearchActionsMenu = () => {
   const toggleShareSearch = useCallback(() => setShowShareSearch((cur) => !cur), []);
 
   const pluggableSearchActions = usePluginEntities('views.components.searchActions');
-  const searchActions = useMemo(() => pluggableSearchActions.map((PluggableSearchAction) => <PluggableSearchAction loaded={loaded} view={view} />), [pluggableSearchActions, loaded, view]);
+  const searchActions = useMemo(() => pluggableSearchActions.map(
+    ({ component: PluggableSearchAction, key }) => (
+      <PluggableSearchAction key={key} loaded={loaded} view={view} />
+    ),
+  ), [pluggableSearchActions, loaded, view]);
 
   const saveSearch = useCallback(async (newTitle: string) => {
     if (!view.id) {

--- a/graylog2-web-interface/src/views/types.ts
+++ b/graylog2-web-interface/src/views/types.ts
@@ -397,13 +397,22 @@ declare module 'graylog-web-plugin/plugin' {
     valueActions?: Array<ActionDefinition>;
     'views.completers'?: Array<Completer>;
     'views.components.dashboardActions'?: Array<DashboardAction>;
-    'views.components.eventActions'?: Array<React.ComponentType<EventActionComponentProps>>;
+    'views.components.eventActions'?: Array<{
+      component: React.ComponentType<EventActionComponentProps>,
+      key: string,
+    }>;
     'views.components.widgets.messageTable.previewOptions'?: Array<MessagePreviewOption>;
     'views.components.widgets.messageTable.messageRowOverride'?: Array<React.ComponentType<MessageRowOverrideProps>>;
     'views.components.widgets.messageDetails.contextProviders'?: Array<React.ComponentType<React.PropsWithChildren<MessageDetailContextProviderProps>>>;
     'views.components.widgets.messageTable.contextProviders'?: Array<React.ComponentType<React.PropsWithChildren<{}>>>;
-    'views.components.widgets.messageTable.messageActions'?: Array<React.ComponentType<MessageActionComponentProps>>;
-    'views.components.searchActions'?: Array<React.ComponentType<SearchActionComponentProps>>;
+    'views.components.widgets.messageTable.messageActions'?: Array<{
+      component: React.ComponentType<MessageActionComponentProps>,
+      key: string,
+    }>;
+    'views.components.searchActions'?: Array<{
+      component: React.ComponentType<SearchActionComponentProps>,
+      key: string,
+    }>;
     'views.components.searchBar'?: Array<() => SearchBarControl | null>;
     'views.components.saveViewForm'?: Array<() => SaveViewControls | null>;
     'views.elements.header'?: Array<React.ComponentType>;


### PR DESCRIPTION
_Please note this PR needs to be merged together with https://github.com/Graylog2/graylog-plugin-enterprise/pull/5133._

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Before this change rendering the investigation plugins throw a warning in the console:
`Warning: Each child in a list should have a unique "key" prop.`

With this PR we are defining a key when rendering plugins. This can be tested by e.g. opening the message details in the message table widget.

/jenkins-pr-deps https://github.com/Graylog2/graylog-plugin-enterprise/pull/5133
/nocl