### PR TITLE
CSR and CA code refactored, so that generation can be invoked outside…

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/security/certutil/CertificateGenerator.java
+++ b/graylog2-server/src/main/java/org/graylog/security/certutil/CertificateGenerator.java
@@ -35,7 +35,7 @@ import java.time.Instant;
 import java.util.Date;
 
 public class CertificateGenerator {
-    protected static KeyPair generate(CertRequest request) throws Exception {
+    public static KeyPair generate(CertRequest request) throws Exception {
         KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");
         java.security.KeyPair certKeyPair = keyGen.generateKeyPair();
         X500Name name = new X500Name("CN=" + request.cnName());

--- a/graylog2-server/src/main/java/org/graylog/security/certutil/CertutilCa.java
+++ b/graylog2-server/src/main/java/org/graylog/security/certutil/CertutilCa.java
@@ -18,14 +18,14 @@ package org.graylog.security.certutil;
 
 import com.github.rvesse.airline.annotations.Command;
 import com.github.rvesse.airline.annotations.Option;
+import org.graylog.security.certutil.ca.CACreator;
+import org.graylog.security.certutil.ca.storage.CAKeystoreFileStorage;
 import org.graylog.security.certutil.console.CommandLineConsole;
 import org.graylog.security.certutil.console.SystemConsole;
 import org.graylog2.bootstrap.CliCommand;
 
-import java.io.FileOutputStream;
 import java.nio.file.Path;
 import java.security.KeyStore;
-import java.security.cert.X509Certificate;
 import java.time.Duration;
 
 @Command(name = "ca", description = "Manage certificate authority for data-node", groupNames = {"certutil"})
@@ -34,14 +34,20 @@ public class CertutilCa implements CliCommand {
     @Option(name = "--filename", description = "Filename for the CA keystore")
     protected String keystoreFilename = "datanode-ca.p12";
     private final CommandLineConsole console;
+    private final CACreator caCreator;
+    private final CAKeystoreFileStorage caKeystoreStorage;
 
     public CertutilCa() {
         this.console = new SystemConsole();
+        this.caCreator = new CACreator();
+        this.caKeystoreStorage = new CAKeystoreFileStorage();
     }
 
     public CertutilCa(String keystoreFilename, CommandLineConsole console) {
         this.keystoreFilename = keystoreFilename;
         this.console = console;
+        this.caCreator = new CACreator();
+        this.caKeystoreStorage = new CAKeystoreFileStorage();
     }
 
     @Override
@@ -49,31 +55,18 @@ public class CertutilCa implements CliCommand {
         try {
 
             console.printLine("This tool will generate a self-signed certificate authority for datanode");
-
             char[] password = this.console.readPassword("Enter CA password: ");
-
             console.printLine("Generating datanode CA");
 
             final Duration certificateValidity = Duration.ofDays(10 * 365);
-            KeyPair rootCA = CertificateGenerator.generate(CertRequest.selfSigned("root").isCA(true).validity(certificateValidity));
-            KeyPair intermediateCA = CertificateGenerator.generate(CertRequest.signed("ca", rootCA).isCA(true).validity(certificateValidity));
-
-            KeyStore caKeystore = KeyStore.getInstance("PKCS12");
-            caKeystore.load(null, null);
-
-            caKeystore.setKeyEntry("root", rootCA.privateKey(), password,
-                    new X509Certificate[]{rootCA.certificate()});
-            caKeystore.setKeyEntry("ca", intermediateCA.privateKey(), password,
-                    new X509Certificate[]{intermediateCA.certificate(), rootCA.certificate()});
+            KeyStore caKeystore = caCreator.createCA(password, certificateValidity);
 
             console.printLine("Private keys and certificates for root and intermediate CA generated");
 
             final Path keystorePath = Path.of(keystoreFilename);
-
-            try (FileOutputStream store = new FileOutputStream(keystorePath.toFile())) {
-                caKeystore.store(store, password);
-                console.printLine("Keys and certificates stored in " + keystorePath.toAbsolutePath());
-            }
+            //TODO: it is probably a bad idea to use the same password for CA and its storage...
+            caKeystoreStorage.writeCAKeyStore(keystorePath, caKeystore, password);
+            console.printLine("Keys and certificates stored in " + keystorePath.toAbsolutePath());
 
         } catch (Exception e) {
             throw new RuntimeException("Failed to generate CA certificate", e);

--- a/graylog2-server/src/main/java/org/graylog/security/certutil/ca/CACreator.java
+++ b/graylog2-server/src/main/java/org/graylog/security/certutil/ca/CACreator.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.security.certutil.ca;
+
+import org.graylog.security.certutil.CertRequest;
+import org.graylog.security.certutil.CertificateGenerator;
+import org.graylog.security.certutil.KeyPair;
+import org.graylog.security.certutil.ca.exceptions.CACreationException;
+
+import java.security.KeyStore;
+import java.security.cert.X509Certificate;
+import java.time.Duration;
+
+public class CACreator {
+
+    public KeyStore createCA(final char[] password,
+                             final Duration certificateValidity) throws CACreationException {
+
+        try {
+            KeyPair rootCA = CertificateGenerator.generate(
+                    CertRequest.selfSigned("root")
+                            .isCA(true)
+                            .validity(certificateValidity)
+            );
+            KeyPair intermediateCA = CertificateGenerator.generate(
+                    CertRequest.signed("ca", rootCA)
+                            .isCA(true)
+                            .validity(certificateValidity)
+            );
+
+            KeyStore caKeystore = KeyStore.getInstance("PKCS12");
+            caKeystore.load(null, null);
+
+            caKeystore.setKeyEntry("root",
+                    rootCA.privateKey(),
+                    password,
+                    new X509Certificate[]{rootCA.certificate()});
+            caKeystore.setKeyEntry("ca",
+                    intermediateCA.privateKey(),
+                    password,
+                    new X509Certificate[]{intermediateCA.certificate(), rootCA.certificate()});
+
+            return caKeystore;
+
+        } catch (Exception e) {
+            throw new CACreationException("Failed to create a Certificate Authority", e);
+        }
+
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/security/certutil/ca/exceptions/CACreationException.java
+++ b/graylog2-server/src/main/java/org/graylog/security/certutil/ca/exceptions/CACreationException.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.security.certutil.ca.exceptions;
+
+public class CACreationException extends Exception {
+
+    public CACreationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/security/certutil/ca/exceptions/CAStorageException.java
+++ b/graylog2-server/src/main/java/org/graylog/security/certutil/ca/exceptions/CAStorageException.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.security.certutil.ca.exceptions;
+
+public class CAStorageException extends Exception {
+
+    public CAStorageException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/security/certutil/ca/storage/CAKeystoreFileStorage.java
+++ b/graylog2-server/src/main/java/org/graylog/security/certutil/ca/storage/CAKeystoreFileStorage.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.security.certutil.ca.storage;
+
+import org.graylog.security.certutil.ca.exceptions.CAStorageException;
+
+import java.io.FileOutputStream;
+import java.nio.file.Path;
+import java.security.KeyStore;
+
+public class CAKeystoreFileStorage implements CAKeystoreStorage {
+
+    @Override
+    public void writeCAKeyStore(final Path keystorePath,
+                                final KeyStore caKeyStore,
+                                final char[] password) throws CAStorageException {
+        try (FileOutputStream store = new FileOutputStream(keystorePath.toFile())) {
+            caKeyStore.store(store, password);
+        } catch (Exception ex) {
+            throw new CAStorageException("Failed to save keystore with CA information", ex);
+        }
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/security/certutil/ca/storage/CAKeystoreStorage.java
+++ b/graylog2-server/src/main/java/org/graylog/security/certutil/ca/storage/CAKeystoreStorage.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.security.certutil.ca.storage;
+
+import org.graylog.security.certutil.ca.exceptions.CAStorageException;
+
+import java.nio.file.Path;
+import java.security.KeyStore;
+
+public interface CAKeystoreStorage {
+
+    void writeCAKeyStore(final Path keystorePath,
+                         final KeyStore caKeyStore,
+                         final char[] password)
+            throws CAStorageException;
+
+    //TODO: we may need a read method as well, for CSR processing
+
+}

--- a/graylog2-server/src/main/java/org/graylog/security/certutil/csr/CsrGenerator.java
+++ b/graylog2-server/src/main/java/org/graylog/security/certutil/csr/CsrGenerator.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.security.certutil.csr;
+
+import org.bouncycastle.asn1.DEROctetString;
+import org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers;
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.asn1.x509.Extension;
+import org.bouncycastle.asn1.x509.Extensions;
+import org.bouncycastle.asn1.x509.GeneralName;
+import org.bouncycastle.asn1.x509.GeneralNames;
+import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+import org.bouncycastle.pkcs.PKCS10CertificationRequest;
+import org.bouncycastle.pkcs.PKCS10CertificationRequestBuilder;
+import org.bouncycastle.pkcs.jcajce.JcaPKCS10CertificationRequestBuilder;
+import org.graylog.security.certutil.csr.exceptions.CSRGenerationException;
+import org.graylog.security.certutil.privatekey.PrivateKeyEncryptedStorage;
+
+import javax.security.auth.x500.X500Principal;
+import java.security.KeyPairGenerator;
+import java.util.List;
+
+public class CsrGenerator {
+
+    /**
+     * Generates new CSR.
+     *
+     * @param privateKeyPassword         Password to protect private key.
+     * @param altNames                   List of alternative names to be stored in CSR
+     * @param privateKeyEncryptedStorage Mechanism for storing private keys.
+     * @return A new CSR, instance of {@link PKCS10CertificationRequest}
+     */
+    public PKCS10CertificationRequest generateCSR(final char[] privateKeyPassword,
+                                                  final String principalName,
+                                                  final List<String> altNames,
+                                                  final PrivateKeyEncryptedStorage privateKeyEncryptedStorage) throws CSRGenerationException {
+        try {
+            KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");
+            java.security.KeyPair certKeyPair = keyGen.generateKeyPair();
+
+            privateKeyEncryptedStorage.writeEncryptedKey(privateKeyPassword, certKeyPair.getPrivate());
+
+
+            PKCS10CertificationRequestBuilder p10Builder = new JcaPKCS10CertificationRequestBuilder(
+                    new X500Principal("CN=" + principalName),
+                    certKeyPair.getPublic()
+            );
+
+            if (altNames != null && !altNames.isEmpty()) {
+                Extension subjectAltNames = new Extension(Extension.subjectAlternativeName, false,
+                        new DEROctetString(
+                                new GeneralNames(
+                                        altNames.stream()
+                                                .map(alternativeName -> new GeneralName(
+                                                        new X500Name("CN=" + alternativeName))
+                                                )
+                                                .toArray(GeneralName[]::new)
+                                )
+                        )
+                );
+                p10Builder.addAttribute(
+                        PKCSObjectIdentifiers.pkcs_9_at_extensionRequest,
+                        new Extensions(subjectAltNames));
+            }
+
+
+            JcaContentSignerBuilder csBuilder = new JcaContentSignerBuilder("SHA256withRSA");
+            ContentSigner signer = csBuilder.build(certKeyPair.getPrivate());
+            return p10Builder.build(signer);
+
+        } catch (Exception e) {
+            throw new CSRGenerationException("Failed to generate Certificate Signing Request", e);
+        }
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/security/certutil/csr/exceptions/CSRGenerationException.java
+++ b/graylog2-server/src/main/java/org/graylog/security/certutil/csr/exceptions/CSRGenerationException.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.security.certutil.csr.exceptions;
+
+public class CSRGenerationException extends Exception {
+
+    public CSRGenerationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/security/certutil/csr/storage/CsrFileStorage.java
+++ b/graylog2-server/src/main/java/org/graylog/security/certutil/csr/storage/CsrFileStorage.java
@@ -14,7 +14,7 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-package org.graylog.security.certutil.csr;
+package org.graylog.security.certutil.csr.storage;
 
 import org.bouncycastle.openssl.PEMParser;
 import org.bouncycastle.openssl.jcajce.JcaPEMWriter;

--- a/graylog2-server/src/main/java/org/graylog/security/certutil/csr/storage/CsrStorage.java
+++ b/graylog2-server/src/main/java/org/graylog/security/certutil/csr/storage/CsrStorage.java
@@ -14,7 +14,7 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-package org.graylog.security.certutil.csr;
+package org.graylog.security.certutil.csr.storage;
 
 import org.bouncycastle.operator.OperatorCreationException;
 import org.bouncycastle.pkcs.PKCS10CertificationRequest;

--- a/graylog2-server/src/test/java/org/graylog/security/certutil/csr/CsrFileStorageTest.java
+++ b/graylog2-server/src/test/java/org/graylog/security/certutil/csr/CsrFileStorageTest.java
@@ -21,6 +21,7 @@ import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
 import org.bouncycastle.pkcs.PKCS10CertificationRequest;
 import org.bouncycastle.pkcs.PKCS10CertificationRequestBuilder;
 import org.bouncycastle.pkcs.jcajce.JcaPKCS10CertificationRequestBuilder;
+import org.graylog.security.certutil.csr.storage.CsrFileStorage;
 import org.junit.jupiter.api.Test;
 
 import javax.security.auth.x500.X500Principal;


### PR DESCRIPTION
… of command-line commands

<!--- Provide a general summary of your changes in the Title above -->

## Description
CSR and CA code refactored, so that generation can be invoked outside of command-line commands.
Preparation for abstraction around storage mechanism, as some elements may be not stored in the filesystem, as originally, but in MongoDB (or even sent through Rest API calls).
/nocl

## Motivation and Context
In the preflight (during data-node preparation), we will need to invoke certain PKI-related functionality during different stages of start-up.

## How Has This Been Tested?
CA and CSR commands have been run.
Their output have been verified with `openssl` command.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

