### PR TITLE
Backport 5.1: Add Sigma Repository information to UPGRADING.md (#15427)

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -89,6 +89,20 @@ Unless user-specified defaults are specified, the following new defaults will be
 - Shards: 1 (previously 4 in many cases)
 - Rotation Strategy: Time Size Optimizing - 30-40 days (previously Index Time [1D] in many cases)
 
+#### Import Custom Sigma Rule Repositories
+Previously, the official Sigma HQ rule repository was the only repository that could be used to import Sigma rules. Now
+any public Git repository containing Sigma rule source files can be imported to Graylog and rules can be imported from
+them. Since Graylog no longer reads directly from the Sigma HQ repository, it must be imported before new rules can be
+added from it. To expedite this process, on the `Security > Sigma Rules > Sigma Repos` page there is an `Add SigmaHQ`
+button that will import the repository. The repository is about 10MB and all Sigma rule source files will be copied into
+MongoDB so the clone may take a minute to complete. Once the repository has been added rules can be imported as they were
+in 5.0.
+
+The rules within imported repositories must conform to the
+[Sigma specification](https://github.com/SigmaHQ/sigma-specification/blob/main/Sigma_specification.md) in order to be
+successfully added. Since the repositories are stored locally they will not have the latest changes automatically applied
+but can easily be refreshed in the `Sigma Repos` tab using the `Refresh` menu item for each repository.
+
 ## Removal of deprecated Inputs
 
 The following inputs are no longer available:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
5.1 changes how Sigma rules can be imported from Git by adding the option to import rules from repositories other than the official Sigma HQ repo. This information should prepare users for these changes. backport of #15427
/nocl
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

