### PR TITLE
Do not run pivotForField with empty array in UseCreateViewForEvent

### DIFF
--- a/graylog2-web-interface/src/hooks/useEventDefinition.tsx
+++ b/graylog2-web-interface/src/hooks/useEventDefinition.tsx
@@ -31,7 +31,7 @@ export type EventDefinitionAggregation = {
   value: number,
   function: string,
   fnSeries: string,
-  field: string
+  field?: string
 }
 export const definitionsUrl = (definitionId: string) => qualifyUrl(`/events/definitions/${definitionId}`);
 

--- a/graylog2-web-interface/src/views/logic/views/UseCreateViewForEvent.test.ts
+++ b/graylog2-web-interface/src/views/logic/views/UseCreateViewForEvent.test.ts
@@ -18,9 +18,14 @@ import { renderHook } from 'wrappedTestingLibrary/hooks';
 import ObjectID from 'bson-objectid';
 
 import {
-  mockedMappedAggregation, mockedViewWithOneAggregation,
+  mockedMappedAggregation,
+  mockedMappedAggregationNoField,
+  mockedViewWithOneAggregation,
+  mockedViewWithOneAggregationNoField,
   mockedViewWithTwoAggregations,
-  mockEventData, mockEventDefinitionOneAggregation,
+  mockEventData,
+  mockEventDefinitionOneAggregation,
+  mockEventDefinitionOneAggregationNoFields,
   mockEventDefinitionTwoAggregations,
 } from 'helpers/mocking/EventAndEventDefinitions_mock';
 import { UseCreateViewForEvent } from 'views/logic/views/UseCreateViewForEvent';
@@ -43,6 +48,8 @@ const generateIdCounterTwoAggregations = counter();
 const objectIdCounterTwoAggregations = counter();
 const generateIdCounterOneAggregation = counter();
 const objectIdCounterOneAggregations = counter();
+const generateIdCounterOneAggregationNoField = counter();
+const objectIdCounterOneAggregationsNoField = counter();
 
 const mockedGenerateIdTwoAggregations = () => {
   const idSet = ['query-id', 'mc-widget-id', 'allm-widget-id', 'field1-widget-id', 'field2-widget-id', 'summary-widget-id'];
@@ -65,9 +72,23 @@ const mockedObjectIdOneAggregation = () => {
   return idSet[index];
 };
 
+const mockedObjectIdOneAggregationNoFields = () => {
+  const idSet = ['', 'view-id', 'search-id'];
+  const index = objectIdCounterOneAggregationsNoField();
+
+  return idSet[index];
+};
+
 const mockedGenerateIdOneAggregation = () => {
   const idSet = ['query-id', 'mc-widget-id', 'allm-widget-id', 'field1-widget-id'];
   const index = generateIdCounterOneAggregation();
+
+  return idSet[index];
+};
+
+const mockedGenerateIdOneAggregationNoFields = () => {
+  const idSet = ['query-id', 'mc-widget-id', 'allm-widget-id', 'field1-widget-id'];
+  const index = generateIdCounterOneAggregationNoField();
 
   return idSet[index];
 };
@@ -122,5 +143,18 @@ describe('UseCreateViewForEvent', () => {
     const view = await result.current.then((r) => r);
 
     expect(withCurrentDate(view)).toEqual(withCurrentDate(mockedViewWithOneAggregation));
+  });
+
+  it('should create view with 1 aggregation widgets when aggregation has no fields and grouping by', async () => {
+    asMock(generateId).mockImplementation(mockedGenerateIdOneAggregationNoFields);
+
+    asMock(ObjectID).mockImplementation(() => ({
+      toString: () => mockedObjectIdOneAggregationNoFields(),
+    }) as ObjectID);
+
+    const { result } = renderHook(() => UseCreateViewForEvent({ eventData: mockEventData.event, eventDefinition: mockEventDefinitionOneAggregationNoFields, aggregations: mockedMappedAggregationNoField }));
+    const view = await result.current.then((r) => r);
+
+    expect(withCurrentDate(view)).toEqual(withCurrentDate(mockedViewWithOneAggregationNoField));
   });
 });

--- a/graylog2-web-interface/src/views/logic/views/UseCreateViewForEvent.ts
+++ b/graylog2-web-interface/src/views/logic/views/UseCreateViewForEvent.ts
@@ -76,7 +76,8 @@ const createViewPosition = ({ index, SUMMARY_ROW_DELTA }) => {
 };
 
 const createViewWidget = ({ field, groupBy, fnSeries, expr }) => {
-  const rowPivots = [pivotForField(uniq([field, ...groupBy].filter((v) => !!v)), new FieldType('value', [], []))];
+  const uniqPivotFields = uniq([field, ...groupBy].filter((v) => !!v));
+  const rowPivots = uniqPivotFields.length ? [pivotForField(uniqPivotFields, new FieldType('value', [], []))] : [];
   const fnSeriesForFunc = Series.forFunction(fnSeries);
   const direction = ['>', '>=', '=='].includes(expr) ? Direction.Descending : Direction.Ascending;
   const sort = [new SortConfig(SortConfig.SERIES_TYPE, fnSeries, direction)];

--- a/graylog2-web-interface/test/helpers/mocking/EventAndEventDefinitions_mock.ts
+++ b/graylog2-web-interface/test/helpers/mocking/EventAndEventDefinitions_mock.ts
@@ -198,6 +198,14 @@ export const mockedMappedAggregation: Array<EventDefinitionAggregation> = [
   },
 ];
 
+export const mockedMappedAggregationNoField: Array<EventDefinitionAggregation> = [
+  {
+    expr: '>',
+    value: 500,
+    function: 'count',
+    fnSeries: 'count()',
+  },
+];
 const eventData = mockEventData.event;
 const query = QueryGenerator(eventData.replay_info.streams, 'query-id', {
   type: 'absolute',
@@ -220,6 +228,21 @@ const field1Widget = AggregationWidget.builder()
       .rowPivots([Pivot.create(['field1', 'field2'], 'values', { limit: 15 })])
       .series([Series.forFunction('count(field1)')])
       .sort([new SortConfig(SortConfig.SERIES_TYPE, 'count(field1)', Direction.Descending)])
+      .visualization('table')
+      .rollup(true)
+      .build(),
+  )
+  .build();
+
+const noFieldWidget = AggregationWidget.builder()
+  .id('field1-widget-id')
+  .type('pivot')
+  .config(
+    AggregationWidgetConfig.builder()
+      .columnPivots([])
+      .rowPivots([])
+      .series([Series.forFunction('count()')])
+      .sort([new SortConfig(SortConfig.SERIES_TYPE, 'count()', Direction.Descending)])
       .visualization('table')
       .rollup(true)
       .build(),
@@ -257,6 +280,12 @@ const summaryWidget = AggregationWidget.builder()
   .build();
 const widgetsWithOneAggregation = [
   field1Widget,
+  histogram,
+  messageTable,
+];
+
+const widgetsWithOneAggregationNoField = [
+  noFieldWidget,
   histogram,
   messageTable,
 ];
@@ -342,6 +371,34 @@ export const mockedViewWithOneAggregation = View.create()
   .search(searchOneAggregation)
   .build();
 
+export const mockedViewWithOneAggregationNoField = View.create()
+  .toBuilder()
+  .id('view-id')
+  .type(View.Type.Search)
+  .state({
+    'query-id': ViewState.create()
+      .toBuilder()
+      .titles({
+        widget: {
+          'field1-widget-id': 'count() > 500',
+          'mc-widget-id': 'Message Count',
+          'allm-widget-id': 'All Messages',
+        },
+      })
+      .widgets(widgetsWithOneAggregationNoField)
+      .widgetMapping(Immutable.Map(
+        ['field1-widget-id', 'mc-widget-id', 'allm-widget-id'].map((item) => [item, Immutable.Set([undefined])]),
+      ))
+      .widgetPositions({
+        'field1-widget-id': new WidgetPosition(1, 1, 3, 6),
+        'mc-widget-id': new WidgetPosition(1, 4, 2, Infinity),
+        'allm-widget-id': new WidgetPosition(1, 6, 6, Infinity),
+      })
+      .build(),
+  })
+  .search(searchOneAggregation)
+  .build();
+
 const queryED = QueryGenerator(eventData.replay_info.streams, 'query-id', {
   type: 'relative',
   range: 60,
@@ -374,3 +431,28 @@ export const mockedViewWithOneAggregationED = mockedViewWithOneAggregation
     ).build()]).build(),
   )
   .build();
+
+export const mockEventDefinitionOneAggregationNoFields = {
+  ...mockEventDefinitionTwoAggregations,
+  id: 'event-definition-id-1',
+  config: {
+    ...mockEventDefinitionTwoAggregations.config,
+    group_by: [],
+    series: [],
+    conditions: {
+      expression: {
+        expr: '||',
+        left: {
+          expr: '>',
+          left: {
+            expr: 'number-ref',
+          },
+          right: {
+            expr: 'number',
+            value: 500.0,
+          },
+        },
+      },
+    },
+  },
+};


### PR DESCRIPTION
Note: This is a backport of https://github.com/Graylog2/graylog2-server/pull/15418 to 5.1.

<!--- Provide a general summary of your changes in the Title above -->

## Description
In the case with no pivot fields, fn pivotForField runs with an empty array. As a result, it creates a pivot without a field that the widget does not expect. This PR fixes this problem. In case of no pivot fields we return an empty array as rowPivots

## Motivation and Context
fix: https://github.com/Graylog2/graylog2-server/issues/15413

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

/nocl

