### PR TITLE
Create search before loading stream search page.

### DIFF
--- a/graylog2-web-interface/src/views/pages/StreamSearchPage.test.tsx
+++ b/graylog2-web-interface/src/views/pages/StreamSearchPage.test.tsx
@@ -30,6 +30,8 @@ import { loadViewsPlugin, unloadViewsPlugin } from 'views/test/testViewsPlugin';
 import useProcessHooksForView from 'views/logic/views/UseProcessHooksForView';
 import { createSearch } from 'fixtures/searches';
 import SearchExecutionState from 'views/logic/search/SearchExecutionState';
+import useCreateSearch from 'views/hooks/useCreateSearch';
+import type View from 'views/logic/views/View';
 
 import StreamSearchPage from './StreamSearchPage';
 
@@ -67,6 +69,7 @@ describe('StreamSearchPage', () => {
     asMock(useParams).mockReturnValue({ streamId });
     asMock(useCreateSavedSearch).mockReturnValue(Promise.resolve(mockView));
     asMock(useProcessHooksForView).mockReturnValue({ status: 'loaded', view: mockView, executionState: SearchExecutionState.empty() });
+    asMock(useCreateSearch).mockImplementation(async (view: Promise<View>) => view);
   });
 
   it('shows loading spinner before rendering page', async () => {

--- a/graylog2-web-interface/src/views/pages/StreamSearchPage.tsx
+++ b/graylog2-web-interface/src/views/pages/StreamSearchPage.tsx
@@ -22,6 +22,7 @@ import { loadNewViewForStream } from 'views/logic/views/Actions';
 import { useSearchURLQueryParams } from 'views/logic/NormalizeSearchURLQueryParams';
 import useParams from 'routing/useParams';
 import useHistory from 'routing/useHistory';
+import useCreateSearch from 'views/hooks/useCreateSearch';
 
 import SearchPage from './SearchPage';
 
@@ -34,11 +35,12 @@ const StreamSearchPage = () => {
   }
 
   const { timeRange, queryString } = useSearchURLQueryParams();
-  const newView = useCreateSavedSearch(streamId, timeRange, queryString);
+  const viewPromise = useCreateSavedSearch(streamId, timeRange, queryString);
+  const view = useCreateSearch(viewPromise);
 
   const _loadNewView = useCallback(() => loadNewViewForStream(history, streamId), [history, streamId]);
 
-  return <SearchPage loadNewView={_loadNewView} view={newView} isNew />;
+  return <SearchPage loadNewView={_loadNewView} view={view} isNew />;
 };
 
 export default StreamSearchPage;


### PR DESCRIPTION
**Note:** This requires a backport to `5.1`.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

In #15437 creating a search for a new saved search/dashboard was made explicit. Unfortunately, creating the search for a new stream search (a saved search scoped to a specific stream) was not adjusted, leading to the stream search page not loading properly.

This PR is changing this by making search creation explicit for the stream search page as well.

/nocl Fixing a regression introduced in development.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.