### PR TITLE
Fix issue when loading modal out of router context

### DIFF
--- a/graylog2-web-interface/src/components/common/withModalTelemetry.tsx
+++ b/graylog2-web-interface/src/components/common/withModalTelemetry.tsx
@@ -17,7 +17,6 @@
 // eslint-disable-next-line no-restricted-imports
 import type { ModalProps } from 'react-bootstrap';
 import React, { useEffect } from 'react';
-import { useLocation } from 'react-router-dom';
 import kebabCase from 'lodash/kebabCase';
 
 import useSendTelemetry from 'logic/telemetry/useSendTelemetry';
@@ -26,11 +25,9 @@ const withModalTelemetry = (Component) => {
   return (props: ModalProps) => {
     const { show, 'data-event-element': eventElement, 'data-app-section': appSection }: any = props;
     const sendTelemetry = useSendTelemetry();
-    const { pathname } = useLocation();
 
     useEffect(() => {
       const telemetryEvent = {
-        app_pathname: kebabCase(pathname),
         app_section: kebabCase(appSection),
         app_action_value: kebabCase(eventElement),
       };
@@ -44,7 +41,7 @@ const withModalTelemetry = (Component) => {
           sendTelemetry('modal_close', telemetryEvent);
         }
       };
-    }, [show, eventElement, appSection, sendTelemetry, pathname]);
+    }, [show, eventElement, appSection, sendTelemetry]);
 
     return <Component {...props} />;
   };

--- a/graylog2-web-interface/src/components/common/withPopoverTelemetry.tsx
+++ b/graylog2-web-interface/src/components/common/withPopoverTelemetry.tsx
@@ -17,7 +17,6 @@
 // eslint-disable-next-line no-restricted-imports
 import type { PopoverProps } from 'react-bootstrap';
 import React, { useEffect } from 'react';
-import { useLocation } from 'react-router-dom';
 import kebabCase from 'lodash/kebabCase';
 
 import useSendTelemetry from 'logic/telemetry/useSendTelemetry';
@@ -26,11 +25,9 @@ const withPopoverTelemetry = (Component) => {
   return (props: PopoverProps) => {
     const { 'data-event-element': eventElement, 'data-app-section': appSection }: any = props;
     const sendTelemetry = useSendTelemetry();
-    const { pathname } = useLocation();
 
     useEffect(() => {
       const telemetryEvent = {
-        app_pathname: kebabCase(pathname),
         app_section: kebabCase(appSection),
         app_action_value: kebabCase(eventElement),
       };
@@ -44,7 +41,7 @@ const withPopoverTelemetry = (Component) => {
           sendTelemetry('popover_close', telemetryEvent);
         }
       };
-    }, [eventElement, appSection, sendTelemetry, pathname]);
+    }, [eventElement, appSection, sendTelemetry]);
 
     return <Component {...props} />;
   };


### PR DESCRIPTION
This change removes the pathname from withModalTelemetry. 

Fix #15455
/nocl
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

