### PR TITLE
SearchesClusterConfig contains new section for timerange presets

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/searches/SearchesClusterConfig.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/searches/SearchesClusterConfig.java
@@ -23,10 +23,12 @@ import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.graylog.autovalue.WithBeanGetter;
+import org.graylog2.indexer.searches.timerangepresets.TimerangePreset;
 import org.graylog2.plugin.Message;
 import org.joda.time.Period;
 
 import javax.annotation.Nullable;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -81,6 +83,9 @@ public abstract class SearchesClusterConfig {
 
     private static final Period DEFAULT_AUTO_REFRESH_DEFAULT_OPTION = Period.seconds(5);
 
+    @JsonProperty("quick_access_timerange_presets")
+    public abstract List<TimerangePreset> quickAccessTimerangePresets();
+
     @JsonProperty("query_time_range_limit")
     public abstract Period queryTimeRangeLimit();
 
@@ -109,8 +114,11 @@ public abstract class SearchesClusterConfig {
                                                @JsonProperty("surrounding_filter_fields") Set<String> surroundingFilterFields,
                                                @JsonProperty("analysis_disabled_fields") @Nullable Set<String> analysisDisabledFields,
                                                @JsonProperty("auto_refresh_timerange_options") @Nullable Map<Period, String> autoRefreshTimerangeOptions,
-                                               @JsonProperty("default_auto_refresh_option") Period defaultAutoRefreshOption) {
+                                               @JsonProperty("default_auto_refresh_option") Period defaultAutoRefreshOption,
+                                               @JsonProperty("quick_access_timerange_presets") @Nullable List<TimerangePreset> quickAccessTimerangePresets
+    ) {
         return builder()
+                .quickAccessTimerangePresets(quickAccessTimerangePresets == null ? List.of() : quickAccessTimerangePresets)
                 .queryTimeRangeLimit(queryTimeRangeLimit)
                 .relativeTimerangeOptions(relativeTimerangeOptions)
                 .surroundingTimerangeOptions(surroundingTimerangeOptions)
@@ -141,12 +149,20 @@ public abstract class SearchesClusterConfig {
 
     @AutoValue.Builder
     public static abstract class Builder {
+        public abstract Builder quickAccessTimerangePresets(List<TimerangePreset> quickAccessTimerangePresets);
+
         public abstract Builder queryTimeRangeLimit(Period queryTimeRangeLimit);
+
         public abstract Builder relativeTimerangeOptions(Map<Period, String> relativeTimerangeOptions);
+
         public abstract Builder surroundingTimerangeOptions(Map<Period, String> surroundingTimerangeOptions);
+
         public abstract Builder surroundingFilterFields(Set<String> surroundingFilterFields);
+
         public abstract Builder analysisDisabledFields(Set<String> analysisDisabledFields);
+
         public abstract Builder autoRefreshTimerangeOptions(Map<Period, String> autoRefreshTimerangeOptions);
+
         public abstract Builder defaultAutoRefreshOption(Period defaultAutoRefreshOption);
 
         public abstract SearchesClusterConfig build();

--- a/graylog2-server/src/main/java/org/graylog2/indexer/searches/timerangepresets/TimerangePreset.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/searches/timerangepresets/TimerangePreset.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.indexer.searches.timerangepresets;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
+
+public record TimerangePreset(@JsonProperty("timerange") TimeRange timeRange,
+                              @JsonProperty("description") String description) {
+}


### PR DESCRIPTION
…resets, with a list of timeranges of keyword/relative/absolute type.

<!--- Provide a general summary of your changes in the Title above -->

## Description
SearchesClusterConfig contains new section : quick_access_timerange_presets, with a list of timeranges of keyword/relative/absolute type.
/nocl

## Motivation and Context
Needed by FE for Time Range Presets task.

## How Has This Been Tested?
Manually.

## Screenshots (if appropriate):

![Screenshot 2023-05-10 at 11-25-11 Graylog REST API browser](https://github.com/Graylog2/graylog2-server/assets/100699120/4bd8d1a6-7799-4dd3-a7e4-c6c381394ff4)

![Screenshot 2023-05-10 at 11-24-43 Graylog REST API browser](https://github.com/Graylog2/graylog2-server/assets/100699120/964ca6eb-9b87-4c26-bb6a-570ac6f5e0e8)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

