### PR TITLE
Backport (5.1): Fix BulkActions dialog not closing after clicking on Confirm (#15384)

### DIFF
--- a/changelog/unreleased/issue-15259.toml
+++ b/changelog/unreleased/issue-15259.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Fix: BulkActions dialog not closing after clicking on Confirm."
+
+issues = ["15259"]
+pulls = ["15384"]

--- a/graylog2-web-interface/src/components/event-definitions/event-definitions/BulkActions.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definitions/BulkActions.tsx
@@ -128,6 +128,7 @@ const BulkActions = ({ selectedDefinitionsIds, setSelectedEventDefinitionsIds }:
 
   const handleConfirm = () => {
     onAction();
+    setShowDialog(false);
   };
 
   return (


### PR DESCRIPTION
backport https://github.com/Graylog2/graylog2-server/pull/15384

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fixes https://github.com/Graylog2/graylog2-server/issues/15259

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

