### PR TITLE
Change log level of root logger to "info"

### DIFF
--- a/graylog2-server/src/main/resources/log4j2.xml
+++ b/graylog2-server/src/main/resources/log4j2.xml
@@ -34,7 +34,7 @@
         <Logger name="com.azure.messaging.eventhubs.PartitionPumpManager" level="off"/>
         <Logger name="com.azure.core.amqp.implementation.ReactorReceiver" level="off"/>
         <Logger name="com.azure.core.amqp.implementation.ReactorDispatcher" level="off"/>
-        <Root level="warn">
+        <Root level="info">
             <AppenderRef ref="STDOUT"/>
             <AppenderRef ref="graylog-internal-logs"/>
         </Root>


### PR DESCRIPTION
This is the de-facto standard anyways, because during server startup we are modifying the root logger level with "info" being the default. This happens in `CmdLineTool`.

Before this change, commands that don't inherit from `CmdLineTool` had to perform the same kind of log level change. Now, they can just run with the default "info" level which is what we probably want most of the time.

/nocl (shouldn't be noticeable when running the server or any of the existing commands)