### PR TITLE
Allow configuring proxied requests timeout in full backend tests.

### DIFF
--- a/graylog2-server/src/test/java/org/graylog/testing/completebackend/ContainerizedGraylogBackend.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/completebackend/ContainerizedGraylogBackend.java
@@ -109,23 +109,11 @@ public class ContainerizedGraylogBackend implements GraylogBackend, AutoCloseabl
     }
 
     private void createLicenses(final MongoDBInstance mongoDBInstance, final String... licenseStrs) {
-        final List<String> licenses = Arrays.stream(licenseStrs).map(System::getenv).filter(p -> StringUtils.isNotBlank(p)).collect(Collectors.toList());
+        final List<String> licenses = Arrays.stream(licenseStrs).map(System::getenv).filter(StringUtils::isNotBlank).collect(Collectors.toList());
         if(!licenses.isEmpty()) {
             ServiceLoader<TestLicenseImporter> loader = ServiceLoader.load(TestLicenseImporter.class);
             loader.forEach(importer -> importer.importLicenses(mongoDBInstance, licenses));
         }
-    }
-
-    public void purgeData() {
-        mongodb.dropDatabase();
-        searchServer.cleanUp();
-    }
-
-    public void fullReset(List<URL> mongoDBFixtures) {
-        LOG.debug("Resetting backend.");
-        purgeData();
-        mongodb.importFixtures(mongoDBFixtures);
-        node.restart();
     }
 
     @Override
@@ -161,10 +149,6 @@ public class ContainerizedGraylogBackend implements GraylogBackend, AutoCloseabl
     @Override
     public Network network() {
         return this.network;
-    }
-
-    public MongoDBInstance mongoDB() {
-        return mongodb;
     }
 
     public Optional<MailServerInstance> getEmailServerInstance() {

--- a/graylog2-server/src/test/java/org/graylog/testing/graylognode/NodeContainerConfig.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/graylognode/NodeContainerConfig.java
@@ -25,6 +25,7 @@ import org.testcontainers.containers.Network;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 public class NodeContainerConfig {
 
@@ -42,6 +43,7 @@ public class NodeContainerConfig {
     public final PluginJarsProvider pluginJarsProvider;
     public final MavenProjectDirProvider mavenProjectDirProvider;
     private final List<String> enabledFeatureFlags;
+    public final Optional<String> proxiedRequestsTimeout;
 
     public NodeContainerConfig(Network network,
                                String mongoDbUri,
@@ -61,11 +63,16 @@ public class NodeContainerConfig {
         this.pluginJarsProvider = pluginJarsProvider;
         this.mavenProjectDirProvider = mavenProjectDirProvider;
         this.enabledFeatureFlags = enabledFeatureFlags == null ? Collections.emptyList() : enabledFeatureFlags;
+        this.proxiedRequestsTimeout = stringFromEnvVar("GRAYLOG_IT_PROXIED_REQUESTS_TIMEOUT");
     }
 
     private static boolean flagFromEnvVar(String flagName) {
         String flag = System.getenv(flagName);
         return flag != null && flag.equalsIgnoreCase("true");
+    }
+
+    private static Optional<String> stringFromEnvVar(String flagName) {
+        return Optional.ofNullable(System.getenv(flagName));
     }
 
     public Integer[] portsToExpose() {

--- a/graylog2-server/src/test/java/org/graylog/testing/graylognode/NodeContainerFactory.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/graylognode/NodeContainerFactory.java
@@ -24,7 +24,6 @@ import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.Container;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
-import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.containers.wait.strategy.WaitAllStrategy;
 import org.testcontainers.images.builder.ImageFromDockerfile;
 import org.testcontainers.utility.MountableFile;
@@ -38,7 +37,6 @@ import java.nio.file.attribute.PosixFilePermissions;
 import java.time.Duration;
 import java.util.List;
 import java.util.Locale;
-import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import static java.time.temporal.ChronoUnit.SECONDS;
@@ -170,6 +168,8 @@ public class NodeContainerFactory {
             container.withEnv("DEVELOPMENT", "true");
         }
 
+        config.proxiedRequestsTimeout.ifPresent(proxiedRequestsTimeout -> container.withEnv("GRAYLOG_PROXIED_REQUESTS_DEFAULT_CALL_TIMEOUT", proxiedRequestsTimeout));
+
         pluginJars.forEach(hostPath -> {
             if (Files.exists(hostPath)) {
                 final Path containerPath = Paths.get(GRAYLOG_HOME, "plugin", hostPath.getFileName().toString());
@@ -202,7 +202,7 @@ public class NodeContainerFactory {
                 .stream()
                 .map(e -> e.startsWith(FEATURE_PREFIX) ? e : String.join("_", FEATURE_PREFIX, e))
                 .map(e -> e.toUpperCase(Locale.ENGLISH))
-                .collect(Collectors.toList());
+                .toList();
 
         for (String name : prefixed) {
             container.withEnv(name, "on");

--- a/graylog2-server/src/test/java/org/graylog/testing/graylognode/NodeInstance.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/graylognode/NodeInstance.java
@@ -59,7 +59,7 @@ public class NodeInstance implements Closeable {
     }
 
     public String uri() {
-        return String.format(Locale.US, "http://%s", container.getContainerIpAddress());
+        return String.format(Locale.US, "http://%s", container.getHost());
     }
 
     public int apiPort() {

--- a/graylog2-server/src/test/java/org/junit/platform/engine/support/hierarchical/ContainerMatrixHierarchicalTestEngine.java
+++ b/graylog2-server/src/test/java/org/junit/platform/engine/support/hierarchical/ContainerMatrixHierarchicalTestEngine.java
@@ -60,9 +60,7 @@ public abstract class ContainerMatrixHierarchicalTestEngine<C extends EngineExec
             if (descriptor instanceof ContainerMatrixTestWithRunningESMongoTestsDescriptor) {
                 GraylogBackend backend = RunningGraylogBackend.createStarted();
                 this.execute(request, descriptor.getChildren(), backend);
-            } else if (descriptor instanceof ContainerMatrixTestsDescriptor) {
-                ContainerMatrixTestsDescriptor containerMatrixTestsDescriptor = (ContainerMatrixTestsDescriptor) descriptor;
-
+            } else if (descriptor instanceof ContainerMatrixTestsDescriptor containerMatrixTestsDescriptor) {
                 SearchVersion esVersion = containerMatrixTestsDescriptor.getEsVersion();
                 MongodbServer mongoVersion = containerMatrixTestsDescriptor.getMongoVersion();
                 int[] extraPorts = containerMatrixTestsDescriptor.getExtraPorts();


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This change allows passing a non-default timeout for proxied requests to the Graylog server started from full backend tests. This allows mitigation of overly slow/overloaded environments resulting in test failures due to timeouts of proxied API requests.

/nocl

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.