### PR TITLE
Fix GELF output blocking and output processing race condition

### DIFF
--- a/changelog/unreleased/issue-9917.toml
+++ b/changelog/unreleased/issue-9917.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Fix GELF output to not block output processing."
+
+issues = ["9917", "graylog-plugin-enterprise#4623"]
+pulls = ["15385"]

--- a/graylog2-server/src/main/java/org/graylog2/outputs/GelfOutput.java
+++ b/graylog2-server/src/main/java/org/graylog2/outputs/GelfOutput.java
@@ -47,6 +47,7 @@ import java.io.File;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -181,7 +182,13 @@ public class GelfOutput implements MessageOutput {
 
     @Override
     public void write(final Message message) throws Exception {
-        transport.send(toGELFMessage(message));
+        // Use #trySend instead of #send on the transport, so we don't block and can handle the shutdown of the output.
+        while (isRunning() && !transport.trySend(toGELFMessage(message))) {
+            if (LOG.isTraceEnabled()) {
+                LOG.trace("Couldn't send message to GELF transport. Waiting 100 ms before trying again.");
+            }
+            TimeUnit.MICROSECONDS.sleep(100);
+        }
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/outputs/OutputRegistry.java
+++ b/graylog2-server/src/main/java/org/graylog2/outputs/OutputRegistry.java
@@ -27,7 +27,6 @@ import com.google.common.collect.Sets;
 import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
 import com.google.common.util.concurrent.UncheckedExecutionException;
-import com.swrve.ratelimitedlogger.RateLimitedLog;
 import org.graylog2.database.NotFoundException;
 import org.graylog2.notifications.Notification;
 import org.graylog2.notifications.NotificationService;
@@ -60,10 +59,6 @@ import java.util.stream.Collectors;
 @Singleton
 public class OutputRegistry {
     private static final Logger LOG = LoggerFactory.getLogger(OutputRegistry.class);
-    private static final Logger RATE_LIMITED_LOG = RateLimitedLog.withRateLimit(LOG)
-            .maxRate(1)
-            .every(Duration.ofSeconds(5))
-            .build();
 
     private final Cache<String, MessageOutput> runningMessageOutputs;
     private final MessageOutput defaultMessageOutput;
@@ -156,7 +151,7 @@ public class OutputRegistry {
             }
         } catch (ExecutionException | UncheckedExecutionException e) {
             if (e.getCause() instanceof NotFoundException || e.getCause() instanceof IllegalArgumentException) {
-                RATE_LIMITED_LOG.debug("Unable to fetch output <{}> for stream <{}/{}>: {}", id, stream.getTitle(), stream.getId(), e.getMessage());
+                LOG.debug("Unable to fetch output <{}> for stream <{}/{}>: {}", id, stream.getTitle(), stream.getId(), e.getMessage());
             } else {
                 final int number = faultCount.addAndGet(1);
                 LOG.error("Unable to fetch output " + id + ", fault #" + number, e);

--- a/graylog2-server/src/test/java/org/graylog2/outputs/GelfOutputTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/outputs/GelfOutputTest.java
@@ -32,6 +32,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class GelfOutputTest {
     @Test
@@ -41,10 +42,11 @@ public class GelfOutputTest {
         final GelfMessage gelfMessage = new GelfMessage("Test");
         final GelfOutput gelfOutput = Mockito.spy(new GelfOutput(transport));
         doReturn(gelfMessage).when(gelfOutput).toGELFMessage(message);
+        when(transport.trySend(gelfMessage)).thenReturn(true);
 
         gelfOutput.write(message);
 
-        verify(transport).send(eq(gelfMessage));
+        verify(transport).trySend(eq(gelfMessage));
     }
 
     @Test

--- a/graylog2-server/src/test/java/org/graylog2/outputs/OutputRegistryTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/outputs/OutputRegistryTest.java
@@ -96,6 +96,10 @@ public class OutputRegistryTest {
     public void testLaunchNewOutput() throws Exception {
         final String outputId = "foobar";
         final Stream stream = mock(Stream.class);
+        when(stream.getId()).thenReturn("stream-for-output-" + outputId);
+        when(stream.getOutputs()).thenReturn(Set.of(output));
+        when(output.getId()).thenReturn(outputId);
+        when(streamService.load("stream-for-output-" + outputId)).thenReturn(stream);
         when(messageOutputFactory.fromStreamOutput(eq(output), eq(stream), any(Configuration.class))).thenReturn(messageOutput);
         when(outputService.load(eq(outputId))).thenReturn(output);
 
@@ -176,6 +180,9 @@ public class OutputRegistryTest {
     private void loadIntoRegistry(Output... outputs) throws Exception {
         for (final Output output : outputs) {
             Stream stream = mock(Stream.class);
+            when(stream.getId()).thenReturn("stream-for-output-" + output.hashCode());
+            when(stream.getOutputs()).thenReturn(Set.of(output));
+            when(streamService.load("stream-for-output-" + output.hashCode())).thenReturn(stream);
             when(outputService.load(eq(output.getId()))).thenReturn(output);
             when(messageOutputFactory.fromStreamOutput(eq(output), eq(stream), any(Configuration.class)))
                     .thenReturn(messageOutput);


### PR DESCRIPTION
Switch from GelfTransport#send() to GelfTransport#trySend() to avoid blocking output threads. We retry the send operation as long as the output is running.
This fixes an issue where removing an output from a stream or deleting it doesn't unblock processing. (with a slow output target)

A race condition in OutputRegistry was contributing to the problem.

When the OutputRegistry didn't have a cached output instance, we loaded the output configuration from the database and started the output. The problem is that each message holds a stream object that might be outdated because the output could have been removed since adding the stream object to the message object.

So instead of just starting an output, we need to check if the output is still assigned to the stream.

Fixes #9917
Fixes Graylog2/graylog-plugin-enterprise#4623

(cherry picked from commit 30b9a912fde4f031ae04ad3a3d8983c9f7e616dc)
