### PR TITLE
Do not extend session when fetching indexer cluster health.

### DIFF
--- a/changelog/unreleased/pr-15505.toml
+++ b/changelog/unreleased/pr-15505.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Do not extend session when fetching indexer cluster health."
+
+pulls = ["15505"]
+

--- a/graylog2-web-interface/src/components/indexers/IndexerClusterHealth.tsx
+++ b/graylog2-web-interface/src/components/indexers/IndexerClusterHealth.tsx
@@ -26,7 +26,7 @@ import DocsHelper from 'util/DocsHelper';
 import { IndexerClusterHealthSummary } from 'components/indexers';
 import type FetchError from 'logic/errors/FetchError';
 import ApiRoutes from 'routing/ApiRoutes';
-import fetch from 'logic/rest/FetchProvider';
+import { fetchPeriodically } from 'logic/rest/FetchProvider';
 import * as URLUtils from 'util/URLUtils';
 import useCurrentUser from 'hooks/useCurrentUser';
 
@@ -43,13 +43,13 @@ const GET_INDEXER_CLUSTER_NAME = 'indexerCluster.name';
 const getIndexerClusterHealth = () => {
   const url = URLUtils.qualifyUrl(ApiRoutes.IndexerClusterApiController.health().url);
 
-  return fetch('GET', url);
+  return fetchPeriodically('GET', url);
 };
 
 const getIndexerClusterName = () => {
   const url = URLUtils.qualifyUrl(ApiRoutes.IndexerClusterApiController.name().url);
 
-  return fetch('GET', url);
+  return fetchPeriodically('GET', url);
 };
 
 const useLoadHealthAndName = (enabled: boolean) => {


### PR DESCRIPTION
_This PR needs a backport for `5.0` and `5.1`._

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This is a follow-up for https://github.com/Graylog2/graylog2-server/pull/15465. 
With this PR we make sure we do not extend the session when fetching indexer cluster health periodically.
Please have a look at https://github.com/Graylog2/graylog2-server/pull/15465 for more information.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
