### PR TITLE
Provide method for applying timeout multiplier.

### DIFF
--- a/graylog2-server/src/test/java/org/graylog/testing/completebackend/TimeoutHelpers.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/completebackend/TimeoutHelpers.java
@@ -1,0 +1,22 @@
+package org.graylog.testing.completebackend;
+
+import java.util.Optional;
+
+public class TimeoutHelpers {
+    private static final double DEFAULT_MULTIPLIER = 1.5;
+
+    public static Number applyTimeoutMultiplier(Number timeout) {
+        return timeout.doubleValue() * timeoutMultiplier();
+    }
+
+    private static double timeoutMultiplier() {
+        return Optional.ofNullable(System.getenv("TIMEOUT_MULTIPLIER"))
+                .map(timeoutMultiplier -> {
+                    try {
+                        return Double.parseDouble(timeoutMultiplier);
+                    } catch (NumberFormatException e) {
+                        return DEFAULT_MULTIPLIER;
+                    }
+                }).orElse(DEFAULT_MULTIPLIER);
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog/testing/completebackend/TimeoutHelpers.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/completebackend/TimeoutHelpers.java
@@ -19,7 +19,7 @@ package org.graylog.testing.completebackend;
 import java.util.Optional;
 
 public class TimeoutHelpers {
-    private static final double DEFAULT_MULTIPLIER = 1.5;
+    private static final double DEFAULT_MULTIPLIER = 1.0;
 
     public static Number applyTimeoutMultiplier(Number timeout) {
         return timeout.doubleValue() * timeoutMultiplier();

--- a/graylog2-server/src/test/java/org/graylog/testing/completebackend/TimeoutHelpers.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/completebackend/TimeoutHelpers.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog.testing.completebackend;
 
 import java.util.Optional;


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Like for the frontend tests, there might be scenarios where we want to
apply environment-specific multiplier to timeouts in tests. For slower
environments, we can set a higher multiplier to avoid test failures
under load.

This PR is adding a `TimeoutHelpers.applyTimeoutMultiplier` method,
which is taking the `TIMEOUT_MULTIPLIER` setting from the environment
and applying it to the given number. If the environment variable is not
set, `1.0` will be used.

/nocl

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.