### PR TITLE
Do not extend session when fetching cluster overview. (`5.0`)

### DIFF
--- a/changelog/unreleased/pr-15508.toml
+++ b/changelog/unreleased/pr-15508.toml
@@ -1,0 +1,6 @@
+type = "fixed"
+message = "Fixing session expiration on the nodes page."
+
+issues = ["Graylog2/graylog-plugin-enterprise#5158"]
+pulls = ["15508"]
+

--- a/graylog2-web-interface/src/stores/cluster/ClusterOverviewStore.js
+++ b/graylog2-web-interface/src/stores/cluster/ClusterOverviewStore.js
@@ -18,7 +18,7 @@ import Reflux from 'reflux';
 
 import * as URLUtils from 'util/URLUtils';
 import UserNotification from 'util/UserNotification';
-import fetch from 'logic/rest/FetchProvider';
+import fetch, { fetchPeriodically } from 'logic/rest/FetchProvider';
 import { singletonStore } from 'logic/singleton';
 import { NodesStore } from 'stores/nodes/NodesStore';
 import { SystemLoadBalancerStore } from 'stores/load-balancer/SystemLoadBalancerStore';
@@ -43,7 +43,7 @@ export const ClusterOverviewStore = singletonStore(
     },
 
     cluster() {
-      const promise = fetch('GET', URLUtils.qualifyUrl(this.sourceUrl));
+      const promise = fetchPeriodically('GET', URLUtils.qualifyUrl(this.sourceUrl));
 
       promise.then(
         (response) => {


### PR DESCRIPTION
**Note:** This is a backport of #15465 to `5.0`.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Prior to this PR, any page that loads the `ClusterOverviewStore` would trigger a permanent session extension. This happens because the store is listening to `NodesStore.list`, calling `cluster()` for every update.  This function is doing a fetch in turn, which is not disabling session extension.

This PR is fixing this by using `fetchPeriodically` for the cluster overview call.

Fixes Graylog2/graylog-plugin-enterprise#5158.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.