### PR TITLE
Manage zstd-jni and commons-lang3 dependencies in graylog-parent

### DIFF
--- a/graylog-project-parent/pom.xml
+++ b/graylog-project-parent/pom.xml
@@ -347,11 +347,6 @@
                     </exclusion>
                 </exclusions>
             </dependency>
-            <dependency>
-                <groupId>com.github.luben</groupId>
-                <artifactId>zstd-jni</artifactId>
-                <version>${zstd.version}</version>
-            </dependency>
 
             <dependency>
                 <groupId>com.rabbitmq</groupId>

--- a/graylog2-server/pom.xml
+++ b/graylog2-server/pom.xml
@@ -251,6 +251,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.glassfish.jersey.inject</groupId>
             <artifactId>jersey-hk2</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,7 @@
         <classgraph.version>4.8.157</classgraph.version>
         <commons-codec.version>1.14</commons-codec.version>
         <commons-email.version>1.5</commons-email.version>
+        <commons-lang3.version>3.12.0</commons-lang3.version>
         <commons-validator.version>1.6</commons-validator.version>
         <commons-io.version>2.6</commons-io.version>
         <disruptor.version>3.4.2</disruptor.version>
@@ -281,6 +282,18 @@
                 <artifactId>netty-tcnative-boringssl-static</artifactId>
                 <version>${netty-tcnative-boringssl-static.version}</version>
                 <classifier>linux-x86_64</classifier>
+            </dependency>
+            <!-- Ensure consistent commons-lang3 versions across dependencies and transitive dependencies -->
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>${commons-lang3.version}</version>
+            </dependency>
+            <!-- Ensure consistent zstd-jni versions across dependencies and transitive dependencies -->
+            <dependency>
+                <groupId>com.github.luben</groupId>
+                <artifactId>zstd-jni</artifactId>
+                <version>${zstd.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Move zstd-jni from graylog-project-parent to graylog-parent because some transitive plugin dependencies are using it.

Add version property for the latest commons-lang3 dependency.

/nocl