### PR TITLE
PKCS12 keystore file, with certificate and password, is stored in Mongo.

### DIFF
--- a/data-node/src/main/java/org/graylog/datanode/bootstrap/preflight/DataNodePreflightGeneratePeriodical.java
+++ b/data-node/src/main/java/org/graylog/datanode/bootstrap/preflight/DataNodePreflightGeneratePeriodical.java
@@ -16,11 +16,14 @@
  */
 package org.graylog.datanode.bootstrap.preflight;
 
-import org.bouncycastle.operator.OperatorCreationException;
+import org.bouncycastle.operator.OperatorException;
+import org.graylog.datanode.Configuration;
+import org.graylog.security.certutil.cert.storage.CertMongoStorage;
+import org.graylog.security.certutil.cert.storage.CertStorage;
+import org.graylog.security.certutil.csr.CertificateAndPrivateKeyMerger;
 import org.graylog.security.certutil.csr.CsrGenerator;
 import org.graylog.security.certutil.csr.exceptions.CSRGenerationException;
 import org.graylog.security.certutil.csr.storage.CsrMongoStorage;
-import org.graylog.security.certutil.csr.storage.CsrStorage;
 import org.graylog.security.certutil.privatekey.PrivateKeyEncryptedFileStorage;
 import org.graylog2.cluster.NodeNotFoundException;
 import org.graylog2.cluster.NodePreflightConfig;
@@ -34,6 +37,10 @@ import org.slf4j.LoggerFactory;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.io.IOException;
+import java.security.cert.X509Certificate;
+import java.util.Optional;
+
+import static org.graylog.security.certutil.CertutilHttp.DATANODE_KEY_ALIAS;
 
 @Singleton
 public class DataNodePreflightGeneratePeriodical extends Periodical {
@@ -43,8 +50,11 @@ public class DataNodePreflightGeneratePeriodical extends Periodical {
     private final NodeService nodeService;
     private final NodeId nodeId;
     private final PrivateKeyEncryptedFileStorage privateKeyEncryptedStorage;
-    private final CsrStorage csrStorage;
+    private final CsrMongoStorage csrStorage;
     private final CsrGenerator csrGenerator;
+    private final CertStorage certMongoStorage;
+    private final CertificateAndPrivateKeyMerger certificateAndPrivateKeyMerger;
+    private final Configuration configuration;
 
     //TODO: decide on password handling
     private static final String DEFAULT_PASSWORD = "admin";
@@ -54,12 +64,18 @@ public class DataNodePreflightGeneratePeriodical extends Periodical {
                                                final NodeService nodeService,
                                                final NodeId nodeId,
                                                final CsrMongoStorage csrStorage,
-                                               final CsrGenerator csrGenerator) {
+                                               final CsrGenerator csrGenerator,
+                                               final CertMongoStorage certMongoStorage,
+                                               final CertificateAndPrivateKeyMerger certificateAndPrivateKeyMerger,
+                                               final Configuration configuration) {
         this.nodePreflightConfigService = nodePreflightConfigService;
         this.nodeService = nodeService;
         this.nodeId = nodeId;
         this.csrStorage = csrStorage;
         this.csrGenerator = csrGenerator;
+        this.certMongoStorage = certMongoStorage;
+        this.certificateAndPrivateKeyMerger = certificateAndPrivateKeyMerger;
+        this.configuration = configuration;
         // TODO: merge with real storage
         this.privateKeyEncryptedStorage = new PrivateKeyEncryptedFileStorage("privateKeyFilename.cert");
     }
@@ -75,13 +91,36 @@ public class DataNodePreflightGeneratePeriodical extends Periodical {
             try {
                 var node = nodeService.byNodeId(nodeId);
                 var csr = csrGenerator.generateCSR(DEFAULT_PASSWORD.toCharArray(), node.getHostname(), cfg.altNames(), privateKeyEncryptedStorage);
-                csrStorage.writeCsr(csr);
+                csrStorage.writeCsr(csr, nodeId.getNodeId());
                 LOG.info("created CSR for this node");
-            } catch (CSRGenerationException | IOException | NodeNotFoundException | OperatorCreationException ex) {
+            } catch (CSRGenerationException | IOException | NodeNotFoundException | OperatorException ex) {
                 LOG.error("error generating a CSR: " + ex.getMessage(), ex);
                 nodePreflightConfigService.save(cfg.toBuilder().state(NodePreflightConfig.State.ERROR).errorMsg(ex.getMessage()).build());
             }
         } else if (NodePreflightConfig.State.SIGNED.equals(cfg.state())) {
+            if (cfg.certificate() == null) {
+                LOG.error("Config entry in signed state, but no certificate data present in Mongo");
+            } else {
+                try {
+                    final Optional<X509Certificate> x509Certificate = certMongoStorage.readCert(nodeId.getNodeId());
+                    if (x509Certificate.isPresent()) {
+                        //TODO: done for HTTP cert, we still need to make decision if we want to process HTTP and transport certs separetely
+                        certificateAndPrivateKeyMerger.merge(
+                                x509Certificate.get(),
+                                privateKeyEncryptedStorage,
+                                DEFAULT_PASSWORD.toCharArray(),
+                                configuration.getDatanodeHttpCertificatePassword().toCharArray(),
+                                DATANODE_KEY_ALIAS
+                        );
+
+                        //should be in one transaction, but we miss transactions...
+                        nodePreflightConfigService.changeState(nodeId.getNodeId(), NodePreflightConfig.State.STORED);
+                    }
+                } catch (Exception ex) {
+                    LOG.error("Config entry in signed state, but no certificate data present in Mongo");
+                }
+            }
+
             // write certificate to local truststore
             // configure SSL
             // start DataNode

--- a/graylog2-server/src/main/java/org/graylog/security/certutil/cert/storage/CertStorage.java
+++ b/graylog2-server/src/main/java/org/graylog/security/certutil/cert/storage/CertStorage.java
@@ -19,9 +19,13 @@ package org.graylog.security.certutil.cert.storage;
 import org.bouncycastle.operator.OperatorCreationException;
 
 import java.io.IOException;
+import java.security.GeneralSecurityException;
 import java.security.cert.X509Certificate;
+import java.util.Optional;
 
 public interface CertStorage {
-    void writeCert(X509Certificate cert)
+    void writeCert(X509Certificate cert, String nodeId)
             throws IOException, OperatorCreationException;
+
+    Optional<X509Certificate> readCert(String nodeId) throws IOException, GeneralSecurityException;
 }

--- a/graylog2-server/src/main/java/org/graylog/security/certutil/csr/storage/CsrFileStorage.java
+++ b/graylog2-server/src/main/java/org/graylog/security/certutil/csr/storage/CsrFileStorage.java
@@ -18,7 +18,7 @@ package org.graylog.security.certutil.csr.storage;
 
 import org.bouncycastle.openssl.PEMParser;
 import org.bouncycastle.openssl.jcajce.JcaPEMWriter;
-import org.bouncycastle.operator.OperatorCreationException;
+import org.bouncycastle.operator.OperatorException;
 import org.bouncycastle.pkcs.PKCS10CertificationRequest;
 
 import java.io.BufferedReader;
@@ -37,7 +37,7 @@ public record CsrFileStorage(String csrFilename) implements CsrStorage {
 
     @Override
     public void writeCsr(PKCS10CertificationRequest csr)
-            throws IOException, OperatorCreationException {
+            throws IOException, OperatorException {
 
         try (JcaPEMWriter jcaPEMWriter = new JcaPEMWriter(new FileWriter(csrFilename, Charset.defaultCharset()))) {
             jcaPEMWriter.writeObject(csr);
@@ -46,7 +46,7 @@ public record CsrFileStorage(String csrFilename) implements CsrStorage {
 
     @Override
     public PKCS10CertificationRequest readCsr()
-            throws IOException, OperatorCreationException {
+            throws IOException, OperatorException {
 
         Reader pemReader = new BufferedReader(new FileReader(csrFilename, Charset.defaultCharset()));
         PEMParser pemParser = new PEMParser(pemReader);

--- a/graylog2-server/src/main/java/org/graylog/security/certutil/keystore/storage/KeystoreMongoStorage.java
+++ b/graylog2-server/src/main/java/org/graylog/security/certutil/keystore/storage/KeystoreMongoStorage.java
@@ -42,7 +42,7 @@ public class KeystoreMongoStorage {
         final String nodeIdValue = nodeId.getNodeId();
         try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
             keyStore.store(baos, password);
-            final String keystoreDataAsString = baos.toString();
+            final String keystoreDataAsString = baos.toString(StandardCharsets.UTF_8);
             certificatesService.writeCert(nodeIdValue, keystoreDataAsString);
         } catch (Exception ex) {
             throw new KeyStoreStorageException("Failed to save keystore to Mongo collection for node " + nodeIdValue, ex);

--- a/graylog2-server/src/main/java/org/graylog/security/certutil/keystore/storage/KeystoreMongoStorage.java
+++ b/graylog2-server/src/main/java/org/graylog/security/certutil/keystore/storage/KeystoreMongoStorage.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.security.certutil.keystore.storage;
+
+import org.graylog.security.certutil.ca.exceptions.KeyStoreStorageException;
+import org.graylog2.cluster.certificates.CertificatesService;
+import org.graylog2.plugin.system.NodeId;
+
+import javax.inject.Inject;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyStore;
+import java.util.Optional;
+
+public class KeystoreMongoStorage {
+
+    private final CertificatesService certificatesService;
+
+    @Inject
+    public KeystoreMongoStorage(CertificatesService certificatesService) {
+        this.certificatesService = certificatesService;
+    }
+
+
+    public void writeKeyStore(NodeId nodeId, KeyStore keyStore, char[] password) throws KeyStoreStorageException {
+
+        final String nodeIdValue = nodeId.getNodeId();
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+            keyStore.store(baos, password);
+            final String keystoreDataAsString = baos.toString();
+            certificatesService.writeCert(nodeIdValue, keystoreDataAsString);
+        } catch (Exception ex) {
+            throw new KeyStoreStorageException("Failed to save keystore to Mongo collection for node " + nodeIdValue, ex);
+        }
+    }
+
+    public Optional<KeyStore> readKeyStore(NodeId nodeId, char[] password) throws KeyStoreStorageException {
+
+        final String nodeIdValue = nodeId.getNodeId();
+        final Optional<String> keystoreAsString = certificatesService.readCert(nodeIdValue);
+        if (keystoreAsString.isPresent()) {
+            try (ByteArrayInputStream bais = new ByteArrayInputStream(keystoreAsString.get().getBytes(StandardCharsets.UTF_8))) {
+                KeyStore keyStore = KeyStore.getInstance("PKCS12");
+                keyStore.load(bais, password);
+                return Optional.of(keyStore);
+            } catch (Exception ex) {
+                throw new KeyStoreStorageException("Failed to load keystore from Mongo collection for node " + nodeIdValue, ex);
+            }
+        }
+
+        return Optional.empty();
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/bootstrap/preflight/GraylogPreflightGeneratePeriodical.java
+++ b/graylog2-server/src/main/java/org/graylog2/bootstrap/preflight/GraylogPreflightGeneratePeriodical.java
@@ -17,9 +17,9 @@
 package org.graylog2.bootstrap.preflight;
 
 import org.graylog.security.certutil.cert.storage.CertMongoStorage;
+import org.graylog.security.certutil.cert.storage.CertStorage;
 import org.graylog.security.certutil.csr.CsrSigner;
 import org.graylog.security.certutil.csr.storage.CsrMongoStorage;
-import org.graylog.security.certutil.csr.storage.CsrStorage;
 import org.graylog2.cluster.NodePreflightConfig;
 import org.graylog2.cluster.NodePreflightConfigService;
 import org.graylog2.plugin.periodical.Periodical;
@@ -45,8 +45,8 @@ public class GraylogPreflightGeneratePeriodical extends Periodical {
 
     private final NodePreflightConfigService nodePreflightConfigService;
 
-    private final CsrStorage csrStorage;
-    private final CertMongoStorage certMongoStorage;
+    private final CsrMongoStorage csrStorage;
+    private final CertStorage certMongoStorage;
 
     private String caKeystoreFilename = "datanode-ca.p12";
     private Integer DEFAULT_VALIDITY = 90;
@@ -81,9 +81,17 @@ public class GraylogPreflightGeneratePeriodical extends Periodical {
                     .filter(c -> NodePreflightConfig.State.CSR.equals(c.state()))
                     .forEach(c -> {
                         try {
-                            var csr = csrStorage.readCsr();
-                            var cert = CsrSigner.sign(caPrivateKey, caCertificate, csr, c.validFor() != null ? c.validFor() : DEFAULT_VALIDITY);
-                            certMongoStorage.writeCert(cert);
+                            var csr = csrStorage.readCsr(c.nodeId());
+                            if (csr.isEmpty()) {
+                                LOG.error("Node in CSR state, but no CSR present : " + c.nodeId());
+                                nodePreflightConfigService.save(c.toBuilder()
+                                        .state(NodePreflightConfig.State.ERROR)
+                                        .errorMsg("Node in CSR state, but no CSR present")
+                                        .build());
+                            } else {
+                                var cert = CsrSigner.sign(caPrivateKey, caCertificate, csr.get(), c.validFor() != null ? c.validFor() : DEFAULT_VALIDITY);
+                                certMongoStorage.writeCert(cert, c.nodeId());
+                            }
                         } catch (Exception e) {
                             LOG.error("Could not sign CSR: " + e.getMessage(), e);
                             nodePreflightConfigService.save(c.toBuilder().state(NodePreflightConfig.State.ERROR).errorMsg(e.getMessage()).build());

--- a/graylog2-server/src/main/java/org/graylog2/cluster/NodePreflightConfig.java
+++ b/graylog2-server/src/main/java/org/graylog2/cluster/NodePreflightConfig.java
@@ -36,6 +36,7 @@ public abstract class  NodePreflightConfig {
         CONFIGURED, // the DataNode has been configured by the Preflight UI
         CSR, // DataNode created the CSR
         SIGNED, // Graylog CA signed the CSR
+        STORED, // Certificate is combined with private key and stored in Mongo
         CONNECTED, // DataNode started with the certificate
         ERROR // sh*t happened
     }

--- a/graylog2-server/src/main/java/org/graylog2/cluster/NodePreflightConfigService.java
+++ b/graylog2-server/src/main/java/org/graylog2/cluster/NodePreflightConfigService.java
@@ -29,6 +29,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
+import java.util.Optional;
 
 import static org.graylog2.cluster.NodePreflightConfig.FIELD_CERTIFICATE;
 import static org.graylog2.cluster.NodePreflightConfig.FIELD_CSR;
@@ -86,6 +87,29 @@ public class NodePreflightConfigService extends PaginatedDbService<NodePreflight
                 false);
 
         return result.getN() > 0;
+    }
+
+    public Optional<String> readCert(final String nodeId) {
+        final NodePreflightConfig config = dbCollection.findOne(
+                DBQuery.is(FIELD_NODEID, nodeId)
+        );
+        if (config != null) {
+            return Optional.ofNullable(config.certificate());
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    public boolean changeState(final String nodeId, final NodePreflightConfig.State state) {
+        final WriteResult<NodePreflightConfig, String> result = dbCollection.update(
+                DBQuery.is(FIELD_NODEID, nodeId),
+                new DBUpdate.Builder()
+                        .set(FIELD_STATE, state),
+                false,
+                false);
+
+        return result.getN() > 0;
+
     }
 
     public void deleteAll() {

--- a/graylog2-server/src/main/java/org/graylog2/cluster/certificates/CertificatesService.java
+++ b/graylog2-server/src/main/java/org/graylog2/cluster/certificates/CertificatesService.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.cluster.certificates;
+
+import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
+import org.graylog2.database.MongoConnection;
+import org.graylog2.database.PaginatedDbService;
+import org.graylog2.database.indices.MongoDbIndexTools;
+import org.graylog2.security.encryption.EncryptedValue;
+import org.graylog2.security.encryption.EncryptedValueService;
+import org.mongojack.DBQuery;
+import org.mongojack.DBUpdate;
+import org.mongojack.JacksonDBCollection;
+import org.mongojack.WriteResult;
+
+import javax.inject.Inject;
+import java.util.Optional;
+
+import static org.graylog2.cluster.certificates.NodeCertificate.FIELD_ENCR_CERTIFICATE;
+import static org.graylog2.cluster.certificates.NodeCertificate.FIELD_NODEID;
+
+
+public class CertificatesService extends PaginatedDbService<NodeCertificate> {
+    public static final String COLLECTION_NAME = "data_node_certificates";
+
+    private final JacksonDBCollection<NodeCertificate, String> dbCollection;
+    private final EncryptedValueService encryptionService;
+
+    @Inject
+    public CertificatesService(final MongoJackObjectMapperProvider mongoJackObjectMapperProvider,
+                               final MongoConnection mongoConnection,
+                               final EncryptedValueService encryptionService) {
+        super(mongoConnection, mongoJackObjectMapperProvider, NodeCertificate.class, COLLECTION_NAME);
+        this.dbCollection = JacksonDBCollection.wrap(mongoConnection.getDatabase().getCollection(COLLECTION_NAME), NodeCertificate.class, String.class, mongoJackObjectMapperProvider.get());
+        new MongoDbIndexTools(db).createUniqueIndex(FIELD_NODEID);
+        this.encryptionService = encryptionService;
+
+    }
+
+    public boolean writeCert(final String nodeId,
+                             final String cert) {
+        final EncryptedValue encrypted = encryptionService.encrypt(cert);
+        final WriteResult<NodeCertificate, String> result = dbCollection.update(
+                DBQuery.is(FIELD_NODEID, nodeId),
+                DBUpdate
+                        .set(FIELD_NODEID, nodeId)
+                        .set(FIELD_ENCR_CERTIFICATE, encrypted),
+                true,
+                false
+        );
+        return result.getN() > 0;
+    }
+
+    public Optional<String> readCert(final String nodeId) {
+        final NodeCertificate nod = dbCollection.findOneById(nodeId);
+        if (nod != null && nod.encryptedCertificate() != null) {
+            return Optional.ofNullable(encryptionService.decrypt(nod.encryptedCertificate()));
+        } else {
+            return Optional.empty();
+        }
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/cluster/certificates/NodeCertificate.java
+++ b/graylog2-server/src/main/java/org/graylog2/cluster/certificates/NodeCertificate.java
@@ -14,18 +14,15 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-package org.graylog.security.certutil.csr.storage;
+package org.graylog2.cluster.certificates;
 
-import org.bouncycastle.operator.OperatorException;
-import org.bouncycastle.pkcs.PKCS10CertificationRequest;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.graylog2.security.encryption.EncryptedValue;
 
-import java.io.IOException;
+public record NodeCertificate(@JsonProperty(FIELD_NODEID) String nodeId,
+                              @JsonProperty(FIELD_ENCR_CERTIFICATE) EncryptedValue encryptedCertificate) {
 
-public interface CsrStorage {
+    public static final String FIELD_NODEID = "node_id";
+    public static final String FIELD_ENCR_CERTIFICATE = "encrypted_certificate_keystore";
 
-    void writeCsr(PKCS10CertificationRequest csr)
-            throws IOException, OperatorException;
-
-    PKCS10CertificationRequest readCsr()
-            throws IOException, OperatorException;
 }

--- a/graylog2-server/src/test/java/org/graylog/security/certutil/csr/storage/CsrFileStorageTest.java
+++ b/graylog2-server/src/test/java/org/graylog/security/certutil/csr/storage/CsrFileStorageTest.java
@@ -14,41 +14,24 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-package org.graylog.security.certutil.csr;
+package org.graylog.security.certutil.csr.storage;
 
-import org.bouncycastle.operator.ContentSigner;
-import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
 import org.bouncycastle.pkcs.PKCS10CertificationRequest;
-import org.bouncycastle.pkcs.PKCS10CertificationRequestBuilder;
-import org.bouncycastle.pkcs.jcajce.JcaPKCS10CertificationRequestBuilder;
-import org.graylog.security.certutil.csr.storage.CsrFileStorage;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-import javax.security.auth.x500.X500Principal;
 import java.nio.file.Path;
-import java.security.KeyPairGenerator;
 
-import static org.graylog.security.certutil.CertConstants.KEY_GENERATION_ALGORITHM;
-import static org.graylog.security.certutil.CertConstants.SIGNING_ALGORITHM;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class CsrFileStorageTest {
 
     @Test
     void testCsrStorageSaveAndRetrieve(@TempDir Path tmpDir) throws Exception {
-        KeyPairGenerator keyGen = KeyPairGenerator.getInstance(KEY_GENERATION_ALGORITHM);
-        java.security.KeyPair certKeyPair = keyGen.generateKeyPair();
-        PKCS10CertificationRequestBuilder p10Builder = new JcaPKCS10CertificationRequestBuilder(
-                new X500Principal("CN=localhost"), certKeyPair.getPublic());
-        JcaContentSignerBuilder csBuilder = new JcaContentSignerBuilder(SIGNING_ALGORITHM);
-        ContentSigner signer = csBuilder.build(certKeyPair.getPrivate());
-        PKCS10CertificationRequest csr = p10Builder.build(signer);
-
+        final PKCS10CertificationRequest csr = CsrTestTools.getCsrForTests();
         CsrFileStorage csrFileStorage = new CsrFileStorage(tmpDir.resolve("test.csr").toString());
         csrFileStorage.writeCsr(csr);
         final PKCS10CertificationRequest readCsr = csrFileStorage.readCsr();
-
         assertEquals(csr, readCsr);
     }
 

--- a/graylog2-server/src/test/java/org/graylog/security/certutil/csr/storage/CsrTestTools.java
+++ b/graylog2-server/src/test/java/org/graylog/security/certutil/csr/storage/CsrTestTools.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.security.certutil.csr.storage;
+
+import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.OperatorCreationException;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+import org.bouncycastle.pkcs.PKCS10CertificationRequest;
+import org.bouncycastle.pkcs.PKCS10CertificationRequestBuilder;
+import org.bouncycastle.pkcs.jcajce.JcaPKCS10CertificationRequestBuilder;
+
+import javax.security.auth.x500.X500Principal;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+
+import static org.graylog.security.certutil.CertConstants.KEY_GENERATION_ALGORITHM;
+import static org.graylog.security.certutil.CertConstants.SIGNING_ALGORITHM;
+
+public interface CsrTestTools {
+
+    static PKCS10CertificationRequest getCsrForTests() throws NoSuchAlgorithmException, OperatorCreationException {
+        KeyPairGenerator keyGen = KeyPairGenerator.getInstance(KEY_GENERATION_ALGORITHM);
+        java.security.KeyPair certKeyPair = keyGen.generateKeyPair();
+        PKCS10CertificationRequestBuilder p10Builder = new JcaPKCS10CertificationRequestBuilder(
+                new X500Principal("CN=localhost"), certKeyPair.getPublic());
+        JcaContentSignerBuilder csBuilder = new JcaContentSignerBuilder(SIGNING_ALGORITHM);
+        ContentSigner signer = csBuilder.build(certKeyPair.getPrivate());
+        return p10Builder.build(signer);
+    }
+}


### PR DESCRIPTION
## Description
PKCS12 keystore file, with certificate and password, is stored in Mongo.
It is protected with keystore password and additionally encrypted. Significant part of the communication between data-node and GL server, related to certificates, works as expected in main scenario.

/nocl

## Motivation and Context
Provide more building blocks to reach "happy path" implementation.

## How Has This Been Tested?
Only manually.

## Screenshots (if appropriate):

![Screenshot 2023-05-18 at 14-53-07 data_node_certificates - Mongo Express](https://github.com/Graylog2/graylog2-server/assets/100699120/8252d84e-ed25-4cb9-adb3-6b27d1cae2ad)
![Screenshot 2023-05-18 at 14-53-18 node_preflight_config - Mongo Express](https://github.com/Graylog2/graylog2-server/assets/100699120/93941921-1d87-421c-98d0-bb130a0cb9be)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

