### PR TITLE
Add vendor_subtype GIM schema field

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/schema/VendorFields.java
+++ b/graylog2-server/src/main/java/org/graylog/schema/VendorFields.java
@@ -32,6 +32,7 @@ public class VendorFields {
     public static final String VENDOR_PUBLIC_IP = "vendor_public_ip";
     public static final String VENDOR_PUBLIC_IPV6 = "vendor_public_ipv6";
     public static final String VENDOR_SIGNIN_PROTOCOL = "vendor_signin_protocol";
+    public static final String VENDOR_SUBTYPE = "vendor_subtype";
     public static final String VENDOR_THREAT_SUSPECTED = "vendor_threat_suspected";
     public static final String VENDOR_TRANSACTION_ID = "vendor_transaction_id";
     public static final String VENDOR_TRANSACTION_TYPE = "vendor_transaction_type";


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add vendor_subtype GIM schema field constant.

/nocl

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Allows common constant to be used in https://github.com/Graylog2/graylog-plugin-enterprise-integrations/pull/1058

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
N/A