### PR TITLE
Properly prefix frontend route path if custom path suffix is configured.

### DIFF
--- a/changelog/unreleased/issue-15536.toml
+++ b/changelog/unreleased/issue-15536.toml
@@ -1,0 +1,6 @@
+type = "fixed"
+message = "Properly prefix frontend paths to prevent error when custom app path suffix is used."
+
+issues = ["15536"]
+pulls = ["15540"]
+

--- a/graylog2-web-interface/src/routing/AppRouter.tsx
+++ b/graylog2-web-interface/src/routing/AppRouter.tsx
@@ -155,7 +155,7 @@ const AppRouter = () => {
         ...pluginRoutesWithParent,
         ...pluginRoutesWithAppParent,
         {
-          path: '/',
+          path: `${AppConfig.gl2AppPathPrefix()}/`,
           element: <PageContentLayout />,
           children: [
             { path: RoutePaths.message_show(':index', ':messageId'), element: <ShowMessagePage /> },


### PR DESCRIPTION
**Note:** This needs a backport to `5.1`.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

While migrating to `react-router` v6, a programmatic error sneaked in that prevents the root path to be properly suffixed if the user configures a custom path suffix (either through the config file or an HTTP header).

This PR is now making sure that the router's root path is also suffixed with the custom path, preventing the error to show up.

Fixes #15536.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.