### PR TITLE
Use grid-based gap detection for placeholder creation.

### DIFF
--- a/changelog/unreleased/pr-15545.toml
+++ b/changelog/unreleased/pr-15545.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Improve widget placement for specific widget sizes/positions."
+
+pulls = ["15545"]
+issues = ["15308", "15538"]

--- a/graylog2-web-interface/src/views/components/GridGaps.test.ts
+++ b/graylog2-web-interface/src/views/components/GridGaps.test.ts
@@ -424,4 +424,74 @@ describe('GridGaps', () => {
       },
     }]);
   });
+
+  it('does not generate invalid gaps', () => {
+    const items = [
+      {
+        start: {
+          x: 1,
+          y: 1,
+        },
+        end: {
+          x: 5,
+          y: 3,
+        },
+      },
+      {
+        start: {
+          x: 5,
+          y: 1,
+        },
+        end: {
+          x: 9,
+          y: 7,
+        },
+      },
+      {
+        start: {
+          x: 1,
+          y: 3,
+        },
+        end: {
+          x: 5,
+          y: 6,
+        },
+      },
+      {
+        start: {
+          x: 1,
+          y: 6,
+        },
+        end: {
+          x: 4,
+          y: 9,
+        },
+      },
+    ];
+
+    const result = findGaps(items);
+
+    expect(result).toEqual([
+      {
+        end: {
+          x: 13,
+          y: 7,
+        },
+        start: {
+          x: 9,
+          y: 1,
+        },
+      },
+      {
+        end: {
+          x: 13,
+          y: 9,
+        },
+        start: {
+          x: 4,
+          y: 7,
+        },
+      },
+    ]);
+  });
 });

--- a/graylog2-web-interface/src/views/components/GridGaps.test.ts
+++ b/graylog2-web-interface/src/views/components/GridGaps.test.ts
@@ -496,7 +496,9 @@ describe('GridGaps', () => {
 
     const result = findGaps(items);
 
-    expect(result).toEqual([
+    expect(result).toHaveLength(2);
+
+    expect(result).toEqual(expect.arrayContaining([
       {
         end: {
           x: 13,
@@ -517,6 +519,6 @@ describe('GridGaps', () => {
           y: 7,
         },
       },
-    ].map(convertItem));
+    ].map(convertItem)));
   });
 });

--- a/graylog2-web-interface/src/views/components/GridGaps.test.ts
+++ b/graylog2-web-interface/src/views/components/GridGaps.test.ts
@@ -16,6 +16,30 @@
  */
 import findGaps from './GridGaps';
 
+type Item = {
+  start: {
+    x: number,
+    y: number,
+  },
+  end: {
+    x: number,
+    y: number
+  }
+};
+
+type Position = {
+  col: number,
+  row: number,
+  width: number,
+  height: number,
+};
+const convertItem = (item: Item): Position => ({
+  col: item.start.x,
+  row: item.start.y,
+  width: item.end.x - item.start.x,
+  height: item.end.y - item.start.y,
+});
+
 describe('GridGaps', () => {
   it('finds single gap between two items', () => {
     const items = [
@@ -27,12 +51,12 @@ describe('GridGaps', () => {
         start: { x: 3, y: 0 },
         end: { x: 4, y: 1 },
       },
-    ];
+    ].map(convertItem);
 
-    expect(findGaps(items)).toContainEqual({
+    expect(findGaps(items)).toContainEqual(convertItem({
       start: { x: 1, y: 0 },
       end: { x: 3, y: 1 },
-    });
+    }));
   });
 
   it('does not find gaps for two items below each other occupying max width', () => {
@@ -45,7 +69,7 @@ describe('GridGaps', () => {
         start: { x: 1, y: 3 },
         end: { x: Infinity, y: 10 },
       },
-    ];
+    ].map(convertItem);
 
     expect(findGaps(items)).toEqual([]);
   });
@@ -82,9 +106,9 @@ describe('GridGaps', () => {
           y: 11,
         },
       },
-    ];
+    ].map(convertItem);
 
-    expect(findGaps(items)).toContainEqual(
+    expect(findGaps(items)).toContainEqual(convertItem(
       {
         start: {
           x: 4,
@@ -94,7 +118,8 @@ describe('GridGaps', () => {
           x: 7,
           y: 5,
         },
-      });
+      },
+    ));
   });
 
   it('finds initial gap', () => {
@@ -103,12 +128,12 @@ describe('GridGaps', () => {
         start: { x: 3, y: 1 },
         end: { x: 12, y: 2 },
       },
-    ];
+    ].map(convertItem);
 
-    expect(findGaps(items)).toContainEqual({
+    expect(findGaps(items)).toContainEqual(convertItem({
       start: { x: 1, y: 1 },
       end: { x: 3, y: 2 },
-    });
+    }));
   });
 
   it('calculates initial gap correctly', () => {
@@ -133,12 +158,12 @@ describe('GridGaps', () => {
           y: 11,
         },
       },
-    ];
+    ].map(convertItem);
 
     expect(findGaps(items)).toEqual([{
       start: { x: 1, y: 1 },
       end: { x: 5, y: 5 },
-    }]);
+    }].map(convertItem));
   });
 
   describe('calculates overlapping gaps correctly', () => {
@@ -163,12 +188,12 @@ describe('GridGaps', () => {
           y: 10,
         },
       },
-    ];
+    ].map(convertItem);
 
     it('leading gaps', () => {
       const result = findGaps(items);
 
-      expect(result).toContainEqual({
+      expect(result).toContainEqual(convertItem({
         start: {
           x: 1,
           y: 2,
@@ -177,9 +202,9 @@ describe('GridGaps', () => {
           x: 5,
           y: 6,
         },
-      });
+      }));
 
-      expect(result).toContainEqual({
+      expect(result).toContainEqual(convertItem({
         start: {
           x: 1,
           y: 6,
@@ -188,13 +213,13 @@ describe('GridGaps', () => {
           x: 4,
           y: 10,
         },
-      });
+      }));
     });
 
     it('trailing gaps', () => {
       const result = findGaps(items);
 
-      expect(result).toContainEqual({
+      expect(result).toContainEqual(convertItem({
         start: {
           x: 9,
           y: 2,
@@ -203,9 +228,9 @@ describe('GridGaps', () => {
           x: 13,
           y: 6,
         },
-      });
+      }));
 
-      expect(result).toContainEqual({
+      expect(result).toContainEqual(convertItem({
         start: {
           x: 8,
           y: 6,
@@ -214,7 +239,7 @@ describe('GridGaps', () => {
           x: 13,
           y: 10,
         },
-      });
+      }));
     });
   });
 
@@ -250,12 +275,12 @@ describe('GridGaps', () => {
           y: 7,
         },
       },
-    ];
+    ].map(convertItem);
 
     expect(findGaps(items)).toEqual([{
       start: { x: 4, y: 1 },
       end: { x: 7, y: 7 },
-    }]);
+    }].map(convertItem));
   });
 
   it('avoid occupying empty row(s)', () => {
@@ -280,12 +305,12 @@ describe('GridGaps', () => {
           y: 15,
         },
       },
-    ];
+    ].map(convertItem);
 
     expect(findGaps(items)).toEqual([{
       start: { x: 4, y: 1 },
       end: { x: 13, y: 4 },
-    }]);
+    }].map(convertItem));
   });
 
   it('should not generate gaps for overlapping widgets', () => {
@@ -310,7 +335,7 @@ describe('GridGaps', () => {
           y: 3,
         },
       },
-    ];
+    ].map(convertItem);
 
     expect(findGaps(items)).toEqual([]);
   });
@@ -347,7 +372,7 @@ describe('GridGaps', () => {
         y: 11,
       },
     },
-    ];
+    ].map(convertItem);
 
     expect(findGaps(items)).toEqual([{
       start: {
@@ -367,7 +392,7 @@ describe('GridGaps', () => {
         x: 5,
         y: 11,
       },
-    }]);
+    }].map(convertItem));
   });
 
   it('should not overlap final placeholders with other widgets', () => {
@@ -402,7 +427,7 @@ describe('GridGaps', () => {
           y: 11,
         },
       },
-    ];
+    ].map(convertItem);
 
     expect(findGaps(items)).toEqual([{
       start: {
@@ -422,7 +447,7 @@ describe('GridGaps', () => {
         x: 13,
         y: 11,
       },
-    }]);
+    }].map(convertItem));
   });
 
   it('does not generate invalid gaps', () => {
@@ -467,7 +492,7 @@ describe('GridGaps', () => {
           y: 9,
         },
       },
-    ];
+    ].map(convertItem);
 
     const result = findGaps(items);
 
@@ -492,6 +517,6 @@ describe('GridGaps', () => {
           y: 7,
         },
       },
-    ]);
+    ].map(convertItem));
   });
 });

--- a/graylog2-web-interface/src/views/components/GridGaps.ts
+++ b/graylog2-web-interface/src/views/components/GridGaps.ts
@@ -111,11 +111,7 @@ const findGaps = (_items: Position[], minWidth: number = 1, maxWidth: number = 1
 
   for (let x = minWidth; x < maxWidth - 1; x++) {
     for (let y = minY; y <= maxY; y++) {
-      if (rowIsEmpty(grid, y)) {
-        continue;
-      }
-
-      if (grid[y]?.[x] === undefined) {
+      if (!rowIsEmpty(grid, y) && grid[y]?.[x] === undefined) {
         const gap = { col: x, row: y, height: 1, width: 1 };
 
         while (gap.col + gap.width < maxWidth && grid[y]?.[gap.col + gap.width] === undefined) {

--- a/graylog2-web-interface/src/views/components/GridGaps.ts
+++ b/graylog2-web-interface/src/views/components/GridGaps.ts
@@ -47,22 +47,6 @@ const placeItemInGrid = <T extends boolean | string | number>(grid: Grid<T>, ite
   return overlap;
 };
 
-const drawGrid = (items: Position[]) => {
-  const grid = [];
-
-  items.forEach((item, idx) => placeItemInGrid(grid, item, String(idx), 'X'));
-
-  const plot = [];
-
-  for (let x = 0; x < 12; x++) {
-    for (let y = 0; y < grid.length; y++) {
-      (plot[y] ??= [])[x] = grid[y]?.[x] ?? '.';
-    }
-  }
-
-  return plot.map((row) => row.join('')).join('\n');
-};
-
 const itemsOverlap = (items: Position[]) => {
   if (items.length === 0) {
     return false;
@@ -95,7 +79,6 @@ const findGaps = (_items: Position[], minWidth: number = 1, maxWidth: number = 1
   }
 
   const items = _items.map((item) => normalizeInfinity(item, maxWidth));
-  console.log(drawGrid(items));
   const minY = Math.min(...items.map(({ row }) => row));
   const maxY = Math.max(...items.map(({ row, height }) => row + height - 1));
 

--- a/graylog2-web-interface/src/views/components/GridGaps.ts
+++ b/graylog2-web-interface/src/views/components/GridGaps.ts
@@ -118,17 +118,19 @@ const findGaps = (_items: Position[], minWidth: number = 1, maxWidth: number = 1
           gap.width += 1;
         }
 
-        while (gap.row + gap.height <= maxY) {
-          if (range(gap.col, gap.col + gap.width - 1).every((k) => !grid[gap.row + gap.height]?.[k])) {
-            gap.height += 1;
-          } else {
-            break;
+        if (gap.width > 1) {
+          while (!rowIsEmpty(grid, gap.row + gap.height) && gap.row + gap.height <= maxY) {
+            if (range(gap.col, gap.col + gap.width - 1).every((k) => !grid[gap.row + gap.height]?.[k])) {
+              gap.height += 1;
+            } else {
+              break;
+            }
           }
+
+          placeItemInGrid(grid, gap, true);
+
+          gaps.push(gap);
         }
-
-        placeItemInGrid(grid, gap, true);
-
-        gaps.push(gap);
       }
     }
   }

--- a/graylog2-web-interface/src/views/components/GridGaps.ts
+++ b/graylog2-web-interface/src/views/components/GridGaps.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-plusplus */
 /*
  * Copyright (C) 2020 Graylog, Inc.
  *
@@ -16,144 +17,127 @@
  */
 import uniq from 'lodash/uniq';
 
-type Item = {
-  start: { x: number, y: number },
-  end: { x: number, y: number },
-};
-
 const range = (start: number, end: number): Array<number> => [
   ...Array((end + 1) - start).keys(),
 ].map((i) => i + start);
 
-const itemsInRow = (items: Item[], row: number): Item[] => items.filter(({ start, end }) => start.y <= row && end.y > row);
+const normalizeInfinity = ({ width, height, col, row }: Position, maxWidth: number): Position => ({
+  col,
+  row,
+  height,
+  width: Number.isFinite(width) ? width : maxWidth,
+});
 
-function isRightToItem(item: Item, i: Item) {
-  return item.start.x <= i.start.x;
-}
+type Grid<T> = Array<Array<T>>;
 
-const sortByStartXAsc = (item1: Item, item2: Item) => item1.start.x - item2.start.x;
+const placeItemInGrid = <T extends boolean | string | number>(grid: Grid<T>, item: Position, value: T, overlapValue: T = value) => {
+  let overlap = false;
 
-const neighborsToRight = (item: Item, rowItems: { [row: string]: Item[] }) => {
-  const rows = range(item.start.y, item.end.y - 1);
-  const neighbors = rows.flatMap((row) => rowItems[row].filter((i) => i !== item).filter((i) => isRightToItem(item, i)).sort(sortByStartXAsc)[0])
-    .filter((i) => i !== undefined);
+  range(item.col, item.col + item.width - 1).forEach((x) => {
+    range(item.row, item.row + item.height - 1).forEach((y) => {
+      if (grid[y]?.[x] !== undefined) {
+        overlap = true;
+      }
 
-  return uniq(neighbors);
+      // eslint-disable-next-line no-param-reassign
+      (grid[y] ??= [])[x] = (grid[y]?.[x] !== undefined) ? overlapValue : value;
+    });
+  });
+
+  return overlap;
 };
 
-const gapBetween = (item: Item, neighbor: Item): Item => ({
-  start: { x: item.end.x, y: Math.min(item.start.y, neighbor.start.y) },
-  end: { x: neighbor.start.x, y: Math.min(item.end.y, neighbor.end.y) },
-});
+const drawGrid = (items: Position[]) => {
+  const grid = [];
 
-const normalizeInfinity = ({ start, end }: Item, maxWidth: number): Item => ({
-  start,
-  end: {
-    x: Number.isFinite(end.x) ? end.x : maxWidth,
-    y: end.y,
-  },
-});
+  items.forEach((item, idx) => placeItemInGrid(grid, item, String(idx), 'X'));
 
-type RowItems = { [row: string]: Item[] };
+  const plot = [];
 
-const findInitialGaps = (rows: Array<number>, rowItems: RowItems, minWidth: number) => rows
-  .filter((row) => rowItems[row].length > 0)
-  .map((row) => [row, Math.min(...rowItems[row].map((item) => item.start.x))])
-  .filter(([, startX]) => startX > minWidth)
-  .reduce((gaps, [row, startX]) => {
-    if (gaps.length === 0) {
-      return [{ start: { x: minWidth, y: row }, end: { x: startX, y: row + 1 } }] as Item[];
+  for (let x = 0; x < 12; x++) {
+    for (let y = 0; y < grid.length; y++) {
+      (plot[y] ??= [])[x] = grid[y]?.[x] ?? '.';
     }
+  }
 
-    const [gap, ...rest] = gaps.reverse();
+  return plot.map((row) => row.join('')).join('\n');
+};
 
-    if (gap.end.x !== startX || gap.end.y < row) {
-      return [...rest, gap, { start: { x: minWidth, y: row }, end: { x: startX, y: row + 1 } }];
-    }
-
-    return [...rest, { start: gap.start, end: { x: startX, y: row + 1 } }];
-  }, [] as Item[]);
-
-const findFinalGaps = (rows: Array<number>, rowItems: RowItems, maxWidth: number) => rows
-  .filter((row) => rowItems[row].length > 0)
-  .map((row) => [row, Math.max(...rowItems[row].map((item) => item.end.x))])
-  .filter(([, endX]) => endX < maxWidth)
-  .reduce((gaps, [row, endX]) => {
-    if (gaps.length === 0) {
-      return [{ start: { x: endX, y: row }, end: { x: maxWidth, y: row + 1 } }] as Item[];
-    }
-
-    const [gap, ...rest] = gaps.reverse();
-
-    if (gap.start.x !== endX || gap.end.y < row) {
-      return [...rest, gap, { start: { x: endX, y: row }, end: { x: maxWidth, y: row + 1 } }];
-    }
-
-    return [...rest, { start: gap.start, end: { x: maxWidth, y: row + 1 } }];
-  }, [] as Item[]);
-
-const itemsOverlap = (items: Item[]) => {
+const itemsOverlap = (items: Position[]) => {
   if (items.length === 0) {
     return false;
   }
 
-  const minY = Math.min(...items.map(({ start: { y } }) => y));
-  const maxY = Math.max(...items.map(({ end: { y } }) => y - 1));
-
-  const spaces = [];
-
-  for (let row = minY; row <= maxY; row += 1) {
-    spaces[row] = [];
-  }
+  const grid = [];
 
   // eslint-disable-next-line no-restricted-syntax
   for (const item of items) {
-    const { start, end } = item;
-
-    for (let { x } = start; x < end.x; x += 1) {
-      for (let { y } = start; y < end.y; y += 1) {
-        if (spaces[y][x] !== undefined) {
-          return true;
-        }
-
-        spaces[y][x] = true;
-      }
+    if (placeItemInGrid(grid, item, true)) {
+      return true;
     }
   }
 
   return false;
 };
 
-const findGaps = (_items: Item[], minWidth: number = 1, maxWidth: number = 13): Item[] => {
+type Position = {
+  col: number,
+  row: number,
+  height: number,
+  width: number,
+};
+
+const rowIsEmpty = <T extends boolean | string | number>(grid: Grid<T>, row: number) => (grid[row] ?? []).every((cell) => cell === undefined);
+
+const findGaps = (_items: Position[], minWidth: number = 1, maxWidth: number = 13): Position[] => {
   if (_items.length === 0) {
     return [];
   }
 
   const items = _items.map((item) => normalizeInfinity(item, maxWidth));
+  console.log(drawGrid(items));
+  const minY = Math.min(...items.map(({ row }) => row));
+  const maxY = Math.max(...items.map(({ row, height }) => row + height - 1));
 
   if (itemsOverlap(items)) {
     return [];
   }
 
-  const minY = Math.min(...items.map(({ start: { y } }) => y));
-  const maxY = Math.max(...items.map(({ end: { y } }) => y - 1));
+  const grid = [];
 
-  const rows = range(minY, maxY);
+  items.forEach((item) => placeItemInGrid(grid, item, true));
 
-  const rowItems = Object.fromEntries(rows.map((row) => [row, itemsInRow(items, row)]));
+  const gaps = [];
 
-  const initialGaps = findInitialGaps(rows, rowItems, minWidth);
+  for (let x = minWidth; x < maxWidth - 1; x++) {
+    for (let y = minY; y <= maxY; y++) {
+      if (rowIsEmpty(grid, y)) {
+        continue;
+      }
 
-  const finalGaps = findFinalGaps(rows, rowItems, maxWidth);
+      if (grid[y]?.[x] === undefined) {
+        const gap = { col: x, row: y, height: 1, width: 1 };
 
-  const gaps = items.flatMap((item) => {
-    const neighbors = neighborsToRight(item, rowItems);
+        while (gap.col + gap.width < maxWidth && grid[y]?.[gap.col + gap.width] === undefined) {
+          gap.width += 1;
+        }
 
-    return neighbors.filter((neighbor) => neighbor.start.x > item.end.x)
-      .map((neighbor) => gapBetween(item, neighbor));
-  });
+        while (gap.row + gap.height <= maxY) {
+          if (range(gap.col, gap.col + gap.width - 1).every((k) => !grid[gap.row + gap.height]?.[k])) {
+            gap.height += 1;
+          } else {
+            break;
+          }
+        }
 
-  return uniq([...gaps, ...initialGaps, ...finalGaps]);
+        placeItemInGrid(grid, gap, true);
+
+        gaps.push(gap);
+      }
+    }
+  }
+
+  return uniq(gaps);
 };
 
 export default findGaps;

--- a/graylog2-web-interface/src/views/components/WidgetGrid.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetGrid.tsx
@@ -174,20 +174,18 @@ const _onSyncLayout = (positions: WidgetPositions, newPositions: Array<BackendWi
 };
 
 const renderGaps = (widgets: Widget[], positions: WidgetPositions) => {
-  const items = widgets.map((widget) => positions[widget.id])
-    .filter((position) => !!position)
-    .map((p) => ({ start: { x: p.col, y: p.row }, end: { x: p.col + p.width, y: p.row + p.height } }));
-  const gaps = findGaps(items);
+  const gaps = findGaps(widgets.map((widget) => positions[widget.id]));
   const _positions = { ...positions };
 
   const gapsItems = gaps.map((gap) => {
     const id = `gap-${generateId()}`;
 
+    const { col, row, height, width } = gap;
     const gapPosition = WidgetPosition.builder()
-      .col(gap.start.x)
-      .row(gap.start.y)
-      .height(gap.end.y - gap.start.y)
-      .width(gap.end.x - gap.start.x)
+      .col(col)
+      .row(row)
+      .height(height)
+      .width(width)
       .build();
 
     _positions[id] = gapPosition;


### PR DESCRIPTION
**Note:** This requires a backport to `5.1`.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is implementing a different approach for detecting gaps in the widget grid in order to create placeholders for inline widget creation.

Instead of detecting leading, trailing and intermediate gaps by comparing widgets to the boundaries of the grid and itself, it fills a m x n grid with markers for existing widgets. After that, it tries to fill rectangles of the biggest possible size in the unfilled spaces. It avoids creating placeholders for rectangles with a width lower than 2, as well as skipping empty rows between widgets.

This is supposed to avoid placement problems that we have seen in #15308 & #15538.

Fixes #15308.
Fixes #15538.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.