### PR TITLE
DataNode: Print warning if keystore file does not exist

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/bootstrap/preflight/GraylogPreflightGeneratePeriodical.java
+++ b/graylog2-server/src/main/java/org/graylog2/bootstrap/preflight/GraylogPreflightGeneratePeriodical.java
@@ -30,6 +30,7 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
@@ -65,6 +66,11 @@ public class GraylogPreflightGeneratePeriodical extends Periodical {
     public void doRun() {
         LOG.debug("checking if there are configuration steps to take care of");
         final Path caKeystorePath = Path.of(caKeystoreFilename);
+
+        if(!Files.exists(caKeystorePath)) {
+            LOG.warn("mandatory keystore file does not exist.");
+            return;
+        }
 
         try {
             char[] password = DEFAULT_PASSWORD.toCharArray();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The periodical that checks for work on the Graylog Server side throws an exception if there is no ca-file. A warning makes more sense for now. It's only preliminary anyway and solved differently with #15546


/nocl

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

