### PR TITLE
Fix small typo

### DIFF
--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -130,7 +130,7 @@ plugin_dir = plugin
 #
 # When using Graylog Collector, this URI will be used to receive heartbeat messages and must be accessible for all collectors.
 #
-# This setting can be overriden on a per-request basis with the "X-Graylog-Server-URL" HTTP request header.
+# This setting can be overridden on a per-request basis with the "X-Graylog-Server-URL" HTTP request header.
 #
 # Default: $http_publish_uri
 #http_external_uri =


### PR DESCRIPTION
Fix small typo in graylog.conf file.

/nocl