### PR TITLE
Fix NodeService#allActive behaviour (return only nodes of the correct…

### DIFF
--- a/changelog/unreleased/pr-15565.toml
+++ b/changelog/unreleased/pr-15565.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "NodeService#allActive returns only nodes of correct type based on current server type"
+
+pulls = ["15505"]
+

--- a/graylog2-server/src/main/java/org/graylog2/cluster/NodeServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/cluster/NodeServiceImpl.java
@@ -122,13 +122,7 @@ public class NodeServiceImpl extends PersistedServiceImpl implements NodeService
     @Deprecated
     @Override
     public Map<String, Node> allActive() {
-        Map<String, Node> nodes = Maps.newHashMap();
-
-        for (Node.Type type : Node.Type.values()) {
-            nodes.putAll(allActive(type));
-        }
-
-        return nodes;
+        return allActive(type());
     }
 
     private List<? extends DBObject> recentHeartbeat(List<? extends Map<String, Object>> additionalMatches) {


### PR DESCRIPTION
The allActive call returned originally all active nodes. But now datanodes are also registered in this service and may be also set as leader. This could cause problems in calls that expect only SERVER type of nodes. 

This PR adapts the behaviour of the allActive method, returning only nodes of the same type as the current server instance (server for graylog-server, datanode for datanodes).

## Motivation and Context
Fixes integration tests randomly failing due to random order of nodes and inclusion of the datanode.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

