### PR TITLE
Apply previous row/column limits to pivots when installing from content pack. (`5.1`)

### DIFF
--- a/changelog/unreleased/issue-15509.toml
+++ b/changelog/unreleased/issue-15509.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Apply pivot limits correctly when installing saved searches/dashboard from pre-5.1 content packs."
+
+issues = ["15509"]
+pulls = ["15523"]

--- a/changelog/unreleased/issue-15509.toml
+++ b/changelog/unreleased/issue-15509.toml
@@ -2,4 +2,4 @@ type = "fixed"
 message = "Apply pivot limits correctly when installing saved searches/dashboard from pre-5.1 content packs."
 
 issues = ["15509"]
-pulls = ["15523"]
+pulls = ["15582"]

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/buckets/Values.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/buckets/Values.java
@@ -17,8 +17,6 @@
 package org.graylog.plugins.views.search.searchtypes.pivot.buckets;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -27,7 +25,6 @@ import com.google.auto.value.AutoValue;
 import org.graylog.plugins.views.search.searchtypes.pivot.BucketSpec;
 import org.graylog.plugins.views.search.searchtypes.pivot.TypedBuilder;
 
-import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.List;
 
@@ -53,6 +50,12 @@ public abstract class Values implements BucketSpec {
                 .type(NAME)
                 .limit(DEFAULT_LIMIT);
     }
+
+    public Values withLimit(int limit) {
+        return toBuilder().limit(limit).build();
+    }
+
+    abstract Builder toBuilder();
 
     @AutoValue.Builder
     @JsonPOJOBuilder(withPrefix = "")

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/widgets/aggregation/PivotDTO.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/widgets/aggregation/PivotDTO.java
@@ -25,7 +25,6 @@ import org.graylog.autovalue.WithBeanGetter;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.OptionalInt;
 
 @AutoValue
 @JsonDeserialize(builder = PivotDTO.Builder.class)
@@ -44,6 +43,12 @@ public abstract class PivotDTO {
 
     @JsonProperty(FIELD_CONFIG)
     public abstract PivotConfigDTO config();
+
+    abstract Builder toBuilder();
+
+    public PivotDTO withConfig(PivotConfigDTO config) {
+        return toBuilder().config(config).build();
+    }
 
     @AutoValue.Builder
     public static abstract class Builder {

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/widgets/aggregation/ValueConfigDTO.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/widgets/aggregation/ValueConfigDTO.java
@@ -17,8 +17,6 @@
 package org.graylog.plugins.views.search.views.widgets.aggregation;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -38,6 +36,12 @@ public abstract class ValueConfigDTO implements PivotConfigDTO {
 
     public static ValueConfigDTO create() {
         return Builder.builder().build();
+    }
+
+    abstract Builder toBuilder();
+
+    public ValueConfigDTO withLimit(int limit) {
+        return toBuilder().limit(limit).build();
     }
 
     @AutoValue.Builder

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/dashboardV1/EntityConverter.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/dashboardV1/EntityConverter.java
@@ -65,7 +65,7 @@ public class EntityConverter {
 
         final Map<DashboardWidgetEntity, List<WidgetEntity>> widgets = convertWidgets();
         final Map<String, WidgetPositionDTO> widgetPositionMap = DashboardEntity.positionMap(parameters, widgets);
-        final  Titles titles = DashboardEntity.widgetTitles(widgets, parameters);
+        final Titles titles = DashboardEntity.widgetTitles(widgets, parameters);
 
         final Map<String, Set<String>> widgetMapping = new HashMap<>();
         final Set<SearchTypeEntity> searchTypes = new HashSet<>();

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/PivotEntity.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/PivotEntity.java
@@ -45,7 +45,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.OptionalInt;
 import java.util.Set;
 
 import static com.google.common.collect.ImmutableList.of;
@@ -92,10 +91,10 @@ public abstract class PivotEntity implements SearchTypeEntity {
     public abstract List<UsedSearchFilter> filters();
 
     @JsonProperty("row_limit")
-    public abstract OptionalInt rowLimit();
+    public abstract Optional<Integer> rowLimit();
 
     @JsonProperty("column_limit")
-    public abstract OptionalInt columnLimit();
+    public abstract Optional<Integer> columnLimit();
 
     public abstract Builder toBuilder();
 
@@ -140,10 +139,10 @@ public abstract class PivotEntity implements SearchTypeEntity {
         public abstract Builder columnGroups(List<BucketSpec> columnGroups);
 
         @JsonProperty("row_limit")
-        public abstract Builder rowLimit(int rowLimit);
+        public abstract Builder rowLimit(@Nullable Integer rowLimit);
 
         @JsonProperty("column_limit")
-        public abstract Builder columnLimit(int columnLimit);
+        public abstract Builder columnLimit(@Nullable Integer columnLimit);
 
         @JsonProperty
         public abstract Builder series(List<SeriesSpec> series);
@@ -186,8 +185,8 @@ public abstract class PivotEntity implements SearchTypeEntity {
 
     @Override
     public SearchType toNativeEntity(Map<String, ValueReference> parameters, Map<EntityDescriptor, Object> nativeEntities) {
-        var rowGroups = rowLimit().isPresent() ? applyGroupLimit(rowGroups(), rowLimit().getAsInt()) : rowGroups();
-        var columnGroups = columnLimit().isPresent() ? applyGroupLimit(columnGroups(), columnLimit().getAsInt()) : columnGroups();
+        var rowGroups = rowLimit().map(rowLimit -> applyGroupLimit(rowGroups(), rowLimit)).orElse(rowGroups());
+        var columnGroups = columnLimit().map(columnLimit -> applyGroupLimit(columnGroups(), columnLimit)).orElse(columnGroups());
         return Pivot.builder()
                 .streams(mappedStreams(nativeEntities))
                 .name(name().orElse(null))

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/ViewEntity.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/ViewEntity.java
@@ -178,9 +178,7 @@ public abstract class ViewEntity implements NativeEntityConverter<ViewDTO.Builde
                 .properties(this.properties())
                 .createdAt(this.createdAt())
                 .requires(this.requires());
-        if (this.owner().isPresent()) {
-            viewBuilder.owner(this.owner().get());
-        }
+        this.owner().ifPresent(viewBuilder::owner);
         return viewBuilder;
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/WidgetEntity.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/WidgetEntity.java
@@ -160,8 +160,7 @@ public abstract class WidgetEntity implements NativeEntityConverter<WidgetDTO> {
                         .map(object -> {
                             if (object == null) {
                                 throw new ContentPackException("Missing Stream for widget entity");
-                            } else if (object instanceof Stream) {
-                                Stream stream = (Stream) object;
+                            } else if (object instanceof final Stream stream) {
                                 return stream.getId();
                             } else {
                                 throw new ContentPackException(
@@ -179,7 +178,7 @@ public abstract class WidgetEntity implements NativeEntityConverter<WidgetDTO> {
     }
 
     public List<SearchTypeEntity> createSearchTypeEntity() {
-        if (! type().matches(AggregationConfigDTO.NAME)) {
+        if (!type().matches(AggregationConfigDTO.NAME)) {
             return ImmutableList.of();
         }
         AggregationConfigDTO config = (AggregationConfigDTO) config();


### PR DESCRIPTION
**Note:** This is a backport of #15523 to `5.1`.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is adding the required changes to make sure that if a previous row/column limit is existing in saved search/dashboard of a content pack, this limit will be applied to value pivots. This makes sure that content packs created from pre-5.1 versions containing saved searches/dashboards are installed correctly.

Fixes #15509.
Fixes Graylog2/graylog-plugin-enterprise#5205.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.