### PR TITLE
Making sure that query order is kept when exporting view to content pack. (`5.0`)

### DIFF
--- a/changelog/unreleased/pr-15539.toml
+++ b/changelog/unreleased/pr-15539.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Keep query order when exporting saved searches/dashboards to content packs."
+
+pulls = ["15505"]
+issues = ["15341", "15528"]

--- a/changelog/unreleased/pr-15584.toml
+++ b/changelog/unreleased/pr-15584.toml
@@ -1,5 +1,5 @@
 type = "fixed"
 message = "Keep query order when exporting saved searches/dashboards to content packs."
 
-pulls = ["15505"]
+pulls = ["15584"]
 issues = ["15341", "15528"]

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/Search.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/Search.java
@@ -41,6 +41,7 @@ import org.mongojack.ObjectId;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -224,10 +225,11 @@ public abstract class Search implements ContentPackable<SearchEntity>, Parameter
 
     @Override
     public SearchEntity toContentPackEntity(EntityDescriptorIds entityDescriptorIds) {
+        var queries = this.queries().stream()
+                .map(query -> query.toContentPackEntity(entityDescriptorIds))
+                .collect(Collectors.toCollection(LinkedHashSet::new));
         final SearchEntity.Builder searchEntityBuilder = SearchEntity.builder()
-                .queries(ImmutableSet.copyOf(this.queries().stream()
-                        .map(query -> query.toContentPackEntity(entityDescriptorIds))
-                        .collect(Collectors.toSet())))
+                .queries(ImmutableSet.copyOf(queries))
                 .parameters(this.parameters())
                 .requires(this.requires())
                 .createdAt(this.createdAt());

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/SearchEntity.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/SearchEntity.java
@@ -34,6 +34,7 @@ import org.joda.time.DateTimeZone;
 
 import javax.annotation.Nullable;
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -115,11 +116,11 @@ public abstract class SearchEntity implements NativeEntityConverter<Search> {
     @Override
     public Search toNativeEntity(Map<String, ValueReference> parameters,
                                  Map<EntityDescriptor, Object> nativeEntities) {
+        var queries = queries().stream()
+                .map(q -> q.toNativeEntity(parameters, nativeEntities))
+                .collect(Collectors.toCollection(LinkedHashSet::new));
         final Search.Builder searchBuilder = Search.builder()
-                .queries(ImmutableSet.copyOf(
-                        queries().stream()
-                                .map(q -> q.toNativeEntity(parameters, nativeEntities))
-                                .collect(Collectors.toSet())))
+                .queries(ImmutableSet.copyOf(queries))
                 .parameters(this.parameters())
                 .requires(this.requires())
                 .createdAt(this.createdAt());

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/SearchEntity.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/SearchEntity.java
@@ -25,15 +25,10 @@ import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import org.graylog.plugins.views.search.Parameter;
-import org.graylog.plugins.views.search.Query;
 import org.graylog.plugins.views.search.Search;
-import org.graylog.plugins.views.search.SearchType;
 import org.graylog.plugins.views.search.views.PluginMetadataSummary;
 import org.graylog2.contentpacks.NativeEntityConverter;
-import org.graylog2.contentpacks.exceptions.ContentPackException;
-import org.graylog2.contentpacks.model.ModelTypes;
 import org.graylog2.contentpacks.model.entities.references.ValueReference;
-import org.graylog2.plugin.streams.Stream;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/SearchTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/SearchTest.java
@@ -21,6 +21,7 @@ import org.graylog.plugins.views.search.filter.StreamFilter;
 import org.graylog.plugins.views.search.rest.ExecutionState;
 import org.graylog.plugins.views.search.rest.ExecutionStateGlobalOverride;
 import org.graylog.plugins.views.search.searchtypes.MessageList;
+import org.graylog2.contentpacks.model.entities.QueryEntity;
 import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
 import org.graylog2.shared.rest.exceptions.MissingStreamPermissionException;
 import org.junit.jupiter.api.Test;
@@ -147,6 +148,15 @@ public class SearchTest {
                 .hasSize(5)
                 .contains("a", "b", "x", "y", "z");
 
+    }
+
+    @Test
+    void exportingToContentPackEntityKeepsOrderOfQueries() {
+        var search = Search.builder().queries(queriesWithSearchTypes("one", "two", "three", "for", "five", "six", "seven")).build();
+        var queryIdsBefore = search.queries().stream().map(Query::id).toList();
+        var contentPackSearch = search.toContentPackEntity(null);
+        var queryIdsAfter = contentPackSearch.queries().stream().map(QueryEntity::id).toList();
+        assertThat(queryIdsAfter).isEqualTo(queryIdsBefore);
     }
 
     private Set<String> searchTypeIdsFrom(Search search) {


### PR DESCRIPTION
**Note:** This is a backport of #15539 to `5.0`.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR fixing that content packs exporting saved searches/dashboards are not keeping the query order in the associated search object.

Fixes #15528.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.