### PR TITLE
Keep order and pivot limits when importing content packs.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/PivotEntity.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/PivotEntity.java
@@ -45,7 +45,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.OptionalInt;
 import java.util.Set;
 
 import static com.google.common.collect.ImmutableList.of;
@@ -92,10 +91,10 @@ public abstract class PivotEntity implements SearchTypeEntity {
     public abstract List<UsedSearchFilter> filters();
 
     @JsonProperty("row_limit")
-    public abstract OptionalInt rowLimit();
+    public abstract Optional<Integer> rowLimit();
 
     @JsonProperty("column_limit")
-    public abstract OptionalInt columnLimit();
+    public abstract Optional<Integer> columnLimit();
 
     public abstract Builder toBuilder();
 
@@ -140,10 +139,10 @@ public abstract class PivotEntity implements SearchTypeEntity {
         public abstract Builder columnGroups(List<BucketSpec> columnGroups);
 
         @JsonProperty("row_limit")
-        public abstract Builder rowLimit(int rowLimit);
+        public abstract Builder rowLimit(@Nullable Integer rowLimit);
 
         @JsonProperty("column_limit")
-        public abstract Builder columnLimit(int columnLimit);
+        public abstract Builder columnLimit(@Nullable Integer columnLimit);
 
         @JsonProperty
         public abstract Builder series(List<SeriesSpec> series);
@@ -186,8 +185,8 @@ public abstract class PivotEntity implements SearchTypeEntity {
 
     @Override
     public SearchType toNativeEntity(Map<String, ValueReference> parameters, Map<EntityDescriptor, Object> nativeEntities) {
-        var rowGroups = rowLimit().isPresent() ? applyGroupLimit(rowGroups(), rowLimit().getAsInt()) : rowGroups();
-        var columnGroups = columnLimit().isPresent() ? applyGroupLimit(columnGroups(), columnLimit().getAsInt()) : columnGroups();
+        var rowGroups = rowLimit().map(rowLimit -> applyGroupLimit(rowGroups(), rowLimit)).orElse(rowGroups());
+        var columnGroups = columnLimit().map(columnLimit -> applyGroupLimit(columnGroups(), columnLimit)).orElse(columnGroups());
         return Pivot.builder()
                 .streams(mappedStreams(nativeEntities))
                 .name(name().orElse(null))

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/SearchEntity.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/SearchEntity.java
@@ -34,6 +34,7 @@ import org.joda.time.DateTimeZone;
 
 import javax.annotation.Nullable;
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -115,11 +116,11 @@ public abstract class SearchEntity implements NativeEntityConverter<Search> {
     @Override
     public Search toNativeEntity(Map<String, ValueReference> parameters,
                                  Map<EntityDescriptor, Object> nativeEntities) {
+        var queries = queries().stream()
+                .map(q -> q.toNativeEntity(parameters, nativeEntities))
+                .collect(Collectors.toCollection(LinkedHashSet::new));
         final Search.Builder searchBuilder = Search.builder()
-                .queries(ImmutableSet.copyOf(
-                        queries().stream()
-                                .map(q -> q.toNativeEntity(parameters, nativeEntities))
-                                .collect(Collectors.toSet())))
+                .queries(ImmutableSet.copyOf(queries))
                 .parameters(this.parameters())
                 .requires(this.requires())
                 .createdAt(this.createdAt());


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This is a follow-up to #15539, which took care of keeping the order of queries when _exporting_ content packs. This PR is making sure that the order is kept when _importing_ content packs, as well as fixing the import of row/column limits for pivot aggregations, where previously a `null` value was interpreted as `0`.

Refs #15528.

/nocl

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.