### PR TITLE
Use search query from URL params for dashboard page search input.

### DIFF
--- a/changelog/unreleased/issue-15547.toml
+++ b/changelog/unreleased/issue-15547.toml
@@ -1,0 +1,6 @@
+type = "fixed"
+message = "Use search query from URL params for dashboard page search input."
+
+issues = ["15536"]
+pulls = ["15540"]
+

--- a/graylog2-web-interface/src/views/components/dashboard/DashboardsOverview/DashboardsOverview.tsx
+++ b/graylog2-web-interface/src/views/components/dashboard/DashboardsOverview/DashboardsOverview.tsx
@@ -41,7 +41,7 @@ const renderBulkActions = (
 );
 
 const DashboardsOverview = () => {
-  const [query, setQuery] = useQueryParam('q', StringParam);
+  const [query, setQuery] = useQueryParam('query', StringParam);
   const { layoutConfig, isInitialLoading: isLoadingLayoutPreferences } = useTableLayout({
     entityTableId: ENTITY_TABLE_ID,
     defaultPageSize: DEFAULT_LAYOUT.pageSize,
@@ -103,6 +103,7 @@ const DashboardsOverview = () => {
         <SearchForm onSearch={onSearch}
                     queryHelpComponent={<QueryHelper entityName="dashboard" commonFields={['id', 'title', 'description', 'summary']} />}
                     onReset={onReset}
+                    query={query}
                     topMargin={0} />
       </div>
       {!dashboards?.length && !query && (


### PR DESCRIPTION
_Please note, this PR needs a backport for 5.1_

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is fixing a problem with the dashboards overview. Before this change we were not using the search query provided by the URL params for the search input. The URL params were already being updated when changing the value of the search input.

Fixes https://github.com/Graylog2/graylog2-server/issues/15547

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)