### PR TITLE
Execute search when global query override is set.

### DIFF
--- a/changelog/unreleased/issue-15519.toml
+++ b/changelog/unreleased/issue-15519.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Make sure that search is reexecuted when 'Add to query'/'Remove from query' on dashboards."
+
+issues = ["15519"]
+pulls = ["15593"]

--- a/graylog2-web-interface/src/views/logic/slices/viewSlice.ts
+++ b/graylog2-web-interface/src/views/logic/slices/viewSlice.ts
@@ -277,7 +277,7 @@ export const updateQueryString = (queryId: string, newQueryString: string) => (d
     return dispatch(setQueryString(queryId, newQueryString));
   }
 
-  return dispatch(setGlobalOverrideQuery(newQueryString));
+  return dispatch(setGlobalOverrideQuery(newQueryString)).then(() => dispatch(execute()));
 };
 
 export const updateViewState = (id: QueryId, newViewState: ViewStateType) => (dispatch: AppDispatch, getState: () => RootState) => {


### PR DESCRIPTION
**Note:** This PR needs a backport to `5.1`.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is fixing an issue where using the "Add to query"/"Exclude from query" value actions are not executing the search when used on dashboards.

This is being fixed by making sure that the `updateQueryString` is consistent in that it executes the search regardless if it is being called on a saved search or a dashboard.

Fixes #15519.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.