### PR TITLE
Delay opensearch start till configuration is available

### DIFF
--- a/data-node/src/main/java/org/graylog/datanode/management/CommandLineProcess.java
+++ b/data-node/src/main/java/org/graylog/datanode/management/CommandLineProcess.java
@@ -33,8 +33,6 @@ import java.util.concurrent.TimeoutException;
 
 
 class CommandLineProcess {
-    private static final String JAVA_HOME_ENV = "JAVA_HOME";
-
     private final Path executable;
     private final List<String> arguments;
     private final ProcessListener listener;
@@ -57,7 +55,7 @@ class CommandLineProcess {
 
     private static final Logger LOG = LoggerFactory.getLogger(CommandLineProcess.class);
 
-    public void start() throws IOException {
+    public void start() {
 
         LOG.info("Running process from " + executable.toAbsolutePath());
 
@@ -70,13 +68,13 @@ class CommandLineProcess {
         executor.setStreamHandler(new PumpStreamHandler(new LoggingOutputStream(listener::onStdOut), new LoggingOutputStream(listener::onStdErr)));
         executor.setWatchdog(watchDog);
 
-        executor.execute(cmdLine, environment.getEnv(), listener);
         try {
+            executor.execute(cmdLine, environment.getEnv(), listener);
             this.process = executor.getProcess().get(30, TimeUnit.SECONDS);
             listener.onStart();
         } catch (TimeoutException e) {
             throw new RuntimeException("Failed to obtain process", e);
-        } catch (ExecutionException | InterruptedException e) {
+        } catch (ExecutionException | InterruptedException | IOException e) {
             throw new RuntimeException(e);
         }
     }

--- a/data-node/src/main/java/org/graylog/datanode/management/ManagableProcess.java
+++ b/data-node/src/main/java/org/graylog/datanode/management/ManagableProcess.java
@@ -21,7 +21,9 @@ import org.graylog.datanode.process.ProcessState;
 
 import java.io.IOException;
 
-public interface ManagableProcess {
+public interface ManagableProcess<ConfigurationType> {
+
+    void startWithConfig(ConfigurationType configuration);
 
     void start() throws IOException;
 

--- a/data-node/src/main/java/org/graylog/datanode/management/OpensearchDynamicConfiguration.java
+++ b/data-node/src/main/java/org/graylog/datanode/management/OpensearchDynamicConfiguration.java
@@ -16,27 +16,5 @@
  */
 package org.graylog.datanode.management;
 
-import org.graylog.datanode.process.ProcessInfo;
-import org.graylog.shaded.opensearch2.org.opensearch.client.RestHighLevelClient;
-
-import java.net.URI;
-import java.util.List;
-
-public interface OpensearchProcess extends ManagableProcess<OpensearchDynamicConfiguration> {
-
-    ProcessInfo processInfo();
-
-    RestHighLevelClient restClient();
-
-    Object nodeName();
-
-    boolean isLeaderNode();
-    void setLeaderNode(boolean isManagerNode);
-
-    String opensearchVersion();
-
-    List<String> stdOutLogs();
-    List<String> stdErrLogs();
-
-    URI getOpensearchBaseUrl();
+public class OpensearchDynamicConfiguration {
 }

--- a/data-node/src/main/java/org/graylog/datanode/management/OpensearchProcessImpl.java
+++ b/data-node/src/main/java/org/graylog/datanode/management/OpensearchProcessImpl.java
@@ -19,7 +19,6 @@ package org.graylog.datanode.management;
 import com.github.oxo42.stateless4j.StateMachine;
 import org.apache.commons.collections4.queue.CircularFifoQueue;
 import org.apache.commons.exec.ExecuteException;
-import org.graylog.datanode.ProcessProvidingExecutor;
 import org.graylog.datanode.process.OpensearchConfiguration;
 import org.graylog.datanode.process.ProcessEvent;
 import org.graylog.datanode.process.ProcessInfo;
@@ -36,11 +35,9 @@ import org.graylog.shaded.opensearch2.org.opensearch.client.RestHighLevelClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
@@ -159,14 +156,14 @@ class OpensearchProcessImpl implements OpensearchProcess, ProcessListener {
     public void startWithConfig(OpensearchDynamicConfiguration configuration) {
         if(!Objects.equals(dynamicConfiguration, configuration)) {
             this.dynamicConfiguration = configuration;
-            start();
+            restart();
         } else {
             LOG.info("Dynamic configuration not changed, ignoring");
         }
     }
 
     @Override
-    public synchronized void start()  {
+    public synchronized void restart()  {
         if(dynamicConfiguration == null) {
             throw new IllegalArgumentException("Dynamic runtime configuration required but not supplied!");
         }

--- a/data-node/src/main/java/org/graylog/datanode/management/OpensearchProcessService.java
+++ b/data-node/src/main/java/org/graylog/datanode/management/OpensearchProcessService.java
@@ -39,7 +39,7 @@ public class OpensearchProcessService extends AbstractIdleService implements Pro
     @Override
     protected void startUp() {
         this.process.startWithConfig(new OpensearchDynamicConfiguration());
-        this.processWatchdog.start();
+       this.processWatchdog.start();
     }
 
 

--- a/data-node/src/main/java/org/graylog/datanode/management/OpensearchProcessService.java
+++ b/data-node/src/main/java/org/graylog/datanode/management/OpensearchProcessService.java
@@ -37,8 +37,8 @@ public class OpensearchProcessService extends AbstractIdleService implements Pro
     }
 
     @Override
-    protected void startUp() throws Exception {
-        this.process.start();
+    protected void startUp() {
+        this.process.startWithConfig(new OpensearchDynamicConfiguration());
         this.processWatchdog.start();
     }
 

--- a/data-node/src/main/java/org/graylog/datanode/management/ProcessWatchdog.java
+++ b/data-node/src/main/java/org/graylog/datanode/management/ProcessWatchdog.java
@@ -76,7 +76,7 @@ public class ProcessWatchdog implements Runnable {
     private void restartProcess() {
         try {
             LOG.info("Detected terminated process, restarting");
-            process.start();
+            process.restart();
         } catch (IOException e) {
             LOG.warn("Failed to start the process.", e);
         } finally {

--- a/data-node/src/main/java/org/graylog/datanode/periodicals/OpensearchNodeHeartbeat.java
+++ b/data-node/src/main/java/org/graylog/datanode/periodicals/OpensearchNodeHeartbeat.java
@@ -44,7 +44,7 @@ public class OpensearchNodeHeartbeat extends Periodical {
     @Override
     // This method is "synchronized" because we are also calling it directly in AutomaticLeaderElectionService
     public synchronized void doRun() {
-        if (!process.isInState(ProcessState.TERMINATED)) {
+        if (!process.isInState(ProcessState.TERMINATED) && !process.isInState(ProcessState.WAITING_FOR_CONFIGURATION)) {
             try {
                 final MainResponse health = process.restClient()
                         .info(RequestOptions.DEFAULT);

--- a/data-node/src/main/java/org/graylog/datanode/process/ProcessState.java
+++ b/data-node/src/main/java/org/graylog/datanode/process/ProcessState.java
@@ -20,7 +20,7 @@ public enum ProcessState {
     /**
      * Fresh created process, not started yet
      */
-    NEW,
+    WAITING_FOR_CONFIGURATION,
     /**
      * The process is running on the underlying OS and has a process ID. It's not responding to the REST API yet
      */

--- a/data-node/src/main/java/org/graylog/datanode/rest/StatusController.java
+++ b/data-node/src/main/java/org/graylog/datanode/rest/StatusController.java
@@ -16,6 +16,7 @@
  */
 package org.graylog.datanode.rest;
 
+import org.graylog.datanode.management.OpensearchDynamicConfiguration;
 import org.graylog.datanode.management.OpensearchProcess;
 import org.graylog2.plugin.Version;
 
@@ -24,6 +25,7 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
+import java.io.IOException;
 
 @Path("/")
 @Produces(MediaType.APPLICATION_JSON)
@@ -44,5 +46,12 @@ public class StatusController {
                 version,
                 new StatusResponse(openSearch.opensearchVersion(), openSearch.processInfo())
         );
+    }
+
+    @GET
+    @Path("/start")
+    public DataNodeStatus start() throws IOException {
+        openSearch.startWithConfig(new OpensearchDynamicConfiguration());
+        return status();
     }
 }

--- a/data-node/src/test/java/org/graylog/datanode/management/ProcessWatchdogTest.java
+++ b/data-node/src/test/java/org/graylog/datanode/management/ProcessWatchdogTest.java
@@ -36,7 +36,7 @@ class ProcessWatchdogTest {
     void testLifecycle() throws IOException, ExecutionException, RetryException {
         final TestableProcess process = new TestableProcess();
         final ProcessWatchdog watchdog = new ProcessWatchdog(process, 100);
-        process.start();
+        process.restart();
         watchdog.start();
 
         // both process and watchdog are running now. Let's stop the process and see if the watchdog will restart it

--- a/data-node/src/test/java/org/graylog/datanode/management/TestableProcess.java
+++ b/data-node/src/test/java/org/graylog/datanode/management/TestableProcess.java
@@ -33,11 +33,11 @@ public class TestableProcess implements ManagableProcess<String> {
 
     @Override
     public void startWithConfig(String ignored) {
-        start();
+        restart();
     }
 
     @Override
-    public void start() {
+    public void restart() {
         LOG.debug("Starting process");
         this.state = ProcessState.STARTING;
     }

--- a/data-node/src/test/java/org/graylog/datanode/management/TestableProcess.java
+++ b/data-node/src/test/java/org/graylog/datanode/management/TestableProcess.java
@@ -21,14 +21,19 @@ import org.graylog.datanode.process.ProcessState;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class TestableProcess implements ManagableProcess {
+public class TestableProcess implements ManagableProcess<String> {
 
     private static final Logger LOG = LoggerFactory.getLogger(TestableProcess.class);
 
     private volatile ProcessState state;
 
     public TestableProcess() {
-        this.state = ProcessState.NEW;
+        this.state = ProcessState.WAITING_FOR_CONFIGURATION;
+    }
+
+    @Override
+    public void startWithConfig(String ignored) {
+        start();
     }
 
     @Override

--- a/data-node/src/test/java/org/graylog/datanode/process/ProcessStateMachineTest.java
+++ b/data-node/src/test/java/org/graylog/datanode/process/ProcessStateMachineTest.java
@@ -25,7 +25,7 @@ class ProcessStateMachineTest {
     @Test
     void testOptimalScenario() {
         final StateMachine<ProcessState, ProcessEvent> machine = ProcessStateMachine.createNew();
-        Assertions.assertEquals(machine.getState(), ProcessState.NEW);
+        Assertions.assertEquals(machine.getState(), ProcessState.WAITING_FOR_CONFIGURATION);
 
         machine.fire(ProcessEvent.PROCESS_STARTED);
         Assertions.assertEquals(ProcessState.STARTING, machine.getState());
@@ -40,7 +40,7 @@ class ProcessStateMachineTest {
     @Test
     void testRestFailing() {
         final StateMachine<ProcessState, ProcessEvent> machine = ProcessStateMachine.createNew();
-        Assertions.assertEquals(machine.getState(), ProcessState.NEW);
+        Assertions.assertEquals(machine.getState(), ProcessState.WAITING_FOR_CONFIGURATION);
 
         machine.fire(ProcessEvent.PROCESS_STARTED);
         Assertions.assertEquals(ProcessState.STARTING, machine.getState());
@@ -65,7 +65,7 @@ class ProcessStateMachineTest {
     @Test
     void testStartupFailure() {
         final StateMachine<ProcessState, ProcessEvent> machine = ProcessStateMachine.createNew();
-        Assertions.assertEquals(machine.getState(), ProcessState.NEW);
+        Assertions.assertEquals(machine.getState(), ProcessState.WAITING_FOR_CONFIGURATION);
 
         machine.fire(ProcessEvent.PROCESS_STARTED);
         Assertions.assertEquals(ProcessState.STARTING, machine.getState());
@@ -84,7 +84,7 @@ class ProcessStateMachineTest {
     @Test
     void testStartupFailureResolved() {
         final StateMachine<ProcessState, ProcessEvent> machine = ProcessStateMachine.createNew();
-        Assertions.assertEquals(machine.getState(), ProcessState.NEW);
+        Assertions.assertEquals(machine.getState(), ProcessState.WAITING_FOR_CONFIGURATION);
 
         machine.fire(ProcessEvent.PROCESS_STARTED);
         Assertions.assertEquals(ProcessState.STARTING, machine.getState());


### PR DESCRIPTION
/nocl
This PR add a `startWithConfig` method that will start the opensearch process. The start may be delayed or triggered anytime, based on configuration change.

## Motivation and Context
Needed for postponing opensearch startup till the TLS configuration is available.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

