### PR TITLE
Refactoring keystore storage

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/security/certutil/CertutilCa.java
+++ b/graylog2-server/src/main/java/org/graylog/security/certutil/CertutilCa.java
@@ -22,6 +22,7 @@ import org.graylog.security.certutil.ca.CACreator;
 import org.graylog.security.certutil.console.CommandLineConsole;
 import org.graylog.security.certutil.console.SystemConsole;
 import org.graylog.security.certutil.keystore.storage.KeystoreFileStorage;
+import org.graylog.security.certutil.keystore.storage.location.KeystoreFileLocation;
 import org.graylog2.bootstrap.CliCommand;
 
 import java.nio.file.Path;
@@ -65,7 +66,7 @@ public class CertutilCa implements CliCommand {
 
             final Path keystorePath = Path.of(keystoreFilename);
             //TODO: it is probably a bad idea to use the same password for CA and its storage...
-            caKeystoreStorage.writeKeyStore(keystorePath, caKeystore, password);
+            caKeystoreStorage.writeKeyStore(new KeystoreFileLocation(keystorePath), caKeystore, password);
             console.printLine("Keys and certificates stored in " + keystorePath.toAbsolutePath());
 
         } catch (Exception e) {

--- a/graylog2-server/src/main/java/org/graylog/security/certutil/csr/CertificateAndPrivateKeyMerger.java
+++ b/graylog2-server/src/main/java/org/graylog/security/certutil/csr/CertificateAndPrivateKeyMerger.java
@@ -20,6 +20,8 @@ import org.bouncycastle.operator.OperatorCreationException;
 import org.bouncycastle.pkcs.PKCSException;
 import org.graylog.security.certutil.ca.exceptions.KeyStoreStorageException;
 import org.graylog.security.certutil.keystore.storage.KeystoreMongoStorage;
+import org.graylog.security.certutil.keystore.storage.location.KeystoreMongoCollections;
+import org.graylog.security.certutil.keystore.storage.location.KeystoreMongoLocation;
 import org.graylog.security.certutil.privatekey.PrivateKeyEncryptedStorage;
 import org.graylog2.plugin.system.NodeId;
 
@@ -67,6 +69,8 @@ public class CertificateAndPrivateKeyMerger {
             throw new GeneralSecurityException("Private key from CSR and public key from certificate do not form a valid pair");
         }
 
-        keystoreMongoStorage.writeKeyStore(nodeId, nodeKeystore, certFilePassword);
+        keystoreMongoStorage.writeKeyStore(new KeystoreMongoLocation(nodeId.getNodeId(), KeystoreMongoCollections.DATA_NODE_KEYSTORE_COLLECTION),
+                nodeKeystore, certFilePassword);
+
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/security/certutil/keystore/storage/KeystoreFileStorage.java
+++ b/graylog2-server/src/main/java/org/graylog/security/certutil/keystore/storage/KeystoreFileStorage.java
@@ -18,6 +18,7 @@ package org.graylog.security.certutil.keystore.storage;
 
 import org.graylog.security.certutil.CertConstants;
 import org.graylog.security.certutil.ca.exceptions.KeyStoreStorageException;
+import org.graylog.security.certutil.keystore.storage.location.KeystoreFileLocation;
 
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -27,12 +28,13 @@ import java.security.GeneralSecurityException;
 import java.security.KeyStore;
 import java.util.Optional;
 
-public class KeystoreFileStorage implements KeystoreStorage {
+public final class KeystoreFileStorage implements KeystoreStorage<KeystoreFileLocation> {
 
     @Override
-    public void writeKeyStore(final Path keystorePath,
+    public void writeKeyStore(final KeystoreFileLocation location,
                               final KeyStore keyStore,
                               final char[] password) throws KeyStoreStorageException {
+        final Path keystorePath = location.keystorePath();
         try (FileOutputStream store = new FileOutputStream(keystorePath.toFile())) {
             keyStore.store(store, password);
         } catch (Exception ex) {
@@ -40,8 +42,9 @@ public class KeystoreFileStorage implements KeystoreStorage {
         }
     }
 
-    public Optional<KeyStore> readKeyStore(final Path keystorePath, char[] password) throws KeyStoreStorageException {
-        try (var in = Files.newInputStream(keystorePath)) {
+    @Override
+    public Optional<KeyStore> readKeyStore(final KeystoreFileLocation location, char[] password) throws KeyStoreStorageException {
+        try (var in = Files.newInputStream(location.keystorePath())) {
             KeyStore caKeystore = KeyStore.getInstance(CertConstants.PKCS12);
             caKeystore.load(in, password);
             return Optional.of(caKeystore);
@@ -49,4 +52,17 @@ public class KeystoreFileStorage implements KeystoreStorage {
             throw new KeyStoreStorageException("Could not read keystore: " + ex.getMessage(), ex);
         }
     }
+
+    @Deprecated
+    public Optional<KeyStore> readKeyStore(final Path keystorePath, char[] password) throws KeyStoreStorageException {
+        return readKeyStore(new KeystoreFileLocation(keystorePath), password);
+    }
+
+    @Deprecated
+    public void writeKeyStore(final Path keystorePath,
+                              final KeyStore keyStore,
+                              final char[] password) throws KeyStoreStorageException {
+        writeKeyStore(new KeystoreFileLocation(keystorePath), keyStore, password);
+    }
+
 }

--- a/graylog2-server/src/main/java/org/graylog/security/certutil/keystore/storage/KeystoreMongoStorage.java
+++ b/graylog2-server/src/main/java/org/graylog/security/certutil/keystore/storage/KeystoreMongoStorage.java
@@ -17,6 +17,7 @@
 package org.graylog.security.certutil.keystore.storage;
 
 import org.graylog.security.certutil.ca.exceptions.KeyStoreStorageException;
+import org.graylog.security.certutil.keystore.storage.location.KeystoreMongoLocation;
 import org.graylog2.cluster.certificates.CertificatesService;
 import org.graylog2.plugin.system.NodeId;
 
@@ -29,7 +30,7 @@ import java.util.Optional;
 
 import static org.graylog.security.certutil.CertConstants.PKCS12;
 
-public class KeystoreMongoStorage {
+public final class KeystoreMongoStorage implements KeystoreStorage<KeystoreMongoLocation> {
 
     private final CertificatesService certificatesService;
 
@@ -38,8 +39,34 @@ public class KeystoreMongoStorage {
         this.certificatesService = certificatesService;
     }
 
-    public void writeKeyStore(NodeId nodeId, KeyStore keyStore, char[] password) throws KeyStoreStorageException {
+    @Override
+    public void writeKeyStore(KeystoreMongoLocation location, KeyStore keyStore, char[] password) throws KeyStoreStorageException {
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+            keyStore.store(baos, password);
+            final String keystoreDataAsString = Base64.getEncoder().encodeToString(baos.toByteArray());
+            certificatesService.writeCert(location, keystoreDataAsString);
+        } catch (Exception ex) {
+            throw new KeyStoreStorageException("Failed to save keystore to Mongo collection for node " + location.nodeId(), ex);
+        }
+    }
 
+    @Override
+    public Optional<KeyStore> readKeyStore(KeystoreMongoLocation location, char[] password) throws KeyStoreStorageException {
+        final Optional<String> keystoreAsString = certificatesService.readCert(location);
+        if (keystoreAsString.isPresent()) {
+            try (ByteArrayInputStream bais = new ByteArrayInputStream(Base64.getDecoder().decode(keystoreAsString.get()))) {
+                KeyStore keyStore = KeyStore.getInstance(PKCS12);
+                keyStore.load(bais, password);
+                return Optional.of(keyStore);
+            } catch (Exception ex) {
+                throw new KeyStoreStorageException("Failed to load keystore from Mongo collection for node " + location.nodeId(), ex);
+            }
+        }
+        return Optional.empty();
+    }
+
+    @Deprecated
+    public void writeKeyStore(NodeId nodeId, KeyStore keyStore, char[] password) throws KeyStoreStorageException {
         final String nodeIdValue = nodeId.getNodeId();
         try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
             keyStore.store(baos, password);
@@ -50,6 +77,7 @@ public class KeystoreMongoStorage {
         }
     }
 
+    @Deprecated
     public Optional<KeyStore> readKeyStore(NodeId nodeId, char[] password) throws KeyStoreStorageException {
 
         final String nodeIdValue = nodeId.getNodeId();

--- a/graylog2-server/src/main/java/org/graylog/security/certutil/keystore/storage/KeystoreStorage.java
+++ b/graylog2-server/src/main/java/org/graylog/security/certutil/keystore/storage/KeystoreStorage.java
@@ -17,15 +17,18 @@
 package org.graylog.security.certutil.keystore.storage;
 
 import org.graylog.security.certutil.ca.exceptions.KeyStoreStorageException;
+import org.graylog.security.certutil.keystore.storage.location.KeystoreLocation;
 
-import java.nio.file.Path;
 import java.security.KeyStore;
+import java.util.Optional;
 
-public interface KeystoreStorage {
+public sealed interface KeystoreStorage<T extends KeystoreLocation> permits KeystoreFileStorage, KeystoreMongoStorage, SmartKeystoreStorage {
 
-    void writeKeyStore(final Path keystorePath,
+    void writeKeyStore(final T location,
                        final KeyStore keyStore,
                        final char[] password)
             throws KeyStoreStorageException;
+
+    Optional<KeyStore> readKeyStore(final T location, char[] password) throws KeyStoreStorageException;
 
 }

--- a/graylog2-server/src/main/java/org/graylog/security/certutil/keystore/storage/SmartKeystoreStorage.java
+++ b/graylog2-server/src/main/java/org/graylog/security/certutil/keystore/storage/SmartKeystoreStorage.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.security.certutil.keystore.storage;
+
+import org.graylog.security.certutil.ca.exceptions.KeyStoreStorageException;
+import org.graylog.security.certutil.keystore.storage.location.KeystoreFileLocation;
+import org.graylog.security.certutil.keystore.storage.location.KeystoreLocation;
+import org.graylog.security.certutil.keystore.storage.location.KeystoreMongoLocation;
+import org.graylog2.cluster.certificates.CertificatesService;
+
+import javax.inject.Inject;
+import java.security.KeyStore;
+import java.util.Optional;
+
+//TODO: It is only a concept, do not use it yet!
+//The idea is that client code creates proper KeystoreLocation, and does not cate which implementation to choose for the location, it is done automagically
+@Deprecated
+public final class SmartKeystoreStorage implements KeystoreStorage<KeystoreLocation> {
+
+    private final KeystoreMongoStorage keystoreMongoStorage;
+    private final KeystoreFileStorage keystoreFileStorage;
+
+    @Inject
+    public SmartKeystoreStorage(final CertificatesService certificatesService) {
+        keystoreMongoStorage = new KeystoreMongoStorage(certificatesService);
+        keystoreFileStorage = new KeystoreFileStorage();
+    }
+
+    @Override
+    public void writeKeyStore(KeystoreLocation location,
+                              KeyStore keyStore,
+                              char[] password) throws KeyStoreStorageException {
+        if (location instanceof final KeystoreMongoLocation mongoLocation) {
+            keystoreMongoStorage.writeKeyStore(mongoLocation, keyStore, password);
+        } else if (location instanceof final KeystoreFileLocation fileLocation) {
+            keystoreFileStorage.writeKeyStore(fileLocation, keyStore, password);
+        }
+    }
+
+    @Override
+    public Optional<KeyStore> readKeyStore(KeystoreLocation location,
+                                           char[] password) throws KeyStoreStorageException {
+        if (location instanceof final KeystoreMongoLocation mongoLocation) {
+            return keystoreMongoStorage.readKeyStore(mongoLocation, password);
+        } else if (location instanceof final KeystoreFileLocation fileLocation) {
+            return keystoreFileStorage.readKeyStore(fileLocation, password);
+        } else {
+            return Optional.empty();
+        }
+    }
+
+
+}

--- a/graylog2-server/src/main/java/org/graylog/security/certutil/keystore/storage/location/KeystoreFileLocation.java
+++ b/graylog2-server/src/main/java/org/graylog/security/certutil/keystore/storage/location/KeystoreFileLocation.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.security.certutil.keystore.storage.location;
+
+import java.nio.file.Path;
+
+public record KeystoreFileLocation(Path keystorePath) implements KeystoreLocation {
+
+}

--- a/graylog2-server/src/main/java/org/graylog/security/certutil/keystore/storage/location/KeystoreLocation.java
+++ b/graylog2-server/src/main/java/org/graylog/security/certutil/keystore/storage/location/KeystoreLocation.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.security.certutil.keystore.storage.location;
+
+public sealed interface KeystoreLocation permits KeystoreMongoLocation, KeystoreFileLocation {
+}

--- a/graylog2-server/src/main/java/org/graylog/security/certutil/keystore/storage/location/KeystoreMongoCollection.java
+++ b/graylog2-server/src/main/java/org/graylog/security/certutil/keystore/storage/location/KeystoreMongoCollection.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.security.certutil.keystore.storage.location;
+
+public record KeystoreMongoCollection(String collectionName,
+                                      String identifierField,
+                                      String encryptedCertificateField) {
+}

--- a/graylog2-server/src/main/java/org/graylog/security/certutil/keystore/storage/location/KeystoreMongoCollections.java
+++ b/graylog2-server/src/main/java/org/graylog/security/certutil/keystore/storage/location/KeystoreMongoCollections.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.security.certutil.keystore.storage.location;
+
+import java.util.Collection;
+import java.util.List;
+
+public interface KeystoreMongoCollections {
+
+    KeystoreMongoCollection DATA_NODE_KEYSTORE_COLLECTION = new KeystoreMongoCollection(
+            "data_node_certificates",
+            "node_id",
+            "encrypted_certificate_keystore"
+    );
+
+    Collection<KeystoreMongoCollection> ALL_KEYSTORE_COLLECTIONS = List.of(
+            DATA_NODE_KEYSTORE_COLLECTION
+    );
+
+}

--- a/graylog2-server/src/main/java/org/graylog/security/certutil/keystore/storage/location/KeystoreMongoLocation.java
+++ b/graylog2-server/src/main/java/org/graylog/security/certutil/keystore/storage/location/KeystoreMongoLocation.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.security.certutil.keystore.storage.location;
+
+public record KeystoreMongoLocation(String nodeId, KeystoreMongoCollection collection) implements KeystoreLocation {
+}

--- a/graylog2-server/src/main/java/org/graylog2/cluster/certificates/CertificatesService.java
+++ b/graylog2-server/src/main/java/org/graylog2/cluster/certificates/CertificatesService.java
@@ -16,63 +16,107 @@
  */
 package org.graylog2.cluster.certificates;
 
-import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
+import com.mongodb.client.FindIterable;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.model.IndexOptions;
+import com.mongodb.client.model.UpdateOptions;
+import com.mongodb.client.result.UpdateResult;
+import org.bson.Document;
+import org.graylog.security.certutil.keystore.storage.location.KeystoreMongoCollection;
+import org.graylog.security.certutil.keystore.storage.location.KeystoreMongoCollections;
+import org.graylog.security.certutil.keystore.storage.location.KeystoreMongoLocation;
 import org.graylog2.database.MongoConnection;
-import org.graylog2.database.PaginatedDbService;
-import org.graylog2.database.indices.MongoDbIndexTools;
 import org.graylog2.security.encryption.EncryptedValue;
 import org.graylog2.security.encryption.EncryptedValueService;
-import org.mongojack.DBQuery;
-import org.mongojack.DBUpdate;
-import org.mongojack.JacksonDBCollection;
-import org.mongojack.WriteResult;
 
 import javax.inject.Inject;
 import java.util.Optional;
 
-import static org.graylog2.cluster.certificates.NodeCertificate.FIELD_ENCR_CERTIFICATE;
-import static org.graylog2.cluster.certificates.NodeCertificate.FIELD_NODEID;
+import static com.mongodb.client.model.Filters.eq;
+import static com.mongodb.client.model.Indexes.ascending;
+import static com.mongodb.client.model.Updates.combine;
+import static com.mongodb.client.model.Updates.set;
+import static org.graylog.security.certutil.keystore.storage.location.KeystoreMongoCollections.DATA_NODE_KEYSTORE_COLLECTION;
 
 
-public class CertificatesService extends PaginatedDbService<NodeCertificate> {
-    public static final String COLLECTION_NAME = "data_node_certificates";
+public class CertificatesService {
 
-    private final JacksonDBCollection<NodeCertificate, String> dbCollection;
+    private static final String ENCRYPTED_VALUE_SUBFIELD = "encrypted_value";
+    private static final String SALT_SUBFIELD = "salt";
+
+    private final MongoDatabase mongoDatabase;
     private final EncryptedValueService encryptionService;
 
     @Inject
-    public CertificatesService(final MongoJackObjectMapperProvider mongoJackObjectMapperProvider,
-                               final MongoConnection mongoConnection,
+    public CertificatesService(final MongoConnection mongoConnection,
                                final EncryptedValueService encryptionService) {
-        super(mongoConnection, mongoJackObjectMapperProvider, NodeCertificate.class, COLLECTION_NAME);
-        this.dbCollection = JacksonDBCollection.wrap(mongoConnection.getDatabase().getCollection(COLLECTION_NAME), NodeCertificate.class, String.class, mongoJackObjectMapperProvider.get());
-        new MongoDbIndexTools(db).createUniqueIndex(FIELD_NODEID);
+
+        this.mongoDatabase = mongoConnection.getMongoDatabase();
         this.encryptionService = encryptionService;
+        KeystoreMongoCollections.ALL_KEYSTORE_COLLECTIONS.forEach(collection -> {
+            final MongoCollection<Document> dbCollection = mongoDatabase
+                    .getCollection(collection.collectionName());
+            dbCollection.createIndex(
+                    ascending(collection.identifierField()),
+                    new IndexOptions().unique(true));
+        });
+
 
     }
 
+    public boolean writeCert(final KeystoreMongoLocation keystoreMongoLocation,
+                             final String cert) {
+        final KeystoreMongoCollection collection = keystoreMongoLocation.collection();
+        MongoCollection<Document> dbCollection = mongoDatabase.getCollection(collection.collectionName());
+        final EncryptedValue encrypted = encryptionService.encrypt(cert);
+        final UpdateResult result = dbCollection.updateOne(
+                eq(collection.identifierField(), keystoreMongoLocation.nodeId()),
+                combine(
+                        set(collection.identifierField(), keystoreMongoLocation.nodeId()),
+                        set(collection.encryptedCertificateField() + "." + ENCRYPTED_VALUE_SUBFIELD, encrypted.value()),
+                        set(collection.encryptedCertificateField() + "." + SALT_SUBFIELD, encrypted.salt())
+                ),
+                new UpdateOptions().upsert(true)
+        );
+        return result.getModifiedCount() > 0 || result.getUpsertedId() != null;
+    }
+
+    public Optional<String> readCert(final KeystoreMongoLocation keystoreMongoLocation) {
+        final KeystoreMongoCollection collection = keystoreMongoLocation.collection();
+        MongoCollection<Document> dbCollection = mongoDatabase.getCollection(collection.collectionName());
+        final FindIterable<Document> objects = dbCollection.find(
+                eq(
+                        collection.identifierField(),
+                        keystoreMongoLocation.nodeId()
+                )
+        );
+        final Document nodeCertificate = objects.first();
+
+        if (nodeCertificate != null) {
+            final Document encryptedCertificateDocument = nodeCertificate.get(collection.encryptedCertificateField(), Document.class);
+            if (encryptedCertificateDocument != null) {
+                final EncryptedValue encryptedCertificate = EncryptedValue.builder()
+                        .value(encryptedCertificateDocument.getString(ENCRYPTED_VALUE_SUBFIELD))
+                        .salt(encryptedCertificateDocument.getString(SALT_SUBFIELD))
+                        .isDeleteValue(false)
+                        .isKeepValue(false)
+                        .build();
+
+                return Optional.ofNullable(encryptionService.decrypt(encryptedCertificate));
+            }
+        }
+        return Optional.empty();
+    }
+
+    @Deprecated
     public boolean writeCert(final String nodeId,
                              final String cert) {
-        final EncryptedValue encrypted = encryptionService.encrypt(cert);
-        final WriteResult<NodeCertificate, String> result = dbCollection.update(
-                DBQuery.is(FIELD_NODEID, nodeId),
-                DBUpdate
-                        .set(FIELD_NODEID, nodeId)
-                        .set(FIELD_ENCR_CERTIFICATE, encrypted),
-                true,
-                false
-        );
-        return result.getN() > 0;
+        return writeCert(new KeystoreMongoLocation(nodeId, DATA_NODE_KEYSTORE_COLLECTION), cert);
     }
 
+    @Deprecated
     public Optional<String> readCert(final String nodeId) {
-        final NodeCertificate nodeCertificate = dbCollection.findOne(
-                DBQuery.is(FIELD_NODEID, nodeId)
-        );
-        if (nodeCertificate != null && nodeCertificate.encryptedCertificate() != null) {
-            return Optional.ofNullable(encryptionService.decrypt(nodeCertificate.encryptedCertificate()));
-        } else {
-            return Optional.empty();
-        }
+        return readCert(new KeystoreMongoLocation(nodeId, DATA_NODE_KEYSTORE_COLLECTION));
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/cluster/certificates/CertificatesServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/cluster/certificates/CertificatesServiceTest.java
@@ -16,14 +16,9 @@
  */
 package org.graylog2.cluster.certificates;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.module.SimpleModule;
+import org.graylog.security.certutil.keystore.storage.location.KeystoreMongoLocation;
 import org.graylog.testing.mongodb.MongoDBInstance;
-import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
 import org.graylog2.database.MongoConnection;
-import org.graylog2.security.encryption.EncryptedValue;
-import org.graylog2.security.encryption.EncryptedValueDeserializer;
-import org.graylog2.security.encryption.EncryptedValueSerializer;
 import org.graylog2.security.encryption.EncryptedValueService;
 import org.junit.Before;
 import org.junit.Rule;
@@ -31,6 +26,7 @@ import org.junit.Test;
 
 import java.util.Optional;
 
+import static org.graylog.security.certutil.keystore.storage.location.KeystoreMongoCollections.DATA_NODE_KEYSTORE_COLLECTION;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -46,26 +42,33 @@ public class CertificatesServiceTest {
     public void setUp() {
         final MongoConnection mongoConnection = mongodb.mongoConnection();
         encryptedValueService = new EncryptedValueService("abracadabra! abracadabra!");
-        final MongoJackObjectMapperProvider objectMapperProvider = new MongoJackObjectMapperProvider(
-                new ObjectMapper().registerModule(new SimpleModule("Graylog")
-                        .addSerializer(EncryptedValue.class, new EncryptedValueSerializer())
-                        .addDeserializer(EncryptedValue.class, new EncryptedValueDeserializer(encryptedValueService))
-                )
-
-        );
-        certificatesService = new CertificatesService(objectMapperProvider, mongoConnection, encryptedValueService);
-
+        certificatesService = new CertificatesService(mongoConnection, encryptedValueService);
     }
 
     @Test
-    public void testReadUnexisting() {
-        final Optional<String> result = certificatesService.readCert("there is no node with this id");
+    public void testReadUnExisting() {
+        final Optional<String> result = certificatesService.readCert(
+                new KeystoreMongoLocation("there is no node with this id", DATA_NODE_KEYSTORE_COLLECTION));
         assertTrue(result.isEmpty());
-
     }
 
     @Test
     public void testReadAndWrite() {
+        boolean writeResult = certificatesService.writeCert(new KeystoreMongoLocation("node_id_1", DATA_NODE_KEYSTORE_COLLECTION), "Certificate string representation");
+        assertTrue(writeResult);
+        final Optional<String> readResult = certificatesService.readCert(new KeystoreMongoLocation("node_id_1", DATA_NODE_KEYSTORE_COLLECTION));
+        assertTrue(readResult.isPresent());
+        assertEquals("Certificate string representation", readResult.get());
+    }
+
+    @Test
+    public void testReadUnExistingDeprecatedMethod() {
+        final Optional<String> result = certificatesService.readCert("there is no node with this id");
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void testReadAndWriteDeprecatedMethod() {
         boolean writeResult = certificatesService.writeCert("node_id_1", "Certificate string representation");
         assertTrue(writeResult);
         final Optional<String> readResult = certificatesService.readCert("node_id_1");


### PR DESCRIPTION
## Description
Refactoring keystore storage.

## Motivation and Context
1. Client code does not have to pick KeystoreStorage implementation, instead location object for storage is created and passed to SmartKeystoreStorage, which can pick proper implementation by itself.
2. CertificateService becomes more universal (and who knows, maybe it can be made even more universal than that...).

/nocl


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

