### PR TITLE
Sliding expiration for authentication cookie. (`5.0`)

### DIFF
--- a/changelog/unreleased/pr-15504.toml
+++ b/changelog/unreleased/pr-15504.toml
@@ -1,0 +1,6 @@
+type = "fixed"
+message = "Extend authentication cookie's max age on every session extension."
+
+issues = ["15502"]
+pulls = ["15504"]
+

--- a/changelog/unreleased/pr-15651.toml
+++ b/changelog/unreleased/pr-15651.toml
@@ -2,5 +2,5 @@ type = "fixed"
 message = "Extend authentication cookie's max age on every session extension."
 
 issues = ["15502"]
-pulls = ["15504"]
+pulls = ["15651"]
 

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/SlidingExpirationCookieFilter.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/SlidingExpirationCookieFilter.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.rest.resources.system;
+
+import org.apache.shiro.session.Session;
+import org.apache.shiro.subject.Subject;
+import org.graylog2.rest.models.system.sessions.responses.SessionResponseFactory;
+import org.graylog2.shared.security.ShiroPrincipal;
+
+import javax.inject.Inject;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.core.NewCookie;
+import javax.ws.rs.core.SecurityContext;
+import java.io.IOException;
+import java.util.Optional;
+
+import static org.graylog2.security.realm.SessionAuthenticator.X_GRAYLOG_NO_SESSION_EXTENSION;
+
+public class SlidingExpirationCookieFilter implements ContainerResponseFilter {
+    private final CookieFactory cookieFactory;
+    private final SessionResponseFactory sessionResponseFactory;
+
+    @Inject
+    public SlidingExpirationCookieFilter(CookieFactory cookieFactory, SessionResponseFactory sessionResponseFactory) {
+        this.cookieFactory = cookieFactory;
+        this.sessionResponseFactory = sessionResponseFactory;
+    }
+
+    @Override
+    public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) throws IOException {
+        if (noSessionExtension(requestContext)) {
+            return;
+        }
+
+        sessionFromRequest(requestContext).ifPresent(session -> {
+            var response = sessionResponseFactory.forSession(session);
+            var cookie = cookieFactory.createAuthenticationCookie(response, requestContext);
+
+            setCookie(responseContext, cookie);
+        });
+    }
+
+    private Optional<Session> sessionFromRequest(ContainerRequestContext requestContext) {
+        return Optional.ofNullable(requestContext.getSecurityContext())
+                .map(SecurityContext::getUserPrincipal)
+                .filter(p -> p instanceof ShiroPrincipal)
+                .map(principal -> ((ShiroPrincipal) principal).getSubject())
+                .filter(Subject::isAuthenticated)
+                .map(subject -> subject.getSession(false));
+    }
+
+    private boolean noSessionExtension(ContainerRequestContext requestContext) {
+        return Optional.ofNullable(requestContext.getHeaderString(X_GRAYLOG_NO_SESSION_EXTENSION))
+                .map("true"::equalsIgnoreCase)
+                .orElse(false);
+    }
+
+    private void setCookie(ContainerResponseContext responseContext, NewCookie cookie) {
+        responseContext.getHeaders().add("Set-Cookie", cookie);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/shared/initializers/JerseyService.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/initializers/JerseyService.java
@@ -47,6 +47,7 @@ import org.graylog2.plugin.inject.Graylog2Module;
 import org.graylog2.plugin.rest.PluginRestResource;
 import org.graylog2.rest.MoreMediaTypes;
 import org.graylog2.rest.filter.WebAppNotFoundResponseFilter;
+import org.graylog2.rest.resources.system.SlidingExpirationCookieFilter;
 import org.graylog2.shared.rest.CORSFilter;
 import org.graylog2.shared.rest.ContentTypeOptionFilter;
 import org.graylog2.shared.rest.EmbeddingControlFilter;
@@ -265,7 +266,8 @@ public class JerseyService extends AbstractIdleService {
                         NotAuthorizedResponseFilter.class,
                         WebAppNotFoundResponseFilter.class,
                         EmbeddingControlFilter.class,
-                        ContentTypeOptionFilter.class)
+                        ContentTypeOptionFilter.class,
+                        SlidingExpirationCookieFilter.class)
                 // Replacing this with a lambda leads to missing subtypes - https://github.com/Graylog2/graylog2-server/pull/10617#discussion_r630236360
                 .register(new ContextResolver<ObjectMapper>() {
                     @Override


### PR DESCRIPTION
**Note:** This is a backport of #15504 to `5.0`.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Prior to this PR, the `authentication` cookie set when authenticating via `POST /api/system/sessions` had a max-age defined by the session lifetime of the user. This max-age was unfortunately not extended by subsequent request, leading to early logout (due to the browser invalidating the cookie) in the frontend, although the session was still valid, unless the user performed a full-page refresh.

This PR is changing this by adding a sliding expiration mechanism extending the max-age of the cookie on every request that does not disable session extension.

Fixes #15502.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.