### PR TITLE
Save modified search when query is changed through URL parameters. (`5.1`)

### DIFF
--- a/changelog/unreleased/issue-15642.toml
+++ b/changelog/unreleased/issue-15642.toml
@@ -1,0 +1,6 @@
+type = "f"
+message = "Save modified search when query is changed through URL parameters."
+
+issues = ["15642"]
+pulls = ["15653"]
+

--- a/changelog/unreleased/issue-15642.toml
+++ b/changelog/unreleased/issue-15642.toml
@@ -2,5 +2,5 @@ type = "f"
 message = "Save modified search when query is changed through URL parameters."
 
 issues = ["15642"]
-pulls = ["15653"]
+pulls = ["15654"]
 

--- a/graylog2-web-interface/src/views/hooks/BindSearchParamsFromQuery.test.ts
+++ b/graylog2-web-interface/src/views/hooks/BindSearchParamsFromQuery.test.ts
@@ -26,6 +26,8 @@ import bindSearchParamsFromQuery from './BindSearchParamsFromQuery';
 
 const MOCK_VIEW_QUERY_ID = 'query-id';
 
+jest.mock('views/logic/slices/createSearch', () => (s: Search) => s);
+
 describe('BindSearchParamsFromQuery should', () => {
   const query = Query.builder()
     .id(MOCK_VIEW_QUERY_ID)


### PR DESCRIPTION
**Note:** This is a backport of #15653 to `5.1`.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Prior to this PR, when manipulating the query of a saved search through URL parameters did not work. The reason for this is that the in-memory query was manipulated, but the search was not saved.

This PR is now making sure that if the query is manipulated through URL parameters, a new search will be created and saved.

Fixes #15642.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.