### PR TITLE
Use correct email attribute for AD users

### DIFF
--- a/changelog/unreleased/issue-15652.toml
+++ b/changelog/unreleased/issue-15652.toml
@@ -1,0 +1,6 @@
+type = "fixed"
+message = "Restore mail attribute for AD authentication."
+
+issues = ["15536"]
+pulls = [""]
+

--- a/graylog2-server/src/main/java/org/graylog/security/authservice/backend/ADAuthServiceBackend.java
+++ b/graylog2-server/src/main/java/org/graylog/security/authservice/backend/ADAuthServiceBackend.java
@@ -41,7 +41,7 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 import java.security.GeneralSecurityException;
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -150,7 +150,7 @@ public class ADAuthServiceBackend implements AuthServiceBackend {
                 .userUniqueIdAttribute(AD_OBJECT_GUID)
                 .userNameAttribute(config.userNameAttribute())
                 .userFullNameAttribute(config.userFullNameAttribute())
-                .emailAttributes(new ArrayList<>())
+                .emailAttributes(Arrays.asList("mail"))
                 .build();
 
         return ldapConnector.searchUserByPrincipal(connection, searchConfig, authCredentials.username());


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Use `mail` as the hardcoded email attribute for AD user sync. This is the behavior through version 5.0 and was inadvertently broken in 5.1.
See linked issue for details.

Fixed #15652 
