### PR TITLE
OTR Reencryption and Key Storage refactoring for password change

### DIFF
--- a/data-node/src/main/java/org/graylog/datanode/bindings/ServerBindings.java
+++ b/data-node/src/main/java/org/graylog/datanode/bindings/ServerBindings.java
@@ -16,12 +16,13 @@
  */
 package org.graylog.datanode.bindings;
 
-import com.google.inject.Scopes;
 import com.google.inject.multibindings.Multibinder;
 import com.google.inject.multibindings.OptionalBinder;
 import org.graylog.datanode.Configuration;
 import org.graylog.datanode.cluster.DataNodeServiceImpl;
 import org.graylog.datanode.shared.system.activities.DataNodeActivityWriter;
+import org.graylog.security.certutil.keystore.storage.KeystoreContentMover;
+import org.graylog.security.certutil.keystore.storage.PrivateKeyEntryOnlyKeystoreContentMover;
 import org.graylog2.bindings.providers.ClusterEventBusProvider;
 import org.graylog2.cluster.ClusterConfigServiceImpl;
 import org.graylog2.cluster.NodeService;
@@ -74,6 +75,7 @@ public class ServerBindings extends Graylog2Module {
 
     private void bindSingletons() {
         bind(ClusterConfigService.class).to(ClusterConfigServiceImpl.class).asEagerSingleton();
+        bind(KeystoreContentMover.class).to(PrivateKeyEntryOnlyKeystoreContentMover.class).asEagerSingleton();
     }
 
     private void bindInterfaces() {

--- a/data-node/src/main/java/org/graylog/datanode/bootstrap/preflight/DataNodePreflightGeneratePeriodical.java
+++ b/data-node/src/main/java/org/graylog/datanode/bootstrap/preflight/DataNodePreflightGeneratePeriodical.java
@@ -120,7 +120,7 @@ public class DataNodePreflightGeneratePeriodical extends Periodical {
                         );
 
                         final KeystoreMongoLocation location = new KeystoreMongoLocation(nodeId.getNodeId(), KeystoreMongoCollections.DATA_NODE_KEYSTORE_COLLECTION);
-                        keystoreStorage.writeKeyStore(location, nodeKeystore, configuration.getDatanodeHttpCertificatePassword().toCharArray());
+                        keystoreStorage.writeKeyStore(location, nodeKeystore, configuration.getDatanodeHttpCertificatePassword().toCharArray(), null);
 
                         //should be in one transaction, but we miss transactions...
                         nodePreflightConfigService.changeState(nodeId.getNodeId(), NodePreflightConfig.State.STORED);

--- a/data-node/src/main/java/org/graylog/datanode/configuration/certificates/KeystoreReEncryption.java
+++ b/data-node/src/main/java/org/graylog/datanode/configuration/certificates/KeystoreReEncryption.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.datanode.configuration.certificates;
+
+import org.apache.commons.lang3.RandomStringUtils;
+import org.graylog.security.certutil.ca.exceptions.KeyStoreStorageException;
+import org.graylog.security.certutil.keystore.storage.SmartKeystoreStorage;
+import org.graylog.security.certutil.keystore.storage.location.KeystoreLocation;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import java.security.KeyStore;
+import java.util.Optional;
+
+public class KeystoreReEncryption {
+
+    private final SmartKeystoreStorage keystoreStorage;
+    private final String passwordSecret;
+
+    @Inject
+    public KeystoreReEncryption(final SmartKeystoreStorage keystoreStorage,
+                                final @Named("password_secret") String passwordSecret) {
+        this.keystoreStorage = keystoreStorage;
+        this.passwordSecret = passwordSecret;
+    }
+
+    public void reEncyptWithSecret(final KeystoreLocation originalLocation,
+                                   final char[] originalPassword,
+                                   final KeystoreLocation targetLocation
+    ) throws KeyStoreStorageException {
+        reEncypt(originalLocation, originalPassword, targetLocation, passwordSecret.toCharArray());
+    }
+
+    public char[] reEncyptWithOtp(final KeystoreLocation originalLocation,
+                                  final char[] originalPassword,
+                                  final KeystoreLocation targetLocation
+    ) throws KeyStoreStorageException {
+        final char[] oneTimePassword = RandomStringUtils.randomAlphabetic(256).toCharArray();
+        reEncypt(originalLocation, originalPassword, targetLocation, originalPassword);
+        return oneTimePassword;
+    }
+
+    private void reEncypt(final KeystoreLocation originalLocation,
+                          final char[] originalPassword,
+                          final KeystoreLocation targetLocation,
+                          final char[] newPassword
+    ) throws KeyStoreStorageException {
+
+        final Optional<KeyStore> keyStore = keystoreStorage.readKeyStore(originalLocation, originalPassword);
+        if (keyStore.isPresent()) {
+            final KeyStore originalKeystore = keyStore.get();
+            keystoreStorage.writeKeyStore(targetLocation, originalKeystore, originalPassword, newPassword);
+
+        } else {
+            throw new KeyStoreStorageException("No keystore present in : " + originalLocation);
+        }
+    }
+}

--- a/data-node/src/main/java/org/graylog/datanode/configuration/certificates/KeystoreReEncryption.java
+++ b/data-node/src/main/java/org/graylog/datanode/configuration/certificates/KeystoreReEncryption.java
@@ -50,7 +50,7 @@ public class KeystoreReEncryption {
                                   final KeystoreLocation targetLocation
     ) throws KeyStoreStorageException {
         final char[] oneTimePassword = RandomStringUtils.randomAlphabetic(256).toCharArray();
-        reEncypt(originalLocation, originalPassword, targetLocation, originalPassword);
+        reEncypt(originalLocation, originalPassword, targetLocation, oneTimePassword);
         return oneTimePassword;
     }
 

--- a/data-node/src/test/java/org/graylog/datanode/configuration/TruststoreCreatorTest.java
+++ b/data-node/src/test/java/org/graylog/datanode/configuration/TruststoreCreatorTest.java
@@ -24,7 +24,9 @@ import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
 import org.bouncycastle.operator.ContentSigner;
 import org.bouncycastle.operator.OperatorCreationException;
 import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+import org.graylog.security.certutil.keystore.storage.KeystoreContentMover;
 import org.graylog.security.certutil.keystore.storage.KeystoreFileStorage;
+import org.graylog.security.certutil.keystore.storage.location.KeystoreFileLocation;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -47,6 +49,7 @@ import static org.graylog.security.certutil.CertConstants.KEY_GENERATION_ALGORIT
 import static org.graylog.security.certutil.CertConstants.SIGNING_ALGORITHM;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
 
 
 public class TruststoreCreatorTest {
@@ -73,8 +76,8 @@ public class TruststoreCreatorTest {
 
         assertTrue(trustStoreFile.toFile().exists());
 
-        KeystoreFileStorage keystoreFileStorage = new KeystoreFileStorage();
-        final Optional<KeyStore> keyStoreOptional = keystoreFileStorage.readKeyStore(trustStoreFile, truststorePassword);
+        KeystoreFileStorage keystoreFileStorage = new KeystoreFileStorage(mock(KeystoreContentMover.class));
+        final Optional<KeyStore> keyStoreOptional = keystoreFileStorage.readKeyStore(new KeystoreFileLocation(trustStoreFile), truststorePassword);
 
         assertTrue(keyStoreOptional.isPresent());
 

--- a/graylog2-server/src/main/java/org/graylog/security/certutil/CertutilCa.java
+++ b/graylog2-server/src/main/java/org/graylog/security/certutil/CertutilCa.java
@@ -22,6 +22,7 @@ import org.graylog.security.certutil.ca.CACreator;
 import org.graylog.security.certutil.console.CommandLineConsole;
 import org.graylog.security.certutil.console.SystemConsole;
 import org.graylog.security.certutil.keystore.storage.KeystoreFileStorage;
+import org.graylog.security.certutil.keystore.storage.PrivateKeyEntryOnlyKeystoreContentMover;
 import org.graylog.security.certutil.keystore.storage.location.KeystoreFileLocation;
 import org.graylog2.bootstrap.CliCommand;
 
@@ -41,14 +42,14 @@ public class CertutilCa implements CliCommand {
     public CertutilCa() {
         this.console = new SystemConsole();
         this.caCreator = new CACreator();
-        this.caKeystoreStorage = new KeystoreFileStorage();
+        this.caKeystoreStorage = new KeystoreFileStorage(new PrivateKeyEntryOnlyKeystoreContentMover());
     }
 
     public CertutilCa(String keystoreFilename, CommandLineConsole console) {
         this.keystoreFilename = keystoreFilename;
         this.console = console;
         this.caCreator = new CACreator();
-        this.caKeystoreStorage = new KeystoreFileStorage();
+        this.caKeystoreStorage = new KeystoreFileStorage(new PrivateKeyEntryOnlyKeystoreContentMover());
     }
 
     @Override
@@ -65,8 +66,7 @@ public class CertutilCa implements CliCommand {
             console.printLine("Private keys and certificates for root and intermediate CA generated");
 
             final Path keystorePath = Path.of(keystoreFilename);
-            //TODO: it is probably a bad idea to use the same password for CA and its storage...
-            caKeystoreStorage.writeKeyStore(new KeystoreFileLocation(keystorePath), caKeystore, password);
+            caKeystoreStorage.writeKeyStore(new KeystoreFileLocation(keystorePath), caKeystore, password, null);
             console.printLine("Keys and certificates stored in " + keystorePath.toAbsolutePath());
 
         } catch (Exception e) {

--- a/graylog2-server/src/main/java/org/graylog/security/certutil/keystore/storage/KeystoreContentMover.java
+++ b/graylog2-server/src/main/java/org/graylog/security/certutil/keystore/storage/KeystoreContentMover.java
@@ -14,15 +14,15 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-package org.graylog.security.certutil.ca.exceptions;
+package org.graylog.security.certutil.keystore.storage;
 
-public class KeyStoreStorageException extends Exception {
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.security.KeyStore;
 
-    public KeyStoreStorageException(String message, Throwable cause) {
-        super(message, cause);
-    }
+public interface KeystoreContentMover {
 
-    public KeyStoreStorageException(String message) {
-        super(message);
-    }
+    KeyStore moveContents(final KeyStore originalKeyStore,
+                          char[] currentPassword,
+                          final char[] newPassword) throws GeneralSecurityException, IOException;
 }

--- a/graylog2-server/src/main/java/org/graylog/security/certutil/keystore/storage/KeystoreStorage.java
+++ b/graylog2-server/src/main/java/org/graylog/security/certutil/keystore/storage/KeystoreStorage.java
@@ -26,8 +26,9 @@ public sealed interface KeystoreStorage<T extends KeystoreLocation> permits Keys
 
     void writeKeyStore(final T location,
                        final KeyStore keyStore,
-                       final char[] password)
-            throws KeyStoreStorageException;
+                       final char[] currentPassword,
+                       final char[] newPassword
+    ) throws KeyStoreStorageException;
 
     Optional<KeyStore> readKeyStore(final T location, char[] password) throws KeyStoreStorageException;
 

--- a/graylog2-server/src/main/java/org/graylog/security/certutil/keystore/storage/PrivateKeyEntryOnlyKeystoreContentMover.java
+++ b/graylog2-server/src/main/java/org/graylog/security/certutil/keystore/storage/PrivateKeyEntryOnlyKeystoreContentMover.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.security.certutil.keystore.storage;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.security.KeyStore;
+import java.util.Enumeration;
+
+import static org.graylog.security.certutil.CertConstants.PKCS12;
+
+//TODO: temporary and limited implementation...
+//Supporting all the possibilities would be a nightmare
+//The goal is to introduce a new class for KeyStore, which supports only one type of password across all entries, one entry type...
+public class PrivateKeyEntryOnlyKeystoreContentMover implements KeystoreContentMover {
+
+    @Override
+    public KeyStore moveContents(KeyStore originalKeyStore,
+                                 char[] currentPassword,
+                                 final char[] newPassword) throws GeneralSecurityException, IOException {
+        KeyStore newKeyStore = KeyStore.getInstance(PKCS12);
+        newKeyStore.load(null, newPassword);
+
+        final Enumeration<String> aliases = originalKeyStore.aliases();
+        while (aliases.hasMoreElements()) {
+            String alias = aliases.nextElement();
+            newKeyStore.setKeyEntry(
+                    alias,
+                    originalKeyStore.getKey(alias, currentPassword),
+                    newPassword,
+                    originalKeyStore.getCertificateChain(alias)
+            );
+        }
+        return newKeyStore;
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/security/certutil/keystore/storage/SmartKeystoreStorage.java
+++ b/graylog2-server/src/main/java/org/graylog/security/certutil/keystore/storage/SmartKeystoreStorage.java
@@ -26,26 +26,27 @@ import javax.inject.Inject;
 import java.security.KeyStore;
 import java.util.Optional;
 
-
 public final class SmartKeystoreStorage implements KeystoreStorage<KeystoreLocation> {
 
     private final KeystoreMongoStorage keystoreMongoStorage;
     private final KeystoreFileStorage keystoreFileStorage;
 
     @Inject
-    public SmartKeystoreStorage(final CertificatesService certificatesService) {
-        keystoreMongoStorage = new KeystoreMongoStorage(certificatesService);
-        keystoreFileStorage = new KeystoreFileStorage();
+    public SmartKeystoreStorage(final CertificatesService certificatesService,
+                                final KeystoreContentMover keystoreContentMover) {
+        keystoreMongoStorage = new KeystoreMongoStorage(certificatesService, keystoreContentMover);
+        keystoreFileStorage = new KeystoreFileStorage(keystoreContentMover);
     }
 
     @Override
     public void writeKeyStore(KeystoreLocation location,
                               KeyStore keyStore,
-                              char[] password) throws KeyStoreStorageException {
+                              char[] currentPassword,
+                              final char[] newPassword) throws KeyStoreStorageException {
         if (location instanceof final KeystoreMongoLocation mongoLocation) {
-            keystoreMongoStorage.writeKeyStore(mongoLocation, keyStore, password);
+            keystoreMongoStorage.writeKeyStore(mongoLocation, keyStore, currentPassword, newPassword);
         } else if (location instanceof final KeystoreFileLocation fileLocation) {
-            keystoreFileStorage.writeKeyStore(fileLocation, keyStore, password);
+            keystoreFileStorage.writeKeyStore(fileLocation, keyStore, currentPassword, newPassword);
         }
     }
 

--- a/graylog2-server/src/test/java/org/graylog/security/certutil/keystore/storage/KeystoreFileStorageTest.java
+++ b/graylog2-server/src/test/java/org/graylog/security/certutil/keystore/storage/KeystoreFileStorageTest.java
@@ -18,44 +18,70 @@ package org.graylog.security.certutil.keystore.storage;
 
 import org.graylog.security.certutil.CertConstants;
 import org.graylog.security.certutil.ca.exceptions.KeyStoreStorageException;
-import org.junit.jupiter.api.BeforeEach;
+import org.graylog.security.certutil.keystore.storage.location.KeystoreFileLocation;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.FileInputStream;
 import java.nio.file.Path;
 import java.security.KeyStore;
+import java.security.UnrecoverableKeyException;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 public class KeystoreFileStorageTest {
 
     private KeystoreFileStorage toTest;
 
-    @BeforeEach
-    void setUp() {
-        toTest = new KeystoreFileStorage();
-    }
-
     @Test
-    void testKeyStoreSaveAndRetrieve(@TempDir Path tmpDir) throws Exception {
+    void testKeyStoreSaveAndRetrieveWithNoPasswordChange(@TempDir Path tmpDir) throws Exception {
+        final KeystoreContentMover keystoreContentMover = mock(KeystoreContentMover.class);
+        toTest = new KeystoreFileStorage(keystoreContentMover);
         final Path keystoreFile = tmpDir.resolve("keystore_file.p12");
         KeyStore testKeystore = KeyStore.getInstance(CertConstants.PKCS12);
         testKeystore.load(new FileInputStream("src/test/resources/org/graylog/security/certutil/keystore/storage/sample_certificate_keystore.p12"), "password".toCharArray());
         char[] passwd = "password".toCharArray();
 
-        toTest.writeKeyStore(keystoreFile, testKeystore, passwd);
-        final Optional<KeyStore> keyStore = toTest.readKeyStore(keystoreFile, passwd);
+        final KeystoreFileLocation location = new KeystoreFileLocation(keystoreFile);
+        toTest.writeKeyStore(location, testKeystore, passwd, null);
+        final Optional<KeyStore> keyStore = toTest.readKeyStore(location, passwd);
         assertTrue(keyStore.isPresent());
-        assertEquals(testKeystore.getCertificate("datanode"), keyStore.get().getCertificate("datanode"));
+        final KeyStore keyStoreToVerify = keyStore.get();
+        assertEquals(testKeystore.getCertificate("datanode"), keyStoreToVerify.getCertificate("datanode"));
+        assertEquals("RSA", keyStoreToVerify.getKey("datanode", passwd).getAlgorithm());
+        verifyNoInteractions(keystoreContentMover);
+
+    }
+
+    @Test
+    void testKeyStoreSaveAndRetrieveWithPasswordChange(@TempDir Path tmpDir) throws Exception {
+        toTest = new KeystoreFileStorage(new PrivateKeyEntryOnlyKeystoreContentMover());
+        final Path keystoreFile = tmpDir.resolve("keystore_file.p12");
+        KeyStore testKeystore = KeyStore.getInstance(CertConstants.PKCS12);
+        testKeystore.load(new FileInputStream("src/test/resources/org/graylog/security/certutil/keystore/storage/sample_certificate_keystore.p12"), "password".toCharArray());
+        char[] passwd = "password".toCharArray();
+        char[] newPasswd = "secret".toCharArray();
+
+        final KeystoreFileLocation location = new KeystoreFileLocation(keystoreFile);
+        toTest.writeKeyStore(location, testKeystore, passwd, newPasswd);
+        final Optional<KeyStore> keyStore = toTest.readKeyStore(location, newPasswd);
+        assertTrue(keyStore.isPresent());
+        final KeyStore keyStoreToVerify = keyStore.get();
+        assertEquals(testKeystore.getCertificate("datanode"), keyStoreToVerify.getCertificate("datanode"));
+        assertEquals("RSA", keyStoreToVerify.getKey("datanode", newPasswd).getAlgorithm());
+        assertThrows(UnrecoverableKeyException.class, () -> keyStoreToVerify.getKey("datanode", passwd));
 
     }
 
     @Test
     void testKeystoreReadThrowsExceptionWhenUsingWrongPassword(@TempDir Path tmpDir) throws Exception {
+        final KeystoreContentMover keystoreContentMover = mock(KeystoreContentMover.class);
+        toTest = new KeystoreFileStorage(keystoreContentMover);
         final Path keystoreFile = tmpDir.resolve("keystore_file.p12");
         KeyStore testKeystore = KeyStore.getInstance(CertConstants.PKCS12);
         testKeystore.load(null, null);
@@ -63,6 +89,7 @@ public class KeystoreFileStorageTest {
 
         toTest.writeKeyStore(keystoreFile, testKeystore, passwd);
         assertThrows(KeyStoreStorageException.class, () -> toTest.readKeyStore(keystoreFile, "wrong password".toCharArray()));
+        verifyNoInteractions(keystoreContentMover);
     }
 
 }


### PR DESCRIPTION
## Description
Works on some assumptions:
 - password for keystore and private keys are the same,
 - keystore contains only private-key entries (PK with cert. chain)

Significant change: when writing keystore, you have to provide both original and new password.
The problem with old approach was that it kept old password for PK, and changed password for keystore only.
Now we have a class that moves keystore entries as well, changing their passwords in the process.
/nocl

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

