### PR TITLE
Create search when replaying events/event definitions. (`5.1`)

### DIFF
--- a/changelog/unreleased/pr-15688.toml
+++ b/changelog/unreleased/pr-15688.toml
@@ -1,0 +1,5 @@
+type = "f"
+message = "Fixing search creation when replaying events/event definitions."
+
+pulls = ["15688"]
+issues = ["15552", "15689"]

--- a/graylog2-web-interface/src/views/pages/EventDefinitionReplaySearchPage.tsx
+++ b/graylog2-web-interface/src/views/pages/EventDefinitionReplaySearchPage.tsx
@@ -27,10 +27,12 @@ import useCreateViewForEventDefinition from 'views/logic/views/UseCreateViewForE
 import EventInfoBar from 'components/event-definitions/replay-search/EventInfoBar';
 import { createFromFetchError } from 'logic/errors/ReportedErrors';
 import ErrorsActions from 'actions/errors/ErrorsActions';
+import useCreateSearch from 'views/hooks/useCreateSearch';
 
 const EventView = () => {
   const { eventDefinition, aggregations } = useAlertAndEventDefinitionData();
-  const view = useCreateViewForEventDefinition({ eventDefinition, aggregations });
+  const _view = useCreateViewForEventDefinition({ eventDefinition, aggregations });
+  const view = useCreateSearch(_view);
 
   return (
     <SearchPage view={view}

--- a/graylog2-web-interface/src/views/pages/EventReplaySearchPage.tsx
+++ b/graylog2-web-interface/src/views/pages/EventReplaySearchPage.tsx
@@ -28,10 +28,12 @@ import useAlertAndEventDefinitionData from 'hooks/useAlertAndEventDefinitionData
 import EventInfoBar from 'components/event-definitions/replay-search/EventInfoBar';
 import { createFromFetchError } from 'logic/errors/ReportedErrors';
 import ErrorsActions from 'actions/errors/ErrorsActions';
+import useCreateSearch from 'views/hooks/useCreateSearch';
 
 const EventView = () => {
   const { eventData, eventDefinition, aggregations } = useAlertAndEventDefinitionData();
-  const view = useCreateViewForEvent({ eventData, eventDefinition, aggregations });
+  const _view = useCreateViewForEvent({ eventData, eventDefinition, aggregations });
+  const view = useCreateSearch(_view);
 
   return (
     <SearchPage view={view}


### PR DESCRIPTION
**Note:** This is a backport of #15688 to `5.1`.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This is a follow-up to #15453, applying the same fix also for the pages replaying events/event definitions. This is preventing a 404 being turned into an exception when replaying events/event definitions.

Fixes #15552.
Fixes #15689.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.