### PR TITLE
Increase startup timeout for Kafka test-container to 60 seconds

### DIFF
--- a/graylog2-server/src/test/java/org/graylog/testing/kafka/KafkaContainer.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/kafka/KafkaContainer.java
@@ -117,7 +117,7 @@ public class KafkaContainer extends GenericContainer<KafkaContainer> {
         withCreateContainerCmdModifier(cmd -> cmd.withEntrypoint("sh"));
         withCommand("-c", "while [ ! -f " + KAFKA_ADVERTISED_LISTENERS_FILE + " ]; do sleep 0.1; done; /entrypoint.sh /run.sh");
 
-        waitingFor(Wait.forLogMessage(".*Kafka Server started.*", 1).withStartupTimeout(Duration.ofSeconds(5)));
+        waitingFor(Wait.forLogMessage(".*Kafka Server started.*", 1).withStartupTimeout(Duration.ofSeconds(60)));
     }
 
     private static String generateKraftClusterId() {


### PR DESCRIPTION
This will hopefully reduce startup timeouts that we are seeing on Jenkins.
 
/nocl

