### PR TITLE
Fixed LastOpened and Favorite items to not show up in internal entity lists (backport 5.1)

### DIFF
--- a/changelog/unreleased/issue-15638.toml
+++ b/changelog/unreleased/issue-15638.toml
@@ -1,0 +1,6 @@
+type = "f"
+message = "Remove LastOpened and Favorite items from internal Entity List"
+
+issues = ["15638", "15574"]
+pulls = ["15657"]
+

--- a/changelog/unreleased/issue-15638.toml
+++ b/changelog/unreleased/issue-15638.toml
@@ -2,5 +2,5 @@ type = "f"
 message = "Remove LastOpened and Favorite items from internal Entity List"
 
 issues = ["15638", "15574"]
-pulls = ["15657"]
+pulls = ["15658"]
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/favorites/FavoritesService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/favorites/FavoritesService.java
@@ -19,16 +19,12 @@ package org.graylog.plugins.views.favorites;
 import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
 import com.mongodb.BasicDBObject;
-import com.mongodb.DBObject;
 import com.mongodb.DuplicateKeyException;
 import org.bson.types.ObjectId;
-import org.graylog.grn.GRN;
 import org.graylog.grn.GRNRegistry;
-import org.graylog.grn.GRNTypes;
 import org.graylog.plugins.views.search.permissions.SearchUser;
 import org.graylog.plugins.views.startpage.recentActivities.ActivityType;
 import org.graylog.plugins.views.startpage.recentActivities.RecentActivityEvent;
-import org.graylog.security.entities.EntityOwnershipService;
 import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
 import org.graylog2.database.MongoConnection;
 import org.graylog2.database.PaginatedDbService;
@@ -40,14 +36,12 @@ import org.mongojack.DBQuery;
 import org.mongojack.WriteResult;
 
 import javax.inject.Inject;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
 public class FavoritesService extends PaginatedDbService<FavoritesForUserDTO> {
     public static final String COLLECTION_NAME = "favorites";
 
-    private final EntityOwnershipService entityOwnerShipService;
     private final Catalog catalog;
     private final GRNRegistry grnRegistry;
 
@@ -55,12 +49,10 @@ public class FavoritesService extends PaginatedDbService<FavoritesForUserDTO> {
     protected FavoritesService(final MongoConnection mongoConnection,
                                EventBus eventBus,
                                final MongoJackObjectMapperProvider mapper,
-                               final EntityOwnershipService entityOwnerShipService,
                                final Catalog catalog,
                                final GRNRegistry grnRegistry) {
         super(mongoConnection, mapper, FavoritesForUserDTO.class, COLLECTION_NAME);
         eventBus.register(this);
-        this.entityOwnerShipService = entityOwnerShipService;
         this.catalog = catalog;
         this.grnRegistry = grnRegistry;
 
@@ -116,9 +108,6 @@ public class FavoritesService extends PaginatedDbService<FavoritesForUserDTO> {
         try {
             final WriteResult<FavoritesForUserDTO, ObjectId> result = db.insert(favorite);
             final FavoritesForUserDTO savedObject = result.getSavedObject();
-            if (savedObject != null) {
-                entityOwnerShipService.registerNewEntity(savedObject.id(), searchUser.getUser(), GRNTypes.FAVORITE);
-            }
             return Optional.ofNullable(savedObject);
         } catch (DuplicateKeyException e) {
             throw new IllegalStateException("Unable to create a Favorites collection, collection with this id already exists : " + favorite.id());

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/startpage/lastOpened/LastOpenedService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/startpage/lastOpened/LastOpenedService.java
@@ -40,15 +40,12 @@ import java.util.Optional;
 public class LastOpenedService extends PaginatedDbService<LastOpenedForUserDTO> {
     public static final String COLLECTION_NAME = "last_opened";
 
-    private final EntityOwnershipService entityOwnerShipService;
 
     @Inject
     public LastOpenedService(MongoConnection mongoConnection,
                              MongoJackObjectMapperProvider mapper,
-                             EventBus eventBus,
-                             final EntityOwnershipService entityOwnerShipService) {
+                             EventBus eventBus) {
         super(mongoConnection, mapper, LastOpenedForUserDTO.class, COLLECTION_NAME);
-        this.entityOwnerShipService = entityOwnerShipService;
         eventBus.register(this);
 
         db.createIndex(new BasicDBObject(LastOpenedForUserDTO.FIELD_USER_ID, 1));
@@ -67,9 +64,6 @@ public class LastOpenedService extends PaginatedDbService<LastOpenedForUserDTO> 
         try {
             final WriteResult<LastOpenedForUserDTO, ObjectId> result = db.insert(lastOpenedItems);
             final LastOpenedForUserDTO savedObject = result.getSavedObject();
-            if (savedObject != null) {
-                entityOwnerShipService.registerNewEntity(savedObject.id(), searchUser.getUser(), GRNTypes.LAST_OPENED);
-            }
             return Optional.ofNullable(savedObject);
         } catch (DuplicateKeyException e) {
             throw new IllegalStateException("Unable to create a last opened collection, collection with this id already exists : " + lastOpenedItems.id());

--- a/graylog2-server/src/main/java/org/graylog2/migrations/MigrationsModule.java
+++ b/graylog2-server/src/main/java/org/graylog2/migrations/MigrationsModule.java
@@ -64,5 +64,6 @@ public class MigrationsModule extends PluginModule {
         addMigration(V20230220095500_MigrateStartPageObjectReferencesToGRNbyRemoval.class);
         addMigration(V20230213160000_EncryptedInputConfigMigration.class);
         addMigration(V20230210102500_UniqueUserMigration.class);
+        addMigration(V20230531135500_MigrateRemoveObsoleteItemsFromGrantsCollection.class);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/migrations/V20230531135500_MigrateRemoveObsoleteItemsFromGrantsCollection.java
+++ b/graylog2-server/src/main/java/org/graylog2/migrations/V20230531135500_MigrateRemoveObsoleteItemsFromGrantsCollection.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.migrations;
+
+import com.mongodb.BasicDBObject;
+import com.mongodb.client.model.Filters;
+import org.graylog.plugins.views.startpage.lastOpened.LastOpenedDTO;
+import org.graylog.plugins.views.startpage.lastOpened.LastOpenedForUserDTO;
+import org.graylog.security.DBGrantService;
+import org.graylog2.database.MongoConnection;
+import org.graylog2.plugin.cluster.ClusterConfigService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import java.time.ZonedDateTime;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+/**
+ * This is not really a migration but a deletion of existing elements in the grants collection.
+ * LastOpened and Favorites were added as entities but shouldn't have been (because they don't get shared)
+ */
+public class V20230531135500_MigrateRemoveObsoleteItemsFromGrantsCollection extends Migration {
+    private static final Logger LOG = LoggerFactory.getLogger(V20230531135500_MigrateRemoveObsoleteItemsFromGrantsCollection.class);
+    private final MongoConnection mongoConnection;
+    private final ClusterConfigService clusterConfigService;
+
+    @Inject
+    public V20230531135500_MigrateRemoveObsoleteItemsFromGrantsCollection(MongoConnection mongoConnection, ClusterConfigService clusterConfigService) {
+        this.clusterConfigService = clusterConfigService;
+        this.mongoConnection = mongoConnection;
+    }
+
+    @Override
+    public ZonedDateTime createdAt() {
+        return ZonedDateTime.parse("2023-05-31T13:55:00Z");
+    }
+
+    @Override
+    public void upgrade() {
+        if (clusterConfigService.get(V20230531135500_MigrateRemoveObsoleteItemsFromGrantsCollection.MigrationCompleted.class) != null) {
+            return;
+        }
+
+        final Set<String> names = new HashSet();
+        mongoConnection.getMongoDatabase().listCollectionNames().forEach(names::add);
+
+        if(names.contains(DBGrantService.COLLECTION_NAME)) {
+            var query = new BasicDBObject("target", Pattern.compile("^grn::::favorite:"));
+            mongoConnection.getMongoDatabase().getCollection(DBGrantService.COLLECTION_NAME).deleteMany(query);
+            query = new BasicDBObject("target", Pattern.compile("^grn::::last_opened:"));
+            mongoConnection.getMongoDatabase().getCollection(DBGrantService.COLLECTION_NAME).deleteMany(query);
+        }
+
+        clusterConfigService.write(new MigrationCompleted());
+    }
+
+
+    public record MigrationCompleted() {}
+}

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/favorites/FavoriteServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/favorites/FavoriteServiceTest.java
@@ -96,7 +96,6 @@ public class FavoriteServiceTest {
                 new EventBus(),
                 mongoJackObjectMapperProvider,
                 null,
-                null,
                 grnRegistry);
     }
 

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/startpage/StartPageServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/startpage/StartPageServiceTest.java
@@ -119,8 +119,7 @@ public class StartPageServiceTest {
 
         var eventbus = new EventBus();
         var dbGrantService = new DBGrantService(mongodb.mongoConnection(), mongoJackObjectMapperProvider, grnRegistry);
-        var entityOwnerShipService = new EntityOwnershipService(dbGrantService, grnRegistry);
-        var lastOpenedService = new LastOpenedService(mongodb.mongoConnection(), mongoJackObjectMapperProvider, eventbus, entityOwnerShipService);
+        var lastOpenedService = new LastOpenedService(mongodb.mongoConnection(), mongoJackObjectMapperProvider, eventbus);
         var recentActivityService = new RecentActivityService(mongodb.mongoConnection(), mongoJackObjectMapperProvider, eventbus, grnRegistry, permissionAndRoleResolver);
         startPageService = new StartPageService(new TestCatalog(), grnRegistry, lastOpenedService, recentActivityService, eventbus);
     }

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/startpage/lastOpened/LastOpenedServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/startpage/lastOpened/LastOpenedServiceTest.java
@@ -95,8 +95,7 @@ public class LastOpenedServiceTest {
         this.grnRegistry = grnRegistry;
         this.lastOpenedService = new LastOpenedService(mongodb.mongoConnection(),
                 mongoJackObjectMapperProvider,
-                new EventBus(),
-                null);
+                new EventBus());
     }
 
     @Test

--- a/graylog2-server/src/test/java/org/graylog2/migrations/V20230531135500_MigrateRemoveObsoleteItemsFromGrantsCollectionTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/migrations/V20230531135500_MigrateRemoveObsoleteItemsFromGrantsCollectionTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.migrations;
+
+import com.mongodb.client.MongoCollection;
+import org.bson.Document;
+import org.graylog.security.DBGrantService;
+import org.graylog.testing.mongodb.MongoDBExtension;
+import org.graylog.testing.mongodb.MongoDBFixtures;
+import org.graylog.testing.mongodb.MongoDBTestService;
+import org.graylog2.database.MongoConnection;
+import org.graylog2.plugin.cluster.ClusterConfigService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MongoDBExtension.class)
+@ExtendWith(MockitoExtension.class)
+class V20230531135500_MigrateRemoveObsoleteItemsFromGrantsCollectionTest {
+    private final V20230531135500_MigrateRemoveObsoleteItemsFromGrantsCollection migration;
+    private final MongoCollection<Document> collection;
+
+    private final ClusterConfigService clusterConfigService;
+
+    public V20230531135500_MigrateRemoveObsoleteItemsFromGrantsCollectionTest(MongoDBTestService mongoDBTestService, @Mock ClusterConfigService clusterConfigService) {
+        final MongoConnection mongoConnection = mongoDBTestService.mongoConnection();
+        collection = mongoConnection.getMongoDatabase().getCollection(DBGrantService.COLLECTION_NAME);
+        migration = new V20230531135500_MigrateRemoveObsoleteItemsFromGrantsCollection(mongoConnection, clusterConfigService);
+        this.clusterConfigService = clusterConfigService;
+    }
+
+    @Test
+    @MongoDBFixtures("V20230531135500_MigrateRemoveObsoleteItemsFromGrantsCollectionTest_noElements.json")
+    void notMigratingAnythingIfNoElementsArePresent() {
+        assertThat(this.collection.countDocuments()).isEqualTo(9);
+
+        this.migration.upgrade();
+
+        assertThat(migrationCompleted()).isNotNull();
+        assertThat(this.collection.countDocuments()).isEqualTo(9);
+    }
+
+    @Test
+    @MongoDBFixtures("V20230531135500_MigrateRemoveObsoleteItemsFromGrantsCollectionTests.json")
+    void removingAllObsoleteEntries() {
+        assertThat(this.collection.countDocuments()).isEqualTo(13);
+
+        this.migration.upgrade();
+
+        assertThat(migrationCompleted()).isNotNull();
+        assertThat(this.collection.countDocuments()).isEqualTo(9);
+
+        this.collection.find().forEach(d -> {
+            assertThat(d.get("target").toString()).doesNotContain("favorite");
+            assertThat(d.get("target").toString()).doesNotContain("last_opened");
+        });
+    }
+
+    private V20230531135500_MigrateRemoveObsoleteItemsFromGrantsCollection.MigrationCompleted migrationCompleted() {
+        final ArgumentCaptor<V20230531135500_MigrateRemoveObsoleteItemsFromGrantsCollection.MigrationCompleted> migrationCompletedCaptor = ArgumentCaptor
+                .forClass(V20230531135500_MigrateRemoveObsoleteItemsFromGrantsCollection.MigrationCompleted.class);
+        verify(this.clusterConfigService, times(1)).write(migrationCompletedCaptor.capture());
+        return migrationCompletedCaptor.getValue();
+    }
+}

--- a/graylog2-server/src/test/resources/org/graylog2/migrations/V20230531135500_MigrateRemoveObsoleteItemsFromGrantsCollectionTest_noElements.json
+++ b/graylog2-server/src/test/resources/org/graylog2/migrations/V20230531135500_MigrateRemoveObsoleteItemsFromGrantsCollectionTest_noElements.json
@@ -1,0 +1,156 @@
+{
+  "grants": [
+    {
+      "_id": {
+        "$oid": "63cfeac66349342ff7d3fd2b"
+      },
+      "grantee": "grn::::user:63ce738136a00d0192d2b1c3",
+      "capability": "view",
+      "target": "grn::::event_definition:63ce738136a00d0192d2b1af",
+      "created_by": "admin",
+      "created_at": {
+        "$date": "2023-01-24T14:27:18.937Z"
+      },
+      "updated_by": "admin",
+      "updated_at": {
+        "$date": "2023-01-24T14:27:18.937Z"
+      },
+      "expires_at": null
+    },
+    {
+      "_id": {
+        "$oid": "63f757ae282a965d701b9bb3"
+      },
+      "grantee": "grn::::user:63dcbdb5123c1a49c53c368c",
+      "capability": "own",
+      "target": "grn::::search:63f757aef0a57e53e6822110",
+      "created_by": "jheise",
+      "created_at": {
+        "$date": "2023-02-23T12:10:22.511Z"
+      },
+      "updated_by": "jheise",
+      "updated_at": {
+        "$date": "2023-02-23T12:10:22.511Z"
+      },
+      "expires_at": null
+    },
+    {
+      "_id": {
+        "$oid": "641320178fb433259718029a"
+      },
+      "grantee": "grn::::user:63dcbdb5123c1a49c53c368c",
+      "capability": "view",
+      "target": "grn::::stream:000000000000000000000001",
+      "created_by": "admin",
+      "created_at": {
+        "$date": "2023-03-16T13:56:39.645Z"
+      },
+      "updated_by": "admin",
+      "updated_at": {
+        "$date": "2023-03-16T13:56:39.645Z"
+      },
+      "expires_at": null
+    },
+    {
+      "_id": {
+        "$oid": "643e9699f0715b72fa15955a"
+      },
+      "grantee": "grn::::user:643e9695f0715b72fa1594e6",
+      "capability": "view",
+      "target": "grn::::stream:000000000000000000000001",
+      "created_by": "admin",
+      "created_at": {
+        "$date": "2023-04-18T13:09:45.588Z"
+      },
+      "updated_by": "admin",
+      "updated_at": {
+        "$date": "2023-04-18T13:09:45.588Z"
+      },
+      "expires_at": null
+    },
+    {
+      "_id": {
+        "$oid": "643e9793f0715b72fa1599a9"
+      },
+      "grantee": "grn::::user:643e978ff0715b72fa159946",
+      "capability": "view",
+      "target": "grn::::stream:000000000000000000000001",
+      "created_by": "admin",
+      "created_at": {
+        "$date": "2023-04-18T13:13:55.711Z"
+      },
+      "updated_by": "admin",
+      "updated_at": {
+        "$date": "2023-04-18T13:13:55.711Z"
+      },
+      "expires_at": null
+    },
+    {
+      "_id": {
+        "$oid": "643e980c8c6f56519a3361b0"
+      },
+      "grantee": "grn::::user:643e98088c6f56519a33614f",
+      "capability": "view",
+      "target": "grn::::stream:000000000000000000000001",
+      "created_by": "admin",
+      "created_at": {
+        "$date": "2023-04-18T13:15:56.607Z"
+      },
+      "updated_by": "admin",
+      "updated_at": {
+        "$date": "2023-04-18T13:15:56.607Z"
+      },
+      "expires_at": null
+    },
+    {
+      "_id": {
+        "$oid": "643e98128c6f56519a3361c7"
+      },
+      "grantee": "grn::::user:643e98088c6f56519a33614f",
+      "capability": "own",
+      "target": "grn::::dashboard:643e981152cbc924396d0962",
+      "created_by": "cy-test@email-24876.com",
+      "created_at": {
+        "$date": "2023-04-18T13:16:02.054Z"
+      },
+      "updated_by": "cy-test@email-24876.com",
+      "updated_at": {
+        "$date": "2023-04-18T13:16:02.054Z"
+      },
+      "expires_at": null
+    },
+    {
+      "_id": {
+        "$oid": "644001d97157f24fdd14d580"
+      },
+      "grantee": "grn::::user:63dcbdb5123c1a49c53c368c",
+      "capability": "view",
+      "target": "grn::::dashboard:644001bb5ceda4d926efac86",
+      "created_by": "admin",
+      "created_at": {
+        "$date": "2023-04-19T14:59:37.654Z"
+      },
+      "updated_by": "admin",
+      "updated_at": {
+        "$date": "2023-04-19T14:59:37.654Z"
+      },
+      "expires_at": null
+    },
+    {
+      "_id": {
+        "$oid": "644259e88c9d3b1488aeb5ca"
+      },
+      "grantee": "grn::::user:63dcbdb5123c1a49c53c368c",
+      "capability": "own",
+      "target": "grn::::search:644259e86b6eec4b18e85fe3",
+      "created_by": "jheise",
+      "created_at": {
+        "$date": "2023-04-21T09:39:52.156Z"
+      },
+      "updated_by": "jheise",
+      "updated_at": {
+        "$date": "2023-04-21T09:39:52.156Z"
+      },
+      "expires_at": null
+    }]
+}

--- a/graylog2-server/src/test/resources/org/graylog2/migrations/V20230531135500_MigrateRemoveObsoleteItemsFromGrantsCollectionTests.json
+++ b/graylog2-server/src/test/resources/org/graylog2/migrations/V20230531135500_MigrateRemoveObsoleteItemsFromGrantsCollectionTests.json
@@ -1,0 +1,224 @@
+{
+  "grants": [
+    {
+      "_id": {
+        "$oid": "63cfeac66349342ff7d3fd2b"
+      },
+      "grantee": "grn::::user:63ce738136a00d0192d2b1c3",
+      "capability": "view",
+      "target": "grn::::event_definition:63ce738136a00d0192d2b1af",
+      "created_by": "admin",
+      "created_at": {
+        "$date": "2023-01-24T14:27:18.937Z"
+      },
+      "updated_by": "admin",
+      "updated_at": {
+        "$date": "2023-01-24T14:27:18.937Z"
+      },
+      "expires_at": null
+    },
+    {
+      "_id": {
+        "$oid": "63f757ae282a965d701b9bb3"
+      },
+      "grantee": "grn::::user:63dcbdb5123c1a49c53c368c",
+      "capability": "own",
+      "target": "grn::::search:63f757aef0a57e53e6822110",
+      "created_by": "jheise",
+      "created_at": {
+        "$date": "2023-02-23T12:10:22.511Z"
+      },
+      "updated_by": "jheise",
+      "updated_at": {
+        "$date": "2023-02-23T12:10:22.511Z"
+      },
+      "expires_at": null
+    },
+    {
+      "_id": {
+        "$oid": "641320178fb433259718029a"
+      },
+      "grantee": "grn::::user:63dcbdb5123c1a49c53c368c",
+      "capability": "view",
+      "target": "grn::::stream:000000000000000000000001",
+      "created_by": "admin",
+      "created_at": {
+        "$date": "2023-03-16T13:56:39.645Z"
+      },
+      "updated_by": "admin",
+      "updated_at": {
+        "$date": "2023-03-16T13:56:39.645Z"
+      },
+      "expires_at": null
+    },
+    {
+      "_id": {
+        "$oid": "643e9699f0715b72fa15955a"
+      },
+      "grantee": "grn::::user:643e9695f0715b72fa1594e6",
+      "capability": "view",
+      "target": "grn::::stream:000000000000000000000001",
+      "created_by": "admin",
+      "created_at": {
+        "$date": "2023-04-18T13:09:45.588Z"
+      },
+      "updated_by": "admin",
+      "updated_at": {
+        "$date": "2023-04-18T13:09:45.588Z"
+      },
+      "expires_at": null
+    },
+    {
+      "_id": {
+        "$oid": "643e9793f0715b72fa1599a9"
+      },
+      "grantee": "grn::::user:643e978ff0715b72fa159946",
+      "capability": "view",
+      "target": "grn::::stream:000000000000000000000001",
+      "created_by": "admin",
+      "created_at": {
+        "$date": "2023-04-18T13:13:55.711Z"
+      },
+      "updated_by": "admin",
+      "updated_at": {
+        "$date": "2023-04-18T13:13:55.711Z"
+      },
+      "expires_at": null
+    },
+    {
+      "_id": {
+        "$oid": "643e980c8c6f56519a3361b0"
+      },
+      "grantee": "grn::::user:643e98088c6f56519a33614f",
+      "capability": "view",
+      "target": "grn::::stream:000000000000000000000001",
+      "created_by": "admin",
+      "created_at": {
+        "$date": "2023-04-18T13:15:56.607Z"
+      },
+      "updated_by": "admin",
+      "updated_at": {
+        "$date": "2023-04-18T13:15:56.607Z"
+      },
+      "expires_at": null
+    },
+    {
+      "_id": {
+        "$oid": "643e98128c6f56519a3361c7"
+      },
+      "grantee": "grn::::user:643e98088c6f56519a33614f",
+      "capability": "own",
+      "target": "grn::::dashboard:643e981152cbc924396d0962",
+      "created_by": "cy-test@email-24876.com",
+      "created_at": {
+        "$date": "2023-04-18T13:16:02.054Z"
+      },
+      "updated_by": "cy-test@email-24876.com",
+      "updated_at": {
+        "$date": "2023-04-18T13:16:02.054Z"
+      },
+      "expires_at": null
+    },
+    {
+      "_id": {
+        "$oid": "644001d97157f24fdd14d580"
+      },
+      "grantee": "grn::::user:63dcbdb5123c1a49c53c368c",
+      "capability": "view",
+      "target": "grn::::dashboard:644001bb5ceda4d926efac86",
+      "created_by": "admin",
+      "created_at": {
+        "$date": "2023-04-19T14:59:37.654Z"
+      },
+      "updated_by": "admin",
+      "updated_at": {
+        "$date": "2023-04-19T14:59:37.654Z"
+      },
+      "expires_at": null
+    },
+    {
+      "_id": {
+        "$oid": "644259e88c9d3b1488aeb5ca"
+      },
+      "grantee": "grn::::user:63dcbdb5123c1a49c53c368c",
+      "capability": "own",
+      "target": "grn::::search:644259e86b6eec4b18e85fe3",
+      "created_by": "jheise",
+      "created_at": {
+        "$date": "2023-04-21T09:39:52.156Z"
+      },
+      "updated_by": "jheise",
+      "updated_at": {
+        "$date": "2023-04-21T09:39:52.156Z"
+      },
+      "expires_at": null
+    },
+    {
+      "_id": {
+        "$oid": "6477339b3f251c73e6ea32e2"
+      },
+      "grantee": "grn::::user:63dcbdb5123c1a49c53c368c",
+      "capability": "own",
+      "target": "grn::::last_opened:647733983f251c73e6ea32e1",
+      "created_by": "jheise",
+      "created_at": {
+        "$date": "2023-05-31T11:46:35.507Z"
+      },
+      "updated_by": "jheise",
+      "updated_at": {
+        "$date": "2023-05-31T11:46:35.507Z"
+      },
+      "expires_at": null
+    },
+    {
+      "_id": {
+        "$oid": "6477339b3f251c73e6ea32e3"
+      },
+      "grantee": "grn::::user:63dcbdb5123c1a49c53c368c",
+      "capability": "own",
+      "target": "grn::::last_opened:647733983f251c73e6ea32e3",
+      "created_by": "jheise",
+      "created_at": {
+        "$date": "2023-05-31T11:46:35.507Z"
+      },
+      "updated_by": "jheise",
+      "updated_at": {
+        "$date": "2023-05-31T11:46:35.507Z"
+      },
+      "expires_at": null
+    },
+    {
+      "_id": {
+        "$oid": "6477339b3f251c73e6ea32e4"
+      },
+      "grantee": "grn::::user:63dcbdb5123c1a49c53c368c",
+      "capability": "own",
+      "target": "grn::::favorite:647733983f251c73e6ea32e4",
+      "created_by": "jheise",
+      "created_at": {
+        "$date": "2023-05-31T11:46:35.507Z"
+      },
+      "updated_by": "jheise",
+      "updated_at": {
+        "$date": "2023-05-31T11:46:35.507Z"
+      },
+      "expires_at": null
+    },
+    {
+      "_id": {
+        "$oid": "6477339b3f251c73e6ea32e5"
+      },
+      "grantee": "grn::::user:63dcbdb5123c1a49c53c368c",
+      "capability": "own",
+      "target": "grn::::favorite:647733983f251c73e6ea32e5",
+      "created_by": "jheise",
+      "created_at": {
+        "$date": "2023-05-31T11:46:35.507Z"
+      },
+      "updated_by": "jheise",
+      "updated_at": {
+        "$date": "2023-05-31T11:46:35.507Z"
+      },
+      "expires_at": null
+    }]
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Favorite and LastOpened were registered as full entities, which led to errors on the "shared items" list for users because they are no real manageable entities and have no routes in the FE to be edited. 
Solution is: not register these items as full entities.


** backport to 5.1 from #15658 **

fixes #15574 #15638

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

