### PR TITLE
Let MongoDBPreflightCheck implement PreflightCheck interface

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/bootstrap/preflight/MongoDBPreflightCheck.java
+++ b/graylog2-server/src/main/java/org/graylog2/bootstrap/preflight/MongoDBPreflightCheck.java
@@ -40,7 +40,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-public class MongoDBPreflightCheck {
+public class MongoDBPreflightCheck implements PreflightCheck {
     private static final Logger LOG = LoggerFactory.getLogger(MongoDBPreflightCheck.class);
     private static final String CLUSTER_CONFIG_COLLECTION_NAME = "cluster_config";
 


### PR DESCRIPTION
Adds a missing `implements PreflightCheck` to `MongoDBPreflightCheck`

/nocl
