### PR TITLE
Fix Entity Datable expanded section 

### DIFF
--- a/graylog2-web-interface/src/components/common/EntityDataTable/contexts/ExpandedSectionsProvider.tsx
+++ b/graylog2-web-interface/src/components/common/EntityDataTable/contexts/ExpandedSectionsProvider.tsx
@@ -26,7 +26,7 @@ const ExpandedSectionsProvider = ({ children }: { children: React.ReactNode }): 
   const toggleSection = useCallback((entityId: string, sectionName: string) => setExpandedSections((cur) => {
     const newCur = { ...cur ?? {} };
 
-    if (newCur[entityId]?.includes('rules')) {
+    if (newCur[entityId]?.includes(sectionName)) {
       const newSections = newCur[entityId].filter((section) => section !== sectionName);
 
       if (newSections.length === 0) {


### PR DESCRIPTION
When using an expanded section with a name different than `rules`, it is not displayed. this was caused by the `rules` name being hardcoded in the `ExpandedSectionsProvider`. This PR is fixing that.

/nocl

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

